### PR TITLE
LPS-112886 Comments are not accessible by any user that is not a company admin

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/CommentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/CommentResourceImpl.java
@@ -37,7 +37,13 @@ import com.liferay.portal.kernel.comment.DiscussionPermission;
 import com.liferay.portal.kernel.comment.DuplicateCommentException;
 import com.liferay.portal.kernel.exception.NoSuchModelException;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
+import com.liferay.portal.kernel.search.BooleanQuery;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Hits;
+import com.liferay.portal.kernel.search.IndexSearcherHelperUtil;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.IndexerRegistryUtil;
+import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.Filter;
@@ -55,9 +61,14 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.SearchUtil;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.NotFoundException;
@@ -325,8 +336,7 @@ public class CommentResourceImpl
 			String search, Filter filter, Pagination pagination, Sort[] sorts)
 		throws Exception {
 
-		return SearchUtil.search(
-			actions,
+		SearchContext searchContext = SearchUtil.getSearchContext(
 			booleanQuery -> {
 				BooleanFilter booleanFilter =
 					booleanQuery.getPreBooleanFilter();
@@ -336,20 +346,38 @@ public class CommentResourceImpl
 						"parentMessageId", String.valueOf(commentId)),
 					BooleanClauseOccur.MUST);
 			},
-			filter, MBMessage.class, search, pagination,
+			filter, search, pagination,
 			queryConfig -> queryConfig.setSelectedFieldNames(
 				Field.ENTRY_CLASS_PK),
-			searchContext -> {
-				searchContext.setAttribute("discussion", Boolean.TRUE);
-				searchContext.setAttribute(
-					"searchPermissionContext", StringPool.BLANK);
-				searchContext.setCompanyId(contextCompany.getCompanyId());
-			},
-			sorts,
-			document -> CommentUtil.toComment(
-				_commentManager.fetchComment(
-					GetterUtil.getLong(document.get(Field.ENTRY_CLASS_PK))),
-				_commentManager, _portal));
+			sorts);
+
+		searchContext.setAttribute("discussion", Boolean.TRUE);
+		searchContext.setAttribute("searchPermissionContext", StringPool.BLANK);
+		searchContext.setCompanyId(contextCompany.getCompanyId());
+
+		Indexer<?> indexer = IndexerRegistryUtil.getIndexer(MBMessage.class);
+
+		BooleanQuery booleanQuery = indexer.getFullQuery(searchContext);
+
+		Hits hits = IndexSearcherHelperUtil.search(searchContext, booleanQuery);
+
+		List<Comment> items = Stream.of(
+			transform(
+				Arrays.asList(hits.getDocs()),
+				document -> CommentUtil.toComment(
+					_commentManager.fetchComment(
+						GetterUtil.getLong(document.get(Field.ENTRY_CLASS_PK))),
+					_commentManager, _portal))
+		).flatMap(
+			List::stream
+		).filter(
+			Objects::nonNull
+		).collect(
+			Collectors.toList()
+		);
+
+		return Page.of(
+			actions, items, pagination, indexer.searchCount(searchContext));
 	}
 
 	private DiscussionPermission _getDiscussionPermission() {

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/SearchUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/SearchUtil.java
@@ -78,6 +78,18 @@ public class SearchUtil {
 		return queryDefinition;
 	}
 
+	public static SearchContext getSearchContext(
+			UnsafeConsumer<BooleanQuery, Exception> booleanQueryUnsafeConsumer,
+			Filter filter, String keywords, Pagination pagination,
+			UnsafeConsumer<QueryConfig, Exception> queryConfigUnsafeConsumer,
+			Sort[] sorts)
+		throws Exception {
+
+		return _createSearchContext(
+			_getBooleanClause(booleanQueryUnsafeConsumer, filter), keywords,
+			pagination, queryConfigUnsafeConsumer, sorts);
+	}
+
 	public static <T> Page<T> search(
 			Map<String, Map<String, String>> actions,
 			UnsafeConsumer<BooleanQuery, Exception> booleanQueryUnsafeConsumer,


### PR DESCRIPTION
We are calling a different method than SearchUtil, we use IndexSearcherHelperUtil to search directly without checking permissions.
About exposing the SearchContext we expose a method in SearchUtil that is useful to customize the query even further and creating a SearchContext is difficult without knowing the Search framework, this is also a request that a member of GS did to us.