### PR TITLE
LPS-111902 Code Editor Inconsistent Styling solved

### DIFF
--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/css/_ckeditor_custom.scss
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/css/_ckeditor_custom.scss
@@ -1,0 +1,8 @@
+.cke_readonly .cke .cke_inner .cke_bottom,
+.cke_readonly .cke .cke_inner .cke_top {
+	display: none;
+}
+
+.cke_readonly .cke_chrome {
+	border: none;
+}

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/css/_pages.scss
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/css/_pages.scss
@@ -1,1 +1,2 @@
+@import 'ckeditor_custom';
 @import 'tags';

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/ArticleBodyRenderer.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/ArticleBodyRenderer.es.js
@@ -37,7 +37,7 @@ export function getCKEditorConfig() {
 		autoGrow_onStartup: true,
 		codeSnippet_theme: 'monokai_sublime',
 		extraPlugins: 'autogrow,codesnippet',
-		readOnly:true,
+		readOnly: true,
 		removePlugins: 'elementspath',
 	};
 
@@ -46,10 +46,22 @@ export function getCKEditorConfig() {
 	return config;
 }
 
-export default ({articleBody, encodingFormat, id, signature}) => (
+export default ({
+	articleBody,
+	compactMode = false,
+	encodingFormat,
+	id,
+	signature,
+}) => (
 	<>
 		{encodingFormat === 'bbcode' && <p>{parser.toReact(articleBody)}</p>}
-		{encodingFormat !== 'bbcode' && (
+		{encodingFormat !== 'bbcode' && compactMode && (
+			<div
+				className={`questions-article-body-${id}`}
+				dangerouslySetInnerHTML={{__html: articleBody}}
+			/>
+		)}
+		{encodingFormat !== 'bbcode' && !compactMode && (
 			<div className={`cke_readonly questions-article-body-${id}`}>
 				<Editor
 					config={getCKEditorConfig()}

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/ArticleBodyRenderer.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/ArticleBodyRenderer.es.js
@@ -12,17 +12,51 @@
  * details.
  */
 
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 import parser from 'bbcode-to-react';
+import {Editor} from 'frontend-editor-ckeditor-web';
 import React from 'react';
+
+export function getCKEditorConfig() {
+	const config = {
+		allowedContent: true,
+		autoGrow_minHeight: 200,
+		autoGrow_onStartup: true,
+		codeSnippet_theme: 'monokai_sublime',
+		extraPlugins: 'autogrow,codesnippet',
+		readOnly:true,
+		removePlugins: 'elementspath',
+	};
+
+	config.toolbar = [];
+
+	return config;
+}
 
 export default ({articleBody, encodingFormat, id, signature}) => (
 	<>
 		{encodingFormat === 'bbcode' && <p>{parser.toReact(articleBody)}</p>}
 		{encodingFormat !== 'bbcode' && (
-			<div
-				className={`questions-article-body-${id}`}
-				dangerouslySetInnerHTML={{__html: articleBody}}
-			/>
+			<div className={`cke_readonly questions-article-body-${id}`}>
+				<Editor
+					config={getCKEditorConfig()}
+					data={articleBody}
+					required
+				/>
+			</div>
 		)}
 
 		{signature && (

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/QuestionRow.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/QuestionRow.es.js
@@ -87,6 +87,7 @@ export default ({question}) => {
 				<ArticleBodyRenderer
 					{...question}
 					articleBody={stripHTML(question.articleBody)}
+					compactMode={true}
 				/>
 			</div>
 


### PR DESCRIPTION
The code shown in questions now has the same syntax hightlighting than the one used when Creeating/editing the question.

This has been achieved by using the same CKEEditor (in readonly mode) and tweaking some of the styles to get rid of some toolbars, that is being using in edit mode