### PR TITLE
Revert "LPS-112886 not needed since deprecation doesn't care about ge…

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/SearchUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/SearchUtil.java
@@ -143,8 +143,9 @@ public class SearchUtil {
 			Filter filter, Class<?> indexerClass, String keywords,
 			Pagination pagination,
 			UnsafeConsumer<QueryConfig, Exception> queryConfigUnsafeConsumer,
-			UnsafeConsumer<SearchContext, Exception>
-				searchContextUnsafeConsumer,
+			UnsafeConsumer
+				<com.liferay.portal.kernel.search.SearchContext, Exception>
+					searchContextUnsafeConsumer,
 			UnsafeFunction<Document, T, Exception> transformUnsafeFunction,
 			Sort[] sorts)
 		throws Exception {
@@ -167,8 +168,9 @@ public class SearchUtil {
 			Filter filter, Class<?> indexerClass, String keywords,
 			Pagination pagination,
 			UnsafeConsumer<QueryConfig, Exception> queryConfigUnsafeConsumer,
-			UnsafeConsumer<SearchContext, Exception>
-				searchContextUnsafeConsumer,
+			UnsafeConsumer
+				<com.liferay.portal.kernel.search.SearchContext, Exception>
+					searchContextUnsafeConsumer,
 			UnsafeFunction<Document, T, Exception> transformUnsafeFunction,
 			Sort[] sorts, Map<String, Map<String, String>> actions)
 		throws Exception {


### PR DESCRIPTION
…nerics"

Reverting because it causes some issues in new code that depends on old vulcan versions (commerce 7.1 for example): https://issues.liferay.com/browse/COMMERCE-4016, without this they can cast to old code instead of wrapping like this: https://github.com/ethanbustad/liferay-portal-ee/commit/bbfbb22439f14c3877fff3a6b5470342378798cb