### PR TITLE
LPS-114479 Validate OpenAPI YAML files to check against OpenAPI specification (required fields, ...)

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/YAMLUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/YAMLUtil.java
@@ -18,6 +18,8 @@ import com.liferay.portal.vulcan.yaml.config.ConfigYAML;
 import com.liferay.portal.vulcan.yaml.config.Security;
 import com.liferay.portal.vulcan.yaml.exception.InvalidYAMLException;
 import com.liferay.portal.vulcan.yaml.openapi.Items;
+import com.liferay.portal.vulcan.yaml.openapi.OpenAPIValidator;
+import com.liferay.portal.vulcan.yaml.openapi.OpenAPIValidatorException;
 import com.liferay.portal.vulcan.yaml.openapi.OpenAPIYAML;
 import com.liferay.portal.vulcan.yaml.openapi.Parameter;
 import com.liferay.portal.vulcan.yaml.openapi.PathItem;
@@ -56,6 +58,12 @@ public class YAMLUtil {
 		catch (MarkedYAMLException markedYAMLException) {
 			throw new InvalidYAMLException(markedYAMLException);
 		}
+	}
+
+	public static void validateOpenAPIYAML(String fileName, String yamlString)
+		throws OpenAPIValidatorException {
+
+		OpenAPIValidator.validate(fileName, yamlString, _YAML_OPEN_API);
 	}
 
 	private static final Yaml _YAML_CONFIG;

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/OpenAPIValidator.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/OpenAPIValidator.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.yaml.openapi;
+
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * @author Javier de Arcos
+ */
+public class OpenAPIValidator {
+
+	public static void validate(
+			String fileName, String openAPIYAMLString, Yaml openAPIYAML)
+		throws OpenAPIValidatorException {
+
+		OpenAPIYAML openAPI = openAPIYAML.loadAs(
+			openAPIYAMLString, OpenAPIYAML.class);
+
+		Info info = openAPI.getInfo();
+
+		if (info.getVersion() == null) {
+			throw new OpenAPIValidatorException(
+				String.format(
+					"File %s: Missing required field info: version", fileName));
+		}
+	}
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/OpenAPIValidatorException.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/yaml/openapi/OpenAPIValidatorException.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.yaml.openapi;
+
+/**
+ * @author Javier de Arcos
+ */
+public class OpenAPIValidatorException extends Exception {
+
+	public OpenAPIValidatorException(String message) {
+		super(message);
+	}
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/yaml/openapi/packageinfo
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/yaml/openapi/packageinfo
@@ -1,1 +1,1 @@
-version 1.5.0
+version 1.6.0

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/yaml/packageinfo
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/yaml/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/RESTBuilder.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/RESTBuilder.java
@@ -41,6 +41,7 @@ import com.liferay.portal.vulcan.yaml.openapi.Content;
 import com.liferay.portal.vulcan.yaml.openapi.Info;
 import com.liferay.portal.vulcan.yaml.openapi.Items;
 import com.liferay.portal.vulcan.yaml.openapi.License;
+import com.liferay.portal.vulcan.yaml.openapi.OpenAPIValidatorException;
 import com.liferay.portal.vulcan.yaml.openapi.OpenAPIYAML;
 import com.liferay.portal.vulcan.yaml.openapi.Operation;
 import com.liferay.portal.vulcan.yaml.openapi.Parameter;
@@ -178,6 +179,8 @@ public class RESTBuilder {
 
 		File[] files = FileUtil.getFiles(_configDir, "rest-openapi", ".yaml");
 
+		List<String> validationErrorMessages = new ArrayList<>();
+
 		for (File file : files) {
 			try {
 				_checkOpenAPIYAMLFile(freeMarkerTool, file);
@@ -189,13 +192,15 @@ public class RESTBuilder {
 						exception.getMessage()));
 			}
 
-			OpenAPIYAML openAPIYAML = _loadOpenAPIYAML(FileUtil.read(file));
+			String yamlString = FileUtil.read(file);
 
-			Info info = openAPIYAML.getInfo();
+			if (!_validateOpenAPIYAML(
+					file.getName(), yamlString, validationErrorMessages)) {
 
-			if (Validator.isNull(info.getVersion())) {
 				continue;
 			}
+
+			OpenAPIYAML openAPIYAML = _loadOpenAPIYAML(yamlString);
 
 			Map<String, Schema> allSchemas = OpenAPIUtil.getAllSchemas(
 				openAPIYAML);
@@ -303,6 +308,14 @@ public class RESTBuilder {
 						context, escapedVersion, schemaName);
 				}
 			}
+		}
+
+		if (!validationErrorMessages.isEmpty()) {
+			String validationErrors = StringUtil.merge(
+				validationErrorMessages, StringPool.NEW_LINE);
+
+			throw new RuntimeException(
+				"OpenAPI validation errors found: \n" + validationErrors);
 		}
 
 		FileUtil.deleteFiles(_configYAML.getApiDir(), _files);
@@ -1974,6 +1987,21 @@ public class RESTBuilder {
 					System.out.println(sb.toString());
 				}
 			}
+		}
+	}
+
+	private boolean _validateOpenAPIYAML(
+		String fileName, String yamlString, List<String> validationErrors) {
+
+		try {
+			YAMLUtil.validateOpenAPIYAML(fileName, yamlString);
+
+			return true;
+		}
+		catch (OpenAPIValidatorException openAPIValidatorException) {
+			validationErrors.add(openAPIValidatorException.getMessage());
+
+			return false;
 		}
 	}
 


### PR DESCRIPTION
Followed this line of thought:

1. Trying to find a YAML or OpenAPI Validator. swagger-parser seems to be the best option but it requires a lot of changes
2. Trying to use JSONValidator with a YAML but didn't succeed.
3. **Use a pattern similar to JSONValidator with the implemented YAMLValidator and create a point where we can centralize all OpenAPI validator rules in the future**