### PR TITLE
LPS-114479 Validate OpenAPI YAML files to check against OpenAPI speci…

### DIFF
--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/yaml/OpenAPIValidator.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/yaml/OpenAPIValidator.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.tools.rest.builder.internal.yaml;
+
+import com.liferay.portal.tools.rest.builder.internal.yaml.exception.OpenAPIValidatorException;
+import com.liferay.portal.tools.rest.builder.internal.yaml.openapi.Info;
+import com.liferay.portal.tools.rest.builder.internal.yaml.openapi.OpenAPIYAML;
+
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * @author Javier de Arcos
+ */
+public class OpenAPIValidator {
+
+	public static void validate(
+			String fileName, String openAPIYAMLString, Yaml openAPIYAML)
+		throws OpenAPIValidatorException {
+
+		OpenAPIYAML openAPI = openAPIYAML.loadAs(
+			openAPIYAMLString, OpenAPIYAML.class);
+
+		Info info = openAPI.getInfo();
+
+		if (info.getVersion() == null) {
+			throw new OpenAPIValidatorException(
+				String.format(
+					"File %s: Missing required field info: version", fileName));
+		}
+	}
+
+}

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/yaml/YAMLUtil.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/yaml/YAMLUtil.java
@@ -17,6 +17,7 @@ package com.liferay.portal.tools.rest.builder.internal.yaml;
 import com.liferay.portal.tools.rest.builder.internal.yaml.config.ConfigYAML;
 import com.liferay.portal.tools.rest.builder.internal.yaml.config.Security;
 import com.liferay.portal.tools.rest.builder.internal.yaml.exception.InvalidYAMLException;
+import com.liferay.portal.tools.rest.builder.internal.yaml.exception.OpenAPIValidatorException;
 import com.liferay.portal.tools.rest.builder.internal.yaml.openapi.Items;
 import com.liferay.portal.tools.rest.builder.internal.yaml.openapi.OpenAPIYAML;
 import com.liferay.portal.tools.rest.builder.internal.yaml.openapi.Parameter;
@@ -56,6 +57,12 @@ public class YAMLUtil {
 		catch (MarkedYAMLException markedYAMLException) {
 			throw new InvalidYAMLException(markedYAMLException);
 		}
+	}
+
+	public static void validateOpenAPIYAML(String fileName, String yamlString)
+		throws OpenAPIValidatorException {
+
+		OpenAPIValidator.validate(fileName, yamlString, _YAML_OPEN_API);
 	}
 
 	private static final Yaml _YAML_CONFIG;

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/yaml/exception/OpenAPIValidatorException.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/yaml/exception/OpenAPIValidatorException.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.tools.rest.builder.internal.yaml.exception;
+
+/**
+ * @author Javier de Arcos
+ */
+public class OpenAPIValidatorException extends Exception {
+
+	public OpenAPIValidatorException(String message) {
+		super(message);
+	}
+
+}


### PR DESCRIPTION
…fication (required fields, ...)

I finally put the OpenAPIValidator class in the yaml package, because the yaml.openapi package only contains POJOS about the OpenAPI specification domain and seems more adequate.

It also fit better in the yaml package for its level of abstraction and usage