### PR TITLE
LPS-116703 use administrator user that has a group

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/CommentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/CommentResourceTest.java
@@ -24,8 +24,8 @@ import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HtmlUtil;
 
 import java.util.Objects;
@@ -134,16 +134,15 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 		serviceContext.setScopeGroupId(testGroup.getGroupId());
 
 		return BlogsEntryLocalServiceUtil.addEntry(
-			UserLocalServiceUtil.getDefaultUserId(testGroup.getCompanyId()),
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			serviceContext);
+			TestPropsValues.getUserId(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), serviceContext);
 	}
 
 	private FileEntry _addFileEntry() throws Exception {
 		return DLAppTestUtil.addFileEntryWithWorkflow(
-			UserLocalServiceUtil.getDefaultUserId(testGroup.getCompanyId()),
-			testGroup.getGroupId(), 0, RandomTestUtil.randomString(),
-			RandomTestUtil.randomString(), true, new ServiceContext());
+			TestPropsValues.getUserId(), testGroup.getGroupId(), 0,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), true,
+			new ServiceContext());
 	}
 
 	private JournalArticle _addJournalArticle() throws Exception {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/ContentSetElementResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/ContentSetElementResourceTest.java
@@ -22,7 +22,6 @@ import com.liferay.blogs.model.BlogsEntry;
 import com.liferay.blogs.service.BlogsEntryLocalServiceUtil;
 import com.liferay.headless.delivery.client.dto.v1_0.ContentSetElement;
 import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.search.test.util.SearchTestRule;
@@ -105,9 +104,8 @@ public class ContentSetElementResourceTest
 
 	private BlogsEntry _addBlogsEntry() throws Exception {
 		return BlogsEntryLocalServiceUtil.addEntry(
-			UserLocalServiceUtil.getDefaultUserId(testGroup.getCompanyId()),
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			_serviceContext);
+			TestPropsValues.getUserId(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), _serviceContext);
 	}
 
 	private ContentSetElement _toContentSetElement(BlogsEntry blogsEntry) {


### PR DESCRIPTION
Patching https://issues.liferay.com/browse/LPS-116703, I don't know why the tests did not fail (I guess Lima is not configured to launch headless tests), I'm not sure if Blogs should allow to insert entities when user has no groupId /@4lejandrito 