### PR TITLE
LPS-98330 Add GraphQL contributions

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/graphql/servlet/GraphQLContributor.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/graphql/servlet/GraphQLContributor.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.graphql.servlet;
+
+/**
+ * @author Javier de Arcos
+ */
+public interface GraphQLContributor {
+
+	public Object getMutationContribution();
+
+	public String getContributionPath();
+
+	public Object getQueryContribution();
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/graphql/servlet/GraphQLContributor.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/graphql/servlet/GraphQLContributor.java
@@ -19,10 +19,14 @@ package com.liferay.portal.vulcan.graphql.servlet;
  */
 public interface GraphQLContributor {
 
-	public Object getMutationContribution();
-
 	public String getContributionPath();
 
-	public Object getQueryContribution();
+	public default Object getMutationContribution() {
+		return null;
+	}
+
+	public default Object getQueryContribution() {
+		return null;
+	}
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/graphql/servlet/packageinfo
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/graphql/servlet/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -2034,7 +2034,7 @@ public class GraphQLServletExtender {
 					ServletData.class,
 					ServletDataAdapter.of(graphQLContributor), null);
 
-			_servletDataServiceRegistrationMapping.put(
+			_servletDataServiceRegistrationMap.put(
 				graphQLContributor, servletDataServiceRegistration);
 
 			return graphQLContributor;
@@ -2052,7 +2052,7 @@ public class GraphQLServletExtender {
 			GraphQLContributor graphQLContributor) {
 
 			Optional.ofNullable(
-				_servletDataServiceRegistrationMapping.remove(
+				_servletDataServiceRegistrationMap.remove(
 					graphQLContributor)
 			).ifPresent(
 				ServiceRegistration::unregister
@@ -2062,7 +2062,7 @@ public class GraphQLServletExtender {
 		}
 
 		private final Map<GraphQLContributor, ServiceRegistration<ServletData>>
-			_servletDataServiceRegistrationMapping = new ConcurrentHashMap<>();
+			_servletDataServiceRegistrationMap = new ConcurrentHashMap<>();
 
 	}
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -2052,8 +2052,7 @@ public class GraphQLServletExtender {
 			GraphQLContributor graphQLContributor) {
 
 			Optional.ofNullable(
-				_servletDataServiceRegistrationMap.remove(
-					graphQLContributor)
+				_servletDataServiceRegistrationMap.remove(graphQLContributor)
 			).ifPresent(
 				ServiceRegistration::unregister
 			);

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -45,6 +45,7 @@ import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLTypeExtension;
+import com.liferay.portal.vulcan.graphql.servlet.GraphQLContributor;
 import com.liferay.portal.vulcan.graphql.servlet.ServletData;
 import com.liferay.portal.vulcan.internal.accept.language.AcceptLanguageImpl;
 import com.liferay.portal.vulcan.internal.configuration.VulcanConfiguration;
@@ -168,6 +169,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -317,6 +319,12 @@ public class GraphQLServletExtender {
 		_defaultTypeFunction.register(new MapTypeFunction());
 		_defaultTypeFunction.register(new ObjectTypeFunction());
 
+		_graphQLContributorServiceTracker = new ServiceTracker<>(
+			bundleContext, GraphQLContributor.class,
+			new GraphQLContributorServiceTrackerCustomizer());
+
+		_graphQLContributorServiceTracker.open();
+
 		Dictionary<String, Object> properties = new HashMapDictionary<>();
 
 		properties.put(
@@ -402,6 +410,8 @@ public class GraphQLServletExtender {
 
 	@Deactivate
 	protected void deactivate() {
+		_graphQLContributorServiceTracker.close();
+
 		_servletDataServiceTracker.close();
 
 		_servletServiceRegistration.unregister();
@@ -1501,6 +1511,8 @@ public class GraphQLServletExtender {
 	@Reference
 	private FilterParserProvider _filterParserProvider;
 
+	private ServiceTracker<GraphQLContributor, GraphQLContributor>
+		_graphQLContributorServiceTracker;
 	private GraphQLFieldRetriever _graphQLFieldRetriever;
 
 	@Reference
@@ -2003,6 +2015,54 @@ public class GraphQLServletExtender {
 					dataFetcherExceptionHandlerParameters.getSourceLocation())
 			).build();
 		}
+
+	}
+
+	private class GraphQLContributorServiceTrackerCustomizer
+		implements ServiceTrackerCustomizer
+			<GraphQLContributor, GraphQLContributor> {
+
+		@Override
+		public GraphQLContributor addingService(
+			ServiceReference<GraphQLContributor> serviceReference) {
+
+			GraphQLContributor graphQLContributor = _bundleContext.getService(
+				serviceReference);
+
+			ServiceRegistration<ServletData> servletDataServiceRegistration =
+				_bundleContext.registerService(
+					ServletData.class,
+					ServletDataAdapter.of(graphQLContributor), null);
+
+			_servletDataServiceRegistrationMapping.put(
+				graphQLContributor, servletDataServiceRegistration);
+
+			return graphQLContributor;
+		}
+
+		@Override
+		public void modifiedService(
+			ServiceReference<GraphQLContributor> serviceReference,
+			GraphQLContributor graphQLContributor) {
+		}
+
+		@Override
+		public void removedService(
+			ServiceReference<GraphQLContributor> serviceReference,
+			GraphQLContributor graphQLContributor) {
+
+			Optional.ofNullable(
+				_servletDataServiceRegistrationMapping.remove(
+					graphQLContributor)
+			).ifPresent(
+				ServiceRegistration::unregister
+			);
+
+			_bundleContext.ungetService(serviceReference);
+		}
+
+		private final Map<GraphQLContributor, ServiceRegistration<ServletData>>
+			_servletDataServiceRegistrationMapping = new ConcurrentHashMap<>();
 
 	}
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/ServletDataAdapter.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/ServletDataAdapter.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.internal.graphql.servlet;
+
+import com.liferay.portal.vulcan.graphql.servlet.GraphQLContributor;
+import com.liferay.portal.vulcan.graphql.servlet.ServletData;
+
+/**
+ * @author Javier de Arcos
+ */
+public class ServletDataAdapter implements ServletData {
+
+	public static ServletData of(GraphQLContributor graphQLContributor) {
+		return new ServletDataAdapter(graphQLContributor);
+	}
+
+	@Override
+	public Object getMutation() {
+		return _graphQLContributor.getMutationContribution();
+	}
+
+	@Override
+	public String getPath() {
+		return _graphQLContributor.getContributionPath();
+	}
+
+	@Override
+	public Object getQuery() {
+		return _graphQLContributor.getQueryContribution();
+	}
+
+	private ServletDataAdapter(GraphQLContributor graphQLContributor) {
+		_graphQLContributor = graphQLContributor;
+	}
+
+	private final GraphQLContributor _graphQLContributor;
+
+}


### PR DESCRIPTION
Thin infrastructure to ease the use of GraphQL contributions to external clients.

This feature is already accessible to them but it is not very intuitive, mostly because of the naming.

With this infrastructure the client should implement a Component implementing the GraphQLContributor interface. This class should return an object which uses GraphQL annotations: GraphQLTypeExtension to select the class to contribute to and, inside the class,  GraphQLFields to add the contributed fields.

An example would be:
```
@Component(immediate = true, service = GraphQLContributor.class)
public class StructureContentGraphQLContributor implements GraphQLContributor {

	@Override
	public String getContributionPath() {
		return "/headless-delivery-graphql/v1_0";
	}

	@Override
	public Object getMutationContribution() {
		return null;
	}

	@Override
	public QueryContributor getQueryContribution() {
		return new QueryContributor();
	}

	public static class QueryContributor {

		@GraphQLTypeExtension(StructuredContent.class)
		public class MyStructuredContentTypeExtension {

			public MyStructuredContentTypeExtension(
				StructuredContent structuredContent) {

				_structuredContent = structuredContent;
			}

			@GraphQLField
			public String externalContribution() {
				return "External contribution of " +
					_structuredContent.getTitle();
			}

			private final StructuredContent _structuredContent;
		}
	}
}
```

