### PR TITLE
WIP -- LPS 118194 Questions crash when returning from questions related to tags

### DIFF
--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/App.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/App.es.js
@@ -20,7 +20,6 @@ import {AppContextProvider} from './AppContext.es';
 import {ErrorBoundary} from './components/ErrorBoundary.es';
 import ForumsToQuestion from './components/ForumsToQuestion.es';
 import ProtectedRoute from './components/ProtectedRoute.es';
-import NavigationBar from './pages/NavigationBar.es';
 import EditAnswer from './pages/answers/EditAnswer.es';
 import Home from './pages/home/Home';
 import UserActivity from './pages/home/UserActivity.es';
@@ -64,8 +63,6 @@ export default (props) => {
 								path="/questions/:sectionTitle"
 								render={({match: {path}}) => (
 									<>
-										<NavigationBar />
-
 										<Switch>
 											<Route
 												component={Questions}

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/NavigationBar.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/NavigationBar.es.js
@@ -14,12 +14,13 @@
 
 import ClayLink from '@clayui/link';
 import ClayNavigationBar from '@clayui/navigation-bar';
-import React, {useContext} from 'react';
+import React, {useContext, useEffect, useState} from 'react';
 import {withRouter} from 'react-router-dom';
 
 import {AppContext} from '../AppContext.es';
 import useQueryParams from '../hooks/useQueryParams.es';
-import {historyPushWithSlug} from '../utils/utils.es';
+import {getSections} from '../utils/client.es';
+import {historyPushWithSlug, slugToText} from '../utils/utils.es';
 
 export default withRouter(
 	({
@@ -32,6 +33,8 @@ export default withRouter(
 		const context = useContext(AppContext);
 
 		const queryParams = useQueryParams(location);
+
+		const [section, setSection] = useState({});
 
 		sectionTitle = sectionTitle || queryParams.get('sectiontitle');
 
@@ -53,6 +56,14 @@ export default withRouter(
 
 		const historyPushParser = historyPushWithSlug(history.push);
 
+		useEffect(() => {
+			if (sectionTitle) {
+				getSections(slugToText(sectionTitle), context.siteKey).then(
+					setSection
+				);
+			}
+		}, [sectionTitle, context.siteKey]);
+
 		return (
 			<section className="border-bottom questions-section questions-section-nav">
 				<div className="questions-container">
@@ -71,7 +82,7 @@ export default withRouter(
 										}
 										onClick={() =>
 											historyPushParser(
-												sectionTitle
+												section
 													? `/questions/${sectionTitle}`
 													: '/'
 											)
@@ -89,7 +100,7 @@ export default withRouter(
 										active={isActive('tags')}
 										onClick={() =>
 											historyPushParser(
-												sectionTitle
+												section
 													? `/questions/${sectionTitle}/tags`
 													: '/'
 											)
@@ -112,7 +123,9 @@ export default withRouter(
 										}
 										onClick={() =>
 											historyPushParser(
-												`/subscriptions/${context.userId}?sectionTitle=${sectionTitle}`
+												section
+													? `/subscriptions/${context.userId}?sectionTitle=${sectionTitle}`
+													: '/'
 											)
 										}
 									>
@@ -135,7 +148,9 @@ export default withRouter(
 										}
 										onClick={() =>
 											historyPushParser(
-												`/activity/${context.userId}?sectionTitle=${sectionTitle}`
+												section
+													? `/activity/${context.userId}?sectionTitle=${sectionTitle}`
+													: '/'
 											)
 										}
 									>

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/NavigationBar.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/NavigationBar.es.js
@@ -14,161 +14,127 @@
 
 import ClayLink from '@clayui/link';
 import ClayNavigationBar from '@clayui/navigation-bar';
-import React, {useContext, useEffect, useState} from 'react';
-import {withRouter} from 'react-router-dom';
+import React, {useContext} from 'react';
 
 import {AppContext} from '../AppContext.es';
-import useQueryParams from '../hooks/useQueryParams.es';
-import {getSections} from '../utils/client.es';
-import {historyPushWithSlug, slugToText} from '../utils/utils.es';
+import {historyPushWithSlug} from '../utils/utils.es';
+import Link from '../components/Link.es';
 
-export default withRouter(
-	({
-		history,
-		location,
-		match: {
-			params: {sectionTitle},
-		},
-	}) => {
-		const context = useContext(AppContext);
+export default ({pathname, sectionTitle}) => {
+	const context = useContext(AppContext);
 
-		const queryParams = useQueryParams(location);
+	const isActive = (value) => pathname.includes(value);
 
-		const [section, setSection] = useState({});
+	const label = () => {
+		if (pathname.includes('tags')) {
+			return Liferay.Language.get('tags');
+		}
+		else if (pathname.includes('activity')) {
+			return Liferay.Language.get('my-activity');
+		}
+		else if (pathname.includes('subscriptions')) {
+			return Liferay.Language.get('my-subscriptions');
+		}
 
-		sectionTitle = sectionTitle || queryParams.get('sectiontitle');
+		return Liferay.Language.get('questions');
+	};
 
-		const isActive = (value) => location.pathname.includes(value);
+	const historyPushParser = historyPushWithSlug(history.push);
 
-		const label = () => {
-			if (location.pathname.includes('tags')) {
-				return Liferay.Language.get('tags');
-			}
-			else if (location.pathname.includes('activity')) {
-				return Liferay.Language.get('my-activity');
-			}
-			else if (location.pathname.includes('subscriptions')) {
-				return Liferay.Language.get('my-subscriptions');
-			}
-
-			return Liferay.Language.get('questions');
-		};
-
-		const historyPushParser = historyPushWithSlug(history.push);
-
-		useEffect(() => {
-			if (sectionTitle) {
-				getSections(slugToText(sectionTitle), context.siteKey).then(
-					setSection
-				);
-			}
-		}, [sectionTitle, context.siteKey]);
-
-		return (
-			<section className="border-bottom questions-section questions-section-nav">
-				<div className="questions-container">
-					<div className="row">
-						{location.pathname !== '/' && (
-							<div className="align-items-center col d-flex justify-content-between">
-								<ClayNavigationBar
-									className="navigation-bar"
-									triggerLabel={label()}
+	return (
+		<section className="border-bottom questions-section questions-section-nav">
+			<div className="questions-container">
+				<div className="row">
+					{pathname !== '/' && (
+						<div className="align-items-center col d-flex justify-content-between">
+							<ClayNavigationBar
+								className="navigation-bar"
+								triggerLabel={label()}
+							>
+								<ClayNavigationBar.Item
+									active={
+										!isActive('activity') &&
+										!isActive('tags') &&
+										!isActive('subscriptions')
+									}
 								>
-									<ClayNavigationBar.Item
-										active={
-											!isActive('activity') &&
-											!isActive('tags') &&
-											!isActive('subscriptions')
-										}
-										onClick={() =>
-											historyPushParser(
-												section
-													? `/questions/${sectionTitle}`
-													: '/'
-											)
+									<Link
+										className="nav-link"
+										displayType="unstyled"
+										to={
+											sectionTitle
+												? `/questions/${sectionTitle}`
+												: '/'
 										}
 									>
-										<ClayLink
-											className="nav-link"
-											displayType="unstyled"
-										>
-											{Liferay.Language.get('questions')}
-										</ClayLink>
-									</ClayNavigationBar.Item>
+										{Liferay.Language.get('questions')}
+									</Link>
+								</ClayNavigationBar.Item>
 
-									<ClayNavigationBar.Item
-										active={isActive('tags')}
-										onClick={() =>
-											historyPushParser(
-												section
-													? `/questions/${sectionTitle}/tags`
-													: '/'
-											)
+								<ClayNavigationBar.Item
+									active={isActive('tags')}
+								>
+									<Link
+										className="nav-link"
+										displayType="unstyled"
+										to={
+											sectionTitle
+												? `/questions/${sectionTitle}/tags`
+												: '/'
 										}
 									>
-										<ClayLink
-											className="nav-link"
-											displayType="unstyled"
-										>
-											{Liferay.Language.get('tags')}
-										</ClayLink>
-									</ClayNavigationBar.Item>
+										{Liferay.Language.get('tags')}
+									</Link>
+								</ClayNavigationBar.Item>
 
-									<ClayNavigationBar.Item
-										active={isActive('subscriptions')}
-										className={
-											Liferay.ThemeDisplay.isSignedIn()
-												? 'ml-md-auto'
-												: 'd-none'
-										}
-										onClick={() =>
-											historyPushParser(
-												section
-													? `/subscriptions/${context.userId}?sectionTitle=${sectionTitle}`
-													: '/'
-											)
+								<ClayNavigationBar.Item
+									active={isActive('subscriptions')}
+									className={
+										Liferay.ThemeDisplay.isSignedIn()
+											? 'ml-md-auto'
+											: 'd-none'
+									}
+								>
+									<Link
+										className="nav-link"
+										displayType="unstyled"
+										to={
+											sectionTitle
+												? `/subscriptions/${context.userId}?sectionTitle=${sectionTitle}`
+												: '/'
 										}
 									>
-										<ClayLink
-											className="nav-link"
-											displayType="unstyled"
-										>
-											{Liferay.Language.get(
-												'my-subscriptions'
-											)}
-										</ClayLink>
-									</ClayNavigationBar.Item>
+										{Liferay.Language.get(
+											'my-subscriptions'
+										)}
+									</Link>
+								</ClayNavigationBar.Item>
 
-									<ClayNavigationBar.Item
-										active={isActive('activity')}
-										className={
-											Liferay.ThemeDisplay.isSignedIn()
-												? ''
-												: 'd-none'
-										}
-										onClick={() =>
-											historyPushParser(
-												section
-													? `/activity/${context.userId}?sectionTitle=${sectionTitle}`
-													: '/'
-											)
+								<ClayNavigationBar.Item
+									active={isActive('activity')}
+									className={
+										Liferay.ThemeDisplay.isSignedIn()
+											? ''
+											: 'd-none'
+									}
+								>
+									<Link
+										className="nav-link"
+										displayType="unstyled"
+										to={
+											sectionTitle
+												? `/activity/${context.userId}?sectionTitle=${sectionTitle}`
+												: '/'
 										}
 									>
-										<ClayLink
-											className="nav-link"
-											displayType="unstyled"
-										>
-											{Liferay.Language.get(
-												'my-activity'
-											)}
-										</ClayLink>
-									</ClayNavigationBar.Item>
-								</ClayNavigationBar>
-							</div>
-						)}
-					</div>
+										{Liferay.Language.get('my-activity')}
+									</Link>
+								</ClayNavigationBar.Item>
+							</ClayNavigationBar>
+						</div>
+					)}
 				</div>
-			</section>
-		);
-	}
-);
+			</div>
+		</section>
+	);
+};

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/answers/EditAnswer.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/answers/EditAnswer.es.js
@@ -24,6 +24,7 @@ import QuestionsEditor from '../../components/QuestionsEditor';
 import TextLengthValidation from '../../components/TextLengthValidation.es';
 import {getMessageQuery, updateMessageQuery} from '../../utils/client.es';
 import {getContextLink, stripHTML} from '../../utils/utils.es';
+import NavigationBar from '../NavigationBar.es';
 
 export default withRouter(
 	({
@@ -58,82 +59,90 @@ export default withRouter(
 		});
 
 		return (
-			<section className="c-mt-5 questions-section questions-sections-answer">
-				<div className="questions-container">
-					<div className="row">
-						<div className="c-mx-auto col-xl-10">
-							<h1>{Liferay.Language.get('edit-answer')}</h1>
+			<>
+				<NavigationBar
+					pathname={location.pathname}
+					sectionTitle={sectionTitle}
+				/>
+				<section className="c-mt-5 questions-section questions-sections-answer">
+					<div className="questions-container">
+						<div className="row">
+							<div className="c-mx-auto col-xl-10">
+								<h1>{Liferay.Language.get('edit-answer')}</h1>
 
-							<ClayForm>
-								<ClayForm.Group className="c-mt-4">
-									<label htmlFor="basicInput">
-										{Liferay.Language.get('answer')}
+								<ClayForm>
+									<ClayForm.Group className="c-mt-4">
+										<label htmlFor="basicInput">
+											{Liferay.Language.get('answer')}
 
-										<span className="c-ml-2 reference-mark">
-											<ClayIcon symbol="asterisk" />
-										</span>
-									</label>
+											<span className="c-ml-2 reference-mark">
+												<ClayIcon symbol="asterisk" />
+											</span>
+										</label>
 
-									<QuestionsEditor
-										contents={
-											data &&
-											data
-												.messageBoardMessageByFriendlyUrlPath
-												.articleBody
+										<QuestionsEditor
+											contents={
+												data &&
+												data
+													.messageBoardMessageByFriendlyUrlPath
+													.articleBody
+											}
+											onChange={(event) =>
+												setArticleBody(
+													event.editor.getData()
+												)
+											}
+											onInstanceReady={() => getMessage()}
+										/>
+
+										<ClayForm.FeedbackGroup>
+											<ClayForm.FeedbackItem>
+												<TextLengthValidation
+													text={articleBody}
+												/>
+											</ClayForm.FeedbackItem>
+										</ClayForm.FeedbackGroup>
+									</ClayForm.Group>
+								</ClayForm>
+
+								<div className="c-mt-4 d-flex flex-column-reverse flex-sm-row">
+									<ClayButton
+										className="c-mt-4 c-mt-sm-0"
+										disabled={
+											!articleBody ||
+											stripHTML(articleBody).length < 15
 										}
-										onChange={(event) =>
-											setArticleBody(
-												event.editor.getData()
-											)
-										}
-										onInstanceReady={() => getMessage()}
-									/>
+										displayType="primary"
+										onClick={() => {
+											addUpdateMessage({
+												variables: {
+													articleBody,
+													messageBoardMessageId:
+														data
+															.messageBoardMessageByFriendlyUrlPath
+															.id,
+												},
+											});
+										}}
+									>
+										{Liferay.Language.get(
+											'update-your-answer'
+										)}
+									</ClayButton>
 
-									<ClayForm.FeedbackGroup>
-										<ClayForm.FeedbackItem>
-											<TextLengthValidation
-												text={articleBody}
-											/>
-										</ClayForm.FeedbackItem>
-									</ClayForm.FeedbackGroup>
-								</ClayForm.Group>
-							</ClayForm>
-
-							<div className="c-mt-4 d-flex flex-column-reverse flex-sm-row">
-								<ClayButton
-									className="c-mt-4 c-mt-sm-0"
-									disabled={
-										!articleBody ||
-										stripHTML(articleBody).length < 15
-									}
-									displayType="primary"
-									onClick={() => {
-										addUpdateMessage({
-											variables: {
-												articleBody,
-												messageBoardMessageId:
-													data
-														.messageBoardMessageByFriendlyUrlPath
-														.id,
-											},
-										});
-									}}
-								>
-									{Liferay.Language.get('update-your-answer')}
-								</ClayButton>
-
-								<ClayButton
-									className="c-ml-sm-3"
-									displayType="secondary"
-									onClick={() => history.goBack()}
-								>
-									{Liferay.Language.get('cancel')}
-								</ClayButton>
+									<ClayButton
+										className="c-ml-sm-3"
+										displayType="secondary"
+										onClick={() => history.goBack()}
+									>
+										{Liferay.Language.get('cancel')}
+									</ClayButton>
+								</div>
 							</div>
 						</div>
 					</div>
-				</div>
-			</section>
+				</section>
+			</>
 		);
 	}
 );

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/home/UserActivity.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/home/UserActivity.es.js
@@ -95,7 +95,7 @@ export default withRouter(
 
 		return (
 			<>
-				<NavigationBar />
+				<NavigationBar pathname={location.pathname} />
 
 				<section className="questions-section questions-section-list">
 					<div className="questions-container">

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/home/UserSubscriptions.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/home/UserSubscriptions.es.js
@@ -31,7 +31,7 @@ import {
 import {historyPushWithSlug} from '../../utils/utils.es';
 import NavigationBar from '../NavigationBar.es';
 
-export default withRouter(({history}) => {
+export default withRouter(({history, location}) => {
 	const [entity, setEntity] = useState({});
 	const [info, setInfo] = useState({});
 
@@ -132,7 +132,7 @@ export default withRouter(({history}) => {
 
 	return (
 		<>
-			<NavigationBar />
+			<NavigationBar pathname={location.pathname} />
 
 			<section className="questions-section questions-section-list">
 				<div className="c-p-5 questions-container row">

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/EditQuestion.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/EditQuestion.es.js
@@ -26,6 +26,7 @@ import TagSelector from '../../components/TagSelector.es';
 import TextLengthValidation from '../../components/TextLengthValidation.es';
 import {getThreadContentQuery, updateThreadQuery} from '../../utils/client.es';
 import {getContextLink, stripHTML} from '../../utils/utils.es';
+import NavigationBar from '../NavigationBar.es';
 
 export default withRouter(
 	({
@@ -76,125 +77,131 @@ export default withRouter(
 		});
 
 		return (
-			<section className="c-mt-5 questions-section questions-section-edit">
-				<div className="questions-container">
-					<div className="row">
-						<div className="c-mx-auto col-xl-10">
-							<h1>{Liferay.Language.get('edit-question')}</h1>
+			<>
+				<NavigationBar
+					pathname={location.pathname}
+					sectionTitle={sectionTitle}
+				/>
+				<section className="c-mt-5 questions-section questions-section-edit">
+					<div className="questions-container">
+						<div className="row">
+							<div className="c-mx-auto col-xl-10">
+								<h1>{Liferay.Language.get('edit-question')}</h1>
 
-							<ClayForm>
-								<ClayForm.Group className="c-mt-4">
-									<label htmlFor="basicInput">
-										{Liferay.Language.get('title')}
+								<ClayForm>
+									<ClayForm.Group className="c-mt-4">
+										<label htmlFor="basicInput">
+											{Liferay.Language.get('title')}
 
-										<span className="c-ml-2 reference-mark">
-											<ClayIcon symbol="asterisk" />
-										</span>
-									</label>
+											<span className="c-ml-2 reference-mark">
+												<ClayIcon symbol="asterisk" />
+											</span>
+										</label>
 
-									<ClayInput
-										onChange={(event) =>
-											setHeadline(event.target.value)
+										<ClayInput
+											onChange={(event) =>
+												setHeadline(event.target.value)
+											}
+											placeholder={Liferay.Language.get(
+												'what-is-your-question'
+											)}
+											required
+											type="text"
+											value={headline}
+										/>
+
+										<ClayForm.FeedbackGroup>
+											<ClayForm.FeedbackItem>
+												<span className="small text-secondary">
+													{Liferay.Language.get(
+														'be-specific-and-imagine-you-are-asking-a-question-to-another-person'
+													)}
+												</span>
+											</ClayForm.FeedbackItem>
+										</ClayForm.FeedbackGroup>
+									</ClayForm.Group>
+
+									<ClayForm.Group className="c-mt-4">
+										<label htmlFor="basicInput">
+											{Liferay.Language.get('body')}
+
+											<span className="c-ml-2 reference-mark">
+												<ClayIcon symbol="asterisk" />
+											</span>
+										</label>
+
+										<QuestionsEditor
+											contents={articleBody}
+											onChange={(event) => {
+												setArticleBody(
+													event.editor.getData()
+												);
+											}}
+										/>
+
+										<ClayForm.FeedbackGroup>
+											<ClayForm.FeedbackItem>
+												<span className="small text-secondary">
+													{Liferay.Language.get(
+														'include-all-the-information-someone-would-need-to-answer-your-question'
+													)}
+												</span>
+												<TextLengthValidation
+													text={articleBody}
+												/>
+											</ClayForm.FeedbackItem>
+										</ClayForm.FeedbackGroup>
+									</ClayForm.Group>
+
+									<ClayForm.Group className="c-mt-4">
+										<TagSelector
+											tags={tags}
+											tagsChange={(tags) => setTags(tags)}
+											tagsLoaded={setTagsLoaded}
+										/>
+									</ClayForm.Group>
+								</ClayForm>
+
+								<div className="c-mt-4 d-flex flex-column-reverse flex-sm-row">
+									<ClayButton
+										className="c-mt-4 c-mt-sm-0"
+										disabled={
+											!articleBody ||
+											!headline ||
+											!tagsLoaded ||
+											stripHTML(articleBody).length < 15
 										}
-										placeholder={Liferay.Language.get(
-											'what-is-your-question'
-										)}
-										required
-										type="text"
-										value={headline}
-									/>
-
-									<ClayForm.FeedbackGroup>
-										<ClayForm.FeedbackItem>
-											<span className="small text-secondary">
-												{Liferay.Language.get(
-													'be-specific-and-imagine-you-are-asking-a-question-to-another-person'
-												)}
-											</span>
-										</ClayForm.FeedbackItem>
-									</ClayForm.FeedbackGroup>
-								</ClayForm.Group>
-
-								<ClayForm.Group className="c-mt-4">
-									<label htmlFor="basicInput">
-										{Liferay.Language.get('body')}
-
-										<span className="c-ml-2 reference-mark">
-											<ClayIcon symbol="asterisk" />
-										</span>
-									</label>
-
-									<QuestionsEditor
-										contents={articleBody}
-										onChange={(event) => {
-											setArticleBody(
-												event.editor.getData()
-											);
+										displayType="primary"
+										onClick={() => {
+											updateThread({
+												variables: {
+													articleBody,
+													headline,
+													keywords: tags.map(
+														(tag) => tag.value
+													),
+													messageBoardThreadId: id,
+												},
+											});
 										}}
-									/>
+									>
+										{Liferay.Language.get(
+											'update-your-question'
+										)}
+									</ClayButton>
 
-									<ClayForm.FeedbackGroup>
-										<ClayForm.FeedbackItem>
-											<span className="small text-secondary">
-												{Liferay.Language.get(
-													'include-all-the-information-someone-would-need-to-answer-your-question'
-												)}
-											</span>
-											<TextLengthValidation
-												text={articleBody}
-											/>
-										</ClayForm.FeedbackItem>
-									</ClayForm.FeedbackGroup>
-								</ClayForm.Group>
-
-								<ClayForm.Group className="c-mt-4">
-									<TagSelector
-										tags={tags}
-										tagsChange={(tags) => setTags(tags)}
-										tagsLoaded={setTagsLoaded}
-									/>
-								</ClayForm.Group>
-							</ClayForm>
-
-							<div className="c-mt-4 d-flex flex-column-reverse flex-sm-row">
-								<ClayButton
-									className="c-mt-4 c-mt-sm-0"
-									disabled={
-										!articleBody ||
-										!headline ||
-										!tagsLoaded ||
-										stripHTML(articleBody).length < 15
-									}
-									displayType="primary"
-									onClick={() => {
-										updateThread({
-											variables: {
-												articleBody,
-												headline,
-												keywords: tags.map(
-													(tag) => tag.value
-												),
-												messageBoardThreadId: id,
-											},
-										});
-									}}
-								>
-									{Liferay.Language.get(
-										'update-your-question'
-									)}
-								</ClayButton>
-
-								<Link
-									className="btn btn-secondary c-ml-sm-3"
-									to={`/questions/${sectionTitle}/${questionId}`}
-								>
-									{Liferay.Language.get('cancel')}
-								</Link>
+									<Link
+										className="btn btn-secondary c-ml-sm-3"
+										to={`/questions/${sectionTitle}/${questionId}`}
+									>
+										{Liferay.Language.get('cancel')}
+									</Link>
+								</div>
 							</div>
 						</div>
 					</div>
-				</div>
-			</section>
+				</section>
+			</>
 		);
 	}
 );

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/NewQuestion.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/NewQuestion.es.js
@@ -34,6 +34,7 @@ import {
 	stripHTML,
 	useDebounceCallback,
 } from '../../utils/utils.es';
+import NavigationBar from '../NavigationBar.es';
 
 export default withRouter(
 	({
@@ -101,145 +102,157 @@ export default withRouter(
 		};
 
 		return (
-			<section className="c-mt-5 questions-section questions-section-new">
-				<div className="questions-container">
-					<div className="row">
-						<div className="c-mx-auto col-xl-10">
-							<h1>{Liferay.Language.get('new-question')}</h1>
-							<ClayForm className="c-mt-5">
-								<ClayForm.Group>
-									<label htmlFor="basicInput">
-										{Liferay.Language.get('title')}
+			<>
+				<NavigationBar
+					pathname={location.pathname}
+					sectionTitle={sectionTitle}
+				/>
+				<section className="c-mt-5 questions-section questions-section-new">
+					<div className="questions-container">
+						<div className="row">
+							<div className="c-mx-auto col-xl-10">
+								<h1>{Liferay.Language.get('new-question')}</h1>
+								<ClayForm className="c-mt-5">
+									<ClayForm.Group>
+										<label htmlFor="basicInput">
+											{Liferay.Language.get('title')}
 
-										<span className="c-ml-2 reference-mark">
-											<ClayIcon symbol="asterisk" />
-										</span>
-									</label>
-
-									<ClayInput
-										maxLength={75}
-										onChange={(event) =>
-											setHeadline(event.target.value)
-										}
-										placeholder={Liferay.Language.get(
-											'what-is-your-question'
-										)}
-										required
-										type="text"
-										value={headline}
-									/>
-
-									<ClayForm.FeedbackGroup>
-										<ClayForm.FeedbackItem>
-											<span className="small text-secondary">
-												{Liferay.Language.get(
-													'be-specific-and-imagine-you-are-asking-a-question-to-another-person'
-												)}
+											<span className="c-ml-2 reference-mark">
+												<ClayIcon symbol="asterisk" />
 											</span>
-										</ClayForm.FeedbackItem>
-									</ClayForm.FeedbackGroup>
-								</ClayForm.Group>
+										</label>
 
-								<ClayForm.Group className="c-mt-4">
-									<label htmlFor="basicInput">
-										{Liferay.Language.get('body')}
+										<ClayInput
+											maxLength={75}
+											onChange={(event) =>
+												setHeadline(event.target.value)
+											}
+											placeholder={Liferay.Language.get(
+												'what-is-your-question'
+											)}
+											required
+											type="text"
+											value={headline}
+										/>
 
-										<span className="c-ml-2 reference-mark">
-											<ClayIcon symbol="asterisk" />
-										</span>
-									</label>
+										<ClayForm.FeedbackGroup>
+											<ClayForm.FeedbackItem>
+												<span className="small text-secondary">
+													{Liferay.Language.get(
+														'be-specific-and-imagine-you-are-asking-a-question-to-another-person'
+													)}
+												</span>
+											</ClayForm.FeedbackItem>
+										</ClayForm.FeedbackGroup>
+									</ClayForm.Group>
 
-									<QuestionsEditor
-										onChange={(event) => {
-											setArticleBody(
-												event.editor.getData()
-											);
-										}}
-									/>
-
-									<ClayForm.FeedbackGroup>
-										<ClayForm.FeedbackItem>
-											<span className="small text-secondary">
-												{Liferay.Language.get(
-													'include-all-the-information-someone-would-need-to-answer-your-question'
-												)}
-											</span>
-
-											<TextLengthValidation
-												text={articleBody}
-											/>
-										</ClayForm.FeedbackItem>
-									</ClayForm.FeedbackGroup>
-								</ClayForm.Group>
-
-								{sections.length > 1 && (
 									<ClayForm.Group className="c-mt-4">
 										<label htmlFor="basicInput">
-											{Liferay.Language.get('topic')}
+											{Liferay.Language.get('body')}
+
+											<span className="c-ml-2 reference-mark">
+												<ClayIcon symbol="asterisk" />
+											</span>
 										</label>
-										<ClaySelect
-											onChange={(event) =>
-												setSectionId(event.target.value)
-											}
-										>
-											{sections.map(({id, title}) => (
-												<ClaySelect.Option
-													key={id}
-													label={title}
-													selected={sectionId === id}
-													value={id}
+
+										<QuestionsEditor
+											onChange={(event) => {
+												setArticleBody(
+													event.editor.getData()
+												);
+											}}
+										/>
+
+										<ClayForm.FeedbackGroup>
+											<ClayForm.FeedbackItem>
+												<span className="small text-secondary">
+													{Liferay.Language.get(
+														'include-all-the-information-someone-would-need-to-answer-your-question'
+													)}
+												</span>
+
+												<TextLengthValidation
+													text={articleBody}
 												/>
-											))}
-										</ClaySelect>
+											</ClayForm.FeedbackItem>
+										</ClayForm.FeedbackGroup>
 									</ClayForm.Group>
-								)}
 
-								<TagSelector
-									className="c-mt-3"
-									tags={tags}
-									tagsChange={(tags) => setTags(tags)}
-									tagsLoaded={setTagsLoaded}
-								/>
-							</ClayForm>
+									{sections.length > 1 && (
+										<ClayForm.Group className="c-mt-4">
+											<label htmlFor="basicInput">
+												{Liferay.Language.get('topic')}
+											</label>
+											<ClaySelect
+												onChange={(event) =>
+													setSectionId(
+														event.target.value
+													)
+												}
+											>
+												{sections.map(({id, title}) => (
+													<ClaySelect.Option
+														key={id}
+														label={title}
+														selected={
+															sectionId === id
+														}
+														value={id}
+													/>
+												))}
+											</ClaySelect>
+										</ClayForm.Group>
+									)}
 
-							<div className="c-mt-4 d-flex flex-column-reverse flex-sm-row">
-								<ClayButton
-									className="c-mt-4 c-mt-sm-0"
-									disabled={
-										!articleBody ||
-										!headline ||
-										!tagsLoaded ||
-										stripHTML(articleBody).length < 15
-									}
-									displayType="primary"
-									onClick={() => {
-										createQuestion({
-											variables: {
-												articleBody,
-												headline,
-												keywords: tags.map(
-													(tag) => tag.label
-												),
-												messageBoardSectionId: sectionId,
-											},
-										}).catch(processError);
-									}}
-								>
-									{Liferay.Language.get('post-your-question')}
-								</ClayButton>
+									<TagSelector
+										className="c-mt-3"
+										tags={tags}
+										tagsChange={(tags) => setTags(tags)}
+										tagsLoaded={setTagsLoaded}
+									/>
+								</ClayForm>
 
-								<Link
-									className="btn btn-secondary c-ml-sm-3"
-									to={`/questions/${sectionTitle}`}
-								>
-									{Liferay.Language.get('cancel')}
-								</Link>
+								<div className="c-mt-4 d-flex flex-column-reverse flex-sm-row">
+									<ClayButton
+										className="c-mt-4 c-mt-sm-0"
+										disabled={
+											!articleBody ||
+											!headline ||
+											!tagsLoaded ||
+											stripHTML(articleBody).length < 15
+										}
+										displayType="primary"
+										onClick={() => {
+											createQuestion({
+												variables: {
+													articleBody,
+													headline,
+													keywords: tags.map(
+														(tag) => tag.label
+													),
+													messageBoardSectionId: sectionId,
+												},
+											}).catch(processError);
+										}}
+									>
+										{Liferay.Language.get(
+											'post-your-question'
+										)}
+									</ClayButton>
+
+									<Link
+										className="btn btn-secondary c-ml-sm-3"
+										to={`/questions/${sectionTitle}`}
+									>
+										{Liferay.Language.get('cancel')}
+									</Link>
+								</div>
 							</div>
 						</div>
 					</div>
-				</div>
-				<Alert info={error} />
-			</section>
+					<Alert info={error} />
+				</section>
+			</>
 		);
 	}
 );

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/Question.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/Question.es.js
@@ -49,6 +49,7 @@ import {
 	getContextLink,
 	stripHTML,
 } from '../../utils/utils.es';
+import NavigationBar from '../NavigationBar.es';
 
 export default withRouter(
 	({
@@ -193,284 +194,294 @@ export default withRouter(
 		);
 
 		return (
-			<section className="questions-section questions-section-single">
-				<Breadcrumb section={question.messageBoardSection} />
+			<>
+				<NavigationBar
+					pathname={location.pathname}
+					sectionTitle={sectionTitle}
+				/>
+				<section className="questions-section questions-section-single">
+					<Breadcrumb section={question.messageBoardSection} />
 
-				<div className="c-mt-5 questions-container">
-					{!loading && (
-						<div className="row">
-							<div className="col-md-1 text-md-center">
-								<Rating
-									aggregateRating={question.aggregateRating}
-									entityId={question.id}
-									myRating={
-										question.myRating &&
-										question.myRating.ratingValue
-									}
-									type={'Thread'}
-								/>
-							</div>
-
-							<div className="col-md-10">
-								<div className="align-items-end flex-column-reverse flex-md-row row">
-									<div className="c-mt-4 c-mt-md-0 col-md-8">
-										{!!question.messageBoardSection
-											.numberOfMessageBoardSections && (
-											<Link
-												to={`/questions/${question.messageBoardSection.title}`}
-											>
-												<SectionLabel
-													section={
-														question.messageBoardSection
-													}
-												/>
-											</Link>
-										)}
-
-										<h1
-											className={classNames(
-												'c-mt-2',
-												'question-headline',
-												{
-													'question-seen':
-														question.seen,
-												}
-											)}
-										>
-											{question.headline}
-										</h1>
-
-										<p className="c-mb-0 small text-secondary">
-											{Liferay.Language.get('asked')}{' '}
-											{dateToBriefInternationalHuman(
-												question.dateCreated
-											)}
-											{' - '}
-											{Liferay.Language.get(
-												'active'
-											)}{' '}
-											{dateToBriefInternationalHuman(
-												question.dateModified
-											)}
-											{' - '}
-											{lang.sub(
-												Liferay.Language.get(
-													'viewed-x-times'
-												),
-												[question.viewCount]
-											)}
-										</p>
-									</div>
-
-									<div className="col-md-4 text-right">
-										<ClayButton.Group
-											className="questions-actions"
-											spaced={true}
-										>
-											{question.actions.subscribe && (
-												<Subscription
-													question={question}
-												/>
-											)}
-
-											{question.actions.delete && (
-												<>
-													<DeleteThread
-														question={question}
-														showDeleteModalPanel={
-															showDeleteModalPanel
-														}
-													/>
-													<ClayButton
-														displayType="secondary"
-														onClick={() =>
-															setShowDeleteModalPanel(
-																true
-															)
-														}
-													>
-														<ClayIcon symbol="trash" />
-													</ClayButton>
-												</>
-											)}
-
-											{question.actions.replace && (
-												<Link to={`${url}/edit`}>
-													<ClayButton displayType="secondary">
-														{Liferay.Language.get(
-															'edit'
-														)}
-													</ClayButton>
-												</Link>
-											)}
-										</ClayButton.Group>
-									</div>
-								</div>
-
-								<div className="c-mt-4">
-									<ArticleBodyRenderer {...question} />
-								</div>
-
-								<div className="c-mt-4">
-									<TagList
-										sectionTitle={
-											question.messageBoardSection &&
-											question.messageBoardSection.title
+					<div className="c-mt-5 questions-container">
+						{!loading && (
+							<div className="row">
+								<div className="col-md-1 text-md-center">
+									<Rating
+										aggregateRating={
+											question.aggregateRating
 										}
-										tags={question.keywords}
+										entityId={question.id}
+										myRating={
+											question.myRating &&
+											question.myRating.ratingValue
+										}
+										type={'Thread'}
 									/>
 								</div>
 
-								<div className="c-mt-4 position-relative questions-creator text-center text-md-right">
-									<CreatorRow question={question} />
-								</div>
-
-								<h3 className="c-mt-4 text-secondary">
-									{answers.totalCount}{' '}
-									{Liferay.Language.get('answers')}
-								</h3>
-
-								{!!answers.totalCount && (
-									<div className="border-bottom c-mt-3">
-										<ClayNavigationBar triggerLabel="Active">
-											<ClayNavigationBar.Item
-												active={sort === 'active'}
-											>
+								<div className="col-md-10">
+									<div className="align-items-end flex-column-reverse flex-md-row row">
+										<div className="c-mt-4 c-mt-md-0 col-md-8">
+											{!!question.messageBoardSection
+												.numberOfMessageBoardSections && (
 												<Link
-													className="link-unstyled nav-link"
-													to={`${url}?sort=active`}
+													to={`/questions/${question.messageBoardSection.title}`}
 												>
-													{Liferay.Language.get(
-														'active'
-													)}
+													<SectionLabel
+														section={
+															question.messageBoardSection
+														}
+													/>
 												</Link>
-											</ClayNavigationBar.Item>
+											)}
 
-											<ClayNavigationBar.Item
-												active={sort === 'oldest'}
-											>
-												<Link
-													className="link-unstyled nav-link"
-													to={`${url}?sort=oldest`}
-												>
-													{Liferay.Language.get(
-														'oldest'
-													)}
-												</Link>
-											</ClayNavigationBar.Item>
-
-											<ClayNavigationBar.Item
-												active={sort === 'votes'}
-											>
-												<Link
-													className="link-unstyled nav-link"
-													to={`${url}?sort=votes`}
-												>
-													{Liferay.Language.get(
-														'votes'
-													)}
-												</Link>
-											</ClayNavigationBar.Item>
-										</ClayNavigationBar>
-									</div>
-								)}
-
-								<div className="c-mt-3">
-									<PaginatedList
-										activeDelta={pageSize}
-										activePage={page}
-										changeDelta={setPageSize}
-										changePage={setPage}
-										data={answers}
-									>
-										{(answer) => (
-											<Answer
-												answer={answer}
-												answerChange={answerChange}
-												canMarkAsAnswer={
-													!!question.actions.replace
-												}
-												deleteAnswer={deleteAnswer}
-												key={answer.id}
-											/>
-										)}
-									</PaginatedList>
-								</div>
-
-								{question &&
-									question.actions &&
-									question.actions['reply-to-thread'] && (
-										<div className="c-mt-5">
-											<ClayForm>
-												<ClayForm.Group className="form-group-sm">
-													<label htmlFor="basicInput">
-														{Liferay.Language.get(
-															'your-answer'
-														)}
-
-														<span className="c-ml-2 reference-mark">
-															<ClayIcon symbol="asterisk" />
-														</span>
-													</label>
-
-													<div className="c-mt-2">
-														<QuestionsEditor
-															contents={
-																articleBody
-															}
-															onChange={(
-																event
-															) => {
-																setArticleBody(
-																	event.editor.getData()
-																);
-															}}
-														/>
-													</div>
-
-													<ClayForm.FeedbackGroup>
-														<ClayForm.FeedbackItem>
-															<TextLengthValidation
-																text={
-																	articleBody
-																}
-															/>
-														</ClayForm.FeedbackItem>
-													</ClayForm.FeedbackGroup>
-												</ClayForm.Group>
-											</ClayForm>
-
-											<ClayButton
-												disabled={
-													!articleBody ||
-													stripHTML(articleBody)
-														.length < 15
-												}
-												displayType="primary"
-												onClick={() => {
-													createAnswer({
-														variables: {
-															articleBody,
-															messageBoardThreadId:
-																question.id,
-														},
-													});
-												}}
-											>
-												{Liferay.Language.get(
-													'post-answer'
+											<h1
+												className={classNames(
+													'c-mt-2',
+													'question-headline',
+													{
+														'question-seen':
+															question.seen,
+													}
 												)}
-											</ClayButton>
+											>
+												{question.headline}
+											</h1>
+
+											<p className="c-mb-0 small text-secondary">
+												{Liferay.Language.get('asked')}{' '}
+												{dateToBriefInternationalHuman(
+													question.dateCreated
+												)}
+												{' - '}
+												{Liferay.Language.get(
+													'active'
+												)}{' '}
+												{dateToBriefInternationalHuman(
+													question.dateModified
+												)}
+												{' - '}
+												{lang.sub(
+													Liferay.Language.get(
+														'viewed-x-times'
+													),
+													[question.viewCount]
+												)}
+											</p>
+										</div>
+
+										<div className="col-md-4 text-right">
+											<ClayButton.Group
+												className="questions-actions"
+												spaced={true}
+											>
+												{question.actions.subscribe && (
+													<Subscription
+														question={question}
+													/>
+												)}
+
+												{question.actions.delete && (
+													<>
+														<DeleteThread
+															question={question}
+															showDeleteModalPanel={
+																showDeleteModalPanel
+															}
+														/>
+														<ClayButton
+															displayType="secondary"
+															onClick={() =>
+																setShowDeleteModalPanel(
+																	true
+																)
+															}
+														>
+															<ClayIcon symbol="trash" />
+														</ClayButton>
+													</>
+												)}
+
+												{question.actions.replace && (
+													<Link to={`${url}/edit`}>
+														<ClayButton displayType="secondary">
+															{Liferay.Language.get(
+																'edit'
+															)}
+														</ClayButton>
+													</Link>
+												)}
+											</ClayButton.Group>
+										</div>
+									</div>
+
+									<div className="c-mt-4">
+										<ArticleBodyRenderer {...question} />
+									</div>
+
+									<div className="c-mt-4">
+										<TagList
+											sectionTitle={
+												question.messageBoardSection &&
+												question.messageBoardSection
+													.title
+											}
+											tags={question.keywords}
+										/>
+									</div>
+
+									<div className="c-mt-4 position-relative questions-creator text-center text-md-right">
+										<CreatorRow question={question} />
+									</div>
+
+									<h3 className="c-mt-4 text-secondary">
+										{answers.totalCount}{' '}
+										{Liferay.Language.get('answers')}
+									</h3>
+
+									{!!answers.totalCount && (
+										<div className="border-bottom c-mt-3">
+											<ClayNavigationBar triggerLabel="Active">
+												<ClayNavigationBar.Item
+													active={sort === 'active'}
+												>
+													<Link
+														className="link-unstyled nav-link"
+														to={`${url}?sort=active`}
+													>
+														{Liferay.Language.get(
+															'active'
+														)}
+													</Link>
+												</ClayNavigationBar.Item>
+
+												<ClayNavigationBar.Item
+													active={sort === 'oldest'}
+												>
+													<Link
+														className="link-unstyled nav-link"
+														to={`${url}?sort=oldest`}
+													>
+														{Liferay.Language.get(
+															'oldest'
+														)}
+													</Link>
+												</ClayNavigationBar.Item>
+
+												<ClayNavigationBar.Item
+													active={sort === 'votes'}
+												>
+													<Link
+														className="link-unstyled nav-link"
+														to={`${url}?sort=votes`}
+													>
+														{Liferay.Language.get(
+															'votes'
+														)}
+													</Link>
+												</ClayNavigationBar.Item>
+											</ClayNavigationBar>
 										</div>
 									)}
+
+									<div className="c-mt-3">
+										<PaginatedList
+											activeDelta={pageSize}
+											activePage={page}
+											changeDelta={setPageSize}
+											changePage={setPage}
+											data={answers}
+										>
+											{(answer) => (
+												<Answer
+													answer={answer}
+													answerChange={answerChange}
+													canMarkAsAnswer={
+														!!question.actions
+															.replace
+													}
+													deleteAnswer={deleteAnswer}
+													key={answer.id}
+												/>
+											)}
+										</PaginatedList>
+									</div>
+
+									{question &&
+										question.actions &&
+										question.actions['reply-to-thread'] && (
+											<div className="c-mt-5">
+												<ClayForm>
+													<ClayForm.Group className="form-group-sm">
+														<label htmlFor="basicInput">
+															{Liferay.Language.get(
+																'your-answer'
+															)}
+
+															<span className="c-ml-2 reference-mark">
+																<ClayIcon symbol="asterisk" />
+															</span>
+														</label>
+
+														<div className="c-mt-2">
+															<QuestionsEditor
+																contents={
+																	articleBody
+																}
+																onChange={(
+																	event
+																) => {
+																	setArticleBody(
+																		event.editor.getData()
+																	);
+																}}
+															/>
+														</div>
+
+														<ClayForm.FeedbackGroup>
+															<ClayForm.FeedbackItem>
+																<TextLengthValidation
+																	text={
+																		articleBody
+																	}
+																/>
+															</ClayForm.FeedbackItem>
+														</ClayForm.FeedbackGroup>
+													</ClayForm.Group>
+												</ClayForm>
+
+												<ClayButton
+													disabled={
+														!articleBody ||
+														stripHTML(articleBody)
+															.length < 15
+													}
+													displayType="primary"
+													onClick={() => {
+														createAnswer({
+															variables: {
+																articleBody,
+																messageBoardThreadId:
+																	question.id,
+															},
+														});
+													}}
+												>
+													{Liferay.Language.get(
+														'post-answer'
+													)}
+												</ClayButton>
+											</div>
+										)}
+								</div>
 							</div>
-						</div>
-					)}
-					{question && question.id && (
-						<RelatedQuestions question={question} />
-					)}
-				</div>
-			</section>
+						)}
+						{question && question.id && (
+							<RelatedQuestions question={question} />
+						)}
+					</div>
+				</section>
+			</>
 		);
 	}
 );

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/Questions.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/Questions.es.js
@@ -35,6 +35,7 @@ import {
 	slugToText,
 	useDebounceCallback,
 } from '../../utils/utils.es';
+import NavigationBar from '../NavigationBar.es';
 
 function getFilterOptions() {
 	return [
@@ -212,85 +213,93 @@ export default withRouter(
 		};
 
 		return (
-			<section className="questions-section questions-section-list">
-				<div className="questions-container">
-					<div className="row">
-						<div className="c-mt-3 col col-xl-12">
-							<Breadcrumb section={section} />
-						</div>
+			<>
+				<NavigationBar
+					pathname={location.pathname}
+					sectionTitle={sectionTitle}
+				/>
+				<section className="questions-section questions-section-list">
+					<div className="questions-container">
+						<div className="row">
+							<div className="c-mt-3 col col-xl-12">
+								<Breadcrumb section={section} />
+							</div>
 
-						<div className="c-mt-3 col col-xl-12">
-							<QuestionsNavigationBar />
-						</div>
+							<div className="c-mt-3 col col-xl-12">
+								<QuestionsNavigationBar />
+							</div>
 
-						{!!search && !loading && (
-							<ResultsMessage
-								maxNumberOfSearchResults={
-									MAX_NUMBER_OF_QUESTIONS
-								}
-								searchCriteria={search}
-								totalCount={totalCount}
-							/>
-						)}
+							{!!search && !loading && (
+								<ResultsMessage
+									maxNumberOfSearchResults={
+										MAX_NUMBER_OF_QUESTIONS
+									}
+									searchCriteria={search}
+									totalCount={totalCount}
+								/>
+							)}
 
-						<div className="c-mx-auto c-px-0 col-xl-10">
-							<PaginatedList
-								activeDelta={pageSize}
-								activePage={page}
-								changeDelta={(pageSize) =>
-									changePage(page, pageSize)
-								}
-								changePage={(page) =>
-									changePage(page, pageSize)
-								}
-								data={questions}
-								emptyState={
-									!search && !filter ? (
-										<ClayEmptyState
-											description="There are no questions inside this topic, be the first to ask something!"
-											imgSrc={
-												context.includeContextPath +
-												'/assets/empty_questions_list.png'
-											}
-											title="This topic is empty."
-										>
-											<ClayButton
-												displayType="primary"
-												onClick={navigateToNewQuestion}
+							<div className="c-mx-auto c-px-0 col-xl-10">
+								<PaginatedList
+									activeDelta={pageSize}
+									activePage={page}
+									changeDelta={(pageSize) =>
+										changePage(page, pageSize)
+									}
+									changePage={(page) =>
+										changePage(page, pageSize)
+									}
+									data={questions}
+									emptyState={
+										!search && !filter ? (
+											<ClayEmptyState
+												description="There are no questions inside this topic, be the first to ask something!"
+												imgSrc={
+													context.includeContextPath +
+													'/assets/empty_questions_list.png'
+												}
+												title="This topic is empty."
 											>
-												{Liferay.Language.get(
-													'ask-question'
+												<ClayButton
+													displayType="primary"
+													onClick={
+														navigateToNewQuestion
+													}
+												>
+													{Liferay.Language.get(
+														'ask-question'
+													)}
+												</ClayButton>
+											</ClayEmptyState>
+										) : (
+											<ClayEmptyState
+												title={Liferay.Language.get(
+													'there-are-no-results'
 												)}
-											</ClayButton>
-										</ClayEmptyState>
-									) : (
-										<ClayEmptyState
-											title={Liferay.Language.get(
-												'there-are-no-results'
-											)}
+											/>
+										)
+									}
+									loading={loading}
+									totalCount={totalCount}
+								>
+									{(question) => (
+										<QuestionRow
+											currentSection={sectionTitle}
+											key={question.id}
+											question={question}
+											showSectionLabel={
+												!!section.numberOfMessageBoardSections
+											}
 										/>
-									)
-								}
-								loading={loading}
-								totalCount={totalCount}
-							>
-								{(question) => (
-									<QuestionRow
-										currentSection={sectionTitle}
-										key={question.id}
-										question={question}
-										showSectionLabel={
-											!!section.numberOfMessageBoardSections
-										}
-									/>
-								)}
-							</PaginatedList>
+									)}
+								</PaginatedList>
 
-							<Alert info={error} />
+								<Alert info={error} />
+							</div>
 						</div>
 					</div>
-				</div>
-			</section>
+				</section>
+			</>
 		);
 
 		function QuestionsNavigationBar() {

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/tags/Tags.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/tags/Tags.es.js
@@ -31,6 +31,7 @@ import {
 	historyPushWithSlug,
 	useDebounceCallback,
 } from '../../utils/utils.es';
+import NavigationBar from '../NavigationBar.es';
 
 function getOrderByOptions() {
 	return [
@@ -104,6 +105,10 @@ export default withRouter(
 
 		return (
 			<>
+				<NavigationBar
+					pathname={location.pathname}
+					sectionTitle={sectionTitle}
+				/>
 				<div className="container">
 					<div className="d-flex flex-row">
 						<div className="d-flex flex-column flex-grow-1">


### PR DESCRIPTION
Do not send this PR.
I suspect that this bug seems to be related to how 'react-router' match the paths. As we have something like this:
```
...

<Route
     path="/questions/:sectionTitle"
     render={({match: {path}}) => (
	<>
	      <NavigationBar />

		  <Switch>
			<Route
				component={Questions}
				exact
				path={`/questions/tag/:tag`}
			/>
...
```
When we access a path like `/questions/tag/mytag` the component `NavigationBar` interprets that the _sectionTitle_ is `tag` and that makes the application crash.

I propose two solutions:

- Check if the section exists when navigate, if not, we go to the landing page. (See commit [68157e4](https://github.com/liferay-headless/liferay-portal/commit/68157e4f4e4aac574f9b614cd708fa5b3fd7471d))
- Delete component _NavigationBar_ from _App.es.js_ and add it to every component which needs it (See commit [36a9fad](https://github.com/liferay-headless/liferay-portal/commit/36a9fade253ee2d3294a6010b180a9b4a4c10182))