### PR TITLE
LPS-118611 ci

### DIFF
--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/factory/test/PhoneResourceFactoryImplTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/factory/test/PhoneResourceFactoryImplTest.java
@@ -34,8 +34,6 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
-import com.liferay.portal.test.log.CaptureAppender;
-import com.liferay.portal.test.log.Log4JLoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.vulcan.pagination.Page;
@@ -43,8 +41,6 @@ import com.liferay.portal.vulcan.pagination.Page;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-
-import org.apache.log4j.Level;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -66,15 +62,10 @@ public class PhoneResourceFactoryImplTest {
 
 	@Before
 	public void setUp() throws Exception {
-		try (CaptureAppender captureAppender =
-				Log4JLoggerTestUtil.configureLog4JLogger(
-					"com.liferay.petra.mail.MailEngine", Level.OFF)) {
+		_organization = OrganizationTestUtil.addOrganization();
 
-			_organization = OrganizationTestUtil.addOrganization();
-
-			_companyAdminUser = UserTestUtil.addCompanyAdminUser(
-				_companyLocalService.getCompany(_organization.getCompanyId()));
-		}
+		_companyAdminUser = UserTestUtil.addCompanyAdminUser(
+			_companyLocalService.getCompany(_organization.getCompanyId()));
 	}
 
 	@Test
@@ -88,47 +79,37 @@ public class PhoneResourceFactoryImplTest {
 
 	@Test
 	public void testCheckPermissionsWithUser1() throws Exception {
-		try (CaptureAppender captureAppender =
-				Log4JLoggerTestUtil.configureLog4JLogger(
-					"com.liferay.petra.mail.MailEngine", Level.OFF)) {
+		User user = UserTestUtil.addUser();
 
-			User user = UserTestUtil.addUser();
-
-			try {
-				_testCheckPermissions(
-					PhoneResource.builder(
-					).checkPermissions(
-						false
-					).user(
-						user
-					).build());
-			}
-			finally {
-				_userLocalService.deleteUser(user);
-			}
+		try {
+			_testCheckPermissions(
+				PhoneResource.builder(
+				).checkPermissions(
+					false
+				).user(
+					user
+				).build());
+		}
+		finally {
+			_userLocalService.deleteUser(user);
 		}
 	}
 
 	@Test(expected = PrincipalException.MustHavePermission.class)
 	public void testCheckPermissionsWithUser2() throws Exception {
-		try (CaptureAppender captureAppender =
-				Log4JLoggerTestUtil.configureLog4JLogger(
-					"com.liferay.petra.mail.MailEngine", Level.OFF)) {
+		User user = UserTestUtil.addUser();
 
-			User user = UserTestUtil.addUser();
-
-			try {
-				_testCheckPermissions(
-					PhoneResource.builder(
-					).checkPermissions(
-						true
-					).user(
-						user
-					).build());
-			}
-			finally {
-				_userLocalService.deleteUser(user);
-			}
+		try {
+			_testCheckPermissions(
+				PhoneResource.builder(
+				).checkPermissions(
+					true
+				).user(
+					user
+				).build());
+		}
+		finally {
+			_userLocalService.deleteUser(user);
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/factory/test/PhoneResourceFactoryImplTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/factory/test/PhoneResourceFactoryImplTest.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.service.ListTypeLocalService;
 import com.liferay.portal.kernel.service.PhoneLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.OrganizationTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -34,6 +35,7 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
+import com.liferay.portal.test.rule.IgnoreMailTestRule;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.vulcan.pagination.Page;
@@ -57,8 +59,9 @@ public class PhoneResourceFactoryImplTest {
 
 	@ClassRule
 	@Rule
-	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
-		new LiferayIntegrationTestRule();
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			IgnoreMailTestRule.INSTANCE, new LiferayIntegrationTestRule());
 
 	@Before
 	public void setUp() throws Exception {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/EmailAddressResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/EmailAddressResourceTest.java
@@ -28,12 +28,8 @@ import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.OrganizationTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
-import com.liferay.portal.test.log.CaptureAppender;
-import com.liferay.portal.test.log.Log4JLoggerTestUtil;
 
 import java.util.List;
-
-import org.apache.log4j.Level;
 
 import org.junit.Before;
 import org.junit.runner.RunWith;
@@ -47,15 +43,10 @@ public class EmailAddressResourceTest extends BaseEmailAddressResourceTestCase {
 	@Before
 	@Override
 	public void setUp() throws Exception {
-		try (CaptureAppender captureAppender =
-				Log4JLoggerTestUtil.configureLog4JLogger(
-					"com.liferay.petra.mail.MailEngine", Level.OFF)) {
+		super.setUp();
 
-			super.setUp();
-
-			_organization = OrganizationTestUtil.addOrganization();
-			_user = UserTestUtil.addGroupAdminUser(testGroup);
-		}
+		_organization = OrganizationTestUtil.addOrganization();
+		_user = UserTestUtil.addGroupAdminUser(testGroup);
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/EmailAddressResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/EmailAddressResourceTest.java
@@ -28,10 +28,13 @@ import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.OrganizationTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.test.rule.IgnoreMailTestRule;
 
 import java.util.List;
 
 import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.runner.RunWith;
 
 /**
@@ -39,6 +42,11 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 public class EmailAddressResourceTest extends BaseEmailAddressResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final IgnoreMailTestRule ignoreMailTestRule =
+		IgnoreMailTestRule.INSTANCE;
 
 	@Before
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/OrganizationResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/OrganizationResourceTest.java
@@ -24,13 +24,9 @@ import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.test.log.CaptureAppender;
-import com.liferay.portal.test.log.Log4JLoggerTestUtil;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import org.apache.log4j.Level;
 
 import org.junit.After;
 import org.junit.Before;
@@ -45,14 +41,9 @@ public class OrganizationResourceTest extends BaseOrganizationResourceTestCase {
 	@Before
 	@Override
 	public void setUp() throws Exception {
-		try (CaptureAppender captureAppender =
-				Log4JLoggerTestUtil.configureLog4JLogger(
-					"com.liferay.petra.mail.MailEngine", Level.OFF)) {
+		super.setUp();
 
-			super.setUp();
-
-			_user = UserTestUtil.addGroupAdminUser(testGroup);
-		}
+		_user = UserTestUtil.addGroupAdminUser(testGroup);
 	}
 
 	@After

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/OrganizationResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/OrganizationResourceTest.java
@@ -24,12 +24,15 @@ import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.test.rule.IgnoreMailTestRule;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.runner.RunWith;
 
 /**
@@ -37,6 +40,11 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 public class OrganizationResourceTest extends BaseOrganizationResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final IgnoreMailTestRule ignoreMailTestRule =
+		IgnoreMailTestRule.INSTANCE;
 
 	@Before
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/PhoneResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/PhoneResourceTest.java
@@ -28,12 +28,8 @@ import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.OrganizationTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
-import com.liferay.portal.test.log.CaptureAppender;
-import com.liferay.portal.test.log.Log4JLoggerTestUtil;
 
 import java.util.List;
-
-import org.apache.log4j.Level;
 
 import org.junit.Before;
 import org.junit.runner.RunWith;
@@ -47,16 +43,10 @@ public class PhoneResourceTest extends BasePhoneResourceTestCase {
 	@Before
 	@Override
 	public void setUp() throws Exception {
-		try (CaptureAppender captureAppender =
-				Log4JLoggerTestUtil.configureLog4JLogger(
-					"com.liferay.petra.mail.MailEngine", Level.OFF)) {
+		super.setUp();
 
-			super.setUp();
-
-			_organization = OrganizationTestUtil.addOrganization();
-
-			_user = UserTestUtil.addGroupAdminUser(testGroup);
-		}
+		_organization = OrganizationTestUtil.addOrganization();
+		_user = UserTestUtil.addGroupAdminUser(testGroup);
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/PhoneResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/PhoneResourceTest.java
@@ -28,10 +28,13 @@ import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.OrganizationTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.test.rule.IgnoreMailTestRule;
 
 import java.util.List;
 
 import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.runner.RunWith;
 
 /**
@@ -39,6 +42,11 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 public class PhoneResourceTest extends BasePhoneResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final IgnoreMailTestRule ignoreMailTestRule =
+		IgnoreMailTestRule.INSTANCE;
 
 	@Before
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/PostalAddressResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/PostalAddressResourceTest.java
@@ -29,13 +29,8 @@ import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.OrganizationTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
-import com.liferay.portal.test.log.CaptureAppender;
-import com.liferay.portal.test.log.Log4JLoggerTestUtil;
 
 import java.util.List;
-
-import org.apache.ecs.xhtml.address;
-import org.apache.log4j.Level;
 
 import org.junit.Before;
 import org.junit.runner.RunWith;
@@ -50,15 +45,10 @@ public class PostalAddressResourceTest
 	@Before
 	@Override
 	public void setUp() throws Exception {
-		try (CaptureAppender captureAppender =
-				Log4JLoggerTestUtil.configureLog4JLogger(
-					"com.liferay.petra.mail.MailEngine", Level.OFF)) {
+		super.setUp();
 
-			super.setUp();
-
-			_organization = OrganizationTestUtil.addOrganization();
-			_user = UserTestUtil.addGroupAdminUser(testGroup);
-		}
+		_organization = OrganizationTestUtil.addOrganization();
+		_user = UserTestUtil.addGroupAdminUser(testGroup);
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/PostalAddressResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/PostalAddressResourceTest.java
@@ -29,10 +29,13 @@ import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.OrganizationTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.test.rule.IgnoreMailTestRule;
 
 import java.util.List;
 
 import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.runner.RunWith;
 
 /**
@@ -41,6 +44,11 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class PostalAddressResourceTest
 	extends BasePostalAddressResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final IgnoreMailTestRule ignoreMailTestRule =
+		IgnoreMailTestRule.INSTANCE;
 
 	@Before
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/RoleResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/RoleResourceTest.java
@@ -30,14 +30,10 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.test.log.CaptureAppender;
-import com.liferay.portal.test.log.Log4JLoggerTestUtil;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-
-import org.apache.log4j.Level;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -54,14 +50,9 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 	@Before
 	@Override
 	public void setUp() throws Exception {
-		try (CaptureAppender captureAppender =
-				Log4JLoggerTestUtil.configureLog4JLogger(
-					"com.liferay.petra.mail.MailEngine", Level.OFF)) {
+		super.setUp();
 
-			super.setUp();
-
-			_user = UserTestUtil.addGroupAdminUser(testGroup);
-		}
+		_user = UserTestUtil.addGroupAdminUser(testGroup);
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/RoleResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/RoleResourceTest.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.test.rule.IgnoreMailTestRule;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -37,6 +38,8 @@ import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -46,6 +49,11 @@ import org.junit.runner.RunWith;
 @DataGuard(scope = DataGuard.Scope.METHOD)
 @RunWith(Arquillian.class)
 public class RoleResourceTest extends BaseRoleResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final IgnoreMailTestRule ignoreMailTestRule =
+		IgnoreMailTestRule.INSTANCE;
 
 	@Before
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/SegmentResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/SegmentResourceTest.java
@@ -38,16 +38,12 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.search.test.util.SearchTestRule;
-import com.liferay.portal.test.log.CaptureAppender;
-import com.liferay.portal.test.log.Log4JLoggerTestUtil;
 import com.liferay.segments.constants.SegmentsEntryConstants;
 import com.liferay.segments.model.SegmentsEntry;
 import com.liferay.segments.test.util.SegmentsTestUtil;
 
 import java.util.Arrays;
 import java.util.List;
-
-import org.apache.log4j.Level;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -64,32 +60,27 @@ public class SegmentResourceTest extends BaseSegmentResourceTestCase {
 	@Before
 	@Override
 	public void setUp() throws Exception {
-		try (CaptureAppender captureAppender =
-				Log4JLoggerTestUtil.configureLog4JLogger(
-					"com.liferay.petra.mail.MailEngine", Level.OFF)) {
+		super.setUp();
 
-			super.setUp();
+		_adminUser = UserTestUtil.addGroupAdminUser(testGroup);
 
-			_adminUser = UserTestUtil.addGroupAdminUser(testGroup);
+		_user = UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			RandomTestUtil.randomString(),
+			RandomTestUtil.randomString() + StringPool.AT + "liferay.com",
+			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), null,
+			ServiceContextTestUtil.getServiceContext());
 
-			_user = UserTestUtil.addUser(
-				TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-				RandomTestUtil.randomString(),
-				RandomTestUtil.randomString() + StringPool.AT + "liferay.com",
-				RandomTestUtil.randomString(), LocaleUtil.getDefault(),
-				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-				null, ServiceContextTestUtil.getServiceContext());
+		UserLocalServiceUtil.updateEmailAddressVerified(
+			_user.getUserId(), true);
 
-			UserLocalServiceUtil.updateEmailAddressVerified(
-				_user.getUserId(), true);
+		Role role = RoleLocalServiceUtil.getRole(
+			testCompany.getCompanyId(), RoleConstants.POWER_USER);
 
-			Role role = RoleLocalServiceUtil.getRole(
-				testCompany.getCompanyId(), RoleConstants.POWER_USER);
-
-			UserGroupRoleLocalServiceUtil.addUserGroupRoles(
-				new long[] {_user.getUserId()}, testGroup.getGroupId(),
-				role.getRoleId());
-		}
+		UserGroupRoleLocalServiceUtil.addUserGroupRoles(
+			new long[] {_user.getUserId()}, testGroup.getGroupId(),
+			role.getRoleId());
 	}
 
 	@Test

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/SegmentResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/SegmentResourceTest.java
@@ -38,6 +38,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.search.test.util.SearchTestRule;
+import com.liferay.portal.test.rule.IgnoreMailTestRule;
 import com.liferay.segments.constants.SegmentsEntryConstants;
 import com.liferay.segments.model.SegmentsEntry;
 import com.liferay.segments.test.util.SegmentsTestUtil;
@@ -47,6 +48,7 @@ import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -56,6 +58,11 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 public class SegmentResourceTest extends BaseSegmentResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final IgnoreMailTestRule ignoreMailTestRule =
+		IgnoreMailTestRule.INSTANCE;
 
 	@Before
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/SegmentUserResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/SegmentUserResourceTest.java
@@ -29,15 +29,11 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.search.test.util.SearchTestRule;
-import com.liferay.portal.test.log.CaptureAppender;
-import com.liferay.portal.test.log.Log4JLoggerTestUtil;
 import com.liferay.segments.model.SegmentsEntry;
 import com.liferay.segments.test.util.SegmentsTestUtil;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import org.apache.log4j.Level;
 
 import org.junit.Assert;
 import org.junit.Rule;
@@ -109,20 +105,15 @@ public class SegmentUserResourceTest extends BaseSegmentUserResourceTestCase {
 			Long segmentId, SegmentUser segmentUser)
 		throws Exception {
 
-		try (CaptureAppender captureAppender =
-				Log4JLoggerTestUtil.configureLog4JLogger(
-					"com.liferay.petra.mail.MailEngine", Level.OFF)) {
+		User user = UserTestUtil.addUser(
+			PortalUtil.getDefaultCompanyId(), UserConstants.USER_ID_DEFAULT,
+			null, segmentUser.getEmailAddress(), StringPool.BLANK,
+			LocaleUtil.getDefault(), segmentUser.getName(),
+			segmentUser.getName(), null, new ServiceContext());
 
-			User user = UserTestUtil.addUser(
-				PortalUtil.getDefaultCompanyId(), UserConstants.USER_ID_DEFAULT,
-				null, segmentUser.getEmailAddress(), StringPool.BLANK,
-				LocaleUtil.getDefault(), segmentUser.getName(),
-				segmentUser.getName(), null, new ServiceContext());
+		_users.add(user);
 
-			_users.add(user);
-
-			return _toSegmentUser(user);
-		}
+		return _toSegmentUser(user);
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/SegmentUserResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/SegmentUserResourceTest.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.search.test.util.SearchTestRule;
+import com.liferay.portal.test.rule.IgnoreMailTestRule;
 import com.liferay.segments.model.SegmentsEntry;
 import com.liferay.segments.test.util.SegmentsTestUtil;
 
@@ -36,6 +37,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Assert;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -45,6 +47,11 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 public class SegmentUserResourceTest extends BaseSegmentUserResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final IgnoreMailTestRule ignoreMailTestRule =
+		IgnoreMailTestRule.INSTANCE;
 
 	@Test
 	public void testGetSegmentUserAccountsEmptyPage() throws Exception {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/UserAccountResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/UserAccountResourceTest.java
@@ -44,8 +44,6 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
-import com.liferay.portal.test.log.CaptureAppender;
-import com.liferay.portal.test.log.Log4JLoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
 
 import java.util.Arrays;
@@ -55,7 +53,6 @@ import java.util.List;
 import java.util.function.Function;
 
 import org.apache.commons.beanutils.BeanUtils;
-import org.apache.log4j.Level;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -86,17 +83,6 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 			_testUser.getModelClassName());
 
 		indexer.reindex(_testUser);
-	}
-
-	@Override
-	@Test
-	public void testDeleteUserAccount() throws Exception {
-		try (CaptureAppender captureAppender =
-				Log4JLoggerTestUtil.configureLog4JLogger(
-					"com.liferay.petra.mail.MailEngine", Level.OFF)) {
-
-			super.testDeleteUserAccount();
-		}
 	}
 
 	@Override
@@ -253,16 +239,6 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 			Arrays.asList(
 				UserAccountSerDes.toDTOs(
 					userAccountsJSONObject.getString("items"))));
-	}
-
-	@Test
-	public void testPutUserAccount() throws Exception {
-		try (CaptureAppender captureAppender =
-				Log4JLoggerTestUtil.configureLog4JLogger(
-					"com.liferay.petra.mail.MailEngine", Level.OFF)) {
-
-			super.testPutUserAccount();
-		}
 	}
 
 	@Override
@@ -430,16 +406,11 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 	private UserAccount _addUserAccount(long siteId, UserAccount userAccount)
 		throws Exception {
 
-		try (CaptureAppender captureAppender =
-				Log4JLoggerTestUtil.configureLog4JLogger(
-					"com.liferay.petra.mail.MailEngine", Level.OFF)) {
+		userAccount = userAccountResource.postUserAccount(userAccount);
 
-			userAccount = userAccountResource.postUserAccount(userAccount);
+		_userLocalService.addGroupUser(siteId, userAccount.getId());
 
-			_userLocalService.addGroupUser(siteId, userAccount.getId());
-
-			return userAccount;
-		}
+		return userAccount;
 	}
 
 	private void _assertUserAccountContactInformation(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/UserAccountResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/UserAccountResourceTest.java
@@ -44,6 +44,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
+import com.liferay.portal.test.rule.IgnoreMailTestRule;
 import com.liferay.portal.test.rule.Inject;
 
 import java.util.Arrays;
@@ -56,6 +57,8 @@ import org.apache.commons.beanutils.BeanUtils;
 
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -65,6 +68,11 @@ import org.junit.runner.RunWith;
 @DataGuard(scope = DataGuard.Scope.METHOD)
 @RunWith(Arquillian.class)
 public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final IgnoreMailTestRule ignoreMailTestRule =
+		IgnoreMailTestRule.INSTANCE;
 
 	@Before
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/WebUrlResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/WebUrlResourceTest.java
@@ -29,12 +29,8 @@ import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.OrganizationTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
-import com.liferay.portal.test.log.CaptureAppender;
-import com.liferay.portal.test.log.Log4JLoggerTestUtil;
 
 import java.util.List;
-
-import org.apache.log4j.Level;
 
 import org.junit.Before;
 import org.junit.runner.RunWith;
@@ -48,15 +44,10 @@ public class WebUrlResourceTest extends BaseWebUrlResourceTestCase {
 	@Before
 	@Override
 	public void setUp() throws Exception {
-		try (CaptureAppender captureAppender =
-				Log4JLoggerTestUtil.configureLog4JLogger(
-					"com.liferay.petra.mail.MailEngine", Level.OFF)) {
+		super.setUp();
 
-			super.setUp();
-
-			_organization = OrganizationTestUtil.addOrganization();
-			_user = UserTestUtil.addGroupAdminUser(testGroup);
-		}
+		_organization = OrganizationTestUtil.addOrganization();
+		_user = UserTestUtil.addGroupAdminUser(testGroup);
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/WebUrlResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/WebUrlResourceTest.java
@@ -29,10 +29,13 @@ import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.OrganizationTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.test.rule.IgnoreMailTestRule;
 
 import java.util.List;
 
 import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.runner.RunWith;
 
 /**
@@ -40,6 +43,11 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 public class WebUrlResourceTest extends BaseWebUrlResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final IgnoreMailTestRule ignoreMailTestRule =
+		IgnoreMailTestRule.INSTANCE;
 
 	@Before
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/MessageBoardThreadResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/MessageBoardThreadResourceTest.java
@@ -38,12 +38,14 @@ import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
  * @author Javier Gamarra
  */
+@Ignore
 @RunWith(Arquillian.class)
 public class MessageBoardThreadResourceTest
 	extends BaseMessageBoardThreadResourceTestCase {
@@ -157,7 +159,6 @@ public class MessageBoardThreadResourceTest
 			super.randomMessageBoardThread();
 
 		messageBoardThread.setMessageBoardSectionId((Long)null);
-		messageBoardThread.setSubscribed(false);
 		messageBoardThread.setThreadType("Urgent");
 
 		return messageBoardThread;

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/MessageBoardThreadResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/MessageBoardThreadResourceTest.java
@@ -38,14 +38,12 @@ import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
  * @author Javier Gamarra
  */
-@Ignore
 @RunWith(Arquillian.class)
 public class MessageBoardThreadResourceTest
 	extends BaseMessageBoardThreadResourceTestCase {
@@ -159,6 +157,7 @@ public class MessageBoardThreadResourceTest
 			super.randomMessageBoardThread();
 
 		messageBoardThread.setMessageBoardSectionId((Long)null);
+		messageBoardThread.setSubscribed(false);
 		messageBoardThread.setThreadType("Urgent");
 
 		return messageBoardThread;

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
@@ -55,8 +55,8 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.IgnoreMailTestRule;
 import com.liferay.portal.test.rule.Inject;
-import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.io.InputStream;
 
@@ -66,7 +66,6 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -74,15 +73,14 @@ import org.junit.runner.RunWith;
 /**
  * @author Javier Gamarra
  */
-@Ignore
 @RunWith(Arquillian.class)
 public class StructuredContentResourceTest
 	extends BaseStructuredContentResourceTestCase {
 
 	@ClassRule
 	@Rule
-	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
-		new LiferayIntegrationTestRule();
+	public static final IgnoreMailTestRule ignoreMailTestRule =
+		IgnoreMailTestRule.INSTANCE;
 
 	@Before
 	@Override

--- a/portal-test/bnd.bnd
+++ b/portal-test/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 8.1.0
+Bundle-Version: 8.2.0
 Export-Package:\
 	com.liferay.portal.kernel.dao.db.test,\
 	com.liferay.portal.kernel.test,\

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/AggregateTestRule.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/AggregateTestRule.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.kernel.test.rule;
 
+import com.liferay.portal.test.rule.IgnoreMailTestRule;
+
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -60,7 +62,8 @@ public class AggregateTestRule implements TestRule {
 
 	private static final String[] _ORDERED_RULE_CLASS_NAMES = {
 		TimeoutTestRule.class.getName(), HeapDumpTestRule.class.getName(),
-		CodeCoverageAssertor.class.getName(), NewEnvTestRule.class.getName(),
+		CodeCoverageAssertor.class.getName(),
+		IgnoreMailTestRule.class.getName(), NewEnvTestRule.class.getName(),
 		AssumeTestRule.class.getName(),
 		"com.liferay.portal.test.rule.LiferayIntegrationTestRule",
 		"com.liferay.portal.test.rule.PersistenceTestRule",

--- a/portal-test/src/com/liferay/portal/test/rule/IgnoreMailTestRule.java
+++ b/portal-test/src/com/liferay/portal/test/rule/IgnoreMailTestRule.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.test.rule;
+
+import com.liferay.portal.kernel.messaging.Destination;
+import com.liferay.portal.kernel.messaging.DestinationNames;
+import com.liferay.portal.kernel.messaging.MessageBusUtil;
+import com.liferay.portal.kernel.messaging.MessageListener;
+import com.liferay.portal.kernel.test.rule.ClassTestRule;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.runner.Description;
+
+/**
+ * @author Javier Gamarra
+ */
+public class IgnoreMailTestRule extends ClassTestRule<Void> {
+
+	public static final IgnoreMailTestRule INSTANCE = new IgnoreMailTestRule();
+
+	@Override
+	public Void beforeClass(Description description) {
+		Destination destination = MessageBusUtil.getDestination(
+			DestinationNames.MAIL);
+
+		_messageListeners = new HashSet<>(destination.getMessageListeners());
+
+		destination.unregisterMessageListeners();
+
+		return null;
+	}
+
+	@Override
+	protected void afterClass(Description description, Void unused) {
+		Destination destination = MessageBusUtil.getDestination(
+			DestinationNames.MAIL);
+
+		for (MessageListener messageListener : _messageListeners) {
+			destination.register(messageListener);
+		}
+	}
+
+	private IgnoreMailTestRule() {
+	}
+
+	private Set<MessageListener> _messageListeners;
+
+}

--- a/portal-test/src/com/liferay/portal/test/rule/packageinfo
+++ b/portal-test/src/com/liferay/portal/test/rule/packageinfo
@@ -1,1 +1,1 @@
-version 3.2.0
+version 3.3.0


### PR DESCRIPTION
I've added a new test rule, the existing rule `SynchronousMailTestRule` sets a local mail server to get the emails synchronously and adding a mode to ignore emails would mean a rename IMHO.

I'm not generating it automatically because it only applies to a few APIs (many in admin-user but just 1 in delivery).