### PR TITLE
LPS-102002 Extensibility unit tests alternatives minimizing the use of mocks

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/jaxrs/util/JAXRSExtensionContextUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/jaxrs/util/JAXRSExtensionContextUtil.java
@@ -1,0 +1,168 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.internal.jaxrs.util;
+
+import com.liferay.portal.vulcan.jaxrs.context.EntityExtensionContext;
+import com.liferay.portal.vulcan.jaxrs.context.ExtensionContext;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.ext.ContextResolver;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Providers;
+
+/**
+ * @author Javier de Arcos
+ */
+public class JAXRSExtensionContextUtil {
+
+	public static Providers getNoContextResolverProviders() {
+		return new NoContextResolverProviders();
+	}
+
+	public static Map<String, Object> getTestExtendedProperties() {
+		return _extendedProperties;
+	}
+
+	public static TestObject getTestObject() {
+		return new TestObject();
+	}
+
+	public static Providers getTestProviders() {
+		return new TestProviders();
+	}
+
+	public static class TestObject {
+
+		private TestObject() {
+		}
+
+	}
+
+	private static final Map<String, Object> _extendedProperties =
+		Collections.singletonMap("extendedProperty", "test");
+
+	private static class NoContextResolverProviders implements Providers {
+
+		@Override
+		public <T> ContextResolver<T> getContextResolver(
+			Class<T> aClass, MediaType mediaType) {
+
+			return null;
+		}
+
+		@Override
+		public <T extends Throwable> ExceptionMapper<T> getExceptionMapper(
+			Class<T> aClass) {
+
+			return null;
+		}
+
+		@Override
+		public <T> MessageBodyReader<T> getMessageBodyReader(
+			Class<T> aClass, Type type, Annotation[] annotations,
+			MediaType mediaType) {
+
+			return null;
+		}
+
+		@Override
+		public <T> MessageBodyWriter<T> getMessageBodyWriter(
+			Class<T> aClass, Type type, Annotation[] annotations,
+			MediaType mediaType) {
+
+			return null;
+		}
+
+	}
+
+	private static class TestExtensionContext
+		extends EntityExtensionContext<TestObject> {
+
+		@Override
+		public Map<String, Object> getEntityExtendedProperties(
+			TestObject entity) {
+
+			return _extendedProperties;
+		}
+
+		@Override
+		public Set<String> getEntityFilteredPropertyKeys(TestObject entity) {
+			return null;
+		}
+
+	}
+
+	private static class TestExtensionContextResolver
+		implements ContextResolver<ExtensionContext> {
+
+		@Override
+		public ExtensionContext getContext(Class<?> aClass) {
+			if (TestObject.class.isAssignableFrom(aClass)) {
+				return new TestExtensionContext();
+			}
+
+			return null;
+		}
+
+	}
+
+	private static class TestProviders implements Providers {
+
+		@Override
+		public <T> ContextResolver<T> getContextResolver(
+			Class<T> aClass, MediaType mediaType) {
+
+			if (aClass.isAssignableFrom(ExtensionContext.class)) {
+				return (ContextResolver)new TestExtensionContextResolver();
+			}
+
+			return null;
+		}
+
+		@Override
+		public <T extends Throwable> ExceptionMapper<T> getExceptionMapper(
+			Class<T> aClass) {
+
+			return null;
+		}
+
+		@Override
+		public <T> MessageBodyReader<T> getMessageBodyReader(
+			Class<T> aClass, Type type, Annotation[] annotations,
+			MediaType mediaType) {
+
+			return null;
+		}
+
+		@Override
+		public <T> MessageBodyWriter<T> getMessageBodyWriter(
+			Class<T> aClass, Type type, Annotation[] annotations,
+			MediaType mediaType) {
+
+			return null;
+		}
+
+	}
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/jaxrs/writer/interceptor/EntityExtensionWriterInterceptorTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/jaxrs/writer/interceptor/EntityExtensionWriterInterceptorTest.java
@@ -1,0 +1,190 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.internal.jaxrs.writer.interceptor;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.vulcan.internal.jaxrs.extension.ExtendedEntity;
+import com.liferay.portal.vulcan.jaxrs.context.ExtensionContext;
+
+import java.io.IOException;
+
+import java.util.Collections;
+import java.util.Map;
+
+import javax.ws.rs.ext.ContextResolver;
+import javax.ws.rs.ext.Providers;
+import javax.ws.rs.ext.WriterInterceptorContext;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+/**
+ * @author Javier de Arcos
+ */
+public class EntityExtensionWriterInterceptorTest {
+
+	@Before
+	public void setUp() {
+		_entityExtensionWriterInterceptor =
+			new EntityExtensionWriterInterceptor();
+		_mockedProviders = Mockito.mock(Providers.class);
+		_mockedWriterInterceptorContext = Mockito.mock(
+			WriterInterceptorContext.class);
+
+		ReflectionTestUtil.setFieldValue(
+			_entityExtensionWriterInterceptor, "_providers", _mockedProviders);
+	}
+
+	@Test
+	public void testAroundWriteWithExtensionContextWithExtendedType()
+		throws IOException {
+
+		Dummy entity = new Dummy();
+		Map<String, Object> extendedProperties = Collections.singletonMap(
+			"testProperty", "test");
+		ArgumentCaptor<ExtendedEntity> extendedEntityCaptor =
+			ArgumentCaptor.forClass(ExtendedEntity.class);
+
+		ContextResolver<ExtensionContext> mockedContextResolver = Mockito.mock(
+			ContextResolver.class);
+		ExtensionContext mockedExtensionContext = Mockito.mock(
+			ExtensionContext.class);
+
+		Mockito.when(
+			mockedContextResolver.getContext(eq(Dummy.class))
+		).thenReturn(
+			mockedExtensionContext
+		);
+		Mockito.when(
+			mockedExtensionContext.getExtendedProperties(eq(entity))
+		).thenReturn(
+			extendedProperties
+		);
+
+		Mockito.when(
+			_mockedProviders.getContextResolver(
+				eq(ExtensionContext.class), any())
+		).thenReturn(
+			mockedContextResolver
+		);
+		Mockito.when(
+			_mockedWriterInterceptorContext.getEntity()
+		).thenReturn(
+			entity
+		);
+		Mockito.when(
+			_mockedWriterInterceptorContext.getType()
+		).thenReturn(
+			(Class)entity.getClass()
+		);
+
+		_entityExtensionWriterInterceptor.aroundWriteTo(
+			_mockedWriterInterceptorContext);
+
+		Mockito.verify(
+			_mockedWriterInterceptorContext
+		).setEntity(
+			extendedEntityCaptor.capture()
+		);
+		ExtendedEntity extendedEntity = extendedEntityCaptor.getValue();
+
+		Assert.assertEquals(entity, extendedEntity.getEntity());
+		Assert.assertEquals(
+			extendedProperties, extendedEntity.getExtendedProperties());
+
+		Mockito.verify(
+			_mockedWriterInterceptorContext
+		).setGenericType(
+			eq(ExtendedEntity.class)
+		);
+
+		Mockito.verify(
+			_mockedWriterInterceptorContext
+		).proceed();
+	}
+
+	@Test
+	public void testAroundWriteWithExtensionContextWithNoExtendedType()
+		throws IOException {
+
+		ContextResolver<ExtensionContext> mockedContextResolver = Mockito.mock(
+			ContextResolver.class);
+
+		Mockito.when(
+			_mockedProviders.getContextResolver(
+				eq(ExtensionContext.class), any())
+		).thenReturn(
+			mockedContextResolver
+		);
+
+		_entityExtensionWriterInterceptor.aroundWriteTo(
+			_mockedWriterInterceptorContext);
+
+		Mockito.verify(
+			_mockedWriterInterceptorContext, Mockito.never()
+		).setEntity(
+			any()
+		);
+
+		Mockito.verify(
+			_mockedWriterInterceptorContext, Mockito.never()
+		).setGenericType(
+			any()
+		);
+
+		Mockito.verify(
+			_mockedWriterInterceptorContext
+		).proceed();
+	}
+
+	@Test
+	public void testAroundWriteWithoutExtensionContextResolver()
+		throws IOException {
+
+		_entityExtensionWriterInterceptor.aroundWriteTo(
+			_mockedWriterInterceptorContext);
+
+		Mockito.verify(
+			_mockedWriterInterceptorContext, Mockito.never()
+		).setEntity(
+			any()
+		);
+
+		Mockito.verify(
+			_mockedWriterInterceptorContext, Mockito.never()
+		).setGenericType(
+			any()
+		);
+
+		Mockito.verify(
+			_mockedWriterInterceptorContext
+		).proceed();
+	}
+
+	private EntityExtensionWriterInterceptor _entityExtensionWriterInterceptor;
+	private Providers _mockedProviders;
+	private WriterInterceptorContext _mockedWriterInterceptorContext;
+
+	private static class Dummy {
+	}
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/jaxrs/writer/interceptor/PageEntityExtensionWriterInterceptorTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/jaxrs/writer/interceptor/PageEntityExtensionWriterInterceptorTest.java
@@ -1,0 +1,285 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.internal.jaxrs.writer.interceptor;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.vulcan.internal.jaxrs.extension.ExtendedEntity;
+import com.liferay.portal.vulcan.jaxrs.context.ExtensionContext;
+import com.liferay.portal.vulcan.pagination.Page;
+
+import java.io.IOException;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.ext.ContextResolver;
+import javax.ws.rs.ext.Providers;
+import javax.ws.rs.ext.WriterInterceptorContext;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+/**
+ * @author Javier de Arcos
+ */
+public class PageEntityExtensionWriterInterceptorTest {
+
+	@Before
+	public void setUp() {
+		_mockedProviders = Mockito.mock(Providers.class);
+		_mockedWriterInterceptorContext = Mockito.mock(
+			WriterInterceptorContext.class);
+
+		_pageEntityExtensionWriterInterceptor =
+			new PageEntityExtensionWriterInterceptor();
+
+		ReflectionTestUtil.setFieldValue(
+			_pageEntityExtensionWriterInterceptor, "_providers",
+			_mockedProviders);
+	}
+
+	@Test
+	public void testAroundWriteNotPage() throws IOException {
+		Mockito.when(
+			_mockedWriterInterceptorContext.getType()
+		).thenReturn(
+			(Class)Dummy.class
+		);
+
+		_pageEntityExtensionWriterInterceptor.aroundWriteTo(
+			_mockedWriterInterceptorContext);
+
+		Mockito.verify(
+			_mockedWriterInterceptorContext, Mockito.never()
+		).setEntity(
+			any()
+		);
+
+		Mockito.verify(
+			_mockedWriterInterceptorContext, Mockito.never()
+		).setGenericType(
+			any()
+		);
+
+		Mockito.verify(
+			_mockedWriterInterceptorContext
+		).proceed();
+	}
+
+	@Test
+	public void testAroundWritePageWithExtensionContextWithExtendedType()
+		throws IOException {
+
+		Dummy entity = new Dummy();
+
+		Page<Dummy> page = Page.of(Collections.singleton(entity));
+
+		Map<String, Object> extendedProperties = Collections.singletonMap(
+			"testProperty", "test");
+		ArgumentCaptor<Page> extendedPageCaptor = ArgumentCaptor.forClass(
+			Page.class);
+
+		ContextResolver<ExtensionContext> mockedContextResolver = Mockito.mock(
+			ContextResolver.class);
+		ExtensionContext mockedExtensionContext = Mockito.mock(
+			ExtensionContext.class);
+
+		Mockito.when(
+			mockedContextResolver.getContext(eq(Dummy.class))
+		).thenReturn(
+			mockedExtensionContext
+		);
+		Mockito.when(
+			mockedExtensionContext.getExtendedProperties(eq(entity))
+		).thenReturn(
+			extendedProperties
+		);
+
+		Mockito.when(
+			_mockedProviders.getContextResolver(
+				eq(ExtensionContext.class), any())
+		).thenReturn(
+			mockedContextResolver
+		);
+		Mockito.when(
+			_mockedWriterInterceptorContext.getEntity()
+		).thenReturn(
+			page
+		);
+		Mockito.when(
+			_mockedWriterInterceptorContext.getGenericType()
+		).thenReturn(
+			new GenericType<Page<Dummy>>() {
+			}.getType()
+		);
+		Mockito.when(
+			_mockedWriterInterceptorContext.getType()
+		).thenReturn(
+			(Class)page.getClass()
+		);
+
+		_pageEntityExtensionWriterInterceptor.aroundWriteTo(
+			_mockedWriterInterceptorContext);
+
+		Mockito.verify(
+			_mockedWriterInterceptorContext
+		).setEntity(
+			extendedPageCaptor.capture()
+		);
+		Page<ExtendedEntity> extendedPage = extendedPageCaptor.getValue();
+
+		Assert.assertEquals(page.getActions(), extendedPage.getActions());
+
+		Collection<ExtendedEntity> items = extendedPage.getItems();
+
+		ExtendedEntity extendedEntity = items.toArray(new ExtendedEntity[0])[0];
+
+		Assert.assertEquals(entity, extendedEntity.getEntity());
+		Assert.assertEquals(
+			extendedProperties, extendedEntity.getExtendedProperties());
+
+		Assert.assertEquals(page.getPage(), extendedPage.getPage());
+		Assert.assertEquals(page.getPageSize(), extendedPage.getPageSize());
+		Assert.assertEquals(page.getLastPage(), page.getLastPage());
+		Assert.assertEquals(page.getTotalCount(), page.getTotalCount());
+
+		Mockito.verify(
+			_mockedWriterInterceptorContext
+		).setGenericType(
+			eq(
+				new GenericType<Page<ExtendedEntity>>() {
+				}.getType())
+		);
+
+		Mockito.verify(
+			_mockedWriterInterceptorContext
+		).proceed();
+	}
+
+	@Test
+	public void testAroundWritePageWithExtensionContextWithNoExtendedType()
+		throws IOException {
+
+		Page<Dummy> page = Page.of(Collections.singleton(new Dummy()));
+
+		ContextResolver<ExtensionContext> mockedContextResolver = Mockito.mock(
+			ContextResolver.class);
+
+		Mockito.when(
+			_mockedProviders.getContextResolver(
+				eq(ExtensionContext.class), any())
+		).thenReturn(
+			mockedContextResolver
+		);
+
+		Mockito.when(
+			_mockedWriterInterceptorContext.getEntity()
+		).thenReturn(
+			page
+		);
+		Mockito.when(
+			_mockedWriterInterceptorContext.getGenericType()
+		).thenReturn(
+			new GenericType<Page<Dummy>>() {
+			}.getType()
+		);
+		Mockito.when(
+			_mockedWriterInterceptorContext.getType()
+		).thenReturn(
+			(Class)page.getClass()
+		);
+
+		_pageEntityExtensionWriterInterceptor.aroundWriteTo(
+			_mockedWriterInterceptorContext);
+
+		Mockito.verify(
+			_mockedWriterInterceptorContext, Mockito.never()
+		).setEntity(
+			any()
+		);
+
+		Mockito.verify(
+			_mockedWriterInterceptorContext, Mockito.never()
+		).setGenericType(
+			any()
+		);
+
+		Mockito.verify(
+			_mockedWriterInterceptorContext
+		).proceed();
+	}
+
+	@Test
+	public void testAroundWritePageWithoutExtensionContextResolver()
+		throws IOException {
+
+		Page<Dummy> page = Page.of(Collections.singleton(new Dummy()));
+
+		Mockito.when(
+			_mockedWriterInterceptorContext.getEntity()
+		).thenReturn(
+			page
+		);
+
+		Mockito.when(
+			_mockedWriterInterceptorContext.getGenericType()
+		).thenReturn(
+			new GenericType<Page<Dummy>>() {
+			}.getType()
+		);
+		Mockito.when(
+			_mockedWriterInterceptorContext.getType()
+		).thenReturn(
+			(Class)page.getClass()
+		);
+
+		_pageEntityExtensionWriterInterceptor.aroundWriteTo(
+			_mockedWriterInterceptorContext);
+
+		Mockito.verify(
+			_mockedWriterInterceptorContext, Mockito.never()
+		).setEntity(
+			any()
+		);
+
+		Mockito.verify(
+			_mockedWriterInterceptorContext, Mockito.never()
+		).setGenericType(
+			any()
+		);
+
+		Mockito.verify(
+			_mockedWriterInterceptorContext
+		).proceed();
+	}
+
+	private Providers _mockedProviders;
+	private WriterInterceptorContext _mockedWriterInterceptorContext;
+	private PageEntityExtensionWriterInterceptor
+		_pageEntityExtensionWriterInterceptor;
+
+	private static class Dummy {
+	}
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/jaxrs/writer/interceptor/PageEntityExtensionWriterInterceptorTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/jaxrs/writer/interceptor/PageEntityExtensionWriterInterceptorTest.java
@@ -19,18 +19,15 @@ import static org.mockito.Matchers.eq;
 
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.vulcan.internal.jaxrs.extension.ExtendedEntity;
-import com.liferay.portal.vulcan.jaxrs.context.ExtensionContext;
+import com.liferay.portal.vulcan.internal.jaxrs.util.JAXRSExtensionContextUtil;
 import com.liferay.portal.vulcan.pagination.Page;
 
 import java.io.IOException;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Map;
 
 import javax.ws.rs.core.GenericType;
-import javax.ws.rs.ext.ContextResolver;
-import javax.ws.rs.ext.Providers;
 import javax.ws.rs.ext.WriterInterceptorContext;
 
 import org.junit.Assert;
@@ -47,7 +44,6 @@ public class PageEntityExtensionWriterInterceptorTest {
 
 	@Before
 	public void setUp() {
-		_mockedProviders = Mockito.mock(Providers.class);
 		_mockedWriterInterceptorContext = Mockito.mock(
 			WriterInterceptorContext.class);
 
@@ -56,7 +52,7 @@ public class PageEntityExtensionWriterInterceptorTest {
 
 		ReflectionTestUtil.setFieldValue(
 			_pageEntityExtensionWriterInterceptor, "_providers",
-			_mockedProviders);
+			JAXRSExtensionContextUtil.getTestProviders());
 	}
 
 	@Test
@@ -64,7 +60,7 @@ public class PageEntityExtensionWriterInterceptorTest {
 		Mockito.when(
 			_mockedWriterInterceptorContext.getType()
 		).thenReturn(
-			(Class)Dummy.class
+			(Class)JAXRSExtensionContextUtil.TestObject.class
 		);
 
 		_pageEntityExtensionWriterInterceptor.aroundWriteTo(
@@ -91,37 +87,15 @@ public class PageEntityExtensionWriterInterceptorTest {
 	public void testAroundWritePageWithExtensionContextWithExtendedType()
 		throws IOException {
 
-		Dummy entity = new Dummy();
+		JAXRSExtensionContextUtil.TestObject entity =
+			JAXRSExtensionContextUtil.getTestObject();
 
-		Page<Dummy> page = Page.of(Collections.singleton(entity));
+		Page<JAXRSExtensionContextUtil.TestObject> page = Page.of(
+			Collections.singleton(entity));
 
-		Map<String, Object> extendedProperties = Collections.singletonMap(
-			"testProperty", "test");
 		ArgumentCaptor<Page> extendedPageCaptor = ArgumentCaptor.forClass(
 			Page.class);
 
-		ContextResolver<ExtensionContext> mockedContextResolver = Mockito.mock(
-			ContextResolver.class);
-		ExtensionContext mockedExtensionContext = Mockito.mock(
-			ExtensionContext.class);
-
-		Mockito.when(
-			mockedContextResolver.getContext(eq(Dummy.class))
-		).thenReturn(
-			mockedExtensionContext
-		);
-		Mockito.when(
-			mockedExtensionContext.getExtendedProperties(eq(entity))
-		).thenReturn(
-			extendedProperties
-		);
-
-		Mockito.when(
-			_mockedProviders.getContextResolver(
-				eq(ExtensionContext.class), any())
-		).thenReturn(
-			mockedContextResolver
-		);
 		Mockito.when(
 			_mockedWriterInterceptorContext.getEntity()
 		).thenReturn(
@@ -130,7 +104,7 @@ public class PageEntityExtensionWriterInterceptorTest {
 		Mockito.when(
 			_mockedWriterInterceptorContext.getGenericType()
 		).thenReturn(
-			new GenericType<Page<Dummy>>() {
+			new GenericType<Page<JAXRSExtensionContextUtil.TestObject>>() {
 			}.getType()
 		);
 		Mockito.when(
@@ -157,7 +131,8 @@ public class PageEntityExtensionWriterInterceptorTest {
 
 		Assert.assertEquals(entity, extendedEntity.getEntity());
 		Assert.assertEquals(
-			extendedProperties, extendedEntity.getExtendedProperties());
+			JAXRSExtensionContextUtil.getTestExtendedProperties(),
+			extendedEntity.getExtendedProperties());
 
 		Assert.assertEquals(page.getPage(), extendedPage.getPage());
 		Assert.assertEquals(page.getPageSize(), extendedPage.getPageSize());
@@ -181,33 +156,24 @@ public class PageEntityExtensionWriterInterceptorTest {
 	public void testAroundWritePageWithExtensionContextWithNoExtendedType()
 		throws IOException {
 
-		Page<Dummy> page = Page.of(Collections.singleton(new Dummy()));
-
-		ContextResolver<ExtensionContext> mockedContextResolver = Mockito.mock(
-			ContextResolver.class);
-
-		Mockito.when(
-			_mockedProviders.getContextResolver(
-				eq(ExtensionContext.class), any())
-		).thenReturn(
-			mockedContextResolver
-		);
+		Page<Object> page = Page.of(Collections.singleton(new Object()));
 
 		Mockito.when(
 			_mockedWriterInterceptorContext.getEntity()
 		).thenReturn(
 			page
 		);
+
 		Mockito.when(
 			_mockedWriterInterceptorContext.getGenericType()
 		).thenReturn(
-			new GenericType<Page<Dummy>>() {
+			new GenericType<Page<Object>>() {
 			}.getType()
 		);
 		Mockito.when(
 			_mockedWriterInterceptorContext.getType()
 		).thenReturn(
-			(Class)page.getClass()
+			(Class)Object.class
 		);
 
 		_pageEntityExtensionWriterInterceptor.aroundWriteTo(
@@ -234,7 +200,12 @@ public class PageEntityExtensionWriterInterceptorTest {
 	public void testAroundWritePageWithoutExtensionContextResolver()
 		throws IOException {
 
-		Page<Dummy> page = Page.of(Collections.singleton(new Dummy()));
+		ReflectionTestUtil.setFieldValue(
+			_pageEntityExtensionWriterInterceptor, "_providers",
+			JAXRSExtensionContextUtil.getNoContextResolverProviders());
+
+		Page<Object> page = Page.of(
+			Collections.singleton(JAXRSExtensionContextUtil.getTestObject()));
 
 		Mockito.when(
 			_mockedWriterInterceptorContext.getEntity()
@@ -245,7 +216,7 @@ public class PageEntityExtensionWriterInterceptorTest {
 		Mockito.when(
 			_mockedWriterInterceptorContext.getGenericType()
 		).thenReturn(
-			new GenericType<Page<Dummy>>() {
+			new GenericType<Page<JAXRSExtensionContextUtil.TestObject>>() {
 			}.getType()
 		);
 		Mockito.when(
@@ -274,12 +245,8 @@ public class PageEntityExtensionWriterInterceptorTest {
 		).proceed();
 	}
 
-	private Providers _mockedProviders;
 	private WriterInterceptorContext _mockedWriterInterceptorContext;
 	private PageEntityExtensionWriterInterceptor
 		_pageEntityExtensionWriterInterceptor;
-
-	private static class Dummy {
-	}
 
 }


### PR DESCRIPTION
As you asked, I've tried to rewrite the tests removing the mocks to see if it the logic is more clear.

I wasn't able to remove all mocks because:
- The methods to test return void and I have to verify its behavior.
- The argument passed to the method, that I could implement with a test double, is an interface with a lot of methods and it would get very messy.

I made a Util class to avoid duplicating the code.

Honestly, I think is better the first approach, because developers are used to Mockito and will have all the information needed to understand the test in the same class, instead of having to check the custom test doubles to see how they work.
