### PR TITLE
LPS-118009 Embed structured contents and taxonomy categories using nestedFields in APIs

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/StructuredContentLink.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/StructuredContentLink.java
@@ -33,6 +33,8 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
+import javax.validation.Valid;
+
 import javax.xml.bind.annotation.XmlRootElement;
 
 /**
@@ -76,6 +78,43 @@ public class StructuredContentLink {
 	@GraphQLField
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String contentType;
+
+	@Schema(
+		description = "optional field with the structured content, can be embedded with nestedFields"
+	)
+	@Valid
+	public StructuredContent getEmbeddedStructuredContent() {
+		return embeddedStructuredContent;
+	}
+
+	public void setEmbeddedStructuredContent(
+		StructuredContent embeddedStructuredContent) {
+
+		this.embeddedStructuredContent = embeddedStructuredContent;
+	}
+
+	@JsonIgnore
+	public void setEmbeddedStructuredContent(
+		UnsafeSupplier<StructuredContent, Exception>
+			embeddedStructuredContentUnsafeSupplier) {
+
+		try {
+			embeddedStructuredContent =
+				embeddedStructuredContentUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(
+		description = "optional field with the structured content, can be embedded with nestedFields"
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected StructuredContent embeddedStructuredContent;
 
 	@Schema(description = "The resource's ID.")
 	public Long getId() {
@@ -171,6 +210,16 @@ public class StructuredContentLink {
 			sb.append(_escape(contentType));
 
 			sb.append("\"");
+		}
+
+		if (embeddedStructuredContent != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"embeddedStructuredContent\": ");
+
+			sb.append(String.valueOf(embeddedStructuredContent));
 		}
 
 		if (id != null) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/TaxonomyCategoryBrief.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/TaxonomyCategoryBrief.java
@@ -52,6 +52,41 @@ public class TaxonomyCategoryBrief {
 	}
 
 	@Schema(
+		description = "Optional field with the embedded taxonomy category, can be embedded with nestedFields"
+	)
+	@Valid
+	public Object getEmbeddedTaxonomyCategory() {
+		return embeddedTaxonomyCategory;
+	}
+
+	public void setEmbeddedTaxonomyCategory(Object embeddedTaxonomyCategory) {
+		this.embeddedTaxonomyCategory = embeddedTaxonomyCategory;
+	}
+
+	@JsonIgnore
+	public void setEmbeddedTaxonomyCategory(
+		UnsafeSupplier<Object, Exception>
+			embeddedTaxonomyCategoryUnsafeSupplier) {
+
+		try {
+			embeddedTaxonomyCategory =
+				embeddedTaxonomyCategoryUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(
+		description = "Optional field with the embedded taxonomy category, can be embedded with nestedFields"
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Object embeddedTaxonomyCategory;
+
+	@Schema(
 		description = "The category's ID. This can be used to retrieve more information in the `TaxonomyCategory` API."
 	)
 	public Long getTaxonomyCategoryId() {
@@ -171,6 +206,16 @@ public class TaxonomyCategoryBrief {
 		StringBundler sb = new StringBundler();
 
 		sb.append("{");
+
+		if (embeddedTaxonomyCategory != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"embeddedTaxonomyCategory\": ");
+
+			sb.append(String.valueOf(embeddedTaxonomyCategory));
+		}
 
 		if (taxonomyCategoryId != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/StructuredContentLink.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/StructuredContentLink.java
@@ -53,6 +53,31 @@ public class StructuredContentLink implements Cloneable {
 
 	protected String contentType;
 
+	public StructuredContent getEmbeddedStructuredContent() {
+		return embeddedStructuredContent;
+	}
+
+	public void setEmbeddedStructuredContent(
+		StructuredContent embeddedStructuredContent) {
+
+		this.embeddedStructuredContent = embeddedStructuredContent;
+	}
+
+	public void setEmbeddedStructuredContent(
+		UnsafeSupplier<StructuredContent, Exception>
+			embeddedStructuredContentUnsafeSupplier) {
+
+		try {
+			embeddedStructuredContent =
+				embeddedStructuredContentUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected StructuredContent embeddedStructuredContent;
+
 	public Long getId() {
 		return id;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/TaxonomyCategoryBrief.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/TaxonomyCategoryBrief.java
@@ -33,6 +33,29 @@ public class TaxonomyCategoryBrief implements Cloneable {
 		return TaxonomyCategoryBriefSerDes.toDTO(json);
 	}
 
+	public Object getEmbeddedTaxonomyCategory() {
+		return embeddedTaxonomyCategory;
+	}
+
+	public void setEmbeddedTaxonomyCategory(Object embeddedTaxonomyCategory) {
+		this.embeddedTaxonomyCategory = embeddedTaxonomyCategory;
+	}
+
+	public void setEmbeddedTaxonomyCategory(
+		UnsafeSupplier<Object, Exception>
+			embeddedTaxonomyCategoryUnsafeSupplier) {
+
+		try {
+			embeddedTaxonomyCategory =
+				embeddedTaxonomyCategoryUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Object embeddedTaxonomyCategory;
+
 	public Long getTaxonomyCategoryId() {
 		return taxonomyCategoryId;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/StructuredContentLinkSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/StructuredContentLinkSerDes.java
@@ -69,6 +69,18 @@ public class StructuredContentLinkSerDes {
 			sb.append("\"");
 		}
 
+		if (structuredContentLink.getEmbeddedStructuredContent() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"embeddedStructuredContent\": ");
+
+			sb.append(
+				String.valueOf(
+					structuredContentLink.getEmbeddedStructuredContent()));
+		}
+
 		if (structuredContentLink.getId() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -123,6 +135,16 @@ public class StructuredContentLinkSerDes {
 				String.valueOf(structuredContentLink.getContentType()));
 		}
 
+		if (structuredContentLink.getEmbeddedStructuredContent() == null) {
+			map.put("embeddedStructuredContent", null);
+		}
+		else {
+			map.put(
+				"embeddedStructuredContent",
+				String.valueOf(
+					structuredContentLink.getEmbeddedStructuredContent()));
+		}
+
 		if (structuredContentLink.getId() == null) {
 			map.put("id", null);
 		}
@@ -162,6 +184,15 @@ public class StructuredContentLinkSerDes {
 				if (jsonParserFieldValue != null) {
 					structuredContentLink.setContentType(
 						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "embeddedStructuredContent")) {
+
+				if (jsonParserFieldValue != null) {
+					structuredContentLink.setEmbeddedStructuredContent(
+						StructuredContentSerDes.toDTO(
+							(String)jsonParserFieldValue));
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "id")) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/TaxonomyCategoryBriefSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/TaxonomyCategoryBriefSerDes.java
@@ -55,6 +55,21 @@ public class TaxonomyCategoryBriefSerDes {
 
 		sb.append("{");
 
+		if (taxonomyCategoryBrief.getEmbeddedTaxonomyCategory() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"embeddedTaxonomyCategory\": ");
+
+			sb.append("\"");
+
+			sb.append(
+				_escape(taxonomyCategoryBrief.getEmbeddedTaxonomyCategory()));
+
+			sb.append("\"");
+		}
+
 		if (taxonomyCategoryBrief.getTaxonomyCategoryId() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -111,6 +126,16 @@ public class TaxonomyCategoryBriefSerDes {
 
 		Map<String, String> map = new TreeMap<>();
 
+		if (taxonomyCategoryBrief.getEmbeddedTaxonomyCategory() == null) {
+			map.put("embeddedTaxonomyCategory", null);
+		}
+		else {
+			map.put(
+				"embeddedTaxonomyCategory",
+				String.valueOf(
+					taxonomyCategoryBrief.getEmbeddedTaxonomyCategory()));
+		}
+
 		if (taxonomyCategoryBrief.getTaxonomyCategoryId() == null) {
 			map.put("taxonomyCategoryId", null);
 		}
@@ -161,7 +186,17 @@ public class TaxonomyCategoryBriefSerDes {
 			TaxonomyCategoryBrief taxonomyCategoryBrief,
 			String jsonParserFieldName, Object jsonParserFieldValue) {
 
-			if (Objects.equals(jsonParserFieldName, "taxonomyCategoryId")) {
+			if (Objects.equals(
+					jsonParserFieldName, "embeddedTaxonomyCategory")) {
+
+				if (jsonParserFieldValue != null) {
+					taxonomyCategoryBrief.setEmbeddedTaxonomyCategory(
+						(Object)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "taxonomyCategoryId")) {
+
 				if (jsonParserFieldValue != null) {
 					taxonomyCategoryBrief.setTaxonomyCategoryId(
 						Long.valueOf((String)jsonParserFieldValue));

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -494,6 +494,13 @@ components:
                         contentType:
                             readOnly: true
                             type: string
+                        embeddedStructuredContent:
+                            allOf:
+                                - $ref: "#/components/schemas/StructuredContent"
+                            # @review
+                            description:
+                                optional field with the structured content, can be embedded with nestedFields
+                            readOnly: true
                         id:
                             description:
                                 The resource's ID.

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -2823,6 +2823,12 @@ components:
             type: object
         TaxonomyCategoryBrief:
             properties:
+                embeddedTaxonomyCategory:
+                    # @review
+                    description:
+                        Optional field with the embedded taxonomy category, can be embedded with nestedFields
+                    readOnly: true
+                    type: object
                 taxonomyCategoryId:
                     description:
                         The category's ID. This can be used to retrieve more information in the

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/BlogPostingDTOConverter.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/BlogPostingDTOConverter.java
@@ -108,8 +108,7 @@ public class BlogPostingDTOConverter
 						BlogsEntry.class.getName(), blogsEntry.getEntryId()),
 					assetCategory ->
 						TaxonomyCategoryBriefUtil.toTaxonomyCategoryBrief(
-							dtoConverterContext.isAcceptAllLanguages(),
-							assetCategory, dtoConverterContext.getLocale()),
+							assetCategory, dtoConverterContext),
 					TaxonomyCategoryBrief.class);
 			}
 		};

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/DocumentDTOConverter.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/DocumentDTOConverter.java
@@ -158,8 +158,7 @@ public class DocumentDTOConverter
 						fileEntry.getFileEntryId()),
 					assetCategory ->
 						TaxonomyCategoryBriefUtil.toTaxonomyCategoryBrief(
-							dtoConverterContext.isAcceptAllLanguages(),
-							assetCategory, dtoConverterContext.getLocale()),
+							assetCategory, dtoConverterContext),
 					TaxonomyCategoryBrief.class);
 				title = fileEntry.getTitle();
 			}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/KnowledgeBaseArticleDTOConverter.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/KnowledgeBaseArticleDTOConverter.java
@@ -125,8 +125,7 @@ public class KnowledgeBaseArticleDTOConverter
 						KBArticle.class.getName(), kbArticle.getClassPK()),
 					assetCategory ->
 						TaxonomyCategoryBriefUtil.toTaxonomyCategoryBrief(
-							dtoConverterContext.isAcceptAllLanguages(),
-							assetCategory, dtoConverterContext.getLocale()),
+							assetCategory, dtoConverterContext),
 					TaxonomyCategoryBrief.class);
 				title = kbArticle.getTitle();
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/MessageBoardThreadDTOConverter.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/MessageBoardThreadDTOConverter.java
@@ -145,8 +145,7 @@ public class MessageBoardThreadDTOConverter
 						MBMessage.class.getName(), mbThread.getRootMessageId()),
 					assetCategory ->
 						TaxonomyCategoryBriefUtil.toTaxonomyCategoryBrief(
-							dtoConverterContext.isAcceptAllLanguages(),
-							assetCategory, dtoConverterContext.getLocale()),
+							assetCategory, dtoConverterContext),
 					TaxonomyCategoryBrief.class);
 				threadType = _toThreadType(
 					languageId, mbThread.getGroupId(), mbThread.getPriority());

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/StructuredContentDTOConverter.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/StructuredContentDTOConverter.java
@@ -173,8 +173,7 @@ public class StructuredContentDTOConverter
 						journalArticle.getResourcePrimKey()),
 					assetCategory ->
 						TaxonomyCategoryBriefUtil.toTaxonomyCategoryBrief(
-							dtoConverterContext.isAcceptAllLanguages(),
-							assetCategory, dtoConverterContext.getLocale()),
+							assetCategory, dtoConverterContext),
 					TaxonomyCategoryBrief.class);
 				title = journalArticle.getTitle(
 					dtoConverterContext.getLocale());

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/WikiPageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/WikiPageResourceImpl.java
@@ -51,6 +51,7 @@ import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.vulcan.aggregation.Aggregation;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
+import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
@@ -66,6 +67,7 @@ import com.liferay.wiki.service.WikiPageService;
 
 import java.io.Serializable;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -402,9 +404,14 @@ public class WikiPageResourceImpl
 						wikiPage.getPageId()),
 					assetCategory ->
 						TaxonomyCategoryBriefUtil.toTaxonomyCategoryBrief(
-							contextAcceptLanguage.isAcceptAllLanguages(),
 							assetCategory,
-							contextAcceptLanguage.getPreferredLocale()),
+							new DefaultDTOConverterContext(
+								contextAcceptLanguage.isAcceptAllLanguages(),
+								Collections.emptyMap(), _dtoConverterRegistry,
+								contextHttpServletRequest,
+								assetCategory.getCategoryId(),
+								contextAcceptLanguage.getPreferredLocale(),
+								contextUriInfo, contextUser)),
 					TaxonomyCategoryBrief.class);
 
 				setParentWikiPageId(


### PR DESCRIPTION
Add new fields in Headless Delivery OpenAPI to allow embedding structured contents in StructuredContentLink and taxonomy categories in TaxonomyCategoryBrief.

Implement feature using nested fields