### PR TITLE
LPS-121535 Fix a problem in GraphQL Servlet reinitialization when an API module was redeployed

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -310,7 +310,7 @@ public class GraphQLServletExtender {
 				GraphQLType graphQLType = graphQLTypes.get(typeName);
 
 				if ((graphQLType != null) &&
-					!_classNames.contains(clazz.getName())) {
+					!_registeredClassNames.contains(clazz.getName())) {
 
 					String name = clazz.getName();
 
@@ -336,7 +336,7 @@ public class GraphQLServletExtender {
 
 				processingStack.push(typeName);
 
-				_classNames.add(clazz.getName());
+				_registeredClassNames.add(clazz.getName());
 
 				if (clazz.getAnnotation(GraphQLUnion.class) != null) {
 					graphQLType = new UnionBuilder(
@@ -475,8 +475,6 @@ public class GraphQLServletExtender {
 
 				return typeName;
 			}
-
-			private final Set<String> _classNames = new HashSet<>();
 
 		};
 
@@ -1173,6 +1171,8 @@ public class GraphQLServletExtender {
 
 			PropertyDataFetcher.clearReflectionCache();
 
+			_registeredClassNames.clear();
+
 			ProcessingElementsContainer processingElementsContainer =
 				new ProcessingElementsContainer(_defaultTypeFunction);
 
@@ -1787,6 +1787,8 @@ public class GraphQLServletExtender {
 
 	@Reference
 	private Portal _portal;
+
+	private final Set<String> _registeredClassNames = new HashSet<>();
 
 	@Reference
 	private ResourceActionLocalService _resourceActionLocalService;


### PR DESCRIPTION
Move the field of an inner class _className to be a field of the main class to be able to clear the collection to reinit the GraphQL servlet correctly.

As moving this field to the main class seems that more context is needed, I renamed the field to registerClassNames to explain that this collection is used to register the class names as we are processing the APIs