### PR TITLE
LPS-121640 Check if a topic name has a hyphen

### DIFF
--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/Breadcrumb.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/Breadcrumb.es.js
@@ -24,6 +24,7 @@ import {
 	getSectionQuery,
 } from '../utils/client.es';
 import {historyPushWithSlug, stringToSlug} from '../utils/utils.es';
+import Alert from './Alert.es';
 import BreadcrumbNode from './BreadcrumbNode.es';
 import NewTopicModal from './NewTopicModal.es';
 
@@ -35,6 +36,7 @@ export default withRouter(({allowCreateTopicInRootTopic, history, section}) => {
 	const MAX_SECTIONS_IN_BREADCRUMB = 3;
 	const historyPushParser = historyPushWithSlug(history.push);
 	const [breadcrumbNodes, setBreadcrumbNodes] = useState([]);
+	const [error, setError] = useState({});
 	const [visible, setVisible] = useState(false);
 
 	const getSubSections = (section) =>
@@ -119,40 +121,44 @@ export default withRouter(({allowCreateTopicInRootTopic, history, section}) => {
 	}, [buildBreadcrumbNodesData, rootTopicId, section]);
 
 	return (
-		<section className="align-items-center d-flex mb-0 questions-breadcrumb">
-			<ol className="breadcrumb m-0">
-				{breadcrumbNodes.length > MAX_SECTIONS_IN_BREADCRUMB ? (
-					<ShortenedBreadcrumb />
-				) : (
-					<AllBreadcrumb />
+		<>
+			<section className="align-items-center d-flex mb-0 questions-breadcrumb">
+				<ol className="breadcrumb m-0">
+					{breadcrumbNodes.length > MAX_SECTIONS_IN_BREADCRUMB ? (
+						<ShortenedBreadcrumb />
+					) : (
+						<AllBreadcrumb />
+					)}
+				</ol>
+				{((section &&
+					section.actions &&
+					section.actions['add-subcategory']) ||
+					allowCreateTopicInRootTopic) && (
+					<>
+						<NewTopicModal
+							currentSectionId={section && section.id}
+							onClose={() => setVisible(false)}
+							onCreateNavigateTo={(topic) =>
+								historyPushParser(
+									`/questions/${stringToSlug(topic)}`
+								)
+							}
+							setError={setError}
+							visible={visible}
+						/>
+						<ClayButton
+							className="breadcrumb-button c-ml-3 c-p-2"
+							displayType="unstyled"
+							onClick={() => setVisible(true)}
+						>
+							<ClayIcon className="c-mr-2" symbol="plus" />
+							{Liferay.Language.get('new-topic')}
+						</ClayButton>
+					</>
 				)}
-			</ol>
-			{((section &&
-				section.actions &&
-				section.actions['add-subcategory']) ||
-				allowCreateTopicInRootTopic) && (
-				<>
-					<NewTopicModal
-						currentSectionId={section && section.id}
-						onClose={() => setVisible(false)}
-						onCreateNavigateTo={(topic) =>
-							historyPushParser(
-								`/questions/${stringToSlug(topic)}`
-							)
-						}
-						visible={visible}
-					/>
-					<ClayButton
-						className="breadcrumb-button c-ml-3 c-p-2"
-						displayType="unstyled"
-						onClick={() => setVisible(true)}
-					>
-						<ClayIcon className="c-mr-2" symbol="plus" />
-						{Liferay.Language.get('new-topic')}
-					</ClayButton>
-				</>
-			)}
-		</section>
+			</section>
+			<Alert info={error} />
+		</>
 	);
 
 	function AllBreadcrumb() {

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/home/Home.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/home/Home.js
@@ -195,6 +195,7 @@ export default withRouter(({history}) => {
 							historyPushParser(`/tmp`);
 							history.goBack();
 						}}
+						setError={setError}
 						visible={topicModalVisibility}
 					/>
 				</div>

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/utils/utils.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/utils/utils.es.js
@@ -122,27 +122,15 @@ export function normalize(ratingValue) {
 }
 
 export function stringToSlug(text) {
-	const hyphens = /-+/g;
 	const whiteSpaces = /\s+/g;
 
-	text = text.toLowerCase();
-
-	text = text.replace(hyphens, '--');
-
-	text = text.replace(whiteSpaces, '-');
-
-	return text;
+	return text.replace(whiteSpaces, '-').toLowerCase();
 }
 
 export function slugToText(slug) {
-	const encodedHyphens = /--+/g;
-	const hyphens = /(?<!-)-(?!-.)/g;
+	const hyphens = /-+/g;
 
-	slug = slug.replace(hyphens, ' ');
-
-	slug = slug.replace(encodedHyphens, '-').toLowerCase();
-
-	return slug;
+	return slug.replace(hyphens, ' ').toLowerCase();
 }
 
 export function historyPushWithSlug(push) {

--- a/modules/apps/questions/questions-web/test/js/utils/utils.es.js
+++ b/modules/apps/questions/questions-web/test/js/utils/utils.es.js
@@ -21,31 +21,15 @@ describe('utils', () => {
 				'lorem ipsum dolor'
 			);
 		});
-
-		it('return a text with hyphens or spaces depending on the input text format', () => {
-			expect(
-				Utils.slugToText(
-					'Lorem-ipsum-dolor--sit-amet--consectetur-adipiscing--elit'
-				)
-			).toEqual('lorem ipsum dolor-sit amet-consectetur adipiscing-elit');
-		});
 	});
 
 	describe('stringToSlug', () => {
 		it('return a text with hyphens instead of spaces', () => {
-			expect(Utils.stringToSlug('Lorem ipsum dolor')).toEqual(
-				'lorem-ipsum-dolor'
-			);
-		});
-
-		it('return a text with hyphens instead of spaces or double hyphens instead of simple hyphens', () => {
 			expect(
 				Utils.stringToSlug(
-					'lorem ipsum dolor-sit amet-consectetur adipiscing-elit'
+					'lorem ipsum dolor sit amet consectetur adipiscing elit'
 				)
-			).toEqual(
-				'lorem-ipsum-dolor--sit-amet--consectetur-adipiscing--elit'
-			);
+			).toEqual('lorem-ipsum-dolor-sit-amet-consectetur-adipiscing-elit');
 		});
 	});
 });


### PR DESCRIPTION
We found an error about how Questions handle the hyphens. The LPS that we revert works when a user adds a topic with a hyphen in its title which was the bug we wanted to fix. But, the problem comes with the friendlyURL of the questions. That friendlyURLs comes with its hyphens and we use that to generate the complete URL of the question (topic + question friendlyURL). 

When we try to convert the complete URL, Questions adds hyphens to the friendlyURL and get lost.
We do not have a fix for that in the short-term and we will need to rewrite a lot of code (making it more difficult and convoluted) more if we take into account that exists a task to add a friendlyURL for MBCategory (which are the topics of Questions internally) and will solve the problems with the URLs.

So, we consider that right now it is better to assume that a user cannot create a topic with hyphens. Functionality that will be added in the future.