### PR TITLE
LPS-92033 Segments list API improvements

### DIFF
--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/bnd.bnd
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Admin User API
 Bundle-SymbolicName: com.liferay.headless.admin.user.api
-Bundle-Version: 13.7.2
+Bundle-Version: 14.0.0
 Export-Package:\
 	com.liferay.headless.admin.user.dto.v1_0,\
 	com.liferay.headless.admin.user.resource.v1_0

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/Segment.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/Segment.java
@@ -37,7 +37,9 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -92,17 +94,18 @@ public class Segment {
 	protected Boolean active;
 
 	@Schema(description = "The segment's criteria.")
-	public String getCriteria() {
+	@Valid
+	public Object getCriteria() {
 		return criteria;
 	}
 
-	public void setCriteria(String criteria) {
+	public void setCriteria(Object criteria) {
 		this.criteria = criteria;
 	}
 
 	@JsonIgnore
 	public void setCriteria(
-		UnsafeSupplier<String, Exception> criteriaUnsafeSupplier) {
+		UnsafeSupplier<Object, Exception> criteriaUnsafeSupplier) {
 
 		try {
 			criteria = criteriaUnsafeSupplier.get();
@@ -117,8 +120,8 @@ public class Segment {
 
 	@GraphQLField(description = "The segment's criteria.")
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
-	@NotEmpty
-	protected String criteria;
+	@NotNull
+	protected Object criteria;
 
 	@Schema(description = "The segment's creation date.")
 	public Date getDateCreated() {
@@ -332,11 +335,7 @@ public class Segment {
 
 			sb.append("\"criteria\": ");
 
-			sb.append("\"");
-
-			sb.append(_escape(criteria));
-
-			sb.append("\"");
+			sb.append(String.valueOf(criteria));
 		}
 
 		if (dateCreated != null) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/resources/com/liferay/headless/admin/user/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/resources/com/liferay/headless/admin/user/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 5.3.0
+version 6.0.0

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/dto/v1_0/Segment.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/dto/v1_0/Segment.java
@@ -54,16 +54,16 @@ public class Segment implements Cloneable {
 
 	protected Boolean active;
 
-	public String getCriteria() {
+	public Object getCriteria() {
 		return criteria;
 	}
 
-	public void setCriteria(String criteria) {
+	public void setCriteria(Object criteria) {
 		this.criteria = criteria;
 	}
 
 	public void setCriteria(
-		UnsafeSupplier<String, Exception> criteriaUnsafeSupplier) {
+		UnsafeSupplier<Object, Exception> criteriaUnsafeSupplier) {
 
 		try {
 			criteria = criteriaUnsafeSupplier.get();
@@ -73,7 +73,7 @@ public class Segment implements Cloneable {
 		}
 	}
 
-	protected String criteria;
+	protected Object criteria;
 
 	public Date getDateCreated() {
 		return dateCreated;

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/SegmentSerDes.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/SegmentSerDes.java
@@ -268,7 +268,7 @@ public class SegmentSerDes {
 			}
 			else if (Objects.equals(jsonParserFieldName, "criteria")) {
 				if (jsonParserFieldValue != null) {
-					segment.setCriteria((String)jsonParserFieldValue);
+					segment.setCriteria((Object)jsonParserFieldValue);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "dateCreated")) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
@@ -459,7 +459,7 @@ components:
                     description:
                         The segment's criteria.
                     readOnly: true
-                    type: string
+                    type: object
                 dateCreated:
                     description:
                         The segment's creation date.

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/constants/SegmentsSourceConstants.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/constants/SegmentsSourceConstants.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.headless.admin.user.internal.constants;
+
+/**
+ * @author Sarai Díaz
+ */
+public class SegmentsSourceConstants {
+
+	public static final String SOURCE_ASAH_FARO_BACKEND = "Analytics Cloud";
+
+	public static final String SOURCE_DEFAULT = "Liferay";
+
+}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/SegmentResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/SegmentResourceImpl.java
@@ -15,6 +15,7 @@
 package com.liferay.headless.admin.user.internal.resource.v1_0;
 
 import com.liferay.headless.admin.user.dto.v1_0.Segment;
+import com.liferay.headless.admin.user.internal.constants.SegmentsSourceConstants;
 import com.liferay.headless.admin.user.resource.v1_0.SegmentResource;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.UserService;
@@ -23,6 +24,7 @@ import com.liferay.portal.kernel.util.CamelCaseUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.segments.constants.SegmentsEntryConstants;
 import com.liferay.segments.context.Context;
 import com.liferay.segments.model.SegmentsEntry;
 import com.liferay.segments.provider.SegmentsEntryProviderRegistry;
@@ -33,6 +35,7 @@ import java.time.ZonedDateTime;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MultivaluedMap;
@@ -131,14 +134,27 @@ public class SegmentResourceImpl extends BaseSegmentResourceImpl {
 		return new Segment() {
 			{
 				active = segmentsEntry.isActive();
-				criteria = segmentsEntry.getCriteria();
+				criteria = segmentsEntry.getCriteriaObj();
 				dateCreated = segmentsEntry.getCreateDate();
 				dateModified = segmentsEntry.getModifiedDate();
 				id = segmentsEntry.getSegmentsEntryId();
 				name = segmentsEntry.getName(
 					segmentsEntry.getDefaultLanguageId());
 				siteId = segmentsEntry.getGroupId();
-				source = segmentsEntry.getSource();
+
+				setSource(
+					() -> {
+						if (Objects.equals(
+								segmentsEntry.getSource(),
+								SegmentsEntryConstants.
+									SOURCE_ASAH_FARO_BACKEND)) {
+
+							return SegmentsSourceConstants.
+								SOURCE_ASAH_FARO_BACKEND;
+						}
+
+						return SegmentsSourceConstants.SOURCE_DEFAULT;
+					});
 			}
 		};
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSegmentResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSegmentResourceTestCase.java
@@ -181,7 +181,6 @@ public abstract class BaseSegmentResourceTestCase {
 
 		Segment segment = randomSegment();
 
-		segment.setCriteria(regex);
 		segment.setName(regex);
 		segment.setSource(regex);
 
@@ -191,7 +190,6 @@ public abstract class BaseSegmentResourceTestCase {
 
 		segment = SegmentSerDes.toDTO(json);
 
-		Assert.assertEquals(regex, segment.getCriteria());
 		Assert.assertEquals(regex, segment.getName());
 		Assert.assertEquals(regex, segment.getSource());
 	}
@@ -773,11 +771,8 @@ public abstract class BaseSegmentResourceTestCase {
 		}
 
 		if (entityFieldName.equals("criteria")) {
-			sb.append("'");
-			sb.append(String.valueOf(segment.getCriteria()));
-			sb.append("'");
-
-			return sb.toString();
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
 		}
 
 		if (entityFieldName.equals("dateCreated")) {
@@ -913,8 +908,6 @@ public abstract class BaseSegmentResourceTestCase {
 		return new Segment() {
 			{
 				active = RandomTestUtil.randomBoolean();
-				criteria = StringUtil.toLowerCase(
-					RandomTestUtil.randomString());
 				dateCreated = RandomTestUtil.nextDate();
 				dateModified = RandomTestUtil.nextDate();
 				id = RandomTestUtil.randomLong();

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/SegmentResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/SegmentResourceTest.java
@@ -225,7 +225,7 @@ public class SegmentResourceTest extends BaseSegmentResourceTestCase {
 		return _toSegment(
 			SegmentsTestUtil.addSegmentsEntry(
 				segment.getName(), segment.getName(), null,
-				segment.getCriteria(), segment.getSource(),
+				String.valueOf(segment.getCriteria()), segment.getSource(),
 				User.class.getName(), serviceContext));
 	}
 


### PR DESCRIPTION
**Description**

* Ticket: [Improvements in segments list API](https://issues.liferay.com/browse/LPS-92033)

Updated the segments list endpoint form a site to:

* Render `criteria` field in JSON format instead of String: change to `type: object` in `rest-openapi.yaml`
* Not render the internal information in `source` field: DEFAULT = Liferay and ASAH_FARO_BACKEND = Analytics Cloud

The endpoint is:

```
http://localhost:8080/o/headless-admin-user/v1.0/sites/{siteId}/segments
```

**Screenshot**

<img width="1264" alt="Screenshot 2020-10-02 at 12 59 54" src="https://user-images.githubusercontent.com/15845466/94916566-329efc00-04af-11eb-99d1-dc5f0fe7cba4.png">