### PR TITLE
LPS-123283 [Do not backport] Map the content field name property in APIs to fieldReference DDMFormField internal field

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/util/ContentFieldUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/util/ContentFieldUtil.java
@@ -93,7 +93,7 @@ public class ContentFieldUtil {
 				label_i18n = LocalizedMapUtil.getI18nMap(
 					dtoConverterContext.isAcceptAllLanguages(),
 					localizedValue.getValues());
-				name = ddmFormField.getName();
+				name = ddmFormField.getFieldReference();
 				nestedContentFields = TransformUtil.transformToArray(
 					ddmFormFieldValue.getNestedDDMFormFieldValues(),
 					value -> toContentField(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/util/ContentStructureUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/util/ContentStructureUtil.java
@@ -132,7 +132,7 @@ public class ContentStructureUtil {
 					acceptAllLanguage, labelLocalizedValue.getValues());
 				localizable = ddmFormField.isLocalizable();
 				multiple = ddmFormField.isMultiple();
-				name = ddmFormField.getName();
+				name = ddmFormField.getFieldReference();
 				nestedContentStructureFields = TransformUtil.transformToArray(
 					ddmFormField.getNestedDDMFormFields(),
 					ddmFormField -> _toContentStructureField(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/util/DDMFormValuesUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/util/DDMFormValuesUtil.java
@@ -69,7 +69,8 @@ public class DDMFormValuesUtil {
 					_flattenDDMFormFieldValues(
 						rootDDMFormFields,
 						ddmFormField -> _toDDMFormFieldValues(
-							contentFieldMap.get(ddmFormField.getName()),
+							contentFieldMap.get(
+								ddmFormField.getFieldReference()),
 							ddmFormField, dlAppService, groupId,
 							journalArticleService, layoutLocalService,
 							locale)));
@@ -126,12 +127,13 @@ public class DDMFormValuesUtil {
 		return new DDMFormFieldValue() {
 			{
 				setName(ddmFormField.getName());
+				setFieldReference(ddmFormField.getFieldReference());
 				setNestedDDMFormFields(
 					_flattenDDMFormFieldValues(
 						ddmFormField.getNestedDDMFormFields(),
 						field -> _toDDMFormFieldValues(
-							contentFieldMap.get(field.getName()), field,
-							dlAppService, groupId, journalArticleService,
+							contentFieldMap.get(field.getFieldReference()),
+							field, dlAppService, groupId, journalArticleService,
 							layoutLocalService, locale)));
 				setValue(value);
 			}
@@ -148,7 +150,7 @@ public class DDMFormValuesUtil {
 			if (ddmFormField.isRequired()) {
 				throw new BadRequestException(
 					"No value is specified for field " +
-						ddmFormField.getName());
+						ddmFormField.getFieldReference());
 			}
 
 			return Collections.singletonList(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/util/DDMValueUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/util/DDMValueUtil.java
@@ -68,7 +68,8 @@ public class DDMValueUtil {
 
 		if (contentFieldValue == null) {
 			throw new BadRequestException(
-				"No value is specified for field " + ddmFormField.getName());
+				"No value is specified for field " +
+					ddmFormField.getFieldReference());
 		}
 
 		if (ddmFormField.isLocalizable()) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/EntityFieldsProvider.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/EntityFieldsProvider.java
@@ -83,7 +83,7 @@ public class EntityFieldsProvider {
 
 		if (Objects.equals(ddmFormField.getType(), DDMFormFieldType.CHECKBOX)) {
 			return new BooleanEntityField(
-				ddmFormField.getName(),
+				ddmFormField.getFieldReference(),
 				locale -> _toFilterableOrSortableFieldName(
 					ddmStructure.getStructureId(), ddmFormField.getName(),
 					locale, "String"));
@@ -92,7 +92,7 @@ public class EntityFieldsProvider {
 					ddmFormField.getDataType(), FieldConstants.DATE)) {
 
 			return new DateEntityField(
-				ddmFormField.getName(),
+				ddmFormField.getFieldReference(),
 				locale -> _toFilterableOrSortableFieldName(
 					ddmStructure.getStructureId(), ddmFormField.getName(),
 					locale, "String"),
@@ -107,7 +107,7 @@ public class EntityFieldsProvider {
 					 ddmFormField.getDataType(), FieldConstants.NUMBER)) {
 
 			return new DoubleEntityField(
-				ddmFormField.getName(),
+				ddmFormField.getFieldReference(),
 				locale -> _toFilterableOrSortableFieldName(
 					ddmStructure.getStructureId(), ddmFormField.getName(),
 					locale, "Number"));
@@ -118,7 +118,7 @@ public class EntityFieldsProvider {
 					 ddmFormField.getDataType(), FieldConstants.LONG)) {
 
 			return new IntegerEntityField(
-				ddmFormField.getName(),
+				ddmFormField.getFieldReference(),
 				locale -> _toFilterableOrSortableFieldName(
 					ddmStructure.getStructureId(), ddmFormField.getName(),
 					locale, "Number"));
@@ -130,7 +130,7 @@ public class EntityFieldsProvider {
 				  Objects.equals(ddmFormField.getIndexType(), "keyword"))) {
 
 			return new StringEntityField(
-				ddmFormField.getName(),
+				ddmFormField.getFieldReference(),
 				locale -> _toFilterableOrSortableFieldName(
 					ddmStructure.getStructureId(), ddmFormField.getName(),
 					locale, "String"));


### PR DESCRIPTION
This PR should not be backport.

This fix is needed due to changes in the internal fields of DDMFormField after Data Engine integration