### PR TITLE
LPS-101028 Modify service builder POC

### DIFF
--- a/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/Entity.java
+++ b/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/Entity.java
@@ -97,10 +97,10 @@ public class Entity implements Comparable<Entity> {
 	public Entity(ServiceBuilder serviceBuilder, String name) {
 		this(
 			serviceBuilder, null, null, null, name, null, null, null, null,
-			null, null, false, false, false, false, true, true, null, null,
-			null, null, null, true, false, false, false, false, false, null,
-			false, null, null, false, null, null, null, null, null, null, null,
-			null, null, null, false);
+			null, null, false, false, false, null, false, true, true, null,
+			null, null, null, null, true, false, false, false, false, false,
+			null, false, null, null, false, null, null, null, null, null, null,
+			null, null, null, null, false);
 	}
 
 	public Entity(
@@ -109,13 +109,13 @@ public class Entity implements Comparable<Entity> {
 		String variableName, String pluralName, String pluralVariableName,
 		String humanName, String table, String alias, boolean uuid,
 		boolean uuidAccessor, boolean externalReferenceCode,
-		boolean localService, boolean remoteService, boolean persistence,
-		String persistenceClassName, String finderClassName, String dataSource,
-		String sessionFactory, String txManager, boolean cacheEnabled,
-		boolean changeTrackingEnabled, boolean dynamicUpdateEnabled,
-		boolean jsonEnabled, boolean mvccEnabled, boolean trashEnabled,
-		String uadApplicationName, boolean uadAutoDelete, String uadOutputPath,
-		String uadPackagePath, boolean deprecated,
+		String externalReferenceCodeScope, boolean localService,
+		boolean remoteService, boolean persistence, String persistenceClassName,
+		String finderClassName, String dataSource, String sessionFactory,
+		String txManager, boolean cacheEnabled, boolean changeTrackingEnabled,
+		boolean dynamicUpdateEnabled, boolean jsonEnabled, boolean mvccEnabled,
+		boolean trashEnabled, String uadApplicationName, boolean uadAutoDelete,
+		String uadOutputPath, String uadPackagePath, boolean deprecated,
 		List<EntityColumn> pkEntityColumns,
 		List<EntityColumn> regularEntityColumns,
 		List<EntityColumn> blobEntityColumns,
@@ -154,6 +154,7 @@ public class Entity implements Comparable<Entity> {
 		_uuid = uuid;
 		_uuidAccessor = uuidAccessor;
 		_externalReferenceCode = externalReferenceCode;
+		_externalReferenceCodeScope = externalReferenceCodeScope;
 		_localService = localService;
 		_remoteService = remoteService;
 		_persistence = persistence;
@@ -342,6 +343,10 @@ public class Entity implements Comparable<Entity> {
 
 	public EntityOrder getEntityOrder() {
 		return _entityOrder;
+	}
+
+	public String getExternalReferenceCodeScope() {
+		return _externalReferenceCodeScope;
 	}
 
 	public EntityColumn getFilterPKEntityColumn() {
@@ -1309,6 +1314,7 @@ public class Entity implements Comparable<Entity> {
 	private final List<EntityFinder> _entityFinders;
 	private final EntityOrder _entityOrder;
 	private final boolean _externalReferenceCode;
+	private final String _externalReferenceCodeScope;
 	private final String _finderClassName;
 	private final List<EntityColumn> _finderEntityColumns;
 	private final String _humanName;

--- a/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/ServiceBuilder.java
+++ b/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/ServiceBuilder.java
@@ -5980,8 +5980,6 @@ public class ServiceBuilder {
 			entityElement.attributeValue("uuid"));
 		boolean uuidAccessor = GetterUtil.getBoolean(
 			entityElement.attributeValue("uuid-accessor"));
-		boolean externalReferenceCode = GetterUtil.getBoolean(
-			entityElement.attributeValue("external-reference-code"));
 		boolean localService = GetterUtil.getBoolean(
 			entityElement.attributeValue("local-service"));
 		boolean remoteService = GetterUtil.getBoolean(
@@ -5993,6 +5991,16 @@ public class ServiceBuilder {
 			StringBundler.concat(
 				_packagePath, ".service.persistence.impl.", entityName,
 				"PersistenceImpl"));
+
+		boolean externalReferenceCode = false;
+		String externalReferenceCodeScope = GetterUtil.getString(
+			entityElement.attributeValue("external-reference-code"), "false");
+
+		if (!StringUtil.equals(externalReferenceCodeScope, "false")) {
+			externalReferenceCode = true;
+			externalReferenceCodeScope = StringUtil.replace(
+				externalReferenceCodeScope, "true", "company");
+		}
 
 		String finderClassName = "";
 
@@ -6460,18 +6468,23 @@ public class ServiceBuilder {
 			finderElements.add(0, finderElement);
 		}
 
-		if (externalReferenceCode &&
-			entityColumns.contains(new EntityColumn(this, "companyId"))) {
-
+		if (externalReferenceCode) {
 			Element finderElement = DocumentHelper.createElement("finder");
 
-			finderElement.addAttribute("name", "C_ERC");
+			String scopeUpperCase = StringUtil.toUpperCase(
+				externalReferenceCodeScope);
+
+			char scopeId = scopeUpperCase.charAt(0);
+
+			finderElement.addAttribute("name", scopeId + "_ERC");
+
 			finderElement.addAttribute("return-type", entityName);
 
 			Element finderColumnElement = finderElement.addElement(
 				"finder-column");
 
-			finderColumnElement.addAttribute("name", "companyId");
+			finderColumnElement.addAttribute(
+				"name", externalReferenceCodeScope + "Id");
 
 			finderColumnElement = finderElement.addElement("finder-column");
 
@@ -6699,14 +6712,15 @@ public class ServiceBuilder {
 		Entity entity = new Entity(
 			this, _packagePath, _apiPackagePath, _portletShortName, entityName,
 			variableName, pluralName, pluralVariableName, humanName, tableName,
-			alias, uuid, uuidAccessor, externalReferenceCode, localService,
-			remoteService, persistence, persistenceClassName, finderClassName,
-			dataSource, sessionFactory, txManager, cacheEnabled,
-			changeTrackingEnabled, dynamicUpdateEnabled, jsonEnabled,
-			mvccEnabled, trashEnabled, uadApplicationName, uadAutoDelete,
-			uadOutputPath, uadPackagePath, deprecated, pkEntityColumns,
-			regularEntityColumns, blobEntityColumns, collectionEntityColumns,
-			entityColumns, entityOrder, entityFinders, referenceEntities,
+			alias, uuid, uuidAccessor, externalReferenceCode,
+			externalReferenceCodeScope, localService, remoteService,
+			persistence, persistenceClassName, finderClassName, dataSource,
+			sessionFactory, txManager, cacheEnabled, changeTrackingEnabled,
+			dynamicUpdateEnabled, jsonEnabled, mvccEnabled, trashEnabled,
+			uadApplicationName, uadAutoDelete, uadOutputPath, uadPackagePath,
+			deprecated, pkEntityColumns, regularEntityColumns,
+			blobEntityColumns, collectionEntityColumns, entityColumns,
+			entityOrder, entityFinders, referenceEntities,
 			unresolvedReferenceEntityNames, txRequiredMethodNames,
 			resourceActionModel);
 

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/service_base_impl.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/service_base_impl.ftl
@@ -482,11 +482,11 @@ import org.osgi.service.component.annotations.Reference;
 			</#if>
 		</#if>
 
-		<#if entity.hasExternalReferenceCode() && entity.hasEntityColumn("companyId") && !entity.versionEntity??>
+		<#if entity.hasExternalReferenceCode() && !entity.versionEntity??>
 			/**
-			 * Returns the ${entity.humanName} with the matching external reference code and company.
+			 * Returns the ${entity.humanName} with the matching external reference code and ${entity.externalReferenceCodeScope}.
 			 *
-			 * @param companyId the primary key of the company
+			 * @param ${entity.externalReferenceCodeScope}Id the primary key of the ${entity.externalReferenceCodeScope}
 			 * @param externalReferenceCode the ${entity.humanName}'s external reference code
 			 * @return the matching ${entity.humanName}, or <code>null</code> if a matching ${entity.humanName} could not be found
 			<#list serviceBaseExceptions as exception>
@@ -494,8 +494,8 @@ import org.osgi.service.component.annotations.Reference;
 			</#list>
 			 */
 			@Override
-			public ${entity.name} fetch${entity.name}ByReferenceCode(long companyId, String externalReferenceCode) <#if (serviceBaseExceptions?size gt 0)>throws ${stringUtil.merge(serviceBaseExceptions)} </#if>{
-				return ${entity.variableName}Persistence.fetchByC_ERC(companyId, externalReferenceCode);
+			public ${entity.name} fetch${entity.name}ByReferenceCode(long ${entity.externalReferenceCodeScope}Id, String externalReferenceCode) <#if (serviceBaseExceptions?size gt 0)>throws ${stringUtil.merge(serviceBaseExceptions)} </#if>{
+				return ${entity.variableName}Persistence.fetchBy${entity.externalReferenceCodeScope?cap_first[0..0]}_ERC(${entity.externalReferenceCodeScope}Id, externalReferenceCode);
 			}
 		</#if>
 


### PR DESCRIPTION
POC of a possible modification of the Service Builder tool to allow the definition of a external reference code scoped by groupId.

This implementation check if the entity have a groupId column defined, and considering this entity is in consequence scoped by GroupId, add the externalReferenceCode scoped by groupId. Otherwise the externalReferenceCode is scoped by companyId.

Other option would be to allow specifying the scope in the externalReferenceCode attribute value, instead of true or false and considering true the default, that would be companyId, but I found this approach a little messier.

Last two commits only demonstrate the usage and code generated by this solution and should not be consider to be sent in the PR with the final solution