### PR TITLE
LPS-127827 Set a limit to the number of journal articles and journal folders that can be stored

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -353,7 +353,8 @@ public class JournalArticleLocalServiceImpl
 			(journalArticlePersistence.countByCompanyId(user.getCompanyId()) >=
 				PropsValues.DATA_LIMIT_MAX_JOURNAL_ARTICLE_COUNT)) {
 
-			throw new DataLimitException("Exceed maximum allowed articles");
+			throw new DataLimitException(
+				"Unable to exceed maximum number of allowed journal articles");
 		}
 
 		articleId = StringUtil.toUpperCase(StringUtil.trim(articleId));

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -175,6 +175,7 @@ import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.kernel.xml.Node;
 import com.liferay.portal.kernel.xml.SAXReaderUtil;
 import com.liferay.portal.kernel.xml.XPath;
+import com.liferay.portal.util.PropsValues;
 import com.liferay.portal.validation.ModelValidator;
 import com.liferay.portal.validation.ModelValidatorRegistryUtil;
 import com.liferay.social.kernel.model.SocialActivityConstants;
@@ -346,6 +347,14 @@ public class JournalArticleLocalServiceImpl
 		// Article
 
 		User user = userLocalService.getUser(userId);
+
+		if ((PropsValues.DATA_LIMIT_MAX_ARTICLE_COUNT > 0) &&
+			(journalArticlePersistence.countByCompanyId(user.getCompanyId()) >=
+				PropsValues.DATA_LIMIT_MAX_ARTICLE_COUNT)) {
+
+			throw new PortalException("Exceed maximum allowed articles");
+		}
+
 		articleId = StringUtil.toUpperCase(StringUtil.trim(articleId));
 
 		Date displayDate = _portal.getDate(

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -92,6 +92,7 @@ import com.liferay.portal.kernel.dao.orm.QueryDefinition;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
 import com.liferay.portal.kernel.diff.DiffHtmlUtil;
+import com.liferay.portal.kernel.exception.DataLimitException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
@@ -352,7 +353,7 @@ public class JournalArticleLocalServiceImpl
 			(journalArticlePersistence.countByCompanyId(user.getCompanyId()) >=
 				PropsValues.DATA_LIMIT_MAX_JOURNAL_ARTICLE_COUNT)) {
 
-			throw new PortalException("Exceed maximum allowed articles");
+			throw new DataLimitException("Exceed maximum allowed articles");
 		}
 
 		articleId = StringUtil.toUpperCase(StringUtil.trim(articleId));

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -348,9 +348,9 @@ public class JournalArticleLocalServiceImpl
 
 		User user = userLocalService.getUser(userId);
 
-		if ((PropsValues.DATA_LIMIT_MAX_ARTICLE_COUNT > 0) &&
+		if ((PropsValues.DATA_LIMIT_MAX_JOURNAL_ARTICLE_COUNT > 0) &&
 			(journalArticlePersistence.countByCompanyId(user.getCompanyId()) >=
-				PropsValues.DATA_LIMIT_MAX_ARTICLE_COUNT)) {
+				PropsValues.DATA_LIMIT_MAX_JOURNAL_ARTICLE_COUNT)) {
 
 			throw new PortalException("Exceed maximum allowed articles");
 		}

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalFolderLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalFolderLocalServiceImpl.java
@@ -100,9 +100,9 @@ public class JournalFolderLocalServiceImpl
 
 		User user = userLocalService.getUser(userId);
 
-		if ((PropsValues.DATA_LIMIT_MAX_ARTICLE_FOLDER_COUNT > 0) &&
+		if ((PropsValues.DATA_LIMIT_MAX_JOURNAL_FOLDER_COUNT > 0) &&
 			(journalFolderPersistence.countByCompanyId(user.getCompanyId()) >=
-				PropsValues.DATA_LIMIT_MAX_ARTICLE_FOLDER_COUNT)) {
+				PropsValues.DATA_LIMIT_MAX_JOURNAL_FOLDER_COUNT)) {
 
 			throw new PortalException("Exceed maximum allowed article folders");
 		}

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalFolderLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalFolderLocalServiceImpl.java
@@ -106,7 +106,7 @@ public class JournalFolderLocalServiceImpl
 				PropsValues.DATA_LIMIT_MAX_JOURNAL_FOLDER_COUNT)) {
 
 			throw new DataLimitException(
-				"Exceed maximum allowed article folders");
+				"Unable to exceed maximum number of allowed journal folders");
 		}
 
 		parentFolderId = getParentFolderId(groupId, parentFolderId);

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalFolderLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalFolderLocalServiceImpl.java
@@ -100,6 +100,13 @@ public class JournalFolderLocalServiceImpl
 
 		User user = userLocalService.getUser(userId);
 
+		if ((PropsValues.DATA_LIMIT_MAX_ARTICLE_FOLDER_COUNT > 0) &&
+			(journalFolderPersistence.countByCompanyId(user.getCompanyId()) >=
+				PropsValues.DATA_LIMIT_MAX_ARTICLE_FOLDER_COUNT)) {
+
+			throw new PortalException("Exceed maximum allowed article folders");
+		}
+
 		parentFolderId = getParentFolderId(groupId, parentFolderId);
 
 		validateFolder(0, groupId, parentFolderId, name);

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalFolderLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalFolderLocalServiceImpl.java
@@ -33,6 +33,7 @@ import com.liferay.journal.util.JournalValidator;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.dao.orm.QueryDefinition;
+import com.liferay.portal.kernel.exception.DataLimitException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -104,7 +105,8 @@ public class JournalFolderLocalServiceImpl
 			(journalFolderPersistence.countByCompanyId(user.getCompanyId()) >=
 				PropsValues.DATA_LIMIT_MAX_JOURNAL_FOLDER_COUNT)) {
 
-			throw new PortalException("Exceed maximum allowed article folders");
+			throw new DataLimitException(
+				"Exceed maximum allowed article folders");
 		}
 
 		parentFolderId = getParentFolderId(groupId, parentFolderId);

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.backgroundtask.BackgroundTaskManagerUtil;
 import com.liferay.portal.kernel.backgroundtask.constants.BackgroundTaskConstants;
 import com.liferay.portal.kernel.cache.thread.local.ThreadLocalCachable;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.exception.DataLimitException;
 import com.liferay.portal.kernel.exception.DuplicateGroupException;
 import com.liferay.portal.kernel.exception.GroupFriendlyURLException;
 import com.liferay.portal.kernel.exception.GroupInheritContentException;
@@ -258,7 +259,7 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 			(groupPersistence.countByC_S(user.getCompanyId(), site) >=
 				PropsValues.DATA_LIMIT_MAX_SITE_COUNT)) {
 
-			throw new PortalException(
+			throw new DataLimitException(
 				"Unable to exceed maximum number of allowed sites");
 		}
 

--- a/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
@@ -18,6 +18,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryDefinition;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.exception.DataLimitException;
 import com.liferay.portal.kernel.exception.DuplicateOrganizationException;
 import com.liferay.portal.kernel.exception.OrganizationNameException;
 import com.liferay.portal.kernel.exception.OrganizationParentException;
@@ -250,7 +251,7 @@ public class OrganizationLocalServiceImpl
 			(organizationPersistence.countByCompanyId(user.getCompanyId()) >=
 				PropsValues.DATA_LIMIT_MAX_ORGANIZATION_COUNT)) {
 
-			throw new PortalException(
+			throw new DataLimitException(
 				"Unable to exceed maximum number of allowed organizations");
 		}
 

--- a/portal-impl/src/com/liferay/portal/service/impl/RoleLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/RoleLocalServiceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.dao.orm.ProjectionFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
+import com.liferay.portal.kernel.exception.DataLimitException;
 import com.liferay.portal.kernel.exception.DuplicateRoleException;
 import com.liferay.portal.kernel.exception.NoSuchRoleException;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -133,7 +134,7 @@ public class RoleLocalServiceImpl extends RoleLocalServiceBaseImpl {
 			(rolePersistence.countByCompanyId(user.getCompanyId()) >=
 				PropsValues.DATA_LIMIT_MAX_ROLE_COUNT)) {
 
-			throw new PortalException(
+			throw new DataLimitException(
 				"Unable to exceed maximum number of allowed roles");
 		}
 

--- a/portal-impl/src/com/liferay/portal/service/impl/TeamLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/TeamLocalServiceImpl.java
@@ -17,6 +17,7 @@ package com.liferay.portal.service.impl;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.exception.DataLimitException;
 import com.liferay.portal.kernel.exception.DuplicateTeamException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.TeamNameException;
@@ -57,7 +58,7 @@ public class TeamLocalServiceImpl extends TeamLocalServiceBaseImpl {
 			(teamPersistence.countByCompanyId(user.getCompanyId()) >=
 				PropsValues.DATA_LIMIT_MAX_TEAM_COUNT)) {
 
-			throw new PortalException(
+			throw new DataLimitException(
 				"Unable to exceed maximum number of allowed teams");
 		}
 

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.dao.orm.WildcardMode;
 import com.liferay.portal.kernel.exception.CompanyMaxUsersException;
 import com.liferay.portal.kernel.exception.ContactBirthdayException;
 import com.liferay.portal.kernel.exception.ContactNameException;
+import com.liferay.portal.kernel.exception.DataLimitException;
 import com.liferay.portal.kernel.exception.DuplicateGoogleUserIdException;
 import com.liferay.portal.kernel.exception.DuplicateOpenIdException;
 import com.liferay.portal.kernel.exception.ModelListenerException;
@@ -1009,7 +1010,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 			(userPersistence.countByCompanyId(companyId) >=
 				PropsValues.DATA_LIMIT_MAX_USER_COUNT)) {
 
-			throw new PortalException(
+			throw new DataLimitException(
 				"Unable to exceed maximum number of allowed users");
 		}
 

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -622,6 +622,10 @@ public class PropsValues {
 	public static final long DATA_LIMIT_MAX_ARTICLE_COUNT = GetterUtil.getLong(
 		PropsUtil.get(PropsKeys.DATA_LIMIT_MAX_ARTICLE_COUNT));
 
+	public static final long DATA_LIMIT_MAX_ARTICLE_FOLDER_COUNT =
+		GetterUtil.getLong(
+			PropsUtil.get(PropsKeys.DATA_LIMIT_MAX_ARTICLE_FOLDER_COUNT));
+
 	public static final long DATA_LIMIT_MAX_DL_STORAGE_SIZE =
 		GetterUtil.getLong(
 			PropsUtil.get(PropsKeys.DATA_LIMIT_MAX_DL_STORAGE_SIZE));

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -619,16 +619,17 @@ public class PropsValues {
 	public static final String CUSTOM_SQL_FUNCTION_ISNULL = PropsUtil.get(
 		PropsKeys.CUSTOM_SQL_FUNCTION_ISNULL);
 
-	public static final long DATA_LIMIT_MAX_ARTICLE_COUNT = GetterUtil.getLong(
-		PropsUtil.get(PropsKeys.DATA_LIMIT_MAX_ARTICLE_COUNT));
-
-	public static final long DATA_LIMIT_MAX_ARTICLE_FOLDER_COUNT =
-		GetterUtil.getLong(
-			PropsUtil.get(PropsKeys.DATA_LIMIT_MAX_ARTICLE_FOLDER_COUNT));
-
 	public static final long DATA_LIMIT_MAX_DL_STORAGE_SIZE =
 		GetterUtil.getLong(
 			PropsUtil.get(PropsKeys.DATA_LIMIT_MAX_DL_STORAGE_SIZE));
+
+	public static final long DATA_LIMIT_MAX_JOURNAL_ARTICLE_COUNT =
+		GetterUtil.getLong(
+			PropsUtil.get(PropsKeys.DATA_LIMIT_MAX_JOURNAL_ARTICLE_COUNT));
+
+	public static final long DATA_LIMIT_MAX_JOURNAL_FOLDER_COUNT =
+		GetterUtil.getLong(
+			PropsUtil.get(PropsKeys.DATA_LIMIT_MAX_JOURNAL_FOLDER_COUNT));
 
 	public static final long DATA_LIMIT_MAX_ORGANIZATION_COUNT =
 		GetterUtil.getLong(

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -619,6 +619,9 @@ public class PropsValues {
 	public static final String CUSTOM_SQL_FUNCTION_ISNULL = PropsUtil.get(
 		PropsKeys.CUSTOM_SQL_FUNCTION_ISNULL);
 
+	public static final long DATA_LIMIT_MAX_ARTICLE_COUNT = GetterUtil.getLong(
+		PropsUtil.get(PropsKeys.DATA_LIMIT_MAX_ARTICLE_COUNT));
+
 	public static final long DATA_LIMIT_MAX_DL_STORAGE_SIZE =
 		GetterUtil.getLong(
 			PropsUtil.get(PropsKeys.DATA_LIMIT_MAX_DL_STORAGE_SIZE));

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -1480,6 +1480,14 @@
 ##
 
     #
+    # Set the maximum allowed articles per company. Set this to 0 or a negative
+    # value to disable this limit.
+    #
+    # Env: LIFERAY_DATA_PERIOD_LIMIT_PERIOD_MAX_PERIOD_ARTICLE_PERIOD_COUNT
+    #
+    data.limit.max.article.count=0
+
+    #
     # Set the maximum allowed document library storage size per company. Set
     # this to 0 or a negative value to disable this limit.
     #

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -1480,28 +1480,28 @@
 ##
 
     #
-    # Set the maximum allowed articles per company. Set this to 0 or a negative
-    # value to disable this limit.
-    #
-    # Env: LIFERAY_DATA_PERIOD_LIMIT_PERIOD_MAX_PERIOD_ARTICLE_PERIOD_COUNT
-    #
-    data.limit.max.article.count=0
-
-    #
-    # Set the maximum allowed article folders per company. Set this to 0 or a
-    # negative value to disable this limit.
-    #
-    # Env: LIFERAY_DATA_PERIOD_LIMIT_PERIOD_MAX_PERIOD_ARTICLE_PERIOD_FOLDER_PERIOD_COUNT
-    #
-    data.limit.max.article.folder.count=0
-
-    #
     # Set the maximum allowed document library storage size per company. Set
     # this to 0 or a negative value to disable this limit.
     #
     # Env: LIFERAY_DATA_PERIOD_LIMIT_PERIOD_MAX_PERIOD_DL_PERIOD_STORAGE_PERIOD_SIZE
     #
     data.limit.max.dl.storage.size=0
+
+    #
+    # Set the maximum allowed journal articles per company. Set this to 0 or a
+    # negative value to disable this limit.
+    #
+    # Env: LIFERAY_DATA_PERIOD_LIMIT_PERIOD_MAX_PERIOD_JOURNAL_PERIOD_ARTICLE_PERIOD_COUNT
+    #
+    data.limit.max.journal.article.count=0
+
+    #
+    # Set the maximum allowed journal folders per company. Set this to 0 or a
+    # negative value to disable this limit.
+    #
+    # Env: LIFERAY_DATA_PERIOD_LIMIT_PERIOD_MAX_PERIOD_JOURNAL_PERIOD_FOLDER_PERIOD_COUNT
+    #
+    data.limit.max.journal.folder.count=0
 
     #
     # Set the maximum allowed mail messages per company within a period. Set

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -1488,6 +1488,14 @@
     data.limit.max.article.count=0
 
     #
+    # Set the maximum allowed article folders per company. Set this to 0 or a
+    # negative value to disable this limit.
+    #
+    # Env: LIFERAY_DATA_PERIOD_LIMIT_PERIOD_MAX_PERIOD_ARTICLE_PERIOD_FOLDER_PERIOD_COUNT
+    #
+    data.limit.max.article.folder.count=0
+
+    #
     # Set the maximum allowed document library storage size per company. Set
     # this to 0 or a negative value to disable this limit.
     #

--- a/portal-kernel/src/com/liferay/portal/kernel/exception/DataLimitException.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/exception/DataLimitException.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.exception;
+
+/**
+ * @author Javier de Arcos
+ */
+public class DataLimitException extends PortalException {
+
+	public DataLimitException() {
+	}
+
+	public DataLimitException(String msg) {
+		super(msg);
+	}
+
+	public DataLimitException(String msg, Throwable throwable) {
+		super(msg, throwable);
+	}
+
+	public DataLimitException(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -658,6 +658,9 @@ public interface PropsKeys {
 	public static final String CUSTOM_SQL_FUNCTION_ISNULL =
 		"custom.sql.function.isnull";
 
+	public static final String DATA_LIMIT_MAX_ARTICLE_COUNT =
+		"data.limit.max.article.count";
+
 	public static final String DATA_LIMIT_MAX_DL_STORAGE_SIZE =
 		"data.limit.max.dl.storage.size";
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -661,6 +661,9 @@ public interface PropsKeys {
 	public static final String DATA_LIMIT_MAX_ARTICLE_COUNT =
 		"data.limit.max.article.count";
 
+	public static final String DATA_LIMIT_MAX_ARTICLE_FOLDER_COUNT =
+		"data.limit.max.article.folder.count";
+
 	public static final String DATA_LIMIT_MAX_DL_STORAGE_SIZE =
 		"data.limit.max.dl.storage.size";
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -658,14 +658,14 @@ public interface PropsKeys {
 	public static final String CUSTOM_SQL_FUNCTION_ISNULL =
 		"custom.sql.function.isnull";
 
-	public static final String DATA_LIMIT_MAX_ARTICLE_COUNT =
-		"data.limit.max.article.count";
-
-	public static final String DATA_LIMIT_MAX_ARTICLE_FOLDER_COUNT =
-		"data.limit.max.article.folder.count";
-
 	public static final String DATA_LIMIT_MAX_DL_STORAGE_SIZE =
 		"data.limit.max.dl.storage.size";
+
+	public static final String DATA_LIMIT_MAX_JOURNAL_ARTICLE_COUNT =
+		"data.limit.max.journal.article.count";
+
+	public static final String DATA_LIMIT_MAX_JOURNAL_FOLDER_COUNT =
+		"data.limit.max.journal.folder.count";
 
 	public static final String DATA_LIMIT_MAX_MAIL_MESSAGE_COUNT =
 		"data.limit.max.mail.message.count";


### PR DESCRIPTION
Add specific exception DataLimitException and use it where it fits.

Updated the journal article and journal folder DataLimitException messages to match pattern:
`Unable to exceed maximum number of allowed {entity}`