### PR TITLE
LPS-92033 Segments list API improvements

### DIFF
--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/Segment.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/Segment.java
@@ -39,6 +39,7 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotEmpty;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -121,6 +122,36 @@ public class Segment implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	@NotEmpty
 	protected String criteria;
+
+	@Schema(description = "The segment's criteria in a JSONObject.")
+	@Valid
+	public Map<String, Object> getCriteriaValue() {
+		return criteriaValue;
+	}
+
+	public void setCriteriaValue(Map<String, Object> criteriaValue) {
+		this.criteriaValue = criteriaValue;
+	}
+
+	@JsonIgnore
+	public void setCriteriaValue(
+		UnsafeSupplier<Map<String, Object>, Exception>
+			criteriaValueUnsafeSupplier) {
+
+		try {
+			criteriaValue = criteriaValueUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(description = "The segment's criteria in a JSONObject.")
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Map<String, Object> criteriaValue;
 
 	@Schema(description = "The segment's creation date.")
 	public Date getDateCreated() {
@@ -339,6 +370,16 @@ public class Segment implements Serializable {
 			sb.append(_escape(criteria));
 
 			sb.append("\"");
+		}
+
+		if (criteriaValue != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"criteriaValue\": ");
+
+			sb.append(_toJSON(criteriaValue));
 		}
 
 		if (dateCreated != null) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/resources/com/liferay/headless/admin/user/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/resources/com/liferay/headless/admin/user/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 5.4.0
+version 5.5.0

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/dto/v1_0/Segment.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/dto/v1_0/Segment.java
@@ -20,6 +20,7 @@ import com.liferay.headless.admin.user.client.serdes.v1_0.SegmentSerDes;
 import java.io.Serializable;
 
 import java.util.Date;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -76,6 +77,28 @@ public class Segment implements Cloneable, Serializable {
 	}
 
 	protected String criteria;
+
+	public Map<String, Object> getCriteriaValue() {
+		return criteriaValue;
+	}
+
+	public void setCriteriaValue(Map<String, Object> criteriaValue) {
+		this.criteriaValue = criteriaValue;
+	}
+
+	public void setCriteriaValue(
+		UnsafeSupplier<Map<String, Object>, Exception>
+			criteriaValueUnsafeSupplier) {
+
+		try {
+			criteriaValue = criteriaValueUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Map<String, Object> criteriaValue;
 
 	public Date getDateCreated() {
 		return dateCreated;

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/SegmentSerDes.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/SegmentSerDes.java
@@ -83,6 +83,16 @@ public class SegmentSerDes {
 			sb.append("\"");
 		}
 
+		if (segment.getCriteriaValue() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"criteriaValue\": ");
+
+			sb.append(_toJSON(segment.getCriteriaValue()));
+		}
+
 		if (segment.getDateCreated() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -195,6 +205,14 @@ public class SegmentSerDes {
 			map.put("criteria", String.valueOf(segment.getCriteria()));
 		}
 
+		if (segment.getCriteriaValue() == null) {
+			map.put("criteriaValue", null);
+		}
+		else {
+			map.put(
+				"criteriaValue", String.valueOf(segment.getCriteriaValue()));
+		}
+
 		if (segment.getDateCreated() == null) {
 			map.put("dateCreated", null);
 		}
@@ -269,6 +287,12 @@ public class SegmentSerDes {
 			else if (Objects.equals(jsonParserFieldName, "criteria")) {
 				if (jsonParserFieldValue != null) {
 					segment.setCriteria((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "criteriaValue")) {
+				if (jsonParserFieldValue != null) {
+					segment.setCriteriaValue(
+						(Map)SegmentSerDes.toMap((String)jsonParserFieldValue));
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "dateCreated")) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
@@ -460,6 +460,13 @@ components:
                         The segment's criteria.
                     readOnly: true
                     type: string
+                criteriaValue:
+                    additionalProperties:
+                        type: object
+                    description:
+                        The segment's criteria in a JSONObject.
+                    readOnly: true
+                    type: object
                 dateCreated:
                     description:
                         The segment's creation date.

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/constants/SegmentsSourceConstants.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/constants/SegmentsSourceConstants.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.headless.admin.user.internal.constants;
+
+/**
+ * @author Sarai Díaz
+ */
+public class SegmentsSourceConstants {
+
+	public static final String SOURCE_ASAH_FARO_BACKEND = "Analytics Cloud";
+
+	public static final String SOURCE_DEFAULT = "Liferay";
+
+	public static final String SOURCE_REFERRED = "Liferay (Compound)";
+
+}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/SegmentDTOConverter.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/SegmentDTOConverter.java
@@ -16,10 +16,18 @@ package com.liferay.headless.admin.user.internal.dto.v1_0.converter;
 
 import com.liferay.headless.admin.user.dto.v1_0.Segment;
 import com.liferay.headless.admin.user.internal.constants.SegmentsSourceConstants;
+import com.liferay.portal.kernel.json.JSONException;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.segments.constants.SegmentsEntryConstants;
 import com.liferay.segments.model.SegmentsEntry;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -43,13 +51,43 @@ public class SegmentDTOConverter
 		return new Segment() {
 			{
 				active = segmentsEntry.isActive();
-				criteria = segmentsEntry.getCriteria();
 				dateCreated = segmentsEntry.getCreateDate();
 				dateModified = segmentsEntry.getModifiedDate();
 				id = segmentsEntry.getSegmentsEntryId();
 				name = segmentsEntry.getName(
 					segmentsEntry.getDefaultLanguageId());
 				siteId = segmentsEntry.getGroupId();
+
+				setCriteria(
+					() -> {
+						String criteria = segmentsEntry.getCriteria();
+
+						if (!criteria.isEmpty()) {
+							return segmentsEntry.getCriteria();
+						}
+
+						return null;
+					});
+
+				setCriteriaValue(
+					() -> {
+						String criteria = segmentsEntry.getCriteria();
+
+						if (!criteria.isEmpty()) {
+							try {
+								return _toMap(
+									JSONFactoryUtil.createJSONObject(
+										segmentsEntry.getCriteria()));
+							}
+							catch (JSONException jsonException) {
+								if (_log.isWarnEnabled()) {
+									_log.warn(jsonException, jsonException);
+								}
+							}
+						}
+
+						return null;
+					});
 
 				setSource(
 					() -> {
@@ -73,5 +111,23 @@ public class SegmentDTOConverter
 			}
 		};
 	}
+
+	private Map<String, Object> _toMap(JSONObject jsonObject) {
+		Map<String, Object> map = new HashMap<>();
+
+		for (String key : jsonObject.keySet()) {
+			if (jsonObject.getJSONObject(key) != null) {
+				map.put(key, _toMap(jsonObject.getJSONObject(key)));
+			}
+			else {
+				map.put(key, jsonObject.get(key));
+			}
+		}
+
+		return map;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		SegmentDTOConverter.class);
 
 }

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/SegmentDTOConverter.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/SegmentDTOConverter.java
@@ -15,7 +15,10 @@
 package com.liferay.headless.admin.user.internal.dto.v1_0.converter;
 
 import com.liferay.headless.admin.user.dto.v1_0.Segment;
+import com.liferay.headless.admin.user.internal.constants.SegmentsSourceConstants;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
+import com.liferay.segments.constants.SegmentsEntryConstants;
 import com.liferay.segments.model.SegmentsEntry;
 
 import org.osgi.service.component.annotations.Component;
@@ -47,7 +50,26 @@ public class SegmentDTOConverter
 				name = segmentsEntry.getName(
 					segmentsEntry.getDefaultLanguageId());
 				siteId = segmentsEntry.getGroupId();
-				source = segmentsEntry.getSource();
+
+				setSource(
+					() -> {
+						if (StringUtil.equals(
+								segmentsEntry.getSource(),
+								SegmentsEntryConstants.
+									SOURCE_ASAH_FARO_BACKEND)) {
+
+							return SegmentsSourceConstants.
+								SOURCE_ASAH_FARO_BACKEND;
+						}
+						else if (StringUtil.equals(
+									segmentsEntry.getSource(),
+									SegmentsEntryConstants.SOURCE_REFERRED)) {
+
+							return SegmentsSourceConstants.SOURCE_REFERRED;
+						}
+
+						return SegmentsSourceConstants.SOURCE_DEFAULT;
+					});
 			}
 		};
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSegmentResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSegmentResourceTestCase.java
@@ -503,6 +503,14 @@ public abstract class BaseSegmentResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("criteriaValue", additionalAssertFieldName)) {
+				if (segment.getCriteriaValue() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("name", additionalAssertFieldName)) {
 				if (segment.getName() == null) {
 					valid = false;
@@ -627,6 +635,17 @@ public abstract class BaseSegmentResourceTestCase {
 			if (Objects.equals("criteria", additionalAssertFieldName)) {
 				if (!Objects.deepEquals(
 						segment1.getCriteria(), segment2.getCriteria())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("criteriaValue", additionalAssertFieldName)) {
+				if (!equals(
+						(Map)segment1.getCriteriaValue(),
+						(Map)segment2.getCriteriaValue())) {
 
 					return false;
 				}
@@ -778,6 +797,11 @@ public abstract class BaseSegmentResourceTestCase {
 			sb.append("'");
 
 			return sb.toString();
+		}
+
+		if (entityFieldName.equals("criteriaValue")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
 		}
 
 		if (entityFieldName.equals("dateCreated")) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/Segment.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/Segment.java
@@ -20,6 +20,7 @@ import com.liferay.headless.delivery.client.serdes.v1_0.SegmentSerDes;
 import java.io.Serializable;
 
 import java.util.Date;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -76,6 +77,28 @@ public class Segment implements Cloneable, Serializable {
 	}
 
 	protected String criteria;
+
+	public Map<String, Object> getCriteriaValue() {
+		return criteriaValue;
+	}
+
+	public void setCriteriaValue(Map<String, Object> criteriaValue) {
+		this.criteriaValue = criteriaValue;
+	}
+
+	public void setCriteriaValue(
+		UnsafeSupplier<Map<String, Object>, Exception>
+			criteriaValueUnsafeSupplier) {
+
+		try {
+			criteriaValue = criteriaValueUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Map<String, Object> criteriaValue;
 
 	public Date getDateCreated() {
 		return dateCreated;

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/SegmentSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/SegmentSerDes.java
@@ -83,6 +83,16 @@ public class SegmentSerDes {
 			sb.append("\"");
 		}
 
+		if (segment.getCriteriaValue() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"criteriaValue\": ");
+
+			sb.append(_toJSON(segment.getCriteriaValue()));
+		}
+
 		if (segment.getDateCreated() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -195,6 +205,14 @@ public class SegmentSerDes {
 			map.put("criteria", String.valueOf(segment.getCriteria()));
 		}
 
+		if (segment.getCriteriaValue() == null) {
+			map.put("criteriaValue", null);
+		}
+		else {
+			map.put(
+				"criteriaValue", String.valueOf(segment.getCriteriaValue()));
+		}
+
 		if (segment.getDateCreated() == null) {
 			map.put("dateCreated", null);
 		}
@@ -269,6 +287,12 @@ public class SegmentSerDes {
 			else if (Objects.equals(jsonParserFieldName, "criteria")) {
 				if (jsonParserFieldValue != null) {
 					segment.setCriteria((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "criteriaValue")) {
+				if (jsonParserFieldValue != null) {
+					segment.setCriteriaValue(
+						(Map)SegmentSerDes.toMap((String)jsonParserFieldValue));
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "dateCreated")) {


### PR DESCRIPTION
**Description**

* Ticket: [Improvements in segments list API](https://issues.liferay.com/browse/LPS-92033)

Updated the segments list endpoint form a site to:

* Render `criteria` field in JSON format instead of String: change to `type: object` in `rest-openapi.yaml`
* Not render the internal information in `source` field: 
   - SOURCE_ASAH_FARO_BACKEND = Analytics Cloud
   - SOURCE_DEFAULT = Liferay
   - SOURCE_REFERRED = Liferay (Compound) 

The endpoint is:

```
http://localhost:8080/o/headless-admin-user/v1.0/sites/{siteId}/segments
```

**Screenshot**

<img width="1264" alt="Screenshot 2020-10-02 at 12 59 54" src="https://user-images.githubusercontent.com/15845466/94916566-329efc00-04af-11eb-99d1-dc5f0fe7cba4.png">