### PR TITLE
[TS] LPS-129055 (Additional Commits)

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/model/KBArticle.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/model/KBArticle.java
@@ -56,6 +56,9 @@ public interface KBArticle extends KBArticleModel, PersistedModel {
 
 		};
 
+	/**
+	 * @see com.liferay.portal.model.impl.OrganizationBaseImpl#buildTreePath()
+	 */
 	public String buildTreePath()
 		throws com.liferay.portal.kernel.exception.PortalException;
 

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/model/KBArticleWrapper.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/model/KBArticleWrapper.java
@@ -256,6 +256,9 @@ public class KBArticleWrapper
 		}
 	}
 
+	/**
+	 * @see com.liferay.portal.model.impl.OrganizationBaseImpl#buildTreePath()
+	 */
 	@Override
 	public String buildTreePath()
 		throws com.liferay.portal.kernel.exception.PortalException {

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/model/impl/KBArticleImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/model/impl/KBArticleImpl.java
@@ -52,6 +52,9 @@ public class KBArticleImpl extends KBArticleBaseImpl {
 	public KBArticleImpl() {
 	}
 
+	/**
+	 * @see com.liferay.portal.model.impl.OrganizationBaseImpl#buildTreePath()
+	 */
 	@Override
 	public String buildTreePath() throws PortalException {
 		List<KBFolder> folders = new ArrayList<>();

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleLocalServiceImpl.java
@@ -974,7 +974,7 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 			curKBArticle.setKbFolderId(kbFolderId);
 			curKBArticle.setPriority(priority);
 
-			kbArticlePersistence.update(curKBArticle);
+			kbArticleLocalService.updateKBArticle(curKBArticle);
 		}
 
 		if (kbArticle.getKbFolderId() != kbFolderId) {
@@ -990,7 +990,7 @@ public class KBArticleLocalServiceImpl extends KBArticleLocalServiceBaseImpl {
 				for (KBArticle kbArticleVersion : kbArticleVersions) {
 					kbArticleVersion.setKbFolderId(kbFolderId);
 
-					kbArticlePersistence.update(kbArticleVersion);
+					kbArticleLocalService.updateKBArticle(kbArticleVersion);
 				}
 			}
 		}


### PR DESCRIPTION
Follow-up for https://github.com/liferay-headless/liferay-portal/pull/651

From @Jesseyeh-liferay:

> Original pull request: #286
> 
> This is an update to [LPS-129055](https://issues.liferay.com/browse/LPS-129055) which:
> 1. Reindexes the KBArticles after they are moved to rebuild their treePaths
> 1. Adds a documentation link to the referenced implementation for `buildTreePath()`
