### PR TITLE
LPS-130131 Fix ClassCastException using batch export in API resources

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/batch/engine/VulcanBatchEngineTaskItemDelegateAdaptor.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/batch/engine/VulcanBatchEngineTaskItemDelegateAdaptor.java
@@ -150,16 +150,14 @@ public class VulcanBatchEngineTaskItemDelegateAdaptor<T>
 			if (key.equals("assetLibraryId") && (value != null)) {
 				parameters.put(
 					key,
-					String.valueOf(
-						siteParamConverterProvider.getDepotGroupId(
-							String.valueOf(value), _company.getCompanyId())));
+					siteParamConverterProvider.getDepotGroupId(
+						String.valueOf(value), _company.getCompanyId()));
 			}
 			else if (key.equals("siteId") && (value != null)) {
 				parameters.put(
 					key,
-					String.valueOf(
-						siteParamConverterProvider.getGroupId(
-							_company.getCompanyId(), String.valueOf(value))));
+					siteParamConverterProvider.getGroupId(
+						_company.getCompanyId(), String.valueOf(value)));
 			}
 		}
 


### PR DESCRIPTION
Inside the Resources that implements VulcanBatchEngineTaskItemDelegate, the siteId parameter is cast to Long but in the map is passed as a String. Change it to pass it directly as a Long inside the parameters map