### PR TITLE
LPS-142229 Add contextPath to handle custom context

### DIFF
--- a/modules/apps/headless/headless-discovery/headless-discovery-impl/src/main/java/com/liferay/headless/discovery/internal/jaxrs/application/HeadlessDiscoveryAPIApplication.java
+++ b/modules/apps/headless/headless-discovery/headless-discovery-impl/src/main/java/com/liferay/headless/discovery/internal/jaxrs/application/HeadlessDiscoveryAPIApplication.java
@@ -22,6 +22,7 @@ import com.liferay.headless.discovery.internal.dto.Resource;
 import com.liferay.headless.discovery.internal.dto.Resources;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.security.auth.AuthTokenUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 
 import java.io.ByteArrayInputStream;
@@ -110,10 +111,12 @@ public class HeadlessDiscoveryAPIApplication extends Application {
 				AuthTokenUtil.getToken(httpServletRequest));
 
 			html = StringUtil.replace(
-				html, "href=\"main.css\"", "href=\"/o/api/main.css\"");
+				html, "href=\"main.css\"",
+				"href=\"" + _portal.getPathContext() + "/o/api/main.css\"");
 			html = StringUtil.replace(
 				html, "src=\"headless-discovery-web-min.js\"",
-				"src=\"/o/api/headless-discovery-web-min.js\"");
+				"src=\"" + _portal.getPathContext() +
+					"/o/api/headless-discovery-web-min.js\"");
 
 			String finalHtml = html;
 
@@ -311,6 +314,9 @@ public class HeadlessDiscoveryAPIApplication extends Application {
 
 	@Reference
 	private JaxrsServiceRuntime _jaxrsServiceRuntime;
+
+	@Reference
+	private Portal _portal;
 
 	@Context
 	private UriInfo _uriInfo;

--- a/modules/apps/headless/headless-discovery/headless-discovery-web/src/js/APIGUI.js
+++ b/modules/apps/headless/headless-discovery/headless-discovery-web/src/js/APIGUI.js
@@ -26,6 +26,10 @@ import apiFetch from './util/apiFetch';
 import 'graphiql/graphiql.css';
 
 const APIGUI = () => {
+	const contextPath = window.location.pathname.substring(
+		0,
+		window.location.pathname.indexOf('/o/')
+	);
 	const urlParams = new URLSearchParams(window.location.search);
 
 	const [active, setActive] = useState(false);
@@ -46,25 +50,25 @@ const APIGUI = () => {
 	};
 
 	useEffect(() => {
-		apiFetch('/o/openapi', 'get', {}).then((response) => {
+		apiFetch(contextPath + '/o/openapi', 'get', {}).then((response) => {
 			setEndpoints(
 				Object.keys(response)
 					.flatMap((key) => response[key])
 					.map((url) => url.replace('openapi.yaml', 'openapi.json'))
 			);
 		});
-	}, []);
+	}, [contextPath]);
 
 	const graphQLFetcher = useCallback(
 		(graphQLParams) =>
 			apiFetch(
-				'/o/graphql',
+				contextPath + '/o/graphql',
 				'post',
 				graphQLParams,
 				'application/json',
 				headers
 			),
-		[headers]
+		[contextPath, headers]
 	);
 
 	const requestInterceptor = (req) => {

--- a/modules/apps/headless/headless-discovery/headless-discovery-web/src/js/Icon.js
+++ b/modules/apps/headless/headless-discovery/headless-discovery-web/src/js/Icon.js
@@ -15,10 +15,16 @@
 import ClayIcon from '@clayui/icon';
 import React from 'react';
 
+const contextPath = window.location.pathname.substring(
+	0,
+	window.location.pathname.indexOf('/o/')
+);
+
 export const spritemap =
 	window.location.protocol +
 	'//' +
 	window.location.host +
+	contextPath +
 	'/o/classic-theme/images/clay/icons.svg';
 
 const Icon = (props) => {


### PR DESCRIPTION
Hi Team,

could you please review my changes?

**Reproduction steps**

1. Change the ROOT folder name (under {LIFERAY_HOME}/tomcat-9.0.17/webapps/ROOT) to 'myportal'.
2. Change the ROOT.xml file name (under {LIFERAY_HOME}
/tomcat-9.0.17/conf/Catalina/localhost/) to 'myportal.xml'.
3. Clear temp and work directories under TOMCAT_HOME.
4. Start the server and log in as admin
5. Try to access: http://localhost:8080/myportal/o/api page

**Expected behaviour:** You should see the REST API test page
**Acutal behaviour:** You will have HTTP 404 errors

**Root cause**
Missing context path from the Urls

**Solution**
Add contextPath to handle custom context

Thanks, Roland

https://issues.liferay.com/browse/LPS-142229