### PR TITLE
LPS-153326 Allow developers to make a relationship with a system object through API

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseRelatedObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseRelatedObjectEntryResourceImpl.java
@@ -26,6 +26,7 @@ import io.swagger.v3.oas.annotations.tags.Tags;
 import javax.validation.constraints.NotNull;
 
 import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -64,6 +65,24 @@ public class BaseRelatedObjectEntryResourceImpl {
 		throws Exception {
 
 		return null;
+	}
+
+	@Path(
+		"/{previousPath: [a-zA-Z0-9-]+}/{objectEntryId: \\d+}/{objectRelationshipName: [a-zA-Z0-9-]+}/{relatedObjectEntryId}"
+	)
+	@Produces({"application/json", "application/xml"})
+	@PUT
+	public void putObjectRelationshipMappingTableValues(
+			@NotNull @Parameter(hidden = true) @PathParam("previousPath") String
+				previousPath,
+			@NotNull @Parameter(hidden = true) @PathParam("objectEntryId") Long
+				objectEntryId,
+			@NotNull @Parameter(hidden = true)
+			@PathParam("objectRelationshipName")
+			String objectRelationshipName,
+			@PathParam("relatedObjectEntryId") Long relatedObjectEntryId,
+			@Context Pagination pagination)
+		throws Exception {
 	}
 
 }

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/RelatedObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/RelatedObjectEntryResourceImpl.java
@@ -85,6 +85,28 @@ public class RelatedObjectEntryResourceImpl
 			pagination);
 	}
 
+	@Override
+	public void putObjectRelationshipMappingTableValues(
+			String previousPath, Long objectEntryId,
+			String objectRelationshipName, Long relatedObjectEntryId,
+			Pagination pagination)
+		throws Exception {
+
+		ObjectDefinition currentObjectDefinition = _getCurrentObjectDefinition(
+			objectEntryId, _getObjectRelationship(objectRelationshipName),
+			_uriInfo);
+
+		ObjectEntryManager objectEntryManager =
+			_objectEntryManagerTracker.getObjectEntryManager(
+				currentObjectDefinition.getStorageType());
+
+		objectEntryManager.addObjectRelationshipMappingTableValues(
+			_getDefaultDTOConverterContext(
+				currentObjectDefinition, objectEntryId, _uriInfo),
+			currentObjectDefinition, objectRelationshipName, objectEntryId,
+			relatedObjectEntryId);
+	}
+
 	private ObjectDefinition _getCurrentObjectDefinition(
 			long objectEntryId, ObjectRelationship objectRelationship,
 			UriInfo uriInfo)

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/openapi/contributor/RelatedObjectEntryOpenAPIContributor.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/openapi/contributor/RelatedObjectEntryOpenAPIContributor.java
@@ -198,42 +198,6 @@ public class RelatedObjectEntryOpenAPIContributor
 		return dtoConverter.getContentType();
 	}
 
-	private String _getIdParameterName(String name) {
-		return StringUtil.lowerCaseFirstLetter(name) + "Id";
-	}
-
-	private String _getIdParameterTemplate(String name) {
-		return StringPool.OPEN_CURLY_BRACE + _getIdParameterName(name) +
-			StringPool.CLOSE_CURLY_BRACE;
-	}
-
-	private String _getJaxRsVersion(UriInfo uriInfo) {
-		String path = uriInfo.getPath();
-
-		return path.split(StringPool.SLASH)[0];
-	}
-
-	private String _getObjectDefinitionPathName(
-		ObjectDefinition objectDefinition) {
-
-		return _getIdParameterTemplate(objectDefinition.getShortName());
-	}
-
-	private Schema _getObjectDefinitionSchema(ObjectDefinition objectDefinition)
-		throws Exception {
-
-		Response response = _objectEntryOpenAPIResource.getOpenAPI(
-			objectDefinition.getObjectDefinitionId(), "json", null);
-
-		OpenAPI openAPI = (OpenAPI)response.getEntity();
-
-		Components components = openAPI.getComponents();
-
-		Map<String, Schema> schemas = components.getSchemas();
-
-		return schemas.get(objectDefinition.getShortName());
-	}
-
 	private Operation _getGetOperation(
 			ObjectRelationship objectRelationship,
 			SystemObjectDefinitionMetadata systemObjectDefinitionMetadata)
@@ -278,6 +242,42 @@ public class RelatedObjectEntryOpenAPIContributor
 						_getContentType(systemObjectDefinitionMetadata)));
 			}
 		};
+	}
+
+	private String _getIdParameterName(String name) {
+		return StringUtil.lowerCaseFirstLetter(name) + "Id";
+	}
+
+	private String _getIdParameterTemplate(String name) {
+		return StringPool.OPEN_CURLY_BRACE + _getIdParameterName(name) +
+			StringPool.CLOSE_CURLY_BRACE;
+	}
+
+	private String _getJaxRsVersion(UriInfo uriInfo) {
+		String path = uriInfo.getPath();
+
+		return path.split(StringPool.SLASH)[0];
+	}
+
+	private String _getObjectDefinitionPathName(
+		ObjectDefinition objectDefinition) {
+
+		return _getIdParameterTemplate(objectDefinition.getShortName());
+	}
+
+	private Schema _getObjectDefinitionSchema(ObjectDefinition objectDefinition)
+		throws Exception {
+
+		Response response = _objectEntryOpenAPIResource.getOpenAPI(
+			objectDefinition.getObjectDefinitionId(), "json", null);
+
+		OpenAPI openAPI = (OpenAPI)response.getEntity();
+
+		Components components = openAPI.getComponents();
+
+		Map<String, Schema> schemas = components.getSchemas();
+
+		return schemas.get(objectDefinition.getShortName());
 	}
 
 	private Operation _getPutOperation(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/openapi/contributor/RelatedObjectEntryOpenAPIContributor.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/openapi/contributor/RelatedObjectEntryOpenAPIContributor.java
@@ -140,7 +140,7 @@ public class RelatedObjectEntryOpenAPIContributor
 			new PathItem() {
 				{
 					get(
-						_getOperation(
+						_getGetOperation(
 							systemObjectRelationship,
 							systemObjectDefinitionMetadata));
 				}
@@ -234,7 +234,7 @@ public class RelatedObjectEntryOpenAPIContributor
 		return schemas.get(objectDefinition.getShortName());
 	}
 
-	private Operation _getOperation(
+	private Operation _getGetOperation(
 			ObjectRelationship objectRelationship,
 			SystemObjectDefinitionMetadata systemObjectDefinitionMetadata)
 		throws Exception {


### PR DESCRIPTION
**WORK IN PROGRESS**

Related ticket -> [LPS-153326](https://issues.liferay.com/browse/LPS-153326)

**What do we do?**

This is the first PR to create the endpoints to relate 2 objects. Let's see an example. Imagine a University with their subjects and their students in this way:

* University is a custom object. Has a one-to-many relationship with Student and a many-to-many relationship with Subject
* A user of Liferay represents a student, so, it is a System Object. It also has a many-to-many relationship with Subject
* Subject is a custom object.
 * According to these requisites, there should be an endpoint to link the student and the subjects, and this endpoint should be in the existing REST API headless-admin-user

**How to test it**

Deploy the following modules:

 * object-rest-impl

Set the following feature flag to true:

* feature.flag.LPS-153324

Create the necessary objects and relationships according to the previous example and populate them with some data.

Make a request to link the student with the subject:

```bash
curl "http://localhost:8080/o/headless-admin-user/v1.0/user-accounts/41492/studentSubjects/1234
```

This request should return 204 and the relationship should be made.