### PR TITLE
LPS-159408: Generate permissions endpoints in Object Entry 

### DIFF
--- a/modules/apps/object/object-rest-api/bnd.bnd
+++ b/modules/apps/object/object-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object REST API
 Bundle-SymbolicName: com.liferay.object.rest.api
-Bundle-Version: 6.4.1
+Bundle-Version: 6.5.0
 Export-Package:\
 	com.liferay.object.rest.dto.v1_0,\
 	com.liferay.object.rest.dto.v1_0.util,\

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/resource/v1_0/ObjectEntryResource.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/resource/v1_0/ObjectEntryResource.java
@@ -118,6 +118,16 @@ public interface ObjectEntryResource {
 	public Response putObjectEntryBatch(String callbackURL, Object object)
 		throws Exception;
 
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			getObjectEntryPermissionsPage(Long objectEntryId, String roleNames)
+		throws Exception;
+
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putObjectEntryPermissionsPage(
+				Long objectEntryId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
+		throws Exception;
+
 	public Page<ObjectEntry> getScopeScopeKeyPage(
 			String scopeKey, Boolean flatten, String search,
 			com.liferay.portal.vulcan.aggregation.Aggregation aggregation,

--- a/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/resource/v1_0/packageinfo
+++ b/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.3.0
+version 1.4.0

--- a/modules/apps/object/object-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-rest-impl/rest-openapi.yaml
@@ -437,6 +437,45 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/ObjectEntry"
             tags: ["ObjectEntry"]
+    "/{objectEntryId}/permissions":
+        get:
+            operationId: getObjectEntryPermissionsPage
+            parameters:
+                - in: path
+                  name: objectEntryId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+                - in: query
+                  name: roleNames
+                  schema:
+                      type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ObjectEntry"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/ObjectEntry"
+            tags: ["ObjectEntry"]
+        put:
+            operationId: putObjectEntryPermissionsPage
+            parameters:
+                - in: path
+                  name: objectEntryId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+            responses:
+                204:
+                    content:
+                        application/json: {}
+                        application/xml: {}
+            tags: ["ObjectEntry"]
     /scopes/{scopeKey}:
         get:
             operationId: getScopeScopeKeyPage

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
@@ -401,6 +401,19 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 		super.update(objectEntries, parameters);
 	}
 
+	@Override
+	protected Long getPermissionCheckerGroupId(Object id) throws Exception {
+		return contextCompany.getCompanyId();
+	}
+
+	@Override
+	protected String getPermissionCheckerResourceName(Object id)
+		throws Exception {
+
+		return ObjectDefinition.class.getName() + "#" +
+			_objectDefinition.getObjectDefinitionId(); // ObjectDefinition#44002
+	}
+
 	private DefaultDTOConverterContext _getDTOConverterContext(
 		Long objectEntryId) {
 


### PR DESCRIPTION
**What is new?**
- Add `GET` and `PUT` permissions endpoints in _rest-openapi.yaml_
- Implement `getPermissionCheckerGroupId` and `getPermissionCheckerResourceName` methods.

**GET METHOD RESPONSE:**

```
{
  "actions": {
    "get": {
      "method": "GET",
      "href": "http://localhost:8080/o/c/testobjects/46735/permissions"
    },
    "replace": {
      "method": "PUT",
      "href": "http://localhost:8080/o/c/testobjects/46735/permissions"
    }
  },
  "facets": [],
  "items": [
    {
      "actionIds": [
        "DELETE",
        "PERMISSIONS",
        "UPDATE",
        "VIEW"
      ],
      "roleName": "Owner"
    },
    {
      "actionIds": [
        "DELETE",
        "PERMISSIONS"
      ],
      "roleName": "Power User"
    }
  ],
  "lastPage": 1,
  "page": 1,
  "pageSize": 2,
  "totalCount": 2
}
```

![image](https://user-images.githubusercontent.com/44723449/188897805-6c9d8833-2c16-4ce7-8c58-5d827da4b932.png)

**How to Reproduce it:**
- Deploy `object-rest-api` and `object-rest-impl`

**JIRA TICKET**
https://issues.liferay.com/browse/LPS-159408