### PR TITLE
COMMERCE-9809 DI - Batch Engine - support nested objects in CSV and XLSX

### DIFF
--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/writer/CSVBatchEngineExportTaskItemWriterImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/writer/CSVBatchEngineExportTaskItemWriterImpl.java
@@ -38,6 +38,8 @@ import org.apache.commons.csv.CSVPrinter;
 
 /**
  * @author Ivica Cardic
+ * @author Igor Beslic
+ * @author Matija Petanjek
  */
 public class CSVBatchEngineExportTaskItemWriterImpl
 	implements BatchEngineExportTaskItemWriter {
@@ -66,7 +68,7 @@ public class CSVBatchEngineExportTaskItemWriterImpl
 				(String)parameters.getOrDefault(
 					"containsHeaders", StringPool.TRUE))) {
 
-			_csvPrinter.printRecord(fieldNames);
+			_csvPrinter.printRecord(_columnValuesExtractor.getHeaders());
 		}
 	}
 
@@ -81,7 +83,9 @@ public class CSVBatchEngineExportTaskItemWriterImpl
 			"yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
 
 		for (Object item : items) {
-			_write(dateFormat, _columnValuesExtractor.extractValues(item));
+			for (Object[] row : _columnValuesExtractor.extractValues(item)) {
+				_write(dateFormat, row);
+			}
 		}
 	}
 
@@ -93,7 +97,7 @@ public class CSVBatchEngineExportTaskItemWriterImpl
 		return builder.build();
 	}
 
-	private void _write(DateFormat dateFormat, Collection<?> values)
+	private void _write(DateFormat dateFormat, Object[] values)
 		throws Exception {
 
 		for (Object value : values) {

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/writer/ItemClassIndexUtil.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/writer/ItemClassIndexUtil.java
@@ -67,15 +67,17 @@ public class ItemClassIndexUtil {
 
 						Class<?> fieldClass = field.getType();
 
-						if (!isSingleColumnAdoptableValue(fieldClass) &&
-							!isSingleColumnAdoptableArray(fieldClass)) {
+						if (!isMap(fieldClass) &&
+							!isSingleColumnAdoptableValue(fieldClass) &&
+							!isSingleColumnAdoptableArray(fieldClass) &&
+							!Objects.equals(clazz, fieldClass)) {
 
 							index(fieldClass);
 						}
 					}
 
-					if (clazz.isAnonymousClass() || clazz.isLocalClass() ||
-						clazz.isMemberClass()) {
+					if (Objects.equals(
+							clazz.getSuperclass(), clazz.getDeclaringClass())) {
 
 						break;
 					}
@@ -89,6 +91,14 @@ public class ItemClassIndexUtil {
 
 	public static boolean isListEntry(Object object) {
 		if (object instanceof ListEntry) {
+			return true;
+		}
+
+		return false;
+	}
+
+	public static boolean isMap(Class<?> valueClass) {
+		if (Objects.equals(valueClass, Map.class)) {
 			return true;
 		}
 
@@ -150,6 +160,6 @@ public class ItemClassIndexUtil {
 	private static final List<Class<?>> _objectTypes = Arrays.asList(
 		Boolean.class, BigDecimal.class, BigInteger.class, Byte.class,
 		Date.class, Double.class, Float.class, Integer.class, Long.class,
-		Map.class, String.class);
+		String.class);
 
 }

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/writer/XLSBatchEngineExportTaskItemWriterImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/writer/XLSBatchEngineExportTaskItemWriterImpl.java
@@ -54,7 +54,7 @@ public class XLSBatchEngineExportTaskItemWriterImpl
 
 		_sheet = _workbook.createSheet();
 
-		_write(fieldNames);
+		_write(_columnValuesExtractor.getHeaders());
 	}
 
 	@Override
@@ -69,11 +69,13 @@ public class XLSBatchEngineExportTaskItemWriterImpl
 	@Override
 	public void write(Collection<?> items) throws Exception {
 		for (Object item : items) {
-			_write(_columnValuesExtractor.extractValues(item));
+			for (Object[] row : _columnValuesExtractor.extractValues(item)) {
+				_write(row);
+			}
 		}
 	}
 
-	private void _write(Collection<?> values) {
+	private void _write(Object[] values) {
 		Row row = _sheet.createRow(_rowNum++);
 
 		int column = 0;

--- a/modules/apps/batch-engine/batch-engine-service/src/test/java/com/liferay/batch/engine/internal/writer/XLSBatchEngineExportTaskItemWriterImplTest.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/test/java/com/liferay/batch/engine/internal/writer/XLSBatchEngineExportTaskItemWriterImplTest.java
@@ -16,6 +16,9 @@ package com.liferay.batch.engine.internal.writer;
 
 import com.liferay.petra.io.unsync.UnsyncByteArrayOutputStream;
 import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.CSVUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.io.ByteArrayInputStream;
@@ -30,6 +33,7 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellStyle;
@@ -65,20 +69,18 @@ public class XLSBatchEngineExportTaskItemWriterImplTest
 	@Test
 	public void testWriteRowsWithDefinedFieldNames2() throws Exception {
 		_testWriteRows(
-			Arrays.asList(
-				"createDate", "description", "id", "name_en", "name_hr"));
+			Arrays.asList("createDate", "description", "id", "name"));
 	}
 
 	@Test
 	public void testWriteRowsWithDefinedFieldNames3() throws Exception {
-		_testWriteRows(Arrays.asList("createDate", "id", "name_en"));
+		_testWriteRows(Arrays.asList("createDate", "id", "name"));
 	}
 
 	@Test
 	public void testWriteRowsWithDefinedFieldNames4() throws Exception {
 		_testWriteRows(
-			Arrays.asList(
-				"id", "name_hr", "name_en", "description", "createDate"));
+			Arrays.asList("id", "name", "description", "createDate"));
 	}
 
 	@Test
@@ -177,8 +179,45 @@ public class XLSBatchEngineExportTaskItemWriterImplTest
 
 				cell.setCellValue(cellValue.doubleValue());
 			}
+			else if (value instanceof Map) {
+				Map<?, ?> map = (Map<?, ?>)value;
+
+				StringBundler sb = new StringBundler(map.size() * 3);
+
+				Set<? extends Map.Entry<?, ?>> entries = map.entrySet();
+
+				Iterator<? extends Map.Entry<?, ?>> iterator =
+					entries.iterator();
+
+				while (iterator.hasNext()) {
+					Map.Entry<?, ?> entry = iterator.next();
+
+					sb.append(CSVUtil.encode(entry.getKey()));
+
+					sb.append(StringPool.COLON);
+
+					if (entry.getValue() != null) {
+						sb.append(CSVUtil.encode(entry.getValue()));
+					}
+					else {
+						sb.append(StringPool.BLANK);
+					}
+
+					if (iterator.hasNext()) {
+						sb.append(StringPool.COMMA_AND_SPACE);
+					}
+				}
+
+				cell.setCellValue(sb.toString());
+			}
 			else {
-				cell.setCellValue((String)value);
+				if (value == null) {
+					cell.setCellValue(StringPool.BLANK);
+
+					continue;
+				}
+
+				cell.setCellValue(String.valueOf(value));
 			}
 		}
 	}

--- a/modules/apps/batch-planner/batch-planner-test/src/testFunctional/macros/ImportExport.macro
+++ b/modules/apps/batch-planner/batch-planner-test/src/testFunctional/macros/ImportExport.macro
@@ -44,7 +44,7 @@ definition {
 
 	macro assertExportTemplate {
 		WaitForElementPresent(
-			key_title = "Field Mapping",
+			key_title = "Fields",
 			locator1 = "Header#H4_TITLE");
 
 		AssertSelectedLabel(


### PR DESCRIPTION
What is new:
- it is possible to get BlogPosting.User object fields as a part of csv/xslx file
- good entity to test Account (try with creator field)

This update brings a lot yet undocumented features uncovered by PM requirements (like how to build column name for nested field attribute, how to organize nested field records in CSV/XLSX file etc.

NOTE: for Liferay Objects, please always pick only user defined fields.