### PR TITLE
LPS-152217: Implement NotFoundExceptionMapper

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/WikiPageAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/WikiPageAttachmentResourceImpl.java
@@ -18,6 +18,7 @@ import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.headless.delivery.dto.v1_0.WikiPageAttachment;
 import com.liferay.headless.delivery.dto.v1_0.util.ContentValueUtil;
 import com.liferay.headless.delivery.resource.v1_0.WikiPageAttachmentResource;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepository;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
@@ -35,6 +36,7 @@ import com.liferay.wiki.service.WikiPageService;
 import java.util.Optional;
 
 import javax.ws.rs.BadRequestException;
+import javax.ws.rs.NotFoundException;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -57,9 +59,20 @@ public class WikiPageAttachmentResourceImpl
 				String externalReferenceCode)
 		throws Exception {
 
-		WikiPage wikiPage =
-			_wikiPageService.getLatestPageByExternalReferenceCode(
+		WikiPage wikiPage;
+
+		try {
+			wikiPage = _wikiPageService.getLatestPageByExternalReferenceCode(
 				siteId, wikiPageExternalReferenceCode);
+		}
+		catch (Exception exception) {
+			throw new NotFoundException(
+				StringBundler.concat(
+					"No WikiPage exists with the key {groupId=", siteId,
+					", externalReferenceCode=", wikiPageExternalReferenceCode,
+					"}"),
+				exception);
+		}
 
 		FileEntry fileEntry =
 			wikiPage.getAttachmentsFileEntryByExternalReferenceCode(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/CommentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/CommentResourceTest.java
@@ -52,24 +52,18 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 		super.
 			testDeleteSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCode();
 
-		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				"com.liferay.portal.vulcan.internal.jaxrs.exception.mapper." +
-					"WebApplicationExceptionMapper",
-				LoggerTestUtil.ERROR)) {
+		Comment comment =
+			testDeleteSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCode_addComment();
 
-			Comment comment =
-				testDeleteSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCode_addComment();
+		// Nonexistent blogs entry
 
-			// Nonexistent blogs entry
-
-			assertHttpResponseStatusCode(
-				404,
-				commentResource.
-					deleteSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
-						testDeleteSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
-						RandomTestUtil.randomString(),
-						comment.getExternalReferenceCode()));
-		}
+		assertHttpResponseStatusCode(
+			404,
+			commentResource.
+				deleteSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
+					testDeleteSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
+					RandomTestUtil.randomString(),
+					comment.getExternalReferenceCode()));
 
 		// Nonexistent comment
 
@@ -85,7 +79,7 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 
 		BlogsEntry prevBlogsEntry = _blogsEntry;
 
-		Comment comment =
+		Comment newComment =
 			testDeleteSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCode_addComment();
 
 		assertHttpResponseStatusCode(
@@ -94,7 +88,7 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 				deleteSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
 					testDeleteSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
 					prevBlogsEntry.getExternalReferenceCode(),
-					comment.getExternalReferenceCode()));
+					newComment.getExternalReferenceCode()));
 	}
 
 	@Override
@@ -105,40 +99,34 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 		super.
 			testDeleteSiteCommentByExternalReferenceCodeParentCommentExternalReferenceCodeCommentByExternalReferenceCode();
 
-		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				"com.liferay.portal.vulcan.internal.jaxrs.exception.mapper." +
-					"WebApplicationExceptionMapper",
-				LoggerTestUtil.ERROR)) {
+		Comment comment1 =
+			testDeleteSiteCommentByExternalReferenceCodeParentCommentExternalReferenceCodeCommentByExternalReferenceCode_addComment();
 
-			Comment comment1 =
-				testDeleteSiteCommentByExternalReferenceCodeParentCommentExternalReferenceCodeCommentByExternalReferenceCode_addComment();
+		// Nonexistent parent comment
 
-			// Nonexistent parent comment
+		assertHttpResponseStatusCode(
+			404,
+			commentResource.
+				deleteSiteCommentByExternalReferenceCodeParentCommentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
+					testDeleteSiteCommentByExternalReferenceCodeParentCommentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
+					RandomTestUtil.randomString(),
+					comment1.getExternalReferenceCode()));
 
-			assertHttpResponseStatusCode(
-				404,
-				commentResource.
-					deleteSiteCommentByExternalReferenceCodeParentCommentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
-						testDeleteSiteCommentByExternalReferenceCodeParentCommentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
-						RandomTestUtil.randomString(),
-						comment1.getExternalReferenceCode()));
+		// Comment associated to a different parent comment with same parent
 
-			// Comment associated to a different parent comment with same parent
+		Comment comment2 = commentResource.postCommentComment(
+			comment1.getId(), randomComment());
 
-			Comment comment2 = commentResource.postCommentComment(
-				comment1.getId(), randomComment());
+		Comment comment3 = commentResource.postCommentComment(
+			comment2.getId(), randomComment());
 
-			Comment comment3 = commentResource.postCommentComment(
-				comment2.getId(), randomComment());
-
-			assertHttpResponseStatusCode(
-				404,
-				commentResource.
-					deleteSiteCommentByExternalReferenceCodeParentCommentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
-						testDeleteSiteCommentByExternalReferenceCodeParentCommentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
-						comment1.getExternalReferenceCode(),
-						comment3.getExternalReferenceCode()));
-		}
+		assertHttpResponseStatusCode(
+			404,
+			commentResource.
+				deleteSiteCommentByExternalReferenceCodeParentCommentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
+					testDeleteSiteCommentByExternalReferenceCodeParentCommentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
+					comment1.getExternalReferenceCode(),
+					comment3.getExternalReferenceCode()));
 
 		// Nonexistent comment
 
@@ -154,7 +142,7 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 
 		Comment prevParentComment = _parentComment;
 
-		Comment comment =
+		Comment comment4 =
 			testDeleteSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCode_addComment();
 
 		assertHttpResponseStatusCode(
@@ -163,7 +151,7 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 				deleteSiteCommentByExternalReferenceCodeParentCommentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
 					testDeleteSiteCommentByExternalReferenceCodeParentCommentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
 					prevParentComment.getExternalReferenceCode(),
-					comment.getExternalReferenceCode()));
+					comment4.getExternalReferenceCode()));
 	}
 
 	@Override
@@ -174,24 +162,18 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 		super.
 			testDeleteSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCode();
 
-		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				"com.liferay.portal.vulcan.internal.jaxrs.exception.mapper." +
-					"WebApplicationExceptionMapper",
-				LoggerTestUtil.ERROR)) {
+		Comment comment =
+			testDeleteSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCode_addComment();
 
-			Comment comment =
-				testDeleteSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCode_addComment();
+		// Nonexistent document
 
-			// Nonexistent document
-
-			assertHttpResponseStatusCode(
-				404,
-				commentResource.
-					deleteSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
-						testDeleteSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
-						RandomTestUtil.randomString(),
-						comment.getExternalReferenceCode()));
-		}
+		assertHttpResponseStatusCode(
+			404,
+			commentResource.
+				deleteSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
+					testDeleteSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
+					RandomTestUtil.randomString(),
+					comment.getExternalReferenceCode()));
 
 		// Nonexistent comment
 
@@ -207,7 +189,7 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 
 		FileEntry prevFileEntry = _fileEntry;
 
-		Comment comment =
+		Comment newComment =
 			testDeleteSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCode_addComment();
 
 		assertHttpResponseStatusCode(
@@ -216,7 +198,7 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 				deleteSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
 					testDeleteSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
 					prevFileEntry.getExternalReferenceCode(),
-					comment.getExternalReferenceCode()));
+					newComment.getExternalReferenceCode()));
 	}
 
 	@Override
@@ -227,24 +209,18 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 		super.
 			testDeleteSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCode();
 
-		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				"com.liferay.portal.vulcan.internal.jaxrs.exception.mapper." +
-					"WebApplicationExceptionMapper",
-				LoggerTestUtil.ERROR)) {
+		Comment comment =
+			testDeleteSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCode_addComment();
 
-			Comment comment =
-				testDeleteSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCode_addComment();
+		// Nonexistent journal article
 
-			// Nonexistent journal article
-
-			assertHttpResponseStatusCode(
-				404,
-				commentResource.
-					deleteSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
-						testDeleteSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
-						RandomTestUtil.randomString(),
-						comment.getExternalReferenceCode()));
-		}
+		assertHttpResponseStatusCode(
+			404,
+			commentResource.
+				deleteSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
+					testDeleteSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
+					RandomTestUtil.randomString(),
+					comment.getExternalReferenceCode()));
 
 		// Nonexistent comment
 
@@ -260,7 +236,7 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 
 		JournalArticle prevJournalArticle = _journalArticle;
 
-		Comment comment =
+		Comment newComment =
 			testDeleteSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCode_addComment();
 
 		assertHttpResponseStatusCode(
@@ -269,7 +245,7 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 				deleteSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
 					testDeleteSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
 					prevJournalArticle.getExternalReferenceCode(),
-					comment.getExternalReferenceCode()));
+					newComment.getExternalReferenceCode()));
 	}
 
 	@Override
@@ -280,24 +256,18 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 		super.
 			testGetSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCode();
 
-		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				"com.liferay.portal.vulcan.internal.jaxrs.exception.mapper." +
-					"WebApplicationExceptionMapper",
-				LoggerTestUtil.ERROR)) {
+		Comment comment =
+			testGetSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCode_addComment();
 
-			Comment comment =
-				testGetSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCode_addComment();
+		// Nonexistent blogs entry
 
-			// Nonexistent blogs entry
-
-			assertHttpResponseStatusCode(
-				404,
-				commentResource.
-					getSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
-						testGetSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
-						RandomTestUtil.randomString(),
-						comment.getExternalReferenceCode()));
-		}
+		assertHttpResponseStatusCode(
+			404,
+			commentResource.
+				getSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
+					testGetSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
+					RandomTestUtil.randomString(),
+					comment.getExternalReferenceCode()));
 
 		// Nonexistent comment
 
@@ -313,7 +283,7 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 
 		BlogsEntry prevBlogsEntry = _blogsEntry;
 
-		Comment comment =
+		Comment newComment =
 			testGetSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCode_addComment();
 
 		assertHttpResponseStatusCode(
@@ -322,7 +292,7 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 				getSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
 					testGetSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
 					prevBlogsEntry.getExternalReferenceCode(),
-					comment.getExternalReferenceCode()));
+					newComment.getExternalReferenceCode()));
 	}
 
 	@Override
@@ -333,40 +303,34 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 		super.
 			testGetSiteCommentByExternalReferenceCodeParentCommentExternalReferenceCodeCommentByExternalReferenceCode();
 
-		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				"com.liferay.portal.vulcan.internal.jaxrs.exception.mapper." +
-					"WebApplicationExceptionMapper",
-				LoggerTestUtil.ERROR)) {
+		Comment comment1 =
+			testGetSiteCommentByExternalReferenceCodeParentCommentExternalReferenceCodeCommentByExternalReferenceCode_addComment();
 
-			Comment comment1 =
-				testGetSiteCommentByExternalReferenceCodeParentCommentExternalReferenceCodeCommentByExternalReferenceCode_addComment();
+		// Nonexistent parent comment
 
-			// Nonexistent parent comment
+		assertHttpResponseStatusCode(
+			404,
+			commentResource.
+				getSiteCommentByExternalReferenceCodeParentCommentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
+					testGetSiteCommentByExternalReferenceCodeParentCommentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
+					RandomTestUtil.randomString(),
+					comment1.getExternalReferenceCode()));
 
-			assertHttpResponseStatusCode(
-				404,
-				commentResource.
-					getSiteCommentByExternalReferenceCodeParentCommentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
-						testGetSiteCommentByExternalReferenceCodeParentCommentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
-						RandomTestUtil.randomString(),
-						comment1.getExternalReferenceCode()));
+		// Comment associated to a different parent comment with same parent
 
-			// Comment associated to a different parent comment with same parent
+		Comment comment2 = commentResource.postCommentComment(
+			comment1.getId(), randomComment());
 
-			Comment comment2 = commentResource.postCommentComment(
-				comment1.getId(), randomComment());
+		Comment comment3 = commentResource.postCommentComment(
+			comment2.getId(), randomComment());
 
-			Comment comment3 = commentResource.postCommentComment(
-				comment2.getId(), randomComment());
-
-			assertHttpResponseStatusCode(
-				404,
-				commentResource.
-					getSiteCommentByExternalReferenceCodeParentCommentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
-						testGetSiteCommentByExternalReferenceCodeParentCommentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
-						comment1.getExternalReferenceCode(),
-						comment3.getExternalReferenceCode()));
-		}
+		assertHttpResponseStatusCode(
+			404,
+			commentResource.
+				getSiteCommentByExternalReferenceCodeParentCommentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
+					testGetSiteCommentByExternalReferenceCodeParentCommentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
+					comment1.getExternalReferenceCode(),
+					comment3.getExternalReferenceCode()));
 
 		// Nonexistent comment
 
@@ -382,7 +346,7 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 
 		Comment prevParentComment = _parentComment;
 
-		Comment comment =
+		Comment comment4 =
 			testGetSiteCommentByExternalReferenceCodeParentCommentExternalReferenceCodeCommentByExternalReferenceCode_addComment();
 
 		assertHttpResponseStatusCode(
@@ -391,7 +355,7 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 				getSiteCommentByExternalReferenceCodeParentCommentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
 					testGetSiteCommentByExternalReferenceCodeParentCommentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
 					prevParentComment.getExternalReferenceCode(),
-					comment.getExternalReferenceCode()));
+					comment4.getExternalReferenceCode()));
 	}
 
 	@Override
@@ -402,24 +366,18 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 		super.
 			testGetSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCode();
 
-		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				"com.liferay.portal.vulcan.internal.jaxrs.exception.mapper." +
-					"WebApplicationExceptionMapper",
-				LoggerTestUtil.ERROR)) {
+		Comment comment =
+			testGetSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCode_addComment();
 
-			Comment comment =
-				testGetSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCode_addComment();
+		// Nonexistent document
 
-			// Nonexistent document
-
-			assertHttpResponseStatusCode(
-				404,
-				commentResource.
-					getSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
-						testGetSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
-						RandomTestUtil.randomString(),
-						comment.getExternalReferenceCode()));
-		}
+		assertHttpResponseStatusCode(
+			404,
+			commentResource.
+				getSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
+					testGetSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
+					RandomTestUtil.randomString(),
+					comment.getExternalReferenceCode()));
 
 		// Nonexistent comment
 
@@ -435,7 +393,7 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 
 		FileEntry prevFileEntry = _fileEntry;
 
-		Comment comment =
+		Comment newComment =
 			testGetSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCode_addComment();
 
 		assertHttpResponseStatusCode(
@@ -444,7 +402,7 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 				getSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
 					testGetSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
 					prevFileEntry.getExternalReferenceCode(),
-					comment.getExternalReferenceCode()));
+					newComment.getExternalReferenceCode()));
 	}
 
 	@Override
@@ -455,24 +413,18 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 		super.
 			testGetSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCode();
 
-		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				"com.liferay.portal.vulcan.internal.jaxrs.exception.mapper." +
-					"WebApplicationExceptionMapper",
-				LoggerTestUtil.ERROR)) {
+		Comment comment =
+			testGetSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCode_addComment();
 
-			Comment comment =
-				testGetSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCode_addComment();
+		// Nonexistent structured content
 
-			// Nonexistent structured content
-
-			assertHttpResponseStatusCode(
-				404,
-				commentResource.
-					getSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
-						testGetSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
-						RandomTestUtil.randomString(),
-						comment.getExternalReferenceCode()));
-		}
+		assertHttpResponseStatusCode(
+			404,
+			commentResource.
+				getSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
+					testGetSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
+					RandomTestUtil.randomString(),
+					comment.getExternalReferenceCode()));
 
 		// Nonexistent comment
 
@@ -488,7 +440,7 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 
 		JournalArticle prevJournalArticle = _journalArticle;
 
-		Comment comment =
+		Comment newComment =
 			testGetSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCode_addComment();
 
 		assertHttpResponseStatusCode(
@@ -497,7 +449,7 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 				getSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
 					testGetSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
 					prevJournalArticle.getExternalReferenceCode(),
-					comment.getExternalReferenceCode()));
+					newComment.getExternalReferenceCode()));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/WikiPageAttachmentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/WikiPageAttachmentResourceTest.java
@@ -23,8 +23,6 @@ import com.liferay.portal.kernel.test.constants.TestDataConstants;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.test.log.LogCapture;
-import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.wiki.model.WikiNode;
 import com.liferay.wiki.model.WikiPage;
 import com.liferay.wiki.service.WikiNodeLocalServiceUtil;
@@ -77,24 +75,18 @@ public class WikiPageAttachmentResourceTest
 		super.
 			testDeleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode();
 
-		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				"com.liferay.portal.vulcan.internal.jaxrs.exception.mapper." +
-					"WebApplicationExceptionMapper",
-				LoggerTestUtil.ERROR)) {
+		WikiPageAttachment wikiPageAttachment =
+			testDeleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_addWikiPageAttachment();
 
-			WikiPageAttachment wikiPageAttachment =
-				testDeleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_addWikiPageAttachment();
+		// Nonexistent wiki page
 
-			// Nonexistent wiki page
-
-			assertHttpResponseStatusCode(
-				404,
-				wikiPageAttachmentResource.
-					deleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCodeHttpResponse(
-						testDeleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_getSiteId(),
-						RandomTestUtil.randomString(),
-						wikiPageAttachment.getExternalReferenceCode()));
-		}
+		assertHttpResponseStatusCode(
+			404,
+			wikiPageAttachmentResource.
+				deleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCodeHttpResponse(
+					testDeleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_getSiteId(),
+					RandomTestUtil.randomString(),
+					wikiPageAttachment.getExternalReferenceCode()));
 
 		// Nonexistent wiki page attachment
 
@@ -110,7 +102,7 @@ public class WikiPageAttachmentResourceTest
 
 		WikiPage previousWikiPage = _wikiPage;
 
-		WikiPageAttachment wikiPageAttachment =
+		WikiPageAttachment newWikiPageAttachment =
 			testDeleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_addWikiPageAttachment();
 
 		assertHttpResponseStatusCode(
@@ -119,7 +111,7 @@ public class WikiPageAttachmentResourceTest
 				deleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCodeHttpResponse(
 					testDeleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_getSiteId(),
 					previousWikiPage.getExternalReferenceCode(),
-					wikiPageAttachment.getExternalReferenceCode()));
+					newWikiPageAttachment.getExternalReferenceCode()));
 	}
 
 	@Override
@@ -130,24 +122,18 @@ public class WikiPageAttachmentResourceTest
 		super.
 			testGetSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode();
 
-		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				"com.liferay.portal.vulcan.internal.jaxrs.exception.mapper." +
-					"WebApplicationExceptionMapper",
-				LoggerTestUtil.ERROR)) {
+		WikiPageAttachment wikiPageAttachment =
+			testGetSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_addWikiPageAttachment();
 
-			WikiPageAttachment wikiPageAttachment =
-				testGetSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_addWikiPageAttachment();
+		// Nonexistent wiki page
 
-			// Nonexistent wiki page
-
-			assertHttpResponseStatusCode(
-				404,
-				wikiPageAttachmentResource.
-					getSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCodeHttpResponse(
-						testGetSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_getSiteId(),
-						RandomTestUtil.randomString(),
-						wikiPageAttachment.getExternalReferenceCode()));
-		}
+		assertHttpResponseStatusCode(
+			404,
+			wikiPageAttachmentResource.
+				getSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCodeHttpResponse(
+					testGetSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_getSiteId(),
+					RandomTestUtil.randomString(),
+					wikiPageAttachment.getExternalReferenceCode()));
 
 		// Nonexistent wiki page attachment
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/exception/mapper/NotFoundExceptionMapper.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/exception/mapper/NotFoundExceptionMapper.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.internal.jaxrs.exception.mapper;
+
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
+
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.core.Response;
+
+/**
+ * @author Sergio Jiménez del Coso
+ */
+public class NotFoundExceptionMapper
+	extends BaseExceptionMapper<NotFoundException> {
+
+	@Override
+	protected Problem getProblem(NotFoundException notFoundException) {
+		return new Problem(
+			Response.Status.NOT_FOUND, notFoundException.getMessage());
+	}
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/feature/VulcanFeature.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/feature/VulcanFeature.java
@@ -58,6 +58,7 @@ import com.liferay.portal.vulcan.internal.jaxrs.exception.mapper.JsonMappingExce
 import com.liferay.portal.vulcan.internal.jaxrs.exception.mapper.JsonParseExceptionMapper;
 import com.liferay.portal.vulcan.internal.jaxrs.exception.mapper.NoSuchModelExceptionMapper;
 import com.liferay.portal.vulcan.internal.jaxrs.exception.mapper.NotAcceptableExceptionMapper;
+import com.liferay.portal.vulcan.internal.jaxrs.exception.mapper.NotFoundExceptionMapper;
 import com.liferay.portal.vulcan.internal.jaxrs.exception.mapper.PrincipalExceptionMapper;
 import com.liferay.portal.vulcan.internal.jaxrs.exception.mapper.UnrecognizedPropertyExceptionMapper;
 import com.liferay.portal.vulcan.internal.jaxrs.exception.mapper.ValidationExceptionMapper;
@@ -125,6 +126,7 @@ public class VulcanFeature implements Feature {
 		featureContext.register(NestedFieldsContainerRequestFilter.class);
 		featureContext.register(NoSuchModelExceptionMapper.class);
 		featureContext.register(NotAcceptableExceptionMapper.class);
+		featureContext.register(NotFoundExceptionMapper.class);
 		featureContext.register(ObjectMapperContextResolver.class);
 		featureContext.register(PageEntityExtensionWriterInterceptor.class);
 		featureContext.register(PaginationContextProvider.class);


### PR DESCRIPTION
**What is new?**
- Implement `NotFoundExceptionMapper` in `portal-vulcan`
- Update `WikiPageAttachmentResourceImpl` and `CommentReourceImpl`
- Update `WikiPageAttachmentResourceTest` and `CommentReourceTest`

To see this new endpoint you have to follow these steps:

1. Deploy `portal-vulcan-impl`
2. Deploy `headless-delivery-api` and `headless-delivery-impl` in this order.
3. Go to `/o/api`

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-152217



 
