### PR TITLE
LPS-161698 Avoid send "actions" property for system relationships items for now.

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -825,60 +825,64 @@ public class DefaultObjectEntryManagerImpl
 			com.liferay.object.model.ObjectEntry objectEntry)
 		throws Exception {
 
-		DefaultDTOConverterContext defaultDTOConverterContext =
-			new DefaultDTOConverterContext(
-				dtoConverterContext.isAcceptAllLanguages(),
-				HashMapBuilder.put(
-					"delete",
-					() -> {
-						if (_hasRelatedObjectEntries(
-								ObjectRelationshipConstants.
-									DELETION_TYPE_PREVENT,
-								objectDefinition, objectEntry)) {
+		HashMap<String, Map<String, String>> actions = new HashMap<>();
 
-							return null;
-						}
+		Boolean addActions = (Boolean)dtoConverterContext.getAttribute(
+			"addActions");
 
-						return ActionUtil.addAction(
-							ActionKeys.DELETE, ObjectEntryResourceImpl.class,
-							objectEntry.getObjectEntryId(), "deleteObjectEntry",
-							null, objectEntry.getUserId(),
-							_getObjectEntryPermissionName(
-								objectEntry.getObjectDefinitionId()),
-							objectEntry.getGroupId(),
-							dtoConverterContext.getUriInfo());
+		if ((addActions == null) || addActions) {
+			actions = HashMapBuilder.<String, Map<String, String>>put(
+				"delete",
+				() -> {
+					if (_hasRelatedObjectEntries(
+							ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
+							objectDefinition, objectEntry)) {
+
+						return null;
 					}
-				).put(
-					"get",
-					ActionUtil.addAction(
-						ActionKeys.VIEW, ObjectEntryResourceImpl.class,
-						objectEntry.getObjectEntryId(), "getObjectEntry", null,
-						objectEntry.getUserId(),
-						_getObjectEntryPermissionName(
-							objectEntry.getObjectDefinitionId()),
-						objectEntry.getGroupId(),
-						dtoConverterContext.getUriInfo())
-				).put(
-					"permissions",
-					ActionUtil.addAction(
-						ActionKeys.PERMISSIONS, ObjectEntryResourceImpl.class,
-						objectEntry.getObjectEntryId(), "patchObjectEntry",
+
+					return ActionUtil.addAction(
+						ActionKeys.DELETE, ObjectEntryResourceImpl.class,
+						objectEntry.getObjectEntryId(), "deleteObjectEntry",
 						null, objectEntry.getUserId(),
 						_getObjectEntryPermissionName(
 							objectEntry.getObjectDefinitionId()),
 						objectEntry.getGroupId(),
-						dtoConverterContext.getUriInfo())
-				).put(
-					"update",
-					ActionUtil.addAction(
-						ActionKeys.UPDATE, ObjectEntryResourceImpl.class,
-						objectEntry.getObjectEntryId(), "putObjectEntry", null,
-						objectEntry.getUserId(),
-						_getObjectEntryPermissionName(
-							objectEntry.getObjectDefinitionId()),
-						objectEntry.getGroupId(),
-						dtoConverterContext.getUriInfo())
-				).build(),
+						dtoConverterContext.getUriInfo());
+				}
+			).put(
+				"get",
+				ActionUtil.addAction(
+					ActionKeys.VIEW, ObjectEntryResourceImpl.class,
+					objectEntry.getObjectEntryId(), "getObjectEntry", null,
+					objectEntry.getUserId(),
+					_getObjectEntryPermissionName(
+						objectEntry.getObjectDefinitionId()),
+					objectEntry.getGroupId(), dtoConverterContext.getUriInfo())
+			).put(
+				"permissions",
+				ActionUtil.addAction(
+					ActionKeys.PERMISSIONS, ObjectEntryResourceImpl.class,
+					objectEntry.getObjectEntryId(), "patchObjectEntry", null,
+					objectEntry.getUserId(),
+					_getObjectEntryPermissionName(
+						objectEntry.getObjectDefinitionId()),
+					objectEntry.getGroupId(), dtoConverterContext.getUriInfo())
+			).put(
+				"update",
+				ActionUtil.addAction(
+					ActionKeys.UPDATE, ObjectEntryResourceImpl.class,
+					objectEntry.getObjectEntryId(), "putObjectEntry", null,
+					objectEntry.getUserId(),
+					_getObjectEntryPermissionName(
+						objectEntry.getObjectDefinitionId()),
+					objectEntry.getGroupId(), dtoConverterContext.getUriInfo())
+			).build();
+		}
+
+		DefaultDTOConverterContext defaultDTOConverterContext =
+			new DefaultDTOConverterContext(
+				dtoConverterContext.isAcceptAllLanguages(), actions,
 				dtoConverterContext.getDTOConverterRegistry(),
 				dtoConverterContext.getHttpServletRequest(),
 				objectEntry.getObjectEntryId(), dtoConverterContext.getLocale(),

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/RelatedObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/RelatedObjectEntryResourceImpl.java
@@ -138,11 +138,16 @@ public class RelatedObjectEntryResourceImpl
 		ObjectDefinition objectDefinition, Long objectEntryId,
 		UriInfo uriInfo) {
 
-		return new DefaultDTOConverterContext(
-			_dtoConverterRegistry, objectEntryId,
-			LocaleUtil.fromLanguageId(
-				objectDefinition.getDefaultLanguageId(), true, false),
-			uriInfo, null);
+		DefaultDTOConverterContext defaultDTOConverterContext =
+			new DefaultDTOConverterContext(
+				_dtoConverterRegistry, objectEntryId,
+				LocaleUtil.fromLanguageId(
+					objectDefinition.getDefaultLanguageId(), true, false),
+				uriInfo, null);
+
+		defaultDTOConverterContext.setAttribute("addActions", Boolean.FALSE);
+
+		return defaultDTOConverterContext;
 	}
 
 	private ObjectRelationship _getObjectRelationship(


### PR DESCRIPTION
As we need to improve the information returned by the `actions` property, we are sending it as empty for now.
Of course, this is under a feature flag and should not affect the existing endpoints.

An example, the actions property is empty for collection and for each item of the collection returned by the relationship endpoint.
![imagen](https://user-images.githubusercontent.com/17163902/189927346-c4701278-8cb8-44f6-b183-1dc412f6ba38.png)
