### PR TITLE
LPS-158259 Set scopes to avoid 401 Unauthorized error when using OAuth 2.0 as the authorization mechanism in GraphQL

### DIFF
--- a/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -55,6 +55,10 @@ public class ServletDataImpl implements ServletData {
 			_statusResourceComponentServiceObjects);
 	}
 
+	public String getApplicationName() {
+		return "Liferay.Bulk.REST";
+	}
+
 	@Override
 	public Mutation getMutation() {
 		return new Mutation();

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -68,6 +68,10 @@ public class ServletDataImpl implements ServletData {
 			_accountOrganizationResourceComponentServiceObjects);
 	}
 
+	public String getApplicationName() {
+		return "Liferay.Headless.Commerce.Admin.Account";
+	}
+
 	@Override
 	public Mutation getMutation() {
 		return new Mutation();

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -162,6 +162,10 @@ public class ServletDataImpl implements ServletData {
 			_specificationResourceComponentServiceObjects);
 	}
 
+	public String getApplicationName() {
+		return "Liferay.Headless.Commerce.Admin.Catalog";
+	}
+
 	@Override
 	public Mutation getMutation() {
 		return new Mutation();

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -78,6 +78,10 @@ public class ServletDataImpl implements ServletData {
 			_termResourceComponentServiceObjects);
 	}
 
+	public String getApplicationName() {
+		return "Liferay.Headless.Commerce.Admin.Channel";
+	}
+
 	@Override
 	public Mutation getMutation() {
 		return new Mutation();

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -55,6 +55,10 @@ public class ServletDataImpl implements ServletData {
 			_warehouseItemResourceComponentServiceObjects);
 	}
 
+	public String getApplicationName() {
+		return "Liferay.Headless.Commerce.Admin.Inventory";
+	}
+
 	@Override
 	public Mutation getMutation() {
 		return new Mutation();

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -119,6 +119,10 @@ public class ServletDataImpl implements ServletData {
 			_termOrderTypeResourceComponentServiceObjects);
 	}
 
+	public String getApplicationName() {
+		return "Liferay.Headless.Commerce.Admin.Order";
+	}
+
 	@Override
 	public Mutation getMutation() {
 		return new Mutation();

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -85,6 +85,10 @@ public class ServletDataImpl implements ServletData {
 			_tierPriceResourceComponentServiceObjects);
 	}
 
+	public String getApplicationName() {
+		return "Liferay.Headless.Commerce.Admin.Pricing";
+	}
+
 	@Override
 	public Mutation getMutation() {
 		return new Mutation();

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/graphql/servlet/v2_0/ServletDataImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/graphql/servlet/v2_0/ServletDataImpl.java
@@ -174,6 +174,10 @@ public class ServletDataImpl implements ServletData {
 			_tierPriceResourceComponentServiceObjects);
 	}
 
+	public String getApplicationName() {
+		return "Liferay.Headless.Commerce.Admin.Pricing";
+	}
+
 	@Override
 	public Mutation getMutation() {
 		return new Mutation();

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -55,6 +55,10 @@ public class ServletDataImpl implements ServletData {
 			_shippingAddressResourceComponentServiceObjects);
 	}
 
+	public String getApplicationName() {
+		return "Liferay.Headless.Commerce.Admin.Shipment";
+	}
+
 	@Override
 	public Mutation getMutation() {
 		return new Mutation();

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -60,6 +60,10 @@ public class ServletDataImpl implements ServletData {
 			_warehouseResourceComponentServiceObjects);
 	}
 
+	public String getApplicationName() {
+		return "Liferay.Headless.Commerce.Admin.Site.Setting";
+	}
+
 	@Override
 	public Mutation getMutation() {
 		return new Mutation();

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -64,6 +64,10 @@ public class ServletDataImpl implements ServletData {
 			_shippingMethodResourceComponentServiceObjects);
 	}
 
+	public String getApplicationName() {
+		return "Liferay.Headless.Commerce.Delivery.Cart";
+	}
+
 	@Override
 	public Mutation getMutation() {
 		return new Mutation();

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -69,6 +69,10 @@ public class ServletDataImpl implements ServletData {
 			_skuResourceComponentServiceObjects);
 	}
 
+	public String getApplicationName() {
+		return "Liferay.Headless.Commerce.Delivery.Catalog";
+	}
+
 	@Override
 	public Mutation getMutation() {
 		return new Mutation();

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -54,6 +54,10 @@ public class ServletDataImpl implements ServletData {
 			_placedOrderItemShipmentResourceComponentServiceObjects);
 	}
 
+	public String getApplicationName() {
+		return "Liferay.Headless.Commerce.Delivery.Order";
+	}
+
 	@Override
 	public Mutation getMutation() {
 		return new Mutation();

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/graphql/servlet/v2_0/ServletDataImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/graphql/servlet/v2_0/ServletDataImpl.java
@@ -68,6 +68,10 @@ public class ServletDataImpl implements ServletData {
 			_dataRecordCollectionResourceComponentServiceObjects);
 	}
 
+	public String getApplicationName() {
+		return "Liferay.Data.Engine.REST";
+	}
+
 	@Override
 	public Mutation getMutation() {
 		return new Mutation();

--- a/modules/apps/digital-signature/digital-signature-rest-impl/src/main/java/com/liferay/digital/signature/rest/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/digital-signature/digital-signature-rest-impl/src/main/java/com/liferay/digital/signature/rest/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -45,6 +45,10 @@ public class ServletDataImpl implements ServletData {
 			_dsEnvelopeResourceComponentServiceObjects);
 	}
 
+	public String getApplicationName() {
+		return "Liferay.Digital.Signature.REST";
+	}
+
 	@Override
 	public Mutation getMutation() {
 		return new Mutation();

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -50,6 +50,10 @@ public class ServletDataImpl implements ServletData {
 			_regionResourceComponentServiceObjects);
 	}
 
+	public String getApplicationName() {
+		return "Liferay.Headless.Admin.Address";
+	}
+
 	@Override
 	public Mutation getMutation() {
 		return new Mutation();

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -51,6 +51,10 @@ public class ServletDataImpl implements ServletData {
 			_structuredContentResourceComponentServiceObjects);
 	}
 
+	public String getApplicationName() {
+		return "Liferay.Headless.Admin.Content";
+	}
+
 	@Override
 	public String getGraphQLNamespace() {
 		return "admin";

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -50,6 +50,10 @@ public class ServletDataImpl implements ServletData {
 			_listTypeEntryResourceComponentServiceObjects);
 	}
 
+	public String getApplicationName() {
+		return "Liferay.Headless.Admin.List.Type";
+	}
+
 	@Override
 	public Mutation getMutation() {
 		return new Mutation();

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -55,6 +55,10 @@ public class ServletDataImpl implements ServletData {
 			_taxonomyVocabularyResourceComponentServiceObjects);
 	}
 
+	public String getApplicationName() {
+		return "Liferay.Headless.Admin.Taxonomy";
+	}
+
 	@Override
 	public Mutation getMutation() {
 		return new Mutation();

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -96,6 +96,10 @@ public class ServletDataImpl implements ServletData {
 			_webUrlResourceComponentServiceObjects);
 	}
 
+	public String getApplicationName() {
+		return "Liferay.Headless.Admin.User";
+	}
+
 	@Override
 	public Mutation getMutation() {
 		return new Mutation();

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -70,6 +70,10 @@ public class ServletDataImpl implements ServletData {
 			_workflowTaskResourceComponentServiceObjects);
 	}
 
+	public String getApplicationName() {
+		return "Liferay.Headless.Admin.Workflow";
+	}
+
 	@Override
 	public Mutation getMutation() {
 		return new Mutation();

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -150,6 +150,10 @@ public class ServletDataImpl implements ServletData {
 			_wikiPageAttachmentResourceComponentServiceObjects);
 	}
 
+	public String getApplicationName() {
+		return "Liferay.Headless.Delivery";
+	}
+
 	@Override
 	public Mutation getMutation() {
 		return new Mutation();

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -58,6 +58,10 @@ public class ServletDataImpl implements ServletData {
 			_formStructureResourceComponentServiceObjects);
 	}
 
+	public String getApplicationName() {
+		return "Liferay.Headless.Form";
+	}
+
 	@Override
 	public Mutation getMutation() {
 		return new Mutation();

--- a/modules/apps/notification/notification-rest-impl/src/main/java/com/liferay/notification/rest/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/notification/notification-rest-impl/src/main/java/com/liferay/notification/rest/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -50,6 +50,10 @@ public class ServletDataImpl implements ServletData {
 			_notificationTemplateResourceComponentServiceObjects);
 	}
 
+	public String getApplicationName() {
+		return "Liferay.Notification.REST";
+	}
+
 	@Override
 	public Mutation getMutation() {
 		return new Mutation();

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -75,6 +75,10 @@ public class ServletDataImpl implements ServletData {
 			_objectViewResourceComponentServiceObjects);
 	}
 
+	public String getApplicationName() {
+		return "Liferay.Object.Admin.REST";
+	}
+
 	@Override
 	public Mutation getMutation() {
 		return new Mutation();

--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -42,6 +42,10 @@ public class ServletDataImpl implements ServletData {
 			_suggestionResourceComponentServiceObjects);
 	}
 
+	public String getApplicationName() {
+		return "Liferay.Portal.Search.REST";
+	}
+
 	@Override
 	public Mutation getMutation() {
 		return new Mutation();

--- a/modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Vulcan API
 Bundle-SymbolicName: com.liferay.portal.vulcan.api
-Bundle-Version: 15.1.1
+Bundle-Version: 15.2.0
 Export-Package:\
 	com.liferay.portal.vulcan.accept.language,\
 	com.liferay.portal.vulcan.aggregation,\

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/graphql/contributor/GraphQLContributor.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/graphql/contributor/GraphQLContributor.java
@@ -19,6 +19,10 @@ package com.liferay.portal.vulcan.graphql.contributor;
  */
 public interface GraphQLContributor {
 
+	public default String getApplicationName() {
+		return null;
+	}
+
 	public default String getGraphQLNamespace() {
 		return null;
 	}

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/graphql/servlet/ServletData.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/graphql/servlet/ServletData.java
@@ -19,6 +19,10 @@ package com.liferay.portal.vulcan.graphql.servlet;
  */
 public interface ServletData {
 
+	public default String getApplicationName() {
+		return null;
+	}
+
 	public default String getGraphQLNamespace() {
 		return null;
 	}

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/graphql/contributor/packageinfo
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/graphql/contributor/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/graphql/servlet/packageinfo
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/graphql/servlet/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/build.gradle
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/build.gradle
@@ -62,6 +62,7 @@ dependencies {
 	compileOnly project(":apps:document-library:document-library-api")
 	compileOnly project(":apps:headless:headless-batch-engine:headless-batch-engine-api")
 	compileOnly project(":apps:oauth2-provider:oauth2-provider-scope-api")
+	compileOnly project(":apps:oauth2-provider:oauth2-provider-scope-liferay-api")
 	compileOnly project(":apps:portal-odata:portal-odata-api")
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":apps:static:osgi:osgi-util")

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/constants/GraphQLConstants.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/constants/GraphQLConstants.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.internal.graphql.constants;
+
+/**
+ * @author Carlos Correa
+ */
+public class GraphQLConstants {
+
+	public static final String NAMESPACE_C = "c";
+
+	public static final String NAMESPACE_MUTATION = "mutation";
+
+	public static final String NAMESPACE_QUERY = "query";
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/data/fetcher/BaseOAuth2DataFetcher.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/data/fetcher/BaseOAuth2DataFetcher.java
@@ -1,0 +1,268 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.internal.graphql.data.fetcher;
+
+import com.liferay.oauth2.provider.scope.ScopeChecker;
+import com.liferay.oauth2.provider.scope.liferay.OAuth2ProviderScopeLiferayAccessControlContext;
+import com.liferay.oauth2.provider.scope.liferay.ScopeContext;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.access.control.AccessControlUtil;
+import com.liferay.portal.kernel.security.access.control.AccessControlled;
+import com.liferay.portal.kernel.security.auth.AccessControlContext;
+import com.liferay.portal.kernel.security.auth.verifier.AuthVerifierResult;
+import com.liferay.portal.kernel.security.service.access.policy.ServiceAccessPolicy;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.security.access.control.AccessControlAdvisor;
+import com.liferay.portal.security.access.control.AccessControlAdvisorImpl;
+
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.GraphQLType;
+
+import graphql.servlet.GraphQLContext;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.ForbiddenException;
+import javax.ws.rs.core.Application;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+
+/**
+ * @author Carlos Correa
+ */
+public abstract class BaseOAuth2DataFetcher implements DataFetcher<Object> {
+
+	public BaseOAuth2DataFetcher(
+		String applicationName, Bundle bundle, String httpMethod, Method method,
+		ScopeChecker scopeChecker, ScopeContext scopeContext) {
+
+		_applicationName = applicationName;
+		_bundle = bundle;
+		_httpMethod = httpMethod;
+		this.method = method;
+		_scopeChecker = scopeChecker;
+		_scopeContext = scopeContext;
+	}
+
+	@Override
+	public final Object get(DataFetchingEnvironment dataFetchingEnvironment)
+		throws Exception {
+
+		try {
+			HttpServletRequest httpServletRequest = _getHttpServletRequest(
+				dataFetchingEnvironment);
+
+			GraphQLType graphQLType = dataFetchingEnvironment.getParentType();
+
+			if (_graphQLNamespaces.contains(graphQLType.getName())) {
+				_scopeContext.setApplicationName(_applicationName);
+				_scopeContext.setBundle(_bundle);
+				_scopeContext.setCompanyId(
+					PortalUtil.getCompanyId(httpServletRequest));
+
+				if (OAuth2ProviderScopeLiferayAccessControlContext.
+						isOAuth2AuthVerified()) {
+
+					_enableSAP();
+
+					if (!_scopeChecker.checkScope(_httpMethod)) {
+						throw new ForbiddenException();
+					}
+				}
+
+				if (method != null) {
+					_incrementServiceDepth();
+
+					_accessControlAdvisor.accept(
+						method, new Object[0], _NULL_ACCESS_CONTROLLED);
+				}
+			}
+
+			return get(
+				dataFetchingEnvironment, httpServletRequest,
+				_getHttpServletResponse(dataFetchingEnvironment));
+		}
+		catch (InvocationTargetException invocationTargetException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(invocationTargetException);
+			}
+
+			throw new RuntimeException(
+				invocationTargetException.getTargetException());
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(exception);
+			}
+
+			throw new RuntimeException(exception);
+		}
+	}
+
+	public abstract Object get(
+			DataFetchingEnvironment dataFetchingEnvironment,
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
+		throws Exception;
+
+	protected Method method;
+
+	private void _enableSAP() throws Exception {
+		AccessControlContext accessControlContext =
+			AccessControlUtil.getAccessControlContext();
+
+		AuthVerifierResult authVerifierResult =
+			accessControlContext.getAuthVerifierResult();
+
+		if (authVerifierResult == null) {
+			return;
+		}
+
+		Map<String, Object> settings = authVerifierResult.getSettings();
+
+		List<String> serviceAccessPolicyNames =
+			(List<String>)settings.computeIfAbsent(
+				ServiceAccessPolicy.SERVICE_ACCESS_POLICY_NAMES,
+				value -> new ArrayList<>());
+
+		String policyName = _getPolicyName();
+
+		if (!serviceAccessPolicyNames.contains(policyName)) {
+			serviceAccessPolicyNames.add(policyName);
+		}
+	}
+
+	private HttpServletRequest _getHttpServletRequest(
+		DataFetchingEnvironment dataFetchingEnvironment) {
+
+		GraphQLContext graphQLContext = dataFetchingEnvironment.getContext();
+
+		Optional<HttpServletRequest> httpServletRequestOptional =
+			graphQLContext.getHttpServletRequest();
+
+		return httpServletRequestOptional.orElse(null);
+	}
+
+	private HttpServletResponse _getHttpServletResponse(
+		DataFetchingEnvironment dataFetchingEnvironment) {
+
+		GraphQLContext graphQLContext = dataFetchingEnvironment.getContext();
+
+		Optional<HttpServletResponse> httpServletResponseOptional =
+			graphQLContext.getHttpServletResponse();
+
+		return httpServletResponseOptional.orElse(null);
+	}
+
+	private String _getPolicyName() throws Exception {
+		BundleContext bundleContext = _bundle.getBundleContext();
+
+		List<ServiceReference<Application>> serviceReferences =
+			(List<ServiceReference<Application>>)
+				bundleContext.getServiceReferences(
+					Application.class,
+					"(osgi.jaxrs.name=" + _applicationName + ")");
+
+		if (ListUtil.isNotEmpty(serviceReferences)) {
+			for (ServiceReference<?> serviceReference : serviceReferences) {
+				String policyName = (String)serviceReference.getProperty(
+					"oauth2.service.access.policy.name");
+
+				if (!Validator.isBlank(policyName)) {
+					return policyName;
+				}
+			}
+		}
+
+		return "AUTHORIZED_OAUTH2_SAP";
+	}
+
+	private void _incrementServiceDepth() {
+		AccessControlContext accessControlContext =
+			AccessControlUtil.getAccessControlContext();
+
+		if (accessControlContext == null) {
+			return;
+		}
+
+		Map<String, Object> settings = accessControlContext.getSettings();
+
+		Integer serviceDepth = (Integer)settings.get(
+			AccessControlContext.Settings.SERVICE_DEPTH.toString());
+
+		if (serviceDepth == null) {
+			serviceDepth = Integer.valueOf(1);
+		}
+		else {
+			serviceDepth++;
+		}
+
+		settings.put(
+			AccessControlContext.Settings.SERVICE_DEPTH.toString(),
+			serviceDepth);
+	}
+
+	private static final AccessControlled _NULL_ACCESS_CONTROLLED =
+		new AccessControlled() {
+
+			@Override
+			public Class<? extends Annotation> annotationType() {
+				return AccessControlled.class;
+			}
+
+			@Override
+			public boolean guestAccessEnabled() {
+				return false;
+			}
+
+			@Override
+			public boolean hostAllowedValidationEnabled() {
+				return false;
+			}
+
+		};
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		BaseOAuth2DataFetcher.class);
+
+	private static final List<String> _graphQLNamespaces = Arrays.asList(
+		"c", "mutation", "query");
+
+	private final AccessControlAdvisor _accessControlAdvisor =
+		new AccessControlAdvisorImpl();
+	private final String _applicationName;
+	private final Bundle _bundle;
+	private final String _httpMethod;
+	private final ScopeChecker _scopeChecker;
+	private final ScopeContext _scopeContext;
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/data/fetcher/BaseOAuth2DataFetcher.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/data/fetcher/BaseOAuth2DataFetcher.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.security.access.control.AccessControlAdvisor;
 import com.liferay.portal.security.access.control.AccessControlAdvisorImpl;
+import com.liferay.portal.vulcan.internal.graphql.constants.GraphQLConstants;
 
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
@@ -255,7 +256,8 @@ public abstract class BaseOAuth2DataFetcher implements DataFetcher<Object> {
 		BaseOAuth2DataFetcher.class);
 
 	private static final List<String> _graphQLNamespaces = Arrays.asList(
-		"c", "mutation", "query");
+		GraphQLConstants.NAMESPACE_C, GraphQLConstants.NAMESPACE_MUTATION,
+		GraphQLConstants.NAMESPACE_QUERY);
 
 	private final AccessControlAdvisor _accessControlAdvisor =
 		new AccessControlAdvisorImpl();

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/data/fetcher/GraphQLDTOContributorDataFetcher.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/data/fetcher/GraphQLDTOContributorDataFetcher.java
@@ -14,32 +14,40 @@
 
 package com.liferay.portal.vulcan.internal.graphql.data.fetcher;
 
+import com.liferay.oauth2.provider.scope.ScopeChecker;
+import com.liferay.oauth2.provider.scope.liferay.ScopeContext;
 import com.liferay.portal.vulcan.graphql.dto.GraphQLDTOContributor;
 import com.liferay.portal.vulcan.graphql.dto.GraphQLDTOProperty;
 import com.liferay.portal.vulcan.internal.graphql.data.processor.GraphQLDTOContributorDataFetchingProcessor;
 
-import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
-
-import graphql.servlet.GraphQLContext;
 
 import java.io.Serializable;
 
 import java.util.Map;
-import java.util.Optional;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.framework.Bundle;
 
 /**
  * @author Carlos Correa
  */
-public class GraphQLDTOContributorDataFetcher implements DataFetcher<Object> {
+public class GraphQLDTOContributorDataFetcher extends BaseOAuth2DataFetcher {
 
 	public GraphQLDTOContributorDataFetcher(
+		String applicationName, Bundle bundle,
 		GraphQLDTOContributor graphQLDTOContributor,
 		GraphQLDTOContributorDataFetchingProcessor
 			graphQLDTOContributorDataFetchingProcessor,
-		GraphQLDTOProperty graphQLDTOProperty, Operation operation) {
+		GraphQLDTOProperty graphQLDTOProperty, String httpMethod,
+		Operation operation, ScopeChecker scopeChecker,
+		ScopeContext scopeContext) {
+
+		super(
+			applicationName, bundle, httpMethod, null, scopeChecker,
+			scopeContext);
 
 		_graphQLDTOContributor = graphQLDTOContributor;
 		_graphQLDTOContributorDataFetchingProcessor =
@@ -49,26 +57,31 @@ public class GraphQLDTOContributorDataFetcher implements DataFetcher<Object> {
 	}
 
 	public GraphQLDTOContributorDataFetcher(
+		String applicationName, Bundle bundle,
 		GraphQLDTOContributor graphQLDTOContributor,
 		GraphQLDTOContributorDataFetchingProcessor
 			graphQLDTOContributorDataFetchingProcessor,
-		Operation operation) {
+		String httpMethod, Operation operation, ScopeChecker scopeChecker,
+		ScopeContext scopeContext) {
 
 		this(
-			graphQLDTOContributor, graphQLDTOContributorDataFetchingProcessor,
-			null, operation);
+			applicationName, bundle, graphQLDTOContributor,
+			graphQLDTOContributorDataFetchingProcessor, null, httpMethod,
+			operation, scopeChecker, scopeContext);
 	}
 
 	@Override
-	public Object get(DataFetchingEnvironment dataFetchingEnvironment)
+	public Object get(
+			DataFetchingEnvironment dataFetchingEnvironment,
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
 		throws Exception {
 
 		if (_operation == Operation.CREATE) {
 			return _graphQLDTOContributorDataFetchingProcessor.create(
 				dataFetchingEnvironment.getArgument(
 					_graphQLDTOContributor.getResourceName()),
-				_graphQLDTOContributor,
-				_getHttpServletRequest(dataFetchingEnvironment),
+				_graphQLDTOContributor, httpServletRequest,
 				(String)dataFetchingEnvironment.getArgument("scopeKey"));
 		}
 		else if (_operation == Operation.DELETE) {
@@ -79,8 +92,7 @@ public class GraphQLDTOContributorDataFetcher implements DataFetcher<Object> {
 		}
 		else if (_operation == Operation.GET) {
 			return _graphQLDTOContributorDataFetchingProcessor.get(
-				_graphQLDTOContributor,
-				_getHttpServletRequest(dataFetchingEnvironment),
+				_graphQLDTOContributor, httpServletRequest,
 				dataFetchingEnvironment.getArgument(
 					_graphQLDTOContributor.getIdName()));
 		}
@@ -94,15 +106,14 @@ public class GraphQLDTOContributorDataFetcher implements DataFetcher<Object> {
 			}
 
 			return _graphQLDTOContributorDataFetchingProcessor.getRelationship(
-				_graphQLDTOContributor, _graphQLDTOProperty,
-				_getHttpServletRequest(dataFetchingEnvironment), (long)id);
+				_graphQLDTOContributor, _graphQLDTOProperty, httpServletRequest,
+				(long)id);
 		}
 		else if (_operation == Operation.LIST) {
 			return _graphQLDTOContributorDataFetchingProcessor.list(
 				dataFetchingEnvironment.getArgument("aggregation"),
 				(String)dataFetchingEnvironment.getArgument("filter"),
-				_graphQLDTOContributor,
-				_getHttpServletRequest(dataFetchingEnvironment),
+				_graphQLDTOContributor, httpServletRequest,
 				dataFetchingEnvironment.getArgument("page"),
 				dataFetchingEnvironment.getArgument("pageSize"),
 				dataFetchingEnvironment.getArgument("scopeKey"),
@@ -113,8 +124,7 @@ public class GraphQLDTOContributorDataFetcher implements DataFetcher<Object> {
 			return _graphQLDTOContributorDataFetchingProcessor.update(
 				dataFetchingEnvironment.<Map<String, Serializable>>getArgument(
 					_graphQLDTOContributor.getResourceName()),
-				_graphQLDTOContributor,
-				_getHttpServletRequest(dataFetchingEnvironment),
+				_graphQLDTOContributor, httpServletRequest,
 				dataFetchingEnvironment.getArgument(
 					_graphQLDTOContributor.getIdName()));
 		}
@@ -127,17 +137,6 @@ public class GraphQLDTOContributorDataFetcher implements DataFetcher<Object> {
 
 		CREATE, DELETE, GET, GET_RELATIONSHIP, LIST, UPDATE
 
-	}
-
-	private HttpServletRequest _getHttpServletRequest(
-		DataFetchingEnvironment dataFetchingEnvironment) {
-
-		GraphQLContext graphQLContext = dataFetchingEnvironment.getContext();
-
-		Optional<HttpServletRequest> httpServletRequestOptional =
-			graphQLContext.getHttpServletRequest();
-
-		return httpServletRequestOptional.orElse(null);
 	}
 
 	private final GraphQLDTOContributor _graphQLDTOContributor;

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/data/fetcher/LiferayMethodDataFetcher.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/data/fetcher/LiferayMethodDataFetcher.java
@@ -14,83 +14,56 @@
 
 package com.liferay.portal.vulcan.internal.graphql.data.fetcher;
 
+import com.liferay.oauth2.provider.scope.ScopeChecker;
+import com.liferay.oauth2.provider.scope.liferay.ScopeContext;
 import com.liferay.portal.vulcan.internal.graphql.data.processor.LiferayMethodDataFetchingProcessor;
 
-import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.GraphQLFieldDefinition;
 
-import graphql.servlet.GraphQLContext;
-
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-
-import java.util.Optional;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.osgi.framework.Bundle;
+
 /**
  * @author Carlos Correa
  */
-public class LiferayMethodDataFetcher implements DataFetcher<Object> {
+public class LiferayMethodDataFetcher extends BaseOAuth2DataFetcher {
 
 	public LiferayMethodDataFetcher(
+		String applicationName, Bundle bundle, String httpMethod,
 		LiferayMethodDataFetchingProcessor liferayMethodDataFetchingProcessor,
-		Method method) {
+		Method method, ScopeChecker scopeChecker, ScopeContext scopeContext) {
+
+		super(
+			applicationName, bundle, httpMethod, method, scopeChecker,
+			scopeContext);
 
 		_liferayMethodDataFetchingProcessor =
 			liferayMethodDataFetchingProcessor;
-		_method = method;
 	}
 
 	@Override
-	public Object get(DataFetchingEnvironment dataFetchingEnvironment) {
-		try {
-			GraphQLFieldDefinition graphQLFieldDefinition =
-				dataFetchingEnvironment.getFieldDefinition();
+	public Object get(
+			DataFetchingEnvironment dataFetchingEnvironment,
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
+		throws Exception {
 
-			return _liferayMethodDataFetchingProcessor.process(
-				dataFetchingEnvironment.getArguments(),
-				graphQLFieldDefinition.getName(),
-				_getHttpServletRequest(dataFetchingEnvironment),
-				_getHttpServletResponse(dataFetchingEnvironment), _method,
-				dataFetchingEnvironment.getRoot(),
-				dataFetchingEnvironment.getSource());
-		}
-		catch (InvocationTargetException invocationTargetException) {
-			throw new RuntimeException(
-				invocationTargetException.getTargetException());
-		}
-		catch (Exception exception) {
-			throw new RuntimeException(exception);
-		}
-	}
+		GraphQLFieldDefinition graphQLFieldDefinition =
+			dataFetchingEnvironment.getFieldDefinition();
 
-	private HttpServletRequest _getHttpServletRequest(
-		DataFetchingEnvironment dataFetchingEnvironment) {
-
-		GraphQLContext graphQLContext = dataFetchingEnvironment.getContext();
-
-		Optional<HttpServletRequest> httpServletRequestOptional =
-			graphQLContext.getHttpServletRequest();
-
-		return httpServletRequestOptional.orElse(null);
-	}
-
-	private HttpServletResponse _getHttpServletResponse(
-		DataFetchingEnvironment dataFetchingEnvironment) {
-
-		GraphQLContext graphQLContext = dataFetchingEnvironment.getContext();
-
-		Optional<HttpServletResponse> httpServletResponseOptional =
-			graphQLContext.getHttpServletResponse();
-
-		return httpServletResponseOptional.orElse(null);
+		return _liferayMethodDataFetchingProcessor.process(
+			dataFetchingEnvironment.getArguments(),
+			graphQLFieldDefinition.getName(), httpServletRequest,
+			httpServletResponse, method, dataFetchingEnvironment.getRoot(),
+			dataFetchingEnvironment.getSource());
 	}
 
 	private final LiferayMethodDataFetchingProcessor
 		_liferayMethodDataFetchingProcessor;
-	private final Method _method;
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -49,6 +49,7 @@ import com.liferay.portal.vulcan.graphql.dto.v1_0.Creator;
 import com.liferay.portal.vulcan.graphql.servlet.ServletData;
 import com.liferay.portal.vulcan.internal.configuration.VulcanConfiguration;
 import com.liferay.portal.vulcan.internal.configuration.util.ConfigurationUtil;
+import com.liferay.portal.vulcan.internal.graphql.constants.GraphQLConstants;
 import com.liferay.portal.vulcan.internal.graphql.data.fetcher.GraphQLDTOContributorDataFetcher;
 import com.liferay.portal.vulcan.internal.graphql.data.fetcher.LiferayMethodDataFetcher;
 import com.liferay.portal.vulcan.internal.graphql.data.processor.GraphQLDTOContributorDataFetchingProcessor;
@@ -812,7 +813,8 @@ public class GraphQLServletExtender {
 			GraphQLObjectType.Builder mutationGraphQLObjectTypeBuilder =
 				GraphQLObjectType.newObject();
 
-			mutationGraphQLObjectTypeBuilder.name("mutation");
+			mutationGraphQLObjectTypeBuilder.name(
+				GraphQLConstants.NAMESPACE_MUTATION);
 
 			ProcessingElementsContainer processingElementsContainer =
 				new ProcessingElementsContainer(_defaultTypeFunction);
@@ -859,7 +861,8 @@ public class GraphQLServletExtender {
 			GraphQLObjectType.Builder queryGraphQLObjectTypeBuilder =
 				GraphQLObjectType.newObject();
 
-			queryGraphQLObjectTypeBuilder.name("query");
+			queryGraphQLObjectTypeBuilder.name(
+				GraphQLConstants.NAMESPACE_QUERY);
 
 			_collectObjectFields(
 				ServletData::getQuery, queryGraphQLObjectTypeBuilder, false,
@@ -1379,7 +1382,7 @@ public class GraphQLServletExtender {
 			return;
 		}
 
-		String namespace = "c";
+		String namespace = GraphQLConstants.NAMESPACE_C;
 
 		GraphQLObjectType.Builder queryGraphQLObjectTypeBuilder =
 			new GraphQLObjectType.Builder();
@@ -1415,12 +1418,14 @@ public class GraphQLServletExtender {
 
 		graphQLSchemaBuilder.codeRegistry(
 			graphQLCodeRegistryBuilder.dataFetcher(
-				FieldCoordinates.coordinates("query", namespace),
+				FieldCoordinates.coordinates(
+					GraphQLConstants.NAMESPACE_QUERY, namespace),
 				(DataFetcher<Object>)dataFetchingEnvironment -> new Object()
 			).build());
 		graphQLSchemaBuilder.codeRegistry(
 			graphQLCodeRegistryBuilder.dataFetcher(
-				FieldCoordinates.coordinates("mutation", namespace),
+				FieldCoordinates.coordinates(
+					GraphQLConstants.NAMESPACE_MUTATION, namespace),
 				(DataFetcher<Object>)dataFetchingEnvironment -> new Object()
 			).build());
 	}
@@ -1447,7 +1452,8 @@ public class GraphQLServletExtender {
 
 			graphQLSchemaBuilder.codeRegistry(
 				graphQLCodeRegistryBuilder.dataFetcher(
-					FieldCoordinates.coordinates("query", "graphQLNode"),
+					FieldCoordinates.coordinates(
+						GraphQLConstants.NAMESPACE_QUERY, "graphQLNode"),
 					new NodeDataFetcher()
 				).typeResolver(
 					"GraphQLNode", new GraphQLNodeTypeResolver()
@@ -1549,10 +1555,10 @@ public class GraphQLServletExtender {
 			graphQLObjectTypeBuilder.field(
 				_addField(builder.build(), graphQLNamespace));
 
-			String parentField = "query";
+			String parentField = GraphQLConstants.NAMESPACE_QUERY;
 
 			if (mutation) {
-				parentField = "mutation";
+				parentField = GraphQLConstants.NAMESPACE_MUTATION;
 			}
 
 			graphQLSchemaBuilder.codeRegistry(
@@ -1992,7 +1998,8 @@ public class GraphQLServletExtender {
 				dataFetchingEnvironment.getFieldDefinition();
 
 			DataFetcher<?> dataFetcher = graphQLCodeRegistry.getDataFetcher(
-				(GraphQLFieldsContainer)graphQLTypes.get("query"),
+				(GraphQLFieldsContainer)graphQLTypes.get(
+					GraphQLConstants.NAMESPACE_QUERY),
 				_addField(graphQLFieldDefinition.getType(), fieldName));
 
 			DataFetchingEnvironmentImpl.Builder dataFetchingEnvironmentBuilder =

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -19,6 +19,8 @@ import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 
 import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.oauth2.provider.scope.ScopeChecker;
+import com.liferay.oauth2.provider.scope.liferay.ScopeContext;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapListener;
@@ -185,12 +187,16 @@ import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
+import javax.ws.rs.ForbiddenException;
+import javax.ws.rs.HttpMethod;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.core.Response;
 
 import javax.xml.bind.DatatypeConverter;
 
+import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.cm.Configuration;
@@ -199,6 +205,8 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 import org.osgi.service.http.context.ServletContextHelper;
 import org.osgi.service.http.whiteboard.HttpWhiteboardConstants;
 import org.osgi.util.tracker.ServiceTracker;
@@ -619,6 +627,9 @@ public class GraphQLServletExtender {
 
 							throw invocationTargetException.getCause();
 						}
+						finally {
+							_scopeContext.clear();
+						}
 					}
 
 					private ServletConfig _servletConfig;
@@ -703,9 +714,11 @@ public class GraphQLServletExtender {
 
 	private void _collectObjectFields(
 		Function<ServletData, Object> function,
-		GraphQLObjectType.Builder graphQLObjectTypeBuilder,
+		GraphQLObjectType.Builder graphQLObjectTypeBuilder, boolean mutation,
 		ProcessingElementsContainer processingElementsContainer,
 		List<ServletData> servletDatas) {
+
+		Map<Method, ServletData> servletDataMap = new HashMap<>();
 
 		Stream<ServletData> stream = servletDatas.stream();
 
@@ -724,6 +737,12 @@ public class GraphQLServletExtender {
 				Arrays::stream
 			).filter(
 				method -> _isMethodEnabled(method, servletData.getPath())
+			).map(
+				method -> {
+					servletDataMap.put(method, servletData);
+
+					return method;
+				}
 			)
 		).collect(
 			Collectors.groupingBy(
@@ -736,6 +755,13 @@ public class GraphQLServletExtender {
 				Method method = methodOptional.get();
 
 				Class<?> clazz = method.getDeclaringClass();
+
+				ServletData servletData = servletDataMap.get(method);
+
+				_applicationName = servletData.getApplicationName();
+				_bundle = FrameworkUtil.getBundle(servletData.getClass());
+
+				_httpMethod = _getHttpMethod(method, mutation);
 
 				graphQLObjectTypeBuilder.field(
 					_graphQLFieldRetriever.getField(
@@ -778,6 +804,9 @@ public class GraphQLServletExtender {
 
 			PropertyDataFetcher.clearReflectionCache();
 
+			_applicationName = null;
+			_bundle = null;
+			_httpMethod = null;
 			_registeredClassNames.clear();
 
 			GraphQLObjectType.Builder mutationGraphQLObjectTypeBuilder =
@@ -825,7 +854,7 @@ public class GraphQLServletExtender {
 
 			_collectObjectFields(
 				ServletData::getMutation, mutationGraphQLObjectTypeBuilder,
-				processingElementsContainer, servletDatas);
+				true, processingElementsContainer, servletDatas);
 
 			GraphQLObjectType.Builder queryGraphQLObjectTypeBuilder =
 				GraphQLObjectType.newObject();
@@ -833,7 +862,7 @@ public class GraphQLServletExtender {
 			queryGraphQLObjectTypeBuilder.name("query");
 
 			_collectObjectFields(
-				ServletData::getQuery, queryGraphQLObjectTypeBuilder,
+				ServletData::getQuery, queryGraphQLObjectTypeBuilder, false,
 				processingElementsContainer, servletDatas);
 
 			GraphQLSchema.Builder graphQLSchemaBuilder =
@@ -990,15 +1019,49 @@ public class GraphQLServletExtender {
 						graphQLDTOContributor.getTypeName(),
 						relationshipGraphQLDTOProperty.getName()),
 					new GraphQLDTOContributorDataFetcher(
+						graphQLDTOContributor.getTypeName(),
+						FrameworkUtil.getBundle(
+							graphQLDTOContributor.getClass()),
 						graphQLDTOContributor,
 						_graphQLDTOContributorDataFetchingProcessor,
-						relationshipGraphQLDTOProperty,
+						relationshipGraphQLDTOProperty, HttpMethod.GET,
 						GraphQLDTOContributorDataFetcher.Operation.
-							GET_RELATIONSHIP)
+							GET_RELATIONSHIP,
+						_scopeChecker, _scopeContext)
 				).build());
 		}
 
 		return graphQLObjectTypeBuilder.build();
+	}
+
+	private String _getHttpMethod(Method method, boolean mutation) {
+		String httpMethod = null;
+
+		if (mutation) {
+			if (StringUtil.startsWith(method.getName(), "create")) {
+				httpMethod = HttpMethod.POST;
+			}
+			else if (StringUtil.startsWith(method.getName(), "delete")) {
+				httpMethod = HttpMethod.DELETE;
+			}
+			else if (StringUtil.startsWith(method.getName(), "head")) {
+				httpMethod = HttpMethod.HEAD;
+			}
+			else if (StringUtil.startsWith(method.getName(), "options")) {
+				httpMethod = HttpMethod.OPTIONS;
+			}
+			else if (StringUtil.startsWith(method.getName(), "patch")) {
+				httpMethod = HttpMethod.PATCH;
+			}
+			else if (StringUtil.startsWith(method.getName(), "update")) {
+				httpMethod = HttpMethod.PUT;
+			}
+		}
+		else {
+			httpMethod = HttpMethod.GET;
+		}
+
+		return httpMethod;
 	}
 
 	private GraphQLObjectType _getPageGraphQLObjectType(
@@ -1189,9 +1252,13 @@ public class GraphQLServletExtender {
 			graphQLCodeRegistryBuilder.dataFetcher(
 				FieldCoordinates.coordinates(mutationNamespace, createName),
 				new GraphQLDTOContributorDataFetcher(
+					graphQLDTOContributor.getTypeName(),
+					FrameworkUtil.getBundle(graphQLDTOContributor.getClass()),
 					graphQLDTOContributor,
 					_graphQLDTOContributorDataFetchingProcessor,
-					GraphQLDTOContributorDataFetcher.Operation.CREATE)
+					HttpMethod.POST,
+					GraphQLDTOContributorDataFetcher.Operation.CREATE,
+					_scopeChecker, _scopeContext)
 			).build());
 
 		// Delete
@@ -1209,9 +1276,13 @@ public class GraphQLServletExtender {
 			graphQLCodeRegistryBuilder.dataFetcher(
 				FieldCoordinates.coordinates(mutationNamespace, deleteName),
 				new GraphQLDTOContributorDataFetcher(
+					graphQLDTOContributor.getTypeName(),
+					FrameworkUtil.getBundle(graphQLDTOContributor.getClass()),
 					graphQLDTOContributor,
 					_graphQLDTOContributorDataFetchingProcessor,
-					GraphQLDTOContributorDataFetcher.Operation.DELETE)
+					HttpMethod.DELETE,
+					GraphQLDTOContributorDataFetcher.Operation.DELETE,
+					_scopeChecker, _scopeContext)
 			).build());
 
 		// Get
@@ -1226,9 +1297,12 @@ public class GraphQLServletExtender {
 			graphQLCodeRegistryBuilder.dataFetcher(
 				FieldCoordinates.coordinates(namespace, getName),
 				new GraphQLDTOContributorDataFetcher(
+					graphQLDTOContributor.getTypeName(),
+					FrameworkUtil.getBundle(graphQLDTOContributor.getClass()),
 					graphQLDTOContributor,
-					_graphQLDTOContributorDataFetchingProcessor,
-					GraphQLDTOContributorDataFetcher.Operation.GET)
+					_graphQLDTOContributorDataFetchingProcessor, HttpMethod.GET,
+					GraphQLDTOContributorDataFetcher.Operation.GET,
+					_scopeChecker, _scopeContext)
 			).build());
 
 		// List
@@ -1261,9 +1335,12 @@ public class GraphQLServletExtender {
 			graphQLCodeRegistryBuilder.dataFetcher(
 				FieldCoordinates.coordinates(namespace, listName),
 				new GraphQLDTOContributorDataFetcher(
+					graphQLDTOContributor.getTypeName(),
+					FrameworkUtil.getBundle(graphQLDTOContributor.getClass()),
 					graphQLDTOContributor,
-					_graphQLDTOContributorDataFetchingProcessor,
-					GraphQLDTOContributorDataFetcher.Operation.LIST)
+					_graphQLDTOContributorDataFetchingProcessor, HttpMethod.GET,
+					GraphQLDTOContributorDataFetcher.Operation.LIST,
+					_scopeChecker, _scopeContext)
 			).build());
 
 		// Update
@@ -1280,9 +1357,12 @@ public class GraphQLServletExtender {
 			graphQLCodeRegistryBuilder.dataFetcher(
 				FieldCoordinates.coordinates(mutationNamespace, updateName),
 				new GraphQLDTOContributorDataFetcher(
+					graphQLDTOContributor.getTypeName(),
+					FrameworkUtil.getBundle(graphQLDTOContributor.getClass()),
 					graphQLDTOContributor,
-					_graphQLDTOContributorDataFetchingProcessor,
-					GraphQLDTOContributorDataFetcher.Operation.UPDATE)
+					_graphQLDTOContributorDataFetchingProcessor, HttpMethod.PUT,
+					GraphQLDTOContributorDataFetcher.Operation.UPDATE,
+					_scopeChecker, _scopeContext)
 			).build());
 	}
 
@@ -1440,10 +1520,15 @@ public class GraphQLServletExtender {
 
 			Method[] methods = clazz.getMethods();
 
+			_applicationName = servletData.getApplicationName();
+			_bundle = FrameworkUtil.getBundle(servletData.getClass());
+
 			for (Method method : methods) {
 				if (!_isMethodEnabled(method, servletData.getPath())) {
 					continue;
 				}
+
+				_httpMethod = _getHttpMethod(method, mutation);
 
 				builder.field(
 					_graphQLFieldRetriever.getField(
@@ -1455,7 +1540,9 @@ public class GraphQLServletExtender {
 						FieldCoordinates.coordinates(
 							graphQLNamespace, method.getName()),
 						new LiferayMethodDataFetcher(
-							_liferayMethodDataFetchingProcessor, method)
+							_applicationName, _bundle, _httpMethod,
+							_liferayMethodDataFetchingProcessor, method,
+							_scopeChecker, _scopeContext)
 					).build());
 			}
 
@@ -1795,6 +1882,8 @@ public class GraphQLServletExtender {
 		).build();
 	}
 
+	private String _applicationName;
+	private Bundle _bundle;
 	private BundleContext _bundleContext;
 
 	@Reference
@@ -1819,6 +1908,8 @@ public class GraphQLServletExtender {
 	@Reference
 	private GroupLocalService _groupLocalService;
 
+	private String _httpMethod;
+
 	@Reference
 	private Language _language;
 
@@ -1833,6 +1924,15 @@ public class GraphQLServletExtender {
 
 	@Reference
 	private RoleLocalService _roleLocalService;
+
+	@Reference
+	private ScopeChecker _scopeChecker;
+
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY
+	)
+	private volatile ScopeContext _scopeContext;
 
 	private ServiceRegistration<ServletContextHelper>
 		_servletContextHelperServiceRegistration;
@@ -2089,6 +2189,10 @@ public class GraphQLServletExtender {
 						return _getExtendedGraphQLError(
 							graphQLError, Response.Status.UNAUTHORIZED);
 					}
+					else if (_isForbiddenException(graphQLError)) {
+						return _getExtendedGraphQLError(
+							graphQLError, Response.Status.FORBIDDEN);
+					}
 					else if (_isNotFoundException(graphQLError)) {
 						return _getExtendedGraphQLError(
 							graphQLError, Response.Status.NOT_FOUND);
@@ -2141,6 +2245,25 @@ public class GraphQLServletExtender {
 
 			if (!(graphQLError instanceof Throwable) ||
 				message.contains("ClientErrorException")) {
+
+				return true;
+			}
+
+			return false;
+		}
+
+		private boolean _isForbiddenException(GraphQLError graphQLError) {
+			if (!(graphQLError instanceof ExceptionWhileDataFetching)) {
+				return false;
+			}
+
+			ExceptionWhileDataFetching exceptionWhileDataFetching =
+				(ExceptionWhileDataFetching)graphQLError;
+
+			Throwable throwable = exceptionWhileDataFetching.getException();
+
+			if ((throwable != null) &&
+				(throwable.getCause() instanceof ForbiddenException)) {
 
 				return true;
 			}
@@ -2365,7 +2488,9 @@ public class GraphQLServletExtender {
 
 			graphQLFieldDefinitionBuilder.dataFetcher(
 				new LiferayMethodDataFetcher(
-					_liferayMethodDataFetchingProcessor, method));
+					_applicationName, _bundle, _httpMethod,
+					_liferayMethodDataFetchingProcessor, method, _scopeChecker,
+					_scopeContext));
 
 			DeprecateBuilder deprecateBuilder = new LiferayDeprecateBuilder(
 				method);

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/ServletDataAdapter.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/ServletDataAdapter.java
@@ -26,6 +26,10 @@ public class ServletDataAdapter implements ServletData {
 		return new ServletDataAdapter(graphQLContributor);
 	}
 
+	public String getApplicationName() {
+		return _graphQLContributor.getApplicationName();
+	}
+
 	@Override
 	public String getGraphQLNamespace() {
 		return _graphQLContributor.getGraphQLNamespace();

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -48,6 +48,10 @@ public class ServletDataImpl implements ServletData {
 			_skuForecastResourceComponentServiceObjects);
 	}
 
+	public String getApplicationName() {
+		return "Liferay.Headless.Commerce.Machine.Learning";
+	}
+
 	@Override
 	public Mutation getMutation() {
 		return new Mutation();

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -103,6 +103,10 @@ public class ServletDataImpl implements ServletData {
 			_timeRangeResourceComponentServiceObjects);
 	}
 
+	public String getApplicationName() {
+		return "Liferay.Portal.Workflow.Metrics.REST";
+	}
+
 	@Override
 	public Mutation getMutation() {
 		return new Mutation();

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -75,6 +75,10 @@ public class ServletDataImpl implements ServletData {
 			_searchableAssetNameDisplayResourceComponentServiceObjects);
 	}
 
+	public String getApplicationName() {
+		return "Liferay.Search.Experiences.REST";
+	}
+
 	@Override
 	public Mutation getMutation() {
 		return new Mutation();

--- a/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -51,6 +51,10 @@ public class ServletDataImpl implements ServletData {
 			_experimentResourceComponentServiceObjects);
 	}
 
+	public String getApplicationName() {
+		return "Liferay.Segments.Asah.REST";
+	}
+
 	@Override
 	public Mutation getMutation() {
 		return new Mutation();

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/graphql_servlet_data.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/graphql_servlet_data.ftl
@@ -46,6 +46,10 @@ public class ServletDataImpl implements ServletData {
 		</#list>
 	}
 
+	public String getApplicationName() {
+		return "${configYAML.application.name}";
+	}
+
 	<#if configYAML.graphQLNamespace??>
 		@Override
 		public String getGraphQLNamespace() {


### PR DESCRIPTION
This PR contains the code to allow using OAuth 2.0 as the authorization mechanism to interact with GraphQL: https://issues.liferay.com/browse/LPS-158259.

For each companyId, a java Servlet is created to manage the requests through GraphQL. The servlet is generated by using [this external library](https://www.graphql-java.com/), configuring its schema properly.

As the external library uses the `DataFetcher` class to execute the desired code for each request by invocating the method `get(DataFetchingEnvironment var1)`, the necessary operations to control the scope of the request has been included in that method, as in that point, the request body has been properly parsed by the library.

When parsing the following namespaces, the scope context is set based on the JAX-RS Application that will end up managing the request, its bundle  and the Service Access Policy that is set in the JAX-RS request lifecycle too.
