### PR TITLE
LPS-152217: Update NoSuchModelExceptionMapper returning 404 status code

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/CommentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/CommentResourceImpl.java
@@ -89,8 +89,9 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 				String externalReferenceCode)
 		throws Exception {
 
-		BlogsEntry blogsEntry = _getBlogsEntry(
-			blogPostingExternalReferenceCode, siteId);
+		BlogsEntry blogsEntry =
+			_blogsEntryService.getBlogsEntryByExternalReferenceCode(
+				siteId, blogPostingExternalReferenceCode);
 
 		com.liferay.portal.kernel.comment.Comment comment = _getComment(
 			externalReferenceCode, siteId, BlogsEntry.class.getName(),
@@ -119,8 +120,9 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 				String externalReferenceCode)
 		throws Exception {
 
-		DLFileEntry dlFileEntry = _getDLFileEntry(
-			documentExternalReferenceCode, siteId);
+		DLFileEntry dlFileEntry =
+			_dlFileEntryService.getFileEntryByExternalReferenceCode(
+				siteId, documentExternalReferenceCode);
 
 		com.liferay.portal.kernel.comment.Comment comment = _getComment(
 			externalReferenceCode, siteId, DLFileEntry.class.getName(),
@@ -136,8 +138,9 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 				String externalReferenceCode)
 		throws Exception {
 
-		JournalArticle journalArticle = _getLatestJournalArticle(
-			structuredContentExternalReferenceCode, siteId);
+		JournalArticle journalArticle =
+			_journalArticleService.getLatestArticleByExternalReferenceCode(
+				siteId, structuredContentExternalReferenceCode);
 
 		com.liferay.portal.kernel.comment.Comment comment = _getComment(
 			externalReferenceCode, siteId, JournalArticle.class.getName(),
@@ -278,8 +281,9 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 				String externalReferenceCode)
 		throws Exception {
 
-		BlogsEntry blogsEntry = _getBlogsEntry(
-			blogPostingExternalReferenceCode, siteId);
+		BlogsEntry blogsEntry =
+			_blogsEntryService.getBlogsEntryByExternalReferenceCode(
+				siteId, blogPostingExternalReferenceCode);
 
 		com.liferay.portal.kernel.comment.Comment comment = _getComment(
 			externalReferenceCode, siteId, BlogsEntry.class.getName(),
@@ -320,8 +324,9 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 				String externalReferenceCode)
 		throws Exception {
 
-		DLFileEntry dlFileEntry = _getDLFileEntry(
-			documentExternalReferenceCode, siteId);
+		DLFileEntry dlFileEntry =
+			_dlFileEntryService.getFileEntryByExternalReferenceCode(
+				siteId, documentExternalReferenceCode);
 
 		com.liferay.portal.kernel.comment.Comment comment = _getComment(
 			externalReferenceCode, siteId, DLFileEntry.class.getName(),
@@ -343,8 +348,9 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 				String externalReferenceCode)
 		throws Exception {
 
-		JournalArticle journalArticle = _getLatestJournalArticle(
-			structuredContentExternalReferenceCode, siteId);
+		JournalArticle journalArticle =
+			_journalArticleService.getLatestArticleByExternalReferenceCode(
+				siteId, structuredContentExternalReferenceCode);
 
 		com.liferay.portal.kernel.comment.Comment comment = _getComment(
 			externalReferenceCode, siteId, JournalArticle.class.getName(),
@@ -471,8 +477,9 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 				String externalReferenceCode, Comment comment)
 		throws Exception {
 
-		BlogsEntry blogsEntry = _getBlogsEntry(
-			blogPostingExternalReferenceCode, siteId);
+		BlogsEntry blogsEntry =
+			_blogsEntryService.getBlogsEntryByExternalReferenceCode(
+				siteId, blogPostingExternalReferenceCode);
 
 		com.liferay.portal.kernel.comment.Comment existingComment =
 			_fetchComment(
@@ -528,8 +535,9 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 				String externalReferenceCode, Comment comment)
 		throws Exception {
 
-		DLFileEntry dlFileEntry = _getDLFileEntry(
-			documentExternalReferenceCode, siteId);
+		DLFileEntry dlFileEntry =
+			_dlFileEntryService.getFileEntryByExternalReferenceCode(
+				siteId, documentExternalReferenceCode);
 
 		com.liferay.portal.kernel.comment.Comment existingComment =
 			_fetchComment(
@@ -555,8 +563,9 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 				String externalReferenceCode, Comment comment)
 		throws Exception {
 
-		JournalArticle journalArticle = _getLatestJournalArticle(
-			structuredContentExternalReferenceCode, siteId);
+		JournalArticle journalArticle =
+			_journalArticleService.getLatestArticleByExternalReferenceCode(
+				siteId, structuredContentExternalReferenceCode);
 
 		com.liferay.portal.kernel.comment.Comment existingComment =
 			_fetchComment(
@@ -608,27 +617,6 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 		return null;
 	}
 
-	private BlogsEntry _getBlogsEntry(String externalReferenceCode, Long siteId)
-		throws Exception {
-
-		BlogsEntry blogsEntry =
-			_blogsEntryService.fetchBlogsEntryByExternalReferenceCode(
-				siteId, externalReferenceCode);
-
-		if (blogsEntry == null) {
-			StringBundler sb = new StringBundler(4);
-
-			sb.append("No blog posting exists with external reference code ");
-			sb.append(externalReferenceCode);
-			sb.append(" and site ID ");
-			sb.append(siteId);
-
-			throw new NotFoundException(sb.toString());
-		}
-
-		return blogsEntry;
-	}
-
 	private com.liferay.portal.kernel.comment.Comment _getComment(
 			String externalReferenceCode, long siteId, String className,
 			long classPK)
@@ -657,18 +645,7 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 		throws Exception {
 
 		com.liferay.portal.kernel.comment.Comment comment =
-			_commentManager.fetchComment(siteId, externalReferenceCode);
-
-		if (comment == null) {
-			StringBundler sb = new StringBundler(4);
-
-			sb.append("No comment exists with external reference code ");
-			sb.append(externalReferenceCode);
-			sb.append(" and site ID ");
-			sb.append(siteId);
-
-			throw new NotFoundException(sb.toString());
-		}
+			_commentManager.getComment(siteId, externalReferenceCode);
 
 		DiscussionPermission discussionPermission = _getDiscussionPermission();
 
@@ -745,51 +722,6 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 	private DiscussionPermission _getDiscussionPermission() {
 		return _commentManager.getDiscussionPermission(
 			PermissionThreadLocal.getPermissionChecker());
-	}
-
-	private DLFileEntry _getDLFileEntry(
-			String externalReferenceCode, Long siteId)
-		throws Exception {
-
-		DLFileEntry dlFileEntry =
-			_dlFileEntryService.fetchFileEntryByExternalReferenceCode(
-				siteId, externalReferenceCode);
-
-		if (dlFileEntry == null) {
-			StringBundler sb = new StringBundler(4);
-
-			sb.append("No document exists with external reference code ");
-			sb.append(externalReferenceCode);
-			sb.append(" and site ID ");
-			sb.append(siteId);
-
-			throw new NotFoundException(sb.toString());
-		}
-
-		return dlFileEntry;
-	}
-
-	private JournalArticle _getLatestJournalArticle(
-			String externalReferenceCode, Long siteId)
-		throws Exception {
-
-		JournalArticle journalArticle =
-			_journalArticleService.fetchLatestArticleByExternalReferenceCode(
-				siteId, externalReferenceCode);
-
-		if (journalArticle == null) {
-			StringBundler sb = new StringBundler(4);
-
-			sb.append(
-				"No structured content exists with external reference code ");
-			sb.append(externalReferenceCode);
-			sb.append(" and site ID ");
-			sb.append(siteId);
-
-			throw new NotFoundException(sb.toString());
-		}
-
-		return journalArticle;
 	}
 
 	private long _getUserId() {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/CommentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/CommentResourceTest.java
@@ -52,29 +52,23 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 		super.
 			testDeleteSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCode();
 
-		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				"com.liferay.portal.vulcan.internal.jaxrs.exception.mapper." +
-					"WebApplicationExceptionMapper",
-				LoggerTestUtil.ERROR)) {
+		Comment comment =
+			testDeleteSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCode_addComment();
 
-			Comment comment =
-				testDeleteSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCode_addComment();
+		// Nonexistent blogs entry
 
-			// Nonexistent blogs entry
-
-			assertHttpResponseStatusCode(
-				404,
-				commentResource.
-					deleteSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
-						testDeleteSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
-						RandomTestUtil.randomString(),
-						comment.getExternalReferenceCode()));
-		}
+		assertHttpResponseStatusCode(
+			404,
+			commentResource.
+				deleteSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
+					testDeleteSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
+					RandomTestUtil.randomString(),
+					comment.getExternalReferenceCode()));
 
 		// Nonexistent comment
 
 		assertHttpResponseStatusCode(
-			204,
+			404,
 			commentResource.
 				deleteSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
 					testDeleteSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
@@ -85,16 +79,16 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 
 		BlogsEntry prevBlogsEntry = _blogsEntry;
 
-		Comment comment =
+		Comment newComment =
 			testDeleteSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCode_addComment();
 
 		assertHttpResponseStatusCode(
-			204,
+			404,
 			commentResource.
 				deleteSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
 					testDeleteSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
 					prevBlogsEntry.getExternalReferenceCode(),
-					comment.getExternalReferenceCode()));
+					newComment.getExternalReferenceCode()));
 	}
 
 	@Override
@@ -108,7 +102,7 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				"com.liferay.portal.vulcan.internal.jaxrs.exception.mapper." +
 					"WebApplicationExceptionMapper",
-				LoggerTestUtil.ERROR)) {
+				LoggerTestUtil.WARN)) {
 
 			Comment comment1 =
 				testDeleteSiteCommentByExternalReferenceCodeParentCommentExternalReferenceCodeCommentByExternalReferenceCode_addComment();
@@ -143,7 +137,7 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 		// Nonexistent comment
 
 		assertHttpResponseStatusCode(
-			204,
+			404,
 			commentResource.
 				deleteSiteCommentByExternalReferenceCodeParentCommentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
 					testDeleteSiteCommentByExternalReferenceCodeParentCommentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
@@ -154,16 +148,16 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 
 		Comment prevParentComment = _parentComment;
 
-		Comment comment =
+		Comment comment4 =
 			testDeleteSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCode_addComment();
 
 		assertHttpResponseStatusCode(
-			204,
+			404,
 			commentResource.
 				deleteSiteCommentByExternalReferenceCodeParentCommentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
 					testDeleteSiteCommentByExternalReferenceCodeParentCommentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
 					prevParentComment.getExternalReferenceCode(),
-					comment.getExternalReferenceCode()));
+					comment4.getExternalReferenceCode()));
 	}
 
 	@Override
@@ -174,29 +168,23 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 		super.
 			testDeleteSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCode();
 
-		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				"com.liferay.portal.vulcan.internal.jaxrs.exception.mapper." +
-					"WebApplicationExceptionMapper",
-				LoggerTestUtil.ERROR)) {
+		Comment comment =
+			testDeleteSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCode_addComment();
 
-			Comment comment =
-				testDeleteSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCode_addComment();
+		// Nonexistent document
 
-			// Nonexistent document
-
-			assertHttpResponseStatusCode(
-				404,
-				commentResource.
-					deleteSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
-						testDeleteSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
-						RandomTestUtil.randomString(),
-						comment.getExternalReferenceCode()));
-		}
+		assertHttpResponseStatusCode(
+			404,
+			commentResource.
+				deleteSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
+					testDeleteSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
+					RandomTestUtil.randomString(),
+					comment.getExternalReferenceCode()));
 
 		// Nonexistent comment
 
 		assertHttpResponseStatusCode(
-			204,
+			404,
 			commentResource.
 				deleteSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
 					testDeleteSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
@@ -207,16 +195,16 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 
 		FileEntry prevFileEntry = _fileEntry;
 
-		Comment comment =
+		Comment newComment =
 			testDeleteSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCode_addComment();
 
 		assertHttpResponseStatusCode(
-			204,
+			404,
 			commentResource.
 				deleteSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
 					testDeleteSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
 					prevFileEntry.getExternalReferenceCode(),
-					comment.getExternalReferenceCode()));
+					newComment.getExternalReferenceCode()));
 	}
 
 	@Override
@@ -227,29 +215,23 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 		super.
 			testDeleteSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCode();
 
-		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				"com.liferay.portal.vulcan.internal.jaxrs.exception.mapper." +
-					"WebApplicationExceptionMapper",
-				LoggerTestUtil.ERROR)) {
+		Comment comment =
+			testDeleteSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCode_addComment();
 
-			Comment comment =
-				testDeleteSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCode_addComment();
+		// Nonexistent journal article
 
-			// Nonexistent journal article
-
-			assertHttpResponseStatusCode(
-				404,
-				commentResource.
-					deleteSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
-						testDeleteSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
-						RandomTestUtil.randomString(),
-						comment.getExternalReferenceCode()));
-		}
+		assertHttpResponseStatusCode(
+			404,
+			commentResource.
+				deleteSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
+					testDeleteSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
+					RandomTestUtil.randomString(),
+					comment.getExternalReferenceCode()));
 
 		// Nonexistent comment
 
 		assertHttpResponseStatusCode(
-			204,
+			404,
 			commentResource.
 				deleteSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
 					testDeleteSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
@@ -260,16 +242,16 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 
 		JournalArticle prevJournalArticle = _journalArticle;
 
-		Comment comment =
+		Comment newComment =
 			testDeleteSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCode_addComment();
 
 		assertHttpResponseStatusCode(
-			204,
+			404,
 			commentResource.
 				deleteSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
 					testDeleteSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
 					prevJournalArticle.getExternalReferenceCode(),
-					comment.getExternalReferenceCode()));
+					newComment.getExternalReferenceCode()));
 	}
 
 	@Override
@@ -280,24 +262,18 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 		super.
 			testGetSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCode();
 
-		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				"com.liferay.portal.vulcan.internal.jaxrs.exception.mapper." +
-					"WebApplicationExceptionMapper",
-				LoggerTestUtil.ERROR)) {
+		Comment comment =
+			testGetSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCode_addComment();
 
-			Comment comment =
-				testGetSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCode_addComment();
+		// Nonexistent blogs entry
 
-			// Nonexistent blogs entry
-
-			assertHttpResponseStatusCode(
-				404,
-				commentResource.
-					getSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
-						testGetSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
-						RandomTestUtil.randomString(),
-						comment.getExternalReferenceCode()));
-		}
+		assertHttpResponseStatusCode(
+			404,
+			commentResource.
+				getSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
+					testGetSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
+					RandomTestUtil.randomString(),
+					comment.getExternalReferenceCode()));
 
 		// Nonexistent comment
 
@@ -313,7 +289,7 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 
 		BlogsEntry prevBlogsEntry = _blogsEntry;
 
-		Comment comment =
+		Comment newComment =
 			testGetSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCode_addComment();
 
 		assertHttpResponseStatusCode(
@@ -322,7 +298,7 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 				getSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
 					testGetSiteBlogPostingByExternalReferenceCodeBlogPostingExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
 					prevBlogsEntry.getExternalReferenceCode(),
-					comment.getExternalReferenceCode()));
+					newComment.getExternalReferenceCode()));
 	}
 
 	@Override
@@ -336,7 +312,7 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				"com.liferay.portal.vulcan.internal.jaxrs.exception.mapper." +
 					"WebApplicationExceptionMapper",
-				LoggerTestUtil.ERROR)) {
+				LoggerTestUtil.WARN)) {
 
 			Comment comment1 =
 				testGetSiteCommentByExternalReferenceCodeParentCommentExternalReferenceCodeCommentByExternalReferenceCode_addComment();
@@ -382,7 +358,7 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 
 		Comment prevParentComment = _parentComment;
 
-		Comment comment =
+		Comment comment4 =
 			testGetSiteCommentByExternalReferenceCodeParentCommentExternalReferenceCodeCommentByExternalReferenceCode_addComment();
 
 		assertHttpResponseStatusCode(
@@ -391,7 +367,7 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 				getSiteCommentByExternalReferenceCodeParentCommentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
 					testGetSiteCommentByExternalReferenceCodeParentCommentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
 					prevParentComment.getExternalReferenceCode(),
-					comment.getExternalReferenceCode()));
+					comment4.getExternalReferenceCode()));
 	}
 
 	@Override
@@ -402,24 +378,18 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 		super.
 			testGetSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCode();
 
-		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				"com.liferay.portal.vulcan.internal.jaxrs.exception.mapper." +
-					"WebApplicationExceptionMapper",
-				LoggerTestUtil.ERROR)) {
+		Comment comment =
+			testGetSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCode_addComment();
 
-			Comment comment =
-				testGetSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCode_addComment();
+		// Nonexistent document
 
-			// Nonexistent document
-
-			assertHttpResponseStatusCode(
-				404,
-				commentResource.
-					getSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
-						testGetSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
-						RandomTestUtil.randomString(),
-						comment.getExternalReferenceCode()));
-		}
+		assertHttpResponseStatusCode(
+			404,
+			commentResource.
+				getSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
+					testGetSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
+					RandomTestUtil.randomString(),
+					comment.getExternalReferenceCode()));
 
 		// Nonexistent comment
 
@@ -435,7 +405,7 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 
 		FileEntry prevFileEntry = _fileEntry;
 
-		Comment comment =
+		Comment newComment =
 			testGetSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCode_addComment();
 
 		assertHttpResponseStatusCode(
@@ -444,7 +414,7 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 				getSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
 					testGetSiteDocumentByExternalReferenceCodeDocumentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
 					prevFileEntry.getExternalReferenceCode(),
-					comment.getExternalReferenceCode()));
+					newComment.getExternalReferenceCode()));
 	}
 
 	@Override
@@ -455,24 +425,18 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 		super.
 			testGetSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCode();
 
-		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				"com.liferay.portal.vulcan.internal.jaxrs.exception.mapper." +
-					"WebApplicationExceptionMapper",
-				LoggerTestUtil.ERROR)) {
+		Comment comment =
+			testGetSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCode_addComment();
 
-			Comment comment =
-				testGetSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCode_addComment();
+		// Nonexistent structured content
 
-			// Nonexistent structured content
-
-			assertHttpResponseStatusCode(
-				404,
-				commentResource.
-					getSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
-						testGetSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
-						RandomTestUtil.randomString(),
-						comment.getExternalReferenceCode()));
-		}
+		assertHttpResponseStatusCode(
+			404,
+			commentResource.
+				getSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
+					testGetSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
+					RandomTestUtil.randomString(),
+					comment.getExternalReferenceCode()));
 
 		// Nonexistent comment
 
@@ -488,7 +452,7 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 
 		JournalArticle prevJournalArticle = _journalArticle;
 
-		Comment comment =
+		Comment newComment =
 			testGetSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCode_addComment();
 
 		assertHttpResponseStatusCode(
@@ -497,7 +461,7 @@ public class CommentResourceTest extends BaseCommentResourceTestCase {
 				getSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCodeHttpResponse(
 					testGetSiteStructuredContentByExternalReferenceCodeStructuredContentExternalReferenceCodeCommentByExternalReferenceCode_getSiteId(),
 					prevJournalArticle.getExternalReferenceCode(),
-					comment.getExternalReferenceCode()));
+					newComment.getExternalReferenceCode()));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/WikiPageAttachmentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/WikiPageAttachmentResourceTest.java
@@ -77,29 +77,23 @@ public class WikiPageAttachmentResourceTest
 		super.
 			testDeleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode();
 
-		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				"com.liferay.portal.vulcan.internal.jaxrs.exception.mapper." +
-					"WebApplicationExceptionMapper",
-				LoggerTestUtil.ERROR)) {
+		WikiPageAttachment wikiPageAttachment =
+			testDeleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_addWikiPageAttachment();
 
-			WikiPageAttachment wikiPageAttachment =
-				testDeleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_addWikiPageAttachment();
+		// Nonexistent wiki page
 
-			// Nonexistent wiki page
-
-			assertHttpResponseStatusCode(
-				404,
-				wikiPageAttachmentResource.
-					deleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCodeHttpResponse(
-						testDeleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_getSiteId(),
-						RandomTestUtil.randomString(),
-						wikiPageAttachment.getExternalReferenceCode()));
-		}
+		assertHttpResponseStatusCode(
+			404,
+			wikiPageAttachmentResource.
+				deleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCodeHttpResponse(
+					testDeleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_getSiteId(),
+					RandomTestUtil.randomString(),
+					wikiPageAttachment.getExternalReferenceCode()));
 
 		// Nonexistent wiki page attachment
 
 		assertHttpResponseStatusCode(
-			204,
+			404,
 			wikiPageAttachmentResource.
 				deleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCodeHttpResponse(
 					testDeleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_getSiteId(),
@@ -110,7 +104,7 @@ public class WikiPageAttachmentResourceTest
 
 		WikiPage previousWikiPage = _wikiPage;
 
-		WikiPageAttachment wikiPageAttachment =
+		WikiPageAttachment newWikiPageAttachment =
 			testDeleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_addWikiPageAttachment();
 
 		assertHttpResponseStatusCode(
@@ -119,7 +113,7 @@ public class WikiPageAttachmentResourceTest
 				deleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCodeHttpResponse(
 					testDeleteSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode_getSiteId(),
 					previousWikiPage.getExternalReferenceCode(),
-					wikiPageAttachment.getExternalReferenceCode()));
+					newWikiPageAttachment.getExternalReferenceCode()));
 	}
 
 	@Override

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/exception/mapper/NoSuchModelExceptionMapper.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/exception/mapper/NoSuchModelExceptionMapper.java
@@ -15,39 +15,20 @@
 package com.liferay.portal.vulcan.internal.jaxrs.exception.mapper;
 
 import com.liferay.portal.kernel.exception.NoSuchModelException;
-import com.liferay.portal.kernel.servlet.HttpMethods;
 import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
 import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
 
-import javax.servlet.http.HttpServletRequest;
-
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 
 /**
  * Converts any {@code NoSuchModelException} to a {@code 404} error.
  *
- * <p>In the case of a DELETE request a {@code 204} (NO-CONTENT) response is
- * returned so the request is idempotent.
  *
  * @author Alejandro Hernández
  * @review
  */
 public class NoSuchModelExceptionMapper
 	extends BaseExceptionMapper<NoSuchModelException> {
-
-	@Override
-	public Response toResponse(NoSuchModelException noSuchModelException) {
-		String method = _httpServletRequest.getMethod();
-
-		if (method.equals(HttpMethods.DELETE)) {
-			return Response.status(
-				Response.Status.NO_CONTENT
-			).build();
-		}
-
-		return super.toResponse(noSuchModelException);
-	}
 
 	@Override
 	protected Problem getProblem(NoSuchModelException noSuchModelException) {
@@ -59,8 +40,5 @@ public class NoSuchModelExceptionMapper
 	protected boolean isSanitize() {
 		return false;
 	}
-
-	@Context
-	private HttpServletRequest _httpServletRequest;
 
 }

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/objects/ObjectDefinitionAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/objects/ObjectDefinitionAPI.macro
@@ -494,22 +494,6 @@ definition {
 			expected = "${managerId2}");
 	}
 
-	macro assertResponseIncludesErrorMessage {
-		var actual = JSONUtil.getWithJSONPath("${responseToParse}", "$.title");
-
-		TestUtils.assertEquals(
-			actual = "${actual}",
-			expected = "${expectedValue}");
-	}
-
-	macro assertResponseMessageAfterDeletingObjectEntry {
-		var actual = JSONUtil.getWithJSONPath("${responseToParse}", "$.status");
-
-		TestUtils.assertEquals(
-			actual = "${actual}",
-			expected = "${expectedValue}");
-	}
-
 	macro assertResponseNotIncludeDetailsOfDeletedObject {
 		var actual = JSONUtil.getWithJSONPath("${responseToParse}", "$..universitiesSubjects");
 
@@ -536,6 +520,14 @@ definition {
 			employeeId2 = "${employeeId2}",
 			managerId2 = "${managerId2}",
 			responseToParse = "${responseToParse}");
+	}
+
+	macro assertStatusInResponse {
+		var actual = JSONUtil.getWithJSONPath("${responseToParse}", "$.status");
+
+		TestUtils.assertEquals(
+			actual = "${actual}",
+			expected = "${expectedValue}");
 	}
 
 	macro createAndPublishObjectDefinition {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/SupportManyToManyRelationships.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/SupportManyToManyRelationships.testcase
@@ -1081,7 +1081,7 @@ definition {
 				nestedField = "universitiesSubjects",
 				objects = "universities");
 
-			ObjectDefinitionAPI.assertResponseMessageAfterDeletingObjectEntry(
+			ObjectDefinitionAPI.assertStatusInResponse(
 				expectedValue = "BAD_REQUEST",
 				responseToParse = "${responseToParse}");
 
@@ -1092,6 +1092,7 @@ definition {
 		}
 	}
 
+	@disable-webdriver = "true"
 	@priority = "5"
 	test RelationshipEnpointGetsDeletedWhenObjectDefinitionDeleted {
 		property portal.acceptance = "true";
@@ -1140,8 +1141,8 @@ definition {
 		}
 
 		task ("Then I receive an error message of relationship not present") {
-			ObjectDefinitionAPI.assertResponseIncludesErrorMessage(
-				expectedValue = "No ObjectRelationship exists with the key {objectDefinitionId1=${staticObjectId1}, name=${relationshipName}}",
+			ObjectDefinitionAPI.assertStatusInResponse(
+				expectedValue = "NOT_FOUND",
 				responseToParse = "${responseToParse}");
 		}
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForStructuredContentFolders.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForStructuredContentFolders.testcase
@@ -695,9 +695,9 @@ definition {
 				assetLibraryId = "${assetLibraryId}",
 				externalReferenceCode = "subfolder-erc");
 
-			TestUtils.assertPartialEquals(
-				actual = "${response}",
-				expected = "No JournalFolder exists with the key");
+			ObjectDefinitionAPI.assertStatusInResponse(
+				expectedValue = "NOT_FOUND",
+				responseToParse = "${response}");
 
 			HeadlessWebcontentFolderAPI.assertProperTotalCountOfStructuredContentFoldersInAssetLibrary(
 				assetLibraryId = "${assetLibraryId}",


### PR DESCRIPTION
**What is new?**

- Update `NoSuchModelExceptionMapper` to return a 404 status code in a DELETE method
- Update `CommetResourceImpl` to use `getComment` that throws a NoSuchModelException
- Update `CommentResourceTest` and `WikiPageAttachmentResourceTest`

To see this new endpoint you have to follow these steps:

- Deploy `portal-vulcan-impl`
- Deploy `headless-delivery-api` and `headless-delivery-impl` in this order.
- Go to /o/api

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-152217

