### PR TITLE
LPS-160014 | Expose web content articles information in navigation menus APIs

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/NavigationMenuAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/NavigationMenuAPI.macro
@@ -1,57 +1,43 @@
 definition {
 
-	macro _assertResponseIncludeCorrectDetailsOfContentURL {
-		if (isSet(responseToParseFromSiteId)) {
-			var responseToParse = "${responseToParseFromSiteId}";
+	macro _assertResponseIncludeCorrectElement {
+		Variables.assertDefined(parameterList = "${element},${expectedElement}");
 
-			var actual = JSONUtil.getWithJSONPath("${responseToParse}", "$.items..navigationMenuItems..contentURL");
+		if (isSet(responseFromSite)) {
+			var actual = JSONUtil.getWithJSONPath("${responseToParse}", "$.items..navigationMenuItems..${element}");
 		}
 		else {
-			var responseToParse = "${responseToParseFromNavigationMenuId}";
-
-			var actual = JSONUtil.getWithJSONPath("${responseToParse}", "$.navigationMenuItems..contentURL");
+			var actual = JSONUtil.getWithJSONPath("${responseToParse}", "$.navigationMenuItems..${element}");
 		}
 
 		TestUtils.assertEquals(
 			actual = "${actual}",
-			expected = "${expectedURL}");
+			expected = "${expectedElement}");
 	}
 
-	macro _assertResponseIncludeCorrectDetailsOfType {
-		if (isSet(responseToParseFromSiteId)) {
-			var responseToParse = "${responseToParseFromSiteId}";
+	macro assertResponseHasCorrectInformations {
+		Variables.assertDefined(parameterList = "${expectedURL},${expectedType},${expectedUseCustomName},${responseToParse}");
 
-			var actual = JSONUtil.getWithJSONPath("${responseToParse}", "$.items..navigationMenuItems..type");
-		}
-		else {
-			var responseToParse = "${responseToParseFromNavigationMenuId}";
+		NavigationMenuAPI._assertResponseIncludeCorrectElement(
+			element = "contentURL",
+			expectedElement = "${expectedURL}",
+			responseFromSite = "${responseFromSite}",
+			responseToParse = "${responseToParse}");
 
-			var actual = JSONUtil.getWithJSONPath("${responseToParse}", "$.navigationMenuItems..type");
-		}
+		NavigationMenuAPI._assertResponseIncludeCorrectElement(
+			element = "type",
+			expectedElement = "${expectedType}",
+			responseFromSite = "${responseFromSite}",
+			responseToParse = "${responseToParse}");
 
-		TestUtils.assertEquals(
-			actual = "${actual}",
-			expected = "${expectedType}");
+		NavigationMenuAPI._assertResponseIncludeCorrectElement(
+			element = "useCustomName",
+			expectedElement = "${expectedUseCustomName}",
+			responseFromSite = "${responseFromSite}",
+			responseToParse = "${responseToParse}");
 	}
 
-	macro _assertResponseIncludeCorrectDetailsOfUseCustomName {
-		if (isSet(responseToParseFromSiteId)) {
-			var responseToParse = "${responseToParseFromSiteId}";
-
-			var actual = JSONUtil.getWithJSONPath("${responseToParse}", "$.items..navigationMenuItems..useCustomName");
-		}
-		else {
-			var responseToParse = "${responseToParseFromNavigationMenuId}";
-
-			var actual = JSONUtil.getWithJSONPath("${responseToParse}", "$.navigationMenuItems..useCustomName");
-		}
-
-		TestUtils.assertEquals(
-			actual = "${actual}",
-			expected = "${expectedUseCustomName}");
-	}
-
-	macro _curlNavigationMenu {
+	macro getNavigationMenu {
 		var portalURL = JSONCompany.getPortalURL();
 
 		if (isSet(navigationMenuId)) {
@@ -66,56 +52,6 @@ definition {
 			-u test@liferay.com:test \
 			-H accept: application/json
 		''';
-
-		return "${curl}";
-	}
-
-	macro assertResponseHasCorrectDetailsFromNavigationMenuId {
-		Variables.assertDefined(parameterList = "${expectedURL},${expectedType},${expectedUseCustomName},${responseToParse}");
-
-		NavigationMenuAPI._assertResponseIncludeCorrectDetailsOfContentURL(
-			expectedURL = "${expectedURL}",
-			responseToParseFromNavigationMenuId = "${responseToParse}");
-
-		NavigationMenuAPI._assertResponseIncludeCorrectDetailsOfType(
-			expectedType = "${expectedType}",
-			responseToParseFromNavigationMenuId = "${responseToParse}");
-
-		NavigationMenuAPI._assertResponseIncludeCorrectDetailsOfUseCustomName(
-			expectedUseCustomName = "${expectedUseCustomName}",
-			responseToParseFromNavigationMenuId = "${responseToParse}");
-	}
-
-	macro assertResponseHasCorrectDetailsFromSiteId {
-		Variables.assertDefined(parameterList = "${expectedURL},${expectedType},${expectedUseCustomName},${responseToParse}");
-
-		NavigationMenuAPI._assertResponseIncludeCorrectDetailsOfContentURL(
-			expectedURL = "${expectedURL}",
-			responseToParseFromSiteId = "${responseToParse}");
-
-		NavigationMenuAPI._assertResponseIncludeCorrectDetailsOfType(
-			expectedType = "${expectedType}",
-			responseToParseFromSiteId = "${responseToParse}");
-
-		NavigationMenuAPI._assertResponseIncludeCorrectDetailsOfUseCustomName(
-			expectedUseCustomName = "${expectedUseCustomName}",
-			responseToParseFromSiteId = "${responseToParse}");
-	}
-
-	macro getNavigationMenuByNavigationMenuId {
-		Variables.assertDefined(parameterList = "${navigationMenuId}");
-
-		var curl = NavigationMenuAPI._curlNavigationMenu(navigationMenuId = "${navigationMenuId}");
-
-		var response = JSONCurlUtil.get("${curl}");
-
-		return "${response}";
-	}
-
-	macro getNavigationMenuBySiteId {
-		Variables.assertDefined(parameterList = "${siteId}");
-
-		var curl = NavigationMenuAPI._curlNavigationMenu(siteId = "${siteId}");
 
 		var response = JSONCurlUtil.get("${curl}");
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/NavigationMenuAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/NavigationMenuAPI.macro
@@ -1,0 +1,125 @@
+definition {
+
+	macro _assertResponseIncludeCorrectDetailsOfContentURL {
+		if (isSet(responseToParseFromSiteId)) {
+			var responseToParse = "${responseToParseFromSiteId}";
+
+			var actual = JSONUtil.getWithJSONPath("${responseToParse}", "$.items..navigationMenuItems..contentURL");
+		}
+		else {
+			var responseToParse = "${responseToParseFromNavigationMenuId}";
+
+			var actual = JSONUtil.getWithJSONPath("${responseToParse}", "$.navigationMenuItems..contentURL");
+		}
+
+		TestUtils.assertEquals(
+			actual = "${actual}",
+			expected = "${expectedURL}");
+	}
+
+	macro _assertResponseIncludeCorrectDetailsOfType {
+		if (isSet(responseToParseFromSiteId)) {
+			var responseToParse = "${responseToParseFromSiteId}";
+
+			var actual = JSONUtil.getWithJSONPath("${responseToParse}", "$.items..navigationMenuItems..type");
+		}
+		else {
+			var responseToParse = "${responseToParseFromNavigationMenuId}";
+
+			var actual = JSONUtil.getWithJSONPath("${responseToParse}", "$.navigationMenuItems..type");
+		}
+
+		TestUtils.assertEquals(
+			actual = "${actual}",
+			expected = "${expectedType}");
+	}
+
+	macro _assertResponseIncludeCorrectDetailsOfUseCustomName {
+		if (isSet(responseToParseFromSiteId)) {
+			var responseToParse = "${responseToParseFromSiteId}";
+
+			var actual = JSONUtil.getWithJSONPath("${responseToParse}", "$.items..navigationMenuItems..useCustomName");
+		}
+		else {
+			var responseToParse = "${responseToParseFromNavigationMenuId}";
+
+			var actual = JSONUtil.getWithJSONPath("${responseToParse}", "$.navigationMenuItems..useCustomName");
+		}
+
+		TestUtils.assertEquals(
+			actual = "${actual}",
+			expected = "${expectedUseCustomName}");
+	}
+
+	macro _curlNavigationMenu {
+		var portalURL = JSONCompany.getPortalURL();
+
+		if (isSet(navigationMenuId)) {
+			var api = "navigation-menus/${navigationMenuId}";
+		}
+		else {
+			var api = "sites/${siteId}/navigation-menus/";
+		}
+
+		var curl = '''
+			${portalURL}/o/headless-delivery/v1.0/${api} \
+			-u test@liferay.com:test \
+			-H accept: application/json
+		''';
+
+		return "${curl}";
+	}
+
+	macro assertResponseHasCorrectDetailsFromNavigationMenuId {
+		Variables.assertDefined(parameterList = "${expectedURL},${expectedType},${expectedUseCustomName},${responseToParse}");
+
+		NavigationMenuAPI._assertResponseIncludeCorrectDetailsOfContentURL(
+			expectedURL = "${expectedURL}",
+			responseToParseFromNavigationMenuId = "${responseToParse}");
+
+		NavigationMenuAPI._assertResponseIncludeCorrectDetailsOfType(
+			expectedType = "${expectedType}",
+			responseToParseFromNavigationMenuId = "${responseToParse}");
+
+		NavigationMenuAPI._assertResponseIncludeCorrectDetailsOfUseCustomName(
+			expectedUseCustomName = "${expectedUseCustomName}",
+			responseToParseFromNavigationMenuId = "${responseToParse}");
+	}
+
+	macro assertResponseHasCorrectDetailsFromSiteId {
+		Variables.assertDefined(parameterList = "${expectedURL},${expectedType},${expectedUseCustomName},${responseToParse}");
+
+		NavigationMenuAPI._assertResponseIncludeCorrectDetailsOfContentURL(
+			expectedURL = "${expectedURL}",
+			responseToParseFromSiteId = "${responseToParse}");
+
+		NavigationMenuAPI._assertResponseIncludeCorrectDetailsOfType(
+			expectedType = "${expectedType}",
+			responseToParseFromSiteId = "${responseToParse}");
+
+		NavigationMenuAPI._assertResponseIncludeCorrectDetailsOfUseCustomName(
+			expectedUseCustomName = "${expectedUseCustomName}",
+			responseToParseFromSiteId = "${responseToParse}");
+	}
+
+	macro getNavigationMenuByNavigationMenuId {
+		Variables.assertDefined(parameterList = "${navigationMenuId}");
+
+		var curl = NavigationMenuAPI._curlNavigationMenu(navigationMenuId = "${navigationMenuId}");
+
+		var response = JSONCurlUtil.get("${curl}");
+
+		return "${response}";
+	}
+
+	macro getNavigationMenuBySiteId {
+		Variables.assertDefined(parameterList = "${siteId}");
+
+		var curl = NavigationMenuAPI._curlNavigationMenu(siteId = "${siteId}");
+
+		var response = JSONCurlUtil.get("${curl}");
+
+		return "${response}";
+	}
+
+}

--- a/portal-web/test/functional/com/liferay/portalweb/macros/sitenavigation/sitenavigationmenu/NavigationMenusAdmin.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/sitenavigation/sitenavigationmenu/NavigationMenusAdmin.macro
@@ -92,9 +92,28 @@ definition {
 		}
 
 		if ("${item}" == "Web Content Article") {
-			Click(
-				key_listEntry = "${assetTitle}",
-				locator1 = "LexiconList#LIST_ENTRY_TITLE");
+			if (isSet(depotName)) {
+				AssertClick(
+					key_breadcrumbName = "Sites and Libraries",
+					locator1 = "Breadcrumb#BREADCRUMB_ENTRY",
+					value1 = "Sites and Libraries");
+
+				AssertClick(
+					key_groupTab = "Asset Library",
+					locator1 = "ItemSelector#NAVIGATION_GROUP_TAB",
+					value1 = "Asset Library");
+
+				LexiconCard.clickCard(card = "${depotName}");
+
+				Click(
+					key_listEntry = "${assetTitle}",
+					locator1 = "LexiconList#LIST_ENTRY_TITLE");
+			}
+			else {
+				Click(
+					key_listEntry = "${assetTitle}",
+					locator1 = "LexiconList#LIST_ENTRY_TITLE");
+			}
 		}
 
 		if ("${item}" == "Blogs Entry") {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/sitenavigation/sitenavigationmenu/NavigationMenusAdmin.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/sitenavigation/sitenavigationmenu/NavigationMenusAdmin.macro
@@ -77,6 +77,14 @@ definition {
 
 		SelectFrame(locator1 = "IFrame#MODAL_BODY");
 
+		if (isSet(depotName)) {
+			ItemSelector.changeWorkspaces(
+				customImage = "false",
+				workspacesType = "Asset Library");
+
+			LexiconCard.clickCard(card = "${depotName}");
+		}
+
 		if ("${item}" == "Page") {
 			NavigationMenusAdmin._addItemPage(
 				pageNameList = "${pageNameList}",
@@ -92,28 +100,9 @@ definition {
 		}
 
 		if ("${item}" == "Web Content Article") {
-			if (isSet(depotName)) {
-				AssertClick(
-					key_breadcrumbName = "Sites and Libraries",
-					locator1 = "Breadcrumb#BREADCRUMB_ENTRY",
-					value1 = "Sites and Libraries");
-
-				AssertClick(
-					key_groupTab = "Asset Library",
-					locator1 = "ItemSelector#NAVIGATION_GROUP_TAB",
-					value1 = "Asset Library");
-
-				LexiconCard.clickCard(card = "${depotName}");
-
-				Click(
-					key_listEntry = "${assetTitle}",
-					locator1 = "LexiconList#LIST_ENTRY_TITLE");
-			}
-			else {
-				Click(
-					key_listEntry = "${assetTitle}",
-					locator1 = "LexiconList#LIST_ENTRY_TITLE");
-			}
+			Click(
+				key_listEntry = "${assetTitle}",
+				locator1 = "LexiconList#LIST_ENTRY_TITLE");
 		}
 
 		if ("${item}" == "Blogs Entry") {
@@ -298,6 +287,10 @@ definition {
 
 	macro editItem {
 		NavigationMenusAdmin.openItemSidebar(itemName = "${itemName}");
+
+		if (isSet(useCustomName)) {
+			NavigationMenusAdmin._editItemPage();
+		}
 
 		if ("${item}" == "Page") {
 			if (isSet(customName)) {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeDifferentWidgetsDetailsInNavigationMenus.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeDifferentWidgetsDetailsInNavigationMenus.testcase
@@ -1,0 +1,267 @@
+@component-name = "portal-headless-frontend-infrastructure"
+definition {
+
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.main.component.name = "Headless Frontend Infrastructure";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+
+		task ("Given a navigation menu") {
+			JSONSitenavigation.addSiteNavigationMenu(
+				groupName = "Guest",
+				siteNavigationMenuName = "Navigation Menu Name");
+		}
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if ("${testPortalInstance}" == "true") {
+			PortalInstances.tearDownCP();
+		}
+		else {
+			JSONSitenavigation.deleteSiteNavigationMenu(
+				groupName = "Guest",
+				siteNavigationMenuName = "Navigation Menu Name");
+
+			JSONWebcontent.deleteWebContent(
+				groupName = "Guest",
+				title = "Web Content Title");
+
+			JSONDepot.deleteDepot(depotName = "Test Depot Name");
+		}
+	}
+
+	@priority = "4"
+	test GetAssetLibraryStructuredContentInformationInNavigationMenuWithSiteId {
+		property portal.acceptance = "true";
+
+		task ("And Given an assetlibrary with connect to site") {
+			JSONDepot.addDepot(depotName = "Test Depot Name");
+
+			JSONDepot.connectSite(
+				depotName = "Test Depot Name",
+				groupName = "Guest");
+		}
+
+		task ("And Given a content structure created in asset library") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+
+			WebContentNavigator.openWebContentStructuresAdminInAssetLibrary(depotId = "${assetLibraryId}");
+
+			WebContentStructures.addCP(structureName = "content-structure");
+
+			FormViewBuilder.addFieldByDoubleClick(fieldType = "Text");
+
+			FormFields.editFieldReference(key_fieldReference = "Text");
+
+			Button.clickSave();
+		}
+
+		task ("And Given a web content article is created in asset Library") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
+
+			var responseFromCreate = HeadlessWebcontentAPI.createStructuredContentInAssetLibrary(
+				assetLibraryId = "${assetLibraryId}",
+				data = "<p>My content</p>",
+				ddmStructureId = "${ddmStructureId}",
+				label = "Text",
+				name = "Text",
+				title = "Web Content Title");
+		}
+
+		task ("And Given a navigation menu use cutom name associate with the created web content through UI") {
+			NavigationMenusAdmin.openNavigationMenusAdmin(siteURLKey = "guest");
+
+			NavigationMenusAdmin.editMenu(navigationMenuName = "Navigation Menu Name");
+
+			NavigationMenusAdmin.addItem(
+				assetTitle = "Web Content Title",
+				depotName = "Test Depot Name",
+				item = "Web Content Article");
+
+			NavigationMenusAdmin.editItem(
+				customName = "Web Content Title 1",
+				item = "Page",
+				itemName = "Web Content Title");
+		}
+
+		task ("When with get request and siteId to retrieve the navigation menu") {
+			var siteId = JSONGroupAPI._getSiteIdByGroupKey(groupName = "Guest");
+
+			var response = NavigationMenuAPI.getNavigationMenuBySiteId(siteId = "${siteId}");
+		}
+
+		task ("Then I can see values of useCustomName equals to true, contentURL equals to webcontent endpoint and type equals to structuredContent") {
+			var portalURL = JSONCompany.getPortalURL();
+			var structuredContentId = HeadlessWebcontentAPI.getWebContentIdFromResponse(responseToParse = "${responseFromCreate}");
+
+			NavigationMenuAPI.assertResponseHasCorrectDetailsFromSiteId(
+				expectedType = "structuredContent",
+				expectedURL = "${portalURL}/o/headless-delivery/v1.0/structured-contents/${structuredContentId}",
+				expectedUseCustomName = "true",
+				responseToParse = "${response}");
+		}
+	}
+
+	@priority = "4"
+	test GetAssetLibraryWebContentArticlesInformationWithNavigationMenuId {
+		property portal.acceptance = "true";
+
+		task ("And Given an assetlibrary with connect to site") {
+			JSONDepot.addDepot(depotName = "Test Depot Name");
+
+			JSONDepot.connectSite(
+				depotName = "Test Depot Name",
+				groupName = "Guest");
+		}
+
+		task ("And Given a content structure created in asset library") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+
+			WebContentNavigator.openWebContentStructuresAdminInAssetLibrary(depotId = "${assetLibraryId}");
+
+			WebContentStructures.addCP(structureName = "content-structure");
+
+			FormViewBuilder.addFieldByDoubleClick(fieldType = "Text");
+
+			FormFields.editFieldReference(key_fieldReference = "Text");
+
+			Button.clickSave();
+		}
+
+		task ("And Given a web content article is created in asset Library") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
+
+			var responseFromCreate = HeadlessWebcontentAPI.createStructuredContentInAssetLibrary(
+				assetLibraryId = "${assetLibraryId}",
+				data = "<p>My content</p>",
+				ddmStructureId = "${ddmStructureId}",
+				label = "Text",
+				name = "Text",
+				title = "Web Content Title");
+		}
+
+		task ("And Given a navigation menu doesn't use custom name associate with the web content through UI") {
+			NavigationMenusAdmin.openNavigationMenusAdmin(siteURLKey = "guest");
+
+			NavigationMenusAdmin.editMenu(navigationMenuName = "Navigation Menu Name");
+
+			NavigationMenusAdmin.addItem(
+				assetTitle = "Web Content Title",
+				depotName = "Test Depot Name",
+				item = "Web Content Article");
+		}
+
+		task ("When with get request and navigationMenuId to retrieve the navigation menu") {
+			var navigationMenuId = JSONSitenavigationSetter.setSiteNavigationMenuId(
+				groupName = "Guest",
+				siteNavigationMenuName = "Navigation Menu Name");
+
+			var response = NavigationMenuAPI.getNavigationMenuByNavigationMenuId(navigationMenuId = "${navigationMenuId}");
+		}
+
+		task ("Then I can see values of useCustomName of false, contentURL equals to webcontent endpoint and type equals to structuredContent") {
+			var portalURL = JSONCompany.getPortalURL();
+			var structuredContentId = HeadlessWebcontentAPI.getWebContentIdFromResponse(responseToParse = "${responseFromCreate}");
+
+			NavigationMenuAPI.assertResponseHasCorrectDetailsFromNavigationMenuId(
+				expectedType = "structuredContent",
+				expectedURL = "${portalURL}/o/headless-delivery/v1.0/structured-contents/${structuredContentId}",
+				expectedUseCustomName = "false",
+				responseToParse = "${response}");
+		}
+	}
+
+	@priority = "4"
+	test GetStructuredContentInformationInNavigationMenuWithSiteId {
+		property portal.acceptance = "true";
+
+		task ("And Given a web content article is created") {
+			JSONWebcontent.addWebContent(
+				content = "Web Content Content",
+				groupName = "Guest",
+				title = "Web Content Title");
+		}
+
+		task ("And Given a navigation menu use cutom name associate with the created web content through UI") {
+			NavigationMenusAdmin.openNavigationMenusAdmin(siteURLKey = "guest");
+
+			NavigationMenusAdmin.editMenu(navigationMenuName = "Navigation Menu Name");
+
+			NavigationMenusAdmin.addItem(
+				assetTitle = "Web Content Title",
+				item = "Web Content Article");
+
+			NavigationMenusAdmin.editItem(
+				customName = "Web Content Title 1",
+				item = "Page",
+				itemName = "Web Content Title");
+		}
+
+		task ("When with get request and siteId to retrieve the navigation menu") {
+			var siteId = JSONGroupAPI._getSiteIdByGroupKey(groupName = "Guest");
+
+			var response = NavigationMenuAPI.getNavigationMenuBySiteId(siteId = "${siteId}");
+		}
+
+		task ("Then I can see values of useCustomName equals to true, contentURL equals to webcontent endpoint and type equals to structuredContent") {
+			var portalURL = JSONCompany.getPortalURL();
+			var structuredContentId = HeadlessWebcontentAPI.getStructuredContentIdByTitle(title = "Web Content Title");
+
+			NavigationMenuAPI.assertResponseHasCorrectDetailsFromSiteId(
+				expectedType = "structuredContent",
+				expectedURL = "${portalURL}/o/headless-delivery/v1.0/structured-contents/${structuredContentId}",
+				expectedUseCustomName = "true",
+				responseToParse = "${response}");
+		}
+	}
+
+	@priority = "4"
+	test GetWebContentArticlesInformationWithNavigationMenuId {
+		property portal.acceptance = "true";
+
+		task ("And Given a web content article is created") {
+			JSONWebcontent.addWebContent(
+				content = "Web Content Content",
+				groupName = "Guest",
+				title = "Web Content Title");
+		}
+
+		task ("And Given a navigation menu doesn't use custom name associate with the web content through UI") {
+			NavigationMenusAdmin.openNavigationMenusAdmin(siteURLKey = "guest");
+
+			NavigationMenusAdmin.editMenu(navigationMenuName = "Navigation Menu Name");
+
+			NavigationMenusAdmin.addItem(
+				assetTitle = "Web Content Title",
+				item = "Web Content Article");
+		}
+
+		task ("When with get request and navigationMenuId to retrieve the navigation menu") {
+			var navigationMenuId = JSONSitenavigationSetter.setSiteNavigationMenuId(
+				groupName = "Guest",
+				siteNavigationMenuName = "Navigation Menu Name");
+
+			var response = NavigationMenuAPI.getNavigationMenuByNavigationMenuId(navigationMenuId = "${navigationMenuId}");
+		}
+
+		task ("Then I can see values of useCustomName of false, contentURL equals to webcontent endpoint and type equals to structuredContent") {
+			var portalURL = JSONCompany.getPortalURL();
+			var structuredContentId = HeadlessWebcontentAPI.getStructuredContentIdByTitle(title = "Web Content Title");
+
+			NavigationMenuAPI.assertResponseHasCorrectDetailsFromNavigationMenuId(
+				expectedType = "structuredContent",
+				expectedURL = "${portalURL}/o/headless-delivery/v1.0/structured-contents/${structuredContentId}",
+				expectedUseCustomName = "false",
+				responseToParse = "${response}");
+		}
+	}
+
+}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeInformationInNavigationMenus.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeInformationInNavigationMenus.testcase
@@ -40,7 +40,7 @@ definition {
 	test GetAssetLibraryStructuredContentInformationInNavigationMenuWithSiteId {
 		property portal.acceptance = "true";
 
-		task ("And Given an assetlibrary with connect to site") {
+		task ("And Given an asset library connect to the site") {
 			JSONDepot.addDepot(depotName = "Test Depot Name");
 
 			JSONDepot.connectSite(
@@ -75,7 +75,7 @@ definition {
 				title = "Web Content Title");
 		}
 
-		task ("And Given a navigation menu use cutom name associate with the created web content through UI") {
+		task ("And Given a navigation menu use custom name associate with the created web content through UI") {
 			NavigationMenusAdmin.openNavigationMenusAdmin(siteURLKey = "guest");
 
 			NavigationMenusAdmin.editMenu(navigationMenuName = "Navigation Menu Name");
@@ -86,25 +86,25 @@ definition {
 				item = "Web Content Article");
 
 			NavigationMenusAdmin.editItem(
-				customName = "Web Content Title 1",
-				item = "Page",
-				itemName = "Web Content Title");
+				itemName = "Web Content Title",
+				useCustomName = "true");
 		}
 
 		task ("When with get request and siteId to retrieve the navigation menu") {
 			var siteId = JSONGroupAPI._getSiteIdByGroupKey(groupName = "Guest");
 
-			var response = NavigationMenuAPI.getNavigationMenuBySiteId(siteId = "${siteId}");
+			var response = NavigationMenuAPI.getNavigationMenu(siteId = "${siteId}");
 		}
 
 		task ("Then I can see values of useCustomName equals to true, contentURL equals to webcontent endpoint and type equals to structuredContent") {
 			var portalURL = JSONCompany.getPortalURL();
 			var structuredContentId = HeadlessWebcontentAPI.getWebContentIdFromResponse(responseToParse = "${responseFromCreate}");
 
-			NavigationMenuAPI.assertResponseHasCorrectDetailsFromSiteId(
+			NavigationMenuAPI.assertResponseHasCorrectInformations(
 				expectedType = "structuredContent",
 				expectedURL = "${portalURL}/o/headless-delivery/v1.0/structured-contents/${structuredContentId}",
 				expectedUseCustomName = "true",
+				responseFromSite = "true",
 				responseToParse = "${response}");
 		}
 	}
@@ -113,7 +113,7 @@ definition {
 	test GetAssetLibraryWebContentArticlesInformationWithNavigationMenuId {
 		property portal.acceptance = "true";
 
-		task ("And Given an assetlibrary with connect to site") {
+		task ("And Given an asset library connect to the site") {
 			JSONDepot.addDepot(depotName = "Test Depot Name");
 
 			JSONDepot.connectSite(
@@ -164,14 +164,14 @@ definition {
 				groupName = "Guest",
 				siteNavigationMenuName = "Navigation Menu Name");
 
-			var response = NavigationMenuAPI.getNavigationMenuByNavigationMenuId(navigationMenuId = "${navigationMenuId}");
+			var response = NavigationMenuAPI.getNavigationMenu(navigationMenuId = "${navigationMenuId}");
 		}
 
 		task ("Then I can see values of useCustomName of false, contentURL equals to webcontent endpoint and type equals to structuredContent") {
 			var portalURL = JSONCompany.getPortalURL();
 			var structuredContentId = HeadlessWebcontentAPI.getWebContentIdFromResponse(responseToParse = "${responseFromCreate}");
 
-			NavigationMenuAPI.assertResponseHasCorrectDetailsFromNavigationMenuId(
+			NavigationMenuAPI.assertResponseHasCorrectInformations(
 				expectedType = "structuredContent",
 				expectedURL = "${portalURL}/o/headless-delivery/v1.0/structured-contents/${structuredContentId}",
 				expectedUseCustomName = "false",
@@ -199,26 +199,24 @@ definition {
 				assetTitle = "Web Content Title",
 				item = "Web Content Article");
 
-			NavigationMenusAdmin.editItem(
-				customName = "Web Content Title 1",
-				item = "Page",
-				itemName = "Web Content Title");
+			NavigationMenusAdmin.editMenu(navigationMenuName = "Navigation Menu Name");
 		}
 
 		task ("When with get request and siteId to retrieve the navigation menu") {
 			var siteId = JSONGroupAPI._getSiteIdByGroupKey(groupName = "Guest");
 
-			var response = NavigationMenuAPI.getNavigationMenuBySiteId(siteId = "${siteId}");
+			var response = NavigationMenuAPI.getNavigationMenu(siteId = "${siteId}");
 		}
 
 		task ("Then I can see values of useCustomName equals to true, contentURL equals to webcontent endpoint and type equals to structuredContent") {
 			var portalURL = JSONCompany.getPortalURL();
 			var structuredContentId = HeadlessWebcontentAPI.getStructuredContentIdByTitle(title = "Web Content Title");
 
-			NavigationMenuAPI.assertResponseHasCorrectDetailsFromSiteId(
+			NavigationMenuAPI.assertResponseHasCorrectInformations(
 				expectedType = "structuredContent",
 				expectedURL = "${portalURL}/o/headless-delivery/v1.0/structured-contents/${structuredContentId}",
 				expectedUseCustomName = "true",
+				responseFromSite = "true",
 				responseToParse = "${response}");
 		}
 	}
@@ -249,14 +247,14 @@ definition {
 				groupName = "Guest",
 				siteNavigationMenuName = "Navigation Menu Name");
 
-			var response = NavigationMenuAPI.getNavigationMenuByNavigationMenuId(navigationMenuId = "${navigationMenuId}");
+			var response = NavigationMenuAPI.getNavigationMenu(navigationMenuId = "${navigationMenuId}");
 		}
 
-		task ("Then I can see values of useCustomName of false, contentURL equals to webcontent endpoint and type equals to structuredContent") {
+		task ("Then I can see values of useCustomName is false, contentURL equals to webcontent endpoint and type equals to structuredContent") {
 			var portalURL = JSONCompany.getPortalURL();
 			var structuredContentId = HeadlessWebcontentAPI.getStructuredContentIdByTitle(title = "Web Content Title");
 
-			NavigationMenuAPI.assertResponseHasCorrectDetailsFromNavigationMenuId(
+			NavigationMenuAPI.assertResponseHasCorrectInformations(
 				expectedType = "structuredContent",
 				expectedURL = "${portalURL}/o/headless-delivery/v1.0/structured-contents/${structuredContentId}",
 				expectedUseCustomName = "false",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeInformationInNavigationMenus.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeInformationInNavigationMenus.testcase
@@ -199,7 +199,9 @@ definition {
 				assetTitle = "Web Content Title",
 				item = "Web Content Article");
 
-			NavigationMenusAdmin.editMenu(navigationMenuName = "Navigation Menu Name");
+			NavigationMenusAdmin.editItem(
+				itemName = "Web Content Title",
+				useCustomName = "true");
 		}
 
 		task ("When with get request and siteId to retrieve the navigation menu") {


### PR DESCRIPTION
**Background**
Expose web content articles information in navigation menus APIs

**Test Plan**
Given a navigation menu
And Given a web content article is created
And Given a navigation menu use cutom name associate with the created web content through UI
When with get request and siteId to retrieve the navigation menu
Then I can see values of useCustomName equals to true, contentURL equals to webcontent endpoint and type equals to structuredContent

Given a navigation menu
And Given a web content article is created
And Given a navigation menu doesn't use custom name associate with the web content through UI
When with get request and navigationMenuId to retrieve the navigation menu
Then I can see values of useCustomName of false, contentURL equals to webcontent endpoint and type equals to structuredContent

Given a navigation menu
And Given an assetlibrary with connect to site
And Given a content structure created in asset libraryAnd Given a web content article is created in asset Library
And Given a navigation menu use cutom name associate with the created web content through UI
When with get request and siteId to retrieve the navigation menu
Then I can see values of useCustomName equals to true, contentURL equals to wencontent endpoint and type equals to structuredContent

Given a navigation menu
And Given an assetlibrary with connect to site
And Given a content structure created in asset libraryAnd Given a web content article is created in asset Library
And Given a navigation menu doesn't use custom name associate with the web content through UI
When with get request and navigationMenuId to retrieve the navigation menu
Then I can see values of useCustomName of false, contentURL equals to webcontent endpoint and type equals to structuredContent

**JIRA Link:**
https://issues.liferay.com/browse/LPS-160014