### PR TITLE
LPS-162877: Expose permissions for the object entries collections

### DIFF
--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/resource/v1_0/ObjectEntryResource.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/resource/v1_0/ObjectEntryResource.java
@@ -77,6 +77,15 @@ public interface ObjectEntryResource {
 			String externalReferenceCode, ObjectEntry objectEntry)
 		throws Exception;
 
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			getPermissionsPage(String roleNames)
+		throws Exception;
+
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putPermissionsPage(
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
+		throws Exception;
+
 	public void deleteScopeScopeKeyByExternalReferenceCode(
 			String scopeKey, String externalReferenceCode)
 		throws Exception;
@@ -88,6 +97,16 @@ public interface ObjectEntryResource {
 	public ObjectEntry putScopeScopeKeyByExternalReferenceCode(
 			String scopeKey, String externalReferenceCode,
 			ObjectEntry objectEntry)
+		throws Exception;
+
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			getScopeScopeKeyPermissionsPage(String scopeKey, String roleNames)
+		throws Exception;
+
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putScopeScopeKeyPermissionsPage(
+				String scopeKey,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public Page<ObjectEntry> getCurrentObjectEntriesObjectRelationshipNamePage(

--- a/modules/apps/object/object-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-rest-impl/rest-openapi.yaml
@@ -206,6 +206,28 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/ObjectEntry"
             tags: ["ObjectEntry"]
+    "/permissions":
+        get:
+            operationId: getPermissionsPage
+            parameters:
+                - in: query
+                  name: roleNames
+                  schema:
+                      type: string
+            responses:
+                204:
+                    content:
+                        application/json: {}
+                        application/xml: {}
+            tags: ["ObjectEntry"]
+        put:
+            operationId: putPermissionsPage
+            responses:
+                204:
+                    content:
+                        application/json: {}
+                        application/xml: {}
+            tags: ["ObjectEntry"]
     "/scopes/{scopeKey}/by-external-reference-code/{externalReferenceCode}":
         delete:
             operationId: deleteScopeScopeKeyByExternalReferenceCode
@@ -279,6 +301,37 @@ paths:
                         application/xml:
                             schema:
                                 $ref: "#/components/schemas/ObjectEntry"
+            tags: ["ObjectEntry"]
+    "/scopes/{scopeKey}/permissions":
+        get:
+            operationId: getScopeScopeKeyPermissionsPage
+            parameters:
+                - in: path
+                  name: scopeKey
+                  schema:
+                      type: string
+                - in: query
+                  name: roleNames
+                  schema:
+                      type: string
+            responses:
+                204:
+                    content:
+                        application/json: {}
+                        application/xml: {}
+            tags: ["ObjectEntry"]
+        put:
+            operationId: putScopeScopeKeyPermissionsPage
+            parameters:
+                - in: path
+                  name: scopeKey
+                  schema:
+                      type: string
+            responses:
+                204:
+                    content:
+                        application/json: {}
+                        application/xml: {}
             tags: ["ObjectEntry"]
     "/{currentObjectEntryId}/{objectRelationshipName}":
         get:

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryResourceImpl.java
@@ -266,6 +266,46 @@ public abstract class BaseObjectEntryResourceImpl
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
 			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "roleNames"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "ObjectEntry")}
+	)
+	@javax.ws.rs.GET
+	@javax.ws.rs.Path("/permissions")
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			getPermissionsPage(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.ws.rs.QueryParam("roleNames")
+				String roleNames)
+		throws Exception {
+
+		return Page.of(Collections.emptyList());
+	}
+
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "ObjectEntry")}
+	)
+	@javax.ws.rs.Path("/permissions")
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@javax.ws.rs.PUT
+	@Override
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putPermissionsPage(
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
+		throws Exception {
+
+		return Page.of(Collections.emptyList());
+	}
+
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
 				name = "scopeKey"
 			),
@@ -366,6 +406,64 @@ public abstract class BaseObjectEntryResourceImpl
 		throws Exception {
 
 		return new ObjectEntry();
+	}
+
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "scopeKey"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "roleNames"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "ObjectEntry")}
+	)
+	@javax.ws.rs.GET
+	@javax.ws.rs.Path("/scopes/{scopeKey}/permissions")
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			getScopeScopeKeyPermissionsPage(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.ws.rs.PathParam("scopeKey")
+				String scopeKey,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.ws.rs.QueryParam("roleNames")
+				String roleNames)
+		throws Exception {
+
+		return Page.of(Collections.emptyList());
+	}
+
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "scopeKey"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "ObjectEntry")}
+	)
+	@javax.ws.rs.Path("/scopes/{scopeKey}/permissions")
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@javax.ws.rs.PUT
+	@Override
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putScopeScopeKeyPermissionsPage(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.ws.rs.PathParam("scopeKey")
+				String scopeKey,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
+		throws Exception {
+
+		return Page.of(Collections.emptyList());
 	}
 
 	@io.swagger.v3.oas.annotations.Parameters(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
@@ -31,7 +31,9 @@ import com.liferay.object.service.ObjectRelationshipService;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -39,6 +41,9 @@ import com.liferay.portal.vulcan.aggregation.Aggregation;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.ModelPermissionsUtil;
+import com.liferay.portal.vulcan.permission.Permission;
+import com.liferay.portal.vulcan.permission.PermissionUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
 import java.io.Serializable;
@@ -240,6 +245,33 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 	}
 
 	@Override
+	public Page<Permission> getPermissionsPage(String roleNames)
+		throws Exception {
+
+		Long siteId = _getGroupId(null);
+
+		String portletName = getPermissionCheckerPortletName(siteId);
+
+		PermissionUtil.checkPermission(
+			ActionKeys.PERMISSIONS, groupLocalService, portletName, siteId,
+			siteId);
+
+		return toPermissionPage(
+			HashMapBuilder.put(
+				"get",
+				addAction(
+					ActionKeys.PERMISSIONS, "getPermissionsPage", portletName,
+					siteId)
+			).put(
+				"replace",
+				addAction(
+					ActionKeys.PERMISSIONS, "putPermissionsPage", portletName,
+					siteId)
+			).build(),
+			siteId, portletName, roleNames);
+	}
+
+	@Override
 	public ObjectEntry getScopeScopeKeyByExternalReferenceCode(
 			String scopeKey, String externalReferenceCode)
 		throws Exception {
@@ -271,6 +303,34 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 				ParamUtil.getString(contextHttpServletRequest, "filter"),
 				_objectDefinition.getObjectDefinitionId()),
 			search, sorts);
+	}
+
+	@Override
+	public Page<Permission> getScopeScopeKeyPermissionsPage(
+			String scopeKey, String roleNames)
+		throws Exception {
+
+		Long siteId = _getGroupId(scopeKey);
+
+		String portletName = getPermissionCheckerPortletName(siteId);
+
+		PermissionUtil.checkPermission(
+			ActionKeys.PERMISSIONS, groupLocalService, portletName, siteId,
+			siteId);
+
+		return toPermissionPage(
+			HashMapBuilder.put(
+				"get",
+				addAction(
+					ActionKeys.PERMISSIONS, "getScopeScopeKeyPermissionsPage",
+					portletName, siteId)
+			).put(
+				"replace",
+				addAction(
+					ActionKeys.PERMISSIONS, "putScopeScopeKeyPermissionsPage",
+					portletName, siteId)
+			).build(),
+			siteId, portletName, roleNames);
 	}
 
 	@Override
@@ -353,6 +413,41 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 	}
 
 	@Override
+	public Page<Permission> putPermissionsPage(Permission[] permissions)
+		throws Exception {
+
+		Long siteId = _getGroupId(null);
+
+		String portletName = getPermissionCheckerPortletName(siteId);
+
+		PermissionUtil.checkPermission(
+			ActionKeys.PERMISSIONS, groupLocalService, portletName, siteId,
+			siteId);
+
+		resourcePermissionLocalService.updateResourcePermissions(
+			contextCompany.getCompanyId(), siteId, portletName,
+			String.valueOf(siteId),
+			ModelPermissionsUtil.toModelPermissions(
+				contextCompany.getCompanyId(), permissions, siteId, portletName,
+				resourceActionLocalService, resourcePermissionLocalService,
+				roleLocalService));
+
+		return toPermissionPage(
+			HashMapBuilder.put(
+				"get",
+				addAction(
+					ActionKeys.PERMISSIONS, "getPermissionsPage", portletName,
+					siteId)
+			).put(
+				"replace",
+				addAction(
+					ActionKeys.PERMISSIONS, "putPermissionsPage", portletName,
+					siteId)
+			).build(),
+			siteId, portletName, null);
+	}
+
+	@Override
 	public ObjectEntry putScopeScopeKeyByExternalReferenceCode(
 			String scopeKey, String externalReferenceCode,
 			ObjectEntry objectEntry)
@@ -365,6 +460,42 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 		return objectEntryManager.addOrUpdateObjectEntry(
 			contextCompany.getCompanyId(), _getDTOConverterContext(null),
 			externalReferenceCode, _objectDefinition, objectEntry, scopeKey);
+	}
+
+	@Override
+	public Page<Permission> putScopeScopeKeyPermissionsPage(
+			String scopeKey, Permission[] permissions)
+		throws Exception {
+
+		Long siteId = _getGroupId(scopeKey);
+
+		String portletName = getPermissionCheckerPortletName(siteId);
+
+		PermissionUtil.checkPermission(
+			ActionKeys.PERMISSIONS, groupLocalService, portletName, siteId,
+			siteId);
+
+		resourcePermissionLocalService.updateResourcePermissions(
+			contextCompany.getCompanyId(), siteId, portletName,
+			String.valueOf(siteId),
+			ModelPermissionsUtil.toModelPermissions(
+				contextCompany.getCompanyId(), permissions, siteId, portletName,
+				resourceActionLocalService, resourcePermissionLocalService,
+				roleLocalService));
+
+		return toPermissionPage(
+			HashMapBuilder.put(
+				"get",
+				addAction(
+					ActionKeys.PERMISSIONS, "getScopeScopeKeyPermissionsPage",
+					portletName, siteId)
+			).put(
+				"replace",
+				addAction(
+					ActionKeys.PERMISSIONS, "putScopeScopeKeyPermissionsPage",
+					portletName, siteId)
+			).build(),
+			siteId, portletName, null);
 	}
 
 	@Override
@@ -411,6 +542,13 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 	}
 
 	@Override
+	protected String getPermissionCheckerPortletName(Object id)
+		throws Exception {
+
+		return _objectDefinition.getResourceName();
+	}
+
+	@Override
 	protected String getPermissionCheckerResourceName(Object id)
 		throws Exception {
 
@@ -426,6 +564,14 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 			contextHttpServletRequest, objectEntryId,
 			contextAcceptLanguage.getPreferredLocale(), contextUriInfo,
 			contextUser);
+	}
+
+	private Long _getGroupId(String scopeKey) {
+		if (scopeKey == null) {
+			return Long.valueOf(0);
+		}
+
+		return Long.valueOf(scopeKey);
 	}
 
 	private ObjectEntry _getRelatedObjectEntry(


### PR DESCRIPTION
**What is new?**

- Add GET and PUT permission endpoints in rest-openapi.yaml.
- Implement `getPermissionCheckerPortletName` method.

**NEW ENDPOINTS**
They are created for Objects which are scoped by `companyId` and `groupId`.

**CompanyId**
![image](https://user-images.githubusercontent.com/44723449/190420348-3ebae712-6df3-4314-a277-f1325d2012c8.png)


**SiteId**
![image](https://user-images.githubusercontent.com/44723449/190420144-a7e43fd6-5646-4b08-90c6-04ef269ed0ed.png)


**RESPONSE FROM A GET AND PUT REQUEST**
```
{
  "actions": {
    "get": {
      "method": "GET",
      "href": "http://localhost:8080/o/c/newscopedobjects/scopes/20122/permissions"
    },
    "replace": {
      "method": "PUT",
      "href": "http://localhost:8080/o/c/newscopedobjects/scopes/20122/permissions"
    }
  },
  "facets": [],
  "items": [
    {
      "actionIds": [
        "PERMISSIONS",
        "ADD_OBJECT_ENTRY"
      ],
      "roleName": "Owner"
    },
    {
      "actionIds": [
        "PERMISSIONS",
        "ADD_OBJECT_ENTRY"
      ],
      "roleName": "Site Member"
    }
  ],
  "lastPage": 1,
  "page": 1,
  "pageSize": 2,
  "totalCount": 2
}
```

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-162877

