### PR TITLE
LPS-163169: Expose batch action in the Objects headless APIs

### DIFF
--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectActionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectActionResourceImpl.java
@@ -69,6 +69,12 @@ public class ObjectActionResourceImpl
 					com.liferay.object.model.ObjectDefinition.class.getName(),
 					objectDefinitionId)
 			).put(
+				"createBatch",
+				addAction(
+					ActionKeys.UPDATE, "postObjectDefinitionObjectActionBatch",
+					com.liferay.object.model.ObjectDefinition.class.getName(),
+					objectDefinitionId)
+			).put(
 				"get",
 				addAction(
 					ActionKeys.VIEW, "getObjectDefinitionObjectActionsPage",

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
@@ -109,6 +109,12 @@ public class ObjectDefinitionResourceImpl
 					"postObjectDefinition", ObjectConstants.RESOURCE_NAME,
 					contextCompany.getCompanyId())
 			).put(
+				"createBatch",
+				addAction(
+					ObjectActionKeys.ADD_OBJECT_DEFINITION,
+					"postObjectDefinitionBatch", ObjectConstants.RESOURCE_NAME,
+					contextCompany.getCompanyId())
+			).put(
 				"get",
 				addAction(
 					ActionKeys.VIEW, "getObjectDefinitionsPage",

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectFieldResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectFieldResourceImpl.java
@@ -91,6 +91,12 @@ public class ObjectFieldResourceImpl
 					com.liferay.object.model.ObjectDefinition.class.getName(),
 					objectDefinitionId)
 			).put(
+				"createBatch",
+				addAction(
+					ActionKeys.UPDATE, "postObjectDefinitionObjectFieldBatch",
+					com.liferay.object.model.ObjectDefinition.class.getName(),
+					objectDefinitionId)
+			).put(
 				"get",
 				addAction(
 					ActionKeys.VIEW, "getObjectDefinitionObjectFieldsPage",

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectLayoutResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectLayoutResourceImpl.java
@@ -66,6 +66,11 @@ public class ObjectLayoutResourceImpl extends BaseObjectLayoutResourceImpl {
 					ActionKeys.UPDATE, "postObjectDefinitionObjectLayout",
 					ObjectDefinition.class.getName(), objectDefinitionId)
 			).put(
+				"createBatch",
+				addAction(
+					ActionKeys.UPDATE, "postObjectDefinitionObjectLayoutBatch",
+					ObjectDefinition.class.getName(), objectDefinitionId)
+			).put(
 				"get",
 				addAction(
 					ActionKeys.VIEW, "getObjectDefinitionObjectLayoutsPage",

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectRelationshipResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectRelationshipResourceImpl.java
@@ -35,7 +35,6 @@ import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.util.SearchUtil;
 
-import java.util.Collections;
 import java.util.Objects;
 
 import javax.ws.rs.core.MultivaluedMap;
@@ -79,7 +78,14 @@ public class ObjectRelationshipResourceImpl
 		throws Exception {
 
 		return SearchUtil.search(
-			Collections.emptyMap(),
+			HashMapBuilder.put(
+				"createBatch",
+				addAction(
+					ActionKeys.UPDATE,
+					"postObjectDefinitionObjectRelationshipBatch",
+					com.liferay.object.model.ObjectDefinition.class.getName(),
+					objectDefinitionId)
+			).build(),
 			booleanQuery -> {
 			},
 			filter, com.liferay.object.model.ObjectRelationship.class.getName(),

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectValidationRuleResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectValidationRuleResourceImpl.java
@@ -64,6 +64,12 @@ public class ObjectValidationRuleResourceImpl
 					"postObjectDefinitionObjectValidationRule",
 					ObjectDefinition.class.getName(), objectDefinitionId)
 			).put(
+				"createBatch",
+				addAction(
+					ActionKeys.UPDATE,
+					"postObjectDefinitionObjectValidationRuleBatch",
+					ObjectDefinition.class.getName(), objectDefinitionId)
+			).put(
 				"get",
 				addAction(
 					ActionKeys.VIEW,

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectViewResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectViewResourceImpl.java
@@ -66,6 +66,11 @@ public class ObjectViewResourceImpl extends BaseObjectViewResourceImpl {
 					ActionKeys.UPDATE, "postObjectDefinitionObjectView",
 					ObjectDefinition.class.getName(), objectDefinitionId)
 			).put(
+				"createBatch",
+				addAction(
+					ActionKeys.UPDATE, "postObjectDefinitionObjectViewBatch",
+					ObjectDefinition.class.getName(), objectDefinitionId)
+			).put(
 				"get",
 				addAction(
 					ActionKeys.VIEW, "getObjectDefinitionObjectViewsPage",

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -395,6 +395,14 @@ public class DefaultObjectEntryManagerImpl
 						objectDefinition.getObjectDefinitionId()),
 					groupId, dtoConverterContext.getUriInfo())
 			).put(
+				"createBatch",
+				ActionUtil.addAction(
+					"ADD_OBJECT_ENTRY", ObjectEntryResourceImpl.class, 0L,
+					"postObjectEntryBatch", null, objectDefinition.getUserId(),
+					_getObjectEntriesPermissionName(
+						objectDefinition.getObjectDefinitionId()),
+					groupId, dtoConverterContext.getUriInfo())
+			).put(
 				"get",
 				ActionUtil.addAction(
 					ActionKeys.VIEW, ObjectEntryResourceImpl.class, 0L,


### PR DESCRIPTION
**What is new?**
- Update `object-rest-impl` module to add `createBatch` action in objects that are scoped by `siteId` and `companyId`.
- Update `object-admin-rest-impl` module to add createBatch` action.

**Example of a request method**
![image](https://user-images.githubusercontent.com/44723449/190610777-8d8a5a79-f985-46eb-987a-24e52e998eb0.png)

**HOW TO REPRODUCE**

1. Deploy `object-rest-impl`
2. Deploy `object-admin-rest-impl` 
3. Go to /o/api

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-163169
