### PR TITLE
Lrqa 77281 | Update integration tests on status code

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
@@ -647,7 +647,7 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 			testDeleteAssetLibraryTaxonomyVocabularyByExternalReferenceCode_addTaxonomyVocabulary();
 
 		assertHttpResponseStatusCode(
-			204,
+			404,
 			taxonomyVocabularyResource.
 				deleteAssetLibraryTaxonomyVocabularyByExternalReferenceCodeHttpResponse(
 					testDeleteAssetLibraryTaxonomyVocabularyByExternalReferenceCode_getAssetLibraryId(),

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountRoleResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountRoleResourceTestCase.java
@@ -802,7 +802,7 @@ public abstract class BaseAccountRoleResourceTestCase {
 			testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByEmailAddress_addAccountRole();
 
 		assertHttpResponseStatusCode(
-			204,
+			404,
 			accountRoleResource.
 				deleteAccountByExternalReferenceCodeAccountRoleUserAccountByEmailAddressHttpResponse(
 					testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByEmailAddress_getExternalReferenceCode(),

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseOrganizationResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseOrganizationResourceTestCase.java
@@ -615,7 +615,7 @@ public abstract class BaseOrganizationResourceTestCase {
 			testDeleteAccountByExternalReferenceCodeOrganization_addOrganization();
 
 		assertHttpResponseStatusCode(
-			204,
+			404,
 			organizationResource.
 				deleteAccountByExternalReferenceCodeOrganizationHttpResponse(
 					organization.getExternalReferenceCode(),

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseOrganizationResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseOrganizationResourceTestCase.java
@@ -1032,7 +1032,7 @@ public abstract class BaseOrganizationResourceTestCase {
 			testDeleteAccountOrganization_addOrganization();
 
 		assertHttpResponseStatusCode(
-			204,
+			404,
 			organizationResource.deleteAccountOrganizationHttpResponse(
 				testDeleteAccountOrganization_getAccountId(),
 				organization.getId()));

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
@@ -613,7 +613,7 @@ public abstract class BaseDocumentResourceTestCase {
 			testDeleteAssetLibraryDocumentByExternalReferenceCode_addDocument();
 
 		assertHttpResponseStatusCode(
-			204,
+			404,
 			documentResource.
 				deleteAssetLibraryDocumentByExternalReferenceCodeHttpResponse(
 					testDeleteAssetLibraryDocumentByExternalReferenceCode_getAssetLibraryId(),

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentFolderResourceTestCase.java
@@ -682,7 +682,7 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 			testDeleteAssetLibraryStructuredContentFolderByExternalReferenceCode_addStructuredContentFolder();
 
 		assertHttpResponseStatusCode(
-			204,
+			404,
 			structuredContentFolderResource.
 				deleteAssetLibraryStructuredContentFolderByExternalReferenceCodeHttpResponse(
 					testDeleteAssetLibraryStructuredContentFolderByExternalReferenceCode_getAssetLibraryId(),

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
@@ -649,7 +649,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 			testDeleteAssetLibraryStructuredContentByExternalReferenceCode_addStructuredContent();
 
 		assertHttpResponseStatusCode(
-			204,
+			404,
 			structuredContentResource.
 				deleteAssetLibraryStructuredContentByExternalReferenceCodeHttpResponse(
 					testDeleteAssetLibraryStructuredContentByExternalReferenceCode_getAssetLibraryId(),


### PR DESCRIPTION
**Background**:
- Tests testDeleteAssetLibraryStructuredContentByExternalReferenceCode failed since status code update from 204 to 404
- Tests testDeleteAssetLibraryDocumentByExternalReferenceCode failed since status code update from 204 to 404

**Test Plan**:
- update return code to 404 on StructuredContentResourceTest.testDeleteAssetLibraryStructuredContentByExternalReferenceCode
- update return code to 404 on DocumentResourceTest.testDeleteAssetLibraryDocumentByExternalReferenceCode

**JIRA Ticket**:
- https://issues.liferay.com/browse/LRQA-77281
- https://issues.liferay.com/browse/LRQA-77282