### PR TITLE
LPS-163286: Fixing TaxonomyVocabularyResourceTest > testDeleteAssetLibraryTaxonomyVocabularyByExternalReferenceCode

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
@@ -62,6 +62,15 @@ public class TaxonomyVocabularyResourceTest
 	}
 
 	@Override
+	protected TaxonomyVocabulary
+			testDeleteAssetLibraryTaxonomyVocabularyByExternalReferenceCode_addTaxonomyVocabulary()
+		throws Exception {
+
+		return taxonomyVocabularyResource.postAssetLibraryTaxonomyVocabulary(
+			testDepotEntry.getDepotEntryId(), randomTaxonomyVocabulary());
+	}
+
+	@Override
 	protected Long
 			testDeleteAssetLibraryTaxonomyVocabularyByExternalReferenceCode_getAssetLibraryId()
 		throws Exception {


### PR DESCRIPTION
**What is new?**

- Fixing `add_Vocabulary` by `assetLibraryId` in **TaxonomyVocabularyResourceTest > testDeleteAssetLibraryTaxonomyVocabularyByExternalReferenceCode**

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-163286	

