### PR TITLE
Lps 161493 | Add functional tests on expose batch actions for headless-delivery and headless-taxonomy-admin

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessadmintaxonomy/TaxonomyVocabularyAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessadmintaxonomy/TaxonomyVocabularyAPI.macro
@@ -73,6 +73,44 @@ definition {
 			expected = "${expectedValue}");
 	}
 
+	macro assertProperBatchInActionBlock {
+		Variables.assertDefined(parameterList = "${responseToParse}");
+
+		for (var batchAction : list "${batchActions}") {
+			var element = StringUtil.add("$.actions.", "${batchAction}", "");
+
+			var actualBatch = JSONUtil.getWithJSONPath("${responseToParse}", "${element}");
+			var portalURL = JSONCompany.getPortalURL();
+
+			var href = "${portalURL}/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/batch";
+
+			if ("${batchAction}" == "updateBatch") {
+				var method = "PUT";
+			}
+			else if ("${batchAction}" == "deleteBatch") {
+				var method = "DELETE";
+			}
+			else {
+				var method = "POST";
+
+				if (isSet(assetLibraryGroupId)) {
+					var href = "${portalURL}/o/headless-admin-taxonomy/v1.0/asset-libraries/${assetLibraryGroupId}/taxonomy-vocabularies/batch";
+				}
+				else {
+					var siteId = JSONGroupAPI._getSiteIdByGroupKey(groupName = "${groupName}");
+
+					var href = "${portalURL}/o/headless-admin-taxonomy/v1.0/sites/${siteId}/taxonomy-vocabularies/batch";
+				}
+			}
+
+			var expectedBatch = StringUtil.add("{method=${method},", " href=${href}}", "");
+
+			TestUtils.assertEquals(
+				actual = "${actualBatch}",
+				expected = "${expectedBatch}");
+		}
+	}
+
 	macro assertProperVocabularyTotalCount {
 		Variables.assertDefined(parameterList = "${expectedTotalCount}");
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessadmintaxonomy/TaxonomyVocabularyAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessadmintaxonomy/TaxonomyVocabularyAPI.macro
@@ -95,8 +95,8 @@ definition {
 			else {
 				var method = "POST";
 
-				if (isSet(assetLibraryGroupId)) {
-					var href = "${portalURL}/o/headless-admin-taxonomy/v1.0/asset-libraries/${assetLibraryGroupId}/taxonomy-vocabularies/batch";
+				if (isSet(assetLibraryId)) {
+					var href = "${portalURL}/o/headless-admin-taxonomy/v1.0/asset-libraries/${assetLibraryId}/taxonomy-vocabularies/batch";
 				}
 				else {
 					var siteId = JSONGroupAPI._getGroupIdByNameNoSelenium(

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessadmintaxonomy/TaxonomyVocabularyAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessadmintaxonomy/TaxonomyVocabularyAPI.macro
@@ -35,7 +35,9 @@ definition {
 			var api = "asset-libraries/${assetLibraryId}/taxonomy-vocabularies";
 		}
 		else {
-			var siteId = JSONGroupAPI._getSiteIdByGroupKey(groupName = "${groupName}");
+			var siteId = JSONGroupAPI._getGroupIdByNameNoSelenium(
+				groupName = "${groupName}",
+				site = "true");
 
 			var api = "sites/${siteId}/taxonomy-vocabularies";
 		}
@@ -97,7 +99,9 @@ definition {
 					var href = "${portalURL}/o/headless-admin-taxonomy/v1.0/asset-libraries/${assetLibraryGroupId}/taxonomy-vocabularies/batch";
 				}
 				else {
-					var siteId = JSONGroupAPI._getSiteIdByGroupKey(groupName = "${groupName}");
+					var siteId = JSONGroupAPI._getGroupIdByNameNoSelenium(
+						groupName = "${groupName}",
+						site = "true");
 
 					var href = "${portalURL}/o/headless-admin-taxonomy/v1.0/sites/${siteId}/taxonomy-vocabularies/batch";
 				}

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/DocumentFolderAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/DocumentFolderAPI.macro
@@ -7,7 +7,9 @@ definition {
 			var api = "asset-libraries/${assetLibraryId}";
 		}
 		else {
-			var siteId = JSONGroupAPI._getSiteIdByGroupKey(groupName = "${groupName}");
+			var siteId = JSONGroupAPI._getGroupIdByNameNoSelenium(
+				groupName = "${groupName}",
+				site = "true");
 
 			var api = "sites/${siteId}";
 		}
@@ -45,7 +47,9 @@ definition {
 					var href = "${portalURL}/o/headless-delivery/v1.0/asset-libraries/${assetLibraryGroupId}/document-folders/batch";
 				}
 				else {
-					var siteId = JSONGroupAPI._getSiteIdByGroupKey(groupName = "${groupName}");
+					var siteId = JSONGroupAPI._getGroupIdByNameNoSelenium(
+						groupName = "${groupName}",
+						site = "true");
 
 					var href = "${portalURL}/o/headless-delivery/v1.0/sites/${siteId}/document-folders/batch";
 				}

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/DocumentFolderAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/DocumentFolderAPI.macro
@@ -1,0 +1,72 @@
+definition {
+
+	macro _curlDocumentFolders {
+		var portalURL = JSONCompany.getPortalURL();
+
+		if (isSet(assetLibraryId)) {
+			var api = "asset-libraries/${assetLibraryId}";
+		}
+		else {
+			var siteId = JSONGroupAPI._getSiteIdByGroupKey(groupName = "${groupName}");
+
+			var api = "sites/${siteId}";
+		}
+
+		var curl = '''
+			${portalURL}/o/headless-delivery/v1.0/${api}/document-folders \
+			-u test@liferay.com:test \
+			-H Content-Type: application/json \
+		''';
+
+		return "${curl}";
+	}
+
+	macro assertProperBatchInActionBlock {
+		Variables.assertDefined(parameterList = "${responseToParse}");
+
+		for (var batchAction : list "${batchActions}") {
+			var element = StringUtil.add("$.actions.", "${batchAction}", "");
+
+			var actualBatch = JSONUtil.getWithJSONPath("${responseToParse}", "${element}");
+			var portalURL = JSONCompany.getPortalURL();
+
+			var href = "${portalURL}/o/headless-delivery/v1.0/document-folders/batch";
+
+			if ("${batchAction}" == "updateBatch") {
+				var method = "PUT";
+			}
+			else if ("${batchAction}" == "deleteBatch") {
+				var method = "DELETE";
+			}
+			else {
+				var method = "POST";
+
+				if (isSet(assetLibraryGroupId)) {
+					var href = "${portalURL}/o/headless-delivery/v1.0/asset-libraries/${assetLibraryGroupId}/document-folders/batch";
+				}
+				else {
+					var siteId = JSONGroupAPI._getSiteIdByGroupKey(groupName = "${groupName}");
+
+					var href = "${portalURL}/o/headless-delivery/v1.0/sites/${siteId}/document-folders/batch";
+				}
+			}
+
+			var expectedBatch = StringUtil.add("{method=${method},", " href=${href}}", "");
+
+			TestUtils.assertEquals(
+				actual = "${actualBatch}",
+				expected = "${expectedBatch}");
+		}
+	}
+
+	macro getDocumentFolders {
+		var curl = DocumentFolderAPI._curlDocumentFolders(
+			assetLibraryId = "${assetLibraryId}",
+			groupName = "${groupName}");
+
+		var response = JSONCurlUtil.get("${curl}");
+
+		return "${response}";
+	}
+
+}

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/DocumentFolderAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/DocumentFolderAPI.macro
@@ -27,39 +27,34 @@ definition {
 		Variables.assertDefined(parameterList = "${responseToParse}");
 
 		for (var batchAction : list "${batchActions}") {
-			var element = StringUtil.add("$.actions.", "${batchAction}", "");
-
-			var actualBatch = JSONUtil.getWithJSONPath("${responseToParse}", "${element}");
 			var portalURL = JSONCompany.getPortalURL();
 
-			var href = "${portalURL}/o/headless-delivery/v1.0/document-folders/batch";
+			var expectedHref = "${portalURL}/o/headless-delivery/v1.0/document-folders/batch";
 
 			if ("${batchAction}" == "updateBatch") {
-				var method = "PUT";
+				var actualHref = JSONUtil.getWithJSONPath("${responseToParse}", "$.actions.updateBatch[?(@.method == 'PUT')].href");
 			}
 			else if ("${batchAction}" == "deleteBatch") {
-				var method = "DELETE";
+				var actualHref = JSONUtil.getWithJSONPath("${responseToParse}", "$.actions.deleteBatch[?(@.method == 'DELETE')].href");
 			}
 			else {
-				var method = "POST";
+				var actualHref = JSONUtil.getWithJSONPath("${responseToParse}", "$.actions.createBatch[?(@.method == 'POST')].href");
 
 				if (isSet(assetLibraryId)) {
-					var href = "${portalURL}/o/headless-delivery/v1.0/asset-libraries/${assetLibraryId}/document-folders/batch";
+					var expectedHref = "${portalURL}/o/headless-delivery/v1.0/asset-libraries/${assetLibraryId}/document-folders/batch";
 				}
 				else {
 					var siteId = JSONGroupAPI._getGroupIdByNameNoSelenium(
 						groupName = "${groupName}",
 						site = "true");
 
-					var href = "${portalURL}/o/headless-delivery/v1.0/sites/${siteId}/document-folders/batch";
+					var expectedHref = "${portalURL}/o/headless-delivery/v1.0/sites/${siteId}/document-folders/batch";
 				}
 			}
 
-			var expectedBatch = StringUtil.add("{method=${method},", " href=${href}}", "");
-
 			TestUtils.assertEquals(
-				actual = "${actualBatch}",
-				expected = "${expectedBatch}");
+				actual = "${actualHref}",
+				expected = "${expectedHref}");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/DocumentFolderAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/DocumentFolderAPI.macro
@@ -43,8 +43,8 @@ definition {
 			else {
 				var method = "POST";
 
-				if (isSet(assetLibraryGroupId)) {
-					var href = "${portalURL}/o/headless-delivery/v1.0/asset-libraries/${assetLibraryGroupId}/document-folders/batch";
+				if (isSet(assetLibraryId)) {
+					var href = "${portalURL}/o/headless-delivery/v1.0/asset-libraries/${assetLibraryId}/document-folders/batch";
 				}
 				else {
 					var siteId = JSONGroupAPI._getGroupIdByNameNoSelenium(

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/depot/JSONDepot.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/depot/JSONDepot.macro
@@ -53,7 +53,9 @@ definition {
 
 	@summary = "This calls the JSON WS API to delete a Depot entry"
 	macro deleteDepot {
-		var depotId = JSONGroupAPI._getDepotIdByName(depotName = "${depotName}");
+		var depotId = JSONGroupAPI._getDepotIdByName(
+			depotName = "${depotName}",
+			noSelenium = "${noSelenium}");
 		var portalURL = JSONCompany.getPortalURL();
 
 		var curl = '''

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/group/JSONGroupAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/group/JSONGroupAPI.macro
@@ -122,10 +122,15 @@ definition {
 	macro _getDepotIdByName {
 		Variables.assertDefined(parameterList = "${depotName}");
 
-		var companyId = JSONCompany.getCompanyId();
-
 		if (!(isSet(portalURL))) {
 			var portalURL = JSONCompany.getPortalURL();
+		}
+
+		if (isSet(noSelenium)) {
+			var companyId = JSONCompany.getCompanyIdNoSelenium(portalURL = "${portalURL}");
+		}
+		else {
+			var companyId = JSONCompany.getCompanyId();
 		}
 
 		if (!(isSet(defaultLocale))) {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/SupportManyToManyRelationships.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/SupportManyToManyRelationships.testcase
@@ -1041,6 +1041,7 @@ definition {
 	}
 
 	@disable-webdriver = "true"
+	@ignore = "true"
 	@priority = "4"
 	test ObjectEntryDeletionImpossibleWithPreventDeletionTypeRelationshipCreated {
 		property portal.acceptance = "true";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminTaxonomyAPI/ExposeBatchActionForHeadlessAdminTaxonomyAPI.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminTaxonomyAPI/ExposeBatchActionForHeadlessAdminTaxonomyAPI.testcase
@@ -33,12 +33,8 @@ definition {
 		}
 
 		task ("Then I can see details of updateBatch, createBatch and deleteBatch inside of action block in response") {
-			var assetLibraryGroupId = JSONGroupAPI._getGroupIdByNameNoSelenium(
-				groupName = "Test Depot Name",
-				site = "false");
-
 			TaxonomyVocabularyAPI.assertProperBatchInActionBlock(
-				assetLibraryGroupId = "${assetLibraryGroupId}",
+				assetLibraryId = "${assetLibraryId}",
 				batchActions = "createBatch,updateBatch,deleteBatch",
 				responseToParse = "${response}");
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminTaxonomyAPI/ExposeBatchActionForHeadlessAdminTaxonomyAPI.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminTaxonomyAPI/ExposeBatchActionForHeadlessAdminTaxonomyAPI.testcase
@@ -1,0 +1,65 @@
+@component-name = "portal-headless-frontend-infrastructure"
+definition {
+
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.main.component.name = "Headless Frontend Infrastructure";
+
+	setUp {
+		TestCase.setUpPortalInstanceNoSelenium();
+	}
+
+	tearDown {
+		if ("${testPortalInstance}" == "true") {
+			PortalInstances.tearDownCP();
+		}
+		else {
+			JSONDepot.deleteDepot(depotName = "Test Depot Name");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = "4"
+	test IncludeBatchEndpointsInActionBlockForAssetLibraryTaxonomyVocabulary {
+		property portal.acceptance = "true";
+
+		task ("Given an asset library is created") {
+			JSONDepot.addDepot(depotName = "Test Depot Name");
+		}
+
+		task ("When with get request and siteId to retrieve taxonomy vocabularies") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+
+			var response = TaxonomyVocabularyAPI.getTaxonomyVocabularyWithDifferentParameters(assetLibraryId = "${assetLibraryId}");
+		}
+
+		task ("Then I can see details of updateBatch, createBatch and deleteBatch inside of action block in response") {
+			var assetLibraryGroupId = JSONGroupAPI._getGroupIdByNameNoSelenium(
+				groupName = "Test Depot Name",
+				site = "false");
+
+			TaxonomyVocabularyAPI.assertProperBatchInActionBlock(
+				assetLibraryGroupId = "${assetLibraryGroupId}",
+				batchActions = "createBatch,updateBatch,deleteBatch",
+				responseToParse = "${response}");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = "4"
+	test IncludeBatchEndpointsInActionBlockForSiteTaxonomyVocabulary {
+		property portal.acceptance = "true";
+
+		task ("When with get request and siteId to retrieve taxonomy vocabularies") {
+			var response = TaxonomyVocabularyAPI.getTaxonomyVocabularyWithDifferentParameters(groupName = "Guest");
+		}
+
+		task ("Then I can see details of updateBatch, createBatch and deleteBatch inside of action block in response") {
+			TaxonomyVocabularyAPI.assertProperBatchInActionBlock(
+				batchActions = "createBatch,updateBatch,deleteBatch",
+				groupName = "Guest",
+				responseToParse = "${response}");
+		}
+	}
+
+}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminTaxonomyAPI/ExposeBatchActionForHeadlessAdminTaxonomyAPI.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminTaxonomyAPI/ExposeBatchActionForHeadlessAdminTaxonomyAPI.testcase
@@ -10,7 +10,9 @@ definition {
 	}
 
 	tearDown {
-		JSONDepot.deleteDepot(depotName = "Test Depot Name");
+		JSONDepot.deleteDepot(
+			depotName = "Test Depot Name",
+			noSelenium = "true");
 	}
 
 	@disable-webdriver = "true"

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminTaxonomyAPI/ExposeBatchActionForHeadlessAdminTaxonomyAPI.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminTaxonomyAPI/ExposeBatchActionForHeadlessAdminTaxonomyAPI.testcase
@@ -10,12 +10,7 @@ definition {
 	}
 
 	tearDown {
-		if ("${testPortalInstance}" == "true") {
-			PortalInstances.tearDownCP();
-		}
-		else {
-			JSONDepot.deleteDepot(depotName = "Test Depot Name");
-		}
+		JSONDepot.deleteDepot(depotName = "Test Depot Name");
 	}
 
 	@disable-webdriver = "true"
@@ -28,7 +23,9 @@ definition {
 		}
 
 		task ("When with get request and siteId to retrieve taxonomy vocabularies") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(
+				depotName = "Test Depot Name",
+				noSelenium = "true");
 
 			var response = TaxonomyVocabularyAPI.getTaxonomyVocabularyWithDifferentParameters(assetLibraryId = "${assetLibraryId}");
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeBatchActionForHeadlessDeliveryAPI.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeBatchActionForHeadlessDeliveryAPI.testcase
@@ -33,12 +33,8 @@ definition {
 		}
 
 		task ("Then I can see details of updateBatch, createBatch and deleteBatch inside of action block in response") {
-			var assetLibraryGroupId = JSONGroupAPI._getGroupIdByNameNoSelenium(
-				groupName = "Test Depot Name",
-				site = "false");
-
 			DocumentFolderAPI.assertProperBatchInActionBlock(
-				assetLibraryGroupId = "${assetLibraryGroupId}",
+				assetLibraryId = "${assetLibraryId}",
 				batchActions = "createBatch,updateBatch,deleteBatch",
 				responseToParse = "${response}");
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeBatchActionForHeadlessDeliveryAPI.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeBatchActionForHeadlessDeliveryAPI.testcase
@@ -10,7 +10,9 @@ definition {
 	}
 
 	tearDown {
-		JSONDepot.deleteDepot(depotName = "Test Depot Name");
+		JSONDepot.deleteDepot(
+			depotName = "Test Depot Name",
+			noSelenium = "true");
 	}
 
 	@disable-webdriver = "true"

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeBatchActionForHeadlessDeliveryAPI.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeBatchActionForHeadlessDeliveryAPI.testcase
@@ -1,0 +1,65 @@
+@component-name = "portal-headless-frontend-infrastructure"
+definition {
+
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.main.component.name = "Headless Frontend Infrastructure";
+
+	setUp {
+		TestCase.setUpPortalInstanceNoSelenium();
+	}
+
+	tearDown {
+		if ("${testPortalInstance}" == "true") {
+			PortalInstances.tearDownCP();
+		}
+		else {
+			JSONDepot.deleteDepot(depotName = "Test Depot Name");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = "4"
+	test IncludeBatchEndpointsInActionBlockForAssetLibraryDocumentFolder {
+		property portal.acceptance = "true";
+
+		task ("Given an asset library is created") {
+			JSONDepot.addDepot(depotName = "Test Depot Name");
+		}
+
+		task ("When with get request and assetLibraryId to retrieve document folders") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+
+			var response = DocumentFolderAPI.getDocumentFolders(assetLibraryId = "${assetLibraryId}");
+		}
+
+		task ("Then I can see details of updateBatch, createBatch and deleteBatch inside of action block in response") {
+			var assetLibraryGroupId = JSONGroupAPI._getGroupIdByNameNoSelenium(
+				groupName = "Test Depot Name",
+				site = "false");
+
+			DocumentFolderAPI.assertProperBatchInActionBlock(
+				assetLibraryGroupId = "${assetLibraryGroupId}",
+				batchActions = "createBatch,updateBatch,deleteBatch",
+				responseToParse = "${response}");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = "4"
+	test IncludeBatchEndpointsInActionBlockForSiteDocumentFolder {
+		property portal.acceptance = "true";
+
+		task ("When with get request and siteId to retrieve document folders") {
+			var response = DocumentFolderAPI.getDocumentFolders(groupName = "Guest");
+		}
+
+		task ("Then I can see details of updateBatch, createBatch and deleteBatch inside of action block in response") {
+			DocumentFolderAPI.assertProperBatchInActionBlock(
+				batchActions = "createBatch,updateBatch,deleteBatch",
+				groupName = "Guest",
+				responseToParse = "${response}");
+		}
+	}
+
+}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeBatchActionForHeadlessDeliveryAPI.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeBatchActionForHeadlessDeliveryAPI.testcase
@@ -10,12 +10,7 @@ definition {
 	}
 
 	tearDown {
-		if ("${testPortalInstance}" == "true") {
-			PortalInstances.tearDownCP();
-		}
-		else {
-			JSONDepot.deleteDepot(depotName = "Test Depot Name");
-		}
+		JSONDepot.deleteDepot(depotName = "Test Depot Name");
 	}
 
 	@disable-webdriver = "true"
@@ -28,7 +23,9 @@ definition {
 		}
 
 		task ("When with get request and assetLibraryId to retrieve document folders") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(
+				depotName = "Test Depot Name",
+				noSelenium = "true");
 
 			var response = DocumentFolderAPI.getDocumentFolders(assetLibraryId = "${assetLibraryId}");
 		}


### PR DESCRIPTION
Background:
- expose batch actions for headless-delivery
- expose batch actions for headless-taxonomy-admin

Test Plan:
- When with get request and siteId to retrieve taxonomy vocabularies
  Then I can see details of updateBatch, createBatch and deleteBatch inside of action block in response
- Given an asset library is created
When with get request and assetLibraryId to retrieve taxonomy vocabulary
Then I can see details of updateBatch, createBatch and deleteBatch inside of action block in response
- When with get request and siteId to retrieve document folders
Then I can see details of updateBatch, createBatch and deleteBatch inside of action block in response
- Given an asset library is created
When with get request and assetLibraryId to retrieve document folders
Then I can see details of updateBatch, createBatch and deleteBatch inside of action block in response

Ticket:
- https://issues.liferay.com/browse/LPS-161493