### PR TITLE
LPS-161704 Fix query including a parenthesis when OR is executed

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
@@ -367,15 +367,14 @@ public class ObjectRelationshipLocalServiceImpl
 					false
 				).and(
 					ObjectRelationshipTable.INSTANCE.name.eq(
-						objectRelationshipName
-					).and(
-						ObjectRelationshipTable.INSTANCE.objectDefinitionId1.eq(
-							objectDefinitionId
-						).or(
-							ObjectRelationshipTable.INSTANCE.
-								objectDefinitionId2.eq(objectDefinitionId)
-						)
-					)
+						objectRelationshipName)
+				).and(
+					ObjectRelationshipTable.INSTANCE.objectDefinitionId1.eq(
+						objectDefinitionId
+					).or(
+						ObjectRelationshipTable.INSTANCE.objectDefinitionId2.eq(
+							objectDefinitionId)
+					).withParentheses()
 				)
 			));
 


### PR DESCRIPTION
This PR contains the code to fix the query that gets the object relationship based on the object id and the relationship name

**Before the PR**:

The query returned randomly one of the relationships of the object

```
select * from ObjectRelationship
where ObjectRelationship.reverse = ?
and ObjectRelationship.name = ?
and ObjectRelationship.objectDefinitionId1 = ?
or ObjectRelationship.objectDefinitionId2 = ?
```

**After the PR**:

The query returns the desired relationship

```
select * from ObjectRelationship
where ObjectRelationship.reverse = ?
and ObjectRelationship.name = ?
and (ObjectRelationship.objectDefinitionId1 = ? or ObjectRelationship.objectDefinitionId2 = ?)
```