### PR TITLE
LPS-162964 Refactor to unify the methods to return the Object Entries related to a Object Entry

### DIFF
--- a/modules/apps/object/object-rest-api/bnd.bnd
+++ b/modules/apps/object/object-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object REST API
 Bundle-SymbolicName: com.liferay.object.rest.api
-Bundle-Version: 6.6.1
+Bundle-Version: 7.0.0
 Export-Package:\
 	com.liferay.object.rest.dto.v1_0,\
 	com.liferay.object.rest.dto.v1_0.util,\

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/BaseObjectEntryManager.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/BaseObjectEntryManager.java
@@ -16,8 +16,10 @@ package com.liferay.object.rest.manager.v1_0;
 
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.scope.ObjectScopeProvider;
 import com.liferay.object.scope.ObjectScopeProviderRegistry;
+import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.vulcan.util.GroupUtil;
@@ -55,11 +57,30 @@ public abstract class BaseObjectEntryManager {
 		return 0;
 	}
 
+	protected ObjectDefinition getRelatedObjectDefinition(
+			ObjectDefinition objectDefinition,
+			ObjectRelationship objectRelationship)
+		throws Exception {
+
+		long objectDefinitionId1 = objectRelationship.getObjectDefinitionId1();
+
+		if (objectDefinitionId1 != objectDefinition.getObjectDefinitionId()) {
+			return objectDefinitionLocalService.getObjectDefinition(
+				objectRelationship.getObjectDefinitionId1());
+		}
+
+		return objectDefinitionLocalService.getObjectDefinition(
+			objectRelationship.getObjectDefinitionId2());
+	}
+
 	@Reference
 	protected DepotEntryLocalService depotEntryLocalService;
 
 	@Reference
 	protected GroupLocalService groupLocalService;
+
+	@Reference
+	protected ObjectDefinitionLocalService objectDefinitionLocalService;
 
 	@Reference
 	protected ObjectScopeProviderRegistry objectScopeProviderRegistry;

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/ObjectEntryManager.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/ObjectEntryManager.java
@@ -95,14 +95,9 @@ public interface ObjectEntryManager {
 			ObjectDefinition objectDefinition, String scopeKey)
 		throws Exception;
 
-	public Page<ObjectEntry> getObjectEntryRelatedObjectEntries(
+	public Page<Object> getObjectEntryRelatedObjectEntries(
 			DTOConverterContext dtoConverterContext,
-			ObjectDefinition objectDefinition, Long objectEntryId,
-			String objectRelationshipName, Pagination pagination)
-		throws Exception;
-
-	public Page<Object> getRelatedSystemObjectEntries(
-			ObjectDefinition objectDefinition, Long objectEntryId,
+			ObjectDefinition objectDefinition, long objectEntryId,
 			String objectRelationshipName, Pagination pagination)
 		throws Exception;
 

--- a/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/manager/v1_0/packageinfo
+++ b/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/manager/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 6.1.0
+version 7.0.0

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/graphql/dto/v1_0/ObjectDefinitionGraphQLDTOContributor.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/graphql/dto/v1_0/ObjectDefinitionGraphQLDTOContributor.java
@@ -274,14 +274,15 @@ public class ObjectDefinitionGraphQLDTOContributor
 		}
 
 		if (relationshipIdName == null) {
-			Page<ObjectEntry> page =
+			Page<Object> page =
 				_objectEntryManager.getObjectEntryRelatedObjectEntries(
 					dtoConverterContext, _objectDefinition, id,
 					relationshipName,
 					Pagination.of(QueryUtil.ALL_POS, QueryUtil.ALL_POS));
 
 			return (T)TransformUtil.transform(
-				page.getItems(), itemObjectEntry -> _toMap(itemObjectEntry));
+				page.getItems(),
+				itemObjectEntry -> _toMap((ObjectEntry)itemObjectEntry));
 		}
 
 		Object relationshipId = properties.get(relationshipIdName);

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -36,7 +36,6 @@ import com.liferay.object.rest.internal.resource.v1_0.ObjectEntryResourceImpl;
 import com.liferay.object.rest.manager.v1_0.BaseObjectEntryManager;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.object.rest.petra.sql.dsl.expression.FilterPredicateFactory;
-import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectEntryService;
 import com.liferay.object.service.ObjectFieldLocalService;
@@ -161,7 +160,7 @@ public class DefaultObjectEntryManagerImpl
 
 		return getObjectEntry(
 			dtoConverterContext,
-			_objectDefinitionLocalService.getObjectDefinition(
+			objectDefinitionLocalService.getObjectDefinition(
 				objectRelationship.getObjectDefinitionId2()),
 			primaryKey2);
 	}
@@ -231,7 +230,7 @@ public class DefaultObjectEntryManagerImpl
 		if (objectEntry != null) {
 			if (objectDefinition == null) {
 				objectDefinition =
-					_objectDefinitionLocalService.getObjectDefinition(
+					objectDefinitionLocalService.getObjectDefinition(
 						objectEntry.getObjectDefinitionId());
 			}
 
@@ -477,9 +476,9 @@ public class DefaultObjectEntryManagerImpl
 	}
 
 	@Override
-	public Page<ObjectEntry> getObjectEntryRelatedObjectEntries(
+	public Page<Object> getObjectEntryRelatedObjectEntries(
 			DTOConverterContext dtoConverterContext,
-			ObjectDefinition objectDefinition, Long objectEntryId,
+			ObjectDefinition objectDefinition, long objectEntryId,
 			String objectRelationshipName, Pagination pagination)
 		throws Exception {
 
@@ -488,7 +487,7 @@ public class DefaultObjectEntryManagerImpl
 				objectDefinition.getObjectDefinitionId(),
 				objectRelationshipName);
 
-		ObjectDefinition relatedObjectDefinition = _getRelatedObjectDefinition(
+		ObjectDefinition relatedObjectDefinition = getRelatedObjectDefinition(
 			objectDefinition, objectRelationship);
 
 		ObjectRelatedModelsProvider objectRelatedModelsProvider =
@@ -497,13 +496,22 @@ public class DefaultObjectEntryManagerImpl
 				objectRelationship.getType());
 
 		if (objectDefinition.isSystem()) {
-			return _getSystemObjectRelatedObjectEntries(
-				dtoConverterContext, objectDefinition, objectEntryId,
-				objectRelationship, objectRelatedModelsProvider, pagination);
+			List<Object> objects = _getSystemObjectRelatedObjectEntries(
+				objectDefinition, objectEntryId, objectRelationship,
+				objectRelatedModelsProvider, pagination,
+				relatedObjectDefinition);
+
+			return Page.of(
+				new HashMap<>(),
+				_toObjectEntries(dtoConverterContext, objects));
 		}
 
 		com.liferay.object.model.ObjectEntry objectEntry =
 			_objectEntryService.getObjectEntry(objectEntryId);
+
+		List<Object> objects = _getCustomObjectRelatedObjectEntries(
+			dtoConverterContext, objectEntry, objectRelationship,
+			objectRelatedModelsProvider, pagination, relatedObjectDefinition);
 
 		return Page.of(
 			HashMapBuilder.put(
@@ -517,47 +525,7 @@ public class DefaultObjectEntryManagerImpl
 						objectDefinition.getObjectDefinitionId()),
 					objectEntry.getGroupId(), dtoConverterContext.getUriInfo())
 			).build(),
-			_toObjectEntries(
-				dtoConverterContext,
-				objectRelatedModelsProvider.getRelatedModels(
-					objectEntry.getGroupId(),
-					objectRelationship.getObjectRelationshipId(),
-					objectEntry.getPrimaryKey(), pagination.getStartPosition(),
-					pagination.getEndPosition())));
-	}
-
-	@Override
-	public Page<Object> getRelatedSystemObjectEntries(
-			ObjectDefinition objectDefinition, Long objectEntryId,
-			String objectRelationshipName, Pagination pagination)
-		throws Exception {
-
-		ObjectRelationship objectRelationship =
-			_objectRelationshipService.getObjectRelationship(
-				objectDefinition.getObjectDefinitionId(),
-				objectRelationshipName);
-
-		ObjectDefinition relatedObjectDefinition = _getRelatedObjectDefinition(
-			objectDefinition, objectRelationship);
-
-		ObjectRelatedModelsProvider objectRelatedModelsProvider =
-			_objectRelatedModelsProviderRegistry.getObjectRelatedModelsProvider(
-				relatedObjectDefinition.getClassName(),
-				objectRelationship.getType());
-
-		com.liferay.object.model.ObjectEntry objectEntry =
-			_objectEntryService.getObjectEntry(objectEntryId);
-
-		return Page.of(
-			TransformUtil.transform(
-				(List<BaseModel<?>>)
-					objectRelatedModelsProvider.getRelatedModels(
-						objectEntry.getGroupId(),
-						objectRelationship.getObjectRelationshipId(),
-						objectEntry.getPrimaryKey(),
-						pagination.getStartPosition(),
-						pagination.getEndPosition()),
-				baseModel -> _toDTO(baseModel, objectEntry)));
+			objects);
 	}
 
 	@Override
@@ -625,6 +593,27 @@ public class DefaultObjectEntryManagerImpl
 		return serviceContext;
 	}
 
+	private List<Object> _getCustomObjectRelatedObjectEntries(
+			DTOConverterContext dtoConverterContext,
+			com.liferay.object.model.ObjectEntry objectEntry,
+			ObjectRelationship objectRelationship,
+			ObjectRelatedModelsProvider objectRelatedModelsProvider,
+			Pagination pagination, ObjectDefinition relatedObjectDefinition)
+		throws Exception {
+
+		List<Object> objects = objectRelatedModelsProvider.getRelatedModels(
+			objectEntry.getGroupId(),
+			objectRelationship.getObjectRelationshipId(),
+			objectEntry.getPrimaryKey(), pagination.getStartPosition(),
+			pagination.getEndPosition());
+
+		if (relatedObjectDefinition.isSystem()) {
+			return _toSystemObjectEntries(objects, objectEntry);
+		}
+
+		return _toObjectEntries(dtoConverterContext, objects);
+	}
+
 	private String _getObjectEntriesPermissionName(long objectDefinitionId) {
 		return ObjectConstants.RESOURCE_NAME + "#" + objectDefinitionId;
 	}
@@ -651,29 +640,16 @@ public class DefaultObjectEntryManagerImpl
 		return ObjectDefinition.class.getName() + "#" + objectDefinitionId;
 	}
 
-	private ObjectDefinition _getRelatedObjectDefinition(
-			ObjectDefinition objectDefinition,
-			ObjectRelationship objectRelationship)
-		throws Exception {
-
-		long objectDefinitionId1 = objectRelationship.getObjectDefinitionId1();
-
-		if (objectDefinitionId1 != objectDefinition.getObjectDefinitionId()) {
-			return _objectDefinitionLocalService.getObjectDefinition(
-				objectRelationship.getObjectDefinitionId1());
-		}
-
-		return _objectDefinitionLocalService.getObjectDefinition(
-			objectRelationship.getObjectDefinitionId2());
-	}
-
-	private Page<ObjectEntry> _getSystemObjectRelatedObjectEntries(
-			DTOConverterContext dtoConverterContext,
+	private List<Object> _getSystemObjectRelatedObjectEntries(
 			ObjectDefinition objectDefinition, long objectEntryId,
 			ObjectRelationship objectRelationship,
 			ObjectRelatedModelsProvider objectRelatedModelsProvider,
-			Pagination pagination)
+			Pagination pagination, ObjectDefinition relatedObjectDefinition)
 		throws Exception {
+
+		if (relatedObjectDefinition.isSystem()) {
+			throw new UnsupportedOperationException();
+		}
 
 		long groupId = GroupThreadLocal.getGroupId();
 
@@ -691,14 +667,10 @@ public class DefaultObjectEntryManagerImpl
 			groupId = assetEntry.getGroupId();
 		}
 
-		return Page.of(
-			Collections.emptyMap(),
-			_toObjectEntries(
-				dtoConverterContext,
-				objectRelatedModelsProvider.getRelatedModels(
-					groupId, objectRelationship.getObjectRelationshipId(),
-					assetEntry.getClassPK(), pagination.getStartPosition(),
-					pagination.getEndPosition())));
+		return objectRelatedModelsProvider.getRelatedModels(
+			groupId, objectRelationship.getObjectRelationshipId(),
+			assetEntry.getClassPK(), pagination.getStartPosition(),
+			pagination.getEndPosition());
 	}
 
 	private boolean _hasRelatedObjectEntries(
@@ -712,7 +684,7 @@ public class DefaultObjectEntryManagerImpl
 					false)) {
 
 			ObjectDefinition objectDefinition2 =
-				_objectDefinitionLocalService.getObjectDefinition(
+				objectDefinitionLocalService.getObjectDefinition(
 					objectRelationship.getObjectDefinitionId2());
 
 			ObjectRelatedModelsProvider objectRelatedModelsProvider =
@@ -821,17 +793,21 @@ public class DefaultObjectEntryManagerImpl
 		return dtoConverter.toDTO(defaultDTOConverterContext, baseModel);
 	}
 
-	private List<ObjectEntry> _toObjectEntries(
-		DTOConverterContext dtoConverterContext,
-		List<com.liferay.object.model.ObjectEntry> objectEntries) {
+	private List<Object> _toObjectEntries(
+		DTOConverterContext dtoConverterContext, List<Object> objects) {
 
 		return TransformUtil.transform(
-			objectEntries,
-			objectEntry -> _toObjectEntry(
-				dtoConverterContext,
-				_objectDefinitionLocalService.getObjectDefinition(
-					objectEntry.getObjectDefinitionId()),
-				objectEntry));
+			objects,
+			item -> {
+				com.liferay.object.model.ObjectEntry objectEntry =
+					(com.liferay.object.model.ObjectEntry)item;
+
+				return _toObjectEntry(
+					dtoConverterContext,
+					objectDefinitionLocalService.getObjectDefinition(
+						objectEntry.getObjectDefinitionId()),
+					objectEntry);
+			});
 	}
 
 	private ObjectEntry _toObjectEntry(
@@ -971,6 +947,14 @@ public class DefaultObjectEntryManagerImpl
 		return values;
 	}
 
+	private List<Object> _toSystemObjectEntries(
+		List<Object> objects,
+		com.liferay.object.model.ObjectEntry objectEntry) {
+
+		return TransformUtil.transform(
+			objects, item -> _toDTO((BaseModel<?>)item, objectEntry));
+	}
+
 	private static final long _NONEXISTING_ACCOUNT_ENTRY_ID = -1;
 
 	private static final Log _log = LogFactoryUtil.getLog(
@@ -990,9 +974,6 @@ public class DefaultObjectEntryManagerImpl
 
 	@Reference
 	private FilterPredicateFactory _filterPredicateFactory;
-
-	@Reference
-	private ObjectDefinitionLocalService _objectDefinitionLocalService;
 
 	@Reference
 	private ObjectEntryDTOConverter _objectEntryDTOConverter;

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
@@ -179,7 +179,7 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 			_objectEntryManagerTracker.getObjectEntryManager(
 				_objectDefinition.getStorageType());
 
-		Page<ObjectEntry> page =
+		Page<Object> page =
 			objectEntryManager.getObjectEntryRelatedObjectEntries(
 				_getDTOConverterContext(currentObjectEntryId),
 				_objectDefinition, currentObjectEntryId, objectRelationshipName,
@@ -199,7 +199,7 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 			TransformUtil.transform(
 				page.getItems(),
 				objectEntry -> _getRelatedObjectEntry(
-					objectDefinition2, objectEntry)));
+					objectDefinition2, (ObjectEntry)objectEntry)));
 	}
 
 	@Override

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/RelatedObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/RelatedObjectEntryResourceImpl.java
@@ -67,26 +67,11 @@ public class RelatedObjectEntryResourceImpl
 		ObjectDefinition systemObjectDefinition = _getSystemObjectDefinition(
 			previousPath);
 
-		ObjectRelationship objectRelationship =
-			_objectRelationshipLocalService.
-				getObjectRelationshipByObjectDefinitionId(
-					systemObjectDefinition.getObjectDefinitionId(),
-					objectRelationshipName);
-
-		ObjectDefinition relatedObjectDefinition = _getRelatedObjectDefinition(
-			systemObjectDefinition, objectRelationship);
-
 		ObjectEntryManager objectEntryManager =
 			_objectEntryManagerTracker.getObjectEntryManager(
 				systemObjectDefinition.getStorageType());
 
-		if (relatedObjectDefinition.isSystem()) {
-			return objectEntryManager.getRelatedSystemObjectEntries(
-				systemObjectDefinition, objectEntryId, objectRelationshipName,
-				pagination);
-		}
-
-		return (Page)objectEntryManager.getObjectEntryRelatedObjectEntries(
+		return objectEntryManager.getObjectEntryRelatedObjectEntries(
 			_getDefaultDTOConverterContext(
 				systemObjectDefinition, objectEntryId, _uriInfo),
 			systemObjectDefinition, objectEntryId, objectRelationshipName,

--- a/modules/apps/object/object-storage-salesforce/src/main/java/com/liferay/object/storage/salesforce/internal/rest/manager/v1_0/SalesforceObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-storage-salesforce/src/main/java/com/liferay/object/storage/salesforce/internal/rest/manager/v1_0/SalesforceObjectEntryManagerImpl.java
@@ -219,18 +219,9 @@ public class SalesforceObjectEntryManagerImpl
 	}
 
 	@Override
-	public Page<ObjectEntry> getObjectEntryRelatedObjectEntries(
+	public Page<Object> getObjectEntryRelatedObjectEntries(
 			DTOConverterContext dtoConverterContext,
-			ObjectDefinition objectDefinition, Long objectEntryId,
-			String objectRelationshipName, Pagination pagination)
-		throws Exception {
-
-		return null;
-	}
-
-	@Override
-	public Page<Object> getRelatedSystemObjectEntries(
-			ObjectDefinition objectDefinition, Long objectEntryId,
+			ObjectDefinition objectDefinition, long objectEntryId,
 			String objectRelationshipName, Pagination pagination)
 		throws Exception {
 


### PR DESCRIPTION
This PR contains the code to unify the methods that are returning the Object Entries associated to a Object Entry.

As in the current task we are working on returning the related elements to a System Object as a Nested Field, we found the necessity of unifying the methods into one in order to avoid duplicating the current code of the API REST into a component that manages the Nested Fields.

**Before the PR:**

There were two methods, depending on the type of object:

```java
public interface ObjectEntryManager {

        [...]

	public Page<ObjectEntry> getObjectEntryRelatedObjectEntries(
			DTOConverterContext dtoConverterContext,
			ObjectDefinition objectDefinition, Long objectEntryId,
			String objectRelationshipName, Pagination pagination)
		throws Exception;

	public Page<Object> getRelatedSystemObjectEntries(
			ObjectDefinition objectDefinition, Long objectEntryId,
			String objectRelationshipName, Pagination pagination)
		throws Exception;

        [...]
}
```

- getObjectEntryRelatedObjectEntries: Method to return the Page of Object Entries in case the related elements are Custom Objects.
- getRelatedSystemObjectEntries: Method to return the Page of Objects in case the related elements are System Objects.

```java
public class RelatedObjectEntryResourceImpl
	extends BaseRelatedObjectEntryResourceImpl {

	@Override
	public Page<Object> getRelatedObjectEntriesPage(
			String previousPath, Long objectEntryId,
			String objectRelationshipName, Pagination pagination)
		throws Exception {

		[...]

		if (relatedObjectDefinition.isSystem()) {
			return objectEntryManager.getRelatedSystemObjectEntries(
				systemObjectDefinition, objectEntryId, objectRelationshipName,
				pagination);
		}

		return (Page)objectEntryManager.getObjectEntryRelatedObjectEntries(
			_getDefaultDTOConverterContext(
				systemObjectDefinition, objectEntryId, _uriInfo),
			systemObjectDefinition, objectEntryId, objectRelationshipName,
			pagination);

```


**After the PR:**

There is one method, and inside the method based on the type of object, a private method is called.


```java
public interface ObjectEntryManager {

        [...]


	public Page<Object> getObjectEntryRelatedObjectEntries(
			DTOConverterContext dtoConverterContext,
			ObjectDefinition objectDefinition, long objectEntryId,
			String objectRelationshipName, Pagination pagination)
		throws Exception;

        [...]
}
```

The method getObjectEntryRelatedObjectEntries returns the Page of Objects that are related to an Object Entry.

```java
public class RelatedObjectEntryResourceImpl
	extends BaseRelatedObjectEntryResourceImpl {

	@Override
	public Page<Object> getRelatedObjectEntriesPage(
			String previousPath, Long objectEntryId,
			String objectRelationshipName, Pagination pagination)
		throws Exception {

		[...]

		return objectEntryManager.getObjectEntryRelatedObjectEntries(
			_getDefaultDTOConverterContext(
				systemObjectDefinition, objectEntryId, _uriInfo),
			systemObjectDefinition, objectEntryId, objectRelationshipName,
			pagination);

```