### PR TITLE
Lrqa 77318 | Update functional tests to use & only in curl command to combine multiple parameters

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/BlogPostingAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/BlogPostingAPI.macro
@@ -40,7 +40,7 @@ definition {
 			site = "true");
 
 		var curl = '''
-			${portalURL}/o/headless-delivery/v1.0/sites/${siteId}/blog-postings/batch?createStrategy=${createStrategy}\&importStrategy=${importStrategy} \
+			${portalURL}/o/headless-delivery/v1.0/sites/${siteId}/blog-postings/batch?createStrategy=${createStrategy}&importStrategy=${importStrategy} \
 			-u test@liferay.com:test \
 			-H Content-Type: application/json \
             -d ${body}
@@ -250,7 +250,7 @@ definition {
 			groupName = "Guest",
 			site = "true");
 		var curl = '''
-			${portalURL}/o/headless-delivery/v1.0/blog-postings/batch?updateStrategy=${updateStrategy}\&importStrategy=${importStrategy} \
+			${portalURL}/o/headless-delivery/v1.0/blog-postings/batch?updateStrategy=${updateStrategy}&importStrategy=${importStrategy} \
 			-u test@liferay.com:test \
 			-H Content-Type: application/json \
             -d ${body}

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
@@ -312,7 +312,7 @@ definition {
 			site = "true");
 
 		var curl = '''
-			${portalURL}/o/headless-admin-content/v1.0/sites/${siteId}/structured-contents?filter=${filtervalue}\&sort=${sortvalue} \
+			${portalURL}/o/headless-admin-content/v1.0/sites/${siteId}/structured-contents?filter=${filtervalue}&sort=${sortvalue} \
 			-u test@liferay.com:test \
 			-H accept: application/json
 		''';


### PR DESCRIPTION
**Background:**
- Update to make functional tests work. And I think the root cause might be [LPS-162331](https://issues.liferay.com/browse/LPS-162331) Convert method references to field references in Elasticsearch impl, we can't combine two parameters with `/&`, only `&` works. For example  curl...?filter=xxx&sort=xxx, 

**Test Plan:**
- Test fix in StructuredContentFilteringAndSorting.testcase
- Test fix in HeadlessDeliveryBatchMode.testcase

**Ticket:**
- https://issues.liferay.com/browse/LRQA-77318
- https://issues.liferay.com/browse/LRQA-77319