### PR TITLE
LPS-163790: Update actions to asset library id for headless delivery and headless admin taxonomy

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/ActionUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/ActionUtil.java
@@ -14,8 +14,11 @@
 
 package com.liferay.portal.vulcan.util;
 
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryServiceUtil;
 import com.liferay.oauth2.provider.scope.ScopeChecker;
 import com.liferay.oauth2.provider.scope.liferay.OAuth2ProviderScopeLiferayAccessControlContext;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
@@ -320,8 +323,9 @@ public class ActionUtil {
 	}
 
 	private static Map<String, Object> _getParameterMap(
-		Class<?> clazz, Long id, String methodName, Long siteId,
-		UriInfo uriInfo) {
+			Class<?> clazz, Long id, String methodName, Long siteId,
+			UriInfo uriInfo)
+		throws PortalException {
 
 		MultivaluedMap<String, String> pathParameters =
 			uriInfo.getPathParameters();
@@ -349,6 +353,14 @@ public class ActionUtil {
 
 		if ((siteId != null) && Objects.equals(firstParameterName, "siteId")) {
 			parameterMap.put(firstParameterName, siteId);
+		}
+		else if ((siteId != null) &&
+				 Objects.equals(firstParameterName, "assetLibraryId")) {
+
+			DepotEntry depotEntry = DepotEntryServiceUtil.getGroupDepotEntry(
+				siteId);
+
+			parameterMap.put(firstParameterName, depotEntry.getDepotEntryId());
 		}
 		else {
 			parameterMap.put(firstParameterName, id);


### PR DESCRIPTION
**What is new?**
- Update action href using assetLibraryId instead of `assetLibraryGroupId`.

**Changes in Actions:**
![image](https://user-images.githubusercontent.com/44723449/192274169-71fd59b9-b3cd-491e-972c-5170dfe46cd8.png)

**How to reproduce:**
1. Go to `/o/api`
2. Deploy `portal-vulcan-api`
3. Go to any Schema that is in a Asset Library

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-163790