### PR TITLE
LPS-163766: Improve get asset library information in action block for content template

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/ContentTemplateResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/ContentTemplateResourceImpl.java
@@ -40,6 +40,7 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.util.SearchUtil;
 
 import java.util.Collections;
+import java.util.Map;
 
 import javax.ws.rs.core.MultivaluedMap;
 
@@ -63,7 +64,13 @@ public class ContentTemplateResourceImpl
 			Filter filter, Pagination pagination, Sort[] sorts)
 		throws Exception {
 
-		return getSiteContentTemplatesPage(
+		return _getContentTemplatePage(
+			Collections.singletonMap(
+				"get",
+				addAction(
+					ActionKeys.MANAGE_LAYOUTS,
+					"getAssetLibraryContentTemplatesPage",
+					Group.class.getName(), assetLibraryId)),
 			assetLibraryId, search, aggregation, filter, pagination, sorts);
 	}
 
@@ -92,12 +99,23 @@ public class ContentTemplateResourceImpl
 			Pagination pagination, Sort[] sorts)
 		throws Exception {
 
-		return SearchUtil.search(
+		return _getContentTemplatePage(
 			Collections.singletonMap(
 				"get",
 				addAction(
 					ActionKeys.MANAGE_LAYOUTS, "getSiteContentTemplatesPage",
 					Group.class.getName(), siteId)),
+			siteId, search, aggregation, filter, pagination, sorts);
+	}
+
+	private Page<ContentTemplate> _getContentTemplatePage(
+			Map<String, Map<String, String>> actions, Long assetLibraryId,
+			String search, Aggregation aggregation, Filter filter,
+			Pagination pagination, Sort[] sorts)
+		throws Exception {
+
+		return SearchUtil.search(
+			actions,
 			booleanQuery -> {
 			},
 			filter, DDMTemplate.class.getName(), search, pagination,
@@ -112,7 +130,7 @@ public class ContentTemplateResourceImpl
 					_classNameLocalService.getClassNameId(
 						JournalArticle.class));
 				searchContext.setCompanyId(contextCompany.getCompanyId());
-				searchContext.setGroupIds(new long[] {siteId});
+				searchContext.setGroupIds(new long[] {assetLibraryId});
 			},
 			sorts,
 			document -> {


### PR DESCRIPTION
**What is new?**
- Update get asset library information in block action for `Content Template` entity.

**Changes in actions**
![image](https://user-images.githubusercontent.com/44723449/192289845-21b44828-8aab-4ed4-bd6a-a623803cf75d.png)

**How to reproduce**

1. Go to `/o/api`
2. Deploy `headless-delivery-impl`
3. Go to any `Content Template `

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-163766