### PR TITLE
LPS-162428 Use a PrototypeServiceFactory to register the resource components

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
@@ -21,7 +21,6 @@ import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManagerTracker;
 import com.liferay.object.rest.odata.entity.v1_0.ObjectEntryEntityModel;
 import com.liferay.object.rest.petra.sql.dsl.expression.FilterPredicateFactory;
-import com.liferay.object.rest.resource.v1_0.ObjectEntryResource;
 import com.liferay.object.scope.ObjectScopeProvider;
 import com.liferay.object.scope.ObjectScopeProviderRegistry;
 import com.liferay.object.service.ObjectDefinitionLocalService;
@@ -51,18 +50,28 @@ import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MultivaluedMap;
 
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
-
 /**
  * @author Javier Gamarra
  */
-@Component(
-	factory = "com.liferay.object.rest.internal.resource.v1_0.ObjectEntryResource",
-	properties = "OSGI-INF/liferay/rest/v1_0/object-entry.properties",
-	service = ObjectEntryResource.class
-)
 public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
+
+	public ObjectEntryResourceImpl(
+		FilterPredicateFactory filterPredicateFactory,
+		ObjectDefinitionLocalService objectDefinitionLocalService,
+		ObjectEntryLocalService objectEntryLocalService,
+		ObjectEntryManagerTracker objectEntryManagerTracker,
+		ObjectFieldLocalService objectFieldLocalService,
+		ObjectRelationshipService objectRelationshipService,
+		ObjectScopeProviderRegistry objectScopeProviderRegistry) {
+
+		_filterPredicateFactory = filterPredicateFactory;
+		_objectDefinitionLocalService = objectDefinitionLocalService;
+		_objectEntryLocalService = objectEntryLocalService;
+		_objectEntryManagerTracker = objectEntryManagerTracker;
+		_objectFieldLocalService = objectFieldLocalService;
+		_objectRelationshipService = objectRelationshipService;
+		_objectScopeProviderRegistry = objectScopeProviderRegistry;
+	}
 
 	@Override
 	public void create(
@@ -489,28 +498,16 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 		throw new NotFoundException("Missing parameter \"objectDefinitionId\"");
 	}
 
-	@Reference
-	private FilterPredicateFactory _filterPredicateFactory;
+	private final FilterPredicateFactory _filterPredicateFactory;
 
 	@Context
 	private ObjectDefinition _objectDefinition;
 
-	@Reference
-	private ObjectDefinitionLocalService _objectDefinitionLocalService;
-
-	@Reference
-	private ObjectEntryLocalService _objectEntryLocalService;
-
-	@Reference
-	private ObjectEntryManagerTracker _objectEntryManagerTracker;
-
-	@Reference
-	private ObjectFieldLocalService _objectFieldLocalService;
-
-	@Reference
-	private ObjectRelationshipService _objectRelationshipService;
-
-	@Reference
-	private ObjectScopeProviderRegistry _objectScopeProviderRegistry;
+	private final ObjectDefinitionLocalService _objectDefinitionLocalService;
+	private final ObjectEntryLocalService _objectEntryLocalService;
+	private final ObjectEntryManagerTracker _objectEntryManagerTracker;
+	private final ObjectFieldLocalService _objectFieldLocalService;
+	private final ObjectRelationshipService _objectRelationshipService;
+	private final ObjectScopeProviderRegistry _objectScopeProviderRegistry;
 
 }


### PR DESCRIPTION
Related ticket -> [LPS-162428](https://issues.liferay.com/browse/LPS-162428)
____
## How to deploy it
* Deploy the module object-rest-impl

#### How to test it
* The steps to reproduce it are in the JIRA ticket mentioned above

## Explanation

This PR changes the way the ObjectEntryResources are registered in OSGi.

Previously a ComponentFactory was used to get the components. The problem with that was that each component was registered as a singleton. This was not Thread-safe and was causing trouble with concurrent requests.
```
....
_objectEntryResourceComponentFactory.newInstance(
    HashMapDictionaryBuilder.<String, Object>put(
        "api.version", "v1.0"
    ).put(
        "batch.engine.entity.class.name",
        ObjectEntry.class.getName() + "#" +
            objectDefinition.getName()
    ).put(
        "batch.engine.task.item.delegate", "true"
    ).put(
        "batch.engine.task.item.delegate.name",
        objectDefinition.getShortName()
    ).put(
        "batch.planner.export.enabled", "true"
    ).put(
        "batch.planner.import.enabled", "true"
    ).put(
        "entity.class.name",
        ObjectEntry.class.getName() + "#" +
            objectDefinition.getName()
    ).put(
        "osgi.jaxrs.application.select",
        "(osgi.jaxrs.name=" + objectDefinition.getName() +
            ")"
    ).put(
        "osgi.jaxrs.resource", "true"
    ).build()
...
```
The new implementation use the `PrototypeServiceFactory` interface (see documentation [here](https://docs.osgi.org/specification/osgi.core/7.0.0/framework.api.html#org.osgi.framework.PrototypeServiceFactory)) which every time the OSGi container needs this component the interface will provide a new instance, making this implementation thread-safe

```
...
_bundleContext.registerService(
    ObjectEntryResource.class,
    new PrototypeServiceFactory<ObjectEntryResource>() {

        @Override
        public ObjectEntryResource getService(
            Bundle bundle,
            ServiceRegistration<ObjectEntryResource>
                serviceRegistration) {

            return new ObjectEntryResourceImpl(
                _filterPredicateFactory,
                _objectDefinitionLocalService,
                _objectEntryLocalService,
                _objectEntryManagerTracker,
                _objectFieldLocalService,
                _objectRelationshipService,
                _objectScopeProviderRegistry);
        }

        @Override
        public void ungetService(
            Bundle bundle,
            ServiceRegistration<ObjectEntryResource>
                serviceRegistration,
            ObjectEntryResource objectEntryResource) {
        }

    },
...
```