### PR TITLE
LPS-162964 Allow developers to retrieve the many to many related elements of a system object as nestedFields

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalService.java
@@ -250,8 +250,7 @@ public interface ObjectDefinitionLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ObjectDefinition fetchObjectDefinitionByClassName(
-			long companyId, String className)
-		throws PortalException;
+		long companyId, String className);
 
 	/**
 	 * Returns the object definition with the matching external reference code and company.

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalServiceUtil.java
@@ -284,8 +284,7 @@ public class ObjectDefinitionLocalServiceUtil {
 	}
 
 	public static ObjectDefinition fetchObjectDefinitionByClassName(
-			long companyId, String className)
-		throws PortalException {
+		long companyId, String className) {
 
 		return getService().fetchObjectDefinitionByClassName(
 			companyId, className);

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalServiceWrapper.java
@@ -319,8 +319,7 @@ public class ObjectDefinitionLocalServiceWrapper
 
 	@Override
 	public com.liferay.object.model.ObjectDefinition
-			fetchObjectDefinitionByClassName(long companyId, String className)
-		throws com.liferay.portal.kernel.exception.PortalException {
+		fetchObjectDefinitionByClassName(long companyId, String className) {
 
 		return _objectDefinitionLocalService.fetchObjectDefinitionByClassName(
 			companyId, className);

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectRelationshipLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectRelationshipLocalService.java
@@ -238,6 +238,10 @@ public interface ObjectRelationshipLocalService
 		long objectRelationshipId);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public ObjectRelationship fetchObjectRelationship(
+		long objectDefinitionId1, String name);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ObjectRelationship fetchObjectRelationshipByObjectFieldId2(
 		long objectFieldId2);
 

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectRelationshipLocalServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectRelationshipLocalServiceUtil.java
@@ -264,6 +264,12 @@ public class ObjectRelationshipLocalServiceUtil {
 		return getService().fetchObjectRelationship(objectRelationshipId);
 	}
 
+	public static ObjectRelationship fetchObjectRelationship(
+		long objectDefinitionId1, String name) {
+
+		return getService().fetchObjectRelationship(objectDefinitionId1, name);
+	}
+
 	public static ObjectRelationship fetchObjectRelationshipByObjectFieldId2(
 		long objectFieldId2) {
 

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectRelationshipLocalServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectRelationshipLocalServiceWrapper.java
@@ -298,6 +298,14 @@ public class ObjectRelationshipLocalServiceWrapper
 	}
 
 	@Override
+	public com.liferay.object.model.ObjectRelationship fetchObjectRelationship(
+		long objectDefinitionId1, String name) {
+
+		return _objectRelationshipLocalService.fetchObjectRelationship(
+			objectDefinitionId1, name);
+	}
+
+	@Override
 	public com.liferay.object.model.ObjectRelationship
 		fetchObjectRelationshipByObjectFieldId2(long objectFieldId2) {
 

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -838,12 +838,19 @@ public class DefaultObjectEntryManagerImpl
 			com.liferay.object.model.ObjectEntry objectEntry)
 		throws Exception {
 
-		HashMap<String, Map<String, String>> actions = new HashMap<>();
+		Map<String, Map<String, String>> actions =
+			dtoConverterContext.getActions();
 
 		if (GetterUtil.getBoolean(
 				dtoConverterContext.getAttribute("addActions"), true)) {
 
-			actions = HashMapBuilder.<String, Map<String, String>>put(
+			if (actions == null) {
+				actions = Collections.emptyMap();
+			}
+
+			actions = HashMapBuilder.create(
+				actions
+			).<String, Map<String, String>>put(
 				"delete",
 				() -> {
 					if (_hasRelatedObjectEntries(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/BaseObjectExtensionProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/BaseObjectExtensionProvider.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.rest.internal.vulcan.extension.v1_0;
+
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.vulcan.dto.converter.DTOMapper;
+import com.liferay.portal.vulcan.extension.ExtensionProvider;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Carlos Correa
+ */
+public abstract class BaseObjectExtensionProvider implements ExtensionProvider {
+
+	@Override
+	public Collection<String> getFilteredPropertyNames(
+		long companyId, Object entity) {
+
+		return Collections.emptyList();
+	}
+
+	@Override
+	public boolean isApplicableExtension(long companyId, String className) {
+		ObjectDefinition objectDefinition = getObjectDefinition(
+			companyId, className);
+
+		if ((objectDefinition != null) && objectDefinition.isSystem()) {
+			return true;
+		}
+
+		return false;
+	}
+
+	protected ObjectDefinition getObjectDefinition(
+		long companyId, String className) {
+
+		String internalDTOClassName = dtoMapper.toInternalDTOClassName(
+			className);
+
+		if (internalDTOClassName == null) {
+			return null;
+		}
+
+		try {
+			return objectDefinitionLocalService.
+				fetchObjectDefinitionByClassName(
+					companyId, internalDTOClassName);
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+
+			return null;
+		}
+	}
+
+	protected long getPrimaryKey(Object entity) throws PortalException {
+		JSONObject jsonObject = jsonFactory.createJSONObject(
+			jsonFactory.looseSerializeDeep(entity));
+
+		return jsonObject.getLong("id");
+	}
+
+	@Reference
+	protected DTOMapper dtoMapper;
+
+	@Reference
+	protected JSONFactory jsonFactory;
+
+	@Reference
+	protected ObjectDefinitionLocalService objectDefinitionLocalService;
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		BaseObjectExtensionProvider.class);
+
+}

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/BaseObjectExtensionProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/BaseObjectExtensionProvider.java
@@ -19,8 +19,6 @@ import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.vulcan.dto.converter.DTOMapper;
 import com.liferay.portal.vulcan.extension.ExtensionProvider;
 
@@ -63,18 +61,8 @@ public abstract class BaseObjectExtensionProvider implements ExtensionProvider {
 			return null;
 		}
 
-		try {
-			return objectDefinitionLocalService.
-				fetchObjectDefinitionByClassName(
-					companyId, internalDTOClassName);
-		}
-		catch (PortalException portalException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(portalException);
-			}
-
-			return null;
-		}
+		return objectDefinitionLocalService.fetchObjectDefinitionByClassName(
+			companyId, internalDTOClassName);
 	}
 
 	protected long getPrimaryKey(Object entity) throws PortalException {
@@ -92,8 +80,5 @@ public abstract class BaseObjectExtensionProvider implements ExtensionProvider {
 
 	@Reference
 	protected ObjectDefinitionLocalService objectDefinitionLocalService;
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		BaseObjectExtensionProvider.class);
 
 }

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/ObjectRelationshipExtensionProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/ObjectRelationshipExtensionProvider.java
@@ -1,0 +1,273 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.rest.internal.vulcan.extension.v1_0;
+
+import com.liferay.object.constants.ObjectRelationshipConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectRelationship;
+import com.liferay.object.rest.dto.v1_0.ObjectEntry;
+import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
+import com.liferay.object.rest.manager.v1_0.ObjectEntryManagerTracker;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
+import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
+import com.liferay.portal.vulcan.extension.ExtensionProvider;
+import com.liferay.portal.vulcan.extension.PropertyDefinition;
+import com.liferay.portal.vulcan.extension.validation.PropertyValidator;
+import com.liferay.portal.vulcan.fields.NestedFieldsContext;
+import com.liferay.portal.vulcan.fields.NestedFieldsContextThreadLocal;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+
+import java.io.Serializable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import javax.ws.rs.core.UriInfo;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Carlos Correa
+ */
+@Component(immediate = true, service = ExtensionProvider.class)
+public class ObjectRelationshipExtensionProvider
+	extends BaseObjectExtensionProvider {
+
+	@Override
+	public Map<String, Serializable> getExtendedProperties(
+			long companyId, String className, Object entity)
+		throws Exception {
+
+		NestedFieldsContext nestedFieldsContext =
+			NestedFieldsContextThreadLocal.getNestedFieldsContext();
+
+		if (nestedFieldsContext == null) {
+			return Collections.emptyMap();
+		}
+
+		ObjectDefinition objectDefinition = getObjectDefinition(
+			companyId, className);
+
+		List<ObjectRelationship> objectRelationships = _getObjectRelationships(
+			nestedFieldsContext.getFieldNames(), objectDefinition);
+
+		if (objectRelationships.isEmpty()) {
+			return Collections.emptyMap();
+		}
+
+		ObjectEntryManager objectEntryManager =
+			_objectEntryManagerTracker.getObjectEntryManager(
+				objectDefinition.getStorageType());
+
+		long primaryKey = getPrimaryKey(entity);
+
+		Map<String, Serializable> extendedProperties = new HashMap<>();
+
+		for (ObjectRelationship objectRelationship : objectRelationships) {
+			Page<ObjectEntry> relatedObjectEntriesPage =
+				objectEntryManager.getObjectEntryRelatedObjectEntries(
+					_getDefaultDTOConverterContext(
+						objectDefinition, primaryKey, null),
+					objectDefinition, primaryKey, objectRelationship.getName(),
+					Pagination.of(QueryUtil.ALL_POS, QueryUtil.ALL_POS));
+
+			extendedProperties.put(
+				objectRelationship.getName(),
+				(Serializable)relatedObjectEntriesPage.getItems());
+		}
+
+		return extendedProperties;
+	}
+
+	@Override
+	public Map<String, PropertyDefinition> getExtendedPropertyDefinitions(
+			long companyId, String className)
+		throws Exception {
+
+		Map<String, PropertyDefinition> extendedPropertyDefinitions =
+			new HashMap<>();
+
+		ObjectDefinition objectDefinition = getObjectDefinition(
+			companyId, className);
+
+		for (ObjectRelationship objectRelationship :
+				_objectRelationshipLocalService.getObjectRelationships(
+					objectDefinition.getObjectDefinitionId())) {
+
+			if (!Objects.equals(
+					objectRelationship.getType(),
+					ObjectRelationshipConstants.TYPE_MANY_TO_MANY) &&
+				!Objects.equals(
+					objectRelationship.getType(),
+					ObjectRelationshipConstants.TYPE_ONE_TO_MANY)) {
+
+				continue;
+			}
+
+			ObjectDefinition relatedObjectDefinition =
+				_getRelatedObjectDefinition(
+					objectDefinition, objectRelationship);
+
+			if (relatedObjectDefinition.isSystem()) {
+				continue;
+			}
+
+			String relationshipName = objectRelationship.getName();
+
+			extendedPropertyDefinitions.put(
+				relationshipName,
+				new PropertyDefinition(
+					Collections.singleton(ObjectEntry.class), null,
+					StringUtil.removeFirst(
+						relatedObjectDefinition.getName(), "C_"),
+					StringBundler.concat(
+						"Information about the relationship ", relationshipName,
+						" can be embedded with \"nestedFields\"."),
+					relationshipName,
+					PropertyDefinition.PropertyType.MULTIPLE_ELEMENT,
+					new UnsupportedOperationPropertyValidator(), false));
+		}
+
+		return extendedPropertyDefinitions;
+	}
+
+	@Override
+	public boolean isApplicableExtension(long companyId, String className) {
+		if (!GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-162964"))) {
+			return false;
+		}
+
+		return super.isApplicableExtension(companyId, className);
+	}
+
+	@Override
+	public void setExtendedProperties(
+		long companyId, long userId, String className, Object entity,
+		Map<String, Serializable> extendedProperties) {
+	}
+
+	private DefaultDTOConverterContext _getDefaultDTOConverterContext(
+		ObjectDefinition objectDefinition, Long objectEntryId,
+		UriInfo uriInfo) {
+
+		DefaultDTOConverterContext defaultDTOConverterContext =
+			new DefaultDTOConverterContext(
+				false, null, _dtoConverterRegistry, objectEntryId,
+				LocaleUtil.fromLanguageId(
+					objectDefinition.getDefaultLanguageId(), true, false),
+				uriInfo, null);
+
+		defaultDTOConverterContext.setAttribute("addActions", Boolean.FALSE);
+
+		return defaultDTOConverterContext;
+	}
+
+	private List<ObjectRelationship> _getObjectRelationships(
+			List<String> nestedFieldNames, ObjectDefinition objectDefinition)
+		throws Exception {
+
+		List<ObjectRelationship> objectRelationships = new ArrayList<>();
+
+		for (String nestedFieldName : nestedFieldNames) {
+			ObjectRelationship objectRelationship =
+				_objectRelationshipLocalService.fetchObjectRelationship(
+					objectDefinition.getObjectDefinitionId(), nestedFieldName);
+
+			if ((objectRelationship == null) ||
+				(!Objects.equals(
+					objectRelationship.getType(),
+					ObjectRelationshipConstants.TYPE_MANY_TO_MANY) &&
+				 !Objects.equals(
+					 objectRelationship.getType(),
+					 ObjectRelationshipConstants.TYPE_ONE_TO_MANY))) {
+
+				continue;
+			}
+
+			ObjectDefinition relatedObjectDefinition =
+				_getRelatedObjectDefinition(
+					objectDefinition, objectRelationship);
+
+			if (relatedObjectDefinition.isSystem()) {
+				continue;
+			}
+
+			objectRelationships.add(objectRelationship);
+		}
+
+		return objectRelationships;
+	}
+
+	private ObjectDefinition _getRelatedObjectDefinition(
+			ObjectDefinition objectDefinition,
+			ObjectRelationship objectRelationship)
+		throws Exception {
+
+		long objectDefinitionId1 = objectRelationship.getObjectDefinitionId1();
+
+		if (objectDefinitionId1 != objectDefinition.getObjectDefinitionId()) {
+			return _objectDefinitionLocalService.getObjectDefinition(
+				objectRelationship.getObjectDefinitionId1());
+		}
+
+		return _objectDefinitionLocalService.getObjectDefinition(
+			objectRelationship.getObjectDefinitionId2());
+	}
+
+	@Reference
+	private DTOConverterRegistry _dtoConverterRegistry;
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Reference
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Reference
+	private ObjectEntryManagerTracker _objectEntryManagerTracker;
+
+	@Reference
+	private ObjectRelationshipLocalService _objectRelationshipLocalService;
+
+	private class UnsupportedOperationPropertyValidator
+		implements PropertyValidator {
+
+		@Override
+		public void validate(
+			PropertyDefinition propertyDefinition, Object propertyValue) {
+
+			throw new UnsupportedOperationException(
+				"The property " + propertyDefinition.getPropertyName() +
+					" can not be set");
+		}
+
+	}
+
+}

--- a/modules/apps/object/object-rest-test/build.gradle
+++ b/modules/apps/object/object-rest-test/build.gradle
@@ -1,7 +1,9 @@
 dependencies {
+	testCompileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	testCompileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 
 	testIntegrationCompile group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"
+	testIntegrationCompile group: "org.apache.cxf", name: "cxf-core", version: "3.4.4"
 	testIntegrationCompile project(":apps:account:account-api")
 	testIntegrationCompile project(":apps:document-library:document-library-api")
 	testIntegrationCompile project(":apps:headless:headless-admin-user:headless-admin-user-api")

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/SystemObjectRelatedObjectsTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/SystemObjectRelatedObjectsTest.java
@@ -1,0 +1,374 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.rest.internal.resource.v1_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.headless.admin.user.dto.v1_0.UserAccount;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectRelationshipConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.model.ObjectRelationship;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalServiceUtil;
+import com.liferay.object.service.ObjectRelationshipLocalServiceUtil;
+import com.liferay.object.system.SystemObjectDefinitionMetadata;
+import com.liferay.object.system.SystemObjectDefinitionMetadataTracker;
+import com.liferay.object.util.LocalizedMapUtil;
+import com.liferay.object.util.ObjectFieldUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.servlet.HttpHeaders;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.Base64;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.util.PropsUtil;
+
+import java.io.Serializable;
+
+import java.nio.charset.StandardCharsets;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.http.HttpStatus;
+
+/**
+ * @author Carlos Correa
+ */
+@RunWith(Arquillian.class)
+public class SystemObjectRelatedObjectsTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() {
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-162964", "true"
+			).build());
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-162964", "false"
+			).build());
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		_objectDefinition = _publishObjectDefinition(
+			Collections.singletonList(
+				ObjectFieldUtil.createObjectField(
+					"Text", "String", true, true, null,
+					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME, false)));
+
+		_objectEntry = _addObjectEntry(_OBJECT_FIELD_VALUE);
+
+		_userSystemObjectDefinitionMetadata =
+			_systemObjectDefinitionMetadataTracker.
+				getSystemObjectDefinitionMetadata("User");
+
+		_userSystemObjectDefinition =
+			_objectDefinitionLocalService.fetchSystemObjectDefinition(
+				_userSystemObjectDefinitionMetadata.getName());
+
+		_user = TestPropsValues.getUser();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		for (ObjectRelationship objectRelationship : _objectRelationships) {
+			ObjectRelationshipLocalServiceUtil.
+				deleteObjectRelationshipMappingTableValues(
+					objectRelationship.getObjectRelationshipId(),
+					_objectEntry.getPrimaryKey(), _user.getUserId());
+			ObjectRelationshipLocalServiceUtil.deleteObjectRelationship(
+				objectRelationship);
+		}
+
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			_objectDefinition.getObjectDefinitionId());
+	}
+
+	@Test
+	public void testGetManyToManySystemObjectRelatedObjects() throws Exception {
+		String relationshipName = StringUtil.randomId();
+
+		_addObjectRelationship(
+			relationshipName, _objectDefinition.getObjectDefinitionId(),
+			_userSystemObjectDefinition.getObjectDefinitionId(),
+			_objectEntry.getPrimaryKey(), _user.getUserId(),
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
+			_invoke(_getQueryURL(relationshipName)));
+
+		JSONArray jsonArray = jsonObject.getJSONArray(relationshipName);
+
+		Assert.assertEquals(jsonArray.toString(), 1, jsonArray.length());
+		_assertEquals((JSONObject)jsonArray.get(0), _objectEntry);
+
+		relationshipName = StringUtil.randomId();
+
+		_addObjectRelationship(
+			relationshipName,
+			_userSystemObjectDefinition.getObjectDefinitionId(),
+			_objectDefinition.getObjectDefinitionId(), _user.getUserId(),
+			_objectEntry.getPrimaryKey(),
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		jsonObject = JSONFactoryUtil.createJSONObject(
+			_invoke(_getQueryURL(relationshipName)));
+
+		jsonArray = jsonObject.getJSONArray(relationshipName);
+
+		Assert.assertEquals(jsonArray.toString(), 1, jsonArray.length());
+		_assertEquals((JSONObject)jsonArray.get(0), _objectEntry);
+	}
+
+	@Test
+	public void testGetManyToOneSystemObjectRelatedObjects() throws Exception {
+		String relationshipName = StringUtil.randomId();
+
+		_addObjectRelationship(
+			relationshipName, _objectDefinition.getObjectDefinitionId(),
+			_userSystemObjectDefinition.getObjectDefinitionId(),
+			_objectEntry.getPrimaryKey(), _user.getUserId(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
+			_invoke(_getQueryURL(relationshipName)));
+
+		Assert.assertNull(jsonObject.get(relationshipName));
+	}
+
+	@Test
+	public void testGetNotFoundSystemObjectRelatedObjects() throws Exception {
+		String relationshipName = StringUtil.randomId();
+
+		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
+			_invoke(_getQueryURL(relationshipName)));
+
+		Assert.assertNull(jsonObject.getJSONArray(relationshipName));
+	}
+
+	@Test
+	public void testGetOneToManySystemObjectRelatedObjects() throws Exception {
+		String relationshipName = StringUtil.randomId();
+
+		_addObjectRelationship(
+			relationshipName,
+			_userSystemObjectDefinition.getObjectDefinitionId(),
+			_objectDefinition.getObjectDefinitionId(), _user.getUserId(),
+			_objectEntry.getPrimaryKey(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
+			_invoke(_getQueryURL(relationshipName)));
+
+		JSONArray jsonArray = jsonObject.getJSONArray(relationshipName);
+
+		Assert.assertEquals(jsonArray.toString(), 1, jsonArray.length());
+		_assertEquals((JSONObject)jsonArray.get(0), _objectEntry);
+	}
+
+	@Test
+	public void testPostSystemObjectWithRelationshipName() throws Exception {
+		String relationshipName = StringUtil.randomId();
+
+		_addObjectRelationship(
+			relationshipName, _objectDefinition.getObjectDefinitionId(),
+			_userSystemObjectDefinition.getObjectDefinitionId(),
+			_objectEntry.getPrimaryKey(), _user.getUserId(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		UserAccount userAccount = new UserAccount() {
+			{
+				name = RandomTestUtil.randomString();
+			}
+		};
+
+		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
+			userAccount.toString());
+
+		jsonObject.put(relationshipName, JSONFactoryUtil.createJSONArray());
+
+		int httpCode = _invokeHttpCode(
+			jsonObject.toString(),
+			_userSystemObjectDefinitionMetadata.getRESTContextPath());
+
+		Assert.assertEquals(HttpStatus.BAD_REQUEST.value(), httpCode);
+	}
+
+	private ObjectEntry _addObjectEntry(String objectFieldValue)
+		throws Exception {
+
+		return ObjectEntryLocalServiceUtil.addObjectEntry(
+			TestPropsValues.getUserId(), 0,
+			_objectDefinition.getObjectDefinitionId(),
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME, objectFieldValue
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+	}
+
+	private ObjectRelationship _addObjectRelationship(
+			String name, long objectDefinitionId1, long objectDefinitionId2,
+			long primaryKey1, long primaryKey2, String type)
+		throws Exception {
+
+		ObjectRelationship objectRelationship =
+			ObjectRelationshipLocalServiceUtil.addObjectRelationship(
+				_user.getUserId(), objectDefinitionId1, objectDefinitionId2, 0,
+				ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				name, type);
+
+		ObjectRelationshipLocalServiceUtil.
+			addObjectRelationshipMappingTableValues(
+				_user.getUserId(), objectRelationship.getObjectRelationshipId(),
+				primaryKey1, primaryKey2,
+				ServiceContextTestUtil.getServiceContext());
+
+		_objectRelationships.add(objectRelationship);
+
+		return objectRelationship;
+	}
+
+	private void _assertEquals(JSONObject jsonObject, ObjectEntry objectEntry) {
+		Assert.assertEquals(
+			objectEntry.getObjectEntryId(), jsonObject.getLong("id"));
+	}
+
+	private Http.Options _createOptions(
+		String body, String endpoint, Http.Method httpMethod) {
+
+		Http.Options options = new Http.Options();
+
+		options.addHeader(
+			HttpHeaders.CONTENT_TYPE, ContentTypes.APPLICATION_JSON);
+		options.addHeader(
+			"Authorization",
+			"Basic " + Base64.encode("test@liferay.com:test".getBytes()));
+
+		if (body != null) {
+			options.setBody(
+				body, ContentTypes.APPLICATION_JSON,
+				StandardCharsets.UTF_8.name());
+		}
+
+		options.setLocation("http://localhost:8080/o/" + endpoint);
+		options.setMethod(httpMethod);
+
+		return options;
+	}
+
+	private String _getQueryURL(String relationshipName) {
+		return StringBundler.concat(
+			_userSystemObjectDefinitionMetadata.getRESTContextPath(),
+			StringPool.SLASH, _user.getUserId(), "?nestedFields=",
+			relationshipName);
+	}
+
+	private String _invoke(String endpoint) throws Exception {
+		Http.Options options = _createOptions(null, endpoint, Http.Method.GET);
+
+		return HttpUtil.URLtoString(options);
+	}
+
+	private int _invokeHttpCode(String body, String endpoint) throws Exception {
+		Http.Options options = _createOptions(body, endpoint, Http.Method.POST);
+
+		HttpUtil.URLtoString(options);
+
+		Http.Response response = options.getResponse();
+
+		return response.getResponseCode();
+	}
+
+	private ObjectDefinition _publishObjectDefinition(
+			List<ObjectField> objectFields)
+		throws Exception {
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.addCustomObjectDefinition(
+				TestPropsValues.getUserId(),
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				"A" + RandomTestUtil.randomString(), null, null,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				ObjectDefinitionConstants.SCOPE_COMPANY,
+				ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT, objectFields);
+
+		return _objectDefinitionLocalService.publishCustomObjectDefinition(
+			TestPropsValues.getUserId(),
+			objectDefinition.getObjectDefinitionId());
+	}
+
+	private static final String _OBJECT_FIELD_NAME =
+		"x" + RandomTestUtil.randomString();
+
+	private static final String _OBJECT_FIELD_VALUE =
+		RandomTestUtil.randomString();
+
+	private ObjectDefinition _objectDefinition;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	private ObjectEntry _objectEntry;
+	private final List<ObjectRelationship> _objectRelationships =
+		new ArrayList<>();
+
+	@Inject
+	private SystemObjectDefinitionMetadataTracker
+		_systemObjectDefinitionMetadataTracker;
+
+	private User _user;
+	private ObjectDefinition _userSystemObjectDefinition;
+	private SystemObjectDefinitionMetadata _userSystemObjectDefinitionMetadata;
+
+}

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/test/ObjectRelationshipExtensionProviderTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/test/ObjectRelationshipExtensionProviderTest.java
@@ -1,0 +1,272 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.rest.internal.vulcan.extension.v1_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.headless.admin.user.dto.v1_0.UserAccount;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectRelationshipConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.model.ObjectRelationship;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalServiceUtil;
+import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.object.service.ObjectRelationshipLocalServiceUtil;
+import com.liferay.object.system.SystemObjectDefinitionMetadata;
+import com.liferay.object.system.SystemObjectDefinitionMetadataTracker;
+import com.liferay.object.util.LocalizedMapUtil;
+import com.liferay.object.util.ObjectFieldUtil;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.util.PropsUtil;
+import com.liferay.portal.vulcan.extension.ExtensionProvider;
+import com.liferay.portal.vulcan.extension.PropertyDefinition;
+import com.liferay.portal.vulcan.fields.NestedFieldsContext;
+import com.liferay.portal.vulcan.fields.NestedFieldsContextThreadLocal;
+
+import java.io.Serializable;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Carlos Correa
+ */
+@RunWith(Arquillian.class)
+public class ObjectRelationshipExtensionProviderTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-162964", "true"
+			).build());
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-162964", "false"
+			).build());
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		_objectDefinition = _publishObjectDefinition(
+			Collections.singletonList(
+				ObjectFieldUtil.createObjectField(
+					"Text", "String", true, true, null,
+					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME, false)));
+
+		_objectEntry = _addObjectEntry(_OBJECT_FIELD_VALUE);
+
+		_userSystemObjectDefinitionMetadata =
+			_systemObjectDefinitionMetadataTracker.
+				getSystemObjectDefinitionMetadata("User");
+
+		ObjectDefinition userSystemObjectDefinition =
+			_objectDefinitionLocalService.fetchSystemObjectDefinition(
+				_userSystemObjectDefinitionMetadata.getName());
+
+		_user = TestPropsValues.getUser();
+
+		_objectRelationship =
+			ObjectRelationshipLocalServiceUtil.addObjectRelationship(
+				_user.getUserId(), _objectDefinition.getObjectDefinitionId(),
+				userSystemObjectDefinition.getObjectDefinitionId(), 0,
+				ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				StringUtil.randomId(),
+				ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		ObjectRelationshipLocalServiceUtil.
+			addObjectRelationshipMappingTableValues(
+				_user.getUserId(),
+				_objectRelationship.getObjectRelationshipId(),
+				_objectEntry.getPrimaryKey(), _user.getUserId(),
+				ServiceContextTestUtil.getServiceContext());
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		ObjectRelationshipLocalServiceUtil.
+			deleteObjectRelationshipMappingTableValues(
+				_objectRelationship.getObjectRelationshipId(),
+				_objectEntry.getPrimaryKey(), _user.getUserId());
+		ObjectRelationshipLocalServiceUtil.deleteObjectRelationship(
+			_objectRelationship);
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			_objectDefinition.getObjectDefinitionId());
+	}
+
+	@Test
+	public void testGetExtendedProperties() throws Exception {
+		UserAccount userAccount = new UserAccount() {
+			{
+				id = _user.getUserId();
+			}
+		};
+
+		Map<String, Serializable> extendedProperties =
+			_extensionProvider.getExtendedProperties(
+				TestPropsValues.getCompanyId(), UserAccount.class.getName(),
+				userAccount);
+
+		Assert.assertTrue(extendedProperties.isEmpty());
+
+		NestedFieldsContextThreadLocal.setNestedFieldsContext(
+			_getNestedFieldsContext());
+
+		extendedProperties = _extensionProvider.getExtendedProperties(
+			TestPropsValues.getCompanyId(), UserAccount.class.getName(),
+			userAccount);
+
+		Assert.assertEquals(
+			extendedProperties.toString(), 1, extendedProperties.size());
+		Assert.assertNotNull(
+			extendedProperties.get(_objectRelationship.getName()));
+	}
+
+	@Test
+	public void testGetExtendedPropertyDefinitions() throws Exception {
+		Map<String, PropertyDefinition> extendedPropertyDefinitions =
+			_extensionProvider.getExtendedPropertyDefinitions(
+				TestPropsValues.getCompanyId(), UserAccount.class.getName());
+
+		Assert.assertEquals(
+			extendedPropertyDefinitions.toString(), 1,
+			extendedPropertyDefinitions.size());
+
+		PropertyDefinition propertyDefinition = extendedPropertyDefinitions.get(
+			_objectRelationship.getName());
+
+		Assert.assertEquals(
+			_objectRelationship.getName(),
+			propertyDefinition.getPropertyName());
+		Assert.assertEquals(
+			PropertyDefinition.PropertyType.MULTIPLE_ELEMENT,
+			propertyDefinition.getPropertyType());
+	}
+
+	@Test
+	public void testIsApplicableExtension() throws Exception {
+		Assert.assertFalse(
+			_extensionProvider.isApplicableExtension(
+				TestPropsValues.getCompanyId(), null));
+
+		Assert.assertFalse(
+			_extensionProvider.isApplicableExtension(
+				TestPropsValues.getCompanyId(),
+				com.liferay.object.rest.dto.v1_0.ObjectEntry.class.getName() +
+					"#" + _objectDefinition.getName()));
+
+		Assert.assertTrue(
+			_extensionProvider.isApplicableExtension(
+				TestPropsValues.getCompanyId(), UserAccount.class.getName()));
+	}
+
+	private ObjectEntry _addObjectEntry(String objectFieldValue)
+		throws Exception {
+
+		return ObjectEntryLocalServiceUtil.addObjectEntry(
+			TestPropsValues.getUserId(), 0,
+			_objectDefinition.getObjectDefinitionId(),
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME, objectFieldValue
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+	}
+
+	private NestedFieldsContext _getNestedFieldsContext() {
+		return new NestedFieldsContext(
+			Collections.singletonList(_objectRelationship.getName()), null,
+			null, null, null);
+	}
+
+	private ObjectDefinition _publishObjectDefinition(
+			List<ObjectField> objectFields)
+		throws Exception {
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.addCustomObjectDefinition(
+				TestPropsValues.getUserId(),
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				"A" + RandomTestUtil.randomString(), null, null,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				ObjectDefinitionConstants.SCOPE_COMPANY,
+				ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT, objectFields);
+
+		return _objectDefinitionLocalService.publishCustomObjectDefinition(
+			TestPropsValues.getUserId(),
+			objectDefinition.getObjectDefinitionId());
+	}
+
+	private static final String _OBJECT_FIELD_NAME =
+		"x" + RandomTestUtil.randomString();
+
+	private static final String _OBJECT_FIELD_VALUE =
+		RandomTestUtil.randomString();
+
+	@Inject
+	private static ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private static ObjectFieldLocalService _objectFieldLocalService;
+
+	@Inject(filter = "component.name=*.ObjectRelationshipExtensionProvider")
+	private ExtensionProvider _extensionProvider;
+
+	private ObjectDefinition _objectDefinition;
+	private ObjectEntry _objectEntry;
+	private ObjectRelationship _objectRelationship;
+
+	@Inject
+	private SystemObjectDefinitionMetadataTracker
+		_systemObjectDefinitionMetadataTracker;
+
+	private User _user;
+	private SystemObjectDefinitionMetadata _userSystemObjectDefinitionMetadata;
+
+}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -456,8 +456,7 @@ public class ObjectDefinitionLocalServiceImpl
 
 	@Override
 	public ObjectDefinition fetchObjectDefinitionByClassName(
-			long companyId, String className)
-		throws PortalException {
+		long companyId, String className) {
 
 		return objectDefinitionPersistence.fetchByC_C(companyId, className);
 	}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionServiceImpl.java
@@ -18,7 +18,6 @@ import com.liferay.object.constants.ObjectActionKeys;
 import com.liferay.object.constants.ObjectConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectField;
-import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.base.ObjectDefinitionServiceBaseImpl;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -58,7 +57,7 @@ public class ObjectDefinitionServiceImpl
 			getPermissionChecker(), null,
 			ObjectActionKeys.ADD_OBJECT_DEFINITION);
 
-		return _objectDefinitionLocalService.addCustomObjectDefinition(
+		return objectDefinitionLocalService.addCustomObjectDefinition(
 			getUserId(), labelMap, name, panelAppOrder, panelCategoryKey,
 			pluralLabelMap, scope, storageType, objectFields);
 	}
@@ -71,7 +70,7 @@ public class ObjectDefinitionServiceImpl
 			getPermissionChecker(), null,
 			ObjectActionKeys.ADD_OBJECT_DEFINITION);
 
-		return _objectDefinitionLocalService.addObjectDefinition(
+		return objectDefinitionLocalService.addObjectDefinition(
 			externalReferenceCode, getUserId());
 	}
 
@@ -82,7 +81,7 @@ public class ObjectDefinitionServiceImpl
 		_objectDefinitionModelResourcePermission.check(
 			getPermissionChecker(), objectDefinitionId, ActionKeys.DELETE);
 
-		return _objectDefinitionLocalService.deleteObjectDefinition(
+		return objectDefinitionLocalService.deleteObjectDefinition(
 			objectDefinitionId);
 	}
 
@@ -92,7 +91,7 @@ public class ObjectDefinitionServiceImpl
 		throws PortalException {
 
 		ObjectDefinition objectDefinition =
-			_objectDefinitionLocalService.
+			objectDefinitionLocalService.
 				fetchObjectDefinitionByExternalReferenceCode(
 					companyId, externalReferenceCode);
 
@@ -111,13 +110,13 @@ public class ObjectDefinitionServiceImpl
 		_objectDefinitionModelResourcePermission.check(
 			getPermissionChecker(), objectDefinitionId, ActionKeys.VIEW);
 
-		return _objectDefinitionLocalService.getObjectDefinition(
+		return objectDefinitionLocalService.getObjectDefinition(
 			objectDefinitionId);
 	}
 
 	@Override
 	public List<ObjectDefinition> getObjectDefinitions(int start, int end) {
-		return _objectDefinitionLocalService.getObjectDefinitions(start, end);
+		return objectDefinitionLocalService.getObjectDefinitions(start, end);
 	}
 
 	@Override
@@ -130,14 +129,14 @@ public class ObjectDefinitionServiceImpl
 
 	@Override
 	public int getObjectDefinitionsCount() throws PortalException {
-		return _objectDefinitionLocalService.getObjectDefinitionsCount();
+		return objectDefinitionLocalService.getObjectDefinitionsCount();
 	}
 
 	@Override
 	public int getObjectDefinitionsCount(long companyId)
 		throws PortalException {
 
-		return _objectDefinitionLocalService.getObjectDefinitionsCount(
+		return objectDefinitionLocalService.getObjectDefinitionsCount(
 			companyId);
 	}
 
@@ -150,7 +149,7 @@ public class ObjectDefinitionServiceImpl
 			getPermissionChecker(), null,
 			ObjectActionKeys.PUBLISH_OBJECT_DEFINITION);
 
-		return _objectDefinitionLocalService.publishCustomObjectDefinition(
+		return objectDefinitionLocalService.publishCustomObjectDefinition(
 			getUserId(), objectDefinitionId);
 	}
 
@@ -168,7 +167,7 @@ public class ObjectDefinitionServiceImpl
 		_objectDefinitionModelResourcePermission.check(
 			getPermissionChecker(), objectDefinitionId, ActionKeys.UPDATE);
 
-		return _objectDefinitionLocalService.updateCustomObjectDefinition(
+		return objectDefinitionLocalService.updateCustomObjectDefinition(
 			externalReferenceCode, objectDefinitionId,
 			accountEntryRestrictedObjectFieldId, descriptionObjectFieldId,
 			titleObjectFieldId, accountEntryRestricted, active,
@@ -185,7 +184,7 @@ public class ObjectDefinitionServiceImpl
 		_objectDefinitionModelResourcePermission.check(
 			getPermissionChecker(), objectDefinitionId, ActionKeys.UPDATE);
 
-		return _objectDefinitionLocalService.updateExternalReferenceCode(
+		return objectDefinitionLocalService.updateExternalReferenceCode(
 			objectDefinitionId, externalReferenceCode);
 	}
 
@@ -197,12 +196,9 @@ public class ObjectDefinitionServiceImpl
 		_objectDefinitionModelResourcePermission.check(
 			getPermissionChecker(), objectDefinitionId, ActionKeys.UPDATE);
 
-		return _objectDefinitionLocalService.updateTitleObjectFieldId(
+		return objectDefinitionLocalService.updateTitleObjectFieldId(
 			objectDefinitionId, titleObjectFieldId);
 	}
-
-	@Reference
-	private ObjectDefinitionLocalService _objectDefinitionLocalService;
 
 	@Reference(
 		target = "(model.class.name=com.liferay.object.model.ObjectDefinition)"

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
@@ -58,6 +58,7 @@ import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -315,6 +316,21 @@ public class ObjectRelationshipLocalServiceImpl
 			objectRelationshipLocalService.deleteObjectRelationship(
 				objectRelationship);
 		}
+	}
+
+	@Override
+	public ObjectRelationship fetchObjectRelationship(
+		long objectDefinitionId1, String name) {
+
+		List<ObjectRelationship> objectRelationships =
+			objectRelationshipPersistence.findByODI1_N(
+				objectDefinitionId1, name);
+
+		if (ListUtil.isEmpty(objectRelationships)) {
+			return null;
+		}
+
+		return objectRelationships.get(0);
 	}
 
 	@Override

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/extension/ExtensionProvider.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/extension/ExtensionProvider.java
@@ -29,7 +29,8 @@ public interface ExtensionProvider {
 		throws Exception;
 
 	public Map<String, PropertyDefinition> getExtendedPropertyDefinitions(
-		long companyId, String className);
+			long companyId, String className)
+		throws Exception;
 
 	public Collection<String> getFilteredPropertyNames(
 		long companyId, Object entity);

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/extension/EntityExtensionHandler.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/extension/EntityExtensionHandler.java
@@ -58,7 +58,8 @@ public class EntityExtensionHandler {
 	}
 
 	public Map<String, PropertyDefinition> getExtendedPropertyDefinitions(
-		long companyId, String className) {
+			long companyId, String className)
+		throws Exception {
 
 		Map<String, PropertyDefinition> propertyDefinitions = new HashMap<>();
 
@@ -111,8 +112,9 @@ public class EntityExtensionHandler {
 	}
 
 	public void validate(
-		long companyId, Map<String, Serializable> extendedProperties,
-		boolean partialUpdate) {
+			long companyId, Map<String, Serializable> extendedProperties,
+			boolean partialUpdate)
+		throws Exception {
 
 		Map<String, PropertyDefinition> propertyDefinitions = new HashMap<>();
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/message/body/BaseMessageBodyReader.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/message/body/BaseMessageBodyReader.java
@@ -102,13 +102,18 @@ public abstract class BaseMessageBodyReader
 			Map<String, Serializable> extendedProperties =
 				_getExtendedProperties(clazz, jsonNode, objectMapper);
 
-			entityExtensionHandler.validate(
-				_company.getCompanyId(), extendedProperties,
-				Objects.equals(
-					_httpServletRequest.getMethod(), HttpMethod.PATCH));
+			try {
+				entityExtensionHandler.validate(
+					_company.getCompanyId(), extendedProperties,
+					Objects.equals(
+						_httpServletRequest.getMethod(), HttpMethod.PATCH));
 
-			EntityExtensionThreadLocal.setExtendedProperties(
-				extendedProperties);
+				EntityExtensionThreadLocal.setExtendedProperties(
+					extendedProperties);
+			}
+			catch (Exception exception) {
+				throw new IOException(exception);
+			}
 		}
 		else {
 			object = objectReader.readValue(inputStream);

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/writer/interceptor/EntityExtensionWriterInterceptor.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/writer/interceptor/EntityExtensionWriterInterceptor.java
@@ -22,7 +22,6 @@ import com.liferay.portal.vulcan.internal.jaxrs.extension.ExtendedEntity;
 
 import java.io.IOException;
 
-import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.ext.ContextResolver;
@@ -54,8 +53,9 @@ public class EntityExtensionWriterInterceptor implements WriterInterceptor {
 	}
 
 	private void _extendEntity(
-		EntityExtensionHandler entityExtensionHandler,
-		WriterInterceptorContext writerInterceptorContext) {
+			EntityExtensionHandler entityExtensionHandler,
+			WriterInterceptorContext writerInterceptorContext)
+		throws IOException {
 
 		try {
 			writerInterceptorContext.setEntity(
@@ -73,7 +73,7 @@ public class EntityExtensionWriterInterceptor implements WriterInterceptor {
 		catch (Exception exception) {
 			_log.error(exception);
 
-			throw new WebApplicationException(exception);
+			throw new IOException(exception);
 		}
 	}
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/writer/interceptor/PageEntityExtensionWriterInterceptor.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/writer/interceptor/PageEntityExtensionWriterInterceptor.java
@@ -31,7 +31,6 @@ import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
@@ -71,8 +70,9 @@ public class PageEntityExtensionWriterInterceptor implements WriterInterceptor {
 	}
 
 	private void _extendPageEntities(
-		EntityExtensionHandler entityExtensionHandler,
-		WriterInterceptorContext writerInterceptorContext) {
+			EntityExtensionHandler entityExtensionHandler,
+			WriterInterceptorContext writerInterceptorContext)
+		throws IOException {
 
 		Page<?> page = (Page<?>)writerInterceptorContext.getEntity();
 
@@ -92,7 +92,7 @@ public class PageEntityExtensionWriterInterceptor implements WriterInterceptor {
 		catch (Exception exception) {
 			_log.error(exception);
 
-			throw new WebApplicationException(exception);
+			throw new IOException(exception);
 		}
 
 		Pagination pagination = Pagination.of(

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/resource/OpenAPIResourceImpl.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/resource/OpenAPIResourceImpl.java
@@ -279,8 +279,9 @@ public class OpenAPIResourceImpl implements OpenAPIResource {
 	}
 
 	private List<PropertyDefinition> _getExtendedPropertyDefinitions(
-		String className, long companyId,
-		ExtensionProviderRegistry extensionProviderRegistry) {
+			String className, long companyId,
+			ExtensionProviderRegistry extensionProviderRegistry)
+		throws Exception {
 
 		List<PropertyDefinition> propertyDefinitions = null;
 
@@ -404,8 +405,10 @@ public class OpenAPIResourceImpl implements OpenAPIResource {
 	}
 
 	private OpenAPISchemaFilter _getOpenAPISchemaFilter(
-		String basePath, ExtensionProviderRegistry extensionProviderRegistry,
-		Set<Class<?>> resourceClasses) {
+			String basePath,
+			ExtensionProviderRegistry extensionProviderRegistry,
+			Set<Class<?>> resourceClasses)
+		throws Exception {
 
 		Set<String> classNames = _getDTOClassNames(resourceClasses);
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/extension/EntityExtensionHandlerTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/extension/EntityExtensionHandlerTest.java
@@ -272,7 +272,7 @@ public class EntityExtensionHandlerTest {
 	}
 
 	@Test
-	public void testValidate() {
+	public void testValidate() throws Exception {
 		ExtensionProvider extensionProviderMock1 = Mockito.mock(
 			ExtensionProvider.class);
 		ExtensionProvider extensionProviderMock2 = Mockito.mock(
@@ -350,7 +350,7 @@ public class EntityExtensionHandlerTest {
 	}
 
 	@Test(expected = ValidationException.class)
-	public void testValidateInvalidProperty() {
+	public void testValidateInvalidProperty() throws Exception {
 		ExtensionProvider extensionProviderMock1 = Mockito.mock(
 			ExtensionProvider.class);
 		ExtensionProvider extensionProviderMock2 = Mockito.mock(
@@ -428,7 +428,7 @@ public class EntityExtensionHandlerTest {
 	}
 
 	@Test(expected = ValidationException.class)
-	public void testValidateMissingRequiredProperty() {
+	public void testValidateMissingRequiredProperty() throws Exception {
 		ExtensionProvider extensionProviderMock1 = Mockito.mock(
 			ExtensionProvider.class);
 		ExtensionProvider extensionProviderMock2 = Mockito.mock(
@@ -504,7 +504,9 @@ public class EntityExtensionHandlerTest {
 	}
 
 	@Test
-	public void testValidateMissingRequiredPropertyInPartialUpdate() {
+	public void testValidateMissingRequiredPropertyInPartialUpdate()
+		throws Exception {
+
 		ExtensionProvider extensionProviderMock1 = Mockito.mock(
 			ExtensionProvider.class);
 		ExtensionProvider extensionProviderMock2 = Mockito.mock(
@@ -580,7 +582,7 @@ public class EntityExtensionHandlerTest {
 	}
 
 	@Test(expected = ValidationException.class)
-	public void testValidateUnknownProperty() {
+	public void testValidateUnknownProperty() throws Exception {
 		ExtensionProvider extensionProviderMock1 = Mockito.mock(
 			ExtensionProvider.class);
 		ExtensionProvider extensionProviderMock2 = Mockito.mock(


### PR DESCRIPTION
Related task: https://issues.liferay.com/browse/LPS-162964

This PR contains the code to allow to retrieve the many to many relared elements to a System Object as a nestedField.

**NOTE:** This functionality has been developed over the feature flag `feature.flag.LPS-162964`

For providing the Object Entries related to a System Object, a new `ExtensionProvider` has been implemented. The `ExtensionProvider` interface contains some methods that are invoked by Vulcan in the JAX-RS request-response lifecycle.

The implemented methods of the interface are the following ones:

- `Map<String, PropertyDefinition> getExtendedPropertyDefinitions(long companyId, String className)`: In the ExtensionProvider that returns the relationships, the map contains the PropertyDefinition of the following relationships:

  - **System Object** with _ManyToMany_ relationship to a **Custom Object** (and in the opposite way)
  - **System Object** with _OneToMany_ relationship to a **Custom Object**
  
    The `PropertyValidator` class of the PropertyDefinitions has been included to throw always an exception to avoid allowing the name of the relation in the request body as a parameter, for now it is not allowed. That functionality will be included in the future, for example, to create in the same request an Object Entry and its related Object Entries.

- `Map<String, Serializable> getExtendedProperties(long companyId, String className, Object entity)`: The Map will contain the relationship name recovered with the previous method as the key and the list of Object Entries related to the System Object as the value of the map entry.
  

