### PR TITLE
LPS-164598: Test Fix com.liferay.headless.admin.user.resource module

### DIFF
--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/AccountRoleResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/AccountRoleResourceTest.java
@@ -512,6 +512,8 @@ public class AccountRoleResourceTest extends BaseAccountRoleResourceTestCase {
 			testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByEmailAddress_addAccountRole()
 		throws Exception {
 
+		_userAccount = _addAccountUserAccount(_account);
+
 		return _addAccountAccountRole(_account);
 	}
 
@@ -520,7 +522,7 @@ public class AccountRoleResourceTest extends BaseAccountRoleResourceTestCase {
 			testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByEmailAddress_getEmailAddress()
 		throws Exception {
 
-		return null;
+		return _userAccount.getEmailAddress();
 	}
 
 	@Override
@@ -528,7 +530,7 @@ public class AccountRoleResourceTest extends BaseAccountRoleResourceTestCase {
 			testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByEmailAddress_getExternalReferenceCode()
 		throws Exception {
 
-		return null;
+		return _account.getExternalReferenceCode();
 	}
 
 	@Override
@@ -1000,6 +1002,7 @@ public class AccountRoleResourceTest extends BaseAccountRoleResourceTestCase {
 	private AccountRoleLocalService _accountRoleLocalService;
 
 	private List<AccountRole> _sharedAccountRoles;
+	private UserAccount _userAccount;
 	private UserAccountResource _userAccountResource;
 
 	@Inject

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/OrganizationResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/OrganizationResourceTest.java
@@ -77,6 +77,22 @@ public class OrganizationResourceTest extends BaseOrganizationResourceTestCase {
 
 	@Override
 	@Test
+	public void testDeleteAccountByExternalReferenceCodeOrganization()
+		throws Exception {
+
+		Organization organization =
+			testDeleteAccountByExternalReferenceCodeOrganization_addOrganization();
+
+		assertHttpResponseStatusCode(
+			204,
+			organizationResource.
+				deleteAccountByExternalReferenceCodeOrganizationHttpResponse(
+					_accountEntry.getExternalReferenceCode(),
+					organization.getId()));
+	}
+
+	@Override
+	@Test
 	public void testDeleteUserAccountByEmailAddress() throws Exception {
 		Organization organization = _toOrganization(
 			_addOrganization(randomOrganization(), "0"));
@@ -268,18 +284,22 @@ public class OrganizationResourceTest extends BaseOrganizationResourceTestCase {
 			testDeleteAccountByExternalReferenceCodeOrganization_addOrganization()
 		throws Exception {
 
-		return organizationResource.putOrganizationByExternalReferenceCode(
-			StringUtil.toLowerCase(RandomTestUtil.randomString()),
-			randomOrganization());
+		Organization organization =
+			organizationResource.putOrganizationByExternalReferenceCode(
+				RandomTestUtil.randomString(), randomOrganization());
+
+		_accountEntryOrganizationRelLocalService.addAccountEntryOrganizationRel(
+			_accountEntry.getAccountEntryId(),
+			GetterUtil.getLong(organization.getId()));
+
+		return organization;
 	}
 
 	@Override
 	protected Organization testDeleteAccountOrganization_addOrganization()
 		throws Exception {
 
-		return organizationResource.putOrganizationByExternalReferenceCode(
-			StringUtil.toLowerCase(RandomTestUtil.randomString()),
-			randomOrganization());
+		return testDeleteAccountByExternalReferenceCodeOrganization_addOrganization();
 	}
 
 	@Override
@@ -448,8 +468,7 @@ public class OrganizationResourceTest extends BaseOrganizationResourceTestCase {
 		throws Exception {
 
 		return organizationResource.putOrganizationByExternalReferenceCode(
-			StringUtil.toLowerCase(RandomTestUtil.randomString()),
-			randomOrganization());
+			_accountEntry.getExternalReferenceCode(), randomOrganization());
 	}
 
 	@Override


### PR DESCRIPTION
**What is new?**
- Changes in `OrganizationResourceTest.testDeleteAccountByExternalReferenceCodeOrganization` and `OrganizationResourceTest.testDeleteAccountOrganization` tests cases
- Changes in `AccountRoleResourceTest.testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByEmailAddress` test case
- Each of them returned a status code 404 but now is a 204 one.

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-164598