### PR TITLE
LPS-164593:  Test Fix in com.liferay.headless.delivery.resource.v1_0.test.StructuredContentFolderResourceTest

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentFolderResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentFolderResourceTest.java
@@ -19,6 +19,7 @@ import com.liferay.headless.delivery.client.dto.v1_0.StructuredContentFolder;
 import com.liferay.journal.model.JournalFolder;
 import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 
 import org.junit.runner.RunWith;
 
@@ -37,6 +38,15 @@ public class StructuredContentFolderResourceTest
 	@Override
 	protected String[] getIgnoredEntityFieldNames() {
 		return new String[] {"creatorId"};
+	}
+
+	@Override
+	protected StructuredContentFolder
+			testDeleteAssetLibraryStructuredContentFolderByExternalReferenceCode_addStructuredContentFolder()
+		throws Exception {
+
+		return testPostAssetLibraryStructuredContentFolder_addStructuredContentFolder(
+			randomStructuredContentFolder());
 	}
 
 	@Override
@@ -103,11 +113,60 @@ public class StructuredContentFolderResourceTest
 	}
 
 	@Override
+	protected StructuredContentFolder
+			testPutAssetLibraryStructuredContentFolderByExternalReferenceCode_addStructuredContentFolder()
+		throws Exception {
+
+		return testPostAssetLibraryStructuredContentFolder_addStructuredContentFolder(
+			randomStructuredContentFolder());
+	}
+
+	@Override
+	protected StructuredContentFolder
+			testPutAssetLibraryStructuredContentFolderByExternalReferenceCode_createStructuredContentFolder()
+		throws Exception {
+
+		return _randomStructuredContentFolder();
+	}
+
+	@Override
 	protected Long
 			testPutAssetLibraryStructuredContentFolderByExternalReferenceCode_getAssetLibraryId()
 		throws Exception {
 
 		return testDepotEntry.getDepotEntryId();
+	}
+
+	@Override
+	protected StructuredContentFolder
+			testPutSiteStructuredContentFolderByExternalReferenceCode_createStructuredContentFolder()
+		throws Exception {
+
+		return _randomStructuredContentFolder();
+	}
+
+	private StructuredContentFolder _randomStructuredContentFolder()
+		throws Exception {
+
+		return new StructuredContentFolder() {
+			{
+				assetLibraryKey = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				dateCreated = RandomTestUtil.nextDate();
+				dateModified = RandomTestUtil.nextDate();
+				description = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				externalReferenceCode = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				id = RandomTestUtil.randomLong();
+				name = StringUtil.toLowerCase(RandomTestUtil.randomString());
+				numberOfStructuredContentFolders = RandomTestUtil.randomInt();
+				numberOfStructuredContents = RandomTestUtil.randomInt();
+				parentStructuredContentFolderId = 0L;
+				siteId = testGroup.getGroupId();
+				subscribed = RandomTestUtil.randomBoolean();
+			}
+		};
 	}
 
 }


### PR DESCRIPTION
**What is new?**
- Update `testDeleteAssetLibraryStructuredContentFolderByExternalReferenceCode` test case just updating the `testPostAssetLibraryStructuredContentFolder_addStructuredContentFolder` using the `assetLibraryId` instead of `siteId`
- Update `testPutAssetLibraryStructuredContentFolderByExternalReferenceCode` and `testPutSiteStructuredContentFolderByExternalReferenceCode`. I just override the method `createRandomStructuredContentFolder` because the `parentStructuredContentFolderId` must be 0 and not a RandomLong because it doesn't exist.

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-164593