### PR TITLE
LPS-165841 Check for null mediaTypes

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/container/response/filter/EntityExtensionContainerResponseFilter.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/container/response/filter/EntityExtensionContainerResponseFilter.java
@@ -62,6 +62,10 @@ public class EntityExtensionContainerResponseFilter
 
 		MediaType mediaType = containerResponseContext.getMediaType();
 
+		if (mediaType == null) {
+			mediaType = MediaType.WILDCARD_TYPE;
+		}
+
 		ContextResolver<EntityExtensionHandler> contextResolver =
 			_providers.getContextResolver(
 				EntityExtensionHandler.class, mediaType);


### PR DESCRIPTION
Related ticket [LPS-165841](https://issues.liferay.com/browse/LPS-165841)
___
## Technical details
Sometimes, an endpoint does not expect a specific response and just needs the HTTP method.
For that cases, the media type will be null.

In that case, we can assume that we are using wildcard media type as it is irrelevant to the EntityExtension feature.

## How to test it
Just deploy the module `portal-vulcan-impl` and restart the Liferay server.