### PR TITLE
LPS-164972 Use ServiceContextFactory instead of ServiceContextRequestUtil

### DIFF
--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OrganizationResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OrganizationResourceImpl.java
@@ -35,7 +35,6 @@ import com.liferay.headless.admin.user.internal.dto.v1_0.util.ServiceBuilderWebs
 import com.liferay.headless.admin.user.internal.odata.entity.v1_0.OrganizationEntityModel;
 import com.liferay.headless.admin.user.resource.v1_0.OrganizationResource;
 import com.liferay.headless.admin.user.resource.v1_0.RoleResource;
-import com.liferay.headless.common.spi.service.context.ServiceContextRequestUtil;
 import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -60,6 +59,7 @@ import com.liferay.portal.kernel.service.OrgLaborLocalService;
 import com.liferay.portal.kernel.service.OrganizationLocalService;
 import com.liferay.portal.kernel.service.OrganizationService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.service.UserService;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
@@ -531,12 +531,16 @@ public class OrganizationResourceImpl
 	private ServiceContext _createServiceContext(Organization organization)
 		throws Exception {
 
-		return ServiceContextRequestUtil.createServiceContext(
+		ServiceContext serviceContext = ServiceContextFactory.getInstance(
+			contextHttpServletRequest);
+
+		serviceContext.setExpandoBridgeAttributes(
 			CustomFieldsUtil.toMap(
 				com.liferay.portal.kernel.model.Organization.class.getName(),
 				contextCompany.getCompanyId(), organization.getCustomFields(),
-				contextAcceptLanguage.getPreferredLocale()),
-			contextCompany.getGroupId(), contextHttpServletRequest, null);
+				contextAcceptLanguage.getPreferredLocale()));
+
+		return serviceContext;
 	}
 
 	private List<Address> _getAddresses(Organization organization) {


### PR DESCRIPTION
This PR contains the fix to use ServiceContextFactory instead of ServiceContextRequestUtil as there are several attributes that are not being set in the ServiceContext by the class ServiceContextRequestUtil, as for example, the user id.

So it contains a rollback to set the ServiceContext as before but just including the expando fields in the context.