### PR TITLE
LPS-165909 Use ServiceContextFactory instead of ServiceContextRequestUtil

### DIFF
--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OrganizationResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OrganizationResourceImpl.java
@@ -407,16 +407,13 @@ public class OrganizationResourceImpl
 	public Organization putOrganization(
 			String organizationId, Organization organization)
 		throws Exception {
-
+		ServiceContext serviceContext = _createServiceContext(organization);
+		serviceContext.setUserId(contextUser.getUserId());
 		com.liferay.portal.kernel.model.Organization
 			serviceBuilderOrganization =
 				_organizationResourceDTOConverter.getObject(organizationId);
 		long countryId = _getCountryId(organization);
 		Group group = serviceBuilderOrganization.getGroup();
-
-		ServiceContext serviceContext = _createServiceContext(organization);
-
-		serviceContext.setUserId(contextUser.getUserId());
 
 		return _organizationResourceDTOConverter.toDTO(
 			_getDTOConverterContext(organizationId),
@@ -429,7 +426,8 @@ public class OrganizationResourceImpl
 				organization.getComment(), false, null, group.isSite(),
 				_getAddresses(organization), _getEmailAddresses(organization),
 				_getOrgLabors(organization), _getPhones(organization),
-				_getWebsites(organization), serviceContext));
+				_getWebsites(organization),
+				serviceContext));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OrganizationResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OrganizationResourceImpl.java
@@ -407,8 +407,7 @@ public class OrganizationResourceImpl
 	public Organization putOrganization(
 			String organizationId, Organization organization)
 		throws Exception {
-		ServiceContext serviceContext = _createServiceContext(organization);
-		serviceContext.setUserId(contextUser.getUserId());
+
 		com.liferay.portal.kernel.model.Organization
 			serviceBuilderOrganization =
 				_organizationResourceDTOConverter.getObject(organizationId);
@@ -427,7 +426,7 @@ public class OrganizationResourceImpl
 				_getAddresses(organization), _getEmailAddresses(organization),
 				_getOrgLabors(organization), _getPhones(organization),
 				_getWebsites(organization),
-				serviceContext));
+				_createServiceContext(organization)));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OrganizationResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OrganizationResourceImpl.java
@@ -35,7 +35,6 @@ import com.liferay.headless.admin.user.internal.dto.v1_0.util.ServiceBuilderWebs
 import com.liferay.headless.admin.user.internal.odata.entity.v1_0.OrganizationEntityModel;
 import com.liferay.headless.admin.user.resource.v1_0.OrganizationResource;
 import com.liferay.headless.admin.user.resource.v1_0.RoleResource;
-import com.liferay.headless.common.spi.service.context.ServiceContextRequestUtil;
 import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -60,6 +59,7 @@ import com.liferay.portal.kernel.service.OrgLaborLocalService;
 import com.liferay.portal.kernel.service.OrganizationLocalService;
 import com.liferay.portal.kernel.service.OrganizationService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.service.UserService;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
@@ -531,12 +531,16 @@ public class OrganizationResourceImpl
 	private ServiceContext _createServiceContext(Organization organization)
 		throws Exception {
 
-		return ServiceContextRequestUtil.createServiceContext(
+		ServiceContext serviceContext = ServiceContextFactory.getInstance(
+			contextHttpServletRequest);
+
+		serviceContext.setExpandoBridgeAttributes(
 			CustomFieldsUtil.toMap(
 				com.liferay.portal.kernel.model.Organization.class.getName(),
 				contextCompany.getCompanyId(), organization.getCustomFields(),
-				contextAcceptLanguage.getPreferredLocale()),
-			contextCompany.getGroupId(), contextHttpServletRequest, null);
+				contextAcceptLanguage.getPreferredLocale()));
+
+		return serviceContext;
 	}
 
 	private List<Address> _getAddresses(Organization organization) {


### PR DESCRIPTION
Related bugs: https://issues.liferay.com/browse/LPS-164972 & https://issues.liferay.com/browse/LPS-165909

This PR contains the fix to use `ServiceContextFactory` instead of `ServiceContextRequestUtil` as there are several attributes that are not being set in the ServiceContext by the class ServiceContextRequestUtil, as for example, the `userId`.

So it contains:

- Two reverted commits of setting the `userId`
- Change class to create the ServiceContext as it was being done before, but including the `expandoBridgeAttributes`