### PR TITLE
LPS-163267 adjust the selected class name of the exported template.

### DIFF
--- a/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/TemplateSelect.js
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/TemplateSelect.js
@@ -106,6 +106,7 @@ const TemplateSelect = ({
 					}),
 					{}
 				),
+				taskItemDelegateName: templateDetails.taskItemDelegateName,
 			},
 		});
 	};

--- a/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/edit_batch_planner_plan.js
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/edit_batch_planner_plan.js
@@ -94,10 +94,18 @@ export default function ({
 				externalTypeInput.value = template.externalType;
 			}
 
-			const internalClassTemplateOption = internalClassNameSelect.querySelector(
-				`option[value='${template.internalClassName}']`
-			);
+			const taskItemDelegateName = template.taskItemDelegateName;
 
+			const selectedClassNameValue =
+				template.internalClassName +
+				'' +
+				(taskItemDelegateName !== 'DEFAULT'
+					? '#C_' + taskItemDelegateName
+					: '');
+
+			const internalClassTemplateOption = internalClassNameSelect.querySelector(
+				`option[value='${selectedClassNameValue}']`
+			);
 			internalClassTemplateOption.selected = true;
 
 			await handleClassNameSelectChange();


### PR DESCRIPTION
Motivation
=======
This P/R tends to solve the incorrect selected class name in Clay Select while exporting Liferay Object REST.

Proposed Solution
========
What the author did to solve problem: If the template is **not** default append the postfix value of the template name as follow: `'#C_' + taskItemDelegateName`

Steps to Verify
========

1. Set `feature.flag.COMMERCE-8087=true` and start server
2. Create a new object for example "employee"
3. Add a new field then publish it:
     name - Text
4.  go to Applications > Import/Export Center
5. Click New > Export File
6. Select C_Employee (V1_0 - Liferay Object REST) as the Entity Type
7. Checked id and name as the Attribute Code, checked "include headers"
8. Click Save as Template
9. Enter a template name > Save
10. Go to Applications > Import/Export Center > New > Export File
 11. Choose the existing template.

:heavy_check_mark: Expect behavior:

 `  Entity type set to C_Employee (V1_0 - Liferay Object REST) and id and name are selected under Attribute Codes(This is the way other Entity Template works, for example Account (V1_0 - Liferay Headless  Admin User) template)`

:x: Actual behavior:
```
  Entity type is empty
  No fields in Attribute Code
```
CC: @binhtran92