### PR TITLE
LPS-166284: Update permissions in actions for Object Definition Headless API

### DIFF
--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
@@ -548,12 +548,6 @@ public class ObjectDefinitionResourceImpl
 						ActionKeys.VIEW, "getObjectDefinition", permissionName,
 						objectDefinition.getObjectDefinitionId())
 				).put(
-					"permissions",
-					addAction(
-						ActionKeys.PERMISSIONS, "patchObjectDefinition",
-						permissionName,
-						objectDefinition.getObjectDefinitionId())
-				).put(
 					"publish",
 					() -> {
 						if (objectDefinition.isApproved()) {
@@ -566,7 +560,7 @@ public class ObjectDefinitionResourceImpl
 							objectDefinition.getObjectDefinitionId());
 					}
 				).put(
-					"update",
+					"replace",
 					() -> {
 						if (objectDefinition.isSystem()) {
 							return null;
@@ -577,6 +571,12 @@ public class ObjectDefinitionResourceImpl
 							permissionName,
 							objectDefinition.getObjectDefinitionId());
 					}
+				).put(
+					"update",
+					addAction(
+						ActionKeys.UPDATE, "patchObjectDefinition",
+						permissionName,
+						objectDefinition.getObjectDefinitionId())
 				).build();
 				active = objectDefinition.isActive();
 				dateCreated = objectDefinition.getCreateDate();


### PR DESCRIPTION
**What is new?**
- Change `permissions` action named as `"update"` and change `update` action named as `"replace"`.

**Before PR**
```json
"actions": {
    "permissions": {
      "method": "PATCH",
      "href": "http://localhost:8080/o/object-admin/v1.0/object-definitions/49543"
    },
    "get": {
      "method": "GET",
      "href": "http://localhost:8080/o/object-admin/v1.0/object-definitions/49543"
    },
    "update": {
      "method": "PUT",
      "href": "http://localhost:8080/o/object-admin/v1.0/object-definitions/49543"
    },
    "delete": {
      "method": "DELETE",
      "href": "http://localhost:8080/o/object-admin/v1.0/object-definitions/49543"
    }
  }
```

**After PR**
```json
"actions": {
    "get": {
      "method": "GET",
      "href": "http://localhost:8080/o/object-admin/v1.0/object-definitions/49543"
    },
    "replace": {
      "method": "PUT",
      "href": "http://localhost:8080/o/object-admin/v1.0/object-definitions/49543"
    },
    "update": {
      "method": "PATCH",
      "href": "http://localhost:8080/o/object-admin/v1.0/object-definitions/49543"
    },
    "delete": {
      "method": "DELETE",
      "href": "http://localhost:8080/o/object-admin/v1.0/object-definitions/49543"
    }
  }
```
**Note:** At the momment, it doesn't exist any **Permission** endpoint in Headless Object Definition APIs.

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-166284