### PR TITLE
LPS-166672 Remove disabledBatchSchemaNames parameter

### DIFF
--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
@@ -105,12 +105,8 @@ public class FreeMarkerTool {
 		ConfigYAML configYAML, String javaDataType,
 		List<JavaMethodSignature> javaMethodSignatures, String schemaName) {
 
-		List<String> disabledBatchSchemaNames =
-			configYAML.getDisabledBatchSchemaNames();
-
-		if (!configYAML.isGenerateBatch() ||
-			disabledBatchSchemaNames.contains(schemaName) ||
-			(javaDataType == null) || javaDataType.isEmpty()) {
+		if (!configYAML.isGenerateBatch() || (javaDataType == null) ||
+			javaDataType.isEmpty()) {
 
 			return false;
 		}

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
@@ -117,13 +117,7 @@ public class ResourceOpenAPIParser {
 
 							javaMethodSignatures.add(javaMethodSignature);
 
-							List<String> disabledBatchSchemaNames =
-								configYAML.getDisabledBatchSchemaNames();
-
-							if (configYAML.isGenerateBatch() &&
-								!disabledBatchSchemaNames.contains(
-									schemaName)) {
-
+							if (configYAML.isGenerateBatch()) {
 								_addBatchJavaMethodSignature(
 									javaMethodSignature, javaMethodSignatures);
 							}

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/yaml/config/ConfigYAML.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/yaml/config/ConfigYAML.java
@@ -14,9 +14,6 @@
 
 package com.liferay.portal.tools.rest.builder.internal.yaml.config;
 
-import java.util.Collections;
-import java.util.List;
-
 /**
  * @author Peter Shin
  */
@@ -44,10 +41,6 @@ public class ConfigYAML {
 
 	public String getClientMavenGroupId() {
 		return _clientMavenGroupId;
-	}
-
-	public List<String> getDisabledBatchSchemaNames() {
-		return _disabledBatchSchemaNames;
 	}
 
 	public String getGraphQLNamespace() {
@@ -138,12 +131,6 @@ public class ConfigYAML {
 		_clientMavenGroupId = clientMavenGroupId;
 	}
 
-	public void setDisabledBatchSchemaNames(
-		List<String> disabledBatchSchemaNames) {
-
-		_disabledBatchSchemaNames = disabledBatchSchemaNames;
-	}
-
 	public void setForceClientVersionDescription(
 		boolean forceClientVersionDescription) {
 
@@ -224,7 +211,6 @@ public class ConfigYAML {
 	private String _author;
 	private String _clientDir;
 	private String _clientMavenGroupId;
-	private List<String> _disabledBatchSchemaNames = Collections.emptyList();
 	private boolean _forceClientVersionDescription = true;
 	private boolean _forcePredictableContentApplicationXML = true;
 	private boolean _forcePredictableOperationId;


### PR DESCRIPTION
Related task: https://issues.liferay.com/browse/LPS-166672

---

This PR contains the code to remove the usage of the property `disabledBatchSchemaNames` of the configuration file `rest-config.yaml`. The purpose of the property was to include which entities will be ignored when implementing the interface `VulcanBatchEngineTaskItemDelegate` in its JAX-RS Resource Implementation.

From now, all the entities that has a default implementation of any of the methods `create`, `update`, `read` or `delete` will implement that interface.