### PR TITLE
LPS-164345 Add test on expose createBatch action in headless object api

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/objects/ObjectDefinitionAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/objects/ObjectDefinitionAPI.macro
@@ -430,6 +430,50 @@ definition {
 		return "${response}";
 	}
 
+	macro assertCreateBatchInActionBlock {
+		Variables.assertDefined(parameterList = "${responseToParse}");
+
+		var actualBatch = JSONUtil.getWithJSONPath("${responseToParse}", "$.actions.createBatch");
+		var portalURL = JSONCompany.getPortalURL();
+
+		if (isSet(objectDefinitionId)) {
+			var href = "${portalURL}/o/object-admin/v1.0/object-definitions/${objectDefinitionId}/${objectSchema}/batch";
+		}
+		else if (isSet(en_US_plural_label)) {
+			var href = "${portalURL}/o/c/${en_US_plural_label}/batch";
+		}
+		else {
+			var href = "${portalURL}/o/object-admin/v1.0/object-definitions/batch";
+		}
+
+		var expectedBatch = StringUtil.add("{method=POST,", " href=${href}}", "");
+
+		TestUtils.assertEquals(
+			actual = "${actualBatch}",
+			expected = "${expectedBatch}");
+	}
+
+	macro assertCreateBatchWithGetObjectSchemas {
+		Variables.assertDefined(parameterList = "${objectDefinitionId},${objectSchemas}");
+
+		var portalURL = JSONCompany.getPortalURL();
+
+		for (var objectSchema : list "${objectSchemas}") {
+			var curl = '''
+				${portalURL}/o/object-admin/v1.0/object-definitions/${objectDefinitionId}/${objectSchema} \
+				-H Content-Type: application/json \
+				-u test@liferay.com:test
+			''';
+
+			var response = JSONCurlUtil.get("${curl}");
+
+			ObjectDefinitionAPI.assertCreateBatchInActionBlock(
+				objectDefinitionId = "${objectDefinitionId}",
+				objectSchema = "${objectSchema}",
+				responseToParse = "${response}");
+		}
+	}
+
 	macro assertEmployeeHasNestedFieldManager {
 		ObjectDefinitionAPI._assertEmployeeFirstnameCorrect(
 			expectedEmployeeFirstname = "${expectedEmployeeFirstname}",
@@ -638,6 +682,20 @@ definition {
 		var objectDefinitionId = JSONCurlUtil.get("${curl}", "$.items[?(@['name'] == '${name}')]['id']");
 
 		return "${objectDefinitionId}";
+	}
+
+	macro getObjectDefinitions {
+		var portalURL = JSONCompany.getPortalURL();
+
+		var curl = '''
+			${portalURL}/o/object-admin/v1.0/object-definitions \
+			-H Content-Type: application/json \
+			-u test@liferay.com:test
+		''';
+
+		var response = JSONCurlUtil.get("${curl}");
+
+		return "${response}";
 	}
 
 	macro getObjectEntries {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/ExposeBatchActionForObjectAdminAPI.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/ExposeBatchActionForObjectAdminAPI.testcase
@@ -1,0 +1,89 @@
+@component-name = "portal-headless"
+definition {
+
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.main.component.name = "Headless";
+
+	setUp {
+		TestCase.setUpPortalInstanceNoSelenium();
+	}
+
+	tearDown {
+		if ("${testPortalInstance}" == "true") {
+			PortalInstances.tearDownCP();
+		}
+		else {
+			ObjectAdmin.deleteObjectViaAPI(objectName = "Subject");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = "4"
+	test IncludeCreateBatchInActionsForObjectDefinition {
+		property portal.acceptance = "true";
+
+		task ("When invoking object admin GET '/v1.0/object-definition'") {
+			var response = ObjectDefinitionAPI.getObjectDefinitions();
+		}
+
+		task ("Then the actions block include the information for the createBatch action endpoint") {
+			ObjectDefinitionAPI.assertCreateBatchInActionBlock(responseToParse = "${response}");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = "4"
+	test IncludeCreateBatchInActionsForObjectEntries {
+		property portal.acceptance = "true";
+
+		task ("Given subject object definition is created") {
+			ObjectDefinitionAPI.createAndPublishObjectDefinition(
+				en_US_label = "subject",
+				en_US_plural_label = "subjects",
+				name = "Subject",
+				requiredStringFieldName = "name");
+		}
+
+		task ("And Given subject entry is created") {
+			var subjectId = ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "subjects",
+				name = "Liferay Foundations");
+		}
+
+		task ("When invoking getStudentsPage in c/subjects") {
+			var response = ObjectDefinitionAPI.getObjectEntries(en_US_plural_label = "subjects");
+		}
+
+		task ("Then the actions block include the information for the createBatch action endpoint") {
+			ObjectDefinitionAPI.assertCreateBatchInActionBlock(
+				en_US_plural_label = "subjects",
+				responseToParse = "${response}");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = "3"
+	test IncludeCreateBatchInActionsForObjectSchemas {
+		property portal.acceptance = "true";
+
+		task ("Given an object definition is created") {
+			var objectDefinitionId = ObjectDefinitionAPI.createAndPublishObjectDefinition(
+				en_US_label = "subject",
+				en_US_plural_label = "subjects",
+				name = "Subject",
+				requiredStringFieldName = "name");
+		}
+
+		task ("When with get request and objectDefinitionId to retrieve objectAction, objectField, objectLayout, objectRelationship, objectValidationRule and objectView") {
+			var objectSchemas = "object-actions,object-fields,object-layouts,object-relationships,object-validation-rules,object-views";
+		}
+
+		task ("Then the actions block include the information for the createBatch action endpoint") {
+			ObjectDefinitionAPI.assertCreateBatchWithGetObjectSchemas(
+				objectDefinitionId = "${objectDefinitionId}",
+				objectSchemas = "${objectSchemas}");
+		}
+	}
+
+}


### PR DESCRIPTION
**Background:**

Add poshi functional tests for story: Expose createBatch action in the Object headless APIs

**Test Plan:**

- When invoking object admin GET "/v1.0/object-definitions"
Then the actions block include the information for the createBatch action endpoin
- Given an object definition is created
When with get request and objectDefinitionId to retrieve objectAction, objectField, objectLayout, objectRelationship, objectValidationRule and objectView
Then the actions block include the information for the createBatch action endpoint
- Given student object definition is created
And Given student entry is created
When invoking getStudentsPage in c/student
Then the actions block include the information for the createBatch action endpoint

**Jira Ticket:**

https://issues.liferay.com/browse/LPS-164345