### PR TITLE
LPS-166106 Add integration test for GrapqhQL Type Extension

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-test/build.gradle
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/build.gradle
@@ -1,4 +1,6 @@
 dependencies {
+	testCompileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+
 	testIntegrationCompile group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.13.2"
 	testIntegrationCompile group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"
 	testIntegrationCompile group: "org.apache.cxf", name: "cxf-core", version: "3.4.4"

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/BaseGraphQLServlet.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/BaseGraphQLServlet.java
@@ -1,0 +1,206 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.internal.graphql.servlet.test;
+
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.servlet.HttpHeaders;
+import com.liferay.portal.kernel.util.Base64;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLTypeExtension;
+import com.liferay.portal.vulcan.graphql.servlet.ServletData;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Luis Miguel Barcos
+ */
+public class BaseGraphQLServlet {
+
+	public static class TestQuery {
+
+		public static void setTestId(long testId) {
+			TestQuery._testId = testId;
+		}
+
+		public static void setTestString(String testString) {
+			TestQuery._testString = testString;
+		}
+
+		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+		public BaseGraphQLServlet.TestQuery.TestDTO testDTO() throws Exception {
+			return new TestDTO() {
+				{
+					id = _testId;
+				}
+			};
+		}
+
+		public static class TestDTO {
+
+			public long getId() {
+				return id;
+			}
+
+			public void setId(long id) {
+				this.id = id;
+			}
+
+			@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+			protected long id;
+
+		}
+
+		@GraphQLTypeExtension(TestDTO.class)
+		public class TestGraphQLTypeExtension {
+
+			public TestGraphQLTypeExtension(TestDTO testDTO) {
+				_testDTO = testDTO;
+			}
+
+			@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+			public String field() {
+				return _testString;
+			}
+
+			private final TestDTO _testDTO;
+
+		}
+
+		private static long _testId;
+		private static String _testString;
+
+	}
+
+	public static class TestServletDataImpl implements ServletData {
+
+		public TestServletDataImpl(long testId, String testString) {
+			TestQuery.setTestId(testId);
+			TestQuery.setTestString(testString);
+		}
+
+		@Override
+		public Object getMutation() {
+			return null;
+		}
+
+		@Override
+		public String getPath() {
+			return "/test-path-graphql/v1.0";
+		}
+
+		@Override
+		public Object getQuery() {
+			return new TestQuery();
+		}
+
+	}
+
+	protected JSONObject invokeGraphQLQuery(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField queryGraphQLField = new GraphQLField(
+			"query", graphQLField);
+
+		return _invoke(queryGraphQLField.toString(), Http.Method.POST);
+	}
+
+	protected static class GraphQLField {
+
+		public GraphQLField(String key, GraphQLField... graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			GraphQLField... graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = Arrays.asList(graphQLFields);
+		}
+
+		@Override
+		public String toString() {
+			StringBuilder sb = new StringBuilder(_key);
+
+			if (!_parameterMap.isEmpty()) {
+				sb.append("(");
+
+				for (Map.Entry<String, Object> entry :
+						_parameterMap.entrySet()) {
+
+					sb.append(entry.getKey());
+					sb.append(": ");
+					sb.append(entry.getValue());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append(")");
+			}
+
+			if (!_graphQLFields.isEmpty()) {
+				sb.append("{");
+
+				for (GraphQLField graphQLField : _graphQLFields) {
+					sb.append(graphQLField.toString());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append("}");
+			}
+
+			return sb.toString();
+		}
+
+		private final List<GraphQLField> _graphQLFields;
+		private final String _key;
+		private final Map<String, Object> _parameterMap;
+
+	}
+
+	private JSONObject _invoke(String query, Http.Method httpMethod)
+		throws Exception {
+
+		Http.Options options = new Http.Options();
+
+		options.addHeader(
+			HttpHeaders.CONTENT_TYPE, ContentTypes.APPLICATION_JSON);
+		options.addHeader(
+			"Authorization",
+			"Basic " + Base64.encode("test@liferay.com:test".getBytes()));
+		options.setBody(
+			new Http.Body(
+				JSONUtil.put(
+					"query", query
+				).toString(),
+				ContentTypes.APPLICATION_JSON, "UTF-8"));
+		options.setLocation("http://localhost:8080/o/graphql");
+		options.setMethod(httpMethod);
+
+		return JSONFactoryUtil.createJSONObject(HttpUtil.URLtoString(options));
+	}
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.internal.graphql.servlet.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.vulcan.graphql.servlet.ServletData;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceRegistration;
+
+/**
+ * @author Luis Miguel Barcos
+ */
+@RunWith(Arquillian.class)
+public class GraphQLServletTest extends BaseGraphQLServlet {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() {
+		Bundle bundle = FrameworkUtil.getBundle(GraphQLServletTest.class);
+
+		BundleContext bundleContext = bundle.getBundleContext();
+
+		_serviceRegistration = bundleContext.registerService(
+			ServletData.class,
+			new TestServletDataImpl(_RANDOM_ID, _RANDOM_STRING), null);
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+		_serviceRegistration.unregister();
+	}
+
+	@Test
+	public void testGetDataFromGraphQLTypeExtension() throws Exception {
+		GraphQLField graphQLField = new GraphQLField(
+			"testDTO", new GraphQLField("id"), new GraphQLField("field"));
+
+		JSONObject testJSONObject = JSONUtil.getValueAsJSONObject(
+			invokeGraphQLQuery(graphQLField), "JSONObject/data",
+			"JSONObject/testDTO");
+
+		Assert.assertEquals(testJSONObject.get("id"), _RANDOM_ID);
+
+		Assert.assertEquals(testJSONObject.get("field"), _RANDOM_STRING);
+	}
+
+	private static final long _RANDOM_ID = RandomTestUtil.randomLong();
+
+	private static final String _RANDOM_STRING = RandomTestUtil.randomString();
+
+	private static ServiceRegistration<ServletData> _serviceRegistration;
+
+}


### PR DESCRIPTION
Related ticket -> [LPS-166106](https://issues.liferay.com/browse/LPS-166106)
____
## Purpose of the PR
This PR adds the infrastructure and a test to ensure that a Graphql request gets the information added by the annotation `GraphQLTypeExtension`