### PR TITLE
LPS-163249 Failed to download original file of export task in import/export center

### DIFF
--- a/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/display/context/BatchPlannerPlanDisplayContext.java
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/display/context/BatchPlannerPlanDisplayContext.java
@@ -185,18 +185,20 @@ public class BatchPlannerPlanDisplayContext extends BaseDisplayContext {
 		BatchPlannerPlanDisplay.Builder builder =
 			new BatchPlannerPlanDisplay.Builder();
 
-		builder.batchPlannerPlanId(
+		builder.action(
+			_getAction(batchPlannerPlan.isExport())
+		).batchPlannerPlanId(
 			batchPlannerPlan.getBatchPlannerPlanId()
 		).createDate(
 			batchPlannerPlan.getCreateDate()
+		).export(
+			batchPlannerPlan.isExport()
 		).internalClassName(
 			batchPlannerPlan.getInternalClassName()
 		).title(
 			batchPlannerPlan.getName()
 		).userId(
 			batchPlannerPlan.getUserId()
-		).action(
-			_getAction(batchPlannerPlan.isExport())
 		).status(
 			BatchPlannerPlanConstants.STATUS_INACTIVE
 		);

--- a/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/batch_planner_plan_action.jsp
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/batch_planner_plan_action.jsp
@@ -70,4 +70,25 @@ BatchPlannerPlanDisplay batchPlannerPlanDisplay = (BatchPlannerPlanDisplay)resul
 			module="js/DownloadHelper"
 		/>
 	</c:if>
+
+	<c:if test="<%= batchPlannerPlanDisplay.isStatusCompleted() && batchPlannerPlanDisplay.isExport() %>">
+		<liferay-ui:icon
+			id='<%= "downloadExportFile" + batchPlannerPlanDisplay.getBatchPlannerPlanId() %>'
+			message="download-file"
+			url="#"
+		/>
+
+		<liferay-frontend:component
+			context='<%=
+				HashMapBuilder.<String, Object>put(
+					"externalReferenceCode", batchPlannerPlanDisplay.getBatchPlannerPlanId()
+				).put(
+					"HTMLElementId", liferayPortletResponse.getNamespace() + "downloadExportFile" + batchPlannerPlanDisplay.getBatchPlannerPlanId()
+				).put(
+					"type", "exportFile"
+				).build()
+			%>'
+			module="js/DownloadHelper"
+		/>
+	</c:if>
 </liferay-ui:icon-menu>

--- a/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/DownloadHelper.js
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/DownloadHelper.js
@@ -20,6 +20,7 @@ const getEndpoint = (type, externalReferenceCode) => {
 	const endpoints = {
 		batchPlannerTemplate: `/o/batch-planner/v1.0/plans/${externalReferenceCode}/template`,
 		errorReport: `${HEADLESS_BATCH_ENGINE_URL}/import-task/by-external-reference-code/${externalReferenceCode}/failed-items/report`,
+		exportFile: `${HEADLESS_BATCH_ENGINE_URL}/export-task/by-external-reference-code/${externalReferenceCode}/content`,
 		importFile: `${HEADLESS_BATCH_ENGINE_URL}/import-task/by-external-reference-code/${externalReferenceCode}/content`,
 	};
 


### PR DESCRIPTION
Hi team,
This is related to the ticket: https://issues.liferay.com/browse/LPS-163249
The issue occurs because it missing the download file for the export type.
cc: @ces-huynguyen