### PR TITLE
LPS-166071 Add tests for more batch actions in object admin api and update related macro file

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/objects/ObjectDefinitionAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/objects/ObjectDefinitionAPI.macro
@@ -428,31 +428,44 @@ definition {
 		return "${response}";
 	}
 
-	macro assertCreateBatchInActionBlock {
-		Variables.assertDefined(parameterList = "${responseToParse}");
+	macro assertBatchActionsInResponse {
+		Variables.assertDefined(parameterList = "${responseToParse},${batchActions}");
 
-		var actualBatch = JSONUtil.getWithJSONPath("${responseToParse}", "$.actions.createBatch");
-		var portalURL = JSONCompany.getPortalURL();
+		for (var batchAction : list "${batchActions}") {
+			var portalURL = JSONCompany.getPortalURL();
 
-		if (isSet(objectDefinitionId)) {
-			var href = "${portalURL}/o/object-admin/v1.0/object-definitions/${objectDefinitionId}/${objectSchema}/batch";
+			if (isSet(objectSchema)) {
+				var expectedHref = "${portalURL}/o/object-admin/v1.0/${objectSchema}/batch";
+			}
+			else if (isSet(en_US_plural_label)) {
+				var expectedHref = "${portalURL}/o/c/${en_US_plural_label}/batch";
+			}
+			else {
+				var expectedHref = "${portalURL}/o/object-admin/v1.0/object-definitions/batch";
+			}
+
+			if ("${batchAction}" == "updateBatch") {
+				var actualHref = JSONUtil.getWithJSONPath("${responseToParse}", "$.actions.updateBatch[?(@.method == 'PUT')].href");
+			}
+			else if ("${batchAction}" == "deleteBatch") {
+				var actualHref = JSONUtil.getWithJSONPath("${responseToParse}", "$.actions.deleteBatch[?(@.method == 'DELETE')].href");
+			}
+			else {
+				var actualHref = JSONUtil.getWithJSONPath("${responseToParse}", "$.actions.createBatch[?(@.method == 'POST')].href");
+
+				if (isSet(objectDefinitionId)) {
+					var expectedHref = "${portalURL}/o/object-admin/v1.0/object-definitions/${objectDefinitionId}/${objectSchema}/batch";
+				}
+			}
+
+			TestUtils.assertEquals(
+				actual = "${actualHref}",
+				expected = "${expectedHref}");
 		}
-		else if (isSet(en_US_plural_label)) {
-			var href = "${portalURL}/o/c/${en_US_plural_label}/batch";
-		}
-		else {
-			var href = "${portalURL}/o/object-admin/v1.0/object-definitions/batch";
-		}
-
-		var expectedBatch = StringUtil.add("{method=POST,", " href=${href}}", "");
-
-		TestUtils.assertEquals(
-			actual = "${actualBatch}",
-			expected = "${expectedBatch}");
 	}
 
-	macro assertCreateBatchWithGetObjectSchemas {
-		Variables.assertDefined(parameterList = "${objectDefinitionId},${objectSchemas}");
+	macro assertBatchActionsWithGetObjectSchemas {
+		Variables.assertDefined(parameterList = "${objectDefinitionId},${objectSchemas},${batchActions}");
 
 		var portalURL = JSONCompany.getPortalURL();
 
@@ -465,7 +478,8 @@ definition {
 
 			var response = JSONCurlUtil.get("${curl}");
 
-			ObjectDefinitionAPI.assertCreateBatchInActionBlock(
+			ObjectDefinitionAPI.assertBatchActionsInResponse(
+				batchActions = "${batchActions}",
 				objectDefinitionId = "${objectDefinitionId}",
 				objectSchema = "${objectSchema}",
 				responseToParse = "${response}");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/ExposeBatchActionForObjectAdminAPI.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/ExposeBatchActionForObjectAdminAPI.testcase
@@ -7,6 +7,10 @@ definition {
 
 	setUp {
 		TestCase.setUpPortalInstanceNoSelenium();
+
+		task ("Given an object definition is created") {
+			ObjectDefinitionAPI.setUpGlobalobjectDefinitionId();
+		}
 	}
 
 	tearDown {
@@ -14,7 +18,65 @@ definition {
 			PortalInstances.tearDownCP();
 		}
 		else {
+			ObjectAdmin.deleteObjectViaAPI(objectName = "University");
+
 			ObjectAdmin.deleteObjectViaAPI(objectName = "Subject");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = "4"
+	test IncludeBatchActionsForObjectDefinition {
+		property portal.acceptance = "true";
+
+		task ("When invoking object admin GET '/v1.0/object-definition'") {
+			var response = ObjectDefinitionAPI.getObjectDefinitions();
+		}
+
+		task ("Then the actions block include the information for the updateBatch, deleteBatch action endpoint") {
+			ObjectDefinitionAPI.assertBatchActionsInResponse(
+				batchActions = "updateBatch,deleteBatch",
+				responseToParse = "${response}");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = "4"
+	test IncludeBatchActionsForObjectEntries {
+		property portal.acceptance = "true";
+
+		task ("And Given subject entry is created") {
+			var subjectId = ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "subjects",
+				name = "Liferay Foundations");
+		}
+
+		task ("When invoking getStudentsPage in c/subjects") {
+			var response = ObjectDefinitionAPI.getObjectEntries(en_US_plural_label = "subjects");
+		}
+
+		task ("Then the actions block include the information for the updateBatch, deleteBatch action endpoint") {
+			ObjectDefinitionAPI.assertBatchActionsInResponse(
+				batchActions = "updateBatch,deleteBatch",
+				en_US_plural_label = "subjects",
+				responseToParse = "${response}");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = "4"
+	test IncludeBatchActionsForObjectSchemas {
+		property portal.acceptance = "true";
+
+		task ("When with get request and objectDefinitionId to retrieve objectAction, objectField, objectLayout, objectRelationship, objectValidationRule and objectView") {
+			var objectSchemas = "object-actions,object-fields,object-layouts,object-relationships,object-validation-rules,object-views";
+		}
+
+		task ("Then the actions block include the information for the updatebatch, deleteBatch action endpoint") {
+			ObjectDefinitionAPI.assertBatchActionsWithGetObjectSchemas(
+				batchActions = "updateBatch,deleteBatch",
+				objectDefinitionId = "${staticObjectId1}",
+				objectSchemas = "${objectSchemas}");
 		}
 	}
 
@@ -28,7 +90,9 @@ definition {
 		}
 
 		task ("Then the actions block include the information for the createBatch action endpoint") {
-			ObjectDefinitionAPI.assertCreateBatchInActionBlock(responseToParse = "${response}");
+			ObjectDefinitionAPI.assertBatchActionsInResponse(
+				batchActions = "createBatch",
+				responseToParse = "${response}");
 		}
 	}
 
@@ -36,14 +100,6 @@ definition {
 	@priority = "4"
 	test IncludeCreateBatchInActionsForObjectEntries {
 		property portal.acceptance = "true";
-
-		task ("Given subject object definition is created") {
-			ObjectDefinitionAPI.createAndPublishObjectDefinition(
-				en_US_label = "subject",
-				en_US_plural_label = "subjects",
-				name = "Subject",
-				requiredStringFieldName = "name");
-		}
 
 		task ("And Given subject entry is created") {
 			var subjectId = ObjectDefinitionAPI.createObjectEntryWithName(
@@ -56,7 +112,8 @@ definition {
 		}
 
 		task ("Then the actions block include the information for the createBatch action endpoint") {
-			ObjectDefinitionAPI.assertCreateBatchInActionBlock(
+			ObjectDefinitionAPI.assertBatchActionsInResponse(
+				batchActions = "createBatch",
 				en_US_plural_label = "subjects",
 				responseToParse = "${response}");
 		}
@@ -67,21 +124,14 @@ definition {
 	test IncludeCreateBatchInActionsForObjectSchemas {
 		property portal.acceptance = "true";
 
-		task ("Given an object definition is created") {
-			var objectDefinitionId = ObjectDefinitionAPI.createAndPublishObjectDefinition(
-				en_US_label = "subject",
-				en_US_plural_label = "subjects",
-				name = "Subject",
-				requiredStringFieldName = "name");
-		}
-
 		task ("When with get request and objectDefinitionId to retrieve objectAction, objectField, objectLayout, objectRelationship, objectValidationRule and objectView") {
 			var objectSchemas = "object-actions,object-fields,object-layouts,object-relationships,object-validation-rules,object-views";
 		}
 
 		task ("Then the actions block include the information for the createBatch action endpoint") {
-			ObjectDefinitionAPI.assertCreateBatchWithGetObjectSchemas(
-				objectDefinitionId = "${objectDefinitionId}",
+			ObjectDefinitionAPI.assertBatchActionsWithGetObjectSchemas(
+				batchActions = "createBatch",
+				objectDefinitionId = "${staticObjectId1}",
 				objectSchemas = "${objectSchemas}");
 		}
 	}


### PR DESCRIPTION
**Background:**

- Add poshi functional tests for story: Expose updateBatch/deleteBatch action in the Object headless APIs

**Test Plan:**
- When invoking object admin GET "/v1.0/object-definitions"
Then the actions block include the information for the updateBatch, deleteBatch action endpoint
- Given an object definition is created
When with get request and objectDefinitionId to retrieve objectAction, objectField, objectLayout, objectRelationship, objectValidationRule and objectView
Then the actions block include the information for the updateBatch,deleteBatch action endpoint
- Given student object definition is created
And Given student entry is created
When invoking getStudentsPage in c/student
Then the actions block include the information for the updateBatch,deleteBatch action endpoint

**Jira Ticket:**

- https://issues.liferay.com/browse/LPS-166071