### PR TITLE
LPS-168240 batch-engine - put delegateName to parameters

### DIFF
--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineImportTaskExecutorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineImportTaskExecutorImpl.java
@@ -49,8 +49,8 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import java.io.Serializable;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -156,6 +156,23 @@ public class BatchEngineImportTaskExecutorImpl
 		return batchEngineTaskCompanyConfiguration.csvFileColumnDelimiter();
 	}
 
+	private Map<String, Serializable> _getParameters(
+		BatchEngineImportTask batchEngineImportTask) {
+
+		Map<String, Serializable> parameters =
+			batchEngineImportTask.getParameters();
+
+		if (parameters == null) {
+			parameters = new HashMap<>();
+		}
+
+		parameters.computeIfAbsent(
+			"taskItemDelegateName",
+			f -> batchEngineImportTask.getTaskItemDelegateName());
+
+		return parameters;
+	}
+
 	private void _handleException(
 			BatchEngineImportTask batchEngineImportTask, Exception exception,
 			int processedItemsCount)
@@ -177,12 +194,8 @@ public class BatchEngineImportTaskExecutorImpl
 	private void _importItems(BatchEngineImportTask batchEngineImportTask)
 		throws Throwable {
 
-		Map<String, Serializable> parameters =
-			batchEngineImportTask.getParameters();
-
-		if (parameters == null) {
-			parameters = Collections.emptyMap();
-		}
+		Map<String, Serializable> parameters = _getParameters(
+			batchEngineImportTask);
 
 		try (BatchEngineImportTaskItemReader batchEngineImportTaskItemReader =
 				_batchEngineImportTaskItemReaderFactory.create(


### PR DESCRIPTION
Problem ObjectEntry and ObjectDefinition Resources are common for all Custom Objects. Beside the fact that Batch Engine properly routes execution to this resources, extra configuring is necessary to tell the name of custom object.

Only way for object-rest to know how to resolve correct objectDefinition is to pass batchEngineDelegateName in parameters. REMINDER: in the case of custom object delegate name contains Custom Object technical name and ObjectEntryResourceImpl relies to it to extract DefinitionName

This only reflects Liferay Objects, and presence of delegate name in parameters won't influence other delegates.

In my opinion, Liferay Objects should have dedicated batch module as we are continue pollute code with IFs just to make excellent batch engine code to work with LO.