### PR TITLE
Product QA | Automation Test Creation - LPS-153326 - Allow developers to make a relationship with a system object through API

### DIFF
--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectDefinitionAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectDefinitionAPI.macro
@@ -337,7 +337,12 @@ definition {
 			-u test@liferay.com:test
 		''';
 
-		var relationshipId = JSONCurlUtil.get("${curl}", "$..['id']");
+		if (isSet(relationshipName)) {
+			var relationshipId = JSONCurlUtil.get("${curl}");
+		}
+		else {
+			var relationshipId = JSONCurlUtil.get("${curl}", "$..['id']");
+		}
 
 		return "${relationshipId}";
 	}
@@ -675,7 +680,19 @@ definition {
 	}
 
 	macro deleteRelationship {
-		var relationshipId = ObjectDefinitionAPI._getRelationshipId(objectDefinitionId = "${objectDefinitionId}");
+		if (isSet(relationshipName)) {
+			var relationshipName = "${relationshipName}";
+			var objectDefinitionId = ObjectDefinitionAPI.getObjectDefinitionIdByName(name = "${name}");
+
+			var response = ObjectDefinitionAPI._getRelationshipId(
+				objectDefinitionId = "${objectDefinitionId}",
+				relationshipName = "${relationshipName}");
+
+			var relationshipId = JSONUtil.getWithJSONPath("${response}", "$..items[?(@.name=='${relationshipName}')]..id");
+		}
+		else {
+			var relationshipId = ObjectDefinitionAPI._getRelationshipId(objectDefinitionId = "${objectDefinitionId}");
+		}
 
 		ObjectDefinitionAPI._deleteRelationship(relationshipId = "${relationshipId}");
 	}
@@ -788,6 +805,33 @@ definition {
 		return "${staticObjectId1}";
 
 		return "${staticObjectId2}";
+	}
+
+	macro setUpGlobalObjectEntryId {
+		var objectEntryId1 = ObjectDefinitionAPI.createObjectEntryWithName(
+			en_US_plural_label = "foundations",
+			name = "Foundation First");
+		var objectEntryId2 = ObjectDefinitionAPI.createObjectEntryWithName(
+			en_US_plural_label = "foundations",
+			name = "Foundation Second");
+		var objectEntryId3 = ObjectDefinitionAPI.createObjectEntryWithName(
+			en_US_plural_label = "secondFoundations",
+			name = "Foundation First-1");
+		var objectEntryId4 = ObjectDefinitionAPI.createObjectEntryWithName(
+			en_US_plural_label = "secondFoundations",
+			name = "Foundation Second-1");
+		static var staticObjectEntryId1 = "${objectEntryId1}";
+		static var staticObjectEntryId2 = "${objectEntryId2}";
+		static var staticObjectEntryId3 = "${objectEntryId3}";
+		static var staticObjectEntryId4 = "${objectEntryId4}";
+
+		return "${staticObjectEntryId1}";
+
+		return "${staticObjectEntryId2}";
+
+		return "${staticObjectEntryId3}";
+
+		return "${staticObjectEntryId4}";
 	}
 
 	macro updateEmployee {

--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/UserAccountAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/UserAccountAPI.macro
@@ -5,6 +5,13 @@ definition {
 
 		if (isSet(userAccountId)) {
 			var api = "user-accounts/${userAccountId}";
+
+			if (isSet(customObjectId)) {
+				var api = "user-accounts/${userAccountId}/${relationshipName}/${customObjectId}";
+			}
+			else {
+				var api = "user-accounts/${userAccountId}/${relationshipName}";
+			}
 		}
 		else {
 			var api = "user-accounts";
@@ -18,6 +25,34 @@ definition {
 		''';
 
 		return "${curl}";
+	}
+
+	macro assertResponseHasCorrectRelatedEntryName {
+		Variables.assertDefined(parameterList = "${userAccountId},${relationshipName},${expectedValue}");
+
+		var response = UserAccountAPI.getRelationshipByUserAccountId(
+			relationshipName = "${relationshipName}",
+			userAccountId = "${userAccountId}");
+
+		var actual = JSONUtil.getWithJSONPath("${response}", "$.items[?(@.id==${customObjectEntryId})].name");
+
+		TestUtils.assertEquals(
+			actual = "${actual}",
+			expected = "${expectedValue}");
+	}
+
+	macro assertResponseNotIncludeDetailsOfDeletedObjectEntry {
+		Variables.assertDefined(parameterList = "${userAccountId},${relationshipName},${expectedValue}");
+
+		var response = UserAccountAPI.getRelationshipByUserAccountId(
+			relationshipName = "${relationshipName}",
+			userAccountId = "${userAccountId}");
+
+		var actual = JSONUtil.getWithJSONPath("${response}", "$..items");
+
+		TestUtils.assertEquals(
+			actual = "${actual}",
+			expected = "${expectedValue}");
 	}
 
 	macro createUserAccount {
@@ -37,17 +72,21 @@ definition {
 		return "${response}";
 	}
 
-	macro deleteUserAccount {
-		var curl = UserAccountAPI._curlUserAccount(userAccountId = "${staticUserAccountId}");
+	macro getRelationshipByUserAccountId {
+		var curl = UserAccountAPI._curlUserAccount(
+			relationshipName = "${relationshipName}",
+			userAccountId = "${userAccountId}");
 
-		JSONCurlUtil.delete("${curl}");
+		var response = JSONCurlUtil.get("${curl}");
+
+		return "${response}";
 	}
 
 	macro getUpdatedFieldOfUserAccountWithPatchRequest {
 		Variables.assertDefined(parameterList = "${fieldName},${updatedFieldValue}");
 
 		if (!(isSet(userAccountId))) {
-			var userAccountId = "${staticUserAccountId}";
+			var userAccountId = "${UserAccountId}";
 		}
 
 		var curl = UserAccountAPI._curlUserAccount(userAccountId = "${userAccountId}");
@@ -64,7 +103,7 @@ definition {
 		Variables.assertDefined(parameterList = "${alternateName},${emailAddress},${familyName},${givenName},${fieldName},${updatedFieldValue}");
 
 		if (!(isSet(userAccountId))) {
-			var userAccountId = "${staticUserAccountId}";
+			var userAccountId = "${UserAccountId}";
 		}
 
 		var curl = UserAccountAPI._curlUserAccount(userAccountId = "${userAccountId}");
@@ -85,18 +124,46 @@ definition {
 		return "${valueOfField}";
 	}
 
-	macro setUpGlobalUserAccountId {
-		var response = UserAccountAPI.createUserAccount(
-			alternateName = "${alternateName}",
-			emailAddress = "${emailAddress}",
-			familyName = "${familyName}",
-			fieldName = "${fieldName}",
-			fieldValue = "${fieldValue}",
-			givenName = "${givenName}");
+	macro relateObjectEntries {
+		Variables.assertDefined(parameterList = "${userAccountId},${customObjectId},${relationshipName}");
 
-		static var staticUserAccountId = JSONUtil.getWithJSONPath("${response}", "$.id");
+		var curl = UserAccountAPI._curlUserAccount(
+			customObjectId = "${customObjectId}",
+			relationshipName = "${relationshipName}",
+			userAccountId = "${userAccountId}");
+
+		var response = JSONCurlUtil.put("${curl}");
 
 		return "${response}";
+	}
+
+	macro setUpGlobalUserAccountId {
+		var response1 = UserAccountAPI.createUserAccount(
+			alternateName = "${alternateName1}",
+			emailAddress = "${emailAddress1}",
+			familyName = "${familyName1}",
+			fieldName = "${fieldName1}",
+			fieldValue = "${fieldValue1}",
+			givenName = "${givenName1}");
+		var response2 = UserAccountAPI.createUserAccount(
+			alternateName = "${alternateName2}",
+			emailAddress = "${emailAddress2}",
+			familyName = "${familyName2}",
+			fieldName = "${fieldName2}",
+			fieldValue = "${fieldValue2}",
+			givenName = "${givenName2}");
+		static var staticUserAccountId1 = JSONUtil.getWithJSONPath("${response1}", "$.id");
+		static var staticUserAccountId2 = JSONUtil.getWithJSONPath("${response2}", "$.id");
+		static var staticResponse1 = "${response1}";
+		static var staticResponse2 = "${response2}";
+
+		return "${staticResponse1}";
+
+		return "${staticResponse2}";
+
+		return "${staticUserAccountId1}";
+
+		return "${staticUserAccountId2}";
 	}
 
 }

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/ExtendPropertiesForSystemObjects.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/ExtendPropertiesForSystemObjects.testcase
@@ -17,10 +17,26 @@ definition {
 				name = "passportNumber",
 				objectDefinitionId = "${userObjectId}");
 		}
+
+		task ("When with post request postUserAccount to create a user with the new field") {
+			UserAccountAPI.setUpGlobalUserAccountId(
+				alternateName1 = "userln",
+				alternateName2 = "user2",
+				emailAddress1 = "userln@liferay.com",
+				emailAddress2 = "user2@liferay.com",
+				familyName1 = "userfn",
+				familyName2 = "userfn2",
+				fieldName1 = "passportNumber",
+				fieldValue1 = "passportNum2022",
+				givenName1 = "usergn",
+				givenName2 = "usergn2");
+		}
 	}
 
 	tearDown {
-		UserAccountAPI.deleteUserAccount();
+		for (var userId : list "${staticUserAccountId1},${staticUserAccountId2}") {
+			JSONUser.deleteUserByUserId(userId = "${userId}");
+		}
 
 		ObjectFieldAPI.deleteObjectField();
 	}
@@ -30,18 +46,8 @@ definition {
 	test CanCreateUserAndSetValueOfPropertyAddedtoSystemObject {
 		property portal.acceptance = "true";
 
-		task ("When with post request postUserAccount to create a user with the new field") {
-			var response = UserAccountAPI.setUpGlobalUserAccountId(
-				alternateName = "userln",
-				emailAddress = "userln@liferay.com",
-				familyName = "userfn",
-				fieldName = "passportNumber",
-				fieldValue = "passportNum2022",
-				givenName = "usergn");
-		}
-
 		task ("Then the value of the added field is set successfully in response") {
-			var actualValueOfPassportNumber = JSONUtil.getWithJSONPath("${response}", "$.passportNumber");
+			var actualValueOfPassportNumber = JSONUtil.getWithJSONPath("${staticResponse1}", "$.passportNumber");
 
 			TestUtils.assertEquals(
 				actual = "${actualValueOfPassportNumber}",
@@ -54,20 +60,11 @@ definition {
 	test CanUpdateValueOfPropertyAddedToSystemObjectWithPatchRequest {
 		property portal.acceptance = "true";
 
-		task ("And Given with post request postUserAccount to create a user with the new field") {
-			UserAccountAPI.setUpGlobalUserAccountId(
-				alternateName = "userln",
-				emailAddress = "userln@liferay.com",
-				familyName = "userfn",
-				fieldName = "passportNumber",
-				fieldValue = "passportNum2022",
-				givenName = "usergn");
-		}
-
 		task ("When with PATCH request and existingUserAccountId I update the value of the new field") {
 			var actualValueOfPassportNumber = UserAccountAPI.getUpdatedFieldOfUserAccountWithPatchRequest(
 				fieldName = "passportNumber",
-				updatedFieldValue = "updateByPatch-passportNum2022");
+				updatedFieldValue = "updateByPatch-passportNum2022",
+				userAccountId = "${staticUserAccountId1}");
 		}
 
 		task ("Then the value of the added filed is updated successfully") {
@@ -82,16 +79,6 @@ definition {
 	test CanUpdateValueOfPropertyAddedToSystemObjectWithPutRequest {
 		property portal.acceptance = "true";
 
-		task ("And Given with post request postUserAccount to create a user with the new field") {
-			UserAccountAPI.setUpGlobalUserAccountId(
-				alternateName = "userln",
-				emailAddress = "userln@liferay.com",
-				familyName = "userfn",
-				fieldName = "passportNumber",
-				fieldValue = "passportNum2022",
-				givenName = "usergn");
-		}
-
 		task ("When with PUT request and existingUserAccountId I update the value of the new field") {
 			var actualValueOfPassportNumber = UserAccountAPI.getUpdatedFieldOfUserAccountWithPutRequest(
 				alternateName = "userln",
@@ -99,7 +86,8 @@ definition {
 				familyName = "userfn",
 				fieldName = "passportNumber",
 				givenName = "usergn",
-				updatedFieldValue = "updateByPut-passportNum2022");
+				updatedFieldValue = "updateByPut-passportNum2022",
+				userAccountId = "${staticUserAccountId1}");
 		}
 
 		task ("Then the value of the added filed is replaced successfully in response") {

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/MakeRelationshipWithSystemObject.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/MakeRelationshipWithSystemObject.testcase
@@ -1,0 +1,257 @@
+@component-name = "portal-headless"
+definition {
+
+	property custom.properties = "feature.flag.LPS-162964=true${line.separator}feature.flag.LPS-153324=true";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Object";
+	property testray.main.component.name = "Headless";
+
+	setUp {
+		TestCase.setUpPortalInstanceNoSelenium();
+
+		task ("Given a Foundation object") {
+			var objectDefinitionId2 = ObjectDefinitionAPI.createAndPublishObjectDefinition(
+				en_US_label = "foundation",
+				en_US_plural_label = "foundations",
+				name = "Foundation",
+				requiredStringFieldName = "name");
+		}
+
+		task ("Given a secondFoundation object") {
+			var objectDefinitionId3 = ObjectDefinitionAPI.createAndPublishObjectDefinition(
+				en_US_label = "secondFoundation",
+				en_US_plural_label = "secondFoundations",
+				name = "SecondFoundation",
+				requiredStringFieldName = "name");
+		}
+
+		task ("Given manyToMany relationship usersFoundations created") {
+			var objectDefinitionId1 = ObjectDefinitionAPI.getObjectDefinitionIdByName(name = "User");
+
+			var relationshipName = ObjectDefinitionAPI.createRelationship(
+				deletionType = "cascade",
+				en_US_label = "UsersFoundations",
+				name = "usersFoundations",
+				objectDefinitionId1 = "${objectDefinitionId1}",
+				objectDefinitionId2 = "${objectDefinitionId2}",
+				type = "manyToMany");
+		}
+
+		task ("Given oneToMany relationship userSecondFoundations created") {
+			var relationshipName = ObjectDefinitionAPI.createRelationship(
+				deletionType = "cascade",
+				en_US_label = "UserSecondFoundations",
+				name = "userSecondFoundations",
+				objectDefinitionId1 = "${objectDefinitionId1}",
+				objectDefinitionId2 = "${objectDefinitionId3}",
+				type = "oneToMany");
+		}
+
+		task ("Given object entries created") {
+			ObjectDefinitionAPI.setUpGlobalObjectEntryId();
+		}
+
+		task ("Given two userAccount entries created") {
+			UserAccountAPI.setUpGlobalUserAccountId(
+				alternateName1 = "user1",
+				alternateName2 = "user2",
+				emailAddress1 = "user1@liferay.com",
+				emailAddress2 = "user2@liferay.com",
+				familyName1 = "userfn1",
+				familyName2 = "userfn2",
+				givenName1 = "usergn1",
+				givenName2 = "usergn2");
+		}
+	}
+
+	tearDown {
+		for (var relationshipName : list "usersFoundations,userSecondFoundations") {
+			ObjectDefinitionAPI.deleteRelationship(
+				name = "User",
+				relationshipName = "${relationshipName}");
+		}
+
+		for (var objectName : list "Foundation,SecondFoundation") {
+			ObjectAdmin.deleteObjectViaAPI(objectName = "${objectName}");
+		}
+
+		for (var userId : list "${staticUserAccountId1},${staticUserAccountId2}") {
+			JSONUser.deleteUserByUserId(userId = "${userId}");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = "4"
+	test CanDeleteCustomObjectEntryRelaatedToSystemObjectByManyToMany {
+		property portal.acceptance = "true";
+
+		task ("Given each foundation is related to each userAccount through userAccounts PUT endpoint") {
+			UserAccountAPI.relateObjectEntries(
+				customObjectId = "${staticObjectEntryId1}",
+				relationshipName = "usersFoundations",
+				userAccountId = "${staticUserAccountId1}");
+
+			UserAccountAPI.relateObjectEntries(
+				customObjectId = "${staticObjectEntryId2}",
+				relationshipName = "usersFoundations",
+				userAccountId = "${staticUserAccountId2}");
+		}
+
+		task ("When deleting one of the foundation entries") {
+			ObjectDefinitionAPI.deleteObjectEntry(
+				en_US_plural_label = "foundations",
+				objectEntryId = "${staticObjectEntryId1}");
+		}
+
+		task ("Then I can see only one entry correctly related in GET request response") {
+			UserAccountAPI.assertResponseNotIncludeDetailsOfDeletedObjectEntry(
+				expectedValue = "[]",
+				relationshipName = "usersFoundations",
+				userAccountId = "${staticUserAccountId1}");
+
+			UserAccountAPI.assertResponseHasCorrectRelatedEntryName(
+				customObjectEntryId = "${staticObjectEntryId2}",
+				expectedValue = "Foundation Second",
+				relationshipName = "usersFoundations",
+				userAccountId = "${staticUserAccountId2}");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = "4"
+	test CanDeleteCustomObjectEntryRelatedToSystemObjectByOneToMany {
+		property portal.acceptance = "true";
+
+		task ("Given I relate all the foundation entries with the userAccount entry through the userAccount PUT endpoint") {
+			UserAccountAPI.relateObjectEntries(
+				customObjectId = "${staticObjectEntryId3}",
+				relationshipName = "userSecondFoundations",
+				userAccountId = "${staticUserAccountId1}");
+
+			UserAccountAPI.relateObjectEntries(
+				customObjectId = "${staticObjectEntryId4}",
+				relationshipName = "userSecondFoundations",
+				userAccountId = "${staticUserAccountId1}");
+		}
+
+		task ("When deleting one of the foundation entries") {
+			ObjectDefinitionAPI.deleteObjectEntry(
+				en_US_plural_label = "userSecondFoundations",
+				objectEntryId = "${staticObjectEntryId3}");
+		}
+
+		task ("Then I can see only one entry correctly related in GET request response") {
+			UserAccountAPI.assertResponseHasCorrectRelatedEntryName(
+				customObjectEntryId = "${staticObjectEntryId4}",
+				expectedValue = "Foundation Second-1",
+				relationshipName = "userSecondFoundations",
+				userAccountId = "${staticUserAccountId1}");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = "4"
+	test CanRelateCustomObjectEntriesToSystemObjectEntries {
+		property portal.acceptance = "true";
+
+		task ("When I relate each foundation entry with the userAccount entry through the userAccount PUT endpoint with different relationships") {
+			UserAccountAPI.relateObjectEntries(
+				customObjectId = "${staticObjectEntryId1}",
+				relationshipName = "usersFoundations",
+				userAccountId = "${staticUserAccountId1}");
+
+			UserAccountAPI.relateObjectEntries(
+				customObjectId = "${staticObjectEntryId4}",
+				relationshipName = "userSecondFoundations",
+				userAccountId = "${staticUserAccountId1}");
+		}
+
+		task ("Then I can see the two entries correctly related in GET request response") {
+			UserAccountAPI.assertResponseHasCorrectRelatedEntryName(
+				customObjectEntryId = "${staticObjectEntryId1}",
+				expectedValue = "Foundation First",
+				relationshipName = "usersFoundations",
+				userAccountId = "${staticUserAccountId1}");
+
+			UserAccountAPI.assertResponseHasCorrectRelatedEntryName(
+				customObjectEntryId = "${staticObjectEntryId4}",
+				expectedValue = "Foundation Second-1",
+				relationshipName = "userSecondFoundations",
+				userAccountId = "${staticUserAccountId1}");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = "4"
+	test CanRelateCustomObjectEntriesToSystemObjectEntriesByManyToMany {
+		property portal.acceptance = "true";
+
+		task ("When each foundation is related to each userAccount through userAccounts PUT endpoint") {
+			UserAccountAPI.relateObjectEntries(
+				customObjectId = "${staticObjectEntryId1}",
+				relationshipName = "usersFoundations",
+				userAccountId = "${staticUserAccountId1}");
+
+			UserAccountAPI.relateObjectEntries(
+				customObjectId = "${staticObjectEntryId2}",
+				relationshipName = "usersFoundations",
+				userAccountId = "${staticUserAccountId2}");
+		}
+
+		task ("Then I can see the entry correctly related in GET request response") {
+			UserAccountAPI.assertResponseHasCorrectRelatedEntryName(
+				customObjectEntryId = "${staticObjectEntryId1}",
+				expectedValue = "Foundation First",
+				relationshipName = "usersFoundations",
+				userAccountId = "${staticUserAccountId1}");
+
+			UserAccountAPI.assertResponseHasCorrectRelatedEntryName(
+				customObjectEntryId = "${staticObjectEntryId2}",
+				expectedValue = "Foundation Second",
+				relationshipName = "usersFoundations",
+				userAccountId = "${staticUserAccountId2}");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = "4"
+	test DeletedObjectEntriesDoNotAppearInManyToManyRelationshipDetails {
+		property portal.acceptance = "true";
+
+		task ("Given each foundation is related to each userAccount through userAccounts PUT endpoint") {
+			UserAccountAPI.relateObjectEntries(
+				customObjectId = "${staticObjectEntryId1}",
+				relationshipName = "usersFoundations",
+				userAccountId = "${staticUserAccountId1}");
+
+			UserAccountAPI.relateObjectEntries(
+				customObjectId = "${staticObjectEntryId2}",
+				relationshipName = "usersFoundations",
+				userAccountId = "${staticUserAccountId2}");
+		}
+
+		task ("When deleting all of the foundation entries") {
+			ObjectDefinitionAPI.deleteObjectEntry(
+				en_US_plural_label = "foundations",
+				objectEntryId = "${staticObjectEntryId1}");
+
+			ObjectDefinitionAPI.deleteObjectEntry(
+				en_US_plural_label = "foundations",
+				objectEntryId = "${staticObjectEntryId2}");
+		}
+
+		task ("Then I can see only one entry correctly related in GET request response") {
+			UserAccountAPI.assertResponseNotIncludeDetailsOfDeletedObjectEntry(
+				expectedValue = "[]",
+				relationshipName = "usersFoundations",
+				userAccountId = "${staticUserAccountId1}");
+
+			UserAccountAPI.assertResponseNotIncludeDetailsOfDeletedObjectEntry(
+				expectedValue = "[]",
+				relationshipName = "usersFoundations",
+				userAccountId = "${staticUserAccountId2}");
+		}
+	}
+
+}


### PR DESCRIPTION
**Background**
Add a testcase to make a relationship with a system object through API

**Test Plan**
Given a foundation object
Given manyToMany relationship usersFoundations created
Given two foundation entries created
Given two userAccount entries created
When each foundation is related to each userAccount through userAccounts PUT endpoint
Then I can see the entry correctly related in GET request response

Given a foundation object
Given manyToMany relationship usersFoundations created
Given two foundation entries created
Given two userAccount entries created
Given each foundation is related to each userAccount through userAccounts PUT endpoint
When deleting one of the foundation entries
Then I can see only one entry correctly related in GET request response

Given a foundation object
Given manyToMany relationship usersFoundations created
Given two foundation entries created
Given two userAccount entries created
Given each foundation related to each userAccount through userAccounts PUT endpoint
When deleting all of the foundation entries
Then I can see no one entry correctly related in GET request response

Given a foundation object
Given oneToMany relationship usersFoundations created
Given two foundation entries created
Given the userAccount entry created
Given I relate all the foundation entries with the userAccount entry through the userAccount PUT endpoint
When deleting one of the foundation entries
Then I can see only one entry correctly related in GET request response

Given a firstFoundation object
Given oneToMany relationship usersFirstFoundations created
Given a secondFoundation object
Given manyToMany relationship usersSecondFoundations created
Given two foundation entries created
Given the userAccount entry created
When I relate each foundation entry with the userAccount entry through the userAccount PUT endpoint with different relationships
Then I can see the two entries correctly related in GET request response

**JIRA Link:**
https://issues.liferay.com/browse/LPS-153326