### PR TITLE
LPS-169292 Update to using \& to combine two parameters to batch create blog tests

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/BlogPostingAPI.macro
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/BlogPostingAPI.macro
@@ -40,7 +40,7 @@ definition {
 			site = "true");
 
 		var curl = '''
-			${portalURL}/o/headless-delivery/v1.0/sites/${siteId}/blog-postings/batch?createStrategy=${createStrategy}&importStrategy=${importStrategy} \
+			${portalURL}/o/headless-delivery/v1.0/sites/${siteId}/blog-postings/batch?createStrategy=${createStrategy}\&importStrategy=${importStrategy} \
 			-u test@liferay.com:test \
 			-H Content-Type: application/json \
             -d ${body}
@@ -250,7 +250,7 @@ definition {
 			groupName = "Guest",
 			site = "true");
 		var curl = '''
-			${portalURL}/o/headless-delivery/v1.0/blog-postings/batch?updateStrategy=${updateStrategy}&importStrategy=${importStrategy} \
+			${portalURL}/o/headless-delivery/v1.0/blog-postings/batch?updateStrategy=${updateStrategy}\&importStrategy=${importStrategy} \
 			-u test@liferay.com:test \
 			-H Content-Type: application/json \
             -d ${body}

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/HeadlessWebcontentAPI.macro
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/HeadlessWebcontentAPI.macro
@@ -296,7 +296,7 @@ definition {
 			site = "true");
 
 		var curl = '''
-			${portalURL}/o/headless-admin-content/v1.0/sites/${siteId}/structured-contents?filter=${filtervalue}&sort=${sortvalue} \
+			${portalURL}/o/headless-admin-content/v1.0/sites/${siteId}/structured-contents?filter=${filtervalue}\&sort=${sortvalue} \
 			-u test@liferay.com:test \
 			-H accept: application/json
 		''';


### PR DESCRIPTION
**Background:**
- HeadlessDeliveryBatchMode.testcase functional tests failed on CI 

**Test Plan**
- It is because we need to use `\&` to combine multiple parameters

**JIRA Ticket:**
- https://issues.liferay.com/browse/LPS-169292