### PR TITLE
LPS-167050 strict dispatch executor type validation

### DIFF
--- a/modules/apps/dispatch/dispatch-api/bnd.bnd
+++ b/modules/apps/dispatch/dispatch-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Dispatch API
 Bundle-SymbolicName: com.liferay.dispatch.api
-Bundle-Version: 15.0.1
+Bundle-Version: 15.1.0
 Export-Package:\
 	com.liferay.dispatch.configuration,\
 	com.liferay.dispatch.constants,\

--- a/modules/apps/dispatch/dispatch-api/src/main/java/com/liferay/dispatch/exception/DispatchTriggerTypeException.java
+++ b/modules/apps/dispatch/dispatch-api/src/main/java/com/liferay/dispatch/exception/DispatchTriggerTypeException.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dispatch.exception;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Matija Petanjek
+ */
+public class DispatchTriggerTypeException extends PortalException {
+
+	public DispatchTriggerTypeException() {
+	}
+
+	public DispatchTriggerTypeException(String msg) {
+		super(msg);
+	}
+
+	public DispatchTriggerTypeException(String msg, Throwable throwable) {
+		super(msg, throwable);
+	}
+
+	public DispatchTriggerTypeException(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/modules/apps/dispatch/dispatch-api/src/main/resources/com/liferay/dispatch/exception/packageinfo
+++ b/modules/apps/dispatch/dispatch-api/src/main/resources/com/liferay/dispatch/exception/packageinfo
@@ -1,1 +1,1 @@
-version 1.3.0
+version 1.4.0

--- a/modules/apps/dispatch/dispatch-service/service.xml
+++ b/modules/apps/dispatch/dispatch-service/service.xml
@@ -106,6 +106,7 @@
 		<exception>DispatchTriggerName</exception>
 		<exception>DispatchTriggerScheduler</exception>
 		<exception>DispatchTriggerStartDate</exception>
+		<exception>DispatchTriggerType</exception>
 		<exception>DuplicateDispatchTrigger</exception>
 	</exceptions>
 </service-builder>

--- a/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/internal/executor/DispatchTaskExecutorRegistryImpl.java
+++ b/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/internal/executor/DispatchTaskExecutorRegistryImpl.java
@@ -29,7 +29,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
@@ -141,10 +140,7 @@ public class DispatchTaskExecutorRegistryImpl
 			properties.get(_KEY_DISPATCH_TASK_EXECUTOR_CLUSTER_MODE),
 			DispatchTaskClusterMode.ALL_NODES.getLabel());
 
-		if (Objects.equals(
-				label,
-				DispatchTaskClusterMode.SINGLE_NODE_PERSISTED.getLabel())) {
-
+		if (label.startsWith("single-node")) {
 			_clusterModeSingleNodeDispatchTaskExecutors.add(
 				dispatchTaskExecutorType);
 		}

--- a/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/service/impl/DispatchTriggerLocalServiceImpl.java
+++ b/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/service/impl/DispatchTriggerLocalServiceImpl.java
@@ -18,7 +18,10 @@ import com.liferay.dispatch.exception.DispatchTriggerEndDateException;
 import com.liferay.dispatch.exception.DispatchTriggerNameException;
 import com.liferay.dispatch.exception.DispatchTriggerStartDateException;
 import com.liferay.dispatch.exception.DuplicateDispatchTriggerException;
+import com.liferay.dispatch.exception.NoSuchDispatchTaskExecutor;
 import com.liferay.dispatch.executor.DispatchTaskClusterMode;
+import com.liferay.dispatch.executor.DispatchTaskExecutor;
+import com.liferay.dispatch.executor.DispatchTaskExecutorRegistry;
 import com.liferay.dispatch.internal.helper.DispatchTriggerHelper;
 import com.liferay.dispatch.model.DispatchTrigger;
 import com.liferay.dispatch.service.base.DispatchTriggerLocalServiceBaseImpl;
@@ -70,7 +73,7 @@ public class DispatchTriggerLocalServiceImpl
 
 		User user = _userLocalService.getUser(userId);
 
-		_validate(0, user.getCompanyId(), name);
+		_validate(0, user.getCompanyId(), dispatchTaskExecutorType, name);
 
 		DispatchTrigger dispatchTrigger = dispatchTriggerPersistence.create(
 			counterLocalService.increment());
@@ -323,7 +326,9 @@ public class DispatchTriggerLocalServiceImpl
 		DispatchTrigger dispatchTrigger =
 			dispatchTriggerPersistence.findByPrimaryKey(dispatchTriggerId);
 
-		_validate(dispatchTriggerId, dispatchTrigger.getCompanyId(), name);
+		_validate(
+			dispatchTriggerId, dispatchTrigger.getCompanyId(),
+			dispatchTrigger.getDispatchTaskExecutorType(), name);
 
 		dispatchTrigger.setName(name);
 		dispatchTrigger.setDispatchTaskSettingsUnicodeProperties(
@@ -338,12 +343,25 @@ public class DispatchTriggerLocalServiceImpl
 		return new Date(date.getTime() - timeZone.getOffset(date.getTime()));
 	}
 
-	private void _validate(long dispatchTriggerId, long companyId, String name)
+	private void _validate(
+			long dispatchTriggerId, long companyId,
+			String dispatchTaskExecutorType, String name)
 		throws PortalException {
 
 		if (Validator.isNull(name)) {
 			throw new DispatchTriggerNameException(
 				"Dispatch trigger name is null for company " + companyId);
+		}
+
+		DispatchTaskExecutor dispatchTaskExecutor =
+			_dispatchTaskExecutorRegistry.fetchDispatchTaskExecutor(
+				dispatchTaskExecutorType);
+
+		if (dispatchTaskExecutor == null) {
+			throw new NoSuchDispatchTaskExecutor(
+				StringBundler.concat(
+					"Unable to get dispatch task executor type for \"",
+					dispatchTaskExecutorType, "\""));
 		}
 
 		DispatchTrigger dispatchTrigger = dispatchTriggerPersistence.fetchByC_N(
@@ -367,6 +385,9 @@ public class DispatchTriggerLocalServiceImpl
 
 	@Reference
 	private DispatchLogPersistence _dispatchLogPersistence;
+
+	@Reference
+	private DispatchTaskExecutorRegistry _dispatchTaskExecutorRegistry;
 
 	@Reference
 	private DispatchTriggerHelper _dispatchTriggerHelper;

--- a/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/service/impl/DispatchTriggerLocalServiceImpl.java
+++ b/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/service/impl/DispatchTriggerLocalServiceImpl.java
@@ -275,6 +275,14 @@ public class DispatchTriggerLocalServiceImpl
 		DispatchTrigger dispatchTrigger =
 			dispatchTriggerPersistence.fetchByPrimaryKey(dispatchTriggerId);
 
+		if ((dispatchTaskClusterMode == DispatchTaskClusterMode.ALL_NODES) &&
+			_dispatchTaskExecutorRegistry.isClusterModeSingle(
+				dispatchTrigger.getDispatchTaskExecutorType())) {
+
+			dispatchTaskClusterMode =
+				DispatchTaskClusterMode.SINGLE_NODE_MEMORY_CLUSTERED;
+		}
+
 		dispatchTrigger.setActive(active);
 		dispatchTrigger.setCronExpression(cronExpression);
 

--- a/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/service/impl/DispatchTriggerLocalServiceImpl.java
+++ b/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/service/impl/DispatchTriggerLocalServiceImpl.java
@@ -17,8 +17,8 @@ package com.liferay.dispatch.service.impl;
 import com.liferay.dispatch.exception.DispatchTriggerEndDateException;
 import com.liferay.dispatch.exception.DispatchTriggerNameException;
 import com.liferay.dispatch.exception.DispatchTriggerStartDateException;
+import com.liferay.dispatch.exception.DispatchTriggerTypeException;
 import com.liferay.dispatch.exception.DuplicateDispatchTriggerException;
-import com.liferay.dispatch.exception.NoSuchDispatchTaskExecutor;
 import com.liferay.dispatch.executor.DispatchTaskClusterMode;
 import com.liferay.dispatch.executor.DispatchTaskExecutor;
 import com.liferay.dispatch.executor.DispatchTaskExecutorRegistry;
@@ -370,9 +370,9 @@ public class DispatchTriggerLocalServiceImpl
 				dispatchTaskExecutorType);
 
 		if (dispatchTaskExecutor == null) {
-			throw new NoSuchDispatchTaskExecutor(
+			throw new DispatchTriggerTypeException(
 				StringBundler.concat(
-					"Unable to get dispatch task executor type for \"",
+					"Unknown dispatch task executor type \"",
 					dispatchTaskExecutorType, "\""));
 		}
 	}

--- a/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/service/impl/DispatchTriggerLocalServiceImpl.java
+++ b/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/service/impl/DispatchTriggerLocalServiceImpl.java
@@ -353,6 +353,18 @@ public class DispatchTriggerLocalServiceImpl
 				"Dispatch trigger name is null for company " + companyId);
 		}
 
+		DispatchTrigger dispatchTrigger = dispatchTriggerPersistence.fetchByC_N(
+			companyId, name);
+
+		if ((dispatchTrigger != null) &&
+			(dispatchTrigger.getDispatchTriggerId() != dispatchTriggerId)) {
+
+			throw new DuplicateDispatchTriggerException(
+				StringBundler.concat(
+					"Dispatch trigger name \"", name,
+					"\" already exists for company ", companyId));
+		}
+
 		DispatchTaskExecutor dispatchTaskExecutor =
 			_dispatchTaskExecutorRegistry.fetchDispatchTaskExecutor(
 				dispatchTaskExecutorType);
@@ -363,21 +375,6 @@ public class DispatchTriggerLocalServiceImpl
 					"Unable to get dispatch task executor type for \"",
 					dispatchTaskExecutorType, "\""));
 		}
-
-		DispatchTrigger dispatchTrigger = dispatchTriggerPersistence.fetchByC_N(
-			companyId, name);
-
-		if ((dispatchTrigger == null) ||
-			((dispatchTriggerId > 0) &&
-			 (dispatchTrigger.getDispatchTriggerId() == dispatchTriggerId))) {
-
-			return;
-		}
-
-		throw new DuplicateDispatchTriggerException(
-			StringBundler.concat(
-				"Dispatch trigger name \"", name,
-				"\" already exists for company ", companyId));
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/dispatch/dispatch-test/src/testIntegration/java/com/liferay/dispatch/internal/messaging/test/DispatchMessageListenerTest.java
+++ b/modules/apps/dispatch/dispatch-test/src/testIntegration/java/com/liferay/dispatch/internal/messaging/test/DispatchMessageListenerTest.java
@@ -29,10 +29,8 @@ import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.messaging.MessageListener;
-import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.DataGuard;
-import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
@@ -78,7 +76,8 @@ public class DispatchMessageListenerTest {
 		int executeCount = RandomTestUtil.randomInt(1, 3);
 
 		DispatchTrigger dispatchTrigger = _executeDispatchTrigger(
-			executeCount, 1000, RandomTestUtil.randomBoolean(), "missingType");
+			executeCount, 1000, true,
+			TestDispatchTaskExecutor.DISPATCH_TASK_EXECUTOR_TYPE_TEST);
 
 		List<DispatchLog> dispatchLogs =
 			_dispatchLogLocalService.getDispatchLogs(
@@ -92,7 +91,7 @@ public class DispatchMessageListenerTest {
 
 		for (DispatchLog dispatchLog : dispatchLogs) {
 			Assert.assertEquals(
-				DispatchTaskStatus.CANCELED.getStatus(),
+				DispatchTaskStatus.SUCCESSFUL.getStatus(),
 				dispatchLog.getStatus());
 		}
 	}
@@ -227,9 +226,7 @@ public class DispatchMessageListenerTest {
 			boolean overlapAllowed, String type)
 		throws Exception {
 
-		Company company = CompanyTestUtil.addCompany();
-
-		User user = UserTestUtil.addUser(company);
+		User user = UserTestUtil.addUser();
 
 		DispatchTrigger dispatchTrigger =
 			_dispatchTriggerLocalService.addDispatchTrigger(

--- a/modules/apps/dispatch/dispatch-test/src/testIntegration/java/com/liferay/dispatch/service/test/DispatchLogLocalServiceTest.java
+++ b/modules/apps/dispatch/dispatch-test/src/testIntegration/java/com/liferay/dispatch/service/test/DispatchLogLocalServiceTest.java
@@ -27,12 +27,10 @@ import com.liferay.dispatch.service.DispatchTriggerLocalService;
 import com.liferay.dispatch.service.test.util.DispatchLogTestUtil;
 import com.liferay.dispatch.service.test.util.DispatchTriggerTestUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
-import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
-import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.test.rule.Inject;
@@ -68,9 +66,7 @@ public class DispatchLogLocalServiceTest {
 
 	@Test
 	public void testAddDispatchLogExceptions() throws Exception {
-		Company company = CompanyTestUtil.addCompany();
-
-		User user = UserTestUtil.addUser(company);
+		User user = UserTestUtil.addUser();
 
 		Class<?> exceptionClass = Exception.class;
 
@@ -145,9 +141,7 @@ public class DispatchLogLocalServiceTest {
 
 	@Test
 	public void testDeleteDispatchLogWhileInProgress() throws Exception {
-		Company company = CompanyTestUtil.addCompany();
-
-		User user = UserTestUtil.addUser(company);
+		User user = UserTestUtil.addUser();
 
 		Class<?> exceptionClass = Exception.class;
 
@@ -185,9 +179,7 @@ public class DispatchLogLocalServiceTest {
 	public void testFetchLatestDispatchLog() throws Exception {
 		int dispatchLogsCount = RandomTestUtil.randomInt(10, 40);
 
-		Company company = CompanyTestUtil.addCompany();
-
-		User user = UserTestUtil.addUser(company);
+		User user = UserTestUtil.addUser();
 
 		DispatchTrigger dispatchTrigger = _addDispatchTrigger(
 			DispatchTriggerTestUtil.randomDispatchTrigger(
@@ -253,9 +245,7 @@ public class DispatchLogLocalServiceTest {
 	public void testGetDispatchLogs() throws Exception {
 		int dispatchLogsCount = RandomTestUtil.randomInt(10, 40);
 
-		Company company = CompanyTestUtil.addCompany();
-
-		User user = UserTestUtil.addUser(company);
+		User user = UserTestUtil.addUser();
 
 		DispatchTrigger dispatchTrigger = _addDispatchTrigger(
 			DispatchTriggerTestUtil.randomDispatchTrigger(
@@ -277,9 +267,7 @@ public class DispatchLogLocalServiceTest {
 
 	@Test
 	public void testUpdateDispatchLog() throws Exception {
-		Company company = CompanyTestUtil.addCompany();
-
-		User user = UserTestUtil.addUser(company);
+		User user = UserTestUtil.addUser();
 
 		DispatchTrigger dispatchTrigger = _addDispatchTrigger(
 			DispatchTriggerTestUtil.randomDispatchTrigger(
@@ -316,9 +304,7 @@ public class DispatchLogLocalServiceTest {
 
 	@Test
 	public void testUpdateDispatchLogExceptions() throws Exception {
-		Company company = CompanyTestUtil.addCompany();
-
-		User user = UserTestUtil.addUser(company);
+		User user = UserTestUtil.addUser();
 
 		DispatchTrigger dispatchTrigger = _addDispatchTrigger(
 			DispatchTriggerTestUtil.randomDispatchTrigger(

--- a/modules/apps/dispatch/dispatch-test/src/testIntegration/java/com/liferay/dispatch/service/test/DispatchLogLocalServiceTest.java
+++ b/modules/apps/dispatch/dispatch-test/src/testIntegration/java/com/liferay/dispatch/service/test/DispatchLogLocalServiceTest.java
@@ -19,6 +19,7 @@ import com.liferay.dispatch.exception.DispatchLogStartDateException;
 import com.liferay.dispatch.exception.DispatchLogStatusException;
 import com.liferay.dispatch.exception.NoSuchTriggerException;
 import com.liferay.dispatch.executor.DispatchTaskStatus;
+import com.liferay.dispatch.internal.messaging.TestDispatchTaskExecutor;
 import com.liferay.dispatch.model.DispatchLog;
 import com.liferay.dispatch.model.DispatchTrigger;
 import com.liferay.dispatch.service.DispatchLogLocalService;
@@ -92,7 +93,9 @@ public class DispatchLogLocalServiceTest {
 			NoSuchTriggerException.class, exceptionClass);
 
 		DispatchTrigger dispatchTrigger = _addDispatchTrigger(
-			DispatchTriggerTestUtil.randomDispatchTrigger(user, 1));
+			DispatchTriggerTestUtil.randomDispatchTrigger(
+				user, TestDispatchTaskExecutor.DISPATCH_TASK_EXECUTOR_TYPE_TEST,
+				1));
 
 		try {
 			Date startDate = dispatchLog.getStartDate();
@@ -187,7 +190,9 @@ public class DispatchLogLocalServiceTest {
 		User user = UserTestUtil.addUser(company);
 
 		DispatchTrigger dispatchTrigger = _addDispatchTrigger(
-			DispatchTriggerTestUtil.randomDispatchTrigger(user, 1));
+			DispatchTriggerTestUtil.randomDispatchTrigger(
+				user, TestDispatchTaskExecutor.DISPATCH_TASK_EXECUTOR_TYPE_TEST,
+				1));
 
 		DispatchLog dispatchLog =
 			_dispatchLogLocalService.fetchLatestDispatchLog(
@@ -253,7 +258,9 @@ public class DispatchLogLocalServiceTest {
 		User user = UserTestUtil.addUser(company);
 
 		DispatchTrigger dispatchTrigger = _addDispatchTrigger(
-			DispatchTriggerTestUtil.randomDispatchTrigger(user, 1));
+			DispatchTriggerTestUtil.randomDispatchTrigger(
+				user, TestDispatchTaskExecutor.DISPATCH_TASK_EXECUTOR_TYPE_TEST,
+				1));
 
 		_addDispatchLogs(
 			user, dispatchTrigger.getDispatchTriggerId(),
@@ -275,7 +282,9 @@ public class DispatchLogLocalServiceTest {
 		User user = UserTestUtil.addUser(company);
 
 		DispatchTrigger dispatchTrigger = _addDispatchTrigger(
-			DispatchTriggerTestUtil.randomDispatchTrigger(user, 1));
+			DispatchTriggerTestUtil.randomDispatchTrigger(
+				user, TestDispatchTaskExecutor.DISPATCH_TASK_EXECUTOR_TYPE_TEST,
+				1));
 
 		DispatchLog expectedDispatchLog = DispatchLogTestUtil.randomDispatchLog(
 			user, DispatchTaskStatus.FAILED);
@@ -312,7 +321,9 @@ public class DispatchLogLocalServiceTest {
 		User user = UserTestUtil.addUser(company);
 
 		DispatchTrigger dispatchTrigger = _addDispatchTrigger(
-			DispatchTriggerTestUtil.randomDispatchTrigger(user, 1));
+			DispatchTriggerTestUtil.randomDispatchTrigger(
+				user, TestDispatchTaskExecutor.DISPATCH_TASK_EXECUTOR_TYPE_TEST,
+				1));
 
 		DispatchLog expectedDispatchLog = DispatchLogTestUtil.randomDispatchLog(
 			user, DispatchTaskStatus.IN_PROGRESS);

--- a/modules/apps/dispatch/dispatch-test/src/testIntegration/java/com/liferay/dispatch/service/test/DispatchTriggerLocalServiceTest.java
+++ b/modules/apps/dispatch/dispatch-test/src/testIntegration/java/com/liferay/dispatch/service/test/DispatchTriggerLocalServiceTest.java
@@ -19,6 +19,7 @@ import com.liferay.dispatch.exception.DispatchTriggerNameException;
 import com.liferay.dispatch.exception.DispatchTriggerSchedulerException;
 import com.liferay.dispatch.exception.DuplicateDispatchTriggerException;
 import com.liferay.dispatch.executor.DispatchTaskClusterMode;
+import com.liferay.dispatch.executor.DispatchTaskExecutorRegistry;
 import com.liferay.dispatch.executor.DispatchTaskStatus;
 import com.liferay.dispatch.internal.messaging.TestDispatchTaskExecutor;
 import com.liferay.dispatch.model.DispatchLog;
@@ -51,6 +52,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TimeZone;
 
 import org.junit.Assert;
@@ -79,13 +81,15 @@ public class DispatchTriggerLocalServiceTest {
 		User user = UserTestUtil.addUser();
 
 		_addDispatchTrigger(
-			DispatchTriggerTestUtil.randomDispatchTrigger(user, 1));
+			DispatchTriggerTestUtil.randomDispatchTrigger(
+				user, _getRandomDispatchExecutorType(), 1));
 
 		Class<?> exceptionClass = Exception.class;
 
 		try {
 			_addDispatchTrigger(
-				DispatchTriggerTestUtil.randomDispatchTrigger(user, 1));
+				DispatchTriggerTestUtil.randomDispatchTrigger(
+					user, _getRandomDispatchExecutorType(), 1));
 		}
 		catch (Exception exception) {
 			exceptionClass = exception.getClass();
@@ -97,7 +101,8 @@ public class DispatchTriggerLocalServiceTest {
 
 		try {
 			_addDispatchTrigger(
-				DispatchTriggerTestUtil.randomDispatchTrigger(user, -1));
+				DispatchTriggerTestUtil.randomDispatchTrigger(
+					user, _getRandomDispatchExecutorType(), -1));
 		}
 		catch (Exception exception) {
 			exceptionClass = exception.getClass();
@@ -189,7 +194,8 @@ public class DispatchTriggerLocalServiceTest {
 			while (dispatchTriggersCount-- > 0) {
 				_addDispatchTrigger(
 					DispatchTriggerTestUtil.randomDispatchTrigger(
-						user, RandomTestUtil.nextInt()));
+						user, _getRandomDispatchExecutorType(),
+						RandomTestUtil.nextInt()));
 			}
 		}
 
@@ -224,7 +230,8 @@ public class DispatchTriggerLocalServiceTest {
 		User user = UserTestUtil.addUser();
 
 		DispatchTrigger expectedDispatchTrigger =
-			DispatchTriggerTestUtil.randomDispatchTrigger(user, 1);
+			DispatchTriggerTestUtil.randomDispatchTrigger(
+				user, _getRandomDispatchExecutorType(), 1);
 
 		DispatchTrigger dispatchTrigger = _addDispatchTrigger(
 			expectedDispatchTrigger);
@@ -275,9 +282,11 @@ public class DispatchTriggerLocalServiceTest {
 		User user = UserTestUtil.addUser();
 
 		DispatchTrigger dispatchTrigger1 = _addDispatchTrigger(
-			DispatchTriggerTestUtil.randomDispatchTrigger(user, 1));
+			DispatchTriggerTestUtil.randomDispatchTrigger(
+				user, _getRandomDispatchExecutorType(), 1));
 		DispatchTrigger dispatchTrigger2 = _addDispatchTrigger(
-			DispatchTriggerTestUtil.randomDispatchTrigger(user, 2));
+			DispatchTriggerTestUtil.randomDispatchTrigger(
+				user, _getRandomDispatchExecutorType(), 2));
 
 		Class<?> exceptionClass = Exception.class;
 
@@ -317,14 +326,16 @@ public class DispatchTriggerLocalServiceTest {
 		User user1 = UserTestUtil.addUser();
 
 		DispatchTrigger dispatchTrigger1 = _addDispatchTrigger(
-			DispatchTriggerTestUtil.randomDispatchTrigger(user1, 1));
+			DispatchTriggerTestUtil.randomDispatchTrigger(
+				user1, _getRandomDispatchExecutorType(), 1));
 
 		Company company = CompanyTestUtil.addCompany();
 
 		User user2 = UserTestUtil.addUser(company);
 
 		DispatchTrigger dispatchTrigger2 = _addDispatchTrigger(
-			DispatchTriggerTestUtil.randomDispatchTrigger(user2, 1));
+			DispatchTriggerTestUtil.randomDispatchTrigger(
+				user2, _getRandomDispatchExecutorType(), 1));
 
 		Assert.assertEquals(
 			dispatchTrigger1.getName(), dispatchTrigger2.getName());
@@ -419,8 +430,29 @@ public class DispatchTriggerLocalServiceTest {
 				value));
 	}
 
+	private String _getRandomDispatchExecutorType() {
+		Set<String> dispatchTaskExecutorTypes =
+			_dispatchTaskExecutorRegistry.getDispatchTaskExecutorTypes();
+
+		int idx = 0;
+
+		int randomTypeIdx = RandomTestUtil.randomInt(
+			0, dispatchTaskExecutorTypes.size());
+
+		for (String dispatchTaskExecutorType : dispatchTaskExecutorTypes) {
+			if (idx++ == randomTypeIdx) {
+				return dispatchTaskExecutorType;
+			}
+		}
+
+		return TestDispatchTaskExecutor.DISPATCH_TASK_EXECUTOR_TYPE_TEST;
+	}
+
 	@Inject
 	private DispatchLogLocalService _dispatchLogLocalService;
+
+	@Inject
+	private DispatchTaskExecutorRegistry _dispatchTaskExecutorRegistry;
 
 	@Inject
 	private DispatchTriggerLocalService _dispatchTriggerLocalService;

--- a/modules/apps/dispatch/dispatch-test/src/testIntegration/java/com/liferay/dispatch/service/test/DispatchTriggerLocalServiceTest.java
+++ b/modules/apps/dispatch/dispatch-test/src/testIntegration/java/com/liferay/dispatch/service/test/DispatchTriggerLocalServiceTest.java
@@ -116,7 +116,7 @@ public class DispatchTriggerLocalServiceTest {
 		try {
 			_addDispatchTrigger(
 				DispatchTriggerTestUtil.randomDispatchTrigger(
-					user, "INVALID EXECUTOR TYPE", 1));
+					user, "INVALID EXECUTOR TYPE", 2));
 		}
 		catch (Exception exception) {
 			exceptionClass = exception.getClass();

--- a/modules/apps/dispatch/dispatch-test/src/testIntegration/java/com/liferay/dispatch/service/test/DispatchTriggerLocalServiceTest.java
+++ b/modules/apps/dispatch/dispatch-test/src/testIntegration/java/com/liferay/dispatch/service/test/DispatchTriggerLocalServiceTest.java
@@ -17,6 +17,7 @@ package com.liferay.dispatch.service.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.dispatch.exception.DispatchTriggerNameException;
 import com.liferay.dispatch.exception.DispatchTriggerSchedulerException;
+import com.liferay.dispatch.exception.DispatchTriggerTypeException;
 import com.liferay.dispatch.exception.DuplicateDispatchTriggerException;
 import com.liferay.dispatch.executor.DispatchTaskClusterMode;
 import com.liferay.dispatch.executor.DispatchTaskExecutorRegistry;
@@ -111,6 +112,19 @@ public class DispatchTriggerLocalServiceTest {
 		Assert.assertEquals(
 			"Add dispatch trigger with no name",
 			DispatchTriggerNameException.class, exceptionClass);
+
+		try {
+			_addDispatchTrigger(
+				DispatchTriggerTestUtil.randomDispatchTrigger(
+					user, "INVALID EXECUTOR TYPE", 1));
+		}
+		catch (Exception exception) {
+			exceptionClass = exception.getClass();
+		}
+
+		Assert.assertEquals(
+			"Add dispatch trigger with invalid executor type",
+			DispatchTriggerTypeException.class, exceptionClass);
 	}
 
 	@Test

--- a/modules/apps/dispatch/dispatch-test/src/testIntegration/java/com/liferay/dispatch/service/test/util/DispatchTriggerTestUtil.java
+++ b/modules/apps/dispatch/dispatch-test/src/testIntegration/java/com/liferay/dispatch/service/test/util/DispatchTriggerTestUtil.java
@@ -43,14 +43,13 @@ public class DispatchTriggerTestUtil {
 	}
 
 	public static DispatchTrigger randomDispatchTrigger(
-		User user, int nameSalt) {
+		User user, String dispatchTaskExecutorType, int nameSalt) {
 
 		Objects.requireNonNull(user);
 
 		return _randomDispatchTrigger(
 			RandomTestUtil.randomBoolean(), user.getCompanyId(),
-			CronExpressionUtil.getCronExpression(), 0,
-			RandomTestUtil.randomString(20),
+			CronExpressionUtil.getCronExpression(), 0, dispatchTaskExecutorType,
 			RandomTestUtil.randomUnicodeProperties(
 				RandomTestUtil.randomInt(10, 30), 32, 64),
 			_randomName(nameSalt), RandomTestUtil.randomBoolean(),

--- a/modules/apps/dispatch/dispatch-test/src/testIntegration/java/com/liferay/dispatch/web/test/DispatchLogDisplayContextTest.java
+++ b/modules/apps/dispatch/dispatch-test/src/testIntegration/java/com/liferay/dispatch/web/test/DispatchLogDisplayContextTest.java
@@ -17,6 +17,7 @@ package com.liferay.dispatch.web.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.dispatch.exception.NoSuchLogException;
 import com.liferay.dispatch.executor.DispatchTaskStatus;
+import com.liferay.dispatch.internal.messaging.TestDispatchTaskExecutor;
 import com.liferay.dispatch.model.DispatchLog;
 import com.liferay.dispatch.model.DispatchTrigger;
 import com.liferay.dispatch.service.DispatchLogLocalService;
@@ -213,7 +214,8 @@ public class DispatchLogDisplayContextTest {
 
 		DispatchTrigger dispatchTrigger =
 			DispatchTriggerTestUtil.randomDispatchTrigger(
-				user, RandomTestUtil.nextInt());
+				user, TestDispatchTaskExecutor.DISPATCH_TASK_EXECUTOR_TYPE_TEST,
+				RandomTestUtil.nextInt());
 
 		dispatchTrigger = _dispatchTriggerLocalService.addDispatchTrigger(
 			null, dispatchTrigger.getUserId(),

--- a/modules/apps/dispatch/dispatch-test/src/testIntegration/java/com/liferay/dispatch/web/test/DispatchTriggerDisplayContextTest.java
+++ b/modules/apps/dispatch/dispatch-test/src/testIntegration/java/com/liferay/dispatch/web/test/DispatchTriggerDisplayContextTest.java
@@ -117,11 +117,7 @@ public class DispatchTriggerDisplayContextTest {
 				SingleNodeClusterModeDispatchTaskExecutor.
 					DISPATCH_TASK_EXECUTOR_TYPE_SINGLE_NODE));
 
-		Group group = GroupTestUtil.addGroup();
-
-		Company company = _companyLocalService.getCompany(group.getCompanyId());
-
-		User user = UserTestUtil.addUser(company);
+		User user = UserTestUtil.addUser();
 
 		DispatchTrigger dispatchTrigger =
 			_dispatchTriggerLocalService.addDispatchTrigger(
@@ -140,7 +136,8 @@ public class DispatchTriggerDisplayContextTest {
 
 		MockHttpServletRequest mockHttpServletRequest =
 			_getMockHttpServletRequest(
-				company, LayoutTestUtil.addTypePortletLayout(group), user,
+				_companyLocalService.getCompany(user.getCompanyId()),
+				LayoutTestUtil.addTypePortletLayout(user.getGroupId()), user,
 				"dispatchTriggerId",
 				String.valueOf(dispatchTrigger.getDispatchTriggerId()),
 				"active", "true", "cmd", "schedule", "cronExpression",
@@ -159,7 +156,7 @@ public class DispatchTriggerDisplayContextTest {
 		dispatchTrigger = _dispatchTriggerLocalService.getDispatchTrigger(
 			dispatchTrigger.getDispatchTriggerId());
 
-		Assert.assertEquals(
+		Assert.assertNotEquals(
 			dispatchTaskClusterMode.getMode(),
 			dispatchTrigger.getDispatchTaskClusterMode());
 

--- a/modules/dxp/apps/salesforce-connector/salesforce-connector/src/main/java/com/liferay/salesforce/connector/internal/instance/lifecycle/AddSalesforceConnectorPortalInstanceLifecycleListener.java
+++ b/modules/dxp/apps/salesforce-connector/salesforce-connector/src/main/java/com/liferay/salesforce/connector/internal/instance/lifecycle/AddSalesforceConnectorPortalInstanceLifecycleListener.java
@@ -14,6 +14,7 @@
 
 package com.liferay.salesforce.connector.internal.instance.lifecycle;
 
+import com.liferay.dispatch.executor.DispatchTaskExecutor;
 import com.liferay.dispatch.model.DispatchTrigger;
 import com.liferay.dispatch.repository.DispatchFileRepository;
 import com.liferay.dispatch.service.DispatchTriggerLocalService;
@@ -95,6 +96,9 @@ public class AddSalesforceConnectorPortalInstanceLifecycleListener
 
 	@Reference
 	private DispatchFileRepository _dispatchFileRepository;
+
+	@Reference(target = "(dispatch.task.executor.type=talend)")
+	private DispatchTaskExecutor _dispatchTaskExecutor;
 
 	@Reference
 	private DispatchTriggerLocalService _dispatchTriggerLocalService;

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
@@ -17,6 +17,7 @@ package com.liferay.portal.kernel.test.rule;
 import com.liferay.petra.io.unsync.UnsyncPrintWriter;
 import com.liferay.petra.io.unsync.UnsyncStringWriter;
 import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.bean.ClassLoaderBeanHandler;
@@ -355,7 +356,8 @@ public class DataGuardTestRuleUtil {
 				ClassLoader classLoader =
 					persistedModelLocalServiceClass.getClassLoader();
 
-				Class<?> modelClass = classLoader.loadClass(className);
+				Class<?> modelClass = classLoader.loadClass(
+					_sanitizeClassName(className));
 
 				List<BaseModel<?>> currentBaseModels = entry.getValue();
 
@@ -628,6 +630,14 @@ public class DataGuardTestRuleUtil {
 
 		return () -> ReflectionTestUtil.setFieldValue(
 			basePersistence, "_sessionFactory", originalSessionFactory);
+	}
+
+	private static String _sanitizeClassName(String className) {
+		if (!className.contains(StringPool.POUND)) {
+			return className;
+		}
+
+		return className.substring(0, className.indexOf(CharPool.POUND));
 	}
 
 	private static final ThreadLocal<Map<String, Map<Serializable, String>>>


### PR DESCRIPTION
@igorbeslic
[LPS-167050] Validate executor type to avoid attempt of executing non existing executor

[LPS-170042] there are two SINGLE-NODE modes -> CLUSTERED and MEMORY-PERSISTED - adopt code to cover both cases

[LPS-169394] Speed up integration tests - do not create company

[LPS-153260] Prevent DataGuard failures when ObjectDefinitions are present in the system (className contains #NUMBER suffix which breaks allocating class in class loader)