### PR TITLE
Lrqa 78630

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testFunctional/tests/ExposeErcForCategories.testcase
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testFunctional/tests/ExposeErcForCategories.testcase
@@ -60,7 +60,7 @@ definition {
 
 			TestUtils.assertEquals(
 				actual = "${actualValue}",
-				expected = "No AssetCategory exists with the key {groupId=${siteId}, externalReferenceCode=erc}");
+				expected = "No AssetCategory exists with the key {externalReferenceCode=erc, groupId=${siteId}}");
 		}
 	}
 
@@ -158,7 +158,7 @@ definition {
 
 			TestUtils.assertEquals(
 				actual = "${actualValue}",
-				expected = "No AssetCategory exists with the key {groupId=${siteId}, externalReferenceCode=liferay}");
+				expected = "No AssetCategory exists with the key {externalReferenceCode=liferay, groupId=${siteId}}");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcFromAssetLibraryForComments.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcFromAssetLibraryForComments.testcase
@@ -242,7 +242,7 @@ definition {
 		task ("Then I receive an error code response about duplicate erc") {
 			TestUtils.assertPartialEquals(
 				actual = "${response}",
-				expected = "Duplicate MBMessage with external reference code ercComment");
+				expected = "Duplicate message-boards message with external reference code ercComment");
 		}
 
 		task ("And Then another comment with the same external reference code is not being created") {


### PR DESCRIPTION
Background:
- Update tests on erc message related since changes on LPS-163008

Test Plan
- LocalFile.ExposeErcFromAssetLibraryForComments#CannotCreateTwoCommentsWithSameCustomExternalReferenceCode
- LocalFile.ExposeErcForCategories#CanDeleteCategoryByErc
- LocalFile.ExposeErcForCategories#CanRecieveErrorMessageByNotExistErcInCategory

JIRA Ticket:
- https://issues.liferay.com/browse/LRQA-78630
- https://issues.liferay.com/browse/LRQA-78623