### PR TITLE
Lps 170007 Add functional tests to include extend properties for open api

### DIFF
--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectDefinitionAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectDefinitionAPI.macro
@@ -807,6 +807,16 @@ definition {
 		return "${staticObjectId2}";
 	}
 
+	macro setUpGlobalObjectDefinitionIdWithName {
+		Variables.assertDefined(parameterList = "${objectName}");
+
+		var objectId = ObjectDefinitionAPI.getObjectDefinitionIdByName(name = "${objectName}");
+
+		static var staticObjectId = "${objectId}";
+
+		return "${staticObjectId}";
+	}
+
 	macro setUpGlobalObjectEntryId {
 		var objectEntryId1 = ObjectDefinitionAPI.createObjectEntryWithName(
 			en_US_plural_label = "foundations",

--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectFieldAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectFieldAPI.macro
@@ -54,6 +54,16 @@ definition {
 		return "${objectFieldId}";
 	}
 
+	macro getObjectFieldsByObjectId {
+		Variables.assertDefined(parameterList = "${objectDefinitionId}");
+
+		var curl = ObjectFieldAPI._curlObjectField(objectDefinitionId = "${objectDefinitionId}");
+
+		var response = JSONCurlUtil.get("${curl}");
+
+		return "${response}";
+	}
+
 	macro setUpGlobalObjectFieldId {
 		var objectFieldId = ObjectFieldAPI.getIdOfCreatedObjectField(
 			dbType = "${dbType}",

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/IncludeExtendPropertiesForObjectSchemas.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/IncludeExtendPropertiesForObjectSchemas.testcase
@@ -1,0 +1,154 @@
+@component-name = "portal-headless"
+definition {
+
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Object";
+	property testray.main.component.name = "Headless";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+
+		task ("Given a new field is added to the system User object with post request") {
+			ObjectDefinitionAPI.setUpGlobalObjectDefinitionIdWithName(objectName = "User");
+
+			ObjectFieldAPI.setUpGlobalObjectFieldId(
+				dbType = "String",
+				name = "passportNumber",
+				objectDefinitionId = "${staticObjectId}");
+		}
+
+		task ("Given a custom object definition is created with post request") {
+			ObjectDefinitionAPI.setUpGlobalobjectDefinitionId();
+		}
+	}
+
+	tearDown {
+		for (var objectName : list "University,Subject") {
+			ObjectAdmin.deleteObjectViaAPI(objectName = "${objectName}");
+		}
+
+		ObjectFieldAPI.deleteObjectField();
+	}
+
+	@priority = "4"
+	test CanIncludePropertiesInSchemasWithManyToManyRelationship {
+		property portal.acceptance = "true";
+
+		task ("When with post request a manyToMany relationship is set between the two object definitions") {
+			ObjectDefinitionAPI.createRelationship(
+				deletionType = "cascade",
+				en_US_label = "UsersSubjects",
+				name = "usersSubjects",
+				objectDefinitionId1 = "${staticObjectId}",
+				objectDefinitionId2 = "${staticObjectId2}",
+				type = "manyToMany");
+		}
+
+		task ("Then usersSubjects{} is added into both schema for user and subject") {
+			APIExplorer.navigateToOpenAPI(
+				api = "c",
+				version = "subjects");
+
+			AssertElementPresent.assertElementPresent(
+				field = "usersSubjects",
+				locator1 = "OpenAPI#SCHEMA_TITLE",
+				schema = "Subject");
+
+			APIExplorer.navigateToOpenAPI(
+				api = "headless-admin-user",
+				version = "v1.0");
+
+			AssertElementPresent.assertElementPresent(
+				field = "usersSubjects",
+				locator1 = "OpenAPI#SCHEMA_TITLE",
+				schema = "UserAccount");
+		}
+	}
+
+	@priority = "4"
+	test CanIncludePropertiesInSchemasWithOneToManyRelationship {
+		property portal.acceptance = "true";
+
+		task ("When with post request a oneToMany relationship is set between the two object definitions") {
+			ObjectDefinitionAPI.createRelationship(
+				deletionType = "cascade",
+				en_US_label = "UniversityUsers",
+				name = "universityUsers",
+				objectDefinitionId1 = "${staticObjectId1}",
+				objectDefinitionId2 = "${staticObjectId}",
+				type = "oneToMany");
+		}
+
+		task ("Then a new field of universityUsers of type relationship is generated") {
+			var response = ObjectFieldAPI.getObjectFieldsByObjectId(objectDefinitionId = "${staticObjectId}");
+
+			var objectField = JSONUtil.getWithJSONPath("${response}", "$.items[?(@.businessType == 'Relationship')].label.en_US");
+
+			TestUtils.assertEquals(
+				actual = "${objectField}",
+				expected = "UniversityUsers");
+		}
+
+		task ("And Then r_universityUsers_c_universityId is added into userAccount schema") {
+			APIExplorer.navigateToOpenAPI(
+				api = "headless-admin-user",
+				version = "v1.0");
+
+			AssertElementPresent.assertElementPresent(
+				field = "r_universityUsers_c_universityId",
+				locator1 = "OpenAPI#SCHEMA_TITLE",
+				schema = "UserAccount");
+		}
+
+		task ("And Then universityUsers{} is added into /c/universities schema") {
+			APIExplorer.navigateToOpenAPI(
+				api = "c",
+				version = "universities");
+
+			AssertElementPresent.assertElementPresent(
+				field = "universityUsers",
+				locator1 = "OpenAPI#SCHEMA_TITLE",
+				schema = "University");
+		}
+	}
+
+	@priority = "4"
+	test CanIncludePropertyInSchemaForCustomObject {
+		property portal.acceptance = "true";
+
+		task ("When navigate to custom object open api") {
+			APIExplorer.navigateToOpenAPI(
+				api = "c",
+				version = "subjects");
+		}
+
+		task ("Then a new schema with properties is created successfully") {
+			AssertElementPresent.assertElementPresent(
+				field = "name",
+				locator1 = "OpenAPI#SCHEMA_TITLE",
+				schema = "Subject");
+		}
+	}
+
+	@priority = "4"
+	test CanIncludePropertyInSchemaForSystemObject {
+		property portal.acceptance = "true";
+
+		task ("When I expand UserAccount schema") {
+			APIExplorer.navigateToOpenAPI(
+				api = "headless-admin-user",
+				version = "v1.0");
+		}
+
+		task ("Then the new added field is added successfully in the schema") {
+			AssertElementPresent.assertElementPresent(
+				field = "passportNumber",
+				locator1 = "OpenAPI#SCHEMA_TITLE",
+				schema = "UserAccount");
+		}
+	}
+
+}

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portal/openapi/OpenAPI.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portal/openapi/OpenAPI.path
@@ -11,6 +11,19 @@
 
 <tbody>
 
+<!--SCHEMA-->
+
+<tr>
+	<td>SCHEMA_TITLE</td>
+	<td>//div[@id='model-${schema}']</td>
+	<td></td>
+</tr>
+<tr>
+	<td>SCHEMA_FIELD</td>
+	<td>//div[@id='model-${schema}']//td[contains(.,'${field}')]</td>
+	<td></td>
+</tr>
+
 <!--SWAGGER-->
 
 <tr>


### PR DESCRIPTION
**Background**
- Add tests for story LPS-158214 Include Extended properties in the OpenAPI files

**Test Plan**
- Given a new field is added to the system User object with post request
When I expand UserAccount schema
Then the new added field is added successfully in the schema
- Given a custom object definition is created with post request
When publish the new object definition with a required field
Then a new schema with properties is created successfully
- Given a new field is added to the system User object with post request
And Given a custom object definition is published
When with post request a oneToMany relationship is set between the two object definitions
Then a new field of universityUsers of type relationship is generated
And Then r_universityUsers_c_universityId is added into userAccount schema
And Then universityUsers{} is added into /c/universities schema
- Given a new field is added to the system User object with post request
And Given a custom object definition is published
When with post request a manyToMany relationship is set between the two object definitions
Then usersSubjects{} is added into both schema for user and subject

**JIRA Link:**
- https://issues.liferay.com/browse/LPS-170007