### PR TITLE
LPS-169866: Fix SXPBlueprintLocalServiceTest and SXPElementLocalServiceTest updating elemnts with the same ERC

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/service/test/SXPBlueprintLocalServiceTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/service/test/SXPBlueprintLocalServiceTest.java
@@ -24,8 +24,6 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.test.log.LogCapture;
-import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -37,8 +35,6 @@ import com.liferay.search.experiences.service.SXPBlueprintLocalService;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
-import javax.persistence.PersistenceException;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -129,28 +125,6 @@ public class SXPBlueprintLocalServiceTest {
 	public void testUpdateSXPBlueprint() throws Exception {
 		SXPBlueprint sxpBlueprint1 = _addSXPBlueprint(
 			RandomTestUtil.randomString());
-		SXPBlueprint sxpBlueprint2 = _addSXPBlueprint(
-			RandomTestUtil.randomString());
-
-		sxpBlueprint2.setExternalReferenceCode(
-			sxpBlueprint1.getExternalReferenceCode());
-
-		try (LogCapture logCapture1 = LoggerTestUtil.configureLog4JLogger(
-				"org.hibernate.engine.jdbc.batch.internal.BatchingBatch",
-				LoggerTestUtil.ERROR);
-			LogCapture logCapture2 = LoggerTestUtil.configureLog4JLogger(
-				"org.hibernate.engine.jdbc.spi.SqlExceptionHelper",
-				LoggerTestUtil.ERROR)) {
-
-			try {
-				_sxpBlueprintLocalService.updateSXPBlueprint(sxpBlueprint2);
-
-				Assert.fail();
-			}
-			catch (PersistenceException persistenceException) {
-				Assert.assertNotNull(persistenceException);
-			}
-		}
 
 		String externalReferenceCode = RandomTestUtil.randomString();
 
@@ -185,6 +159,21 @@ public class SXPBlueprintLocalServiceTest {
 		Assert.assertEquals(
 			externalReferenceCode, sxpBlueprint1.getExternalReferenceCode());
 		Assert.assertEquals("1.2", sxpBlueprint1.getVersion());
+	}
+
+	@Test(expected = DuplicateSXPBlueprintExternalReferenceCodeException.class)
+	public void testUpdateSXPBlueprintWithSameExternalReferenceCode()
+		throws Exception {
+
+		SXPBlueprint sxpBlueprint1 = _addSXPBlueprint(
+			RandomTestUtil.randomString());
+		SXPBlueprint sxpBlueprint2 = _addSXPBlueprint(
+			RandomTestUtil.randomString());
+
+		sxpBlueprint2.setExternalReferenceCode(
+			sxpBlueprint1.getExternalReferenceCode());
+
+		_sxpBlueprintLocalService.updateSXPBlueprint(sxpBlueprint2);
 	}
 
 	private SXPBlueprint _addSXPBlueprint(String externalReferenceCode)

--- a/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/service/test/SXPElementLocalServiceTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-test/src/testIntegration/java/com/liferay/search/experiences/service/test/SXPElementLocalServiceTest.java
@@ -24,8 +24,6 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.test.log.LogCapture;
-import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -37,8 +35,6 @@ import com.liferay.search.experiences.service.SXPElementLocalService;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
-import javax.persistence.PersistenceException;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -127,27 +123,6 @@ public class SXPElementLocalServiceTest {
 	@Test
 	public void testUpdateSXPElement() throws Exception {
 		SXPElement sxpElement1 = _addSXPElement(RandomTestUtil.randomString());
-		SXPElement sxpElement2 = _addSXPElement(RandomTestUtil.randomString());
-
-		sxpElement2.setExternalReferenceCode(
-			sxpElement1.getExternalReferenceCode());
-
-		try (LogCapture logCapture1 = LoggerTestUtil.configureLog4JLogger(
-				"org.hibernate.engine.jdbc.batch.internal.BatchingBatch",
-				LoggerTestUtil.ERROR);
-			LogCapture logCapture2 = LoggerTestUtil.configureLog4JLogger(
-				"org.hibernate.engine.jdbc.spi.SqlExceptionHelper",
-				LoggerTestUtil.ERROR)) {
-
-			try {
-				_sxpElementLocalService.updateSXPElement(sxpElement2);
-
-				Assert.fail();
-			}
-			catch (PersistenceException persistenceException) {
-				Assert.assertNotNull(persistenceException);
-			}
-		}
 
 		String externalReferenceCode = RandomTestUtil.randomString();
 
@@ -179,6 +154,19 @@ public class SXPElementLocalServiceTest {
 		Assert.assertEquals(
 			externalReferenceCode, sxpElement1.getExternalReferenceCode());
 		Assert.assertEquals("1.2", sxpElement1.getVersion());
+	}
+
+	@Test(expected = DuplicateSXPElementExternalReferenceCodeException.class)
+	public void testUpdateSXPElementWithSameExternalReferenceCode()
+		throws Exception {
+
+		SXPElement sxpElement1 = _addSXPElement(RandomTestUtil.randomString());
+		SXPElement sxpElement2 = _addSXPElement(RandomTestUtil.randomString());
+
+		sxpElement2.setExternalReferenceCode(
+			sxpElement1.getExternalReferenceCode());
+
+		_sxpElementLocalService.updateSXPElement(sxpElement2);
 	}
 
 	private SXPElement _addSXPElement(String externalReferenceCode)


### PR DESCRIPTION
**What is new?**
- Creating new test case, expecting to throw a `Duplicate<EntityName>ExternalReferenceCodeException.`

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-169866