### PR TITLE
Lps 170027 Add functional tests on break relationship between system object and custom object

### DIFF
--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectDefinitionAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectDefinitionAPI.macro
@@ -807,6 +807,16 @@ definition {
 		return "${staticObjectId2}";
 	}
 
+	macro setUpGlobalObjectDefinitionIdWithName {
+		Variables.assertDefined(parameterList = "${objectName}");
+
+		var objectId = ObjectDefinitionAPI.getObjectDefinitionIdByName(name = "${objectName}");
+
+		static var staticObjectId = "${objectId}";
+
+		return "${staticObjectId}";
+	}
+
 	macro setUpGlobalObjectEntryId {
 		var objectEntryId1 = ObjectDefinitionAPI.createObjectEntryWithName(
 			en_US_plural_label = "foundations",

--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/UserAccountAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/UserAccountAPI.macro
@@ -138,28 +138,35 @@ definition {
 	}
 
 	macro setUpGlobalUserAccountId {
+		var response = UserAccountAPI.createUserAccount(
+			alternateName = "user",
+			emailAddress = "user@liferay.com",
+			familyName = "userfn",
+			fieldName = "${fieldName}",
+			fieldValue = "${fieldValue}",
+			givenName = "usergn");
+
+		static var staticResponse = "${response}";
+		static var staticUserAccountId = JSONUtil.getWithJSONPath("${response}", "$.id");
+
+		return "${staticResponse}";
+
+		return "${staticUserAccountId}";
+	}
+
+	macro setUpGlobalUserAccountIds {
 		var response1 = UserAccountAPI.createUserAccount(
 			alternateName = "${alternateName1}",
 			emailAddress = "${emailAddress1}",
 			familyName = "${familyName1}",
-			fieldName = "${fieldName1}",
-			fieldValue = "${fieldValue1}",
 			givenName = "${givenName1}");
 		var response2 = UserAccountAPI.createUserAccount(
 			alternateName = "${alternateName2}",
 			emailAddress = "${emailAddress2}",
 			familyName = "${familyName2}",
-			fieldName = "${fieldName2}",
-			fieldValue = "${fieldValue2}",
 			givenName = "${givenName2}");
 		static var staticUserAccountId1 = JSONUtil.getWithJSONPath("${response1}", "$.id");
 		static var staticUserAccountId2 = JSONUtil.getWithJSONPath("${response2}", "$.id");
-		static var staticResponse1 = "${response1}";
-		static var staticResponse2 = "${response2}";
-
-		return "${staticResponse1}";
-
-		return "${staticResponse2}";
 
 		return "${staticUserAccountId1}";
 

--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/UserAccountAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/UserAccountAPI.macro
@@ -72,6 +72,17 @@ definition {
 		return "${response}";
 	}
 
+	macro deleteUserAccountRelationship {
+		Variables.assertDefined(parameterList = "${userAccountId},${relationshipName},${customObjectId}");
+
+		var curl = UserAccountAPI._curlUserAccount(
+			customObjectId = "${customObjectId}",
+			relationshipName = "${relationshipName}",
+			userAccountId = "${userAccountId}");
+
+		JSONCurlUtil.delete("${curl}");
+	}
+
 	macro getRelationshipByUserAccountId {
 		var curl = UserAccountAPI._curlUserAccount(
 			relationshipName = "${relationshipName}",

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/BreakRelationshipBetweenSystemAndCustonObjects.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/BreakRelationshipBetweenSystemAndCustonObjects.testcase
@@ -1,0 +1,155 @@
+@component-name = "portal-headless"
+definition {
+
+	property custom.properties = "feature.flag.LPS-153324=true";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Object";
+	property testray.main.component.name = "Headless";
+
+	setUp {
+		TestCase.setUpPortalInstanceNoSelenium();
+
+		task ("Given a foundation object") {
+			var customObjectDefinitionId1 = ObjectDefinitionAPI.createAndPublishObjectDefinition(
+				en_US_label = "foundation",
+				en_US_plural_label = "foundations",
+				name = "Foundation",
+				requiredStringFieldName = "name");
+		}
+
+		task ("Given a secondFoundation object") {
+			var customObjectDefinitionId2 = ObjectDefinitionAPI.createAndPublishObjectDefinition(
+				en_US_label = "secondFoundation",
+				en_US_plural_label = "secondFoundations",
+				name = "SecondFoundation",
+				requiredStringFieldName = "name");
+		}
+
+		task ("Given oneToMany relationship userFoundations created") {
+			ObjectDefinitionAPI.setUpGlobalObjectDefinitionIdWithName(objectName = "User");
+
+			var relationshipName = ObjectDefinitionAPI.createRelationship(
+				deletionType = "cascade",
+				en_US_label = "UserFoundations",
+				name = "userFoundations",
+				objectDefinitionId1 = "${staticObjectId}",
+				objectDefinitionId2 = "${customObjectDefinitionId1}",
+				type = "oneToMany");
+		}
+
+		task ("Given manyToMany relationship userSecondFoundations created") {
+			var relationshipName = ObjectDefinitionAPI.createRelationship(
+				deletionType = "cascade",
+				en_US_label = "UsersSecondFoundations",
+				name = "usersSecondFoundations",
+				objectDefinitionId1 = "${staticObjectId}",
+				objectDefinitionId2 = "${customObjectDefinitionId2}",
+				type = "manyToMany");
+		}
+
+		task ("Given object entries created") {
+			ObjectDefinitionAPI.setUpGlobalObjectEntryId();
+		}
+
+		task ("Given userAccount entry created") {
+			UserAccountAPI.setUpGlobalUserAccountId();
+		}
+	}
+
+	tearDown {
+		for (var objectName : list "Foundation,SecondFoundation") {
+			ObjectAdmin.deleteObjectViaAPI(objectName = "${objectName}");
+		}
+
+		JSONUser.deleteUserByUserId(userId = "${staticUserAccountId}");
+	}
+
+	@disable-webdriver = "true"
+	@priority = "4"
+	test CanBreakManyToManyRelationship {
+		property portal.acceptance = "true";
+
+		task ("Given I relate the custom object entry with the userAccount entry through the userAccount PUT endpoint") {
+			UserAccountAPI.relateObjectEntries(
+				customObjectId = "${staticObjectEntryId3}",
+				relationshipName = "usersSecondFoundations",
+				userAccountId = "${staticUserAccountId}");
+		}
+
+		task ("When using the delete request deleteUserAccount{relationshipName}") {
+			UserAccountAPI.deleteUserAccountRelationship(
+				customObjectId = "${staticObjectEntryId3}",
+				relationshipName = "usersSecondFoundations",
+				userAccountId = "${staticUserAccountId}");
+		}
+
+		task ("Then I can see no one entry correctly related in GET request response with the relationshipName={relationshipName}") {
+			UserAccountAPI.assertResponseNotIncludeDetailsOfDeletedObjectEntry(
+				expectedValue = "[]",
+				relationshipName = "usersSecondFoundations",
+				userAccountId = "${staticUserAccountId}");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = "4"
+	test CanBreakOneToManyRelationship {
+		property portal.acceptance = "true";
+
+		task ("Given I relate foundation entry with the userAccount entry through the userAccount PUT endpoint") {
+			UserAccountAPI.relateObjectEntries(
+				customObjectId = "${staticObjectEntryId1}",
+				relationshipName = "userFoundations",
+				userAccountId = "${staticUserAccountId}");
+		}
+
+		task ("When using the delete request deleteUserAccount{relationshipName}") {
+			UserAccountAPI.deleteUserAccountRelationship(
+				customObjectId = "${staticObjectEntryId1}",
+				relationshipName = "userFoundations",
+				userAccountId = "${staticUserAccountId}");
+		}
+
+		task ("Then I can see no one entry correctly related in GET request response with the relationshipName=usersFoundations") {
+			UserAccountAPI.assertResponseNotIncludeDetailsOfDeletedObjectEntry(
+				expectedValue = "[]",
+				relationshipName = "userFoundations",
+				userAccountId = "${staticUserAccountId}");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = "4"
+	test CanBreakOneToManyRelationshipKeepingOtherEntriesRelated {
+		property portal.acceptance = "true";
+
+		task ("Given all foundation is related to userAccount through userAccounts PUT endpoint") {
+			UserAccountAPI.relateObjectEntries(
+				customObjectId = "${staticObjectEntryId1}",
+				relationshipName = "userFoundations",
+				userAccountId = "${staticUserAccountId}");
+
+			UserAccountAPI.relateObjectEntries(
+				customObjectId = "${staticObjectEntryId2}",
+				relationshipName = "userFoundations",
+				userAccountId = "${staticUserAccountId}");
+		}
+
+		task ("When deleting one of the foundation entries with deleteUserAccount{relationshipName} request") {
+			UserAccountAPI.deleteUserAccountRelationship(
+				customObjectId = "${staticObjectEntryId1}",
+				relationshipName = "userFoundations",
+				userAccountId = "${staticUserAccountId}");
+		}
+
+		task ("Then I can see only one entry correctly related in GET request response") {
+			UserAccountAPI.assertResponseHasCorrectRelatedEntryName(
+				customObjectEntryId = "${staticObjectEntryId2}",
+				expectedValue = "Foundation Second",
+				relationshipName = "userFoundations",
+				userAccountId = "${staticUserAccountId}");
+		}
+	}
+
+}

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/ExtendPropertiesForSystemObjects.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/ExtendPropertiesForSystemObjects.testcase
@@ -20,23 +20,13 @@ definition {
 
 		task ("When with post request postUserAccount to create a user with the new field") {
 			UserAccountAPI.setUpGlobalUserAccountId(
-				alternateName1 = "userln",
-				alternateName2 = "user2",
-				emailAddress1 = "userln@liferay.com",
-				emailAddress2 = "user2@liferay.com",
-				familyName1 = "userfn",
-				familyName2 = "userfn2",
-				fieldName1 = "passportNumber",
-				fieldValue1 = "passportNum2022",
-				givenName1 = "usergn",
-				givenName2 = "usergn2");
+				fieldName = "passportNumber",
+				fieldValue = "passportNum2022");
 		}
 	}
 
 	tearDown {
-		for (var userId : list "${staticUserAccountId1},${staticUserAccountId2}") {
-			JSONUser.deleteUserByUserId(userId = "${userId}");
-		}
+		JSONUser.deleteUserByUserId(userId = "${staticUserAccountId}");
 
 		ObjectFieldAPI.deleteObjectField();
 	}
@@ -47,7 +37,7 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Then the value of the added field is set successfully in response") {
-			var actualValueOfPassportNumber = JSONUtil.getWithJSONPath("${staticResponse1}", "$.passportNumber");
+			var actualValueOfPassportNumber = JSONUtil.getWithJSONPath("${staticResponse}", "$.passportNumber");
 
 			TestUtils.assertEquals(
 				actual = "${actualValueOfPassportNumber}",
@@ -64,7 +54,7 @@ definition {
 			var actualValueOfPassportNumber = UserAccountAPI.getUpdatedFieldOfUserAccountWithPatchRequest(
 				fieldName = "passportNumber",
 				updatedFieldValue = "updateByPatch-passportNum2022",
-				userAccountId = "${staticUserAccountId1}");
+				userAccountId = "${staticUserAccountId}");
 		}
 
 		task ("Then the value of the added filed is updated successfully") {
@@ -87,7 +77,7 @@ definition {
 				fieldName = "passportNumber",
 				givenName = "usergn",
 				updatedFieldValue = "updateByPut-passportNum2022",
-				userAccountId = "${staticUserAccountId1}");
+				userAccountId = "${staticUserAccountId}");
 		}
 
 		task ("Then the value of the added filed is replaced successfully in response") {

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/MakeRelationshipWithSystemObject.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/MakeRelationshipWithSystemObject.testcase
@@ -53,7 +53,7 @@ definition {
 		}
 
 		task ("Given two userAccount entries created") {
-			UserAccountAPI.setUpGlobalUserAccountId(
+			UserAccountAPI.setUpGlobalUserAccountIds(
 				alternateName1 = "user1",
 				alternateName2 = "user2",
 				emailAddress1 = "user1@liferay.com",


### PR DESCRIPTION
**Background:**
- Add functional tests on break relationship between system object and custom object(Stroy )

**Test Plan**
- Given a foundation object
Given oneToMany relationship usersFoundations created
Given one foundation entry created
Given the userAccount entry created
Given I relate all the foundation entries with the userAccount entry through the userAccount PUT endpoint
When using the delete request deleteUserAccount{relationshipName}
Then I can see no one entry correctly related in GET request response with the relationshipName=usersFoundations
- Given a foundation object
Given oneToMany relationship usersFoundations created
Given two foundation entries created
Given one userAccount entry created
Given all foundation is related to userAccount through userAccounts PUT endpoint
When deleting one of the foundation entries with deleteUserAccount{relationshipName} request
Then I can see only one entry correctly related in GET request response
- Given a foundation object
Given manyToMany relationship usersFoundations created
Given one foundation entry created
Given one userAccount entry created
Given I relate the foundation entry with the userAccount entry through the userAccount PUT endpoint
When using the delete request deleteUserAccount{relationshipName}
Then I can see no one entry correctly related in GET request response with the relationshipName=usersFoundations

**JIRA Ticket:**
- https://issues.liferay.com/browse/LPS-169885