### PR TITLE
LPS-168255 Excluding empty contributed schemas

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -1388,10 +1388,23 @@ public class GraphQLServletExtender {
 				queryGraphQLObjectTypeBuilder);
 		}
 
-		rootQueryGraphQLObjectTypeBuilder.field(
-			_addField(queryGraphQLObjectTypeBuilder.build(), namespace));
-		rootMutationGraphQLObjectTypeBuilder.field(
-			_addField(mutationGraphQLObjectTypeBuilder.build(), namespace));
+		GraphQLObjectType queryGraphQLObjectType =
+			queryGraphQLObjectTypeBuilder.build();
+
+		if (ListUtil.isNotEmpty(queryGraphQLObjectType.getFieldDefinitions())) {
+			rootQueryGraphQLObjectTypeBuilder.field(
+				_addField(queryGraphQLObjectType, namespace));
+		}
+
+		GraphQLObjectType mutationGraphQLObjectType =
+			mutationGraphQLObjectTypeBuilder.build();
+
+		if (ListUtil.isNotEmpty(
+				mutationGraphQLObjectType.getFieldDefinitions())) {
+
+			rootMutationGraphQLObjectTypeBuilder.field(
+				_addField(mutationGraphQLObjectType, namespace));
+		}
 
 		GraphQLCodeRegistry.Builder graphQLCodeRegistryBuilder =
 			processingElementsContainer.getCodeRegistryBuilder();


### PR DESCRIPTION
The new graphql library version fails with empty schemas.

Contributed ones go into query: {c: {...}} and mutation: {c: {...}}.

We will not be defining the "c" schema if there are no contributed
fields to it.
