### PR TITLE
LPS-170429 Add minLength and maxLength functionality

### DIFF
--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/yaml/openapi/Schema.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/yaml/openapi/Schema.java
@@ -71,8 +71,16 @@ public class Schema {
 		return _maximum;
 	}
 
+	public Integer getMaxLength() {
+		return _maxLength;
+	}
+
 	public Double getMinimum() {
 		return _minimum;
+	}
+
+	public Integer getMinLength() {
+		return _minLength;
 	}
 
 	public String getName() {
@@ -167,8 +175,16 @@ public class Schema {
 		_maximum = maximum;
 	}
 
+	public void setMaxLength(Integer maxLength) {
+		_maxLength = maxLength;
+	}
+
 	public void setMinimum(Double minimum) {
 		_minimum = minimum;
+	}
+
+	public void setMinLength(Integer minLength) {
+		_minLength = minLength;
 	}
 
 	public void setName(String name) {
@@ -221,7 +237,9 @@ public class Schema {
 	private Items _items;
 	private boolean _jsonMap;
 	private Double _maximum;
+	private Integer _maxLength;
 	private Double _minimum;
+	private Integer _minLength;
 	private String _name;
 	private List<Schema> _oneOfSchemas;
 	private Map<String, Schema> _propertySchemas;

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/dto.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/dto.ftl
@@ -51,6 +51,7 @@ import javax.validation.constraints.DecimalMax;
 import javax.validation.constraints.DecimalMin;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
@@ -133,6 +134,7 @@ public class ${schemaName} <#if dtoParentClassName?has_content>extends ${dtoPare
 		<#assign
 			propertySchema = freeMarkerTool.getDTOPropertySchema(propertyName, schema)
 			propertyType = properties[propertyName]
+			sizeParameters = []
 		/>
 
 		<#if propertySchema.maximum??>
@@ -141,6 +143,18 @@ public class ${schemaName} <#if dtoParentClassName?has_content>extends ${dtoPare
 
 		<#if propertySchema.minimum??>
 			@DecimalMin("${propertySchema.minimum}")
+		</#if>
+
+		<#if propertySchema.maxLength??>
+			<#assign sizeParameters = sizeParameters + ["max = ${propertySchema.maxLength}"] />
+		</#if>
+
+		<#if propertySchema.minLength??>
+			<#assign sizeParameters = sizeParameters + ["min = ${propertySchema.minLength}"] />
+		</#if>
+
+		<#if sizeParameters?has_content>
+			@Size(${sizeParameters?join(", ")})
 		</#if>
 
 		<#if propertySchema.jsonMap>


### PR DESCRIPTION
This PR contains the code to add the functionality of the parameters minLength and maxLength of the OpenAPI specification.

How to test it:

- Include a parameter minLength, maxLength or both in a OpenAPI Schema
- Execute REST Builder with the command gw buildREST
- Deploy your REST module
- Execute a request with a valid parameter: It will work
- Execute a request with an invalid parameter: It will fail