### PR TITLE
LPS-167930: Allow developers to break a relationship between 2 custom objects

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -17,6 +17,7 @@ package com.liferay.object.rest.internal.deployer;
 import com.liferay.object.action.engine.ObjectActionEngine;
 import com.liferay.object.deployer.ObjectDefinitionDeployer;
 import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.related.models.ObjectRelatedModelsProviderRegistry;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
 import com.liferay.object.rest.internal.graphql.dto.v1_0.ObjectDefinitionGraphQLDTOContributor;
 import com.liferay.object.rest.internal.jaxrs.application.ObjectEntryApplication;
@@ -418,6 +419,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 							return new ObjectEntryRelatedObjectsResourceImpl(
 								_objectDefinitionLocalService,
 								_objectEntryManagerRegistry,
+								_objectRelatedModelsProviderRegistry,
 								_objectRelationshipService);
 						}
 
@@ -592,6 +594,10 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 
 	@Reference
 	private ObjectFieldLocalService _objectFieldLocalService;
+
+	@Reference
+	private ObjectRelatedModelsProviderRegistry
+		_objectRelatedModelsProviderRegistry;
 
 	@Reference
 	private ObjectRelationshipLocalService _objectRelationshipLocalService;

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryRelatedObjectsResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryRelatedObjectsResourceImpl.java
@@ -34,6 +34,7 @@ import javax.servlet.http.HttpServletRequest;
 
 import javax.validation.constraints.NotNull;
 
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
@@ -46,6 +47,31 @@ import javax.ws.rs.core.UriInfo;
  * @author Carlos Correa
  */
 public abstract class BaseObjectEntryRelatedObjectsResourceImpl {
+
+	@DELETE
+	@Parameters(
+		{
+			@Parameter(in = ParameterIn.PATH, name = "currentObjectEntryId"),
+			@Parameter(in = ParameterIn.PATH, name = "objectRelationshipName"),
+			@Parameter(in = ParameterIn.PATH, name = "relatedObjectEntryId")
+		}
+	)
+	@Path(
+		"/{currentObjectEntryId}/{objectRelationshipName}/{relatedObjectEntryId}"
+	)
+	@Produces({"application/json", "application/xml"})
+	@Tags(@Tag(name = "ObjectEntry"))
+	public abstract void deleteCurrentObjectEntry(
+			@NotNull @Parameter(hidden = true)
+			@PathParam("currentObjectEntryId")
+			Long currentObjectEntryId,
+			@NotNull @Parameter(hidden = true)
+			@PathParam("objectRelationshipName")
+			String objectRelationshipName,
+			@NotNull @Parameter(hidden = true)
+			@PathParam("relatedObjectEntryId")
+			Long relatedObjectEntryId)
+		throws Exception;
 
 	@GET
 	@Parameters(


### PR DESCRIPTION
**What is new?**
- Create new endpoint in `BaseObjectEntryRelatedObjectsResourceImpl`: `deleteCurrentObjectEntry` which will unlink two related custom object entries.
- Modify `ObjectEntryOpenAPIContributor` to add the `DELETE` endpoint in the API Explorer.
- Implement `deleteCurrentObjectEntry` method that checks if both object entries exist and are related to their own ObjectDefinitions.
- Create some tests cases
- Requested changes in https://github.com/brianchandotcom/liferay-portal/pull/127471#issuecomment-1344566698

**NOTE**
If we want to unlink an `currentObjectEntryId` (Custom Object) and a `relatedObjectEntryId` (Custom Object) and if one of them doesn't exist, it will throw a 404 status code.

![image](https://user-images.githubusercontent.com/44723449/202137573-51bbfe74-579c-49fa-8fd4-c3bbce926a33.png)

The aim of this PR is to create the endpoint to unlink 2 objects (both customs). Let's see an example. Imagine a University with their Subjects and their Students in this way:

1. University is a Custom Object. Has a one-to-many relationship with Student (Custom Object) and a many-to-many relationship with Subject (Custom)
2. According to these requisites, there should be an endpoint to link and unlink the student and the subjects, and this endpoint should be in the existing REST API of the corresponding object entry.


**How to test it**
Deploy the following modules:

1. object-rest-api.
2. object-rest-impl.

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-168650