### PR TITLE
LPS-170821 Support non json responses in restClient

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/template/RESTClientTemplateContextContributor.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/template/RESTClientTemplateContextContributor.java
@@ -20,7 +20,6 @@ import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.servlet.PipingServletResponse;
 import com.liferay.portal.kernel.servlet.ServletContextPool;
 import com.liferay.portal.kernel.template.TemplateContextContributor;
-import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.vulcan.internal.template.servlet.RESTClientHttpRequest;
 import com.liferay.portal.vulcan.internal.template.servlet.RESTClientHttpResponse;
@@ -30,7 +29,6 @@ import java.util.Map;
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -50,22 +48,13 @@ public class RESTClientTemplateContextContributor
 		Map<String, Object> contextObjects,
 		HttpServletRequest httpServletRequest) {
 
-		ThemeDisplay themeDisplay = (ThemeDisplay)contextObjects.get(
-			"themeDisplay");
-
-		contextObjects.put(
-			"restClient",
-			new RESTClient(httpServletRequest, themeDisplay.getResponse()));
+		contextObjects.put("restClient", new RESTClient(httpServletRequest));
 	}
 
 	public class RESTClient {
 
-		public RESTClient(
-			HttpServletRequest httpServletRequest,
-			HttpServletResponse httpServletResponse) {
-
+		public RESTClient(HttpServletRequest httpServletRequest) {
 			_httpServletRequest = httpServletRequest;
-			_httpServletResponse = httpServletResponse;
 		}
 
 		public Object get(String path) throws Exception {
@@ -78,15 +67,13 @@ public class RESTClientTemplateContextContributor
 
 			requestDispatcher.forward(
 				new RESTClientHttpRequest(_httpServletRequest),
-				new RESTClientHttpResponse(
-					new PipingServletResponse(
-						_httpServletResponse, unsyncStringWriter)));
+				new PipingServletResponse(
+					new RESTClientHttpResponse(), unsyncStringWriter));
 
 			return _jsonFactory.looseDeserialize(unsyncStringWriter.toString());
 		}
 
 		private final HttpServletRequest _httpServletRequest;
-		private final HttpServletResponse _httpServletResponse;
 
 	}
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/template/servlet/RESTClientHttpRequest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/template/servlet/RESTClientHttpRequest.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.util.Validator;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
@@ -51,6 +52,11 @@ public class RESTClientHttpRequest extends HttpServletRequestWrapper {
 	}
 
 	@Override
+	public Object getAttribute(String name) {
+		return _attributes.getOrDefault(name, super.getAttribute(name));
+	}
+
+	@Override
 	public String getHeader(String name) {
 		return _headers.get(name);
 	}
@@ -71,6 +77,12 @@ public class RESTClientHttpRequest extends HttpServletRequestWrapper {
 		return HttpMethods.GET;
 	}
 
+	@Override
+	public void setAttribute(String name, Object object) {
+		_attributes.put(name, object);
+	}
+
+	private final Map<String, Object> _attributes = new HashMap<>();
 	private final Map<String, String> _headers;
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/template/servlet/RESTClientHttpResponse.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/template/servlet/RESTClientHttpResponse.java
@@ -15,9 +15,34 @@
 package com.liferay.portal.vulcan.internal.template.servlet;
 
 import com.liferay.portal.kernel.servlet.DummyHttpServletResponse;
+import com.liferay.portal.kernel.servlet.HttpHeaders;
+
+import java.util.Objects;
 
 /**
  * @author Alejandro Tardín
  */
 public class RESTClientHttpResponse extends DummyHttpServletResponse {
+
+	@Override
+	public String getContentType() {
+		return _contentType;
+	}
+
+	@Override
+	public void setContentType(String contentType) {
+		_contentType = contentType;
+	}
+
+	@Override
+	public void setHeader(String name, String value) {
+		if (Objects.equals(name, HttpHeaders.CONTENT_TYPE)) {
+			_contentType = value;
+		}
+
+		super.setHeader(name, value);
+	}
+
+	private String _contentType;
+
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/template/servlet/RESTClientHttpResponse.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/template/servlet/RESTClientHttpResponse.java
@@ -14,103 +14,10 @@
 
 package com.liferay.portal.vulcan.internal.template.servlet;
 
-import java.util.Locale;
-
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpServletResponseWrapper;
+import com.liferay.portal.kernel.servlet.DummyHttpServletResponse;
 
 /**
  * @author Alejandro Tardín
  */
-public class RESTClientHttpResponse extends HttpServletResponseWrapper {
-
-	public RESTClientHttpResponse(HttpServletResponse httpServletResponse) {
-		super(httpServletResponse);
-	}
-
-	@Override
-	public void addCookie(Cookie cookie) {
-	}
-
-	@Override
-	public void addDateHeader(String name, long date) {
-	}
-
-	@Override
-	public void addHeader(String name, String value) {
-	}
-
-	@Override
-	public void addIntHeader(String name, int value) {
-	}
-
-	@Override
-	public void flushBuffer() {
-	}
-
-	@Override
-	public void reset() {
-	}
-
-	@Override
-	public void resetBuffer() {
-	}
-
-	@Override
-	public void sendError(int status) {
-	}
-
-	@Override
-	public void sendError(int status, String message) {
-	}
-
-	@Override
-	public void sendRedirect(String location) {
-	}
-
-	@Override
-	public void setBufferSize(int size) {
-	}
-
-	@Override
-	public void setCharacterEncoding(String characterEncoding) {
-	}
-
-	@Override
-	public void setContentLength(int contentLength) {
-	}
-
-	@Override
-	public void setContentLengthLong(long contentLength) {
-	}
-
-	@Override
-	public void setContentType(String contentType) {
-	}
-
-	@Override
-	public void setDateHeader(String name, long date) {
-	}
-
-	@Override
-	public void setHeader(String name, String value) {
-	}
-
-	@Override
-	public void setIntHeader(String name, int value) {
-	}
-
-	@Override
-	public void setLocale(Locale locale) {
-	}
-
-	@Override
-	public void setStatus(int status) {
-	}
-
-	@Override
-	public void setStatus(int status, String message) {
-	}
-
+public class RESTClientHttpResponse extends DummyHttpServletResponse {
 }


### PR DESCRIPTION
Fixes https://issues.liferay.com/browse/LPS-170821. Only serializes json when the content type is json, otherwise will return the content as a string.