### PR TITLE
LPS-168255 Fix the validated method in GraphQL and Questions scopes of the created Service Access Policy

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/vulcan/graphql/validation/OAuth2GraphQLRequestContextValidator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/vulcan/graphql/validation/OAuth2GraphQLRequestContextValidator.java
@@ -85,7 +85,7 @@ public class OAuth2GraphQLRequestContextValidator
 			_checkScope(graphQLRequestContext, serviceReference);
 		}
 
-		Method method = graphQLRequestContext.getMethod();
+		Method method = graphQLRequestContext.getResourceMethod();
 
 		if (method != null) {
 			_setServiceDepth();

--- a/modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Vulcan API
 Bundle-SymbolicName: com.liferay.portal.vulcan.api
-Bundle-Version: 25.2.1
+Bundle-Version: 26.0.0
 Export-Package:\
 	com.liferay.portal.vulcan.accept.language,\
 	com.liferay.portal.vulcan.aggregation,\

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/graphql/validation/GraphQLRequestContext.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/graphql/validation/GraphQLRequestContext.java
@@ -25,8 +25,6 @@ public interface GraphQLRequestContext {
 
 	public long getCompanyId();
 
-	public Method getMethod();
-
 	public String getNamespace();
 
 	public Class<?> getResourceClass();

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/graphql/validation/packageinfo
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/graphql/validation/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 2.0.0

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/validation/GraphQLDTOContributorRequestContext.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/validation/GraphQLDTOContributorRequestContext.java
@@ -45,11 +45,6 @@ public class GraphQLDTOContributorRequestContext
 	}
 
 	@Override
-	public Method getMethod() {
-		return null;
-	}
-
-	@Override
 	public String getNamespace() {
 		return null;
 	}

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/validation/ServletDataRequestContext.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/validation/ServletDataRequestContext.java
@@ -34,7 +34,6 @@ public class ServletDataRequestContext implements GraphQLRequestContext {
 		ServletData servletData) {
 
 		_companyId = companyId;
-		_method = method;
 		_servletData = servletData;
 
 		_namespace = _getNamespace(servletData);
@@ -50,11 +49,6 @@ public class ServletDataRequestContext implements GraphQLRequestContext {
 	@Override
 	public long getCompanyId() {
 		return _companyId;
-	}
-
-	@Override
-	public Method getMethod() {
-		return _method;
 	}
 
 	@Override
@@ -142,7 +136,6 @@ public class ServletDataRequestContext implements GraphQLRequestContext {
 	}
 
 	private final long _companyId;
-	private final Method _method;
 	private final String _namespace;
 	private final Class<?> _resourceClass;
 	private final Method _resourceMethod;

--- a/modules/apps/questions/questions-web/build.gradle
+++ b/modules/apps/questions/questions-web/build.gradle
@@ -17,6 +17,7 @@ dependencies {
 	compileOnly project(":apps:portal-security:portal-security-service-access-policy-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-persistence-api")
+	compileOnly project(":apps:static:portal:portal-upgrade-api")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")

--- a/modules/apps/questions/questions-web/src/main/java/com/liferay/questions/web/internal/configuration/persistence/listener/QuestionsConfigurationModelListener.java
+++ b/modules/apps/questions/questions-web/src/main/java/com/liferay/questions/web/internal/configuration/persistence/listener/QuestionsConfigurationModelListener.java
@@ -146,22 +146,36 @@ public class QuestionsConfigurationModelListener
 			_sapEntryService.deleteSAPEntry(sapEntry);
 		}
 		else if (enableAnonymousRead && (sapEntry == null)) {
-			String mbPackage = "com.liferay.message.boards.service.";
+			String headlessDeliveryPackage =
+				"com.liferay.headless.delivery.internal.resource.v1_0.";
 
 			_sapEntryService.addSAPEntry(
 				StringBundler.concat(
-					"com.liferay.commerce.product.service.",
-					"CommerceCatalogService#getCommerceCatalogs\n",
-					"com.liferay.expando.kernel.service.",
-					"ExpandoValueService#getData\n", mbPackage,
-					"MBCategoryService#getCategory\n", mbPackage,
-					"MBCategoryService#getCategoriesCount\n", mbPackage,
-					"MBMessageService#fetchMBMessageByUrlSubject\n", mbPackage,
-					"MBMessageService#getChildMessages\n", mbPackage,
-					"MBMessageService#getChildMessagesCount\n", mbPackage,
-					"MBMessageService#getMessage\n", mbPackage,
-					"MBThreadService#getThreads\n", mbPackage,
-					"MBThreadService#getThreadsCount\n"),
+					"com.liferay.headless.admin.taxonomy.internal.resource.",
+					"v1_0.KeywordResourceImpl#getKeywordsRankedPage\n",
+					"com.liferay.headless.admin.user.internal.resource.v1_0.",
+					"SubscriptionResourceImpl#",
+					"getMyUserAccountSubscriptionsPage\n",
+					headlessDeliveryPackage,
+					"MessageBoardMessageResourceImpl#getMessageBoardMessage\n",
+					headlessDeliveryPackage, "MessageBoardMessageResourceImpl#",
+					"getMessageBoardThreadMessageBoardMessagesPage\n",
+					headlessDeliveryPackage, "MessageBoardMessageResourceImpl#",
+					"getSiteMessageBoardMessageByFriendlyUrlPath\n",
+					headlessDeliveryPackage, "MessageBoardMessageResourceImpl#",
+					"getSiteMessageBoardMessagesPage\n",
+					headlessDeliveryPackage, "MessageBoardSectionResourceImpl#",
+					"getMessageBoardSection\n", headlessDeliveryPackage,
+					"MessageBoardSectionResourceImpl#",
+					"getSiteMessageBoardSectionsPage\n",
+					headlessDeliveryPackage, "MessageBoardThreadResourceImpl#",
+					"getMessageBoardSectionMessageBoardThreadsPage\n",
+					headlessDeliveryPackage, "MessageBoardThreadResourceImpl#",
+					"getMessageBoardThreadsRankedPage\n",
+					headlessDeliveryPackage, "MessageBoardThreadResourceImpl#",
+					"getSiteMessageBoardThreadByFriendlyUrlPath\n",
+					headlessDeliveryPackage, "MessageBoardThreadResourceImpl#",
+					"getSiteMessageBoardThreadsPage\n"),
 				true, true, name,
 				Collections.singletonMap(
 					LocaleThreadLocal.getDefaultLocale(), name),

--- a/modules/apps/questions/questions-web/src/main/java/com/liferay/questions/web/internal/upgrade/registry/QuestionsWebUpgradeStepRegistrator.java
+++ b/modules/apps/questions/questions-web/src/main/java/com/liferay/questions/web/internal/upgrade/registry/QuestionsWebUpgradeStepRegistrator.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.questions.web.internal.upgrade.registry;
+
+import com.liferay.portal.security.service.access.policy.service.SAPEntryService;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.questions.web.internal.upgrade.v1_0_0.UpdateAllowedServicesSignaturesInSAPEntryUpgradeProcess;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Carlos Correa
+ */
+@Component(service = UpgradeStepRegistrator.class)
+public class QuestionsWebUpgradeStepRegistrator
+	implements UpgradeStepRegistrator {
+
+	@Override
+	public void register(Registry registry) {
+		registry.registerInitialization();
+
+		registry.register(
+			"0.0.1", "1.0.0",
+			new UpdateAllowedServicesSignaturesInSAPEntryUpgradeProcess(
+				_sapEntryService));
+	}
+
+	@Reference
+	private SAPEntryService _sapEntryService;
+
+}

--- a/modules/apps/questions/questions-web/src/main/java/com/liferay/questions/web/internal/upgrade/v1_0_0/UpdateAllowedServicesSignaturesInSAPEntryUpgradeProcess.java
+++ b/modules/apps/questions/questions-web/src/main/java/com/liferay/questions/web/internal/upgrade/v1_0_0/UpdateAllowedServicesSignaturesInSAPEntryUpgradeProcess.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.questions.web.internal.upgrade.v1_0_0;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.security.service.access.policy.service.SAPEntryService;
+
+/**
+ * @author Carlos Correa
+ */
+public class UpdateAllowedServicesSignaturesInSAPEntryUpgradeProcess
+	extends UpgradeProcess {
+
+	public UpdateAllowedServicesSignaturesInSAPEntryUpgradeProcess(
+		SAPEntryService sapEntryService) {
+
+		_sapEntryService = sapEntryService;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		String headlessDeliveryPackage =
+			"com.liferay.headless.delivery.internal.resource.v1_0.";
+
+		String allowedServiceSignatures = StringBundler.concat(
+			"com.liferay.headless.admin.taxonomy.internal.resource.v1_0.",
+			"KeywordResourceImpl#getKeywordsRankedPage\n",
+			"com.liferay.headless.admin.user.internal.resource.v1_0.",
+			"SubscriptionResourceImpl#getMyUserAccountSubscriptionsPage\n",
+			headlessDeliveryPackage,
+			"MessageBoardMessageResourceImpl#getMessageBoardMessage\n",
+			headlessDeliveryPackage, "MessageBoardMessageResourceImpl#",
+			"getMessageBoardThreadMessageBoardMessagesPage\n",
+			headlessDeliveryPackage, "MessageBoardMessageResourceImpl#",
+			"getSiteMessageBoardMessageByFriendlyUrlPath\n",
+			headlessDeliveryPackage, "MessageBoardMessageResourceImpl#",
+			"getSiteMessageBoardMessagesPage\n", headlessDeliveryPackage,
+			"MessageBoardSectionResourceImpl#getMessageBoardSection\n",
+			headlessDeliveryPackage, "MessageBoardSectionResourceImpl#",
+			"getSiteMessageBoardSectionsPage\n", headlessDeliveryPackage,
+			"MessageBoardThreadResourceImpl#",
+			"getMessageBoardSectionMessageBoardThreadsPage\n",
+			headlessDeliveryPackage, "MessageBoardThreadResourceImpl#",
+			"getMessageBoardThreadsRankedPage\n", headlessDeliveryPackage,
+			"MessageBoardThreadResourceImpl#",
+			"getSiteMessageBoardThreadByFriendlyUrlPath\n",
+			headlessDeliveryPackage, "MessageBoardThreadResourceImpl#",
+			"getSiteMessageBoardThreadsPage");
+
+		runSQL(
+			StringBundler.concat(
+				"update SAPEntry set allowedServiceSignatures = ",
+				StringUtil.quote(allowedServiceSignatures), " where name = ",
+				StringUtil.quote("QUESTIONS_SERVICE_ACCESS_POLICY")));
+	}
+
+	private final SAPEntryService _sapEntryService;
+
+}

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
@@ -251,6 +251,11 @@ public class PortalUpgradeProcessRegistryImpl
 
 		upgradeVersionTreeMap.put(
 			new Version(25, 1, 0), new CTModelUpgradeProcess("EmailAddress"));
+
+		upgradeVersionTreeMap.put(
+			new Version(25, 1, 1),
+			UpgradeModulesFactory.create(
+				new String[] {"com.liferay.questions.web"}, null));
 	}
 
 }


### PR DESCRIPTION
This PR contains the code to fix this issue: https://issues.liferay.com/browse/LPS-168255.

For that, it is necessary the following actions:

- Fix the method that is being validated against the `AccessControlAdvisor`.
- As now the scopes are managed by the REST API resource instead of the Service to make GraphQL scopes match with the REST API scopes, the registers must be updated when creating the Service Access Policy.
- For older versions, an Upgrade Process has been created for the `questions-web` module in order to update the content of the Service Access Policy previously created.

---

**How to reproduce it**:

1. Add Questions following this instructions: https://learn.liferay.com/dxp/latest/en/collaboration-and-social/questions/using-the-questions-app.html
2. In Questions, create a topic, a question, some responses and include some tags in it.
3. Go to System Settings -> Message Boards -> Questions -> Select the option "Enable Anonymous Read" and Save
4. Open Questions in a new window without being authenticated.

---

**Before the PR**:

---

![image](https://user-images.githubusercontent.com/32699538/207326248-3041467e-1499-477a-8be3-171dd3e3b261.png)

![image](https://user-images.githubusercontent.com/32699538/207326303-818bf3b6-e413-4909-8e0f-f5645360085a.png)

---

**After the PR**:

---

![image](https://user-images.githubusercontent.com/32699538/207325494-e12accac-2464-4283-947a-16d6f3ad184b.png)

![image](https://user-images.githubusercontent.com/32699538/207325659-da765a4f-03b5-4c71-abb0-f5c2ecd33a2e.png)

![image](https://user-images.githubusercontent.com/32699538/207325725-d74eae46-615a-4573-b226-7150b9009ece.png)

