### PR TITLE
meg test batch

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseKeywordResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseKeywordResourceTestCase.java
@@ -75,6 +75,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -244,7 +246,7 @@ public abstract class BaseKeywordResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantKeyword),
 				(List<Keyword>)page.getItems());
-			assertValid(page);
+			assertValid(page, "/asset-libraries/{assetLibraryId}/keywords");
 		}
 
 		Keyword keyword1 = testGetAssetLibraryKeywordsPage_addKeyword(
@@ -260,7 +262,7 @@ public abstract class BaseKeywordResourceTestCase {
 
 		assertEqualsIgnoringOrder(
 			Arrays.asList(keyword1, keyword2), (List<Keyword>)page.getItems());
-		assertValid(page);
+		assertValid(page, "/asset-libraries/{assetLibraryId}/keywords");
 
 		keywordResource.deleteKeyword(keyword1.getId());
 
@@ -658,7 +660,7 @@ public abstract class BaseKeywordResourceTestCase {
 
 		assertContains(keyword1, (List<Keyword>)page.getItems());
 		assertContains(keyword2, (List<Keyword>)page.getItems());
-		assertValid(page);
+		assertValid(page, "/keywords/ranked");
 
 		keywordResource.deleteKeyword(keyword1.getId());
 
@@ -908,7 +910,7 @@ public abstract class BaseKeywordResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantKeyword),
 				(List<Keyword>)page.getItems());
-			assertValid(page);
+			assertValid(page, "/sites/{siteId}/keywords");
 		}
 
 		Keyword keyword1 = testGetSiteKeywordsPage_addKeyword(
@@ -924,7 +926,7 @@ public abstract class BaseKeywordResourceTestCase {
 
 		assertEqualsIgnoringOrder(
 			Arrays.asList(keyword1, keyword2), (List<Keyword>)page.getItems());
-		assertValid(page);
+		assertValid(page, "/sites/{siteId}/keywords");
 
 		keywordResource.deleteKeyword(keyword1.getId());
 
@@ -1579,7 +1581,7 @@ public abstract class BaseKeywordResourceTestCase {
 		Assert.assertTrue(valid);
 	}
 
-	protected void assertValid(Page<Keyword> page) {
+	protected void assertValid(Page<Keyword> page, String path) {
 		boolean valid = false;
 
 		java.util.Collection<Keyword> keywords = page.getItems();
@@ -1594,6 +1596,97 @@ public abstract class BaseKeywordResourceTestCase {
 		}
 
 		Assert.assertTrue(valid);
+
+		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
+		//this List is temporary and can help us detecting
+		//cases that should match the acceptance criteria, but are not covered with the current approach
+
+		List<String> pathsNotCovered = new ArrayList<>();
+
+		if (path.equals("/asset-libraries/{assetLibraryId}/keywords")) {
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/keywords",
+				path);
+		}
+		else {
+			pathsNotCovered.add("/asset-libraries/{assetLibraryId}/keywords");
+		}
+
+		if (path.equals("/keywords/ranked")) {
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-admin-taxonomy/v1.0/keywords/ranked", path);
+		}
+		else {
+			pathsNotCovered.add("/keywords/ranked");
+		}
+
+		if (path.equals("/sites/{siteId}/keywords")) {
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-admin-taxonomy/v1.0/sites/{siteId}/keywords", path);
+		}
+		else {
+			pathsNotCovered.add("/sites/{siteId}/keywords");
+		}
+
+		if (!pathsNotCovered.isEmpty()) {
+			Assert.fail(
+				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
+					pathsNotCovered.toString());
+		}
+	}
+
+	private void assertBatchAction(
+		Page<Keyword> page, String action, String method, String expectedPath,
+		String path) {
+
+		Map<String, Map> actions = page.getActions();
+
+		Map batchAction = actions.get(action);
+
+		Assert.assertNotNull(
+			"No Actions for " + action + " in path " + path, batchAction);
+		Assert.assertEquals(
+			"The batch action method value is not correct", method,
+			batchAction.get("method"));
+		assertHrefInBatchActionMatchesPath(
+			expectedPath,
+			batchAction.get(
+				"href"
+			).toString(),
+			action, path);
+	}
+
+	private void assertHrefInBatchActionMatchesPath(
+		String expectedPath, String href, String action, String path) {
+
+		//only paths with POST operation available will have createBatch
+		//we need a freeMarker "if" to check whether the path we're checking has it
+		//and then check the createBatch details
+
+		if (action.equals("createBatch")) {
+			String expectedPathReplaced = expectedPath.replaceAll(
+				"(\\Q{\\E.*?\\Q}\\E)", "(.*)");
+			String[] detachActualPathFromServer = href.split("/o/");
+			Pattern expectedPathPattern = Pattern.compile(
+				expectedPathReplaced + "/batch");
+			Matcher actualPathMatcher = expectedPathPattern.matcher(
+				"/" + detachActualPathFromServer[1]);
+			Assert.assertTrue(
+				"The /" + detachActualPathFromServer[1] + " does not match " +
+					expectedPathReplaced + "/batch for " + action +
+						" in the path " + path,
+				actualPathMatcher.matches());
+		}
+
+		if (action.equals("deleteBatch") || action.equals("updateBatch")) {
+			/*TO DO
+			updateBacth and deleteBatch inherit the href from the "simplest" method in the group
+			(that is, no siteId, no assetLibraryId, etc., needed)
+			*/
+		}
 	}
 
 	protected String[] getAdditionalAssertFieldNames() {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseKeywordResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseKeywordResourceTestCase.java
@@ -75,8 +75,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -246,7 +244,10 @@ public abstract class BaseKeywordResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantKeyword),
 				(List<Keyword>)page.getItems());
-			assertValid(page, "/asset-libraries/{assetLibraryId}/keywords");
+			assertValid(
+				page,
+				testGetAssetLibraryKeywordsPage_getExpectedActions(
+					irrelevantAssetLibraryId));
 		}
 
 		Keyword keyword1 = testGetAssetLibraryKeywordsPage_addKeyword(
@@ -262,11 +263,32 @@ public abstract class BaseKeywordResourceTestCase {
 
 		assertEqualsIgnoringOrder(
 			Arrays.asList(keyword1, keyword2), (List<Keyword>)page.getItems());
-		assertValid(page, "/asset-libraries/{assetLibraryId}/keywords");
+		assertValid(
+			page,
+			testGetAssetLibraryKeywordsPage_getExpectedActions(assetLibraryId));
 
 		keywordResource.deleteKeyword(keyword1.getId());
 
 		keywordResource.deleteKeyword(keyword2.getId());
+	}
+
+	protected Map<String, Map>
+			testGetAssetLibraryKeywordsPage_getExpectedActions(
+				Long assetLibraryId)
+		throws Exception {
+
+		Map<String, Map> expectedActions = new HashMap<>();
+
+		Map createBatchAction = new HashMap<>();
+		createBatchAction.put("method", "POST");
+		createBatchAction.put(
+			"href",
+			"http://localhost:8080/o/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/keywords/batch".
+				replace("{assetLibraryId}", String.valueOf(assetLibraryId)));
+
+		expectedActions.put("createBatch", createBatchAction);
+
+		return expectedActions;
 	}
 
 	@Test
@@ -660,11 +682,19 @@ public abstract class BaseKeywordResourceTestCase {
 
 		assertContains(keyword1, (List<Keyword>)page.getItems());
 		assertContains(keyword2, (List<Keyword>)page.getItems());
-		assertValid(page, "/keywords/ranked");
+		assertValid(page, testGetKeywordsRankedPage_getExpectedActions());
 
 		keywordResource.deleteKeyword(keyword1.getId());
 
 		keywordResource.deleteKeyword(keyword2.getId());
+	}
+
+	protected Map<String, Map> testGetKeywordsRankedPage_getExpectedActions()
+		throws Exception {
+
+		Map<String, Map> expectedActions = new HashMap<>();
+
+		return expectedActions;
 	}
 
 	@Test
@@ -910,7 +940,9 @@ public abstract class BaseKeywordResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantKeyword),
 				(List<Keyword>)page.getItems());
-			assertValid(page, "/sites/{siteId}/keywords");
+			assertValid(
+				page,
+				testGetSiteKeywordsPage_getExpectedActions(irrelevantSiteId));
 		}
 
 		Keyword keyword1 = testGetSiteKeywordsPage_addKeyword(
@@ -926,11 +958,29 @@ public abstract class BaseKeywordResourceTestCase {
 
 		assertEqualsIgnoringOrder(
 			Arrays.asList(keyword1, keyword2), (List<Keyword>)page.getItems());
-		assertValid(page, "/sites/{siteId}/keywords");
+		assertValid(page, testGetSiteKeywordsPage_getExpectedActions(siteId));
 
 		keywordResource.deleteKeyword(keyword1.getId());
 
 		keywordResource.deleteKeyword(keyword2.getId());
+	}
+
+	protected Map<String, Map> testGetSiteKeywordsPage_getExpectedActions(
+			Long siteId)
+		throws Exception {
+
+		Map<String, Map> expectedActions = new HashMap<>();
+
+		Map createBatchAction = new HashMap<>();
+		createBatchAction.put("method", "POST");
+		createBatchAction.put(
+			"href",
+			"http://localhost:8080/o/headless-admin-taxonomy/v1.0/sites/{siteId}/keywords/batch".
+				replace("{siteId}", String.valueOf(siteId)));
+
+		expectedActions.put("createBatch", createBatchAction);
+
+		return expectedActions;
 	}
 
 	@Test
@@ -1581,7 +1631,9 @@ public abstract class BaseKeywordResourceTestCase {
 		Assert.assertTrue(valid);
 	}
 
-	protected void assertValid(Page<Keyword> page, String path) {
+	protected void assertValid(
+		Page<Keyword> page, Map<String, Map> expectedActions) {
+
 		boolean valid = false;
 
 		java.util.Collection<Keyword> keywords = page.getItems();
@@ -1597,96 +1649,19 @@ public abstract class BaseKeywordResourceTestCase {
 
 		Assert.assertTrue(valid);
 
-		if (path.equals("/asset-libraries/{assetLibraryId}/keywords")) {
-			assertBatchAction(
-				page, "createBatch", "POST",
-				"/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/keywords",
-				path);
-			assertBatchAction(
-				page, "deleteBatch", "DELETE",
-				"/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/keywords",
-				path);
-		}
-
-		if (path.equals("/keywords/ranked")) {
-			assertBatchAction(
-				page, "createBatch", "POST",
-				"/headless-admin-taxonomy/v1.0/keywords/ranked", path);
-			assertBatchAction(
-				page, "deleteBatch", "DELETE",
-				"/headless-admin-taxonomy/v1.0/keywords/ranked", path);
-		}
-
-		if (path.equals("/sites/{siteId}/keywords")) {
-			assertBatchAction(
-				page, "createBatch", "POST",
-				"/headless-admin-taxonomy/v1.0/sites/{siteId}/keywords", path);
-			assertBatchAction(
-				page, "deleteBatch", "DELETE",
-				"/headless-admin-taxonomy/v1.0/sites/{siteId}/keywords", path);
-		}
-	}
-
-	private void assertBatchAction(
-		Page<Keyword> page, String action, String method, String expectedPath,
-		String path) {
-
 		Map<String, Map> actions = page.getActions();
 
-		Map batchAction = actions.get(action);
+		for (String expectedActionName : expectedActions.keySet()) {
+			Map action = actions.get(expectedActionName);
 
-		Assert.assertNotNull(
-			"No Actions for " + action + " in path " + path, batchAction);
-		Assert.assertEquals(
-			"The batch action method value is not correct", method,
-			batchAction.get("method"));
-		assertHrefInBatchActionMatchesPath(
-			expectedPath,
-			batchAction.get(
-				"href"
-			).toString(),
-			action, path);
-	}
+			Assert.assertNotNull(
+				expectedActionName + " action is missing", action);
 
-	private void assertHrefInBatchActionMatchesPath(
-		String expectedPath, String href, String action, String path) {
+			Map expectedAction = expectedActions.get(expectedActionName);
 
-		//only paths with POST operation available will have createBatch
-		//we need a freeMarker "if" to check whether the path we're checking has it
-		//and then check the createBatch details
-
-		if (action.equals("createBatch")) {
-			String expectedPathReplaced = expectedPath.replaceAll(
-				"(\\Q{\\E.*?\\Q}\\E)", "(.*)");
-			String[] detachActualPathFromServer = href.split("/o/");
-			Pattern expectedPathPattern = Pattern.compile(
-				expectedPathReplaced + "/batch");
-			Matcher actualPathMatcher = expectedPathPattern.matcher(
-				"/" + detachActualPathFromServer[1]);
-			Assert.assertTrue(
-				"The /" + detachActualPathFromServer[1] + " does not match " +
-					expectedPathReplaced + "/batch for " + action +
-						" in the path " + path,
-				actualPathMatcher.matches());
-		}
-
-		if (action.equals("deleteBatch") || action.equals("updateBatch")) {
-			/*TO DO
-			updateBacth and deleteBatch inherit the href from the "simplest" method in the group
-			(that is, no siteId, no assetLibraryId, etc., needed)
-			*/
-			String expectedPathReplaced = expectedPath.replaceAll(
-				"(/v.1.0/(.*?)/\\Q{\\E.*?\\Q}\\E)", "/v.1.0");
-			String[] detachActualPathFromServer = href.split("/o/");
-			Pattern expectedPathPattern = Pattern.compile(
-				expectedPathReplaced + "/batch");
-			Matcher actualPathMatcher = expectedPathPattern.matcher(
-				"/" + detachActualPathFromServer[1]);
-			Assert.assertTrue(
-				"The /" + detachActualPathFromServer[1] + " does not match " +
-					expectedPathReplaced + "/batch for " + action +
-						" in the path " + path,
-				actualPathMatcher.matches());
+			Assert.assertEquals(
+				expectedAction.get("method"), action.get("method"));
+			Assert.assertEquals(expectedAction.get("href"), action.get("href"));
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseKeywordResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseKeywordResourceTestCase.java
@@ -1602,17 +1602,27 @@ public abstract class BaseKeywordResourceTestCase {
 				page, "createBatch", "POST",
 				"/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/keywords",
 				path);
+			assertBatchAction(
+				page, "deleteBatch", "DELETE",
+				"/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/keywords",
+				path);
 		}
 
 		if (path.equals("/keywords/ranked")) {
 			assertBatchAction(
 				page, "createBatch", "POST",
 				"/headless-admin-taxonomy/v1.0/keywords/ranked", path);
+			assertBatchAction(
+				page, "deleteBatch", "DELETE",
+				"/headless-admin-taxonomy/v1.0/keywords/ranked", path);
 		}
 
 		if (path.equals("/sites/{siteId}/keywords")) {
 			assertBatchAction(
 				page, "createBatch", "POST",
+				"/headless-admin-taxonomy/v1.0/sites/{siteId}/keywords", path);
+			assertBatchAction(
+				page, "deleteBatch", "DELETE",
 				"/headless-admin-taxonomy/v1.0/sites/{siteId}/keywords", path);
 		}
 	}
@@ -1665,6 +1675,18 @@ public abstract class BaseKeywordResourceTestCase {
 			updateBacth and deleteBatch inherit the href from the "simplest" method in the group
 			(that is, no siteId, no assetLibraryId, etc., needed)
 			*/
+			String expectedPathReplaced = expectedPath.replaceAll(
+				"(/v.1.0/(.*?)/\\Q{\\E.*?\\Q}\\E)", "/v.1.0");
+			String[] detachActualPathFromServer = href.split("/o/");
+			Pattern expectedPathPattern = Pattern.compile(
+				expectedPathReplaced + "/batch");
+			Matcher actualPathMatcher = expectedPathPattern.matcher(
+				"/" + detachActualPathFromServer[1]);
+			Assert.assertTrue(
+				"The /" + detachActualPathFromServer[1] + " does not match " +
+					expectedPathReplaced + "/batch for " + action +
+						" in the path " + path,
+				actualPathMatcher.matches());
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseKeywordResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseKeywordResourceTestCase.java
@@ -1597,20 +1597,11 @@ public abstract class BaseKeywordResourceTestCase {
 
 		Assert.assertTrue(valid);
 
-		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
-		//this List is temporary and can help us detecting
-		//cases that should match the acceptance criteria, but are not covered with the current approach
-
-		List<String> pathsNotCovered = new ArrayList<>();
-
 		if (path.equals("/asset-libraries/{assetLibraryId}/keywords")) {
 			assertBatchAction(
 				page, "createBatch", "POST",
 				"/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/keywords",
 				path);
-		}
-		else {
-			pathsNotCovered.add("/asset-libraries/{assetLibraryId}/keywords");
 		}
 
 		if (path.equals("/keywords/ranked")) {
@@ -1618,23 +1609,11 @@ public abstract class BaseKeywordResourceTestCase {
 				page, "createBatch", "POST",
 				"/headless-admin-taxonomy/v1.0/keywords/ranked", path);
 		}
-		else {
-			pathsNotCovered.add("/keywords/ranked");
-		}
 
 		if (path.equals("/sites/{siteId}/keywords")) {
 			assertBatchAction(
 				page, "createBatch", "POST",
 				"/headless-admin-taxonomy/v1.0/sites/{siteId}/keywords", path);
-		}
-		else {
-			pathsNotCovered.add("/sites/{siteId}/keywords");
-		}
-
-		if (!pathsNotCovered.isEmpty()) {
-			Assert.fail(
-				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
-					pathsNotCovered.toString());
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
@@ -70,6 +70,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -232,7 +234,7 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 			taxonomyCategory1, (List<TaxonomyCategory>)page.getItems());
 		assertContains(
 			taxonomyCategory2, (List<TaxonomyCategory>)page.getItems());
-		assertValid(page);
+		assertValid(page, "/taxonomy-categories/ranked");
 
 		taxonomyCategoryResource.deleteTaxonomyCategory(
 			taxonomyCategory1.getId());
@@ -340,7 +342,9 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantTaxonomyCategory),
 				(List<TaxonomyCategory>)page.getItems());
-			assertValid(page);
+			assertValid(
+				page,
+				"/taxonomy-categories/{parentTaxonomyCategoryId}/taxonomy-categories");
 		}
 
 		TaxonomyCategory taxonomyCategory1 =
@@ -361,7 +365,9 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(taxonomyCategory1, taxonomyCategory2),
 			(List<TaxonomyCategory>)page.getItems());
-		assertValid(page);
+		assertValid(
+			page,
+			"/taxonomy-categories/{parentTaxonomyCategoryId}/taxonomy-categories");
 
 		taxonomyCategoryResource.deleteTaxonomyCategory(
 			taxonomyCategory1.getId());
@@ -1037,7 +1043,9 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantTaxonomyCategory),
 				(List<TaxonomyCategory>)page.getItems());
-			assertValid(page);
+			assertValid(
+				page,
+				"/taxonomy-vocabularies/{taxonomyVocabularyId}/taxonomy-categories");
 		}
 
 		TaxonomyCategory taxonomyCategory1 =
@@ -1059,7 +1067,9 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(taxonomyCategory1, taxonomyCategory2),
 			(List<TaxonomyCategory>)page.getItems());
-		assertValid(page);
+		assertValid(
+			page,
+			"/taxonomy-vocabularies/{taxonomyVocabularyId}/taxonomy-categories");
 
 		taxonomyCategoryResource.deleteTaxonomyCategory(
 			taxonomyCategory1.getId());
@@ -1886,7 +1896,7 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		Assert.assertTrue(valid);
 	}
 
-	protected void assertValid(Page<TaxonomyCategory> page) {
+	protected void assertValid(Page<TaxonomyCategory> page, String path) {
 		boolean valid = false;
 
 		java.util.Collection<TaxonomyCategory> taxonomyCategories =
@@ -1902,6 +1912,105 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		}
 
 		Assert.assertTrue(valid);
+
+		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
+		//this List is temporary and can help us detecting
+		//cases that should match the acceptance criteria, but are not covered with the current approach
+
+		List<String> pathsNotCovered = new ArrayList<>();
+
+		if (path.equals("/taxonomy-categories/ranked")) {
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-admin-taxonomy/v1.0/taxonomy-categories/ranked",
+				path);
+		}
+		else {
+			pathsNotCovered.add("/taxonomy-categories/ranked");
+		}
+
+		if (path.equals(
+				"/taxonomy-categories/{parentTaxonomyCategoryId}/taxonomy-categories")) {
+
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-admin-taxonomy/v1.0/taxonomy-categories/{parentTaxonomyCategoryId}/taxonomy-categories",
+				path);
+		}
+		else {
+			pathsNotCovered.add(
+				"/taxonomy-categories/{parentTaxonomyCategoryId}/taxonomy-categories");
+		}
+
+		if (path.equals(
+				"/taxonomy-vocabularies/{taxonomyVocabularyId}/taxonomy-categories")) {
+
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{taxonomyVocabularyId}/taxonomy-categories",
+				path);
+		}
+		else {
+			pathsNotCovered.add(
+				"/taxonomy-vocabularies/{taxonomyVocabularyId}/taxonomy-categories");
+		}
+
+		if (!pathsNotCovered.isEmpty()) {
+			Assert.fail(
+				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
+					pathsNotCovered.toString());
+		}
+	}
+
+	private void assertBatchAction(
+		Page<TaxonomyCategory> page, String action, String method,
+		String expectedPath, String path) {
+
+		Map<String, Map> actions = page.getActions();
+
+		Map batchAction = actions.get(action);
+
+		Assert.assertNotNull(
+			"No Actions for " + action + " in path " + path, batchAction);
+		Assert.assertEquals(
+			"The batch action method value is not correct", method,
+			batchAction.get("method"));
+		assertHrefInBatchActionMatchesPath(
+			expectedPath,
+			batchAction.get(
+				"href"
+			).toString(),
+			action, path);
+	}
+
+	private void assertHrefInBatchActionMatchesPath(
+		String expectedPath, String href, String action, String path) {
+
+		//only paths with POST operation available will have createBatch
+		//we need a freeMarker "if" to check whether the path we're checking has it
+		//and then check the createBatch details
+
+		if (action.equals("createBatch")) {
+			String expectedPathReplaced = expectedPath.replaceAll(
+				"(\\Q{\\E.*?\\Q}\\E)", "(.*)");
+			String[] detachActualPathFromServer = href.split("/o/");
+			Pattern expectedPathPattern = Pattern.compile(
+				expectedPathReplaced + "/batch");
+			Matcher actualPathMatcher = expectedPathPattern.matcher(
+				"/" + detachActualPathFromServer[1]);
+			Assert.assertTrue(
+				"The /" + detachActualPathFromServer[1] + " does not match " +
+					expectedPathReplaced + "/batch for " + action +
+						" in the path " + path,
+				actualPathMatcher.matches());
+		}
+
+		if (action.equals("deleteBatch") || action.equals("updateBatch")) {
+			/*TO DO
+			updateBacth and deleteBatch inherit the href from the "simplest" method in the group
+			(that is, no siteId, no assetLibraryId, etc., needed)
+			*/
+		}
 	}
 
 	protected String[] getAdditionalAssertFieldNames() {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
@@ -1918,6 +1918,10 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 				page, "createBatch", "POST",
 				"/headless-admin-taxonomy/v1.0/taxonomy-categories/ranked",
 				path);
+			assertBatchAction(
+				page, "deleteBatch", "DELETE",
+				"/headless-admin-taxonomy/v1.0/taxonomy-categories/ranked",
+				path);
 		}
 
 		if (path.equals(
@@ -1927,6 +1931,10 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 				page, "createBatch", "POST",
 				"/headless-admin-taxonomy/v1.0/taxonomy-categories/{parentTaxonomyCategoryId}/taxonomy-categories",
 				path);
+			assertBatchAction(
+				page, "deleteBatch", "DELETE",
+				"/headless-admin-taxonomy/v1.0/taxonomy-categories/{parentTaxonomyCategoryId}/taxonomy-categories",
+				path);
 		}
 
 		if (path.equals(
@@ -1934,6 +1942,10 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 
 			assertBatchAction(
 				page, "createBatch", "POST",
+				"/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{taxonomyVocabularyId}/taxonomy-categories",
+				path);
+			assertBatchAction(
+				page, "deleteBatch", "DELETE",
 				"/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{taxonomyVocabularyId}/taxonomy-categories",
 				path);
 		}
@@ -1987,6 +1999,18 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 			updateBacth and deleteBatch inherit the href from the "simplest" method in the group
 			(that is, no siteId, no assetLibraryId, etc., needed)
 			*/
+			String expectedPathReplaced = expectedPath.replaceAll(
+				"(/v.1.0/(.*?)/\\Q{\\E.*?\\Q}\\E)", "/v.1.0");
+			String[] detachActualPathFromServer = href.split("/o/");
+			Pattern expectedPathPattern = Pattern.compile(
+				expectedPathReplaced + "/batch");
+			Matcher actualPathMatcher = expectedPathPattern.matcher(
+				"/" + detachActualPathFromServer[1]);
+			Assert.assertTrue(
+				"The /" + detachActualPathFromServer[1] + " does not match " +
+					expectedPathReplaced + "/batch for " + action +
+						" in the path " + path,
+				actualPathMatcher.matches());
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
@@ -70,8 +70,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -234,13 +232,23 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 			taxonomyCategory1, (List<TaxonomyCategory>)page.getItems());
 		assertContains(
 			taxonomyCategory2, (List<TaxonomyCategory>)page.getItems());
-		assertValid(page, "/taxonomy-categories/ranked");
+		assertValid(
+			page, testGetTaxonomyCategoriesRankedPage_getExpectedActions());
 
 		taxonomyCategoryResource.deleteTaxonomyCategory(
 			taxonomyCategory1.getId());
 
 		taxonomyCategoryResource.deleteTaxonomyCategory(
 			taxonomyCategory2.getId());
+	}
+
+	protected Map<String, Map>
+			testGetTaxonomyCategoriesRankedPage_getExpectedActions()
+		throws Exception {
+
+		Map<String, Map> expectedActions = new HashMap<>();
+
+		return expectedActions;
 	}
 
 	@Test
@@ -344,7 +352,8 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 				(List<TaxonomyCategory>)page.getItems());
 			assertValid(
 				page,
-				"/taxonomy-categories/{parentTaxonomyCategoryId}/taxonomy-categories");
+				testGetTaxonomyCategoryTaxonomyCategoriesPage_getExpectedActions(
+					irrelevantParentTaxonomyCategoryId));
 		}
 
 		TaxonomyCategory taxonomyCategory1 =
@@ -367,13 +376,35 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 			(List<TaxonomyCategory>)page.getItems());
 		assertValid(
 			page,
-			"/taxonomy-categories/{parentTaxonomyCategoryId}/taxonomy-categories");
+			testGetTaxonomyCategoryTaxonomyCategoriesPage_getExpectedActions(
+				parentTaxonomyCategoryId));
 
 		taxonomyCategoryResource.deleteTaxonomyCategory(
 			taxonomyCategory1.getId());
 
 		taxonomyCategoryResource.deleteTaxonomyCategory(
 			taxonomyCategory2.getId());
+	}
+
+	protected Map<String, Map>
+			testGetTaxonomyCategoryTaxonomyCategoriesPage_getExpectedActions(
+				String parentTaxonomyCategoryId)
+		throws Exception {
+
+		Map<String, Map> expectedActions = new HashMap<>();
+
+		Map createBatchAction = new HashMap<>();
+		createBatchAction.put("method", "POST");
+		createBatchAction.put(
+			"href",
+			"http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-categories/{parentTaxonomyCategoryId}/taxonomy-categories/batch".
+				replace(
+					"{parentTaxonomyCategoryId}",
+					String.valueOf(parentTaxonomyCategoryId)));
+
+		expectedActions.put("createBatch", createBatchAction);
+
+		return expectedActions;
 	}
 
 	@Test
@@ -1045,7 +1076,8 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 				(List<TaxonomyCategory>)page.getItems());
 			assertValid(
 				page,
-				"/taxonomy-vocabularies/{taxonomyVocabularyId}/taxonomy-categories");
+				testGetTaxonomyVocabularyTaxonomyCategoriesPage_getExpectedActions(
+					irrelevantTaxonomyVocabularyId));
 		}
 
 		TaxonomyCategory taxonomyCategory1 =
@@ -1069,13 +1101,35 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 			(List<TaxonomyCategory>)page.getItems());
 		assertValid(
 			page,
-			"/taxonomy-vocabularies/{taxonomyVocabularyId}/taxonomy-categories");
+			testGetTaxonomyVocabularyTaxonomyCategoriesPage_getExpectedActions(
+				taxonomyVocabularyId));
 
 		taxonomyCategoryResource.deleteTaxonomyCategory(
 			taxonomyCategory1.getId());
 
 		taxonomyCategoryResource.deleteTaxonomyCategory(
 			taxonomyCategory2.getId());
+	}
+
+	protected Map<String, Map>
+			testGetTaxonomyVocabularyTaxonomyCategoriesPage_getExpectedActions(
+				Long taxonomyVocabularyId)
+		throws Exception {
+
+		Map<String, Map> expectedActions = new HashMap<>();
+
+		Map createBatchAction = new HashMap<>();
+		createBatchAction.put("method", "POST");
+		createBatchAction.put(
+			"href",
+			"http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{taxonomyVocabularyId}/taxonomy-categories/batch".
+				replace(
+					"{taxonomyVocabularyId}",
+					String.valueOf(taxonomyVocabularyId)));
+
+		expectedActions.put("createBatch", createBatchAction);
+
+		return expectedActions;
 	}
 
 	@Test
@@ -1896,7 +1950,9 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		Assert.assertTrue(valid);
 	}
 
-	protected void assertValid(Page<TaxonomyCategory> page, String path) {
+	protected void assertValid(
+		Page<TaxonomyCategory> page, Map<String, Map> expectedActions) {
+
 		boolean valid = false;
 
 		java.util.Collection<TaxonomyCategory> taxonomyCategories =
@@ -1913,104 +1969,19 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 
 		Assert.assertTrue(valid);
 
-		if (path.equals("/taxonomy-categories/ranked")) {
-			assertBatchAction(
-				page, "createBatch", "POST",
-				"/headless-admin-taxonomy/v1.0/taxonomy-categories/ranked",
-				path);
-			assertBatchAction(
-				page, "deleteBatch", "DELETE",
-				"/headless-admin-taxonomy/v1.0/taxonomy-categories/ranked",
-				path);
-		}
-
-		if (path.equals(
-				"/taxonomy-categories/{parentTaxonomyCategoryId}/taxonomy-categories")) {
-
-			assertBatchAction(
-				page, "createBatch", "POST",
-				"/headless-admin-taxonomy/v1.0/taxonomy-categories/{parentTaxonomyCategoryId}/taxonomy-categories",
-				path);
-			assertBatchAction(
-				page, "deleteBatch", "DELETE",
-				"/headless-admin-taxonomy/v1.0/taxonomy-categories/{parentTaxonomyCategoryId}/taxonomy-categories",
-				path);
-		}
-
-		if (path.equals(
-				"/taxonomy-vocabularies/{taxonomyVocabularyId}/taxonomy-categories")) {
-
-			assertBatchAction(
-				page, "createBatch", "POST",
-				"/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{taxonomyVocabularyId}/taxonomy-categories",
-				path);
-			assertBatchAction(
-				page, "deleteBatch", "DELETE",
-				"/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{taxonomyVocabularyId}/taxonomy-categories",
-				path);
-		}
-	}
-
-	private void assertBatchAction(
-		Page<TaxonomyCategory> page, String action, String method,
-		String expectedPath, String path) {
-
 		Map<String, Map> actions = page.getActions();
 
-		Map batchAction = actions.get(action);
+		for (String expectedActionName : expectedActions.keySet()) {
+			Map action = actions.get(expectedActionName);
 
-		Assert.assertNotNull(
-			"No Actions for " + action + " in path " + path, batchAction);
-		Assert.assertEquals(
-			"The batch action method value is not correct", method,
-			batchAction.get("method"));
-		assertHrefInBatchActionMatchesPath(
-			expectedPath,
-			batchAction.get(
-				"href"
-			).toString(),
-			action, path);
-	}
+			Assert.assertNotNull(
+				expectedActionName + " action is missing", action);
 
-	private void assertHrefInBatchActionMatchesPath(
-		String expectedPath, String href, String action, String path) {
+			Map expectedAction = expectedActions.get(expectedActionName);
 
-		//only paths with POST operation available will have createBatch
-		//we need a freeMarker "if" to check whether the path we're checking has it
-		//and then check the createBatch details
-
-		if (action.equals("createBatch")) {
-			String expectedPathReplaced = expectedPath.replaceAll(
-				"(\\Q{\\E.*?\\Q}\\E)", "(.*)");
-			String[] detachActualPathFromServer = href.split("/o/");
-			Pattern expectedPathPattern = Pattern.compile(
-				expectedPathReplaced + "/batch");
-			Matcher actualPathMatcher = expectedPathPattern.matcher(
-				"/" + detachActualPathFromServer[1]);
-			Assert.assertTrue(
-				"The /" + detachActualPathFromServer[1] + " does not match " +
-					expectedPathReplaced + "/batch for " + action +
-						" in the path " + path,
-				actualPathMatcher.matches());
-		}
-
-		if (action.equals("deleteBatch") || action.equals("updateBatch")) {
-			/*TO DO
-			updateBacth and deleteBatch inherit the href from the "simplest" method in the group
-			(that is, no siteId, no assetLibraryId, etc., needed)
-			*/
-			String expectedPathReplaced = expectedPath.replaceAll(
-				"(/v.1.0/(.*?)/\\Q{\\E.*?\\Q}\\E)", "/v.1.0");
-			String[] detachActualPathFromServer = href.split("/o/");
-			Pattern expectedPathPattern = Pattern.compile(
-				expectedPathReplaced + "/batch");
-			Matcher actualPathMatcher = expectedPathPattern.matcher(
-				"/" + detachActualPathFromServer[1]);
-			Assert.assertTrue(
-				"The /" + detachActualPathFromServer[1] + " does not match " +
-					expectedPathReplaced + "/batch for " + action +
-						" in the path " + path,
-				actualPathMatcher.matches());
+			Assert.assertEquals(
+				expectedAction.get("method"), action.get("method"));
+			Assert.assertEquals(expectedAction.get("href"), action.get("href"));
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
@@ -1913,20 +1913,11 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 
 		Assert.assertTrue(valid);
 
-		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
-		//this List is temporary and can help us detecting
-		//cases that should match the acceptance criteria, but are not covered with the current approach
-
-		List<String> pathsNotCovered = new ArrayList<>();
-
 		if (path.equals("/taxonomy-categories/ranked")) {
 			assertBatchAction(
 				page, "createBatch", "POST",
 				"/headless-admin-taxonomy/v1.0/taxonomy-categories/ranked",
 				path);
-		}
-		else {
-			pathsNotCovered.add("/taxonomy-categories/ranked");
 		}
 
 		if (path.equals(
@@ -1937,10 +1928,6 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 				"/headless-admin-taxonomy/v1.0/taxonomy-categories/{parentTaxonomyCategoryId}/taxonomy-categories",
 				path);
 		}
-		else {
-			pathsNotCovered.add(
-				"/taxonomy-categories/{parentTaxonomyCategoryId}/taxonomy-categories");
-		}
 
 		if (path.equals(
 				"/taxonomy-vocabularies/{taxonomyVocabularyId}/taxonomy-categories")) {
@@ -1949,16 +1936,6 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 				page, "createBatch", "POST",
 				"/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{taxonomyVocabularyId}/taxonomy-categories",
 				path);
-		}
-		else {
-			pathsNotCovered.add(
-				"/taxonomy-vocabularies/{taxonomyVocabularyId}/taxonomy-categories");
-		}
-
-		if (!pathsNotCovered.isEmpty()) {
-			Assert.fail(
-				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
-					pathsNotCovered.toString());
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
@@ -254,7 +254,7 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantTaxonomyVocabulary),
 				(List<TaxonomyVocabulary>)page.getItems());
-			assertValid(page);
+			assertValid(page, irrelevantAssetLibraryId);
 		}
 
 		TaxonomyVocabulary taxonomyVocabulary1 =
@@ -274,7 +274,7 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(taxonomyVocabulary1, taxonomyVocabulary2),
 			(List<TaxonomyVocabulary>)page.getItems());
-		assertValid(page);
+		assertValid(page,assetLibraryId);
 
 		taxonomyVocabularyResource.deleteTaxonomyVocabulary(
 			taxonomyVocabulary1.getId());
@@ -969,7 +969,7 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantTaxonomyVocabulary),
 				(List<TaxonomyVocabulary>)page.getItems());
-			assertValid(page);
+			assertValid(page, irrelevantSiteId);
 		}
 
 		TaxonomyVocabulary taxonomyVocabulary1 =
@@ -988,7 +988,7 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(taxonomyVocabulary1, taxonomyVocabulary2),
 			(List<TaxonomyVocabulary>)page.getItems());
-		assertValid(page);
+		assertValid(page, siteId);
 
 		taxonomyVocabularyResource.deleteTaxonomyVocabulary(
 			taxonomyVocabulary1.getId());
@@ -2285,7 +2285,7 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		Assert.assertTrue(valid);
 	}
 
-	protected void assertValid(Page<TaxonomyVocabulary> page) {
+	protected void assertValid(Page<TaxonomyVocabulary> page, long groupId) throws Exception {
 		boolean valid = false;
 
 		java.util.Collection<TaxonomyVocabulary> taxonomyVocabularies =

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
@@ -74,6 +74,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -254,7 +256,9 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantTaxonomyVocabulary),
 				(List<TaxonomyVocabulary>)page.getItems());
-			assertValid(page, irrelevantAssetLibraryId);
+			assertValid(
+				page,
+				"/asset-libraries/{assetLibraryId}/taxonomy-vocabularies");
 		}
 
 		TaxonomyVocabulary taxonomyVocabulary1 =
@@ -274,7 +278,8 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(taxonomyVocabulary1, taxonomyVocabulary2),
 			(List<TaxonomyVocabulary>)page.getItems());
-		assertValid(page,assetLibraryId);
+		assertValid(
+			page, "/asset-libraries/{assetLibraryId}/taxonomy-vocabularies");
 
 		taxonomyVocabularyResource.deleteTaxonomyVocabulary(
 			taxonomyVocabulary1.getId());
@@ -969,7 +974,7 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantTaxonomyVocabulary),
 				(List<TaxonomyVocabulary>)page.getItems());
-			assertValid(page, irrelevantSiteId);
+			assertValid(page, "/sites/{siteId}/taxonomy-vocabularies");
 		}
 
 		TaxonomyVocabulary taxonomyVocabulary1 =
@@ -988,7 +993,7 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(taxonomyVocabulary1, taxonomyVocabulary2),
 			(List<TaxonomyVocabulary>)page.getItems());
-		assertValid(page, siteId);
+		assertValid(page, "/sites/{siteId}/taxonomy-vocabularies");
 
 		taxonomyVocabularyResource.deleteTaxonomyVocabulary(
 			taxonomyVocabulary1.getId());
@@ -2285,7 +2290,7 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		Assert.assertTrue(valid);
 	}
 
-	protected void assertValid(Page<TaxonomyVocabulary> page, long groupId) throws Exception {
+	protected void assertValid(Page<TaxonomyVocabulary> page, String path) {
 		boolean valid = false;
 
 		java.util.Collection<TaxonomyVocabulary> taxonomyVocabularies =
@@ -2301,6 +2306,92 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		}
 
 		Assert.assertTrue(valid);
+
+		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
+		//this List is temporary and can help us detecting
+		//cases that should match the acceptance criteria, but are not covered with the current approach
+
+		List<String> pathsNotCovered = new ArrayList<>();
+
+		if (path.equals(
+				"/asset-libraries/{assetLibraryId}/taxonomy-vocabularies")) {
+
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/taxonomy-vocabularies",
+				path);
+		}
+		else {
+			pathsNotCovered.add(
+				"/asset-libraries/{assetLibraryId}/taxonomy-vocabularies");
+		}
+
+		if (path.equals("/sites/{siteId}/taxonomy-vocabularies")) {
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-admin-taxonomy/v1.0/sites/{siteId}/taxonomy-vocabularies",
+				path);
+		}
+		else {
+			pathsNotCovered.add("/sites/{siteId}/taxonomy-vocabularies");
+		}
+
+		if (!pathsNotCovered.isEmpty()) {
+			Assert.fail(
+				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
+					pathsNotCovered.toString());
+		}
+	}
+
+	private void assertBatchAction(
+		Page<TaxonomyVocabulary> page, String action, String method,
+		String expectedPath, String path) {
+
+		Map<String, Map> actions = page.getActions();
+
+		Map batchAction = actions.get(action);
+
+		Assert.assertNotNull(
+			"No Actions for " + action + " in path " + path, batchAction);
+		Assert.assertEquals(
+			"The batch action method value is not correct", method,
+			batchAction.get("method"));
+		assertHrefInBatchActionMatchesPath(
+			expectedPath,
+			batchAction.get(
+				"href"
+			).toString(),
+			action, path);
+	}
+
+	private void assertHrefInBatchActionMatchesPath(
+		String expectedPath, String href, String action, String path) {
+
+		//only paths with POST operation available will have createBatch
+		//we need a freeMarker "if" to check whether the path we're checking has it
+		//and then check the createBatch details
+
+		if (action.equals("createBatch")) {
+			String expectedPathReplaced = expectedPath.replaceAll(
+				"(\\Q{\\E.*?\\Q}\\E)", "(.*)");
+			String[] detachActualPathFromServer = href.split("/o/");
+			Pattern expectedPathPattern = Pattern.compile(
+				expectedPathReplaced + "/batch");
+			Matcher actualPathMatcher = expectedPathPattern.matcher(
+				"/" + detachActualPathFromServer[1]);
+			Assert.assertTrue(
+				"The /" + detachActualPathFromServer[1] + " does not match " +
+					expectedPathReplaced + "/batch for " + action +
+						" in the path " + path,
+				actualPathMatcher.matches());
+		}
+
+		if (action.equals("deleteBatch") || action.equals("updateBatch")) {
+			/*TO DO
+			updateBacth and deleteBatch inherit the href from the "simplest" method in the group
+			(that is, no siteId, no assetLibraryId, etc., needed)
+			*/
+		}
 	}
 
 	protected String[] getAdditionalAssertFieldNames() {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
@@ -2314,11 +2314,19 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 				page, "createBatch", "POST",
 				"/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/taxonomy-vocabularies",
 				path);
+			assertBatchAction(
+				page, "deleteBatch", "DELETE",
+				"/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/taxonomy-vocabularies",
+				path);
 		}
 
 		if (path.equals("/sites/{siteId}/taxonomy-vocabularies")) {
 			assertBatchAction(
 				page, "createBatch", "POST",
+				"/headless-admin-taxonomy/v1.0/sites/{siteId}/taxonomy-vocabularies",
+				path);
+			assertBatchAction(
+				page, "deleteBatch", "DELETE",
 				"/headless-admin-taxonomy/v1.0/sites/{siteId}/taxonomy-vocabularies",
 				path);
 		}
@@ -2372,6 +2380,19 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 			updateBacth and deleteBatch inherit the href from the "simplest" method in the group
 			(that is, no siteId, no assetLibraryId, etc., needed)
 			*/
+			String expectedPathReplaced = expectedPath.replaceAll(
+				"\\Q/\\Ev\\Q.\\E1\\Q.\\E0\\Q/\\E(.*?)\\Q/\\E\\Q{\\E.*?\\Q}\\E", "/v.1.0");
+			Assert.fail(expectedPathReplaced);
+			String[] detachActualPathFromServer = href.split("/o/");
+			Pattern expectedPathPattern = Pattern.compile(
+				expectedPathReplaced + "/batch");
+			Matcher actualPathMatcher = expectedPathPattern.matcher(
+				"/" + detachActualPathFromServer[1]);
+			Assert.assertTrue(
+				"The /" + detachActualPathFromServer[1] + " does not match " +
+					expectedPathReplaced + "/batch for " + action +
+						" in the path " + path,
+				actualPathMatcher.matches());
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
@@ -74,8 +74,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -258,7 +256,8 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 				(List<TaxonomyVocabulary>)page.getItems());
 			assertValid(
 				page,
-				"/asset-libraries/{assetLibraryId}/taxonomy-vocabularies");
+				testGetAssetLibraryTaxonomyVocabulariesPage_getExpectedActions(
+					irrelevantAssetLibraryId));
 		}
 
 		TaxonomyVocabulary taxonomyVocabulary1 =
@@ -279,13 +278,34 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 			Arrays.asList(taxonomyVocabulary1, taxonomyVocabulary2),
 			(List<TaxonomyVocabulary>)page.getItems());
 		assertValid(
-			page, "/asset-libraries/{assetLibraryId}/taxonomy-vocabularies");
+			page,
+			testGetAssetLibraryTaxonomyVocabulariesPage_getExpectedActions(
+				assetLibraryId));
 
 		taxonomyVocabularyResource.deleteTaxonomyVocabulary(
 			taxonomyVocabulary1.getId());
 
 		taxonomyVocabularyResource.deleteTaxonomyVocabulary(
 			taxonomyVocabulary2.getId());
+	}
+
+	protected Map<String, Map>
+			testGetAssetLibraryTaxonomyVocabulariesPage_getExpectedActions(
+				Long assetLibraryId)
+		throws Exception {
+
+		Map<String, Map> expectedActions = new HashMap<>();
+
+		Map createBatchAction = new HashMap<>();
+		createBatchAction.put("method", "POST");
+		createBatchAction.put(
+			"href",
+			"http://localhost:8080/o/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/taxonomy-vocabularies/batch".
+				replace("{assetLibraryId}", String.valueOf(assetLibraryId)));
+
+		expectedActions.put("createBatch", createBatchAction);
+
+		return expectedActions;
 	}
 
 	@Test
@@ -974,7 +994,10 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantTaxonomyVocabulary),
 				(List<TaxonomyVocabulary>)page.getItems());
-			assertValid(page, "/sites/{siteId}/taxonomy-vocabularies");
+			assertValid(
+				page,
+				testGetSiteTaxonomyVocabulariesPage_getExpectedActions(
+					irrelevantSiteId));
 		}
 
 		TaxonomyVocabulary taxonomyVocabulary1 =
@@ -993,13 +1016,33 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(taxonomyVocabulary1, taxonomyVocabulary2),
 			(List<TaxonomyVocabulary>)page.getItems());
-		assertValid(page, "/sites/{siteId}/taxonomy-vocabularies");
+		assertValid(
+			page,
+			testGetSiteTaxonomyVocabulariesPage_getExpectedActions(siteId));
 
 		taxonomyVocabularyResource.deleteTaxonomyVocabulary(
 			taxonomyVocabulary1.getId());
 
 		taxonomyVocabularyResource.deleteTaxonomyVocabulary(
 			taxonomyVocabulary2.getId());
+	}
+
+	protected Map<String, Map>
+			testGetSiteTaxonomyVocabulariesPage_getExpectedActions(Long siteId)
+		throws Exception {
+
+		Map<String, Map> expectedActions = new HashMap<>();
+
+		Map createBatchAction = new HashMap<>();
+		createBatchAction.put("method", "POST");
+		createBatchAction.put(
+			"href",
+			"http://localhost:8080/o/headless-admin-taxonomy/v1.0/sites/{siteId}/taxonomy-vocabularies/batch".
+				replace("{siteId}", String.valueOf(siteId)));
+
+		expectedActions.put("createBatch", createBatchAction);
+
+		return expectedActions;
 	}
 
 	@Test
@@ -2290,7 +2333,9 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		Assert.assertTrue(valid);
 	}
 
-	protected void assertValid(Page<TaxonomyVocabulary> page, String path) {
+	protected void assertValid(
+		Page<TaxonomyVocabulary> page, Map<String, Map> expectedActions) {
+
 		boolean valid = false;
 
 		java.util.Collection<TaxonomyVocabulary> taxonomyVocabularies =
@@ -2307,92 +2352,19 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 
 		Assert.assertTrue(valid);
 
-		if (path.equals(
-				"/asset-libraries/{assetLibraryId}/taxonomy-vocabularies")) {
-
-			assertBatchAction(
-				page, "createBatch", "POST",
-				"/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/taxonomy-vocabularies",
-				path);
-			assertBatchAction(
-				page, "deleteBatch", "DELETE",
-				"/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/taxonomy-vocabularies",
-				path);
-		}
-
-		if (path.equals("/sites/{siteId}/taxonomy-vocabularies")) {
-			assertBatchAction(
-				page, "createBatch", "POST",
-				"/headless-admin-taxonomy/v1.0/sites/{siteId}/taxonomy-vocabularies",
-				path);
-			assertBatchAction(
-				page, "deleteBatch", "DELETE",
-				"/headless-admin-taxonomy/v1.0/sites/{siteId}/taxonomy-vocabularies",
-				path);
-		}
-	}
-
-	private void assertBatchAction(
-		Page<TaxonomyVocabulary> page, String action, String method,
-		String expectedPath, String path) {
-
 		Map<String, Map> actions = page.getActions();
 
-		Map batchAction = actions.get(action);
+		for (String expectedActionName : expectedActions.keySet()) {
+			Map action = actions.get(expectedActionName);
 
-		Assert.assertNotNull(
-			"No Actions for " + action + " in path " + path, batchAction);
-		Assert.assertEquals(
-			"The batch action method value is not correct", method,
-			batchAction.get("method"));
-		assertHrefInBatchActionMatchesPath(
-			expectedPath,
-			batchAction.get(
-				"href"
-			).toString(),
-			action, path);
-	}
+			Assert.assertNotNull(
+				expectedActionName + " action is missing", action);
 
-	private void assertHrefInBatchActionMatchesPath(
-		String expectedPath, String href, String action, String path) {
+			Map expectedAction = expectedActions.get(expectedActionName);
 
-		//only paths with POST operation available will have createBatch
-		//we need a freeMarker "if" to check whether the path we're checking has it
-		//and then check the createBatch details
-
-		if (action.equals("createBatch")) {
-			String expectedPathReplaced = expectedPath.replaceAll(
-				"(\\Q{\\E.*?\\Q}\\E)", "(.*)");
-			String[] detachActualPathFromServer = href.split("/o/");
-			Pattern expectedPathPattern = Pattern.compile(
-				expectedPathReplaced + "/batch");
-			Matcher actualPathMatcher = expectedPathPattern.matcher(
-				"/" + detachActualPathFromServer[1]);
-			Assert.assertTrue(
-				"The /" + detachActualPathFromServer[1] + " does not match " +
-					expectedPathReplaced + "/batch for " + action +
-						" in the path " + path,
-				actualPathMatcher.matches());
-		}
-
-		if (action.equals("deleteBatch") || action.equals("updateBatch")) {
-			/*TO DO
-			updateBacth and deleteBatch inherit the href from the "simplest" method in the group
-			(that is, no siteId, no assetLibraryId, etc., needed)
-			*/
-			String expectedPathReplaced = expectedPath.replaceAll(
-				"\\Q/\\Ev\\Q.\\E1\\Q.\\E0\\Q/\\E(.*?)\\Q/\\E\\Q{\\E.*?\\Q}\\E", "/v.1.0");
-			Assert.fail(expectedPathReplaced);
-			String[] detachActualPathFromServer = href.split("/o/");
-			Pattern expectedPathPattern = Pattern.compile(
-				expectedPathReplaced + "/batch");
-			Matcher actualPathMatcher = expectedPathPattern.matcher(
-				"/" + detachActualPathFromServer[1]);
-			Assert.assertTrue(
-				"The /" + detachActualPathFromServer[1] + " does not match " +
-					expectedPathReplaced + "/batch for " + action +
-						" in the path " + path,
-				actualPathMatcher.matches());
+			Assert.assertEquals(
+				expectedAction.get("method"), action.get("method"));
+			Assert.assertEquals(expectedAction.get("href"), action.get("href"));
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
@@ -2307,12 +2307,6 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 
 		Assert.assertTrue(valid);
 
-		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
-		//this List is temporary and can help us detecting
-		//cases that should match the acceptance criteria, but are not covered with the current approach
-
-		List<String> pathsNotCovered = new ArrayList<>();
-
 		if (path.equals(
 				"/asset-libraries/{assetLibraryId}/taxonomy-vocabularies")) {
 
@@ -2321,25 +2315,12 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 				"/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/taxonomy-vocabularies",
 				path);
 		}
-		else {
-			pathsNotCovered.add(
-				"/asset-libraries/{assetLibraryId}/taxonomy-vocabularies");
-		}
 
 		if (path.equals("/sites/{siteId}/taxonomy-vocabularies")) {
 			assertBatchAction(
 				page, "createBatch", "POST",
 				"/headless-admin-taxonomy/v1.0/sites/{siteId}/taxonomy-vocabularies",
 				path);
-		}
-		else {
-			pathsNotCovered.add("/sites/{siteId}/taxonomy-vocabularies");
-		}
-
-		if (!pathsNotCovered.isEmpty()) {
-			Assert.fail(
-				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
-					pathsNotCovered.toString());
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/KeywordResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/KeywordResourceTest.java
@@ -58,7 +58,7 @@ public class KeywordResourceTest extends BaseKeywordResourceTestCase {
 
 		assertEqualsIgnoringOrder(
 			Arrays.asList(keyword1, keyword2), (List<Keyword>)page.getItems());
-		assertValid(page);
+		assertValid(page, "/keywords/ranked");
 
 		keywordResource.deleteKeyword(keyword1.getId());
 		keywordResource.deleteKeyword(keyword2.getId());

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/KeywordResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/KeywordResourceTest.java
@@ -57,7 +57,7 @@ public class KeywordResourceTest extends BaseKeywordResourceTestCase {
 		Assert.assertEquals(2, page.getTotalCount());
 
 		assertEqualsIgnoringOrder(
-			Arrays.asList(keyword1, keyword2), (List<Keyword>)page.getItems());
+			Arrays.asList(keyword1, keyword2), (List<Keyword>) page.getItems());
 		assertValid(page, "/keywords/ranked");
 
 		keywordResource.deleteKeyword(keyword1.getId());
@@ -77,7 +77,7 @@ public class KeywordResourceTest extends BaseKeywordResourceTestCase {
 		Page<Keyword> page1 = keywordResource.getKeywordsRankedPage(
 			testGroup.getGroupId(), null, Pagination.of(1, 2));
 
-		List<Keyword> keywords1 = (List<Keyword>)page1.getItems();
+		List<Keyword> keywords1 = (List<Keyword>) page1.getItems();
 
 		Assert.assertEquals(keywords1.toString(), 2, keywords1.size());
 
@@ -86,7 +86,7 @@ public class KeywordResourceTest extends BaseKeywordResourceTestCase {
 
 		Assert.assertEquals(3, page2.getTotalCount());
 
-		List<Keyword> keywords2 = (List<Keyword>)page2.getItems();
+		List<Keyword> keywords2 = (List<Keyword>) page2.getItems();
 
 		Assert.assertEquals(keywords2.toString(), 1, keywords2.size());
 
@@ -95,12 +95,12 @@ public class KeywordResourceTest extends BaseKeywordResourceTestCase {
 
 		assertEqualsIgnoringOrder(
 			Arrays.asList(keyword1, keyword2, keyword3),
-			(List<Keyword>)page3.getItems());
+			(List<Keyword>) page3.getItems());
 	}
 
 	@Override
 	protected String[] getAdditionalAssertFieldNames() {
-		return new String[] {"name"};
+		return new String[]{"name"};
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
@@ -17,9 +17,15 @@ package com.liferay.headless.admin.taxonomy.resource.v1_0.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.headless.admin.taxonomy.client.dto.v1_0.AssetType;
 import com.liferay.headless.admin.taxonomy.client.dto.v1_0.TaxonomyVocabulary;
+import com.liferay.headless.admin.taxonomy.client.pagination.Page;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 
+import java.util.Map;
+
+import org.hamcrest.CoreMatchers;
+
+import org.junit.Assert;
 import org.junit.runner.RunWith;
 
 /**
@@ -28,6 +34,46 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class TaxonomyVocabularyResourceTest
 	extends BaseTaxonomyVocabularyResourceTestCase {
+
+	@Override
+	protected void assertValid(Page<TaxonomyVocabulary> page, long groupId)
+		throws Exception {
+
+		super.assertValid(page, groupId);
+
+		Map<String, Map> actions = page.getActions();
+
+		Map updateBatchAction = actions.get("updateBatch");
+
+		Assert.assertNotNull(updateBatchAction);
+		Assert.assertEquals("PUT", updateBatchAction.get("method"));
+		Assert.assertThat(
+			"updateBatch does not contain valid href",
+			String.valueOf(updateBatchAction.get("href")),
+			CoreMatchers.endsWith(
+				"/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/batch"));
+
+		Map createBatchAction = actions.get("createBatch");
+
+		Assert.assertNotNull(createBatchAction);
+		Assert.assertEquals("POST", createBatchAction.get("method"));
+		Assert.assertThat(
+			"createBatch does not contain valid href",
+			String.valueOf(createBatchAction.get("href")),
+			CoreMatchers.endsWith(
+				"/o/headless-admin-taxonomy/v1.0/sites/" + groupId +
+					"/taxonomy-vocabularies/batch"));
+
+		Map deleteBatchAction = actions.get("deleteBatch");
+
+		Assert.assertNotNull(deleteBatchAction);
+		Assert.assertEquals("DELETE", deleteBatchAction.get("method"));
+		Assert.assertThat(
+			"deleteBatch does not contain valid href",
+			String.valueOf(deleteBatchAction.get("href")),
+			CoreMatchers.endsWith(
+				"/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/batch"));
+	}
 
 	@Override
 	protected String[] getAdditionalAssertFieldNames() {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
@@ -25,8 +25,6 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.hamcrest.CoreMatchers;
-
 import org.junit.Assert;
 import org.junit.runner.RunWith;
 
@@ -43,26 +41,15 @@ public class TaxonomyVocabularyResourceTest
 
 		super.assertValid(page, groupId);
 
-		assertBatchAction(page,"updateBatch","PUT","http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies");
-		assertBatchAction(page,"createBatch","POST","http://localhost:8080/o/headless-admin-taxonomy/v1.0/sites/{groupId}/taxonomy-vocabularies");
-		assertBatchAction(page,"deleteBatch","DELETE","http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies");
-	}
-
-	private void assertBatchAction(Page<TaxonomyVocabulary> page, String action, String method, String path) {
-		Map<String, Map> actions = page.getActions();
-
-		Map batchAction = actions.get(action);
-
-		Assert.assertNotNull(batchAction);
-		Assert.assertEquals(method, batchAction.get("method"));
-		assertHrefMatchesPath(path,batchAction.get("href").toString());
-	}
-
-	private void assertHrefMatchesPath(String path, String href) {
-		String pathReplaced = path.replaceAll("(\\Q{\\E.*?\\Q}\\E)","(.*)");
-		Pattern p = Pattern.compile(pathReplaced+"/batch");
-		Matcher m = p.matcher(href);
-		Assert.assertTrue("The " + href +" does not match "+pathReplaced+"/batch",m.matches());
+		assertBatchAction(
+			page, "updateBatch", "PUT",
+			"http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies");
+		assertBatchAction(
+			page, "createBatch", "POST",
+			"http://localhost:8080/o/headless-admin-taxonomy/v1.0/sites/{groupId}/taxonomy-vocabularies");
+		assertBatchAction(
+			page, "deleteBatch", "DELETE",
+			"http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies");
 	}
 
 	@Override
@@ -153,6 +140,35 @@ public class TaxonomyVocabularyResourceTest
 		throws Exception {
 
 		return testDepotEntry.getDepotEntryId();
+	}
+
+	private void assertBatchAction(
+		Page<TaxonomyVocabulary> page, String action, String method,
+		String path) {
+
+		Map<String, Map> actions = page.getActions();
+
+		Map batchAction = actions.get(action);
+
+		Assert.assertNotNull(batchAction);
+		Assert.assertEquals(method, batchAction.get("method"));
+		assertHrefMatchesPath(
+			path,
+			batchAction.get(
+				"href"
+			).toString());
+	}
+
+	private void assertHrefMatchesPath(String path, String href) {
+		String pathReplaced = path.replaceAll("(\\Q{\\E.*?\\Q}\\E)", "(.*)");
+
+		Pattern p = Pattern.compile(pathReplaced + "/batch");
+
+		Matcher m = p.matcher(href);
+
+		Assert.assertTrue(
+			"The " + href + " does not match " + pathReplaced + "/batch",
+			m.matches());
 	}
 
 }

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
@@ -36,23 +36,6 @@ public class TaxonomyVocabularyResourceTest
 	extends BaseTaxonomyVocabularyResourceTestCase {
 
 	@Override
-	protected void assertValid(Page<TaxonomyVocabulary> page, long groupId)
-		throws Exception {
-
-		super.assertValid(page, groupId);
-
-		assertBatchAction(
-			page, "updateBatch", "PUT",
-			"http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies");
-		assertBatchAction(
-			page, "createBatch", "POST",
-			"http://localhost:8080/o/headless-admin-taxonomy/v1.0/sites/{groupId}/taxonomy-vocabularies");
-		assertBatchAction(
-			page, "deleteBatch", "DELETE",
-			"http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies");
-	}
-
-	@Override
 	protected String[] getAdditionalAssertFieldNames() {
 		return new String[] {"assetTypes", "description", "name"};
 	}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
@@ -22,6 +22,8 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.hamcrest.CoreMatchers;
 
@@ -41,38 +43,26 @@ public class TaxonomyVocabularyResourceTest
 
 		super.assertValid(page, groupId);
 
+		assertBatchAction(page,"updateBatch","PUT","http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies");
+		assertBatchAction(page,"createBatch","POST","http://localhost:8080/o/headless-admin-taxonomy/v1.0/sites/{groupId}/taxonomy-vocabularies");
+		assertBatchAction(page,"deleteBatch","DELETE","http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies");
+	}
+
+	private void assertBatchAction(Page<TaxonomyVocabulary> page, String action, String method, String path) {
 		Map<String, Map> actions = page.getActions();
 
-		Map updateBatchAction = actions.get("updateBatch");
+		Map batchAction = actions.get(action);
 
-		Assert.assertNotNull(updateBatchAction);
-		Assert.assertEquals("PUT", updateBatchAction.get("method"));
-		Assert.assertThat(
-			"updateBatch does not contain valid href",
-			String.valueOf(updateBatchAction.get("href")),
-			CoreMatchers.endsWith(
-				"/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/batch"));
+		Assert.assertNotNull(batchAction);
+		Assert.assertEquals(method, batchAction.get("method"));
+		assertHrefMatchesPath(path,batchAction.get("href").toString());
+	}
 
-		Map createBatchAction = actions.get("createBatch");
-
-		Assert.assertNotNull(createBatchAction);
-		Assert.assertEquals("POST", createBatchAction.get("method"));
-		Assert.assertThat(
-			"createBatch does not contain valid href",
-			String.valueOf(createBatchAction.get("href")),
-			CoreMatchers.endsWith(
-				"/o/headless-admin-taxonomy/v1.0/sites/" + groupId +
-					"/taxonomy-vocabularies/batch"));
-
-		Map deleteBatchAction = actions.get("deleteBatch");
-
-		Assert.assertNotNull(deleteBatchAction);
-		Assert.assertEquals("DELETE", deleteBatchAction.get("method"));
-		Assert.assertThat(
-			"deleteBatch does not contain valid href",
-			String.valueOf(deleteBatchAction.get("href")),
-			CoreMatchers.endsWith(
-				"/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/batch"));
+	private void assertHrefMatchesPath(String path, String href) {
+		String pathReplaced = path.replaceAll("(\\Q{\\E.*?\\Q}\\E)","(.*)");
+		Pattern p = Pattern.compile(pathReplaced+"/batch");
+		Matcher m = p.matcher(href);
+		Assert.assertTrue("The " + href +" does not match "+pathReplaced+"/batch",m.matches());
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingImageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingImageResourceTestCase.java
@@ -1082,26 +1082,11 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 
 		Assert.assertTrue(valid);
 
-		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
-		//this List is temporary and can help us detecting
-		//cases that should match the acceptance criteria, but are not covered with the current approach
-
-		List<String> pathsNotCovered = new ArrayList<>();
-
 		if (path.equals("/sites/{siteId}/blog-posting-images")) {
 			assertBatchAction(
 				page, "createBatch", "POST",
 				"/headless-delivery/v1.0/sites/{siteId}/blog-posting-images",
 				path);
-		}
-		else {
-			pathsNotCovered.add("/sites/{siteId}/blog-posting-images");
-		}
-
-		if (!pathsNotCovered.isEmpty()) {
-			Assert.fail(
-				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
-					pathsNotCovered.toString());
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingImageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingImageResourceTestCase.java
@@ -70,6 +70,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -376,7 +378,7 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantBlogPostingImage),
 				(List<BlogPostingImage>)page.getItems());
-			assertValid(page);
+			assertValid(page, "/sites/{siteId}/blog-posting-images");
 		}
 
 		BlogPostingImage blogPostingImage1 =
@@ -395,7 +397,7 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(blogPostingImage1, blogPostingImage2),
 			(List<BlogPostingImage>)page.getItems());
-		assertValid(page);
+		assertValid(page, "/sites/{siteId}/blog-posting-images");
 
 		blogPostingImageResource.deleteBlogPostingImage(
 			blogPostingImage1.getId());
@@ -1063,7 +1065,7 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 			"This method needs to be implemented");
 	}
 
-	protected void assertValid(Page<BlogPostingImage> page) {
+	protected void assertValid(Page<BlogPostingImage> page, String path) {
 		boolean valid = false;
 
 		java.util.Collection<BlogPostingImage> blogPostingImages =
@@ -1079,6 +1081,79 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 		}
 
 		Assert.assertTrue(valid);
+
+		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
+		//this List is temporary and can help us detecting
+		//cases that should match the acceptance criteria, but are not covered with the current approach
+
+		List<String> pathsNotCovered = new ArrayList<>();
+
+		if (path.equals("/sites/{siteId}/blog-posting-images")) {
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/sites/{siteId}/blog-posting-images",
+				path);
+		}
+		else {
+			pathsNotCovered.add("/sites/{siteId}/blog-posting-images");
+		}
+
+		if (!pathsNotCovered.isEmpty()) {
+			Assert.fail(
+				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
+					pathsNotCovered.toString());
+		}
+	}
+
+	private void assertBatchAction(
+		Page<BlogPostingImage> page, String action, String method,
+		String expectedPath, String path) {
+
+		Map<String, Map> actions = page.getActions();
+
+		Map batchAction = actions.get(action);
+
+		Assert.assertNotNull(
+			"No Actions for " + action + " in path " + path, batchAction);
+		Assert.assertEquals(
+			"The batch action method value is not correct", method,
+			batchAction.get("method"));
+		assertHrefInBatchActionMatchesPath(
+			expectedPath,
+			batchAction.get(
+				"href"
+			).toString(),
+			action, path);
+	}
+
+	private void assertHrefInBatchActionMatchesPath(
+		String expectedPath, String href, String action, String path) {
+
+		//only paths with POST operation available will have createBatch
+		//we need a freeMarker "if" to check whether the path we're checking has it
+		//and then check the createBatch details
+
+		if (action.equals("createBatch")) {
+			String expectedPathReplaced = expectedPath.replaceAll(
+				"(\\Q{\\E.*?\\Q}\\E)", "(.*)");
+			String[] detachActualPathFromServer = href.split("/o/");
+			Pattern expectedPathPattern = Pattern.compile(
+				expectedPathReplaced + "/batch");
+			Matcher actualPathMatcher = expectedPathPattern.matcher(
+				"/" + detachActualPathFromServer[1]);
+			Assert.assertTrue(
+				"The /" + detachActualPathFromServer[1] + " does not match " +
+					expectedPathReplaced + "/batch for " + action +
+						" in the path " + path,
+				actualPathMatcher.matches());
+		}
+
+		if (action.equals("deleteBatch") || action.equals("updateBatch")) {
+			/*TO DO
+			updateBacth and deleteBatch inherit the href from the "simplest" method in the group
+			(that is, no siteId, no assetLibraryId, etc., needed)
+			*/
+		}
 	}
 
 	protected String[] getAdditionalAssertFieldNames() {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingResourceTestCase.java
@@ -1647,25 +1647,10 @@ public abstract class BaseBlogPostingResourceTestCase {
 
 		Assert.assertTrue(valid);
 
-		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
-		//this List is temporary and can help us detecting
-		//cases that should match the acceptance criteria, but are not covered with the current approach
-
-		List<String> pathsNotCovered = new ArrayList<>();
-
 		if (path.equals("/sites/{siteId}/blog-postings")) {
 			assertBatchAction(
 				page, "createBatch", "POST",
 				"/headless-delivery/v1.0/sites/{siteId}/blog-postings", path);
-		}
-		else {
-			pathsNotCovered.add("/sites/{siteId}/blog-postings");
-		}
-
-		if (!pathsNotCovered.isEmpty()) {
-			Assert.fail(
-				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
-					pathsNotCovered.toString());
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingResourceTestCase.java
@@ -72,6 +72,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -514,7 +516,7 @@ public abstract class BaseBlogPostingResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantBlogPosting),
 				(List<BlogPosting>)page.getItems());
-			assertValid(page);
+			assertValid(page, "/sites/{siteId}/blog-postings");
 		}
 
 		BlogPosting blogPosting1 = testGetSiteBlogPostingsPage_addBlogPosting(
@@ -531,7 +533,7 @@ public abstract class BaseBlogPostingResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(blogPosting1, blogPosting2),
 			(List<BlogPosting>)page.getItems());
-		assertValid(page);
+		assertValid(page, "/sites/{siteId}/blog-postings");
 
 		blogPostingResource.deleteBlogPosting(blogPosting1.getId());
 
@@ -1629,7 +1631,7 @@ public abstract class BaseBlogPostingResourceTestCase {
 		Assert.assertTrue(valid);
 	}
 
-	protected void assertValid(Page<BlogPosting> page) {
+	protected void assertValid(Page<BlogPosting> page, String path) {
 		boolean valid = false;
 
 		java.util.Collection<BlogPosting> blogPostings = page.getItems();
@@ -1644,6 +1646,78 @@ public abstract class BaseBlogPostingResourceTestCase {
 		}
 
 		Assert.assertTrue(valid);
+
+		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
+		//this List is temporary and can help us detecting
+		//cases that should match the acceptance criteria, but are not covered with the current approach
+
+		List<String> pathsNotCovered = new ArrayList<>();
+
+		if (path.equals("/sites/{siteId}/blog-postings")) {
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/sites/{siteId}/blog-postings", path);
+		}
+		else {
+			pathsNotCovered.add("/sites/{siteId}/blog-postings");
+		}
+
+		if (!pathsNotCovered.isEmpty()) {
+			Assert.fail(
+				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
+					pathsNotCovered.toString());
+		}
+	}
+
+	private void assertBatchAction(
+		Page<BlogPosting> page, String action, String method,
+		String expectedPath, String path) {
+
+		Map<String, Map> actions = page.getActions();
+
+		Map batchAction = actions.get(action);
+
+		Assert.assertNotNull(
+			"No Actions for " + action + " in path " + path, batchAction);
+		Assert.assertEquals(
+			"The batch action method value is not correct", method,
+			batchAction.get("method"));
+		assertHrefInBatchActionMatchesPath(
+			expectedPath,
+			batchAction.get(
+				"href"
+			).toString(),
+			action, path);
+	}
+
+	private void assertHrefInBatchActionMatchesPath(
+		String expectedPath, String href, String action, String path) {
+
+		//only paths with POST operation available will have createBatch
+		//we need a freeMarker "if" to check whether the path we're checking has it
+		//and then check the createBatch details
+
+		if (action.equals("createBatch")) {
+			String expectedPathReplaced = expectedPath.replaceAll(
+				"(\\Q{\\E.*?\\Q}\\E)", "(.*)");
+			String[] detachActualPathFromServer = href.split("/o/");
+			Pattern expectedPathPattern = Pattern.compile(
+				expectedPathReplaced + "/batch");
+			Matcher actualPathMatcher = expectedPathPattern.matcher(
+				"/" + detachActualPathFromServer[1]);
+			Assert.assertTrue(
+				"The /" + detachActualPathFromServer[1] + " does not match " +
+					expectedPathReplaced + "/batch for " + action +
+						" in the path " + path,
+				actualPathMatcher.matches());
+		}
+
+		if (action.equals("deleteBatch") || action.equals("updateBatch")) {
+			/*TO DO
+			updateBacth and deleteBatch inherit the href from the "simplest" method in the group
+			(that is, no siteId, no assetLibraryId, etc., needed)
+			*/
+		}
 	}
 
 	protected void assertValid(Rating rating) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseCommentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseCommentResourceTestCase.java
@@ -67,6 +67,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -224,7 +226,7 @@ public abstract class BaseCommentResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantComment),
 				(List<Comment>)page.getItems());
-			assertValid(page);
+			assertValid(page, "/blog-postings/{blogPostingId}/comments");
 		}
 
 		Comment comment1 = testGetBlogPostingCommentsPage_addComment(
@@ -240,7 +242,7 @@ public abstract class BaseCommentResourceTestCase {
 
 		assertEqualsIgnoringOrder(
 			Arrays.asList(comment1, comment2), (List<Comment>)page.getItems());
-		assertValid(page);
+		assertValid(page, "/blog-postings/{blogPostingId}/comments");
 
 		commentResource.deleteComment(comment1.getId());
 
@@ -715,7 +717,7 @@ public abstract class BaseCommentResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantComment),
 				(List<Comment>)page.getItems());
-			assertValid(page);
+			assertValid(page, "/comments/{parentCommentId}/comments");
 		}
 
 		Comment comment1 = testGetCommentCommentsPage_addComment(
@@ -731,7 +733,7 @@ public abstract class BaseCommentResourceTestCase {
 
 		assertEqualsIgnoringOrder(
 			Arrays.asList(comment1, comment2), (List<Comment>)page.getItems());
-		assertValid(page);
+		assertValid(page, "/comments/{parentCommentId}/comments");
 
 		commentResource.deleteComment(comment1.getId());
 
@@ -1058,7 +1060,7 @@ public abstract class BaseCommentResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantComment),
 				(List<Comment>)page.getItems());
-			assertValid(page);
+			assertValid(page, "/documents/{documentId}/comments");
 		}
 
 		Comment comment1 = testGetDocumentCommentsPage_addComment(
@@ -1074,7 +1076,7 @@ public abstract class BaseCommentResourceTestCase {
 
 		assertEqualsIgnoringOrder(
 			Arrays.asList(comment1, comment2), (List<Comment>)page.getItems());
-		assertValid(page);
+		assertValid(page, "/documents/{documentId}/comments");
 
 		commentResource.deleteComment(comment1.getId());
 
@@ -2532,7 +2534,8 @@ public abstract class BaseCommentResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantComment),
 				(List<Comment>)page.getItems());
-			assertValid(page);
+			assertValid(
+				page, "/structured-contents/{structuredContentId}/comments");
 		}
 
 		Comment comment1 = testGetStructuredContentCommentsPage_addComment(
@@ -2548,7 +2551,8 @@ public abstract class BaseCommentResourceTestCase {
 
 		assertEqualsIgnoringOrder(
 			Arrays.asList(comment1, comment2), (List<Comment>)page.getItems());
-		assertValid(page);
+		assertValid(
+			page, "/structured-contents/{structuredContentId}/comments");
 
 		commentResource.deleteComment(comment1.getId());
 
@@ -3022,7 +3026,7 @@ public abstract class BaseCommentResourceTestCase {
 		Assert.assertTrue(valid);
 	}
 
-	protected void assertValid(Page<Comment> page) {
+	protected void assertValid(Page<Comment> page, String path) {
 		boolean valid = false;
 
 		java.util.Collection<Comment> comments = page.getItems();
@@ -3037,6 +3041,112 @@ public abstract class BaseCommentResourceTestCase {
 		}
 
 		Assert.assertTrue(valid);
+
+		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
+		//this List is temporary and can help us detecting
+		//cases that should match the acceptance criteria, but are not covered with the current approach
+
+		List<String> pathsNotCovered = new ArrayList<>();
+
+		if (path.equals("/blog-postings/{blogPostingId}/comments")) {
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/blog-postings/{blogPostingId}/comments",
+				path);
+		}
+		else {
+			pathsNotCovered.add("/blog-postings/{blogPostingId}/comments");
+		}
+
+		if (path.equals("/comments/{parentCommentId}/comments")) {
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/comments/{parentCommentId}/comments",
+				path);
+		}
+		else {
+			pathsNotCovered.add("/comments/{parentCommentId}/comments");
+		}
+
+		if (path.equals("/documents/{documentId}/comments")) {
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/documents/{documentId}/comments",
+				path);
+		}
+		else {
+			pathsNotCovered.add("/documents/{documentId}/comments");
+		}
+
+		if (path.equals(
+				"/structured-contents/{structuredContentId}/comments")) {
+
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/structured-contents/{structuredContentId}/comments",
+				path);
+		}
+		else {
+			pathsNotCovered.add(
+				"/structured-contents/{structuredContentId}/comments");
+		}
+
+		if (!pathsNotCovered.isEmpty()) {
+			Assert.fail(
+				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
+					pathsNotCovered.toString());
+		}
+	}
+
+	private void assertBatchAction(
+		Page<Comment> page, String action, String method, String expectedPath,
+		String path) {
+
+		Map<String, Map> actions = page.getActions();
+
+		Map batchAction = actions.get(action);
+
+		Assert.assertNotNull(
+			"No Actions for " + action + " in path " + path, batchAction);
+		Assert.assertEquals(
+			"The batch action method value is not correct", method,
+			batchAction.get("method"));
+		assertHrefInBatchActionMatchesPath(
+			expectedPath,
+			batchAction.get(
+				"href"
+			).toString(),
+			action, path);
+	}
+
+	private void assertHrefInBatchActionMatchesPath(
+		String expectedPath, String href, String action, String path) {
+
+		//only paths with POST operation available will have createBatch
+		//we need a freeMarker "if" to check whether the path we're checking has it
+		//and then check the createBatch details
+
+		if (action.equals("createBatch")) {
+			String expectedPathReplaced = expectedPath.replaceAll(
+				"(\\Q{\\E.*?\\Q}\\E)", "(.*)");
+			String[] detachActualPathFromServer = href.split("/o/");
+			Pattern expectedPathPattern = Pattern.compile(
+				expectedPathReplaced + "/batch");
+			Matcher actualPathMatcher = expectedPathPattern.matcher(
+				"/" + detachActualPathFromServer[1]);
+			Assert.assertTrue(
+				"The /" + detachActualPathFromServer[1] + " does not match " +
+					expectedPathReplaced + "/batch for " + action +
+						" in the path " + path,
+				actualPathMatcher.matches());
+		}
+
+		if (action.equals("deleteBatch") || action.equals("updateBatch")) {
+			/*TO DO
+			updateBacth and deleteBatch inherit the href from the "simplest" method in the group
+			(that is, no siteId, no assetLibraryId, etc., needed)
+			*/
+		}
 	}
 
 	protected String[] getAdditionalAssertFieldNames() {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseCommentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseCommentResourceTestCase.java
@@ -3042,20 +3042,11 @@ public abstract class BaseCommentResourceTestCase {
 
 		Assert.assertTrue(valid);
 
-		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
-		//this List is temporary and can help us detecting
-		//cases that should match the acceptance criteria, but are not covered with the current approach
-
-		List<String> pathsNotCovered = new ArrayList<>();
-
 		if (path.equals("/blog-postings/{blogPostingId}/comments")) {
 			assertBatchAction(
 				page, "createBatch", "POST",
 				"/headless-delivery/v1.0/blog-postings/{blogPostingId}/comments",
 				path);
-		}
-		else {
-			pathsNotCovered.add("/blog-postings/{blogPostingId}/comments");
 		}
 
 		if (path.equals("/comments/{parentCommentId}/comments")) {
@@ -3064,18 +3055,12 @@ public abstract class BaseCommentResourceTestCase {
 				"/headless-delivery/v1.0/comments/{parentCommentId}/comments",
 				path);
 		}
-		else {
-			pathsNotCovered.add("/comments/{parentCommentId}/comments");
-		}
 
 		if (path.equals("/documents/{documentId}/comments")) {
 			assertBatchAction(
 				page, "createBatch", "POST",
 				"/headless-delivery/v1.0/documents/{documentId}/comments",
 				path);
-		}
-		else {
-			pathsNotCovered.add("/documents/{documentId}/comments");
 		}
 
 		if (path.equals(
@@ -3085,16 +3070,6 @@ public abstract class BaseCommentResourceTestCase {
 				page, "createBatch", "POST",
 				"/headless-delivery/v1.0/structured-contents/{structuredContentId}/comments",
 				path);
-		}
-		else {
-			pathsNotCovered.add(
-				"/structured-contents/{structuredContentId}/comments");
-		}
-
-		if (!pathsNotCovered.isEmpty()) {
-			Assert.fail(
-				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
-					pathsNotCovered.toString());
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentElementResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentElementResourceTestCase.java
@@ -1143,21 +1143,11 @@ public abstract class BaseContentElementResourceTestCase {
 
 		Assert.assertTrue(valid);
 
-		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
-		//this List is temporary and can help us detecting
-		//cases that should match the acceptance criteria, but are not covered with the current approach
-
-		List<String> pathsNotCovered = new ArrayList<>();
-
 		if (path.equals("/asset-libraries/{assetLibraryId}/content-elements")) {
 			assertBatchAction(
 				page, "createBatch", "POST",
 				"/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/content-elements",
 				path);
-		}
-		else {
-			pathsNotCovered.add(
-				"/asset-libraries/{assetLibraryId}/content-elements");
 		}
 
 		if (path.equals("/sites/{siteId}/content-elements")) {
@@ -1165,15 +1155,6 @@ public abstract class BaseContentElementResourceTestCase {
 				page, "createBatch", "POST",
 				"/headless-delivery/v1.0/sites/{siteId}/content-elements",
 				path);
-		}
-		else {
-			pathsNotCovered.add("/sites/{siteId}/content-elements");
-		}
-
-		if (!pathsNotCovered.isEmpty()) {
-			Assert.fail(
-				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
-					pathsNotCovered.toString());
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentElementResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentElementResourceTestCase.java
@@ -70,6 +70,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -241,7 +243,8 @@ public abstract class BaseContentElementResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantContentElement),
 				(List<ContentElement>)page.getItems());
-			assertValid(page);
+			assertValid(
+				page, "/asset-libraries/{assetLibraryId}/content-elements");
 		}
 
 		ContentElement contentElement1 =
@@ -260,7 +263,7 @@ public abstract class BaseContentElementResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(contentElement1, contentElement2),
 			(List<ContentElement>)page.getItems());
-		assertValid(page);
+		assertValid(page, "/asset-libraries/{assetLibraryId}/content-elements");
 	}
 
 	@Test
@@ -612,7 +615,7 @@ public abstract class BaseContentElementResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantContentElement),
 				(List<ContentElement>)page.getItems());
-			assertValid(page);
+			assertValid(page, "/sites/{siteId}/content-elements");
 		}
 
 		ContentElement contentElement1 =
@@ -631,7 +634,7 @@ public abstract class BaseContentElementResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(contentElement1, contentElement2),
 			(List<ContentElement>)page.getItems());
-		assertValid(page);
+		assertValid(page, "/sites/{siteId}/content-elements");
 	}
 
 	@Test
@@ -1124,7 +1127,7 @@ public abstract class BaseContentElementResourceTestCase {
 		Assert.assertTrue(valid);
 	}
 
-	protected void assertValid(Page<ContentElement> page) {
+	protected void assertValid(Page<ContentElement> page, String path) {
 		boolean valid = false;
 
 		java.util.Collection<ContentElement> contentElements = page.getItems();
@@ -1139,6 +1142,90 @@ public abstract class BaseContentElementResourceTestCase {
 		}
 
 		Assert.assertTrue(valid);
+
+		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
+		//this List is temporary and can help us detecting
+		//cases that should match the acceptance criteria, but are not covered with the current approach
+
+		List<String> pathsNotCovered = new ArrayList<>();
+
+		if (path.equals("/asset-libraries/{assetLibraryId}/content-elements")) {
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/content-elements",
+				path);
+		}
+		else {
+			pathsNotCovered.add(
+				"/asset-libraries/{assetLibraryId}/content-elements");
+		}
+
+		if (path.equals("/sites/{siteId}/content-elements")) {
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/sites/{siteId}/content-elements",
+				path);
+		}
+		else {
+			pathsNotCovered.add("/sites/{siteId}/content-elements");
+		}
+
+		if (!pathsNotCovered.isEmpty()) {
+			Assert.fail(
+				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
+					pathsNotCovered.toString());
+		}
+	}
+
+	private void assertBatchAction(
+		Page<ContentElement> page, String action, String method,
+		String expectedPath, String path) {
+
+		Map<String, Map> actions = page.getActions();
+
+		Map batchAction = actions.get(action);
+
+		Assert.assertNotNull(
+			"No Actions for " + action + " in path " + path, batchAction);
+		Assert.assertEquals(
+			"The batch action method value is not correct", method,
+			batchAction.get("method"));
+		assertHrefInBatchActionMatchesPath(
+			expectedPath,
+			batchAction.get(
+				"href"
+			).toString(),
+			action, path);
+	}
+
+	private void assertHrefInBatchActionMatchesPath(
+		String expectedPath, String href, String action, String path) {
+
+		//only paths with POST operation available will have createBatch
+		//we need a freeMarker "if" to check whether the path we're checking has it
+		//and then check the createBatch details
+
+		if (action.equals("createBatch")) {
+			String expectedPathReplaced = expectedPath.replaceAll(
+				"(\\Q{\\E.*?\\Q}\\E)", "(.*)");
+			String[] detachActualPathFromServer = href.split("/o/");
+			Pattern expectedPathPattern = Pattern.compile(
+				expectedPathReplaced + "/batch");
+			Matcher actualPathMatcher = expectedPathPattern.matcher(
+				"/" + detachActualPathFromServer[1]);
+			Assert.assertTrue(
+				"The /" + detachActualPathFromServer[1] + " does not match " +
+					expectedPathReplaced + "/batch for " + action +
+						" in the path " + path,
+				actualPathMatcher.matches());
+		}
+
+		if (action.equals("deleteBatch") || action.equals("updateBatch")) {
+			/*TO DO
+			updateBacth and deleteBatch inherit the href from the "simplest" method in the group
+			(that is, no siteId, no assetLibraryId, etc., needed)
+			*/
+		}
 	}
 
 	protected String[] getAdditionalAssertFieldNames() {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentSetElementResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentSetElementResourceTestCase.java
@@ -68,6 +68,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -248,7 +250,9 @@ public abstract class BaseContentSetElementResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantContentSetElement),
 				(List<ContentSetElement>)page.getItems());
-			assertValid(page);
+			assertValid(
+				page,
+				"/asset-libraries/{assetLibraryId}/content-sets/by-key/{key}/content-set-elements");
 		}
 
 		ContentSetElement contentSetElement1 =
@@ -269,7 +273,9 @@ public abstract class BaseContentSetElementResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(contentSetElement1, contentSetElement2),
 			(List<ContentSetElement>)page.getItems());
-		assertValid(page);
+		assertValid(
+			page,
+			"/asset-libraries/{assetLibraryId}/content-sets/by-key/{key}/content-set-elements");
 	}
 
 	@Test
@@ -404,7 +410,9 @@ public abstract class BaseContentSetElementResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantContentSetElement),
 				(List<ContentSetElement>)page.getItems());
-			assertValid(page);
+			assertValid(
+				page,
+				"/asset-libraries/{assetLibraryId}/content-sets/by-uuid/{uuid}/content-set-elements");
 		}
 
 		ContentSetElement contentSetElement1 =
@@ -425,7 +433,9 @@ public abstract class BaseContentSetElementResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(contentSetElement1, contentSetElement2),
 			(List<ContentSetElement>)page.getItems());
-		assertValid(page);
+		assertValid(
+			page,
+			"/asset-libraries/{assetLibraryId}/content-sets/by-uuid/{uuid}/content-set-elements");
 	}
 
 	@Test
@@ -551,7 +561,8 @@ public abstract class BaseContentSetElementResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantContentSetElement),
 				(List<ContentSetElement>)page.getItems());
-			assertValid(page);
+			assertValid(
+				page, "/content-sets/{contentSetId}/content-set-elements");
 		}
 
 		ContentSetElement contentSetElement1 =
@@ -570,7 +581,7 @@ public abstract class BaseContentSetElementResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(contentSetElement1, contentSetElement2),
 			(List<ContentSetElement>)page.getItems());
-		assertValid(page);
+		assertValid(page, "/content-sets/{contentSetId}/content-set-elements");
 	}
 
 	@Test
@@ -682,7 +693,9 @@ public abstract class BaseContentSetElementResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantContentSetElement),
 				(List<ContentSetElement>)page.getItems());
-			assertValid(page);
+			assertValid(
+				page,
+				"/sites/{siteId}/content-sets/by-key/{key}/content-set-elements");
 		}
 
 		ContentSetElement contentSetElement1 =
@@ -703,7 +716,9 @@ public abstract class BaseContentSetElementResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(contentSetElement1, contentSetElement2),
 			(List<ContentSetElement>)page.getItems());
-		assertValid(page);
+		assertValid(
+			page,
+			"/sites/{siteId}/content-sets/by-key/{key}/content-set-elements");
 	}
 
 	@Test
@@ -833,7 +848,9 @@ public abstract class BaseContentSetElementResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantContentSetElement),
 				(List<ContentSetElement>)page.getItems());
-			assertValid(page);
+			assertValid(
+				page,
+				"/sites/{siteId}/content-sets/by-uuid/{uuid}/content-set-elements");
 		}
 
 		ContentSetElement contentSetElement1 =
@@ -854,7 +871,9 @@ public abstract class BaseContentSetElementResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(contentSetElement1, contentSetElement2),
 			(List<ContentSetElement>)page.getItems());
-		assertValid(page);
+		assertValid(
+			page,
+			"/sites/{siteId}/content-sets/by-uuid/{uuid}/content-set-elements");
 	}
 
 	@Test
@@ -1084,7 +1103,7 @@ public abstract class BaseContentSetElementResourceTestCase {
 		Assert.assertTrue(valid);
 	}
 
-	protected void assertValid(Page<ContentSetElement> page) {
+	protected void assertValid(Page<ContentSetElement> page, String path) {
 		boolean valid = false;
 
 		java.util.Collection<ContentSetElement> contentSetElements =
@@ -1100,6 +1119,132 @@ public abstract class BaseContentSetElementResourceTestCase {
 		}
 
 		Assert.assertTrue(valid);
+
+		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
+		//this List is temporary and can help us detecting
+		//cases that should match the acceptance criteria, but are not covered with the current approach
+
+		List<String> pathsNotCovered = new ArrayList<>();
+
+		if (path.equals(
+				"/asset-libraries/{assetLibraryId}/content-sets/by-key/{key}/content-set-elements")) {
+
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/content-sets/by-key/{key}/content-set-elements",
+				path);
+		}
+		else {
+			pathsNotCovered.add(
+				"/asset-libraries/{assetLibraryId}/content-sets/by-key/{key}/content-set-elements");
+		}
+
+		if (path.equals(
+				"/asset-libraries/{assetLibraryId}/content-sets/by-uuid/{uuid}/content-set-elements")) {
+
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/content-sets/by-uuid/{uuid}/content-set-elements",
+				path);
+		}
+		else {
+			pathsNotCovered.add(
+				"/asset-libraries/{assetLibraryId}/content-sets/by-uuid/{uuid}/content-set-elements");
+		}
+
+		if (path.equals("/content-sets/{contentSetId}/content-set-elements")) {
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/content-sets/{contentSetId}/content-set-elements",
+				path);
+		}
+		else {
+			pathsNotCovered.add(
+				"/content-sets/{contentSetId}/content-set-elements");
+		}
+
+		if (path.equals(
+				"/sites/{siteId}/content-sets/by-key/{key}/content-set-elements")) {
+
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/sites/{siteId}/content-sets/by-key/{key}/content-set-elements",
+				path);
+		}
+		else {
+			pathsNotCovered.add(
+				"/sites/{siteId}/content-sets/by-key/{key}/content-set-elements");
+		}
+
+		if (path.equals(
+				"/sites/{siteId}/content-sets/by-uuid/{uuid}/content-set-elements")) {
+
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/sites/{siteId}/content-sets/by-uuid/{uuid}/content-set-elements",
+				path);
+		}
+		else {
+			pathsNotCovered.add(
+				"/sites/{siteId}/content-sets/by-uuid/{uuid}/content-set-elements");
+		}
+
+		if (!pathsNotCovered.isEmpty()) {
+			Assert.fail(
+				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
+					pathsNotCovered.toString());
+		}
+	}
+
+	private void assertBatchAction(
+		Page<ContentSetElement> page, String action, String method,
+		String expectedPath, String path) {
+
+		Map<String, Map> actions = page.getActions();
+
+		Map batchAction = actions.get(action);
+
+		Assert.assertNotNull(
+			"No Actions for " + action + " in path " + path, batchAction);
+		Assert.assertEquals(
+			"The batch action method value is not correct", method,
+			batchAction.get("method"));
+		assertHrefInBatchActionMatchesPath(
+			expectedPath,
+			batchAction.get(
+				"href"
+			).toString(),
+			action, path);
+	}
+
+	private void assertHrefInBatchActionMatchesPath(
+		String expectedPath, String href, String action, String path) {
+
+		//only paths with POST operation available will have createBatch
+		//we need a freeMarker "if" to check whether the path we're checking has it
+		//and then check the createBatch details
+
+		if (action.equals("createBatch")) {
+			String expectedPathReplaced = expectedPath.replaceAll(
+				"(\\Q{\\E.*?\\Q}\\E)", "(.*)");
+			String[] detachActualPathFromServer = href.split("/o/");
+			Pattern expectedPathPattern = Pattern.compile(
+				expectedPathReplaced + "/batch");
+			Matcher actualPathMatcher = expectedPathPattern.matcher(
+				"/" + detachActualPathFromServer[1]);
+			Assert.assertTrue(
+				"The /" + detachActualPathFromServer[1] + " does not match " +
+					expectedPathReplaced + "/batch for " + action +
+						" in the path " + path,
+				actualPathMatcher.matches());
+		}
+
+		if (action.equals("deleteBatch") || action.equals("updateBatch")) {
+			/*TO DO
+			updateBacth and deleteBatch inherit the href from the "simplest" method in the group
+			(that is, no siteId, no assetLibraryId, etc., needed)
+			*/
+		}
 	}
 
 	protected String[] getAdditionalAssertFieldNames() {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentSetElementResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentSetElementResourceTestCase.java
@@ -1120,12 +1120,6 @@ public abstract class BaseContentSetElementResourceTestCase {
 
 		Assert.assertTrue(valid);
 
-		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
-		//this List is temporary and can help us detecting
-		//cases that should match the acceptance criteria, but are not covered with the current approach
-
-		List<String> pathsNotCovered = new ArrayList<>();
-
 		if (path.equals(
 				"/asset-libraries/{assetLibraryId}/content-sets/by-key/{key}/content-set-elements")) {
 
@@ -1133,10 +1127,6 @@ public abstract class BaseContentSetElementResourceTestCase {
 				page, "createBatch", "POST",
 				"/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/content-sets/by-key/{key}/content-set-elements",
 				path);
-		}
-		else {
-			pathsNotCovered.add(
-				"/asset-libraries/{assetLibraryId}/content-sets/by-key/{key}/content-set-elements");
 		}
 
 		if (path.equals(
@@ -1147,20 +1137,12 @@ public abstract class BaseContentSetElementResourceTestCase {
 				"/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/content-sets/by-uuid/{uuid}/content-set-elements",
 				path);
 		}
-		else {
-			pathsNotCovered.add(
-				"/asset-libraries/{assetLibraryId}/content-sets/by-uuid/{uuid}/content-set-elements");
-		}
 
 		if (path.equals("/content-sets/{contentSetId}/content-set-elements")) {
 			assertBatchAction(
 				page, "createBatch", "POST",
 				"/headless-delivery/v1.0/content-sets/{contentSetId}/content-set-elements",
 				path);
-		}
-		else {
-			pathsNotCovered.add(
-				"/content-sets/{contentSetId}/content-set-elements");
 		}
 
 		if (path.equals(
@@ -1171,10 +1153,6 @@ public abstract class BaseContentSetElementResourceTestCase {
 				"/headless-delivery/v1.0/sites/{siteId}/content-sets/by-key/{key}/content-set-elements",
 				path);
 		}
-		else {
-			pathsNotCovered.add(
-				"/sites/{siteId}/content-sets/by-key/{key}/content-set-elements");
-		}
 
 		if (path.equals(
 				"/sites/{siteId}/content-sets/by-uuid/{uuid}/content-set-elements")) {
@@ -1183,16 +1161,6 @@ public abstract class BaseContentSetElementResourceTestCase {
 				page, "createBatch", "POST",
 				"/headless-delivery/v1.0/sites/{siteId}/content-sets/by-uuid/{uuid}/content-set-elements",
 				path);
-		}
-		else {
-			pathsNotCovered.add(
-				"/sites/{siteId}/content-sets/by-uuid/{uuid}/content-set-elements");
-		}
-
-		if (!pathsNotCovered.isEmpty()) {
-			Assert.fail(
-				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
-					pathsNotCovered.toString());
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentStructureResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentStructureResourceTestCase.java
@@ -73,6 +73,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -248,7 +250,8 @@ public abstract class BaseContentStructureResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantContentStructure),
 				(List<ContentStructure>)page.getItems());
-			assertValid(page);
+			assertValid(
+				page, "/asset-libraries/{assetLibraryId}/content-structures");
 		}
 
 		ContentStructure contentStructure1 =
@@ -267,7 +270,8 @@ public abstract class BaseContentStructureResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(contentStructure1, contentStructure2),
 			(List<ContentStructure>)page.getItems());
-		assertValid(page);
+		assertValid(
+			page, "/asset-libraries/{assetLibraryId}/content-structures");
 	}
 
 	@Test
@@ -829,7 +833,7 @@ public abstract class BaseContentStructureResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantContentStructure),
 				(List<ContentStructure>)page.getItems());
-			assertValid(page);
+			assertValid(page, "/sites/{siteId}/content-structures");
 		}
 
 		ContentStructure contentStructure1 =
@@ -848,7 +852,7 @@ public abstract class BaseContentStructureResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(contentStructure1, contentStructure2),
 			(List<ContentStructure>)page.getItems());
-		assertValid(page);
+		assertValid(page, "/sites/{siteId}/content-structures");
 	}
 
 	@Test
@@ -1474,7 +1478,7 @@ public abstract class BaseContentStructureResourceTestCase {
 		Assert.assertTrue(valid);
 	}
 
-	protected void assertValid(Page<ContentStructure> page) {
+	protected void assertValid(Page<ContentStructure> page, String path) {
 		boolean valid = false;
 
 		java.util.Collection<ContentStructure> contentStructures =
@@ -1490,6 +1494,92 @@ public abstract class BaseContentStructureResourceTestCase {
 		}
 
 		Assert.assertTrue(valid);
+
+		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
+		//this List is temporary and can help us detecting
+		//cases that should match the acceptance criteria, but are not covered with the current approach
+
+		List<String> pathsNotCovered = new ArrayList<>();
+
+		if (path.equals(
+				"/asset-libraries/{assetLibraryId}/content-structures")) {
+
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/content-structures",
+				path);
+		}
+		else {
+			pathsNotCovered.add(
+				"/asset-libraries/{assetLibraryId}/content-structures");
+		}
+
+		if (path.equals("/sites/{siteId}/content-structures")) {
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/sites/{siteId}/content-structures",
+				path);
+		}
+		else {
+			pathsNotCovered.add("/sites/{siteId}/content-structures");
+		}
+
+		if (!pathsNotCovered.isEmpty()) {
+			Assert.fail(
+				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
+					pathsNotCovered.toString());
+		}
+	}
+
+	private void assertBatchAction(
+		Page<ContentStructure> page, String action, String method,
+		String expectedPath, String path) {
+
+		Map<String, Map> actions = page.getActions();
+
+		Map batchAction = actions.get(action);
+
+		Assert.assertNotNull(
+			"No Actions for " + action + " in path " + path, batchAction);
+		Assert.assertEquals(
+			"The batch action method value is not correct", method,
+			batchAction.get("method"));
+		assertHrefInBatchActionMatchesPath(
+			expectedPath,
+			batchAction.get(
+				"href"
+			).toString(),
+			action, path);
+	}
+
+	private void assertHrefInBatchActionMatchesPath(
+		String expectedPath, String href, String action, String path) {
+
+		//only paths with POST operation available will have createBatch
+		//we need a freeMarker "if" to check whether the path we're checking has it
+		//and then check the createBatch details
+
+		if (action.equals("createBatch")) {
+			String expectedPathReplaced = expectedPath.replaceAll(
+				"(\\Q{\\E.*?\\Q}\\E)", "(.*)");
+			String[] detachActualPathFromServer = href.split("/o/");
+			Pattern expectedPathPattern = Pattern.compile(
+				expectedPathReplaced + "/batch");
+			Matcher actualPathMatcher = expectedPathPattern.matcher(
+				"/" + detachActualPathFromServer[1]);
+			Assert.assertTrue(
+				"The /" + detachActualPathFromServer[1] + " does not match " +
+					expectedPathReplaced + "/batch for " + action +
+						" in the path " + path,
+				actualPathMatcher.matches());
+		}
+
+		if (action.equals("deleteBatch") || action.equals("updateBatch")) {
+			/*TO DO
+			updateBacth and deleteBatch inherit the href from the "simplest" method in the group
+			(that is, no siteId, no assetLibraryId, etc., needed)
+			*/
+		}
 	}
 
 	protected String[] getAdditionalAssertFieldNames() {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentStructureResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentStructureResourceTestCase.java
@@ -1495,12 +1495,6 @@ public abstract class BaseContentStructureResourceTestCase {
 
 		Assert.assertTrue(valid);
 
-		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
-		//this List is temporary and can help us detecting
-		//cases that should match the acceptance criteria, but are not covered with the current approach
-
-		List<String> pathsNotCovered = new ArrayList<>();
-
 		if (path.equals(
 				"/asset-libraries/{assetLibraryId}/content-structures")) {
 
@@ -1509,25 +1503,12 @@ public abstract class BaseContentStructureResourceTestCase {
 				"/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/content-structures",
 				path);
 		}
-		else {
-			pathsNotCovered.add(
-				"/asset-libraries/{assetLibraryId}/content-structures");
-		}
 
 		if (path.equals("/sites/{siteId}/content-structures")) {
 			assertBatchAction(
 				page, "createBatch", "POST",
 				"/headless-delivery/v1.0/sites/{siteId}/content-structures",
 				path);
-		}
-		else {
-			pathsNotCovered.add("/sites/{siteId}/content-structures");
-		}
-
-		if (!pathsNotCovered.isEmpty()) {
-			Assert.fail(
-				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
-					pathsNotCovered.toString());
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentTemplateResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentTemplateResourceTestCase.java
@@ -1324,12 +1324,6 @@ public abstract class BaseContentTemplateResourceTestCase {
 
 		Assert.assertTrue(valid);
 
-		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
-		//this List is temporary and can help us detecting
-		//cases that should match the acceptance criteria, but are not covered with the current approach
-
-		List<String> pathsNotCovered = new ArrayList<>();
-
 		if (path.equals(
 				"/asset-libraries/{assetLibraryId}/content-templates")) {
 
@@ -1338,25 +1332,12 @@ public abstract class BaseContentTemplateResourceTestCase {
 				"/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/content-templates",
 				path);
 		}
-		else {
-			pathsNotCovered.add(
-				"/asset-libraries/{assetLibraryId}/content-templates");
-		}
 
 		if (path.equals("/sites/{siteId}/content-templates")) {
 			assertBatchAction(
 				page, "createBatch", "POST",
 				"/headless-delivery/v1.0/sites/{siteId}/content-templates",
 				path);
-		}
-		else {
-			pathsNotCovered.add("/sites/{siteId}/content-templates");
-		}
-
-		if (!pathsNotCovered.isEmpty()) {
-			Assert.fail(
-				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
-					pathsNotCovered.toString());
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentTemplateResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentTemplateResourceTestCase.java
@@ -70,6 +70,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -250,7 +252,8 @@ public abstract class BaseContentTemplateResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantContentTemplate),
 				(List<ContentTemplate>)page.getItems());
-			assertValid(page);
+			assertValid(
+				page, "/asset-libraries/{assetLibraryId}/content-templates");
 		}
 
 		ContentTemplate contentTemplate1 =
@@ -269,7 +272,8 @@ public abstract class BaseContentTemplateResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(contentTemplate1, contentTemplate2),
 			(List<ContentTemplate>)page.getItems());
-		assertValid(page);
+		assertValid(
+			page, "/asset-libraries/{assetLibraryId}/content-templates");
 	}
 
 	@Test
@@ -621,7 +625,7 @@ public abstract class BaseContentTemplateResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantContentTemplate),
 				(List<ContentTemplate>)page.getItems());
-			assertValid(page);
+			assertValid(page, "/sites/{siteId}/content-templates");
 		}
 
 		ContentTemplate contentTemplate1 =
@@ -640,7 +644,7 @@ public abstract class BaseContentTemplateResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(contentTemplate1, contentTemplate2),
 			(List<ContentTemplate>)page.getItems());
-		assertValid(page);
+		assertValid(page, "/sites/{siteId}/content-templates");
 	}
 
 	@Test
@@ -1303,7 +1307,7 @@ public abstract class BaseContentTemplateResourceTestCase {
 		Assert.assertTrue(valid);
 	}
 
-	protected void assertValid(Page<ContentTemplate> page) {
+	protected void assertValid(Page<ContentTemplate> page, String path) {
 		boolean valid = false;
 
 		java.util.Collection<ContentTemplate> contentTemplates =
@@ -1319,6 +1323,92 @@ public abstract class BaseContentTemplateResourceTestCase {
 		}
 
 		Assert.assertTrue(valid);
+
+		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
+		//this List is temporary and can help us detecting
+		//cases that should match the acceptance criteria, but are not covered with the current approach
+
+		List<String> pathsNotCovered = new ArrayList<>();
+
+		if (path.equals(
+				"/asset-libraries/{assetLibraryId}/content-templates")) {
+
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/content-templates",
+				path);
+		}
+		else {
+			pathsNotCovered.add(
+				"/asset-libraries/{assetLibraryId}/content-templates");
+		}
+
+		if (path.equals("/sites/{siteId}/content-templates")) {
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/sites/{siteId}/content-templates",
+				path);
+		}
+		else {
+			pathsNotCovered.add("/sites/{siteId}/content-templates");
+		}
+
+		if (!pathsNotCovered.isEmpty()) {
+			Assert.fail(
+				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
+					pathsNotCovered.toString());
+		}
+	}
+
+	private void assertBatchAction(
+		Page<ContentTemplate> page, String action, String method,
+		String expectedPath, String path) {
+
+		Map<String, Map> actions = page.getActions();
+
+		Map batchAction = actions.get(action);
+
+		Assert.assertNotNull(
+			"No Actions for " + action + " in path " + path, batchAction);
+		Assert.assertEquals(
+			"The batch action method value is not correct", method,
+			batchAction.get("method"));
+		assertHrefInBatchActionMatchesPath(
+			expectedPath,
+			batchAction.get(
+				"href"
+			).toString(),
+			action, path);
+	}
+
+	private void assertHrefInBatchActionMatchesPath(
+		String expectedPath, String href, String action, String path) {
+
+		//only paths with POST operation available will have createBatch
+		//we need a freeMarker "if" to check whether the path we're checking has it
+		//and then check the createBatch details
+
+		if (action.equals("createBatch")) {
+			String expectedPathReplaced = expectedPath.replaceAll(
+				"(\\Q{\\E.*?\\Q}\\E)", "(.*)");
+			String[] detachActualPathFromServer = href.split("/o/");
+			Pattern expectedPathPattern = Pattern.compile(
+				expectedPathReplaced + "/batch");
+			Matcher actualPathMatcher = expectedPathPattern.matcher(
+				"/" + detachActualPathFromServer[1]);
+			Assert.assertTrue(
+				"The /" + detachActualPathFromServer[1] + " does not match " +
+					expectedPathReplaced + "/batch for " + action +
+						" in the path " + path,
+				actualPathMatcher.matches());
+		}
+
+		if (action.equals("deleteBatch") || action.equals("updateBatch")) {
+			/*TO DO
+			updateBacth and deleteBatch inherit the href from the "simplest" method in the group
+			(that is, no siteId, no assetLibraryId, etc., needed)
+			*/
+		}
 	}
 
 	protected String[] getAdditionalAssertFieldNames() {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentFolderResourceTestCase.java
@@ -2243,21 +2243,11 @@ public abstract class BaseDocumentFolderResourceTestCase {
 
 		Assert.assertTrue(valid);
 
-		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
-		//this List is temporary and can help us detecting
-		//cases that should match the acceptance criteria, but are not covered with the current approach
-
-		List<String> pathsNotCovered = new ArrayList<>();
-
 		if (path.equals("/asset-libraries/{assetLibraryId}/document-folders")) {
 			assertBatchAction(
 				page, "createBatch", "POST",
 				"/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/document-folders",
 				path);
-		}
-		else {
-			pathsNotCovered.add(
-				"/asset-libraries/{assetLibraryId}/document-folders");
 		}
 
 		if (path.equals(
@@ -2268,25 +2258,12 @@ public abstract class BaseDocumentFolderResourceTestCase {
 				"/headless-delivery/v1.0/document-folders/{parentDocumentFolderId}/document-folders",
 				path);
 		}
-		else {
-			pathsNotCovered.add(
-				"/document-folders/{parentDocumentFolderId}/document-folders");
-		}
 
 		if (path.equals("/sites/{siteId}/document-folders")) {
 			assertBatchAction(
 				page, "createBatch", "POST",
 				"/headless-delivery/v1.0/sites/{siteId}/document-folders",
 				path);
-		}
-		else {
-			pathsNotCovered.add("/sites/{siteId}/document-folders");
-		}
-
-		if (!pathsNotCovered.isEmpty()) {
-			Assert.fail(
-				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
-					pathsNotCovered.toString());
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentFolderResourceTestCase.java
@@ -75,6 +75,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -249,7 +251,8 @@ public abstract class BaseDocumentFolderResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantDocumentFolder),
 				(List<DocumentFolder>)page.getItems());
-			assertValid(page);
+			assertValid(
+				page, "/asset-libraries/{assetLibraryId}/document-folders");
 		}
 
 		DocumentFolder documentFolder1 =
@@ -268,7 +271,7 @@ public abstract class BaseDocumentFolderResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(documentFolder1, documentFolder2),
 			(List<DocumentFolder>)page.getItems());
-		assertValid(page);
+		assertValid(page, "/asset-libraries/{assetLibraryId}/document-folders");
 
 		documentFolderResource.deleteDocumentFolder(documentFolder1.getId());
 
@@ -1030,7 +1033,9 @@ public abstract class BaseDocumentFolderResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantDocumentFolder),
 				(List<DocumentFolder>)page.getItems());
-			assertValid(page);
+			assertValid(
+				page,
+				"/document-folders/{parentDocumentFolderId}/document-folders");
 		}
 
 		DocumentFolder documentFolder1 =
@@ -1050,7 +1055,9 @@ public abstract class BaseDocumentFolderResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(documentFolder1, documentFolder2),
 			(List<DocumentFolder>)page.getItems());
-		assertValid(page);
+		assertValid(
+			page,
+			"/document-folders/{parentDocumentFolderId}/document-folders");
 
 		documentFolderResource.deleteDocumentFolder(documentFolder1.getId());
 
@@ -1434,7 +1441,7 @@ public abstract class BaseDocumentFolderResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantDocumentFolder),
 				(List<DocumentFolder>)page.getItems());
-			assertValid(page);
+			assertValid(page, "/sites/{siteId}/document-folders");
 		}
 
 		DocumentFolder documentFolder1 =
@@ -1453,7 +1460,7 @@ public abstract class BaseDocumentFolderResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(documentFolder1, documentFolder2),
 			(List<DocumentFolder>)page.getItems());
-		assertValid(page);
+		assertValid(page, "/sites/{siteId}/document-folders");
 
 		documentFolderResource.deleteDocumentFolder(documentFolder1.getId());
 
@@ -2220,7 +2227,7 @@ public abstract class BaseDocumentFolderResourceTestCase {
 		Assert.assertTrue(valid);
 	}
 
-	protected void assertValid(Page<DocumentFolder> page) {
+	protected void assertValid(Page<DocumentFolder> page, String path) {
 		boolean valid = false;
 
 		java.util.Collection<DocumentFolder> documentFolders = page.getItems();
@@ -2235,6 +2242,103 @@ public abstract class BaseDocumentFolderResourceTestCase {
 		}
 
 		Assert.assertTrue(valid);
+
+		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
+		//this List is temporary and can help us detecting
+		//cases that should match the acceptance criteria, but are not covered with the current approach
+
+		List<String> pathsNotCovered = new ArrayList<>();
+
+		if (path.equals("/asset-libraries/{assetLibraryId}/document-folders")) {
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/document-folders",
+				path);
+		}
+		else {
+			pathsNotCovered.add(
+				"/asset-libraries/{assetLibraryId}/document-folders");
+		}
+
+		if (path.equals(
+				"/document-folders/{parentDocumentFolderId}/document-folders")) {
+
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/document-folders/{parentDocumentFolderId}/document-folders",
+				path);
+		}
+		else {
+			pathsNotCovered.add(
+				"/document-folders/{parentDocumentFolderId}/document-folders");
+		}
+
+		if (path.equals("/sites/{siteId}/document-folders")) {
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/sites/{siteId}/document-folders",
+				path);
+		}
+		else {
+			pathsNotCovered.add("/sites/{siteId}/document-folders");
+		}
+
+		if (!pathsNotCovered.isEmpty()) {
+			Assert.fail(
+				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
+					pathsNotCovered.toString());
+		}
+	}
+
+	private void assertBatchAction(
+		Page<DocumentFolder> page, String action, String method,
+		String expectedPath, String path) {
+
+		Map<String, Map> actions = page.getActions();
+
+		Map batchAction = actions.get(action);
+
+		Assert.assertNotNull(
+			"No Actions for " + action + " in path " + path, batchAction);
+		Assert.assertEquals(
+			"The batch action method value is not correct", method,
+			batchAction.get("method"));
+		assertHrefInBatchActionMatchesPath(
+			expectedPath,
+			batchAction.get(
+				"href"
+			).toString(),
+			action, path);
+	}
+
+	private void assertHrefInBatchActionMatchesPath(
+		String expectedPath, String href, String action, String path) {
+
+		//only paths with POST operation available will have createBatch
+		//we need a freeMarker "if" to check whether the path we're checking has it
+		//and then check the createBatch details
+
+		if (action.equals("createBatch")) {
+			String expectedPathReplaced = expectedPath.replaceAll(
+				"(\\Q{\\E.*?\\Q}\\E)", "(.*)");
+			String[] detachActualPathFromServer = href.split("/o/");
+			Pattern expectedPathPattern = Pattern.compile(
+				expectedPathReplaced + "/batch");
+			Matcher actualPathMatcher = expectedPathPattern.matcher(
+				"/" + detachActualPathFromServer[1]);
+			Assert.assertTrue(
+				"The /" + detachActualPathFromServer[1] + " does not match " +
+					expectedPathReplaced + "/batch for " + action +
+						" in the path " + path,
+				actualPathMatcher.matches());
+		}
+
+		if (action.equals("deleteBatch") || action.equals("updateBatch")) {
+			/*TO DO
+			updateBacth and deleteBatch inherit the href from the "simplest" method in the group
+			(that is, no siteId, no assetLibraryId, etc., needed)
+			*/
+		}
 	}
 
 	protected String[] getAdditionalAssertFieldNames() {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
@@ -78,6 +78,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -259,7 +261,7 @@ public abstract class BaseDocumentResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantDocument),
 				(List<Document>)page.getItems());
-			assertValid(page);
+			assertValid(page, "/asset-libraries/{assetLibraryId}/documents");
 		}
 
 		Document document1 = testGetAssetLibraryDocumentsPage_addDocument(
@@ -276,7 +278,7 @@ public abstract class BaseDocumentResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(document1, document2),
 			(List<Document>)page.getItems());
-		assertValid(page);
+		assertValid(page, "/asset-libraries/{assetLibraryId}/documents");
 
 		documentResource.deleteDocument(document1.getId());
 
@@ -927,7 +929,7 @@ public abstract class BaseDocumentResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantDocument),
 				(List<Document>)page.getItems());
-			assertValid(page);
+			assertValid(page, "/document-folders/{documentFolderId}/documents");
 		}
 
 		Document document1 = testGetDocumentFolderDocumentsPage_addDocument(
@@ -945,7 +947,7 @@ public abstract class BaseDocumentResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(document1, document2),
 			(List<Document>)page.getItems());
-		assertValid(page);
+		assertValid(page, "/document-folders/{documentFolderId}/documents");
 
 		documentResource.deleteDocument(document1.getId());
 
@@ -1570,7 +1572,7 @@ public abstract class BaseDocumentResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantDocument),
 				(List<Document>)page.getItems());
-			assertValid(page);
+			assertValid(page, "/sites/{siteId}/documents");
 		}
 
 		Document document1 = testGetSiteDocumentsPage_addDocument(
@@ -1587,7 +1589,7 @@ public abstract class BaseDocumentResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(document1, document2),
 			(List<Document>)page.getItems());
-		assertValid(page);
+		assertValid(page, "/sites/{siteId}/documents");
 
 		documentResource.deleteDocument(document1.getId());
 
@@ -2631,7 +2633,7 @@ public abstract class BaseDocumentResourceTestCase {
 			"This method needs to be implemented");
 	}
 
-	protected void assertValid(Page<Document> page) {
+	protected void assertValid(Page<Document> page, String path) {
 		boolean valid = false;
 
 		java.util.Collection<Document> documents = page.getItems();
@@ -2646,6 +2648,99 @@ public abstract class BaseDocumentResourceTestCase {
 		}
 
 		Assert.assertTrue(valid);
+
+		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
+		//this List is temporary and can help us detecting
+		//cases that should match the acceptance criteria, but are not covered with the current approach
+
+		List<String> pathsNotCovered = new ArrayList<>();
+
+		if (path.equals("/asset-libraries/{assetLibraryId}/documents")) {
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/documents",
+				path);
+		}
+		else {
+			pathsNotCovered.add("/asset-libraries/{assetLibraryId}/documents");
+		}
+
+		if (path.equals("/document-folders/{documentFolderId}/documents")) {
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/document-folders/{documentFolderId}/documents",
+				path);
+		}
+		else {
+			pathsNotCovered.add(
+				"/document-folders/{documentFolderId}/documents");
+		}
+
+		if (path.equals("/sites/{siteId}/documents")) {
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/sites/{siteId}/documents", path);
+		}
+		else {
+			pathsNotCovered.add("/sites/{siteId}/documents");
+		}
+
+		if (!pathsNotCovered.isEmpty()) {
+			Assert.fail(
+				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
+					pathsNotCovered.toString());
+		}
+	}
+
+	private void assertBatchAction(
+		Page<Document> page, String action, String method, String expectedPath,
+		String path) {
+
+		Map<String, Map> actions = page.getActions();
+
+		Map batchAction = actions.get(action);
+
+		Assert.assertNotNull(
+			"No Actions for " + action + " in path " + path, batchAction);
+		Assert.assertEquals(
+			"The batch action method value is not correct", method,
+			batchAction.get("method"));
+		assertHrefInBatchActionMatchesPath(
+			expectedPath,
+			batchAction.get(
+				"href"
+			).toString(),
+			action, path);
+	}
+
+	private void assertHrefInBatchActionMatchesPath(
+		String expectedPath, String href, String action, String path) {
+
+		//only paths with POST operation available will have createBatch
+		//we need a freeMarker "if" to check whether the path we're checking has it
+		//and then check the createBatch details
+
+		if (action.equals("createBatch")) {
+			String expectedPathReplaced = expectedPath.replaceAll(
+				"(\\Q{\\E.*?\\Q}\\E)", "(.*)");
+			String[] detachActualPathFromServer = href.split("/o/");
+			Pattern expectedPathPattern = Pattern.compile(
+				expectedPathReplaced + "/batch");
+			Matcher actualPathMatcher = expectedPathPattern.matcher(
+				"/" + detachActualPathFromServer[1]);
+			Assert.assertTrue(
+				"The /" + detachActualPathFromServer[1] + " does not match " +
+					expectedPathReplaced + "/batch for " + action +
+						" in the path " + path,
+				actualPathMatcher.matches());
+		}
+
+		if (action.equals("deleteBatch") || action.equals("updateBatch")) {
+			/*TO DO
+			updateBacth and deleteBatch inherit the href from the "simplest" method in the group
+			(that is, no siteId, no assetLibraryId, etc., needed)
+			*/
+		}
 	}
 
 	protected void assertValid(Rating rating) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
@@ -2649,20 +2649,11 @@ public abstract class BaseDocumentResourceTestCase {
 
 		Assert.assertTrue(valid);
 
-		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
-		//this List is temporary and can help us detecting
-		//cases that should match the acceptance criteria, but are not covered with the current approach
-
-		List<String> pathsNotCovered = new ArrayList<>();
-
 		if (path.equals("/asset-libraries/{assetLibraryId}/documents")) {
 			assertBatchAction(
 				page, "createBatch", "POST",
 				"/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/documents",
 				path);
-		}
-		else {
-			pathsNotCovered.add("/asset-libraries/{assetLibraryId}/documents");
 		}
 
 		if (path.equals("/document-folders/{documentFolderId}/documents")) {
@@ -2671,24 +2662,11 @@ public abstract class BaseDocumentResourceTestCase {
 				"/headless-delivery/v1.0/document-folders/{documentFolderId}/documents",
 				path);
 		}
-		else {
-			pathsNotCovered.add(
-				"/document-folders/{documentFolderId}/documents");
-		}
 
 		if (path.equals("/sites/{siteId}/documents")) {
 			assertBatchAction(
 				page, "createBatch", "POST",
 				"/headless-delivery/v1.0/sites/{siteId}/documents", path);
-		}
-		else {
-			pathsNotCovered.add("/sites/{siteId}/documents");
-		}
-
-		if (!pathsNotCovered.isEmpty()) {
-			Assert.fail(
-				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
-					pathsNotCovered.toString());
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseArticleResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseArticleResourceTestCase.java
@@ -2765,12 +2765,6 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 
 		Assert.assertTrue(valid);
 
-		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
-		//this List is temporary and can help us detecting
-		//cases that should match the acceptance criteria, but are not covered with the current approach
-
-		List<String> pathsNotCovered = new ArrayList<>();
-
 		if (path.equals(
 				"/knowledge-base-articles/{parentKnowledgeBaseArticleId}/knowledge-base-articles")) {
 
@@ -2778,10 +2772,6 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 				page, "createBatch", "POST",
 				"/headless-delivery/v1.0/knowledge-base-articles/{parentKnowledgeBaseArticleId}/knowledge-base-articles",
 				path);
-		}
-		else {
-			pathsNotCovered.add(
-				"/knowledge-base-articles/{parentKnowledgeBaseArticleId}/knowledge-base-articles");
 		}
 
 		if (path.equals(
@@ -2792,25 +2782,12 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 				"/headless-delivery/v1.0/knowledge-base-folders/{knowledgeBaseFolderId}/knowledge-base-articles",
 				path);
 		}
-		else {
-			pathsNotCovered.add(
-				"/knowledge-base-folders/{knowledgeBaseFolderId}/knowledge-base-articles");
-		}
 
 		if (path.equals("/sites/{siteId}/knowledge-base-articles")) {
 			assertBatchAction(
 				page, "createBatch", "POST",
 				"/headless-delivery/v1.0/sites/{siteId}/knowledge-base-articles",
 				path);
-		}
-		else {
-			pathsNotCovered.add("/sites/{siteId}/knowledge-base-articles");
-		}
-
-		if (!pathsNotCovered.isEmpty()) {
-			Assert.fail(
-				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
-					pathsNotCovered.toString());
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseArticleResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseArticleResourceTestCase.java
@@ -72,6 +72,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -617,7 +619,9 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantKnowledgeBaseArticle),
 				(List<KnowledgeBaseArticle>)page.getItems());
-			assertValid(page);
+			assertValid(
+				page,
+				"/knowledge-base-articles/{parentKnowledgeBaseArticleId}/knowledge-base-articles");
 		}
 
 		KnowledgeBaseArticle knowledgeBaseArticle1 =
@@ -639,7 +643,9 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(knowledgeBaseArticle1, knowledgeBaseArticle2),
 			(List<KnowledgeBaseArticle>)page.getItems());
-		assertValid(page);
+		assertValid(
+			page,
+			"/knowledge-base-articles/{parentKnowledgeBaseArticleId}/knowledge-base-articles");
 
 		knowledgeBaseArticleResource.deleteKnowledgeBaseArticle(
 			knowledgeBaseArticle1.getId());
@@ -1057,7 +1063,9 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantKnowledgeBaseArticle),
 				(List<KnowledgeBaseArticle>)page.getItems());
-			assertValid(page);
+			assertValid(
+				page,
+				"/knowledge-base-folders/{knowledgeBaseFolderId}/knowledge-base-articles");
 		}
 
 		KnowledgeBaseArticle knowledgeBaseArticle1 =
@@ -1079,7 +1087,9 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(knowledgeBaseArticle1, knowledgeBaseArticle2),
 			(List<KnowledgeBaseArticle>)page.getItems());
-		assertValid(page);
+		assertValid(
+			page,
+			"/knowledge-base-folders/{knowledgeBaseFolderId}/knowledge-base-articles");
 
 		knowledgeBaseArticleResource.deleteKnowledgeBaseArticle(
 			knowledgeBaseArticle1.getId());
@@ -1490,7 +1500,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantKnowledgeBaseArticle),
 				(List<KnowledgeBaseArticle>)page.getItems());
-			assertValid(page);
+			assertValid(page, "/sites/{siteId}/knowledge-base-articles");
 		}
 
 		KnowledgeBaseArticle knowledgeBaseArticle1 =
@@ -1509,7 +1519,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(knowledgeBaseArticle1, knowledgeBaseArticle2),
 			(List<KnowledgeBaseArticle>)page.getItems());
-		assertValid(page);
+		assertValid(page, "/sites/{siteId}/knowledge-base-articles");
 
 		knowledgeBaseArticleResource.deleteKnowledgeBaseArticle(
 			knowledgeBaseArticle1.getId());
@@ -2738,7 +2748,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		Assert.assertTrue(valid);
 	}
 
-	protected void assertValid(Page<KnowledgeBaseArticle> page) {
+	protected void assertValid(Page<KnowledgeBaseArticle> page, String path) {
 		boolean valid = false;
 
 		java.util.Collection<KnowledgeBaseArticle> knowledgeBaseArticles =
@@ -2754,6 +2764,105 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		}
 
 		Assert.assertTrue(valid);
+
+		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
+		//this List is temporary and can help us detecting
+		//cases that should match the acceptance criteria, but are not covered with the current approach
+
+		List<String> pathsNotCovered = new ArrayList<>();
+
+		if (path.equals(
+				"/knowledge-base-articles/{parentKnowledgeBaseArticleId}/knowledge-base-articles")) {
+
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/knowledge-base-articles/{parentKnowledgeBaseArticleId}/knowledge-base-articles",
+				path);
+		}
+		else {
+			pathsNotCovered.add(
+				"/knowledge-base-articles/{parentKnowledgeBaseArticleId}/knowledge-base-articles");
+		}
+
+		if (path.equals(
+				"/knowledge-base-folders/{knowledgeBaseFolderId}/knowledge-base-articles")) {
+
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/knowledge-base-folders/{knowledgeBaseFolderId}/knowledge-base-articles",
+				path);
+		}
+		else {
+			pathsNotCovered.add(
+				"/knowledge-base-folders/{knowledgeBaseFolderId}/knowledge-base-articles");
+		}
+
+		if (path.equals("/sites/{siteId}/knowledge-base-articles")) {
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/sites/{siteId}/knowledge-base-articles",
+				path);
+		}
+		else {
+			pathsNotCovered.add("/sites/{siteId}/knowledge-base-articles");
+		}
+
+		if (!pathsNotCovered.isEmpty()) {
+			Assert.fail(
+				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
+					pathsNotCovered.toString());
+		}
+	}
+
+	private void assertBatchAction(
+		Page<KnowledgeBaseArticle> page, String action, String method,
+		String expectedPath, String path) {
+
+		Map<String, Map> actions = page.getActions();
+
+		Map batchAction = actions.get(action);
+
+		Assert.assertNotNull(
+			"No Actions for " + action + " in path " + path, batchAction);
+		Assert.assertEquals(
+			"The batch action method value is not correct", method,
+			batchAction.get("method"));
+		assertHrefInBatchActionMatchesPath(
+			expectedPath,
+			batchAction.get(
+				"href"
+			).toString(),
+			action, path);
+	}
+
+	private void assertHrefInBatchActionMatchesPath(
+		String expectedPath, String href, String action, String path) {
+
+		//only paths with POST operation available will have createBatch
+		//we need a freeMarker "if" to check whether the path we're checking has it
+		//and then check the createBatch details
+
+		if (action.equals("createBatch")) {
+			String expectedPathReplaced = expectedPath.replaceAll(
+				"(\\Q{\\E.*?\\Q}\\E)", "(.*)");
+			String[] detachActualPathFromServer = href.split("/o/");
+			Pattern expectedPathPattern = Pattern.compile(
+				expectedPathReplaced + "/batch");
+			Matcher actualPathMatcher = expectedPathPattern.matcher(
+				"/" + detachActualPathFromServer[1]);
+			Assert.assertTrue(
+				"The /" + detachActualPathFromServer[1] + " does not match " +
+					expectedPathReplaced + "/batch for " + action +
+						" in the path " + path,
+				actualPathMatcher.matches());
+		}
+
+		if (action.equals("deleteBatch") || action.equals("updateBatch")) {
+			/*TO DO
+			updateBacth and deleteBatch inherit the href from the "simplest" method in the group
+			(that is, no siteId, no assetLibraryId, etc., needed)
+			*/
+		}
 	}
 
 	protected void assertValid(Rating rating) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseAttachmentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseAttachmentResourceTestCase.java
@@ -676,12 +676,6 @@ public abstract class BaseKnowledgeBaseAttachmentResourceTestCase {
 
 		Assert.assertTrue(valid);
 
-		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
-		//this List is temporary and can help us detecting
-		//cases that should match the acceptance criteria, but are not covered with the current approach
-
-		List<String> pathsNotCovered = new ArrayList<>();
-
 		if (path.equals(
 				"/knowledge-base-articles/{knowledgeBaseArticleId}/knowledge-base-attachments")) {
 
@@ -689,16 +683,6 @@ public abstract class BaseKnowledgeBaseAttachmentResourceTestCase {
 				page, "createBatch", "POST",
 				"/headless-delivery/v1.0/knowledge-base-articles/{knowledgeBaseArticleId}/knowledge-base-attachments",
 				path);
-		}
-		else {
-			pathsNotCovered.add(
-				"/knowledge-base-articles/{knowledgeBaseArticleId}/knowledge-base-attachments");
-		}
-
-		if (!pathsNotCovered.isEmpty()) {
-			Assert.fail(
-				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
-					pathsNotCovered.toString());
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseAttachmentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseAttachmentResourceTestCase.java
@@ -65,6 +65,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -241,7 +243,9 @@ public abstract class BaseKnowledgeBaseAttachmentResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantKnowledgeBaseAttachment),
 				(List<KnowledgeBaseAttachment>)page.getItems());
-			assertValid(page);
+			assertValid(
+				page,
+				"/knowledge-base-articles/{knowledgeBaseArticleId}/knowledge-base-attachments");
 		}
 
 		KnowledgeBaseAttachment knowledgeBaseAttachment1 =
@@ -262,7 +266,9 @@ public abstract class BaseKnowledgeBaseAttachmentResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(knowledgeBaseAttachment1, knowledgeBaseAttachment2),
 			(List<KnowledgeBaseAttachment>)page.getItems());
-		assertValid(page);
+		assertValid(
+			page,
+			"/knowledge-base-articles/{knowledgeBaseArticleId}/knowledge-base-attachments");
 
 		knowledgeBaseAttachmentResource.deleteKnowledgeBaseAttachment(
 			knowledgeBaseAttachment1.getId());
@@ -651,7 +657,9 @@ public abstract class BaseKnowledgeBaseAttachmentResourceTestCase {
 			"This method needs to be implemented");
 	}
 
-	protected void assertValid(Page<KnowledgeBaseAttachment> page) {
+	protected void assertValid(
+		Page<KnowledgeBaseAttachment> page, String path) {
+
 		boolean valid = false;
 
 		java.util.Collection<KnowledgeBaseAttachment> knowledgeBaseAttachments =
@@ -667,6 +675,82 @@ public abstract class BaseKnowledgeBaseAttachmentResourceTestCase {
 		}
 
 		Assert.assertTrue(valid);
+
+		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
+		//this List is temporary and can help us detecting
+		//cases that should match the acceptance criteria, but are not covered with the current approach
+
+		List<String> pathsNotCovered = new ArrayList<>();
+
+		if (path.equals(
+				"/knowledge-base-articles/{knowledgeBaseArticleId}/knowledge-base-attachments")) {
+
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/knowledge-base-articles/{knowledgeBaseArticleId}/knowledge-base-attachments",
+				path);
+		}
+		else {
+			pathsNotCovered.add(
+				"/knowledge-base-articles/{knowledgeBaseArticleId}/knowledge-base-attachments");
+		}
+
+		if (!pathsNotCovered.isEmpty()) {
+			Assert.fail(
+				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
+					pathsNotCovered.toString());
+		}
+	}
+
+	private void assertBatchAction(
+		Page<KnowledgeBaseAttachment> page, String action, String method,
+		String expectedPath, String path) {
+
+		Map<String, Map> actions = page.getActions();
+
+		Map batchAction = actions.get(action);
+
+		Assert.assertNotNull(
+			"No Actions for " + action + " in path " + path, batchAction);
+		Assert.assertEquals(
+			"The batch action method value is not correct", method,
+			batchAction.get("method"));
+		assertHrefInBatchActionMatchesPath(
+			expectedPath,
+			batchAction.get(
+				"href"
+			).toString(),
+			action, path);
+	}
+
+	private void assertHrefInBatchActionMatchesPath(
+		String expectedPath, String href, String action, String path) {
+
+		//only paths with POST operation available will have createBatch
+		//we need a freeMarker "if" to check whether the path we're checking has it
+		//and then check the createBatch details
+
+		if (action.equals("createBatch")) {
+			String expectedPathReplaced = expectedPath.replaceAll(
+				"(\\Q{\\E.*?\\Q}\\E)", "(.*)");
+			String[] detachActualPathFromServer = href.split("/o/");
+			Pattern expectedPathPattern = Pattern.compile(
+				expectedPathReplaced + "/batch");
+			Matcher actualPathMatcher = expectedPathPattern.matcher(
+				"/" + detachActualPathFromServer[1]);
+			Assert.assertTrue(
+				"The /" + detachActualPathFromServer[1] + " does not match " +
+					expectedPathReplaced + "/batch for " + action +
+						" in the path " + path,
+				actualPathMatcher.matches());
+		}
+
+		if (action.equals("deleteBatch") || action.equals("updateBatch")) {
+			/*TO DO
+			updateBacth and deleteBatch inherit the href from the "simplest" method in the group
+			(that is, no siteId, no assetLibraryId, etc., needed)
+			*/
+		}
 	}
 
 	protected String[] getAdditionalAssertFieldNames() {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseFolderResourceTestCase.java
@@ -1491,12 +1491,6 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 
 		Assert.assertTrue(valid);
 
-		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
-		//this List is temporary and can help us detecting
-		//cases that should match the acceptance criteria, but are not covered with the current approach
-
-		List<String> pathsNotCovered = new ArrayList<>();
-
 		if (path.equals(
 				"/knowledge-base-folders/{parentKnowledgeBaseFolderId}/knowledge-base-folders")) {
 
@@ -1505,25 +1499,12 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 				"/headless-delivery/v1.0/knowledge-base-folders/{parentKnowledgeBaseFolderId}/knowledge-base-folders",
 				path);
 		}
-		else {
-			pathsNotCovered.add(
-				"/knowledge-base-folders/{parentKnowledgeBaseFolderId}/knowledge-base-folders");
-		}
 
 		if (path.equals("/sites/{siteId}/knowledge-base-folders")) {
 			assertBatchAction(
 				page, "createBatch", "POST",
 				"/headless-delivery/v1.0/sites/{siteId}/knowledge-base-folders",
 				path);
-		}
-		else {
-			pathsNotCovered.add("/sites/{siteId}/knowledge-base-folders");
-		}
-
-		if (!pathsNotCovered.isEmpty()) {
-			Assert.fail(
-				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
-					pathsNotCovered.toString());
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseFolderResourceTestCase.java
@@ -68,6 +68,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -517,7 +519,9 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantKnowledgeBaseFolder),
 				(List<KnowledgeBaseFolder>)page.getItems());
-			assertValid(page);
+			assertValid(
+				page,
+				"/knowledge-base-folders/{parentKnowledgeBaseFolderId}/knowledge-base-folders");
 		}
 
 		KnowledgeBaseFolder knowledgeBaseFolder1 =
@@ -538,7 +542,9 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(knowledgeBaseFolder1, knowledgeBaseFolder2),
 			(List<KnowledgeBaseFolder>)page.getItems());
-		assertValid(page);
+		assertValid(
+			page,
+			"/knowledge-base-folders/{parentKnowledgeBaseFolderId}/knowledge-base-folders");
 
 		knowledgeBaseFolderResource.deleteKnowledgeBaseFolder(
 			knowledgeBaseFolder1.getId());
@@ -679,7 +685,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantKnowledgeBaseFolder),
 				(List<KnowledgeBaseFolder>)page.getItems());
-			assertValid(page);
+			assertValid(page, "/sites/{siteId}/knowledge-base-folders");
 		}
 
 		KnowledgeBaseFolder knowledgeBaseFolder1 =
@@ -698,7 +704,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(knowledgeBaseFolder1, knowledgeBaseFolder2),
 			(List<KnowledgeBaseFolder>)page.getItems());
-		assertValid(page);
+		assertValid(page, "/sites/{siteId}/knowledge-base-folders");
 
 		knowledgeBaseFolderResource.deleteKnowledgeBaseFolder(
 			knowledgeBaseFolder1.getId());
@@ -1468,7 +1474,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		Assert.assertTrue(valid);
 	}
 
-	protected void assertValid(Page<KnowledgeBaseFolder> page) {
+	protected void assertValid(Page<KnowledgeBaseFolder> page, String path) {
 		boolean valid = false;
 
 		java.util.Collection<KnowledgeBaseFolder> knowledgeBaseFolders =
@@ -1484,6 +1490,92 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		}
 
 		Assert.assertTrue(valid);
+
+		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
+		//this List is temporary and can help us detecting
+		//cases that should match the acceptance criteria, but are not covered with the current approach
+
+		List<String> pathsNotCovered = new ArrayList<>();
+
+		if (path.equals(
+				"/knowledge-base-folders/{parentKnowledgeBaseFolderId}/knowledge-base-folders")) {
+
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/knowledge-base-folders/{parentKnowledgeBaseFolderId}/knowledge-base-folders",
+				path);
+		}
+		else {
+			pathsNotCovered.add(
+				"/knowledge-base-folders/{parentKnowledgeBaseFolderId}/knowledge-base-folders");
+		}
+
+		if (path.equals("/sites/{siteId}/knowledge-base-folders")) {
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/sites/{siteId}/knowledge-base-folders",
+				path);
+		}
+		else {
+			pathsNotCovered.add("/sites/{siteId}/knowledge-base-folders");
+		}
+
+		if (!pathsNotCovered.isEmpty()) {
+			Assert.fail(
+				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
+					pathsNotCovered.toString());
+		}
+	}
+
+	private void assertBatchAction(
+		Page<KnowledgeBaseFolder> page, String action, String method,
+		String expectedPath, String path) {
+
+		Map<String, Map> actions = page.getActions();
+
+		Map batchAction = actions.get(action);
+
+		Assert.assertNotNull(
+			"No Actions for " + action + " in path " + path, batchAction);
+		Assert.assertEquals(
+			"The batch action method value is not correct", method,
+			batchAction.get("method"));
+		assertHrefInBatchActionMatchesPath(
+			expectedPath,
+			batchAction.get(
+				"href"
+			).toString(),
+			action, path);
+	}
+
+	private void assertHrefInBatchActionMatchesPath(
+		String expectedPath, String href, String action, String path) {
+
+		//only paths with POST operation available will have createBatch
+		//we need a freeMarker "if" to check whether the path we're checking has it
+		//and then check the createBatch details
+
+		if (action.equals("createBatch")) {
+			String expectedPathReplaced = expectedPath.replaceAll(
+				"(\\Q{\\E.*?\\Q}\\E)", "(.*)");
+			String[] detachActualPathFromServer = href.split("/o/");
+			Pattern expectedPathPattern = Pattern.compile(
+				expectedPathReplaced + "/batch");
+			Matcher actualPathMatcher = expectedPathPattern.matcher(
+				"/" + detachActualPathFromServer[1]);
+			Assert.assertTrue(
+				"The /" + detachActualPathFromServer[1] + " does not match " +
+					expectedPathReplaced + "/batch for " + action +
+						" in the path " + path,
+				actualPathMatcher.matches());
+		}
+
+		if (action.equals("deleteBatch") || action.equals("updateBatch")) {
+			/*TO DO
+			updateBacth and deleteBatch inherit the href from the "simplest" method in the group
+			(that is, no siteId, no assetLibraryId, etc., needed)
+			*/
+		}
 	}
 
 	protected String[] getAdditionalAssertFieldNames() {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseLanguageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseLanguageResourceTestCase.java
@@ -67,6 +67,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -235,7 +237,7 @@ public abstract class BaseLanguageResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantLanguage),
 				(List<Language>)page.getItems());
-			assertValid(page);
+			assertValid(page, "/asset-libraries/{assetLibraryId}/languages");
 		}
 
 		Language language1 = testGetAssetLibraryLanguagesPage_addLanguage(
@@ -251,7 +253,7 @@ public abstract class BaseLanguageResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(language1, language2),
 			(List<Language>)page.getItems());
-		assertValid(page);
+		assertValid(page, "/asset-libraries/{assetLibraryId}/languages");
 	}
 
 	protected Language testGetAssetLibraryLanguagesPage_addLanguage(
@@ -295,7 +297,7 @@ public abstract class BaseLanguageResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantLanguage),
 				(List<Language>)page.getItems());
-			assertValid(page);
+			assertValid(page, "/sites/{siteId}/languages");
 		}
 
 		Language language1 = testGetSiteLanguagesPage_addLanguage(
@@ -311,7 +313,7 @@ public abstract class BaseLanguageResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(language1, language2),
 			(List<Language>)page.getItems());
-		assertValid(page);
+		assertValid(page, "/sites/{siteId}/languages");
 	}
 
 	protected Language testGetSiteLanguagesPage_addLanguage(
@@ -499,7 +501,7 @@ public abstract class BaseLanguageResourceTestCase {
 		Assert.assertTrue(valid);
 	}
 
-	protected void assertValid(Page<Language> page) {
+	protected void assertValid(Page<Language> page, String path) {
 		boolean valid = false;
 
 		java.util.Collection<Language> languages = page.getItems();
@@ -514,6 +516,88 @@ public abstract class BaseLanguageResourceTestCase {
 		}
 
 		Assert.assertTrue(valid);
+
+		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
+		//this List is temporary and can help us detecting
+		//cases that should match the acceptance criteria, but are not covered with the current approach
+
+		List<String> pathsNotCovered = new ArrayList<>();
+
+		if (path.equals("/asset-libraries/{assetLibraryId}/languages")) {
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/languages",
+				path);
+		}
+		else {
+			pathsNotCovered.add("/asset-libraries/{assetLibraryId}/languages");
+		}
+
+		if (path.equals("/sites/{siteId}/languages")) {
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/sites/{siteId}/languages", path);
+		}
+		else {
+			pathsNotCovered.add("/sites/{siteId}/languages");
+		}
+
+		if (!pathsNotCovered.isEmpty()) {
+			Assert.fail(
+				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
+					pathsNotCovered.toString());
+		}
+	}
+
+	private void assertBatchAction(
+		Page<Language> page, String action, String method, String expectedPath,
+		String path) {
+
+		Map<String, Map> actions = page.getActions();
+
+		Map batchAction = actions.get(action);
+
+		Assert.assertNotNull(
+			"No Actions for " + action + " in path " + path, batchAction);
+		Assert.assertEquals(
+			"The batch action method value is not correct", method,
+			batchAction.get("method"));
+		assertHrefInBatchActionMatchesPath(
+			expectedPath,
+			batchAction.get(
+				"href"
+			).toString(),
+			action, path);
+	}
+
+	private void assertHrefInBatchActionMatchesPath(
+		String expectedPath, String href, String action, String path) {
+
+		//only paths with POST operation available will have createBatch
+		//we need a freeMarker "if" to check whether the path we're checking has it
+		//and then check the createBatch details
+
+		if (action.equals("createBatch")) {
+			String expectedPathReplaced = expectedPath.replaceAll(
+				"(\\Q{\\E.*?\\Q}\\E)", "(.*)");
+			String[] detachActualPathFromServer = href.split("/o/");
+			Pattern expectedPathPattern = Pattern.compile(
+				expectedPathReplaced + "/batch");
+			Matcher actualPathMatcher = expectedPathPattern.matcher(
+				"/" + detachActualPathFromServer[1]);
+			Assert.assertTrue(
+				"The /" + detachActualPathFromServer[1] + " does not match " +
+					expectedPathReplaced + "/batch for " + action +
+						" in the path " + path,
+				actualPathMatcher.matches());
+		}
+
+		if (action.equals("deleteBatch") || action.equals("updateBatch")) {
+			/*TO DO
+			updateBacth and deleteBatch inherit the href from the "simplest" method in the group
+			(that is, no siteId, no assetLibraryId, etc., needed)
+			*/
+		}
 	}
 
 	protected String[] getAdditionalAssertFieldNames() {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseLanguageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseLanguageResourceTestCase.java
@@ -517,35 +517,17 @@ public abstract class BaseLanguageResourceTestCase {
 
 		Assert.assertTrue(valid);
 
-		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
-		//this List is temporary and can help us detecting
-		//cases that should match the acceptance criteria, but are not covered with the current approach
-
-		List<String> pathsNotCovered = new ArrayList<>();
-
 		if (path.equals("/asset-libraries/{assetLibraryId}/languages")) {
 			assertBatchAction(
 				page, "createBatch", "POST",
 				"/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/languages",
 				path);
 		}
-		else {
-			pathsNotCovered.add("/asset-libraries/{assetLibraryId}/languages");
-		}
 
 		if (path.equals("/sites/{siteId}/languages")) {
 			assertBatchAction(
 				page, "createBatch", "POST",
 				"/headless-delivery/v1.0/sites/{siteId}/languages", path);
-		}
-		else {
-			pathsNotCovered.add("/sites/{siteId}/languages");
-		}
-
-		if (!pathsNotCovered.isEmpty()) {
-			Assert.fail(
-				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
-					pathsNotCovered.toString());
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardAttachmentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardAttachmentResourceTestCase.java
@@ -795,12 +795,6 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 
 		Assert.assertTrue(valid);
 
-		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
-		//this List is temporary and can help us detecting
-		//cases that should match the acceptance criteria, but are not covered with the current approach
-
-		List<String> pathsNotCovered = new ArrayList<>();
-
 		if (path.equals(
 				"/message-board-messages/{messageBoardMessageId}/message-board-attachments")) {
 
@@ -808,10 +802,6 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 				page, "createBatch", "POST",
 				"/headless-delivery/v1.0/message-board-messages/{messageBoardMessageId}/message-board-attachments",
 				path);
-		}
-		else {
-			pathsNotCovered.add(
-				"/message-board-messages/{messageBoardMessageId}/message-board-attachments");
 		}
 
 		if (path.equals(
@@ -821,16 +811,6 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 				page, "createBatch", "POST",
 				"/headless-delivery/v1.0/message-board-threads/{messageBoardThreadId}/message-board-attachments",
 				path);
-		}
-		else {
-			pathsNotCovered.add(
-				"/message-board-threads/{messageBoardThreadId}/message-board-attachments");
-		}
-
-		if (!pathsNotCovered.isEmpty()) {
-			Assert.fail(
-				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
-					pathsNotCovered.toString());
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardAttachmentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardAttachmentResourceTestCase.java
@@ -65,6 +65,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -391,7 +393,9 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantMessageBoardAttachment),
 				(List<MessageBoardAttachment>)page.getItems());
-			assertValid(page);
+			assertValid(
+				page,
+				"/message-board-messages/{messageBoardMessageId}/message-board-attachments");
 		}
 
 		MessageBoardAttachment messageBoardAttachment1 =
@@ -412,7 +416,9 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(messageBoardAttachment1, messageBoardAttachment2),
 			(List<MessageBoardAttachment>)page.getItems());
-		assertValid(page);
+		assertValid(
+			page,
+			"/message-board-messages/{messageBoardMessageId}/message-board-attachments");
 
 		messageBoardAttachmentResource.deleteMessageBoardAttachment(
 			messageBoardAttachment1.getId());
@@ -511,7 +517,9 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantMessageBoardAttachment),
 				(List<MessageBoardAttachment>)page.getItems());
-			assertValid(page);
+			assertValid(
+				page,
+				"/message-board-threads/{messageBoardThreadId}/message-board-attachments");
 		}
 
 		MessageBoardAttachment messageBoardAttachment1 =
@@ -532,7 +540,9 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(messageBoardAttachment1, messageBoardAttachment2),
 			(List<MessageBoardAttachment>)page.getItems());
-		assertValid(page);
+		assertValid(
+			page,
+			"/message-board-threads/{messageBoardThreadId}/message-board-attachments");
 
 		messageBoardAttachmentResource.deleteMessageBoardAttachment(
 			messageBoardAttachment1.getId());
@@ -768,7 +778,7 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 			"This method needs to be implemented");
 	}
 
-	protected void assertValid(Page<MessageBoardAttachment> page) {
+	protected void assertValid(Page<MessageBoardAttachment> page, String path) {
 		boolean valid = false;
 
 		java.util.Collection<MessageBoardAttachment> messageBoardAttachments =
@@ -784,6 +794,95 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 		}
 
 		Assert.assertTrue(valid);
+
+		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
+		//this List is temporary and can help us detecting
+		//cases that should match the acceptance criteria, but are not covered with the current approach
+
+		List<String> pathsNotCovered = new ArrayList<>();
+
+		if (path.equals(
+				"/message-board-messages/{messageBoardMessageId}/message-board-attachments")) {
+
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/message-board-messages/{messageBoardMessageId}/message-board-attachments",
+				path);
+		}
+		else {
+			pathsNotCovered.add(
+				"/message-board-messages/{messageBoardMessageId}/message-board-attachments");
+		}
+
+		if (path.equals(
+				"/message-board-threads/{messageBoardThreadId}/message-board-attachments")) {
+
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/message-board-threads/{messageBoardThreadId}/message-board-attachments",
+				path);
+		}
+		else {
+			pathsNotCovered.add(
+				"/message-board-threads/{messageBoardThreadId}/message-board-attachments");
+		}
+
+		if (!pathsNotCovered.isEmpty()) {
+			Assert.fail(
+				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
+					pathsNotCovered.toString());
+		}
+	}
+
+	private void assertBatchAction(
+		Page<MessageBoardAttachment> page, String action, String method,
+		String expectedPath, String path) {
+
+		Map<String, Map> actions = page.getActions();
+
+		Map batchAction = actions.get(action);
+
+		Assert.assertNotNull(
+			"No Actions for " + action + " in path " + path, batchAction);
+		Assert.assertEquals(
+			"The batch action method value is not correct", method,
+			batchAction.get("method"));
+		assertHrefInBatchActionMatchesPath(
+			expectedPath,
+			batchAction.get(
+				"href"
+			).toString(),
+			action, path);
+	}
+
+	private void assertHrefInBatchActionMatchesPath(
+		String expectedPath, String href, String action, String path) {
+
+		//only paths with POST operation available will have createBatch
+		//we need a freeMarker "if" to check whether the path we're checking has it
+		//and then check the createBatch details
+
+		if (action.equals("createBatch")) {
+			String expectedPathReplaced = expectedPath.replaceAll(
+				"(\\Q{\\E.*?\\Q}\\E)", "(.*)");
+			String[] detachActualPathFromServer = href.split("/o/");
+			Pattern expectedPathPattern = Pattern.compile(
+				expectedPathReplaced + "/batch");
+			Matcher actualPathMatcher = expectedPathPattern.matcher(
+				"/" + detachActualPathFromServer[1]);
+			Assert.assertTrue(
+				"The /" + detachActualPathFromServer[1] + " does not match " +
+					expectedPathReplaced + "/batch for " + action +
+						" in the path " + path,
+				actualPathMatcher.matches());
+		}
+
+		if (action.equals("deleteBatch") || action.equals("updateBatch")) {
+			/*TO DO
+			updateBacth and deleteBatch inherit the href from the "simplest" method in the group
+			(that is, no siteId, no assetLibraryId, etc., needed)
+			*/
+		}
 	}
 
 	protected String[] getAdditionalAssertFieldNames() {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardMessageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardMessageResourceTestCase.java
@@ -2666,12 +2666,6 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 
 		Assert.assertTrue(valid);
 
-		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
-		//this List is temporary and can help us detecting
-		//cases that should match the acceptance criteria, but are not covered with the current approach
-
-		List<String> pathsNotCovered = new ArrayList<>();
-
 		if (path.equals(
 				"/message-board-messages/{parentMessageBoardMessageId}/message-board-messages")) {
 
@@ -2679,10 +2673,6 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 				page, "createBatch", "POST",
 				"/headless-delivery/v1.0/message-board-messages/{parentMessageBoardMessageId}/message-board-messages",
 				path);
-		}
-		else {
-			pathsNotCovered.add(
-				"/message-board-messages/{parentMessageBoardMessageId}/message-board-messages");
 		}
 
 		if (path.equals(
@@ -2693,25 +2683,12 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 				"/headless-delivery/v1.0/message-board-threads/{messageBoardThreadId}/message-board-messages",
 				path);
 		}
-		else {
-			pathsNotCovered.add(
-				"/message-board-threads/{messageBoardThreadId}/message-board-messages");
-		}
 
 		if (path.equals("/sites/{siteId}/message-board-messages")) {
 			assertBatchAction(
 				page, "createBatch", "POST",
 				"/headless-delivery/v1.0/sites/{siteId}/message-board-messages",
 				path);
-		}
-		else {
-			pathsNotCovered.add("/sites/{siteId}/message-board-messages");
-		}
-
-		if (!pathsNotCovered.isEmpty()) {
-			Assert.fail(
-				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
-					pathsNotCovered.toString());
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardMessageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardMessageResourceTestCase.java
@@ -71,6 +71,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -611,7 +613,9 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantMessageBoardMessage),
 				(List<MessageBoardMessage>)page.getItems());
-			assertValid(page);
+			assertValid(
+				page,
+				"/message-board-messages/{parentMessageBoardMessageId}/message-board-messages");
 		}
 
 		MessageBoardMessage messageBoardMessage1 =
@@ -633,7 +637,9 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(messageBoardMessage1, messageBoardMessage2),
 			(List<MessageBoardMessage>)page.getItems());
-		assertValid(page);
+		assertValid(
+			page,
+			"/message-board-messages/{parentMessageBoardMessageId}/message-board-messages");
 
 		messageBoardMessageResource.deleteMessageBoardMessage(
 			messageBoardMessage1.getId());
@@ -1046,7 +1052,9 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantMessageBoardMessage),
 				(List<MessageBoardMessage>)page.getItems());
-			assertValid(page);
+			assertValid(
+				page,
+				"/message-board-threads/{messageBoardThreadId}/message-board-messages");
 		}
 
 		MessageBoardMessage messageBoardMessage1 =
@@ -1068,7 +1076,9 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(messageBoardMessage1, messageBoardMessage2),
 			(List<MessageBoardMessage>)page.getItems());
-		assertValid(page);
+		assertValid(
+			page,
+			"/message-board-threads/{messageBoardThreadId}/message-board-messages");
 
 		messageBoardMessageResource.deleteMessageBoardMessage(
 			messageBoardMessage1.getId());
@@ -1473,7 +1483,7 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantMessageBoardMessage),
 				(List<MessageBoardMessage>)page.getItems());
-			assertValid(page);
+			assertValid(page, "/sites/{siteId}/message-board-messages");
 		}
 
 		MessageBoardMessage messageBoardMessage1 =
@@ -1492,7 +1502,7 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(messageBoardMessage1, messageBoardMessage2),
 			(List<MessageBoardMessage>)page.getItems());
-		assertValid(page);
+		assertValid(page, "/sites/{siteId}/message-board-messages");
 
 		messageBoardMessageResource.deleteMessageBoardMessage(
 			messageBoardMessage1.getId());
@@ -2639,7 +2649,7 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		Assert.assertTrue(valid);
 	}
 
-	protected void assertValid(Page<MessageBoardMessage> page) {
+	protected void assertValid(Page<MessageBoardMessage> page, String path) {
 		boolean valid = false;
 
 		java.util.Collection<MessageBoardMessage> messageBoardMessages =
@@ -2655,6 +2665,105 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		}
 
 		Assert.assertTrue(valid);
+
+		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
+		//this List is temporary and can help us detecting
+		//cases that should match the acceptance criteria, but are not covered with the current approach
+
+		List<String> pathsNotCovered = new ArrayList<>();
+
+		if (path.equals(
+				"/message-board-messages/{parentMessageBoardMessageId}/message-board-messages")) {
+
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/message-board-messages/{parentMessageBoardMessageId}/message-board-messages",
+				path);
+		}
+		else {
+			pathsNotCovered.add(
+				"/message-board-messages/{parentMessageBoardMessageId}/message-board-messages");
+		}
+
+		if (path.equals(
+				"/message-board-threads/{messageBoardThreadId}/message-board-messages")) {
+
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/message-board-threads/{messageBoardThreadId}/message-board-messages",
+				path);
+		}
+		else {
+			pathsNotCovered.add(
+				"/message-board-threads/{messageBoardThreadId}/message-board-messages");
+		}
+
+		if (path.equals("/sites/{siteId}/message-board-messages")) {
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/sites/{siteId}/message-board-messages",
+				path);
+		}
+		else {
+			pathsNotCovered.add("/sites/{siteId}/message-board-messages");
+		}
+
+		if (!pathsNotCovered.isEmpty()) {
+			Assert.fail(
+				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
+					pathsNotCovered.toString());
+		}
+	}
+
+	private void assertBatchAction(
+		Page<MessageBoardMessage> page, String action, String method,
+		String expectedPath, String path) {
+
+		Map<String, Map> actions = page.getActions();
+
+		Map batchAction = actions.get(action);
+
+		Assert.assertNotNull(
+			"No Actions for " + action + " in path " + path, batchAction);
+		Assert.assertEquals(
+			"The batch action method value is not correct", method,
+			batchAction.get("method"));
+		assertHrefInBatchActionMatchesPath(
+			expectedPath,
+			batchAction.get(
+				"href"
+			).toString(),
+			action, path);
+	}
+
+	private void assertHrefInBatchActionMatchesPath(
+		String expectedPath, String href, String action, String path) {
+
+		//only paths with POST operation available will have createBatch
+		//we need a freeMarker "if" to check whether the path we're checking has it
+		//and then check the createBatch details
+
+		if (action.equals("createBatch")) {
+			String expectedPathReplaced = expectedPath.replaceAll(
+				"(\\Q{\\E.*?\\Q}\\E)", "(.*)");
+			String[] detachActualPathFromServer = href.split("/o/");
+			Pattern expectedPathPattern = Pattern.compile(
+				expectedPathReplaced + "/batch");
+			Matcher actualPathMatcher = expectedPathPattern.matcher(
+				"/" + detachActualPathFromServer[1]);
+			Assert.assertTrue(
+				"The /" + detachActualPathFromServer[1] + " does not match " +
+					expectedPathReplaced + "/batch for " + action +
+						" in the path " + path,
+				actualPathMatcher.matches());
+		}
+
+		if (action.equals("deleteBatch") || action.equals("updateBatch")) {
+			/*TO DO
+			updateBacth and deleteBatch inherit the href from the "simplest" method in the group
+			(that is, no siteId, no assetLibraryId, etc., needed)
+			*/
+		}
 	}
 
 	protected void assertValid(Rating rating) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardSectionResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardSectionResourceTestCase.java
@@ -1841,12 +1841,6 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 
 		Assert.assertTrue(valid);
 
-		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
-		//this List is temporary and can help us detecting
-		//cases that should match the acceptance criteria, but are not covered with the current approach
-
-		List<String> pathsNotCovered = new ArrayList<>();
-
 		if (path.equals(
 				"/message-board-sections/{parentMessageBoardSectionId}/message-board-sections")) {
 
@@ -1855,25 +1849,12 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 				"/headless-delivery/v1.0/message-board-sections/{parentMessageBoardSectionId}/message-board-sections",
 				path);
 		}
-		else {
-			pathsNotCovered.add(
-				"/message-board-sections/{parentMessageBoardSectionId}/message-board-sections");
-		}
 
 		if (path.equals("/sites/{siteId}/message-board-sections")) {
 			assertBatchAction(
 				page, "createBatch", "POST",
 				"/headless-delivery/v1.0/sites/{siteId}/message-board-sections",
 				path);
-		}
-		else {
-			pathsNotCovered.add("/sites/{siteId}/message-board-sections");
-		}
-
-		if (!pathsNotCovered.isEmpty()) {
-			Assert.fail(
-				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
-					pathsNotCovered.toString());
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardSectionResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardSectionResourceTestCase.java
@@ -71,6 +71,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -570,7 +572,9 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantMessageBoardSection),
 				(List<MessageBoardSection>)page.getItems());
-			assertValid(page);
+			assertValid(
+				page,
+				"/message-board-sections/{parentMessageBoardSectionId}/message-board-sections");
 		}
 
 		MessageBoardSection messageBoardSection1 =
@@ -592,7 +596,9 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(messageBoardSection1, messageBoardSection2),
 			(List<MessageBoardSection>)page.getItems());
-		assertValid(page);
+		assertValid(
+			page,
+			"/message-board-sections/{parentMessageBoardSectionId}/message-board-sections");
 
 		messageBoardSectionResource.deleteMessageBoardSection(
 			messageBoardSection1.getId());
@@ -997,7 +1003,7 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantMessageBoardSection),
 				(List<MessageBoardSection>)page.getItems());
-			assertValid(page);
+			assertValid(page, "/sites/{siteId}/message-board-sections");
 		}
 
 		MessageBoardSection messageBoardSection1 =
@@ -1016,7 +1022,7 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(messageBoardSection1, messageBoardSection2),
 			(List<MessageBoardSection>)page.getItems());
-		assertValid(page);
+		assertValid(page, "/sites/{siteId}/message-board-sections");
 
 		messageBoardSectionResource.deleteMessageBoardSection(
 			messageBoardSection1.getId());
@@ -1818,7 +1824,7 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 		Assert.assertTrue(valid);
 	}
 
-	protected void assertValid(Page<MessageBoardSection> page) {
+	protected void assertValid(Page<MessageBoardSection> page, String path) {
 		boolean valid = false;
 
 		java.util.Collection<MessageBoardSection> messageBoardSections =
@@ -1834,6 +1840,92 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 		}
 
 		Assert.assertTrue(valid);
+
+		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
+		//this List is temporary and can help us detecting
+		//cases that should match the acceptance criteria, but are not covered with the current approach
+
+		List<String> pathsNotCovered = new ArrayList<>();
+
+		if (path.equals(
+				"/message-board-sections/{parentMessageBoardSectionId}/message-board-sections")) {
+
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/message-board-sections/{parentMessageBoardSectionId}/message-board-sections",
+				path);
+		}
+		else {
+			pathsNotCovered.add(
+				"/message-board-sections/{parentMessageBoardSectionId}/message-board-sections");
+		}
+
+		if (path.equals("/sites/{siteId}/message-board-sections")) {
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/sites/{siteId}/message-board-sections",
+				path);
+		}
+		else {
+			pathsNotCovered.add("/sites/{siteId}/message-board-sections");
+		}
+
+		if (!pathsNotCovered.isEmpty()) {
+			Assert.fail(
+				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
+					pathsNotCovered.toString());
+		}
+	}
+
+	private void assertBatchAction(
+		Page<MessageBoardSection> page, String action, String method,
+		String expectedPath, String path) {
+
+		Map<String, Map> actions = page.getActions();
+
+		Map batchAction = actions.get(action);
+
+		Assert.assertNotNull(
+			"No Actions for " + action + " in path " + path, batchAction);
+		Assert.assertEquals(
+			"The batch action method value is not correct", method,
+			batchAction.get("method"));
+		assertHrefInBatchActionMatchesPath(
+			expectedPath,
+			batchAction.get(
+				"href"
+			).toString(),
+			action, path);
+	}
+
+	private void assertHrefInBatchActionMatchesPath(
+		String expectedPath, String href, String action, String path) {
+
+		//only paths with POST operation available will have createBatch
+		//we need a freeMarker "if" to check whether the path we're checking has it
+		//and then check the createBatch details
+
+		if (action.equals("createBatch")) {
+			String expectedPathReplaced = expectedPath.replaceAll(
+				"(\\Q{\\E.*?\\Q}\\E)", "(.*)");
+			String[] detachActualPathFromServer = href.split("/o/");
+			Pattern expectedPathPattern = Pattern.compile(
+				expectedPathReplaced + "/batch");
+			Matcher actualPathMatcher = expectedPathPattern.matcher(
+				"/" + detachActualPathFromServer[1]);
+			Assert.assertTrue(
+				"The /" + detachActualPathFromServer[1] + " does not match " +
+					expectedPathReplaced + "/batch for " + action +
+						" in the path " + path,
+				actualPathMatcher.matches());
+		}
+
+		if (action.equals("deleteBatch") || action.equals("updateBatch")) {
+			/*TO DO
+			updateBacth and deleteBatch inherit the href from the "simplest" method in the group
+			(that is, no siteId, no assetLibraryId, etc., needed)
+			*/
+		}
 	}
 
 	protected String[] getAdditionalAssertFieldNames() {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardThreadResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardThreadResourceTestCase.java
@@ -73,6 +73,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -249,7 +251,9 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantMessageBoardThread),
 				(List<MessageBoardThread>)page.getItems());
-			assertValid(page);
+			assertValid(
+				page,
+				"/message-board-sections/{messageBoardSectionId}/message-board-threads");
 		}
 
 		MessageBoardThread messageBoardThread1 =
@@ -271,7 +275,9 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(messageBoardThread1, messageBoardThread2),
 			(List<MessageBoardThread>)page.getItems());
-		assertValid(page);
+		assertValid(
+			page,
+			"/message-board-sections/{messageBoardSectionId}/message-board-threads");
 
 		messageBoardThreadResource.deleteMessageBoardThread(
 			messageBoardThread1.getId());
@@ -673,7 +679,7 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 			messageBoardThread1, (List<MessageBoardThread>)page.getItems());
 		assertContains(
 			messageBoardThread2, (List<MessageBoardThread>)page.getItems());
-		assertValid(page);
+		assertValid(page, "/message-board-threads/ranked");
 
 		messageBoardThreadResource.deleteMessageBoardThread(
 			messageBoardThread1.getId());
@@ -1280,7 +1286,7 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantMessageBoardThread),
 				(List<MessageBoardThread>)page.getItems());
-			assertValid(page);
+			assertValid(page, "/sites/{siteId}/message-board-threads");
 		}
 
 		MessageBoardThread messageBoardThread1 =
@@ -1299,7 +1305,7 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(messageBoardThread1, messageBoardThread2),
 			(List<MessageBoardThread>)page.getItems());
-		assertValid(page);
+		assertValid(page, "/sites/{siteId}/message-board-threads");
 
 		messageBoardThreadResource.deleteMessageBoardThread(
 			messageBoardThread1.getId());
@@ -2394,7 +2400,7 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 		Assert.assertTrue(valid);
 	}
 
-	protected void assertValid(Page<MessageBoardThread> page) {
+	protected void assertValid(Page<MessageBoardThread> page, String path) {
 		boolean valid = false;
 
 		java.util.Collection<MessageBoardThread> messageBoardThreads =
@@ -2410,6 +2416,101 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 		}
 
 		Assert.assertTrue(valid);
+
+		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
+		//this List is temporary and can help us detecting
+		//cases that should match the acceptance criteria, but are not covered with the current approach
+
+		List<String> pathsNotCovered = new ArrayList<>();
+
+		if (path.equals(
+				"/message-board-sections/{messageBoardSectionId}/message-board-threads")) {
+
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/message-board-sections/{messageBoardSectionId}/message-board-threads",
+				path);
+		}
+		else {
+			pathsNotCovered.add(
+				"/message-board-sections/{messageBoardSectionId}/message-board-threads");
+		}
+
+		if (path.equals("/message-board-threads/ranked")) {
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/message-board-threads/ranked", path);
+		}
+		else {
+			pathsNotCovered.add("/message-board-threads/ranked");
+		}
+
+		if (path.equals("/sites/{siteId}/message-board-threads")) {
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/sites/{siteId}/message-board-threads",
+				path);
+		}
+		else {
+			pathsNotCovered.add("/sites/{siteId}/message-board-threads");
+		}
+
+		if (!pathsNotCovered.isEmpty()) {
+			Assert.fail(
+				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
+					pathsNotCovered.toString());
+		}
+	}
+
+	private void assertBatchAction(
+		Page<MessageBoardThread> page, String action, String method,
+		String expectedPath, String path) {
+
+		Map<String, Map> actions = page.getActions();
+
+		Map batchAction = actions.get(action);
+
+		Assert.assertNotNull(
+			"No Actions for " + action + " in path " + path, batchAction);
+		Assert.assertEquals(
+			"The batch action method value is not correct", method,
+			batchAction.get("method"));
+		assertHrefInBatchActionMatchesPath(
+			expectedPath,
+			batchAction.get(
+				"href"
+			).toString(),
+			action, path);
+	}
+
+	private void assertHrefInBatchActionMatchesPath(
+		String expectedPath, String href, String action, String path) {
+
+		//only paths with POST operation available will have createBatch
+		//we need a freeMarker "if" to check whether the path we're checking has it
+		//and then check the createBatch details
+
+		if (action.equals("createBatch")) {
+			String expectedPathReplaced = expectedPath.replaceAll(
+				"(\\Q{\\E.*?\\Q}\\E)", "(.*)");
+			String[] detachActualPathFromServer = href.split("/o/");
+			Pattern expectedPathPattern = Pattern.compile(
+				expectedPathReplaced + "/batch");
+			Matcher actualPathMatcher = expectedPathPattern.matcher(
+				"/" + detachActualPathFromServer[1]);
+			Assert.assertTrue(
+				"The /" + detachActualPathFromServer[1] + " does not match " +
+					expectedPathReplaced + "/batch for " + action +
+						" in the path " + path,
+				actualPathMatcher.matches());
+		}
+
+		if (action.equals("deleteBatch") || action.equals("updateBatch")) {
+			/*TO DO
+			updateBacth and deleteBatch inherit the href from the "simplest" method in the group
+			(that is, no siteId, no assetLibraryId, etc., needed)
+			*/
+		}
 	}
 
 	protected void assertValid(Rating rating) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardThreadResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardThreadResourceTestCase.java
@@ -2417,12 +2417,6 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 
 		Assert.assertTrue(valid);
 
-		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
-		//this List is temporary and can help us detecting
-		//cases that should match the acceptance criteria, but are not covered with the current approach
-
-		List<String> pathsNotCovered = new ArrayList<>();
-
 		if (path.equals(
 				"/message-board-sections/{messageBoardSectionId}/message-board-threads")) {
 
@@ -2431,18 +2425,11 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 				"/headless-delivery/v1.0/message-board-sections/{messageBoardSectionId}/message-board-threads",
 				path);
 		}
-		else {
-			pathsNotCovered.add(
-				"/message-board-sections/{messageBoardSectionId}/message-board-threads");
-		}
 
 		if (path.equals("/message-board-threads/ranked")) {
 			assertBatchAction(
 				page, "createBatch", "POST",
 				"/headless-delivery/v1.0/message-board-threads/ranked", path);
-		}
-		else {
-			pathsNotCovered.add("/message-board-threads/ranked");
 		}
 
 		if (path.equals("/sites/{siteId}/message-board-threads")) {
@@ -2450,15 +2437,6 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 				page, "createBatch", "POST",
 				"/headless-delivery/v1.0/sites/{siteId}/message-board-threads",
 				path);
-		}
-		else {
-			pathsNotCovered.add("/sites/{siteId}/message-board-threads");
-		}
-
-		if (!pathsNotCovered.isEmpty()) {
-			Assert.fail(
-				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
-					pathsNotCovered.toString());
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseNavigationMenuResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseNavigationMenuResourceTestCase.java
@@ -68,6 +68,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -453,7 +455,7 @@ public abstract class BaseNavigationMenuResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantNavigationMenu),
 				(List<NavigationMenu>)page.getItems());
-			assertValid(page);
+			assertValid(page, "/sites/{siteId}/navigation-menus");
 		}
 
 		NavigationMenu navigationMenu1 =
@@ -472,7 +474,7 @@ public abstract class BaseNavigationMenuResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(navigationMenu1, navigationMenu2),
 			(List<NavigationMenu>)page.getItems());
-		assertValid(page);
+		assertValid(page, "/sites/{siteId}/navigation-menus");
 
 		navigationMenuResource.deleteNavigationMenu(navigationMenu1.getId());
 
@@ -935,7 +937,7 @@ public abstract class BaseNavigationMenuResourceTestCase {
 		Assert.assertTrue(valid);
 	}
 
-	protected void assertValid(Page<NavigationMenu> page) {
+	protected void assertValid(Page<NavigationMenu> page, String path) {
 		boolean valid = false;
 
 		java.util.Collection<NavigationMenu> navigationMenus = page.getItems();
@@ -950,6 +952,79 @@ public abstract class BaseNavigationMenuResourceTestCase {
 		}
 
 		Assert.assertTrue(valid);
+
+		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
+		//this List is temporary and can help us detecting
+		//cases that should match the acceptance criteria, but are not covered with the current approach
+
+		List<String> pathsNotCovered = new ArrayList<>();
+
+		if (path.equals("/sites/{siteId}/navigation-menus")) {
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/sites/{siteId}/navigation-menus",
+				path);
+		}
+		else {
+			pathsNotCovered.add("/sites/{siteId}/navigation-menus");
+		}
+
+		if (!pathsNotCovered.isEmpty()) {
+			Assert.fail(
+				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
+					pathsNotCovered.toString());
+		}
+	}
+
+	private void assertBatchAction(
+		Page<NavigationMenu> page, String action, String method,
+		String expectedPath, String path) {
+
+		Map<String, Map> actions = page.getActions();
+
+		Map batchAction = actions.get(action);
+
+		Assert.assertNotNull(
+			"No Actions for " + action + " in path " + path, batchAction);
+		Assert.assertEquals(
+			"The batch action method value is not correct", method,
+			batchAction.get("method"));
+		assertHrefInBatchActionMatchesPath(
+			expectedPath,
+			batchAction.get(
+				"href"
+			).toString(),
+			action, path);
+	}
+
+	private void assertHrefInBatchActionMatchesPath(
+		String expectedPath, String href, String action, String path) {
+
+		//only paths with POST operation available will have createBatch
+		//we need a freeMarker "if" to check whether the path we're checking has it
+		//and then check the createBatch details
+
+		if (action.equals("createBatch")) {
+			String expectedPathReplaced = expectedPath.replaceAll(
+				"(\\Q{\\E.*?\\Q}\\E)", "(.*)");
+			String[] detachActualPathFromServer = href.split("/o/");
+			Pattern expectedPathPattern = Pattern.compile(
+				expectedPathReplaced + "/batch");
+			Matcher actualPathMatcher = expectedPathPattern.matcher(
+				"/" + detachActualPathFromServer[1]);
+			Assert.assertTrue(
+				"The /" + detachActualPathFromServer[1] + " does not match " +
+					expectedPathReplaced + "/batch for " + action +
+						" in the path " + path,
+				actualPathMatcher.matches());
+		}
+
+		if (action.equals("deleteBatch") || action.equals("updateBatch")) {
+			/*TO DO
+			updateBacth and deleteBatch inherit the href from the "simplest" method in the group
+			(that is, no siteId, no assetLibraryId, etc., needed)
+			*/
+		}
 	}
 
 	protected String[] getAdditionalAssertFieldNames() {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseNavigationMenuResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseNavigationMenuResourceTestCase.java
@@ -953,26 +953,11 @@ public abstract class BaseNavigationMenuResourceTestCase {
 
 		Assert.assertTrue(valid);
 
-		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
-		//this List is temporary and can help us detecting
-		//cases that should match the acceptance criteria, but are not covered with the current approach
-
-		List<String> pathsNotCovered = new ArrayList<>();
-
 		if (path.equals("/sites/{siteId}/navigation-menus")) {
 			assertBatchAction(
 				page, "createBatch", "POST",
 				"/headless-delivery/v1.0/sites/{siteId}/navigation-menus",
 				path);
-		}
-		else {
-			pathsNotCovered.add("/sites/{siteId}/navigation-menus");
-		}
-
-		if (!pathsNotCovered.isEmpty()) {
-			Assert.fail(
-				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
-					pathsNotCovered.toString());
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseSitePageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseSitePageResourceTestCase.java
@@ -66,6 +66,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -224,7 +226,7 @@ public abstract class BaseSitePageResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantSitePage),
 				(List<SitePage>)page.getItems());
-			assertValid(page);
+			assertValid(page, "/sites/{siteId}/site-pages");
 		}
 
 		SitePage sitePage1 = testGetSiteSitePagesPage_addSitePage(
@@ -241,7 +243,7 @@ public abstract class BaseSitePageResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(sitePage1, sitePage2),
 			(List<SitePage>)page.getItems());
-		assertValid(page);
+		assertValid(page, "/sites/{siteId}/site-pages");
 	}
 
 	@Test
@@ -567,7 +569,9 @@ public abstract class BaseSitePageResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantSitePage),
 				(List<SitePage>)page.getItems());
-			assertValid(page);
+			assertValid(
+				page,
+				"/sites/{siteId}/site-pages/{friendlyUrlPath}/experiences");
 		}
 
 		SitePage sitePage1 = testGetSiteSitePagesExperiencesPage_addSitePage(
@@ -584,7 +588,8 @@ public abstract class BaseSitePageResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(sitePage1, sitePage2),
 			(List<SitePage>)page.getItems());
-		assertValid(page);
+		assertValid(
+			page, "/sites/{siteId}/site-pages/{friendlyUrlPath}/experiences");
 	}
 
 	protected SitePage testGetSiteSitePagesExperiencesPage_addSitePage(
@@ -912,7 +917,7 @@ public abstract class BaseSitePageResourceTestCase {
 		Assert.assertTrue(valid);
 	}
 
-	protected void assertValid(Page<SitePage> page) {
+	protected void assertValid(Page<SitePage> page, String path) {
 		boolean valid = false;
 
 		java.util.Collection<SitePage> sitePages = page.getItems();
@@ -927,6 +932,127 @@ public abstract class BaseSitePageResourceTestCase {
 		}
 
 		Assert.assertTrue(valid);
+
+		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
+		//this List is temporary and can help us detecting
+		//cases that should match the acceptance criteria, but are not covered with the current approach
+
+		List<String> pathsNotCovered = new ArrayList<>();
+
+		if (path.equals("/sites/{siteId}/site-pages")) {
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/sites/{siteId}/site-pages", path);
+		}
+		else {
+			pathsNotCovered.add("/sites/{siteId}/site-pages");
+		}
+
+		if (path.equals("/sites/{siteId}/site-pages/{friendlyUrlPath}")) {
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/sites/{siteId}/site-pages/{friendlyUrlPath}",
+				path);
+		}
+		else {
+			pathsNotCovered.add("/sites/{siteId}/site-pages/{friendlyUrlPath}");
+		}
+
+		if (path.equals(
+				"/sites/{siteId}/site-pages/{friendlyUrlPath}/experiences")) {
+
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/sites/{siteId}/site-pages/{friendlyUrlPath}/experiences",
+				path);
+		}
+		else {
+			pathsNotCovered.add(
+				"/sites/{siteId}/site-pages/{friendlyUrlPath}/experiences");
+		}
+
+		if (path.equals(
+				"/sites/{siteId}/site-pages/{friendlyUrlPath}/experiences/{experienceKey}/rendered-page")) {
+
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/sites/{siteId}/site-pages/{friendlyUrlPath}/experiences/{experienceKey}/rendered-page",
+				path);
+		}
+		else {
+			pathsNotCovered.add(
+				"/sites/{siteId}/site-pages/{friendlyUrlPath}/experiences/{experienceKey}/rendered-page");
+		}
+
+		if (path.equals(
+				"/sites/{siteId}/site-pages/{friendlyUrlPath}/rendered-page")) {
+
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/sites/{siteId}/site-pages/{friendlyUrlPath}/rendered-page",
+				path);
+		}
+		else {
+			pathsNotCovered.add(
+				"/sites/{siteId}/site-pages/{friendlyUrlPath}/rendered-page");
+		}
+
+		if (!pathsNotCovered.isEmpty()) {
+			Assert.fail(
+				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
+					pathsNotCovered.toString());
+		}
+	}
+
+	private void assertBatchAction(
+		Page<SitePage> page, String action, String method, String expectedPath,
+		String path) {
+
+		Map<String, Map> actions = page.getActions();
+
+		Map batchAction = actions.get(action);
+
+		Assert.assertNotNull(
+			"No Actions for " + action + " in path " + path, batchAction);
+		Assert.assertEquals(
+			"The batch action method value is not correct", method,
+			batchAction.get("method"));
+		assertHrefInBatchActionMatchesPath(
+			expectedPath,
+			batchAction.get(
+				"href"
+			).toString(),
+			action, path);
+	}
+
+	private void assertHrefInBatchActionMatchesPath(
+		String expectedPath, String href, String action, String path) {
+
+		//only paths with POST operation available will have createBatch
+		//we need a freeMarker "if" to check whether the path we're checking has it
+		//and then check the createBatch details
+
+		if (action.equals("createBatch")) {
+			String expectedPathReplaced = expectedPath.replaceAll(
+				"(\\Q{\\E.*?\\Q}\\E)", "(.*)");
+			String[] detachActualPathFromServer = href.split("/o/");
+			Pattern expectedPathPattern = Pattern.compile(
+				expectedPathReplaced + "/batch");
+			Matcher actualPathMatcher = expectedPathPattern.matcher(
+				"/" + detachActualPathFromServer[1]);
+			Assert.assertTrue(
+				"The /" + detachActualPathFromServer[1] + " does not match " +
+					expectedPathReplaced + "/batch for " + action +
+						" in the path " + path,
+				actualPathMatcher.matches());
+		}
+
+		if (action.equals("deleteBatch") || action.equals("updateBatch")) {
+			/*TO DO
+			updateBacth and deleteBatch inherit the href from the "simplest" method in the group
+			(that is, no siteId, no assetLibraryId, etc., needed)
+			*/
+		}
 	}
 
 	protected String[] getAdditionalAssertFieldNames() {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseSitePageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseSitePageResourceTestCase.java
@@ -933,19 +933,10 @@ public abstract class BaseSitePageResourceTestCase {
 
 		Assert.assertTrue(valid);
 
-		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
-		//this List is temporary and can help us detecting
-		//cases that should match the acceptance criteria, but are not covered with the current approach
-
-		List<String> pathsNotCovered = new ArrayList<>();
-
 		if (path.equals("/sites/{siteId}/site-pages")) {
 			assertBatchAction(
 				page, "createBatch", "POST",
 				"/headless-delivery/v1.0/sites/{siteId}/site-pages", path);
-		}
-		else {
-			pathsNotCovered.add("/sites/{siteId}/site-pages");
 		}
 
 		if (path.equals("/sites/{siteId}/site-pages/{friendlyUrlPath}")) {
@@ -953,9 +944,6 @@ public abstract class BaseSitePageResourceTestCase {
 				page, "createBatch", "POST",
 				"/headless-delivery/v1.0/sites/{siteId}/site-pages/{friendlyUrlPath}",
 				path);
-		}
-		else {
-			pathsNotCovered.add("/sites/{siteId}/site-pages/{friendlyUrlPath}");
 		}
 
 		if (path.equals(
@@ -966,10 +954,6 @@ public abstract class BaseSitePageResourceTestCase {
 				"/headless-delivery/v1.0/sites/{siteId}/site-pages/{friendlyUrlPath}/experiences",
 				path);
 		}
-		else {
-			pathsNotCovered.add(
-				"/sites/{siteId}/site-pages/{friendlyUrlPath}/experiences");
-		}
 
 		if (path.equals(
 				"/sites/{siteId}/site-pages/{friendlyUrlPath}/experiences/{experienceKey}/rendered-page")) {
@@ -979,10 +963,6 @@ public abstract class BaseSitePageResourceTestCase {
 				"/headless-delivery/v1.0/sites/{siteId}/site-pages/{friendlyUrlPath}/experiences/{experienceKey}/rendered-page",
 				path);
 		}
-		else {
-			pathsNotCovered.add(
-				"/sites/{siteId}/site-pages/{friendlyUrlPath}/experiences/{experienceKey}/rendered-page");
-		}
 
 		if (path.equals(
 				"/sites/{siteId}/site-pages/{friendlyUrlPath}/rendered-page")) {
@@ -991,16 +971,6 @@ public abstract class BaseSitePageResourceTestCase {
 				page, "createBatch", "POST",
 				"/headless-delivery/v1.0/sites/{siteId}/site-pages/{friendlyUrlPath}/rendered-page",
 				path);
-		}
-		else {
-			pathsNotCovered.add(
-				"/sites/{siteId}/site-pages/{friendlyUrlPath}/rendered-page");
-		}
-
-		if (!pathsNotCovered.isEmpty()) {
-			Assert.fail(
-				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
-					pathsNotCovered.toString());
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentFolderResourceTestCase.java
@@ -2915,12 +2915,6 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 
 		Assert.assertTrue(valid);
 
-		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
-		//this List is temporary and can help us detecting
-		//cases that should match the acceptance criteria, but are not covered with the current approach
-
-		List<String> pathsNotCovered = new ArrayList<>();
-
 		if (path.equals(
 				"/asset-libraries/{assetLibraryId}/structured-content-folders")) {
 
@@ -2929,19 +2923,12 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 				"/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/structured-content-folders",
 				path);
 		}
-		else {
-			pathsNotCovered.add(
-				"/asset-libraries/{assetLibraryId}/structured-content-folders");
-		}
 
 		if (path.equals("/sites/{siteId}/structured-content-folders")) {
 			assertBatchAction(
 				page, "createBatch", "POST",
 				"/headless-delivery/v1.0/sites/{siteId}/structured-content-folders",
 				path);
-		}
-		else {
-			pathsNotCovered.add("/sites/{siteId}/structured-content-folders");
 		}
 
 		if (path.equals(
@@ -2951,16 +2938,6 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 				page, "createBatch", "POST",
 				"/headless-delivery/v1.0/structured-content-folders/{parentStructuredContentFolderId}/structured-content-folders",
 				path);
-		}
-		else {
-			pathsNotCovered.add(
-				"/structured-content-folders/{parentStructuredContentFolderId}/structured-content-folders");
-		}
-
-		if (!pathsNotCovered.isEmpty()) {
-			Assert.fail(
-				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
-					pathsNotCovered.toString());
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentFolderResourceTestCase.java
@@ -75,6 +75,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -266,7 +268,9 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantStructuredContentFolder),
 				(List<StructuredContentFolder>)page.getItems());
-			assertValid(page);
+			assertValid(
+				page,
+				"/asset-libraries/{assetLibraryId}/structured-content-folders");
 		}
 
 		StructuredContentFolder structuredContentFolder1 =
@@ -288,7 +292,9 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(structuredContentFolder1, structuredContentFolder2),
 			(List<StructuredContentFolder>)page.getItems());
-		assertValid(page);
+		assertValid(
+			page,
+			"/asset-libraries/{assetLibraryId}/structured-content-folders");
 
 		structuredContentFolderResource.deleteStructuredContentFolder(
 			structuredContentFolder1.getId());
@@ -1010,7 +1016,7 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantStructuredContentFolder),
 				(List<StructuredContentFolder>)page.getItems());
-			assertValid(page);
+			assertValid(page, "/sites/{siteId}/structured-content-folders");
 		}
 
 		StructuredContentFolder structuredContentFolder1 =
@@ -1030,7 +1036,7 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(structuredContentFolder1, structuredContentFolder2),
 			(List<StructuredContentFolder>)page.getItems());
-		assertValid(page);
+		assertValid(page, "/sites/{siteId}/structured-content-folders");
 
 		structuredContentFolderResource.deleteStructuredContentFolder(
 			structuredContentFolder1.getId());
@@ -1843,7 +1849,9 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantStructuredContentFolder),
 				(List<StructuredContentFolder>)page.getItems());
-			assertValid(page);
+			assertValid(
+				page,
+				"/structured-content-folders/{parentStructuredContentFolderId}/structured-content-folders");
 		}
 
 		StructuredContentFolder structuredContentFolder1 =
@@ -1867,7 +1875,9 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(structuredContentFolder1, structuredContentFolder2),
 			(List<StructuredContentFolder>)page.getItems());
-		assertValid(page);
+		assertValid(
+			page,
+			"/structured-content-folders/{parentStructuredContentFolderId}/structured-content-folders");
 
 		structuredContentFolderResource.deleteStructuredContentFolder(
 			structuredContentFolder1.getId());
@@ -2886,7 +2896,9 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		Assert.assertTrue(valid);
 	}
 
-	protected void assertValid(Page<StructuredContentFolder> page) {
+	protected void assertValid(
+		Page<StructuredContentFolder> page, String path) {
+
 		boolean valid = false;
 
 		java.util.Collection<StructuredContentFolder> structuredContentFolders =
@@ -2902,6 +2914,105 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		}
 
 		Assert.assertTrue(valid);
+
+		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
+		//this List is temporary and can help us detecting
+		//cases that should match the acceptance criteria, but are not covered with the current approach
+
+		List<String> pathsNotCovered = new ArrayList<>();
+
+		if (path.equals(
+				"/asset-libraries/{assetLibraryId}/structured-content-folders")) {
+
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/structured-content-folders",
+				path);
+		}
+		else {
+			pathsNotCovered.add(
+				"/asset-libraries/{assetLibraryId}/structured-content-folders");
+		}
+
+		if (path.equals("/sites/{siteId}/structured-content-folders")) {
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/sites/{siteId}/structured-content-folders",
+				path);
+		}
+		else {
+			pathsNotCovered.add("/sites/{siteId}/structured-content-folders");
+		}
+
+		if (path.equals(
+				"/structured-content-folders/{parentStructuredContentFolderId}/structured-content-folders")) {
+
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/structured-content-folders/{parentStructuredContentFolderId}/structured-content-folders",
+				path);
+		}
+		else {
+			pathsNotCovered.add(
+				"/structured-content-folders/{parentStructuredContentFolderId}/structured-content-folders");
+		}
+
+		if (!pathsNotCovered.isEmpty()) {
+			Assert.fail(
+				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
+					pathsNotCovered.toString());
+		}
+	}
+
+	private void assertBatchAction(
+		Page<StructuredContentFolder> page, String action, String method,
+		String expectedPath, String path) {
+
+		Map<String, Map> actions = page.getActions();
+
+		Map batchAction = actions.get(action);
+
+		Assert.assertNotNull(
+			"No Actions for " + action + " in path " + path, batchAction);
+		Assert.assertEquals(
+			"The batch action method value is not correct", method,
+			batchAction.get("method"));
+		assertHrefInBatchActionMatchesPath(
+			expectedPath,
+			batchAction.get(
+				"href"
+			).toString(),
+			action, path);
+	}
+
+	private void assertHrefInBatchActionMatchesPath(
+		String expectedPath, String href, String action, String path) {
+
+		//only paths with POST operation available will have createBatch
+		//we need a freeMarker "if" to check whether the path we're checking has it
+		//and then check the createBatch details
+
+		if (action.equals("createBatch")) {
+			String expectedPathReplaced = expectedPath.replaceAll(
+				"(\\Q{\\E.*?\\Q}\\E)", "(.*)");
+			String[] detachActualPathFromServer = href.split("/o/");
+			Pattern expectedPathPattern = Pattern.compile(
+				expectedPathReplaced + "/batch");
+			Matcher actualPathMatcher = expectedPathPattern.matcher(
+				"/" + detachActualPathFromServer[1]);
+			Assert.assertTrue(
+				"The /" + detachActualPathFromServer[1] + " does not match " +
+					expectedPathReplaced + "/batch for " + action +
+						" in the path " + path,
+				actualPathMatcher.matches());
+		}
+
+		if (action.equals("deleteBatch") || action.equals("updateBatch")) {
+			/*TO DO
+			updateBacth and deleteBatch inherit the href from the "simplest" method in the group
+			(that is, no siteId, no assetLibraryId, etc., needed)
+			*/
+		}
 	}
 
 	protected String[] getAdditionalAssertFieldNames() {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
@@ -76,6 +76,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -262,7 +264,8 @@ public abstract class BaseStructuredContentResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantStructuredContent),
 				(List<StructuredContent>)page.getItems());
-			assertValid(page);
+			assertValid(
+				page, "/asset-libraries/{assetLibraryId}/structured-contents");
 		}
 
 		StructuredContent structuredContent1 =
@@ -281,7 +284,8 @@ public abstract class BaseStructuredContentResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(structuredContent1, structuredContent2),
 			(List<StructuredContent>)page.getItems());
-		assertValid(page);
+		assertValid(
+			page, "/asset-libraries/{assetLibraryId}/structured-contents");
 
 		structuredContentResource.deleteStructuredContent(
 			structuredContent1.getId());
@@ -978,7 +982,9 @@ public abstract class BaseStructuredContentResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantStructuredContent),
 				(List<StructuredContent>)page.getItems());
-			assertValid(page);
+			assertValid(
+				page,
+				"/content-structures/{contentStructureId}/structured-contents");
 		}
 
 		StructuredContent structuredContent1 =
@@ -999,7 +1005,9 @@ public abstract class BaseStructuredContentResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(structuredContent1, structuredContent2),
 			(List<StructuredContent>)page.getItems());
-		assertValid(page);
+		assertValid(
+			page,
+			"/content-structures/{contentStructureId}/structured-contents");
 
 		structuredContentResource.deleteStructuredContent(
 			structuredContent1.getId());
@@ -1370,7 +1378,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantStructuredContent),
 				(List<StructuredContent>)page.getItems());
-			assertValid(page);
+			assertValid(page, "/sites/{siteId}/structured-contents");
 		}
 
 		StructuredContent structuredContent1 =
@@ -1389,7 +1397,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(structuredContent1, structuredContent2),
 			(List<StructuredContent>)page.getItems());
-		assertValid(page);
+		assertValid(page, "/sites/{siteId}/structured-contents");
 
 		structuredContentResource.deleteStructuredContent(
 			structuredContent1.getId());
@@ -2266,7 +2274,9 @@ public abstract class BaseStructuredContentResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantStructuredContent),
 				(List<StructuredContent>)page.getItems());
-			assertValid(page);
+			assertValid(
+				page,
+				"/structured-content-folders/{structuredContentFolderId}/structured-contents");
 		}
 
 		StructuredContent structuredContent1 =
@@ -2288,7 +2298,9 @@ public abstract class BaseStructuredContentResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(structuredContent1, structuredContent2),
 			(List<StructuredContent>)page.getItems());
-		assertValid(page);
+		assertValid(
+			page,
+			"/structured-content-folders/{structuredContentFolderId}/structured-contents");
 
 		structuredContentResource.deleteStructuredContent(
 			structuredContent1.getId());
@@ -3556,7 +3568,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 		Assert.assertTrue(valid);
 	}
 
-	protected void assertValid(Page<StructuredContent> page) {
+	protected void assertValid(Page<StructuredContent> page, String path) {
 		boolean valid = false;
 
 		java.util.Collection<StructuredContent> structuredContents =
@@ -3572,6 +3584,118 @@ public abstract class BaseStructuredContentResourceTestCase {
 		}
 
 		Assert.assertTrue(valid);
+
+		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
+		//this List is temporary and can help us detecting
+		//cases that should match the acceptance criteria, but are not covered with the current approach
+
+		List<String> pathsNotCovered = new ArrayList<>();
+
+		if (path.equals(
+				"/asset-libraries/{assetLibraryId}/structured-contents")) {
+
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/structured-contents",
+				path);
+		}
+		else {
+			pathsNotCovered.add(
+				"/asset-libraries/{assetLibraryId}/structured-contents");
+		}
+
+		if (path.equals(
+				"/content-structures/{contentStructureId}/structured-contents")) {
+
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/content-structures/{contentStructureId}/structured-contents",
+				path);
+		}
+		else {
+			pathsNotCovered.add(
+				"/content-structures/{contentStructureId}/structured-contents");
+		}
+
+		if (path.equals("/sites/{siteId}/structured-contents")) {
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/sites/{siteId}/structured-contents",
+				path);
+		}
+		else {
+			pathsNotCovered.add("/sites/{siteId}/structured-contents");
+		}
+
+		if (path.equals(
+				"/structured-content-folders/{structuredContentFolderId}/structured-contents")) {
+
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/structured-content-folders/{structuredContentFolderId}/structured-contents",
+				path);
+		}
+		else {
+			pathsNotCovered.add(
+				"/structured-content-folders/{structuredContentFolderId}/structured-contents");
+		}
+
+		if (!pathsNotCovered.isEmpty()) {
+			Assert.fail(
+				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
+					pathsNotCovered.toString());
+		}
+	}
+
+	private void assertBatchAction(
+		Page<StructuredContent> page, String action, String method,
+		String expectedPath, String path) {
+
+		Map<String, Map> actions = page.getActions();
+
+		Map batchAction = actions.get(action);
+
+		Assert.assertNotNull(
+			"No Actions for " + action + " in path " + path, batchAction);
+		Assert.assertEquals(
+			"The batch action method value is not correct", method,
+			batchAction.get("method"));
+		assertHrefInBatchActionMatchesPath(
+			expectedPath,
+			batchAction.get(
+				"href"
+			).toString(),
+			action, path);
+	}
+
+	private void assertHrefInBatchActionMatchesPath(
+		String expectedPath, String href, String action, String path) {
+
+		//only paths with POST operation available will have createBatch
+		//we need a freeMarker "if" to check whether the path we're checking has it
+		//and then check the createBatch details
+
+		if (action.equals("createBatch")) {
+			String expectedPathReplaced = expectedPath.replaceAll(
+				"(\\Q{\\E.*?\\Q}\\E)", "(.*)");
+			String[] detachActualPathFromServer = href.split("/o/");
+			Pattern expectedPathPattern = Pattern.compile(
+				expectedPathReplaced + "/batch");
+			Matcher actualPathMatcher = expectedPathPattern.matcher(
+				"/" + detachActualPathFromServer[1]);
+			Assert.assertTrue(
+				"The /" + detachActualPathFromServer[1] + " does not match " +
+					expectedPathReplaced + "/batch for " + action +
+						" in the path " + path,
+				actualPathMatcher.matches());
+		}
+
+		if (action.equals("deleteBatch") || action.equals("updateBatch")) {
+			/*TO DO
+			updateBacth and deleteBatch inherit the href from the "simplest" method in the group
+			(that is, no siteId, no assetLibraryId, etc., needed)
+			*/
+		}
 	}
 
 	protected void assertValid(Rating rating) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
@@ -3585,12 +3585,6 @@ public abstract class BaseStructuredContentResourceTestCase {
 
 		Assert.assertTrue(valid);
 
-		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
-		//this List is temporary and can help us detecting
-		//cases that should match the acceptance criteria, but are not covered with the current approach
-
-		List<String> pathsNotCovered = new ArrayList<>();
-
 		if (path.equals(
 				"/asset-libraries/{assetLibraryId}/structured-contents")) {
 
@@ -3598,10 +3592,6 @@ public abstract class BaseStructuredContentResourceTestCase {
 				page, "createBatch", "POST",
 				"/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/structured-contents",
 				path);
-		}
-		else {
-			pathsNotCovered.add(
-				"/asset-libraries/{assetLibraryId}/structured-contents");
 		}
 
 		if (path.equals(
@@ -3612,19 +3602,12 @@ public abstract class BaseStructuredContentResourceTestCase {
 				"/headless-delivery/v1.0/content-structures/{contentStructureId}/structured-contents",
 				path);
 		}
-		else {
-			pathsNotCovered.add(
-				"/content-structures/{contentStructureId}/structured-contents");
-		}
 
 		if (path.equals("/sites/{siteId}/structured-contents")) {
 			assertBatchAction(
 				page, "createBatch", "POST",
 				"/headless-delivery/v1.0/sites/{siteId}/structured-contents",
 				path);
-		}
-		else {
-			pathsNotCovered.add("/sites/{siteId}/structured-contents");
 		}
 
 		if (path.equals(
@@ -3634,16 +3617,6 @@ public abstract class BaseStructuredContentResourceTestCase {
 				page, "createBatch", "POST",
 				"/headless-delivery/v1.0/structured-content-folders/{structuredContentFolderId}/structured-contents",
 				path);
-		}
-		else {
-			pathsNotCovered.add(
-				"/structured-content-folders/{structuredContentFolderId}/structured-contents");
-		}
-
-		if (!pathsNotCovered.isEmpty()) {
-			Assert.fail(
-				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
-					pathsNotCovered.toString());
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiNodeResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiNodeResourceTestCase.java
@@ -1355,25 +1355,10 @@ public abstract class BaseWikiNodeResourceTestCase {
 
 		Assert.assertTrue(valid);
 
-		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
-		//this List is temporary and can help us detecting
-		//cases that should match the acceptance criteria, but are not covered with the current approach
-
-		List<String> pathsNotCovered = new ArrayList<>();
-
 		if (path.equals("/sites/{siteId}/wiki-nodes")) {
 			assertBatchAction(
 				page, "createBatch", "POST",
 				"/headless-delivery/v1.0/sites/{siteId}/wiki-nodes", path);
-		}
-		else {
-			pathsNotCovered.add("/sites/{siteId}/wiki-nodes");
-		}
-
-		if (!pathsNotCovered.isEmpty()) {
-			Assert.fail(
-				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
-					pathsNotCovered.toString());
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiNodeResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiNodeResourceTestCase.java
@@ -71,6 +71,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -227,7 +229,7 @@ public abstract class BaseWikiNodeResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantWikiNode),
 				(List<WikiNode>)page.getItems());
-			assertValid(page);
+			assertValid(page, "/sites/{siteId}/wiki-nodes");
 		}
 
 		WikiNode wikiNode1 = testGetSiteWikiNodesPage_addWikiNode(
@@ -244,7 +246,7 @@ public abstract class BaseWikiNodeResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(wikiNode1, wikiNode2),
 			(List<WikiNode>)page.getItems());
-		assertValid(page);
+		assertValid(page, "/sites/{siteId}/wiki-nodes");
 
 		wikiNodeResource.deleteWikiNode(wikiNode1.getId());
 
@@ -1337,7 +1339,7 @@ public abstract class BaseWikiNodeResourceTestCase {
 		Assert.assertTrue(valid);
 	}
 
-	protected void assertValid(Page<WikiNode> page) {
+	protected void assertValid(Page<WikiNode> page, String path) {
 		boolean valid = false;
 
 		java.util.Collection<WikiNode> wikiNodes = page.getItems();
@@ -1352,6 +1354,78 @@ public abstract class BaseWikiNodeResourceTestCase {
 		}
 
 		Assert.assertTrue(valid);
+
+		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
+		//this List is temporary and can help us detecting
+		//cases that should match the acceptance criteria, but are not covered with the current approach
+
+		List<String> pathsNotCovered = new ArrayList<>();
+
+		if (path.equals("/sites/{siteId}/wiki-nodes")) {
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/sites/{siteId}/wiki-nodes", path);
+		}
+		else {
+			pathsNotCovered.add("/sites/{siteId}/wiki-nodes");
+		}
+
+		if (!pathsNotCovered.isEmpty()) {
+			Assert.fail(
+				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
+					pathsNotCovered.toString());
+		}
+	}
+
+	private void assertBatchAction(
+		Page<WikiNode> page, String action, String method, String expectedPath,
+		String path) {
+
+		Map<String, Map> actions = page.getActions();
+
+		Map batchAction = actions.get(action);
+
+		Assert.assertNotNull(
+			"No Actions for " + action + " in path " + path, batchAction);
+		Assert.assertEquals(
+			"The batch action method value is not correct", method,
+			batchAction.get("method"));
+		assertHrefInBatchActionMatchesPath(
+			expectedPath,
+			batchAction.get(
+				"href"
+			).toString(),
+			action, path);
+	}
+
+	private void assertHrefInBatchActionMatchesPath(
+		String expectedPath, String href, String action, String path) {
+
+		//only paths with POST operation available will have createBatch
+		//we need a freeMarker "if" to check whether the path we're checking has it
+		//and then check the createBatch details
+
+		if (action.equals("createBatch")) {
+			String expectedPathReplaced = expectedPath.replaceAll(
+				"(\\Q{\\E.*?\\Q}\\E)", "(.*)");
+			String[] detachActualPathFromServer = href.split("/o/");
+			Pattern expectedPathPattern = Pattern.compile(
+				expectedPathReplaced + "/batch");
+			Matcher actualPathMatcher = expectedPathPattern.matcher(
+				"/" + detachActualPathFromServer[1]);
+			Assert.assertTrue(
+				"The /" + detachActualPathFromServer[1] + " does not match " +
+					expectedPathReplaced + "/batch for " + action +
+						" in the path " + path,
+				actualPathMatcher.matches());
+		}
+
+		if (action.equals("deleteBatch") || action.equals("updateBatch")) {
+			/*TO DO
+			updateBacth and deleteBatch inherit the href from the "simplest" method in the group
+			(that is, no siteId, no assetLibraryId, etc., needed)
+			*/
+		}
 	}
 
 	protected String[] getAdditionalAssertFieldNames() {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageAttachmentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageAttachmentResourceTestCase.java
@@ -847,27 +847,11 @@ public abstract class BaseWikiPageAttachmentResourceTestCase {
 
 		Assert.assertTrue(valid);
 
-		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
-		//this List is temporary and can help us detecting
-		//cases that should match the acceptance criteria, but are not covered with the current approach
-
-		List<String> pathsNotCovered = new ArrayList<>();
-
 		if (path.equals("/wiki-pages/{wikiPageId}/wiki-page-attachments")) {
 			assertBatchAction(
 				page, "createBatch", "POST",
 				"/headless-delivery/v1.0/wiki-pages/{wikiPageId}/wiki-page-attachments",
 				path);
-		}
-		else {
-			pathsNotCovered.add(
-				"/wiki-pages/{wikiPageId}/wiki-page-attachments");
-		}
-
-		if (!pathsNotCovered.isEmpty()) {
-			Assert.fail(
-				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
-					pathsNotCovered.toString());
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageAttachmentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageAttachmentResourceTestCase.java
@@ -65,6 +65,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -574,7 +576,7 @@ public abstract class BaseWikiPageAttachmentResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantWikiPageAttachment),
 				(List<WikiPageAttachment>)page.getItems());
-			assertValid(page);
+			assertValid(page, "/wiki-pages/{wikiPageId}/wiki-page-attachments");
 		}
 
 		WikiPageAttachment wikiPageAttachment1 =
@@ -593,7 +595,7 @@ public abstract class BaseWikiPageAttachmentResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(wikiPageAttachment1, wikiPageAttachment2),
 			(List<WikiPageAttachment>)page.getItems());
-		assertValid(page);
+		assertValid(page, "/wiki-pages/{wikiPageId}/wiki-page-attachments");
 
 		wikiPageAttachmentResource.deleteWikiPageAttachment(
 			wikiPageAttachment1.getId());
@@ -828,7 +830,7 @@ public abstract class BaseWikiPageAttachmentResourceTestCase {
 			"This method needs to be implemented");
 	}
 
-	protected void assertValid(Page<WikiPageAttachment> page) {
+	protected void assertValid(Page<WikiPageAttachment> page, String path) {
 		boolean valid = false;
 
 		java.util.Collection<WikiPageAttachment> wikiPageAttachments =
@@ -844,6 +846,80 @@ public abstract class BaseWikiPageAttachmentResourceTestCase {
 		}
 
 		Assert.assertTrue(valid);
+
+		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
+		//this List is temporary and can help us detecting
+		//cases that should match the acceptance criteria, but are not covered with the current approach
+
+		List<String> pathsNotCovered = new ArrayList<>();
+
+		if (path.equals("/wiki-pages/{wikiPageId}/wiki-page-attachments")) {
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/wiki-pages/{wikiPageId}/wiki-page-attachments",
+				path);
+		}
+		else {
+			pathsNotCovered.add(
+				"/wiki-pages/{wikiPageId}/wiki-page-attachments");
+		}
+
+		if (!pathsNotCovered.isEmpty()) {
+			Assert.fail(
+				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
+					pathsNotCovered.toString());
+		}
+	}
+
+	private void assertBatchAction(
+		Page<WikiPageAttachment> page, String action, String method,
+		String expectedPath, String path) {
+
+		Map<String, Map> actions = page.getActions();
+
+		Map batchAction = actions.get(action);
+
+		Assert.assertNotNull(
+			"No Actions for " + action + " in path " + path, batchAction);
+		Assert.assertEquals(
+			"The batch action method value is not correct", method,
+			batchAction.get("method"));
+		assertHrefInBatchActionMatchesPath(
+			expectedPath,
+			batchAction.get(
+				"href"
+			).toString(),
+			action, path);
+	}
+
+	private void assertHrefInBatchActionMatchesPath(
+		String expectedPath, String href, String action, String path) {
+
+		//only paths with POST operation available will have createBatch
+		//we need a freeMarker "if" to check whether the path we're checking has it
+		//and then check the createBatch details
+
+		if (action.equals("createBatch")) {
+			String expectedPathReplaced = expectedPath.replaceAll(
+				"(\\Q{\\E.*?\\Q}\\E)", "(.*)");
+			String[] detachActualPathFromServer = href.split("/o/");
+			Pattern expectedPathPattern = Pattern.compile(
+				expectedPathReplaced + "/batch");
+			Matcher actualPathMatcher = expectedPathPattern.matcher(
+				"/" + detachActualPathFromServer[1]);
+			Assert.assertTrue(
+				"The /" + detachActualPathFromServer[1] + " does not match " +
+					expectedPathReplaced + "/batch for " + action +
+						" in the path " + path,
+				actualPathMatcher.matches());
+		}
+
+		if (action.equals("deleteBatch") || action.equals("updateBatch")) {
+			/*TO DO
+			updateBacth and deleteBatch inherit the href from the "simplest" method in the group
+			(that is, no siteId, no assetLibraryId, etc., needed)
+			*/
+		}
 	}
 
 	protected String[] getAdditionalAssertFieldNames() {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageResourceTestCase.java
@@ -1343,20 +1343,11 @@ public abstract class BaseWikiPageResourceTestCase {
 
 		Assert.assertTrue(valid);
 
-		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
-		//this List is temporary and can help us detecting
-		//cases that should match the acceptance criteria, but are not covered with the current approach
-
-		List<String> pathsNotCovered = new ArrayList<>();
-
 		if (path.equals("/wiki-nodes/{wikiNodeId}/wiki-pages")) {
 			assertBatchAction(
 				page, "createBatch", "POST",
 				"/headless-delivery/v1.0/wiki-nodes/{wikiNodeId}/wiki-pages",
 				path);
-		}
-		else {
-			pathsNotCovered.add("/wiki-nodes/{wikiNodeId}/wiki-pages");
 		}
 
 		if (path.equals("/wiki-nodes/{wikiNodeId}/wiki-pages")) {
@@ -1365,8 +1356,12 @@ public abstract class BaseWikiPageResourceTestCase {
 				"/headless-delivery/v1.0/wiki-nodes/{wikiNodeId}/wiki-pages",
 				path);
 		}
-		else {
-			pathsNotCovered.add("/wiki-nodes/{wikiNodeId}/wiki-pages");
+
+		if (path.equals("/wiki-pages/{parentWikiPageId}/wiki-pages")) {
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/wiki-pages/{parentWikiPageId}/wiki-pages",
+				path);
 		}
 
 		if (path.equals("/wiki-pages/{parentWikiPageId}/wiki-pages")) {
@@ -1375,18 +1370,11 @@ public abstract class BaseWikiPageResourceTestCase {
 				"/headless-delivery/v1.0/wiki-pages/{parentWikiPageId}/wiki-pages",
 				path);
 		}
-		else {
-			pathsNotCovered.add("/wiki-pages/{parentWikiPageId}/wiki-pages");
-		}
 
-		if (path.equals("/wiki-pages/{parentWikiPageId}/wiki-pages")) {
+		if (path.equals("/wiki-pages/{wikiPageId}")) {
 			assertBatchAction(
 				page, "createBatch", "POST",
-				"/headless-delivery/v1.0/wiki-pages/{parentWikiPageId}/wiki-pages",
-				path);
-		}
-		else {
-			pathsNotCovered.add("/wiki-pages/{parentWikiPageId}/wiki-pages");
+				"/headless-delivery/v1.0/wiki-pages/{wikiPageId}", path);
 		}
 
 		if (path.equals("/wiki-pages/{wikiPageId}")) {
@@ -1394,32 +1382,11 @@ public abstract class BaseWikiPageResourceTestCase {
 				page, "createBatch", "POST",
 				"/headless-delivery/v1.0/wiki-pages/{wikiPageId}", path);
 		}
-		else {
-			pathsNotCovered.add("/wiki-pages/{wikiPageId}");
-		}
 
 		if (path.equals("/wiki-pages/{wikiPageId}")) {
 			assertBatchAction(
 				page, "createBatch", "POST",
 				"/headless-delivery/v1.0/wiki-pages/{wikiPageId}", path);
-		}
-		else {
-			pathsNotCovered.add("/wiki-pages/{wikiPageId}");
-		}
-
-		if (path.equals("/wiki-pages/{wikiPageId}")) {
-			assertBatchAction(
-				page, "createBatch", "POST",
-				"/headless-delivery/v1.0/wiki-pages/{wikiPageId}", path);
-		}
-		else {
-			pathsNotCovered.add("/wiki-pages/{wikiPageId}");
-		}
-
-		if (!pathsNotCovered.isEmpty()) {
-			Assert.fail(
-				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
-					pathsNotCovered.toString());
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageResourceTestCase.java
@@ -70,6 +70,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -412,7 +414,7 @@ public abstract class BaseWikiPageResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantWikiPage),
 				(List<WikiPage>)page.getItems());
-			assertValid(page);
+			assertValid(page, "/wiki-nodes/{wikiNodeId}/wiki-pages");
 		}
 
 		WikiPage wikiPage1 = testGetWikiNodeWikiPagesPage_addWikiPage(
@@ -429,7 +431,7 @@ public abstract class BaseWikiPageResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(wikiPage1, wikiPage2),
 			(List<WikiPage>)page.getItems());
-		assertValid(page);
+		assertValid(page, "/wiki-nodes/{wikiNodeId}/wiki-pages");
 
 		wikiPageResource.deleteWikiPage(wikiPage1.getId());
 
@@ -760,7 +762,7 @@ public abstract class BaseWikiPageResourceTestCase {
 			assertEquals(
 				Arrays.asList(irrelevantWikiPage),
 				(List<WikiPage>)page.getItems());
-			assertValid(page);
+			assertValid(page, "/wiki-pages/{parentWikiPageId}/wiki-pages");
 		}
 
 		WikiPage wikiPage1 = testGetWikiPageWikiPagesPage_addWikiPage(
@@ -776,7 +778,7 @@ public abstract class BaseWikiPageResourceTestCase {
 		assertEqualsIgnoringOrder(
 			Arrays.asList(wikiPage1, wikiPage2),
 			(List<WikiPage>)page.getItems());
-		assertValid(page);
+		assertValid(page, "/wiki-pages/{parentWikiPageId}/wiki-pages");
 
 		wikiPageResource.deleteWikiPage(wikiPage1.getId());
 
@@ -1325,7 +1327,7 @@ public abstract class BaseWikiPageResourceTestCase {
 		Assert.assertTrue(valid);
 	}
 
-	protected void assertValid(Page<WikiPage> page) {
+	protected void assertValid(Page<WikiPage> page, String path) {
 		boolean valid = false;
 
 		java.util.Collection<WikiPage> wikiPages = page.getItems();
@@ -1340,6 +1342,136 @@ public abstract class BaseWikiPageResourceTestCase {
 		}
 
 		Assert.assertTrue(valid);
+
+		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
+		//this List is temporary and can help us detecting
+		//cases that should match the acceptance criteria, but are not covered with the current approach
+
+		List<String> pathsNotCovered = new ArrayList<>();
+
+		if (path.equals("/wiki-nodes/{wikiNodeId}/wiki-pages")) {
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/wiki-nodes/{wikiNodeId}/wiki-pages",
+				path);
+		}
+		else {
+			pathsNotCovered.add("/wiki-nodes/{wikiNodeId}/wiki-pages");
+		}
+
+		if (path.equals("/wiki-nodes/{wikiNodeId}/wiki-pages")) {
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/wiki-nodes/{wikiNodeId}/wiki-pages",
+				path);
+		}
+		else {
+			pathsNotCovered.add("/wiki-nodes/{wikiNodeId}/wiki-pages");
+		}
+
+		if (path.equals("/wiki-pages/{parentWikiPageId}/wiki-pages")) {
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/wiki-pages/{parentWikiPageId}/wiki-pages",
+				path);
+		}
+		else {
+			pathsNotCovered.add("/wiki-pages/{parentWikiPageId}/wiki-pages");
+		}
+
+		if (path.equals("/wiki-pages/{parentWikiPageId}/wiki-pages")) {
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/wiki-pages/{parentWikiPageId}/wiki-pages",
+				path);
+		}
+		else {
+			pathsNotCovered.add("/wiki-pages/{parentWikiPageId}/wiki-pages");
+		}
+
+		if (path.equals("/wiki-pages/{wikiPageId}")) {
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/wiki-pages/{wikiPageId}", path);
+		}
+		else {
+			pathsNotCovered.add("/wiki-pages/{wikiPageId}");
+		}
+
+		if (path.equals("/wiki-pages/{wikiPageId}")) {
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/wiki-pages/{wikiPageId}", path);
+		}
+		else {
+			pathsNotCovered.add("/wiki-pages/{wikiPageId}");
+		}
+
+		if (path.equals("/wiki-pages/{wikiPageId}")) {
+			assertBatchAction(
+				page, "createBatch", "POST",
+				"/headless-delivery/v1.0/wiki-pages/{wikiPageId}", path);
+		}
+		else {
+			pathsNotCovered.add("/wiki-pages/{wikiPageId}");
+		}
+
+		if (!pathsNotCovered.isEmpty()) {
+			Assert.fail(
+				"LIST OF PATHS THAT HAVE NOT BEEN CHECKED: " +
+					pathsNotCovered.toString());
+		}
+	}
+
+	private void assertBatchAction(
+		Page<WikiPage> page, String action, String method, String expectedPath,
+		String path) {
+
+		Map<String, Map> actions = page.getActions();
+
+		Map batchAction = actions.get(action);
+
+		Assert.assertNotNull(
+			"No Actions for " + action + " in path " + path, batchAction);
+		Assert.assertEquals(
+			"The batch action method value is not correct", method,
+			batchAction.get("method"));
+		assertHrefInBatchActionMatchesPath(
+			expectedPath,
+			batchAction.get(
+				"href"
+			).toString(),
+			action, path);
+	}
+
+	private void assertHrefInBatchActionMatchesPath(
+		String expectedPath, String href, String action, String path) {
+
+		//only paths with POST operation available will have createBatch
+		//we need a freeMarker "if" to check whether the path we're checking has it
+		//and then check the createBatch details
+
+		if (action.equals("createBatch")) {
+			String expectedPathReplaced = expectedPath.replaceAll(
+				"(\\Q{\\E.*?\\Q}\\E)", "(.*)");
+			String[] detachActualPathFromServer = href.split("/o/");
+			Pattern expectedPathPattern = Pattern.compile(
+				expectedPathReplaced + "/batch");
+			Matcher actualPathMatcher = expectedPathPattern.matcher(
+				"/" + detachActualPathFromServer[1]);
+			Assert.assertTrue(
+				"The /" + detachActualPathFromServer[1] + " does not match " +
+					expectedPathReplaced + "/batch for " + action +
+						" in the path " + path,
+				actualPathMatcher.matches());
+		}
+
+		if (action.equals("deleteBatch") || action.equals("updateBatch")) {
+			/*TO DO
+			updateBacth and deleteBatch inherit the href from the "simplest" method in the group
+			(that is, no siteId, no assetLibraryId, etc., needed)
+			*/
+		}
 	}
 
 	protected String[] getAdditionalAssertFieldNames() {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/MessageBoardMessageResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/MessageBoardMessageResourceTest.java
@@ -88,7 +88,7 @@ public class MessageBoardMessageResourceTest
 		assertEqualsIgnoringOrder(
 			Arrays.asList(messageBoardMessage1),
 			(List<MessageBoardMessage>)page.getItems());
-		assertValid(page);
+		assertValid(page, "/sites/{siteId}/message-board-messages");
 
 		flatten = true;
 
@@ -103,7 +103,7 @@ public class MessageBoardMessageResourceTest
 		assertEqualsIgnoringOrder(
 			Arrays.asList(messageBoardMessage1, messageBoardMessage2),
 			(List<MessageBoardMessage>)page.getItems());
-		assertValid(page);
+		assertValid(page, "/sites/{siteId}/message-board-messages");
 	}
 
 	@Test

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
@@ -2172,6 +2172,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 		<#if javaMethodSignature.methodName?ends_with("Page") && !javaMethodSignature.path?contains("permissions")>
 			if(path.equals("${javaMethodSignature.path}")){
 				assertBatchAction(page,"createBatch","POST","${configYAML.application.baseURI}/${openAPIYAML.info.version}${javaMethodSignature.path}",path);
+				assertBatchAction(page,"deleteBatch","DELETE","${configYAML.application.baseURI}/${openAPIYAML.info.version}${javaMethodSignature.path}",path);
 			}
 		</#if>
 		</#list>
@@ -2212,6 +2213,18 @@ public abstract class Base${schemaName}ResourceTestCase {
 			updateBacth and deleteBatch inherit the href from the "simplest" method in the group
 			(that is, no siteId, no assetLibraryId, etc., needed)
 			*/
+			String expectedPathReplaced = expectedPath.replaceAll(
+				"(/v.1.0/(.*?)/\\Q{\\E.*?\\Q}\\E)", "/v.1.0");
+			String[] detachActualPathFromServer = href.split("/o/");
+			Pattern expectedPathPattern = Pattern.compile(
+				expectedPathReplaced + "/batch");
+			Matcher actualPathMatcher = expectedPathPattern.matcher(
+				"/" + detachActualPathFromServer[1]);
+			Assert.assertTrue(
+				"The /" + detachActualPathFromServer[1] + " does not match " +
+				expectedPathReplaced + "/batch for " + action +
+				" in the path " + path,
+				actualPathMatcher.matches());
 		}
 	}
 

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
@@ -29,9 +29,6 @@ import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 <#assign
 	javaMethodSignatures = freeMarkerTool.getResourceTestCaseJavaMethodSignatures(configYAML, openAPIYAML, schemaName)
 
@@ -493,7 +490,11 @@ public abstract class Base${schemaName}ResourceTestCase {
 							Assert.assertEquals(1, page.getTotalCount());
 
 							assertEquals(Arrays.asList(irrelevant${schemaName}), (List<${schemaName}>)page.getItems());
-							assertValid(page, "${javaMethodSignature.path}");
+							assertValid(page, test${javaMethodSignature.methodName?cap_first}_getExpectedActions(
+								<#list javaMethodSignature.pathJavaMethodParameters as javaMethodParameter>
+									irrelevant${javaMethodParameter.parameterName?cap_first}
+								</#list>
+							));
 						}
 					</#if>
 
@@ -536,10 +537,18 @@ public abstract class Base${schemaName}ResourceTestCase {
 					<#if topLevel>
 						assertContains(${schemaVarName}1, (List<${schemaName}>)page.getItems());
 						assertContains(${schemaVarName}2, (List<${schemaName}>)page.getItems());
-						assertValid(page, "${javaMethodSignature.path}");
+						assertValid(page, test${javaMethodSignature.methodName?cap_first}_getExpectedActions(
+							<#list javaMethodSignature.pathJavaMethodParameters as javaMethodParameter>
+								${javaMethodParameter.parameterName}
+							</#list>
+						));
 					<#else>
 						assertEqualsIgnoringOrder(Arrays.asList(${schemaVarName}1, ${schemaVarName}2), (List<${schemaName}>)page.getItems());
-						assertValid(page, "${javaMethodSignature.path}");
+						assertValid(page, test${javaMethodSignature.methodName?cap_first}_getExpectedActions(
+							<#list javaMethodSignature.pathJavaMethodParameters as javaMethodParameter>
+								${javaMethodParameter.parameterName}
+							</#list>
+						));
 					</#if>
 
 					<#if freeMarkerTool.hasJavaMethodSignature(javaMethodSignatures, "delete" + schemaName)>
@@ -569,6 +578,27 @@ public abstract class Base${schemaName}ResourceTestCase {
 								</#list>);
 						</#if>
 					</#if>
+				}
+
+				protected Map<String, Map> test${javaMethodSignature.methodName?cap_first}_getExpectedActions(
+					<#list javaMethodSignature.pathJavaMethodParameters as javaMethodParameter>
+						${javaMethodParameter.parameterType} ${javaMethodParameter.parameterName}
+					</#list>
+				) throws Exception {
+
+					Map<String, Map> expectedActions = new HashMap<>();
+
+					<#if (javaMethodSignature.pathJavaMethodParameters?size == 1)>
+						<#assign firstPathJavaMethodParameter = javaMethodSignature.pathJavaMethodParameters[0] />
+
+						Map createBatchAction = new HashMap<>();
+						createBatchAction.put("method", "POST");
+						createBatchAction.put("href", "http://localhost:8080/o${configYAML.application.baseURI}/${openAPIYAML.info.version}${javaMethodSignature.path}/batch".replace("{${firstPathJavaMethodParameter.parameterName}}", String.valueOf(${firstPathJavaMethodParameter.parameterName})));
+
+						expectedActions.put("createBatch", createBatchAction);
+					</#if>
+
+					return expectedActions;
 				}
 
 				<#if parameters?contains("Filter filter")>
@@ -2155,7 +2185,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 		}
 	</#if>
 
-	protected void assertValid(Page<${schemaClientJavaType}> page, String path) {
+	protected void assertValid(Page<${schemaClientJavaType}> page, Map<String, Map> expectedActions) {
 		boolean valid = false;
 
 		java.util.Collection<${schemaClientJavaType}> ${schemaVarNames} = page.getItems();
@@ -2168,63 +2198,17 @@ public abstract class Base${schemaName}ResourceTestCase {
 
 		Assert.assertTrue(valid);
 
-		<#list javaMethodSignatures as javaMethodSignature>
-		<#if javaMethodSignature.methodName?ends_with("Page") && !javaMethodSignature.path?contains("permissions")>
-			if(path.equals("${javaMethodSignature.path}")){
-				assertBatchAction(page,"createBatch","POST","${configYAML.application.baseURI}/${openAPIYAML.info.version}${javaMethodSignature.path}",path);
-				assertBatchAction(page,"deleteBatch","DELETE","${configYAML.application.baseURI}/${openAPIYAML.info.version}${javaMethodSignature.path}",path);
-			}
-		</#if>
-		</#list>
-	}
-
-	private void assertBatchAction(Page<${schemaClientJavaType}> page, String action, String method, String expectedPath, String path) {
 		Map<String, Map> actions = page.getActions();
 
-		Map batchAction = actions.get(action);
+		for (String expectedActionName : expectedActions.keySet()) {
+			Map action = actions.get(expectedActionName);
 
-		Assert.assertNotNull("No Actions for "+action+" in path "+path,batchAction);
-		Assert.assertEquals("The batch action method value is not correct",method, batchAction.get("method"));
-		assertHrefInBatchActionMatchesPath(expectedPath,batchAction.get("href").toString(),action, path);
-	}
+			Assert.assertNotNull(expectedActionName + " action is missing", action);
 
-	private void assertHrefInBatchActionMatchesPath(
-		String expectedPath, String href, String action, String path) {
+			Map expectedAction = expectedActions.get(expectedActionName);
 
-		//only paths with POST operation available will have createBatch
-		//we need a freeMarker "if" to check whether the path we're checking has it
-		//and then check the createBatch details
-
-		if(action.equals("createBatch")){
-			String expectedPathReplaced = expectedPath.replaceAll(
-				"(\\Q{\\E.*?\\Q}\\E)", "(.*)");
-			String[] detachActualPathFromServer = href.split("/o/");
-			Pattern expectedPathPattern = Pattern.compile(expectedPathReplaced + "/batch");
-			Matcher actualPathMatcher = expectedPathPattern.matcher("/" + detachActualPathFromServer[1]);
-			Assert.assertTrue(
-				"The /" + detachActualPathFromServer[1] + " does not match " +
-					expectedPathReplaced + "/batch for " + action +
-						" in the path " + path,
-				actualPathMatcher.matches());
-		}
-
-		if(action.equals("deleteBatch") || action.equals("updateBatch")) {
-			/*TO DO
-			updateBacth and deleteBatch inherit the href from the "simplest" method in the group
-			(that is, no siteId, no assetLibraryId, etc., needed)
-			*/
-			String expectedPathReplaced = expectedPath.replaceAll(
-				"(/v.1.0/(.*?)/\\Q{\\E.*?\\Q}\\E)", "/v.1.0");
-			String[] detachActualPathFromServer = href.split("/o/");
-			Pattern expectedPathPattern = Pattern.compile(
-				expectedPathReplaced + "/batch");
-			Matcher actualPathMatcher = expectedPathPattern.matcher(
-				"/" + detachActualPathFromServer[1]);
-			Assert.assertTrue(
-				"The /" + detachActualPathFromServer[1] + " does not match " +
-				expectedPathReplaced + "/batch for " + action +
-				" in the path " + path,
-				actualPathMatcher.matches());
+			Assert.assertEquals(expectedAction.get("method"), action.get("method"));
+			Assert.assertEquals(expectedAction.get("href"), action.get("href"));
 		}
 	}
 

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
@@ -29,6 +29,9 @@ import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 <#assign
 	javaMethodSignatures = freeMarkerTool.getResourceTestCaseJavaMethodSignatures(configYAML, openAPIYAML, schemaName)
 
@@ -490,7 +493,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 							Assert.assertEquals(1, page.getTotalCount());
 
 							assertEquals(Arrays.asList(irrelevant${schemaName}), (List<${schemaName}>)page.getItems());
-							assertValid(page);
+							assertValid(page, "${javaMethodSignature.path}");
 						}
 					</#if>
 
@@ -533,10 +536,10 @@ public abstract class Base${schemaName}ResourceTestCase {
 					<#if topLevel>
 						assertContains(${schemaVarName}1, (List<${schemaName}>)page.getItems());
 						assertContains(${schemaVarName}2, (List<${schemaName}>)page.getItems());
-						assertValid(page);
+						assertValid(page, "${javaMethodSignature.path}");
 					<#else>
 						assertEqualsIgnoringOrder(Arrays.asList(${schemaVarName}1, ${schemaVarName}2), (List<${schemaName}>)page.getItems());
-						assertValid(page);
+						assertValid(page, "${javaMethodSignature.path}");
 					</#if>
 
 					<#if freeMarkerTool.hasJavaMethodSignature(javaMethodSignatures, "delete" + schemaName)>
@@ -2152,7 +2155,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 		}
 	</#if>
 
-	protected void assertValid(Page<${schemaClientJavaType}> page) {
+	protected void assertValid(Page<${schemaClientJavaType}> page, String path) {
 		boolean valid = false;
 
 		java.util.Collection<${schemaClientJavaType}> ${schemaVarNames} = page.getItems();
@@ -2164,6 +2167,66 @@ public abstract class Base${schemaName}ResourceTestCase {
 		}
 
 		Assert.assertTrue(valid);
+
+		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
+		//this List is temporary and can help us detecting
+		//cases that should match the acceptance criteria, but are not covered with the current approach
+
+		List<String> pathsNotCovered = new ArrayList<>();
+
+		<#list javaMethodSignatures as javaMethodSignature>
+		<#if javaMethodSignature.methodName?ends_with("Page") && !javaMethodSignature.path?contains("permissions")>
+			if(path.equals("${javaMethodSignature.path}")){
+				assertBatchAction(page,"createBatch","POST","${configYAML.application.baseURI}/${openAPIYAML.info.version}${javaMethodSignature.path}",path);
+			}
+			else{
+				pathsNotCovered.add("${javaMethodSignature.path}");
+			}
+		</#if>
+		</#list>
+
+		if(!pathsNotCovered.isEmpty()) {
+				Assert.fail("LIST OF PATHS THAT HAVE NOT BEEN CHECKED: "+pathsNotCovered.toString());
+			}
+
+	}
+
+	private void assertBatchAction(Page<${schemaClientJavaType}> page, String action, String method, String expectedPath, String path) {
+		Map<String, Map> actions = page.getActions();
+
+		Map batchAction = actions.get(action);
+
+		Assert.assertNotNull("No Actions for "+action+" in path "+path,batchAction);
+		Assert.assertEquals("The batch action method value is not correct",method, batchAction.get("method"));
+		assertHrefInBatchActionMatchesPath(expectedPath,batchAction.get("href").toString(),action, path);
+	}
+
+	private void assertHrefInBatchActionMatchesPath(
+		String expectedPath, String href, String action, String path) {
+
+		//only paths with POST operation available will have createBatch
+		//we need a freeMarker "if" to check whether the path we're checking has it
+		//and then check the createBatch details
+
+		if(action.equals("createBatch")){
+			String expectedPathReplaced = expectedPath.replaceAll(
+				"(\\Q{\\E.*?\\Q}\\E)", "(.*)");
+			String[] detachActualPathFromServer = href.split("/o/");
+			Pattern expectedPathPattern = Pattern.compile(expectedPathReplaced + "/batch");
+			Matcher actualPathMatcher = expectedPathPattern.matcher("/" + detachActualPathFromServer[1]);
+			Assert.assertTrue(
+				"The /" + detachActualPathFromServer[1] + " does not match " +
+					expectedPathReplaced + "/batch for " + action +
+						" in the path " + path,
+				actualPathMatcher.matches());
+		}
+
+		if(action.equals("deleteBatch") || action.equals("updateBatch")) {
+			/*TO DO
+			updateBacth and deleteBatch inherit the href from the "simplest" method in the group
+			(that is, no siteId, no assetLibraryId, etc., needed)
+			*/
+		}
 	}
 
 	<#list relatedSchemaNames as relatedSchemaName>

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
@@ -2168,27 +2168,13 @@ public abstract class Base${schemaName}ResourceTestCase {
 
 		Assert.assertTrue(valid);
 
-		//The method we're trying to update seem to only have in mind enpdoints with siteId parameter,
-		//this List is temporary and can help us detecting
-		//cases that should match the acceptance criteria, but are not covered with the current approach
-
-		List<String> pathsNotCovered = new ArrayList<>();
-
 		<#list javaMethodSignatures as javaMethodSignature>
 		<#if javaMethodSignature.methodName?ends_with("Page") && !javaMethodSignature.path?contains("permissions")>
 			if(path.equals("${javaMethodSignature.path}")){
 				assertBatchAction(page,"createBatch","POST","${configYAML.application.baseURI}/${openAPIYAML.info.version}${javaMethodSignature.path}",path);
 			}
-			else{
-				pathsNotCovered.add("${javaMethodSignature.path}");
-			}
 		</#if>
 		</#list>
-
-		if(!pathsNotCovered.isEmpty()) {
-				Assert.fail("LIST OF PATHS THAT HAVE NOT BEEN CHECKED: "+pathsNotCovered.toString());
-			}
-
 	}
 
 	private void assertBatchAction(Page<${schemaClientJavaType}> page, String action, String method, String expectedPath, String path) {


### PR DESCRIPTION
- LPS-169820 Testing batch endpoints for vocabularies
- Taxonomy vocab case
- Moving the case to the .ftl and generating tests for taxonomy and delivery
- Removing unnecessary and stupid if :P
- Trying to create a regular expression to remove the parameter and its id value from the path
- Adding method to retrieve the expected actions for a given endpoint
