### PR TITLE
LPS-167984: Allow developers to break a relationship between a custom object and a system object

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -52,6 +52,7 @@ import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.PersistedModelLocalServiceRegistry;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
@@ -421,7 +422,8 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 								_objectDefinitionLocalService,
 								_objectEntryManagerRegistry,
 								_objectRelatedModelsProviderRegistry,
-								_objectRelationshipService);
+								_objectRelationshipService,
+								_persistedModelLocalServiceRegistry);
 						}
 
 						@Override
@@ -608,6 +610,10 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 
 	@Reference
 	private ObjectScopeProviderRegistry _objectScopeProviderRegistry;
+
+	@Reference
+	private PersistedModelLocalServiceRegistry
+		_persistedModelLocalServiceRegistry;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
@@ -20,6 +20,7 @@ import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectRelationship;
+import com.liferay.object.rest.internal.resource.v1_0.test.util.HTTPTestUtil;
 import com.liferay.object.rest.internal.resource.v1_0.test.util.ObjectDefinitionTestUtil;
 import com.liferay.object.rest.internal.resource.v1_0.test.util.ObjectEntryTestUtil;
 import com.liferay.object.rest.internal.resource.v1_0.test.util.ObjectRelationshipTestUtil;
@@ -107,6 +108,14 @@ public class ObjectEntryRelatedObjectsResourceTest {
 			_objectDefinition, _OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE);
 
 		_user = TestPropsValues.getUser();
+
+		_userSystemObjectDefinitionMetadata =
+			_systemObjectDefinitionMetadataRegistry.
+				getSystemObjectDefinitionMetadata("User");
+
+		_userSystemObjectDefinition =
+			_objectDefinitionLocalService.fetchSystemObjectDefinition(
+				_userSystemObjectDefinitionMetadata.getName());
 	}
 
 	@After
@@ -115,6 +124,38 @@ public class ObjectEntryRelatedObjectsResourceTest {
 			_objectRelationshipLocalService.deleteObjectRelationship(
 				objectRelationship);
 		}
+	}
+
+	@Test
+	public void testDeleteManyToManyCustomObjectWithSystemObject()
+		throws Exception {
+
+		_testDeleteOneToManyAndManyToManyCustomObjectWithSystemObject(
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+	}
+
+	@Test
+	public void testDeleteManyToManyCustomObjectWithSystemObjectNotFound()
+		throws Exception {
+
+		_testDeleteOneToManyAndManyToManyCustomObjectWithSystemObjectNotFound(
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+	}
+
+	@Test
+	public void testDeleteOneToManyCustomObjectWithSystemObject()
+		throws Exception {
+
+		_testDeleteOneToManyAndManyToManyCustomObjectWithSystemObject(
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+	}
+
+	@Test
+	public void testDeleteOneToManyCustomObjectWithSystemObjectNotFound()
+		throws Exception {
+
+		_testDeleteOneToManyAndManyToManyCustomObjectWithSystemObjectNotFound(
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 	}
 
 	@Test
@@ -468,6 +509,84 @@ public class ObjectEntryRelatedObjectsResourceTest {
 		return response.getResponseCode();
 	}
 
+	private void _testDeleteOneToManyAndManyToManyCustomObjectWithSystemObject(
+			String type)
+		throws Exception {
+
+		ObjectRelationship objectRelationship = _addObjectRelationship(
+			_objectDefinition, _userSystemObjectDefinition,
+			_objectEntry.getPrimaryKey(), _user.getUserId(), type);
+
+		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
+			_invoke(
+				Http.Method.GET, _getLocation(objectRelationship.getName())));
+
+		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
+
+		Assert.assertEquals(1, itemsJSONArray.length());
+
+		HTTPTestUtil.invoke(
+			null,
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				_objectEntry.getPrimaryKey(), StringPool.SLASH,
+				objectRelationship.getName(), StringPool.SLASH,
+				_user.getUserId()),
+			Http.Method.DELETE);
+
+		jsonObject = JSONFactoryUtil.createJSONObject(
+			_invoke(
+				Http.Method.GET, _getLocation(objectRelationship.getName())));
+
+		itemsJSONArray = jsonObject.getJSONArray("items");
+
+		Assert.assertEquals(0, itemsJSONArray.length());
+	}
+
+	private void
+			_testDeleteOneToManyAndManyToManyCustomObjectWithSystemObjectNotFound(
+				String type)
+		throws Exception {
+
+		Long irrelevantPrimaryKey = RandomTestUtil.randomLong();
+
+		Long irrelevantUserId = RandomTestUtil.randomLong();
+
+		ObjectRelationship objectRelationship = _addObjectRelationship(
+			_objectDefinition, _userSystemObjectDefinition,
+			_objectEntry.getPrimaryKey(), _user.getUserId(), type);
+
+		JSONObject jsonObject = HTTPTestUtil.invoke(
+			null,
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				irrelevantPrimaryKey, StringPool.SLASH,
+				objectRelationship.getName(), StringPool.SLASH,
+				_user.getUserId()),
+			Http.Method.DELETE);
+
+		Assert.assertEquals("NOT_FOUND", jsonObject.getString("status"));
+
+		jsonObject = HTTPTestUtil.invoke(
+			null,
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				_objectEntry.getPrimaryKey(), StringPool.SLASH,
+				objectRelationship.getName(), StringPool.SLASH,
+				irrelevantUserId),
+			Http.Method.DELETE);
+
+		Assert.assertEquals("NOT_FOUND", jsonObject.getString("status"));
+
+		jsonObject = JSONFactoryUtil.createJSONObject(
+			_invoke(
+				Http.Method.GET, _getLocation(objectRelationship.getName())));
+
+		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
+
+		Assert.assertEquals(1, itemsJSONArray.length());
+	}
+
 	private static final String _OBJECT_FIELD_NAME =
 		"x" + RandomTestUtil.randomString();
 
@@ -496,6 +615,7 @@ public class ObjectEntryRelatedObjectsResourceTest {
 		_systemObjectDefinitionMetadataRegistry;
 
 	private User _user;
+	private ObjectDefinition _userSystemObjectDefinition;
 	private SystemObjectDefinitionMetadata _userSystemObjectDefinitionMetadata;
 
 }


### PR DESCRIPTION
**What is new?**
- Update `ObjectEntry1toMObjectRelatedModelsProviderImpl` to support unlink 1-M relationships between Custom Objects with System Objects.
- Update `ObjectEntryRelatedObjectsResourceImpl` to support unlink relationships between Custom Objects with System Objects.
- Create some test cases

**NOTE**
If we want to unlink an `currentObjectEntryId` (Custom Object) and a `relatedObjectEntryId` (System Object) and if one of them doesn't exist, it will throw a 404 status code.

The aim of this PR is to create the endpoint to unlink 2 objects (Custom Object with System Objects). Let's see an example. Imagine a `University` with their `Subjects` and their `Students` in this way:

1. `University` is a Custom Object. Has a one-to-many relationship with `Student` and a many-to-many relationship with `Subject`
2. A user of Liferay represents a `Student`, so, it is a System Object. It also has a many-to-many relationship with `Subject`.
`Subject` is a custom object.
3. According to these requisites, there should be an endpoint to unlink  the students, and these endpoints should be in the existing REST API `universities` and `subjects`
How to test it

Deploy the following modules:

1. `object-rest-impl`.
2. `object-api` and `object-service`.

Set the following feature flag to true:

`feature.flag.LPS-162966=true`

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-167984