### PR TITLE
LPS-169967 Update testcase to fix the steps

### DIFF
--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/UserAccountAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/UserAccountAPI.macro
@@ -9,6 +9,10 @@ definition {
 			if (isSet(parameter)) {
 				var api = "user-accounts/${userAccountId}?${parameter}=${parameterValue}";
 			}
+
+			if (isSet(relationshipName) && isSet(customObjectEntryId) && isSet(userAccountId)) {
+				var api = "user-accounts/${userAccountId}/${relationshipName}/${customObjectEntryId}";
+			}
 		}
 		else {
 			var api = "user-accounts";
@@ -69,11 +73,11 @@ definition {
 		return "${response}";
 	}
 
-	macro deleteUserAccountRelationship {
-		Variables.assertDefined(parameterList = "${userAccountId},${relationshipName},${customObjectId}");
+	macro deleteObjectEntryRelatedToUserAccount {
+		Variables.assertDefined(parameterList = "${userAccountId},${relationshipName},${customObjectEntryId}");
 
 		var curl = UserAccountAPI._curlUserAccount(
-			customObjectId = "${customObjectId}",
+			customObjectEntryId = "${customObjectEntryId}",
 			relationshipName = "${relationshipName}",
 			userAccountId = "${userAccountId}");
 
@@ -177,7 +181,8 @@ definition {
 			givenName = "usergn");
 
 		static var staticResponse = "${response}";
-		static var staticUserAccountId = JSONUtil.getWithJSONPath("${response}", "$.id");
+
+		static var staticUserAccountId = JSONUtil.getWithJSONPath("${staticResponse}", "$.id");
 
 		return "${staticResponse}";
 

--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/UserAccountAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/UserAccountAPI.macro
@@ -9,12 +9,6 @@ definition {
 			if (isSet(parameter)) {
 				var api = "user-accounts/${userAccountId}?${parameter}=${parameterValue}";
 			}
-			else if (isSet(customObjectId)) {
-				var api = "user-accounts/${userAccountId}/${relationshipName}/${customObjectId}";
-			}
-			else {
-				var api = "user-accounts/${userAccountId}/${relationshipName}";
-			}
 		}
 		else {
 			var api = "user-accounts";
@@ -87,9 +81,16 @@ definition {
 	}
 
 	macro getRelationshipByUserAccountId {
-		var curl = UserAccountAPI._curlUserAccount(
-			relationshipName = "${relationshipName}",
-			userAccountId = "${userAccountId}");
+		Variables.assertDefined(parameterList = "${userAccountId},${relationshipName}");
+
+		var portalURL = JSONCompany.getPortalURL();
+
+		var curl = '''
+			${portalURL}/o/headless-admin-user/v1.0/user-accounts/${userAccountId}/${relationshipName} \
+			-H accept: application/json \
+			-H Content-Type: application/json \
+			-u test@liferay.com:test \
+		''';
 
 		var response = JSONCurlUtil.get("${curl}");
 
@@ -152,10 +153,14 @@ definition {
 	macro relateObjectEntries {
 		Variables.assertDefined(parameterList = "${userAccountId},${customObjectId},${relationshipName}");
 
-		var curl = UserAccountAPI._curlUserAccount(
-			customObjectId = "${customObjectId}",
-			relationshipName = "${relationshipName}",
-			userAccountId = "${userAccountId}");
+		var portalURL = JSONCompany.getPortalURL();
+
+		var curl = '''
+			${portalURL}/o/headless-admin-user/v1.0/user-accounts/${userAccountId}/${relationshipName}/${customObjectId} \
+			-H accept: application/json \
+			-H Content-Type: application/json \
+			-u test@liferay.com:test \
+		''';
 
 		var response = JSONCurlUtil.put("${curl}");
 

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/BreakRelationshipBetweenSystemAndCustonObjects.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/BreakRelationshipBetweenSystemAndCustonObjects.testcase
@@ -78,8 +78,8 @@ definition {
 		}
 
 		task ("When using the delete request deleteUserAccount{relationshipName}") {
-			UserAccountAPI.deleteUserAccountRelationship(
-				customObjectId = "${staticObjectEntryId3}",
+			UserAccountAPI.deleteObjectEntryRelatedToUserAccount(
+				customObjectEntryId = "${staticObjectEntryId3}",
 				relationshipName = "usersSecondFoundations",
 				userAccountId = "${staticUserAccountId}");
 		}
@@ -105,8 +105,8 @@ definition {
 		}
 
 		task ("When using the delete request deleteUserAccount{relationshipName}") {
-			UserAccountAPI.deleteUserAccountRelationship(
-				customObjectId = "${staticObjectEntryId1}",
+			UserAccountAPI.deleteObjectEntryRelatedToUserAccount(
+				customObjectEntryId = "${staticObjectEntryId1}",
 				relationshipName = "userFoundations",
 				userAccountId = "${staticUserAccountId}");
 		}
@@ -137,8 +137,8 @@ definition {
 		}
 
 		task ("When deleting one of the foundation entries with deleteUserAccount{relationshipName} request") {
-			UserAccountAPI.deleteUserAccountRelationship(
-				customObjectId = "${staticObjectEntryId1}",
+			UserAccountAPI.deleteObjectEntryRelatedToUserAccount(
+				customObjectEntryId = "${staticObjectEntryId1}",
 				relationshipName = "userFoundations",
 				userAccountId = "${staticUserAccountId}");
 		}

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/MakeRelationshipsBetweenCustomAndSystemObjects.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/MakeRelationshipsBetweenCustomAndSystemObjects.testcase
@@ -106,17 +106,18 @@ definition {
 				name = "Math");
 		}
 
-		task ("When I request PUT to relate Subject entry to the Account entry with /o/headless-admin-user/v1.0/accounts/{accountId}/subjectAccounts") {
-			AccountAPI.putAccountRelationship(
-				accountId = "${staticAccountId}",
+		task ("When I request PUT to relate Subject entry to the Account entry with /o/c/subjects/{subjectId}/subjectAccounts/{accountId}") {
+			ObjectDefinitionAPI.relateObjectEntries(
+				en_US_plural_label = "subjects",
+				objectEntry1 = "${subjectId}",
+				objectEntry2 = "${staticAccountId}",
 				relationshipName = "subjectAccounts");
 		}
 
-		task ("Then Account entry is not associated to the Subject entry in GET /o/c/subjects/{subjectId}/subjectAccounts") {
-			var response = ObjectDefinitionAPI.getObjectEntryRelation(
-				en_US_plural_label = "subjects",
-				objectId = "${subjectId}",
-				relationshipName = "subjectAccounts");
+		task ("Then subject is not associated to the account in GET /o/headless-admin-user/v1.0/accounts/{accountId}/accountSubjects") {
+			var response = AccountAPI.getRelationshipByAccountId(
+				accountId = "${staticAccountId}",
+				relationshipName = "accountSubjects");
 
 			ObjectDefinitionAPI.assertNoItemsInResponse(responseToParse = "${response}");
 		}


### PR DESCRIPTION
**Background**
Update a testcase to fix the steps in test scenarios

**Test Plan**
Given Subject object definition created
And Given oneToMany accountSubjects relationship created
And Given oneToMany subjectAccounts relationship created
When I request PUT to relate Subject entry to the Account entry with /o/c/subjects/{subjectId}/subjectAccounts/{accountId}
Then subject is not associated to the account in GET /o/headless-admin-user/v1.0/accounts/{accountId}/accountSubjects

**JIRA Link:**
https://issues.liferay.com/browse/LPS-169967