### PR TITLE
LPS-164284: Expose ERC in MessageBoardAttachment and rename in Headless Admin User using externalReferenceCode instead of userAccountExternalReferenceCode

### DIFF
--- a/modules/apps/document-library/document-library-repository-portlet-file-repository-impl/src/main/java/com/liferay/document/library/repository/portlet/file/repository/internal/PortletFileRepositoryImpl.java
+++ b/modules/apps/document-library/document-library-repository-portlet-file-repository-impl/src/main/java/com/liferay/document/library/repository/portlet/file/repository/internal/PortletFileRepositoryImpl.java
@@ -557,7 +557,7 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 
 	@Override
 	public FileEntry getPortletFileEntryByExternalReferenceCode(
-			long groupId, String externalReferenceCode)
+			String externalReferenceCode, long groupId)
 		throws PortalException {
 
 		LocalRepository localRepository =

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/AccountRoleResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/AccountRoleResource.java
@@ -59,19 +59,19 @@ public interface AccountRoleResource {
 	public void
 			deleteAccountByExternalReferenceCodeAccountRoleUserAccountByExternalReferenceCode(
 				String accountExternalReferenceCode, Long accountRoleId,
-				String userAccountExternalReferenceCode)
+				String externalReferenceCode)
 		throws Exception;
 
 	public void
 			postAccountByExternalReferenceCodeAccountRoleUserAccountByExternalReferenceCode(
 				String accountExternalReferenceCode, Long accountRoleId,
-				String userAccountExternalReferenceCode)
+				String externalReferenceCode)
 		throws Exception;
 
 	public Page<AccountRole>
 			getAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeAccountRolesPage(
 				String accountExternalReferenceCode,
-				String userAccountExternalReferenceCode)
+				String externalReferenceCode)
 		throws Exception;
 
 	public Page<AccountRole> getAccountAccountRolesByExternalReferenceCodePage(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/UserAccountResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/UserAccountResource.java
@@ -59,13 +59,13 @@ public interface UserAccountResource {
 	public void
 			deleteAccountByExternalReferenceCodeUserAccountByExternalReferenceCode(
 				String accountExternalReferenceCode,
-				String userAccountExternalReferenceCode)
+				String externalReferenceCode)
 		throws Exception;
 
 	public void
 			postAccountByExternalReferenceCodeUserAccountByExternalReferenceCode(
 				String accountExternalReferenceCode,
-				String userAccountExternalReferenceCode)
+				String externalReferenceCode)
 		throws Exception;
 
 	public Page<UserAccount> getAccountUserAccountsByExternalReferenceCodePage(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/AccountRoleResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/AccountRoleResource.java
@@ -43,37 +43,37 @@ public interface AccountRoleResource {
 	public void
 			deleteAccountByExternalReferenceCodeAccountRoleUserAccountByExternalReferenceCode(
 				String accountExternalReferenceCode, Long accountRoleId,
-				String userAccountExternalReferenceCode)
+				String externalReferenceCode)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
 			deleteAccountByExternalReferenceCodeAccountRoleUserAccountByExternalReferenceCodeHttpResponse(
 				String accountExternalReferenceCode, Long accountRoleId,
-				String userAccountExternalReferenceCode)
+				String externalReferenceCode)
 		throws Exception;
 
 	public void
 			postAccountByExternalReferenceCodeAccountRoleUserAccountByExternalReferenceCode(
 				String accountExternalReferenceCode, Long accountRoleId,
-				String userAccountExternalReferenceCode)
+				String externalReferenceCode)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
 			postAccountByExternalReferenceCodeAccountRoleUserAccountByExternalReferenceCodeHttpResponse(
 				String accountExternalReferenceCode, Long accountRoleId,
-				String userAccountExternalReferenceCode)
+				String externalReferenceCode)
 		throws Exception;
 
 	public Page<AccountRole>
 			getAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeAccountRolesPage(
 				String accountExternalReferenceCode,
-				String userAccountExternalReferenceCode)
+				String externalReferenceCode)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
 			getAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeAccountRolesPageHttpResponse(
 				String accountExternalReferenceCode,
-				String userAccountExternalReferenceCode)
+				String externalReferenceCode)
 		throws Exception;
 
 	public Page<AccountRole> getAccountAccountRolesByExternalReferenceCodePage(
@@ -255,13 +255,13 @@ public interface AccountRoleResource {
 		public void
 				deleteAccountByExternalReferenceCodeAccountRoleUserAccountByExternalReferenceCode(
 					String accountExternalReferenceCode, Long accountRoleId,
-					String userAccountExternalReferenceCode)
+					String externalReferenceCode)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
 				deleteAccountByExternalReferenceCodeAccountRoleUserAccountByExternalReferenceCodeHttpResponse(
 					accountExternalReferenceCode, accountRoleId,
-					userAccountExternalReferenceCode);
+					externalReferenceCode);
 
 			String content = httpResponse.getContent();
 
@@ -303,7 +303,7 @@ public interface AccountRoleResource {
 		public HttpInvoker.HttpResponse
 				deleteAccountByExternalReferenceCodeAccountRoleUserAccountByExternalReferenceCodeHttpResponse(
 					String accountExternalReferenceCode, Long accountRoleId,
-					String userAccountExternalReferenceCode)
+					String externalReferenceCode)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -330,14 +330,12 @@ public interface AccountRoleResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{accountExternalReferenceCode}/account-roles/{accountRoleId}/user-accounts/by-external-reference-code/{userAccountExternalReferenceCode}");
+						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{accountExternalReferenceCode}/account-roles/{accountRoleId}/user-accounts/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path(
 				"accountExternalReferenceCode", accountExternalReferenceCode);
 			httpInvoker.path("accountRoleId", accountRoleId);
-			httpInvoker.path(
-				"userAccountExternalReferenceCode",
-				userAccountExternalReferenceCode);
+			httpInvoker.path("externalReferenceCode", externalReferenceCode);
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);
@@ -348,13 +346,13 @@ public interface AccountRoleResource {
 		public void
 				postAccountByExternalReferenceCodeAccountRoleUserAccountByExternalReferenceCode(
 					String accountExternalReferenceCode, Long accountRoleId,
-					String userAccountExternalReferenceCode)
+					String externalReferenceCode)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
 				postAccountByExternalReferenceCodeAccountRoleUserAccountByExternalReferenceCodeHttpResponse(
 					accountExternalReferenceCode, accountRoleId,
-					userAccountExternalReferenceCode);
+					externalReferenceCode);
 
 			String content = httpResponse.getContent();
 
@@ -396,7 +394,7 @@ public interface AccountRoleResource {
 		public HttpInvoker.HttpResponse
 				postAccountByExternalReferenceCodeAccountRoleUserAccountByExternalReferenceCodeHttpResponse(
 					String accountExternalReferenceCode, Long accountRoleId,
-					String userAccountExternalReferenceCode)
+					String externalReferenceCode)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -423,14 +421,12 @@ public interface AccountRoleResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{accountExternalReferenceCode}/account-roles/{accountRoleId}/user-accounts/by-external-reference-code/{userAccountExternalReferenceCode}");
+						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{accountExternalReferenceCode}/account-roles/{accountRoleId}/user-accounts/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path(
 				"accountExternalReferenceCode", accountExternalReferenceCode);
 			httpInvoker.path("accountRoleId", accountRoleId);
-			httpInvoker.path(
-				"userAccountExternalReferenceCode",
-				userAccountExternalReferenceCode);
+			httpInvoker.path("externalReferenceCode", externalReferenceCode);
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);
@@ -441,13 +437,12 @@ public interface AccountRoleResource {
 		public Page<AccountRole>
 				getAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeAccountRolesPage(
 					String accountExternalReferenceCode,
-					String userAccountExternalReferenceCode)
+					String externalReferenceCode)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
 				getAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeAccountRolesPageHttpResponse(
-					accountExternalReferenceCode,
-					userAccountExternalReferenceCode);
+					accountExternalReferenceCode, externalReferenceCode);
 
 			String content = httpResponse.getContent();
 
@@ -489,7 +484,7 @@ public interface AccountRoleResource {
 		public HttpInvoker.HttpResponse
 				getAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeAccountRolesPageHttpResponse(
 					String accountExternalReferenceCode,
-					String userAccountExternalReferenceCode)
+					String externalReferenceCode)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -516,13 +511,11 @@ public interface AccountRoleResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{accountExternalReferenceCode}/user-accounts/by-external-reference-code/{userAccountExternalReferenceCode}/account-roles");
+						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{accountExternalReferenceCode}/user-accounts/by-external-reference-code/{externalReferenceCode}/account-roles");
 
 			httpInvoker.path(
 				"accountExternalReferenceCode", accountExternalReferenceCode);
-			httpInvoker.path(
-				"userAccountExternalReferenceCode",
-				userAccountExternalReferenceCode);
+			httpInvoker.path("externalReferenceCode", externalReferenceCode);
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/UserAccountResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/UserAccountResource.java
@@ -45,25 +45,25 @@ public interface UserAccountResource {
 	public void
 			deleteAccountByExternalReferenceCodeUserAccountByExternalReferenceCode(
 				String accountExternalReferenceCode,
-				String userAccountExternalReferenceCode)
+				String externalReferenceCode)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
 			deleteAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeHttpResponse(
 				String accountExternalReferenceCode,
-				String userAccountExternalReferenceCode)
+				String externalReferenceCode)
 		throws Exception;
 
 	public void
 			postAccountByExternalReferenceCodeUserAccountByExternalReferenceCode(
 				String accountExternalReferenceCode,
-				String userAccountExternalReferenceCode)
+				String externalReferenceCode)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
 			postAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeHttpResponse(
 				String accountExternalReferenceCode,
-				String userAccountExternalReferenceCode)
+				String externalReferenceCode)
 		throws Exception;
 
 	public Page<UserAccount> getAccountUserAccountsByExternalReferenceCodePage(
@@ -383,13 +383,12 @@ public interface UserAccountResource {
 		public void
 				deleteAccountByExternalReferenceCodeUserAccountByExternalReferenceCode(
 					String accountExternalReferenceCode,
-					String userAccountExternalReferenceCode)
+					String externalReferenceCode)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
 				deleteAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeHttpResponse(
-					accountExternalReferenceCode,
-					userAccountExternalReferenceCode);
+					accountExternalReferenceCode, externalReferenceCode);
 
 			String content = httpResponse.getContent();
 
@@ -431,7 +430,7 @@ public interface UserAccountResource {
 		public HttpInvoker.HttpResponse
 				deleteAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeHttpResponse(
 					String accountExternalReferenceCode,
-					String userAccountExternalReferenceCode)
+					String externalReferenceCode)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -458,13 +457,11 @@ public interface UserAccountResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{accountExternalReferenceCode}/user-accounts/by-external-reference-code/{userAccountExternalReferenceCode}");
+						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{accountExternalReferenceCode}/user-accounts/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path(
 				"accountExternalReferenceCode", accountExternalReferenceCode);
-			httpInvoker.path(
-				"userAccountExternalReferenceCode",
-				userAccountExternalReferenceCode);
+			httpInvoker.path("externalReferenceCode", externalReferenceCode);
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);
@@ -475,13 +472,12 @@ public interface UserAccountResource {
 		public void
 				postAccountByExternalReferenceCodeUserAccountByExternalReferenceCode(
 					String accountExternalReferenceCode,
-					String userAccountExternalReferenceCode)
+					String externalReferenceCode)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
 				postAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeHttpResponse(
-					accountExternalReferenceCode,
-					userAccountExternalReferenceCode);
+					accountExternalReferenceCode, externalReferenceCode);
 
 			String content = httpResponse.getContent();
 
@@ -523,7 +519,7 @@ public interface UserAccountResource {
 		public HttpInvoker.HttpResponse
 				postAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeHttpResponse(
 					String accountExternalReferenceCode,
-					String userAccountExternalReferenceCode)
+					String externalReferenceCode)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -550,13 +546,11 @@ public interface UserAccountResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{accountExternalReferenceCode}/user-accounts/by-external-reference-code/{userAccountExternalReferenceCode}");
+						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{accountExternalReferenceCode}/user-accounts/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path(
 				"accountExternalReferenceCode", accountExternalReferenceCode);
-			httpInvoker.path(
-				"userAccountExternalReferenceCode",
-				userAccountExternalReferenceCode);
+			httpInvoker.path("externalReferenceCode", externalReferenceCode);
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
@@ -1075,7 +1075,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.admin.user.client', and version '4.0.33'."
+        'com.liferay.headless.admin.user.client', and version '4.0.34'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
@@ -1149,7 +1149,7 @@ paths:
                     description:
                         "Account successfully created"
             tags: ["Account"]
-    "/accounts/by-external-reference-code/{accountExternalReferenceCode}/account-roles/{accountRoleId}/user-accounts/by-external-reference-code/{userAccountExternalReferenceCode}":
+    "/accounts/by-external-reference-code/{accountExternalReferenceCode}/account-roles/{accountRoleId}/user-accounts/by-external-reference-code/{externalReferenceCode}":
         delete:
             # @review
             description:
@@ -1168,7 +1168,7 @@ paths:
                       format: int64
                       type: integer
                 - in: path
-                  name: userAccountExternalReferenceCode
+                  name: externalReferenceCode
                   required: true
                   schema:
                       type: string
@@ -1196,7 +1196,7 @@ paths:
                       format: int64
                       type: integer
                 - in: path
-                  name: userAccountExternalReferenceCode
+                  name: externalReferenceCode
                   required: true
                   schema:
                       type: string
@@ -1206,7 +1206,7 @@ paths:
                         application/json: {}
                         application/xml: {}
             tags: ["AccountRole"]
-    "/accounts/by-external-reference-code/{accountExternalReferenceCode}/user-accounts/by-external-reference-code/{userAccountExternalReferenceCode}":
+    "/accounts/by-external-reference-code/{accountExternalReferenceCode}/user-accounts/by-external-reference-code/{externalReferenceCode}":
         delete:
             # @review
             description:
@@ -1219,7 +1219,7 @@ paths:
                   schema:
                       type: string
                 - in: path
-                  name: userAccountExternalReferenceCode
+                  name: externalReferenceCode
                   required: true
                   schema:
                       type: string
@@ -1241,7 +1241,7 @@ paths:
                   schema:
                       type: string
                 - in: path
-                  name: userAccountExternalReferenceCode
+                  name: externalReferenceCode
                   required: true
                   schema:
                       type: string
@@ -1251,7 +1251,7 @@ paths:
                         application/json: {}
                         application/xml: {}
             tags: ["UserAccount"]
-    "/accounts/by-external-reference-code/{accountExternalReferenceCode}/user-accounts/by-external-reference-code/{userAccountExternalReferenceCode}/account-roles":
+    "/accounts/by-external-reference-code/{accountExternalReferenceCode}/user-accounts/by-external-reference-code/{externalReferenceCode}/account-roles":
         get:
             # @review
             description:
@@ -1264,7 +1264,7 @@ paths:
                   schema:
                       type: string
                 - in: path
-                  name: userAccountExternalReferenceCode
+                  name: externalReferenceCode
                   required: true
                   schema:
                       type: string

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/mutation/v1_0/Mutation.java
@@ -356,8 +356,8 @@ public class Mutation {
 				@GraphQLName("accountExternalReferenceCode") String
 					accountExternalReferenceCode,
 				@GraphQLName("accountRoleId") Long accountRoleId,
-				@GraphQLName("userAccountExternalReferenceCode") String
-					userAccountExternalReferenceCode)
+				@GraphQLName("externalReferenceCode") String
+					externalReferenceCode)
 		throws Exception {
 
 		_applyVoidComponentServiceObjects(
@@ -367,7 +367,7 @@ public class Mutation {
 				accountRoleResource.
 					deleteAccountByExternalReferenceCodeAccountRoleUserAccountByExternalReferenceCode(
 						accountExternalReferenceCode, accountRoleId,
-						userAccountExternalReferenceCode));
+						externalReferenceCode));
 
 		return true;
 	}
@@ -380,8 +380,8 @@ public class Mutation {
 				@GraphQLName("accountExternalReferenceCode") String
 					accountExternalReferenceCode,
 				@GraphQLName("accountRoleId") Long accountRoleId,
-				@GraphQLName("userAccountExternalReferenceCode") String
-					userAccountExternalReferenceCode)
+				@GraphQLName("externalReferenceCode") String
+					externalReferenceCode)
 		throws Exception {
 
 		_applyVoidComponentServiceObjects(
@@ -391,7 +391,7 @@ public class Mutation {
 				accountRoleResource.
 					postAccountByExternalReferenceCodeAccountRoleUserAccountByExternalReferenceCode(
 						accountExternalReferenceCode, accountRoleId,
-						userAccountExternalReferenceCode));
+						externalReferenceCode));
 
 		return true;
 	}
@@ -923,8 +923,8 @@ public class Mutation {
 			deleteAccountByExternalReferenceCodeUserAccountByExternalReferenceCode(
 				@GraphQLName("accountExternalReferenceCode") String
 					accountExternalReferenceCode,
-				@GraphQLName("userAccountExternalReferenceCode") String
-					userAccountExternalReferenceCode)
+				@GraphQLName("externalReferenceCode") String
+					externalReferenceCode)
 		throws Exception {
 
 		_applyVoidComponentServiceObjects(
@@ -933,8 +933,7 @@ public class Mutation {
 			userAccountResource ->
 				userAccountResource.
 					deleteAccountByExternalReferenceCodeUserAccountByExternalReferenceCode(
-						accountExternalReferenceCode,
-						userAccountExternalReferenceCode));
+						accountExternalReferenceCode, externalReferenceCode));
 
 		return true;
 	}
@@ -946,8 +945,8 @@ public class Mutation {
 			createAccountByExternalReferenceCodeUserAccountByExternalReferenceCode(
 				@GraphQLName("accountExternalReferenceCode") String
 					accountExternalReferenceCode,
-				@GraphQLName("userAccountExternalReferenceCode") String
-					userAccountExternalReferenceCode)
+				@GraphQLName("externalReferenceCode") String
+					externalReferenceCode)
 		throws Exception {
 
 		_applyVoidComponentServiceObjects(
@@ -956,8 +955,7 @@ public class Mutation {
 			userAccountResource ->
 				userAccountResource.
 					postAccountByExternalReferenceCodeUserAccountByExternalReferenceCode(
-						accountExternalReferenceCode,
-						userAccountExternalReferenceCode));
+						accountExternalReferenceCode, externalReferenceCode));
 
 		return true;
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/query/v1_0/Query.java
@@ -279,7 +279,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {accountByExternalReferenceCodeUserAccountByExternalReferenceCodeAccountRoles(accountExternalReferenceCode: ___, userAccountExternalReferenceCode: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {accountByExternalReferenceCodeUserAccountByExternalReferenceCodeAccountRoles(accountExternalReferenceCode: ___, externalReferenceCode: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(
 		description = "Gets a user's account roles by their external reference code from an account by external reference code"
@@ -288,8 +288,8 @@ public class Query {
 			accountByExternalReferenceCodeUserAccountByExternalReferenceCodeAccountRoles(
 				@GraphQLName("accountExternalReferenceCode") String
 					accountExternalReferenceCode,
-				@GraphQLName("userAccountExternalReferenceCode") String
-					userAccountExternalReferenceCode)
+				@GraphQLName("externalReferenceCode") String
+					externalReferenceCode)
 		throws Exception {
 
 		return _applyComponentServiceObjects(
@@ -298,8 +298,7 @@ public class Query {
 			accountRoleResource -> new AccountRolePage(
 				accountRoleResource.
 					getAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeAccountRolesPage(
-						accountExternalReferenceCode,
-						userAccountExternalReferenceCode)));
+						accountExternalReferenceCode, externalReferenceCode)));
 	}
 
 	/**

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/AccountRoleResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/AccountRoleResourceImpl.java
@@ -87,15 +87,14 @@ public class AccountRoleResourceImpl extends BaseAccountRoleResourceImpl {
 	public void
 			deleteAccountByExternalReferenceCodeAccountRoleUserAccountByExternalReferenceCode(
 				String accountExternalReferenceCode, Long accountRoleId,
-				String userAccountExternalReferenceCode)
+				String externalReferenceCode)
 		throws Exception {
 
 		deleteAccountAccountRoleUserAccountAssociation(
 			_accountResourceDTOConverter.getAccountEntryId(
 				accountExternalReferenceCode),
 			accountRoleId,
-			_userResourceDTOConverter.getUserId(
-				userAccountExternalReferenceCode));
+			_userResourceDTOConverter.getUserId(externalReferenceCode));
 	}
 
 	@Override
@@ -182,7 +181,7 @@ public class AccountRoleResourceImpl extends BaseAccountRoleResourceImpl {
 	public Page<AccountRole>
 			getAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeAccountRolesPage(
 				String accountExternalReferenceCode,
-				String userAccountExternalReferenceCode)
+				String externalReferenceCode)
 		throws Exception {
 
 		return Page.of(
@@ -190,8 +189,7 @@ public class AccountRoleResourceImpl extends BaseAccountRoleResourceImpl {
 				_accountRoleLocalService.getAccountRoles(
 					_accountResourceDTOConverter.getAccountEntryId(
 						accountExternalReferenceCode),
-					_userResourceDTOConverter.getUserId(
-						userAccountExternalReferenceCode)),
+					_userResourceDTOConverter.getUserId(externalReferenceCode)),
 				accountRole -> _toAccountRole(accountRole)));
 	}
 
@@ -256,15 +254,14 @@ public class AccountRoleResourceImpl extends BaseAccountRoleResourceImpl {
 	public void
 			postAccountByExternalReferenceCodeAccountRoleUserAccountByExternalReferenceCode(
 				String accountExternalReferenceCode, Long accountRoleId,
-				String userAccountExternalReferenceCode)
+				String externalReferenceCode)
 		throws Exception {
 
 		postAccountAccountRoleUserAccountAssociation(
 			_accountResourceDTOConverter.getAccountEntryId(
 				accountExternalReferenceCode),
 			accountRoleId,
-			_userResourceDTOConverter.getUserId(
-				userAccountExternalReferenceCode));
+			_userResourceDTOConverter.getUserId(externalReferenceCode));
 	}
 
 	private AccountRole _toAccountRole(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountRoleResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountRoleResourceImpl.java
@@ -79,7 +79,7 @@ public abstract class BaseAccountRoleResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'DELETE' 'http://localhost:8080/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{accountExternalReferenceCode}/account-roles/{accountRoleId}/user-accounts/by-external-reference-code/{userAccountExternalReferenceCode}'  -u 'test@liferay.com:test'
+	 * curl -X 'DELETE' 'http://localhost:8080/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{accountExternalReferenceCode}/account-roles/{accountRoleId}/user-accounts/by-external-reference-code/{externalReferenceCode}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Unassigns account users by external reference code from the account role"
@@ -96,7 +96,7 @@ public abstract class BaseAccountRoleResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
-				name = "userAccountExternalReferenceCode"
+				name = "externalReferenceCode"
 			)
 		}
 	)
@@ -105,7 +105,7 @@ public abstract class BaseAccountRoleResourceImpl
 	)
 	@javax.ws.rs.DELETE
 	@javax.ws.rs.Path(
-		"/accounts/by-external-reference-code/{accountExternalReferenceCode}/account-roles/{accountRoleId}/user-accounts/by-external-reference-code/{userAccountExternalReferenceCode}"
+		"/accounts/by-external-reference-code/{accountExternalReferenceCode}/account-roles/{accountRoleId}/user-accounts/by-external-reference-code/{externalReferenceCode}"
 	)
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
@@ -121,15 +121,15 @@ public abstract class BaseAccountRoleResourceImpl
 				Long accountRoleId,
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("userAccountExternalReferenceCode")
-				String userAccountExternalReferenceCode)
+				@javax.ws.rs.PathParam("externalReferenceCode")
+				String externalReferenceCode)
 		throws Exception {
 	}
 
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{accountExternalReferenceCode}/account-roles/{accountRoleId}/user-accounts/by-external-reference-code/{userAccountExternalReferenceCode}'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{accountExternalReferenceCode}/account-roles/{accountRoleId}/user-accounts/by-external-reference-code/{externalReferenceCode}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Assigns account users by external reference code to the account role"
@@ -146,7 +146,7 @@ public abstract class BaseAccountRoleResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
-				name = "userAccountExternalReferenceCode"
+				name = "externalReferenceCode"
 			)
 		}
 	)
@@ -154,7 +154,7 @@ public abstract class BaseAccountRoleResourceImpl
 		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "AccountRole")}
 	)
 	@javax.ws.rs.Path(
-		"/accounts/by-external-reference-code/{accountExternalReferenceCode}/account-roles/{accountRoleId}/user-accounts/by-external-reference-code/{userAccountExternalReferenceCode}"
+		"/accounts/by-external-reference-code/{accountExternalReferenceCode}/account-roles/{accountRoleId}/user-accounts/by-external-reference-code/{externalReferenceCode}"
 	)
 	@javax.ws.rs.POST
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
@@ -171,15 +171,15 @@ public abstract class BaseAccountRoleResourceImpl
 				Long accountRoleId,
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("userAccountExternalReferenceCode")
-				String userAccountExternalReferenceCode)
+				@javax.ws.rs.PathParam("externalReferenceCode")
+				String externalReferenceCode)
 		throws Exception {
 	}
 
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{accountExternalReferenceCode}/user-accounts/by-external-reference-code/{userAccountExternalReferenceCode}/account-roles'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{accountExternalReferenceCode}/user-accounts/by-external-reference-code/{externalReferenceCode}/account-roles'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Gets a user's account roles by their external reference code from an account by external reference code"
@@ -192,7 +192,7 @@ public abstract class BaseAccountRoleResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
-				name = "userAccountExternalReferenceCode"
+				name = "externalReferenceCode"
 			)
 		}
 	)
@@ -201,7 +201,7 @@ public abstract class BaseAccountRoleResourceImpl
 	)
 	@javax.ws.rs.GET
 	@javax.ws.rs.Path(
-		"/accounts/by-external-reference-code/{accountExternalReferenceCode}/user-accounts/by-external-reference-code/{userAccountExternalReferenceCode}/account-roles"
+		"/accounts/by-external-reference-code/{accountExternalReferenceCode}/user-accounts/by-external-reference-code/{externalReferenceCode}/account-roles"
 	)
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
@@ -213,8 +213,8 @@ public abstract class BaseAccountRoleResourceImpl
 				String accountExternalReferenceCode,
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("userAccountExternalReferenceCode")
-				String userAccountExternalReferenceCode)
+				@javax.ws.rs.PathParam("externalReferenceCode")
+				String externalReferenceCode)
 		throws Exception {
 
 		return Page.of(Collections.emptyList());

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserAccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserAccountResourceImpl.java
@@ -79,7 +79,7 @@ public abstract class BaseUserAccountResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'DELETE' 'http://localhost:8080/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{accountExternalReferenceCode}/user-accounts/by-external-reference-code/{userAccountExternalReferenceCode}'  -u 'test@liferay.com:test'
+	 * curl -X 'DELETE' 'http://localhost:8080/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{accountExternalReferenceCode}/user-accounts/by-external-reference-code/{externalReferenceCode}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Removes a user by their external reference code from an account by external reference code"
@@ -92,7 +92,7 @@ public abstract class BaseUserAccountResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
-				name = "userAccountExternalReferenceCode"
+				name = "externalReferenceCode"
 			)
 		}
 	)
@@ -101,7 +101,7 @@ public abstract class BaseUserAccountResourceImpl
 	)
 	@javax.ws.rs.DELETE
 	@javax.ws.rs.Path(
-		"/accounts/by-external-reference-code/{accountExternalReferenceCode}/user-accounts/by-external-reference-code/{userAccountExternalReferenceCode}"
+		"/accounts/by-external-reference-code/{accountExternalReferenceCode}/user-accounts/by-external-reference-code/{externalReferenceCode}"
 	)
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
@@ -113,15 +113,15 @@ public abstract class BaseUserAccountResourceImpl
 				String accountExternalReferenceCode,
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("userAccountExternalReferenceCode")
-				String userAccountExternalReferenceCode)
+				@javax.ws.rs.PathParam("externalReferenceCode")
+				String externalReferenceCode)
 		throws Exception {
 	}
 
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{accountExternalReferenceCode}/user-accounts/by-external-reference-code/{userAccountExternalReferenceCode}'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{accountExternalReferenceCode}/user-accounts/by-external-reference-code/{externalReferenceCode}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Assigns a user by their external reference code to an account by external reference code"
@@ -134,7 +134,7 @@ public abstract class BaseUserAccountResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
-				name = "userAccountExternalReferenceCode"
+				name = "externalReferenceCode"
 			)
 		}
 	)
@@ -142,7 +142,7 @@ public abstract class BaseUserAccountResourceImpl
 		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "UserAccount")}
 	)
 	@javax.ws.rs.Path(
-		"/accounts/by-external-reference-code/{accountExternalReferenceCode}/user-accounts/by-external-reference-code/{userAccountExternalReferenceCode}"
+		"/accounts/by-external-reference-code/{accountExternalReferenceCode}/user-accounts/by-external-reference-code/{externalReferenceCode}"
 	)
 	@javax.ws.rs.POST
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
@@ -155,8 +155,8 @@ public abstract class BaseUserAccountResourceImpl
 				String accountExternalReferenceCode,
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("userAccountExternalReferenceCode")
-				String userAccountExternalReferenceCode)
+				@javax.ws.rs.PathParam("externalReferenceCode")
+				String externalReferenceCode)
 		throws Exception {
 	}
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.user.client', and version '4.0.33'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin User", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.user.client', and version '4.0.34'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin User", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/UserAccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/UserAccountResourceImpl.java
@@ -136,11 +136,11 @@ public class UserAccountResourceImpl
 	public void
 			deleteAccountByExternalReferenceCodeUserAccountByExternalReferenceCode(
 				String accountExternalReferenceCode,
-				String userAccountExternalReferenceCode)
+				String externalReferenceCode)
 		throws Exception {
 
 		User user = _userLocalService.getUserByExternalReferenceCode(
-			userAccountExternalReferenceCode, contextCompany.getCompanyId());
+			externalReferenceCode, contextCompany.getCompanyId());
 
 		_accountEntryUserRelService.deleteAccountEntryUserRelByEmailAddress(
 			_accountResourceDTOConverter.getAccountEntryId(
@@ -392,11 +392,11 @@ public class UserAccountResourceImpl
 	public void
 			postAccountByExternalReferenceCodeUserAccountByExternalReferenceCode(
 				String accountExternalReferenceCode,
-				String userAccountExternalReferenceCode)
+				String externalReferenceCode)
 		throws Exception {
 
 		User user = _userLocalService.getUserByExternalReferenceCode(
-			userAccountExternalReferenceCode, contextCompany.getCompanyId());
+			externalReferenceCode, contextCompany.getCompanyId());
 
 		_accountEntryUserRelService.addAccountEntryUserRelByEmailAddress(
 			_accountResourceDTOConverter.getAccountEntryId(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/AccountRoleResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/AccountRoleResourceTest.java
@@ -752,7 +752,7 @@ public class AccountRoleResourceTest extends BaseAccountRoleResourceTestCase {
 
 	@Override
 	protected String
-			testGetAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeAccountRolesPage_getUserAccountExternalReferenceCode()
+			testGetAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeAccountRolesPage_getExternalReferenceCode()
 		throws Exception {
 
 		UserAccount userAccount =

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountRoleResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountRoleResourceTestCase.java
@@ -213,7 +213,7 @@ public abstract class BaseAccountRoleResourceTestCase {
 				deleteAccountByExternalReferenceCodeAccountRoleUserAccountByExternalReferenceCodeHttpResponse(
 					testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByExternalReferenceCode_getAccountExternalReferenceCode(),
 					accountRole.getId(),
-					testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByExternalReferenceCode_getUserAccountExternalReferenceCode()));
+					testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByExternalReferenceCode_getExternalReferenceCode()));
 	}
 
 	protected String
@@ -225,7 +225,7 @@ public abstract class BaseAccountRoleResourceTestCase {
 	}
 
 	protected String
-			testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByExternalReferenceCode_getUserAccountExternalReferenceCode()
+			testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByExternalReferenceCode_getExternalReferenceCode()
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -277,33 +277,32 @@ public abstract class BaseAccountRoleResourceTestCase {
 			testGetAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeAccountRolesPage_getAccountExternalReferenceCode();
 		String irrelevantAccountExternalReferenceCode =
 			testGetAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeAccountRolesPage_getIrrelevantAccountExternalReferenceCode();
-		String userAccountExternalReferenceCode =
-			testGetAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeAccountRolesPage_getUserAccountExternalReferenceCode();
-		String irrelevantUserAccountExternalReferenceCode =
-			testGetAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeAccountRolesPage_getIrrelevantUserAccountExternalReferenceCode();
+		String externalReferenceCode =
+			testGetAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeAccountRolesPage_getExternalReferenceCode();
+		String irrelevantExternalReferenceCode =
+			testGetAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeAccountRolesPage_getIrrelevantExternalReferenceCode();
 
 		Page<AccountRole> page =
 			accountRoleResource.
 				getAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeAccountRolesPage(
-					accountExternalReferenceCode,
-					userAccountExternalReferenceCode);
+					accountExternalReferenceCode, externalReferenceCode);
 
 		Assert.assertEquals(0, page.getTotalCount());
 
 		if ((irrelevantAccountExternalReferenceCode != null) &&
-			(irrelevantUserAccountExternalReferenceCode != null)) {
+			(irrelevantExternalReferenceCode != null)) {
 
 			AccountRole irrelevantAccountRole =
 				testGetAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeAccountRolesPage_addAccountRole(
 					irrelevantAccountExternalReferenceCode,
-					irrelevantUserAccountExternalReferenceCode,
+					irrelevantExternalReferenceCode,
 					randomIrrelevantAccountRole());
 
 			page =
 				accountRoleResource.
 					getAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeAccountRolesPage(
 						irrelevantAccountExternalReferenceCode,
-						irrelevantUserAccountExternalReferenceCode);
+						irrelevantExternalReferenceCode);
 
 			Assert.assertEquals(1, page.getTotalCount());
 
@@ -315,19 +314,18 @@ public abstract class BaseAccountRoleResourceTestCase {
 
 		AccountRole accountRole1 =
 			testGetAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeAccountRolesPage_addAccountRole(
-				accountExternalReferenceCode, userAccountExternalReferenceCode,
+				accountExternalReferenceCode, externalReferenceCode,
 				randomAccountRole());
 
 		AccountRole accountRole2 =
 			testGetAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeAccountRolesPage_addAccountRole(
-				accountExternalReferenceCode, userAccountExternalReferenceCode,
+				accountExternalReferenceCode, externalReferenceCode,
 				randomAccountRole());
 
 		page =
 			accountRoleResource.
 				getAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeAccountRolesPage(
-					accountExternalReferenceCode,
-					userAccountExternalReferenceCode);
+					accountExternalReferenceCode, externalReferenceCode);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -340,8 +338,7 @@ public abstract class BaseAccountRoleResourceTestCase {
 	protected AccountRole
 			testGetAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeAccountRolesPage_addAccountRole(
 				String accountExternalReferenceCode,
-				String userAccountExternalReferenceCode,
-				AccountRole accountRole)
+				String externalReferenceCode, AccountRole accountRole)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -364,7 +361,7 @@ public abstract class BaseAccountRoleResourceTestCase {
 	}
 
 	protected String
-			testGetAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeAccountRolesPage_getUserAccountExternalReferenceCode()
+			testGetAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeAccountRolesPage_getExternalReferenceCode()
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -372,7 +369,7 @@ public abstract class BaseAccountRoleResourceTestCase {
 	}
 
 	protected String
-			testGetAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeAccountRolesPage_getIrrelevantUserAccountExternalReferenceCode()
+			testGetAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeAccountRolesPage_getIrrelevantExternalReferenceCode()
 		throws Exception {
 
 		return null;

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserAccountResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserAccountResourceTestCase.java
@@ -238,19 +238,11 @@ public abstract class BaseUserAccountResourceTestCase {
 			userAccountResource.
 				deleteAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeHttpResponse(
 					testDeleteAccountByExternalReferenceCodeUserAccountByExternalReferenceCode_getAccountExternalReferenceCode(),
-					testDeleteAccountByExternalReferenceCodeUserAccountByExternalReferenceCode_getUserAccountExternalReferenceCode()));
+					userAccount.getExternalReferenceCode()));
 	}
 
 	protected String
 			testDeleteAccountByExternalReferenceCodeUserAccountByExternalReferenceCode_getAccountExternalReferenceCode()
-		throws Exception {
-
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
-	}
-
-	protected String
-			testDeleteAccountByExternalReferenceCodeUserAccountByExternalReferenceCode_getUserAccountExternalReferenceCode()
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -277,13 +269,13 @@ public abstract class BaseUserAccountResourceTestCase {
 			204,
 			userAccountResource.
 				postAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeHttpResponse(
-					null, null));
+					null, userAccount.getExternalReferenceCode()));
 
 		assertHttpResponseStatusCode(
 			404,
 			userAccountResource.
 				postAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeHttpResponse(
-					null, null));
+					null, userAccount.getExternalReferenceCode()));
 	}
 
 	protected UserAccount

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/bnd.bnd
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Delivery API
 Bundle-SymbolicName: com.liferay.headless.delivery.api
-Bundle-Version: 46.3.1
+Bundle-Version: 46.4.0
 Export-Package:\
 	com.liferay.headless.delivery.dto.v1_0,\
 	com.liferay.headless.delivery.dto.v1_0.util,\

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/MessageBoardAttachment.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/MessageBoardAttachment.java
@@ -152,6 +152,34 @@ public class MessageBoardAttachment implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String encodingFormat;
 
+	@Schema(description = "The message board's external reference code.")
+	public String getExternalReferenceCode() {
+		return externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		this.externalReferenceCode = externalReferenceCode;
+	}
+
+	@JsonIgnore
+	public void setExternalReferenceCode(
+		UnsafeSupplier<String, Exception> externalReferenceCodeUnsafeSupplier) {
+
+		try {
+			externalReferenceCode = externalReferenceCodeUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(description = "The message board's external reference code.")
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String externalReferenceCode;
+
 	@Schema(description = "The file's extension.")
 	public String getFileExtension() {
 		return fileExtension;
@@ -328,6 +356,20 @@ public class MessageBoardAttachment implements Serializable {
 			sb.append("\"");
 
 			sb.append(_escape(encodingFormat));
+
+			sb.append("\"");
+		}
+
+		if (externalReferenceCode != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"externalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(externalReferenceCode));
 
 			sb.append("\"");
 		}

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/MessageBoardAttachmentResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/MessageBoardAttachmentResource.java
@@ -95,6 +95,18 @@ public interface MessageBoardAttachmentResource {
 			String callbackURL, Object object)
 		throws Exception;
 
+	public void
+			deleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode(
+				Long siteId, String messageBoardMessageExternalReferenceCode,
+				String externalReferenceCode)
+		throws Exception;
+
+	public MessageBoardAttachment
+			getSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode(
+				Long siteId, String messageBoardMessageExternalReferenceCode,
+				String externalReferenceCode)
+		throws Exception;
+
 	public default void setContextAcceptLanguage(
 		AcceptLanguage contextAcceptLanguage) {
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 31.3.0
+version 31.4.0

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 17.1.0
+version 17.2.0

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/MessageBoardAttachment.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/MessageBoardAttachment.java
@@ -97,6 +97,27 @@ public class MessageBoardAttachment implements Cloneable, Serializable {
 
 	protected String encodingFormat;
 
+	public String getExternalReferenceCode() {
+		return externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		this.externalReferenceCode = externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(
+		UnsafeSupplier<String, Exception> externalReferenceCodeUnsafeSupplier) {
+
+		try {
+			externalReferenceCode = externalReferenceCodeUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String externalReferenceCode;
+
 	public String getFileExtension() {
 		return fileExtension;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/MessageBoardAttachmentResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/MessageBoardAttachmentResource.java
@@ -139,6 +139,30 @@ public interface MessageBoardAttachmentResource {
 				Object object)
 		throws Exception;
 
+	public void
+			deleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode(
+				Long siteId, String messageBoardMessageExternalReferenceCode,
+				String externalReferenceCode)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			deleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCodeHttpResponse(
+				Long siteId, String messageBoardMessageExternalReferenceCode,
+				String externalReferenceCode)
+		throws Exception;
+
+	public MessageBoardAttachment
+			getSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode(
+				Long siteId, String messageBoardMessageExternalReferenceCode,
+				String externalReferenceCode)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			getSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCodeHttpResponse(
+				Long siteId, String messageBoardMessageExternalReferenceCode,
+				String externalReferenceCode)
+		throws Exception;
+
 	public static class Builder {
 
 		public Builder authentication(String login, String password) {
@@ -1000,6 +1024,194 @@ public interface MessageBoardAttachmentResource {
 						"/o/headless-delivery/v1.0/message-board-threads/{messageBoardThreadId}/message-board-attachments/batch");
 
 			httpInvoker.path("messageBoardThreadId", messageBoardThreadId);
+
+			httpInvoker.userNameAndPassword(
+				_builder._login + ":" + _builder._password);
+
+			return httpInvoker.invoke();
+		}
+
+		public void
+				deleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode(
+					Long siteId,
+					String messageBoardMessageExternalReferenceCode,
+					String externalReferenceCode)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				deleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCodeHttpResponse(
+					siteId, messageBoardMessageExternalReferenceCode,
+					externalReferenceCode);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return;
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				deleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCodeHttpResponse(
+					Long siteId,
+					String messageBoardMessageExternalReferenceCode,
+					String externalReferenceCode)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.DELETE);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-delivery/v1.0/sites/{siteId}/message-board-messages/by-external-reference-code/{messageBoardMessageExternalReferenceCode}/message-board-attachments/by-external-reference-code/{externalReferenceCode}");
+
+			httpInvoker.path("siteId", siteId);
+			httpInvoker.path(
+				"messageBoardMessageExternalReferenceCode",
+				messageBoardMessageExternalReferenceCode);
+			httpInvoker.path("externalReferenceCode", externalReferenceCode);
+
+			httpInvoker.userNameAndPassword(
+				_builder._login + ":" + _builder._password);
+
+			return httpInvoker.invoke();
+		}
+
+		public MessageBoardAttachment
+				getSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode(
+					Long siteId,
+					String messageBoardMessageExternalReferenceCode,
+					String externalReferenceCode)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCodeHttpResponse(
+					siteId, messageBoardMessageExternalReferenceCode,
+					externalReferenceCode);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return MessageBoardAttachmentSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				getSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCodeHttpResponse(
+					Long siteId,
+					String messageBoardMessageExternalReferenceCode,
+					String externalReferenceCode)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-delivery/v1.0/sites/{siteId}/message-board-messages/by-external-reference-code/{messageBoardMessageExternalReferenceCode}/message-board-attachments/by-external-reference-code/{externalReferenceCode}");
+
+			httpInvoker.path("siteId", siteId);
+			httpInvoker.path(
+				"messageBoardMessageExternalReferenceCode",
+				messageBoardMessageExternalReferenceCode);
+			httpInvoker.path("externalReferenceCode", externalReferenceCode);
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/MessageBoardAttachmentSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/MessageBoardAttachmentSerDes.java
@@ -97,6 +97,21 @@ public class MessageBoardAttachmentSerDes {
 			sb.append("\"");
 		}
 
+		if (messageBoardAttachment.getExternalReferenceCode() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"externalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(
+				_escape(messageBoardAttachment.getExternalReferenceCode()));
+
+			sb.append("\"");
+		}
+
 		if (messageBoardAttachment.getFileExtension() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -193,6 +208,16 @@ public class MessageBoardAttachmentSerDes {
 				String.valueOf(messageBoardAttachment.getEncodingFormat()));
 		}
 
+		if (messageBoardAttachment.getExternalReferenceCode() == null) {
+			map.put("externalReferenceCode", null);
+		}
+		else {
+			map.put(
+				"externalReferenceCode",
+				String.valueOf(
+					messageBoardAttachment.getExternalReferenceCode()));
+		}
+
 		if (messageBoardAttachment.getFileExtension() == null) {
 			map.put("fileExtension", null);
 		}
@@ -261,6 +286,14 @@ public class MessageBoardAttachmentSerDes {
 			else if (Objects.equals(jsonParserFieldName, "encodingFormat")) {
 				if (jsonParserFieldValue != null) {
 					messageBoardAttachment.setEncodingFormat(
+						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "externalReferenceCode")) {
+
+				if (jsonParserFieldValue != null) {
+					messageBoardAttachment.setExternalReferenceCode(
 						(String)jsonParserFieldValue);
 				}
 			}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -12773,6 +12773,7 @@ paths:
             description:
                 Delete the message board attachment by message board message's and message board attachment's external
                 reference codes.
+            operationId: deleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode
             parameters:
                 - in: path
                   name: siteId
@@ -12801,6 +12802,7 @@ paths:
             description:
                 Retrieves the message board attachment by message board message's and message board attachment's
                 external reference codes.
+            operationId: getSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode
             parameters:
                 - in: path
                   name: siteId

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -2572,6 +2572,11 @@ components:
                         The file's media format (e.g., application/pdf, etc.).
                     readOnly: true
                     type: string
+                externalReferenceCode:
+                    # @review
+                    description:
+                        The message board's external reference code.
+                    type: string
                 fileExtension:
                     description:
                         The file's extension.
@@ -12762,6 +12767,75 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/MessageBoardMessage"
             tags: ["MessageBoardMessage"]
+    "/sites/{siteId}/message-board-messages/by-external-reference-code/{messageBoardMessageExternalReferenceCode}/message-board-attachments/by-external-reference-code/{externalReferenceCode}":
+        delete:
+            # @review
+            description:
+                Delete the message board attachment by message board message's and message board attachment's external
+                reference codes.
+            parameters:
+                - in: path
+                  name: siteId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+                - in: path
+                  name: messageBoardMessageExternalReferenceCode
+                  required: true
+                  schema:
+                      type: string
+                - in: path
+                  name: externalReferenceCode
+                  required: true
+                  schema:
+                      type: string
+            responses:
+                204:
+                    content:
+                        application/json: {}
+                        application/xml: {}
+            tags: ["MessageBoardAttachment"]
+        get:
+            # @review
+            description:
+                Retrieves the message board attachment by message board message's and message board attachment's
+                external reference codes.
+            parameters:
+                - in: path
+                  name: siteId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+                - in: path
+                  name: messageBoardMessageExternalReferenceCode
+                  required: true
+                  schema:
+                      type: string
+                - in: path
+                  name: externalReferenceCode
+                  required: true
+                  schema:
+                      type: string
+                - in: query
+                  name: fields
+                  schema:
+                      type: string
+                - in: query
+                  name: restrictFields
+                  schema:
+                      type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/MessageBoardAttachment"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/MessageBoardAttachment"
+            tags: ["MessageBoardAttachment"]
     "/sites/{siteId}/message-board-messages/by-friendly-url-path/{friendlyUrlPath}":
         get:
             operationId: getSiteMessageBoardMessageByFriendlyUrlPath

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/mutation/v1_0/Mutation.java
@@ -2341,6 +2341,31 @@ public class Mutation {
 	}
 
 	@GraphQLField(
+		description = "Delete the message board attachment by message board message's and message board attachment's external reference codes."
+	)
+	public boolean
+			deleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode(
+				@GraphQLName("siteKey") @NotEmpty String siteKey,
+				@GraphQLName("messageBoardMessageExternalReferenceCode") String
+					messageBoardMessageExternalReferenceCode,
+				@GraphQLName("externalReferenceCode") String
+					externalReferenceCode)
+		throws Exception {
+
+		_applyVoidComponentServiceObjects(
+			_messageBoardAttachmentResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			messageBoardAttachmentResource ->
+				messageBoardAttachmentResource.
+					deleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode(
+						Long.valueOf(siteKey),
+						messageBoardMessageExternalReferenceCode,
+						externalReferenceCode));
+
+		return true;
+	}
+
+	@GraphQLField(
 		description = "Deletes the message board message and returns a 204 if the operation succeeds."
 	)
 	public boolean deleteMessageBoardMessage(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/query/v1_0/Query.java
@@ -1976,7 +1976,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {messageBoardAttachment(messageBoardAttachmentId: ___){contentUrl, contentValue, encodingFormat, fileExtension, id, sizeInBytes, title}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {messageBoardAttachment(messageBoardAttachmentId: ___){contentUrl, contentValue, encodingFormat, externalReferenceCode, fileExtension, id, sizeInBytes, title}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(description = "Retrieves the message board attachment.")
 	public MessageBoardAttachment messageBoardAttachment(
@@ -2034,6 +2034,34 @@ public class Query {
 				messageBoardAttachmentResource.
 					getMessageBoardThreadMessageBoardAttachmentsPage(
 						messageBoardThreadId)));
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {messageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode(externalReferenceCode: ___, messageBoardMessageExternalReferenceCode: ___, siteKey: ___){contentUrl, contentValue, encodingFormat, externalReferenceCode, fileExtension, id, sizeInBytes, title}}"}' -u 'test@liferay.com:test'
+	 */
+	@GraphQLField(
+		description = "Retrieves the message board attachment by message board message's and message board attachment's external reference codes."
+	)
+	public MessageBoardAttachment
+			messageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode(
+				@GraphQLName("siteKey") @NotEmpty String siteKey,
+				@GraphQLName("messageBoardMessageExternalReferenceCode") String
+					messageBoardMessageExternalReferenceCode,
+				@GraphQLName("externalReferenceCode") String
+					externalReferenceCode)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_messageBoardAttachmentResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			messageBoardAttachmentResource ->
+				messageBoardAttachmentResource.
+					getSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode(
+						Long.valueOf(siteKey),
+						messageBoardMessageExternalReferenceCode,
+						externalReferenceCode));
 	}
 
 	/**

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -803,6 +803,11 @@ public class ServletDataImpl implements ServletData {
 							MessageBoardAttachmentResourceImpl.class,
 							"postMessageBoardThreadMessageBoardAttachmentBatch"));
 					put(
+						"mutation#deleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode",
+						new ObjectValuePair<>(
+							MessageBoardAttachmentResourceImpl.class,
+							"deleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode"));
+					put(
 						"mutation#deleteMessageBoardMessage",
 						new ObjectValuePair<>(
 							MessageBoardMessageResourceImpl.class,
@@ -1775,6 +1780,11 @@ public class ServletDataImpl implements ServletData {
 						new ObjectValuePair<>(
 							MessageBoardAttachmentResourceImpl.class,
 							"getMessageBoardThreadMessageBoardAttachmentsPage"));
+					put(
+						"query#messageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode",
+						new ObjectValuePair<>(
+							MessageBoardAttachmentResourceImpl.class,
+							"getSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode"));
 					put(
 						"query#messageBoardMessage",
 						new ObjectValuePair<>(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardAttachmentResourceImpl.java
@@ -515,6 +515,128 @@ public abstract class BaseMessageBoardAttachmentResourceImpl
 		).build();
 	}
 
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'DELETE' 'http://localhost:8080/o/headless-delivery/v1.0/sites/{siteId}/message-board-messages/by-external-reference-code/{messageBoardMessageExternalReferenceCode}/message-board-attachments/by-external-reference-code/{externalReferenceCode}'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Delete the message board attachment by message board message's and message board attachment's external reference codes."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "siteId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "messageBoardMessageExternalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "externalReferenceCode"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(
+				name = "MessageBoardAttachment"
+			)
+		}
+	)
+	@javax.ws.rs.DELETE
+	@javax.ws.rs.Path(
+		"/sites/{siteId}/message-board-messages/by-external-reference-code/{messageBoardMessageExternalReferenceCode}/message-board-attachments/by-external-reference-code/{externalReferenceCode}"
+	)
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public void
+			deleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("siteId")
+				Long siteId,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam(
+					"messageBoardMessageExternalReferenceCode"
+				)
+				String messageBoardMessageExternalReferenceCode,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("externalReferenceCode")
+				String externalReferenceCode)
+		throws Exception {
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/headless-delivery/v1.0/sites/{siteId}/message-board-messages/by-external-reference-code/{messageBoardMessageExternalReferenceCode}/message-board-attachments/by-external-reference-code/{externalReferenceCode}'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Retrieves the message board attachment by message board message's and message board attachment's external reference codes."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "siteId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "messageBoardMessageExternalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "externalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "fields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "restrictFields"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(
+				name = "MessageBoardAttachment"
+			)
+		}
+	)
+	@javax.ws.rs.GET
+	@javax.ws.rs.Path(
+		"/sites/{siteId}/message-board-messages/by-external-reference-code/{messageBoardMessageExternalReferenceCode}/message-board-attachments/by-external-reference-code/{externalReferenceCode}"
+	)
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public MessageBoardAttachment
+			getSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("siteId")
+				Long siteId,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam(
+					"messageBoardMessageExternalReferenceCode"
+				)
+				String messageBoardMessageExternalReferenceCode,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("externalReferenceCode")
+				String externalReferenceCode)
+		throws Exception {
+
+		return new MessageBoardAttachment();
+	}
+
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardAttachmentResourceImpl.java
@@ -57,6 +57,25 @@ public class MessageBoardAttachmentResourceImpl
 	}
 
 	@Override
+	public void
+			deleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode(
+				Long siteId, String messageBoardMessageExternalReferenceCode,
+				String externalReferenceCode)
+		throws Exception {
+
+		MBMessage mbMessage =
+			_mbMessageService.getMBMessageByExternalReferenceCode(
+				messageBoardMessageExternalReferenceCode, siteId);
+
+		FileEntry fileEntry =
+			mbMessage.getAttachmentsFileEntryByExternalReferenceCode(
+				externalReferenceCode, siteId);
+
+		_portletFileRepository.deletePortletFileEntry(
+			fileEntry.getFileEntryId());
+	}
+
+	@Override
 	public MessageBoardAttachment getMessageBoardAttachment(
 			Long messageBoardAttachmentId)
 		throws Exception {
@@ -85,6 +104,24 @@ public class MessageBoardAttachmentResourceImpl
 			messageBoardThreadId);
 
 		return _getMessageBoardAttachmentsPage(mbThread.getRootMessageId());
+	}
+
+	@Override
+	public MessageBoardAttachment
+			getSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode(
+				Long siteId, String messageBoardMessageExternalReferenceCode,
+				String externalReferenceCode)
+		throws Exception {
+
+		MBMessage mbMessage =
+			_mbMessageService.getMBMessageByExternalReferenceCode(
+				messageBoardMessageExternalReferenceCode, siteId);
+
+		FileEntry fileEntry =
+			mbMessage.getAttachmentsFileEntryByExternalReferenceCode(
+				externalReferenceCode, siteId);
+
+		return _toMessageBoardAttachment(fileEntry);
 	}
 
 	@Override
@@ -157,6 +194,7 @@ public class MessageBoardAttachmentResourceImpl
 					"contentValue", fileEntry::getContentStream,
 					Optional.of(contextUriInfo));
 				encodingFormat = fileEntry.getMimeType();
+				externalReferenceCode = fileEntry.getExternalReferenceCode();
 				fileExtension = fileEntry.getExtension();
 				id = fileEntry.getFileEntryId();
 				sizeInBytes = fileEntry.getSize();

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardAttachmentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardAttachmentResourceTestCase.java
@@ -192,6 +192,7 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 		messageBoardAttachment.setContentUrl(regex);
 		messageBoardAttachment.setContentValue(regex);
 		messageBoardAttachment.setEncodingFormat(regex);
+		messageBoardAttachment.setExternalReferenceCode(regex);
 		messageBoardAttachment.setFileExtension(regex);
 		messageBoardAttachment.setTitle(regex);
 
@@ -205,6 +206,8 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 		Assert.assertEquals(regex, messageBoardAttachment.getContentUrl());
 		Assert.assertEquals(regex, messageBoardAttachment.getContentValue());
 		Assert.assertEquals(regex, messageBoardAttachment.getEncodingFormat());
+		Assert.assertEquals(
+			regex, messageBoardAttachment.getExternalReferenceCode());
 		Assert.assertEquals(regex, messageBoardAttachment.getFileExtension());
 		Assert.assertEquals(regex, messageBoardAttachment.getTitle());
 	}
@@ -599,6 +602,202 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 				messageBoardAttachment, multipartFiles);
 	}
 
+	@Test
+	public void testDeleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode()
+		throws Exception {
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		MessageBoardAttachment messageBoardAttachment =
+			testDeleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode_addMessageBoardAttachment();
+
+		assertHttpResponseStatusCode(
+			204,
+			messageBoardAttachmentResource.
+				deleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCodeHttpResponse(
+					testDeleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode_getSiteId(),
+					testDeleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode_getMessageBoardMessageExternalReferenceCode(),
+					messageBoardAttachment.getExternalReferenceCode()));
+
+		assertHttpResponseStatusCode(
+			404,
+			messageBoardAttachmentResource.
+				getSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCodeHttpResponse(
+					testDeleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode_getSiteId(),
+					testDeleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode_getMessageBoardMessageExternalReferenceCode(),
+					messageBoardAttachment.getExternalReferenceCode()));
+
+		assertHttpResponseStatusCode(
+			404,
+			messageBoardAttachmentResource.
+				getSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCodeHttpResponse(
+					testDeleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode_getSiteId(),
+					testDeleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode_getMessageBoardMessageExternalReferenceCode(),
+					messageBoardAttachment.getExternalReferenceCode()));
+	}
+
+	protected Long
+			testDeleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode_getSiteId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected String
+			testDeleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode_getMessageBoardMessageExternalReferenceCode()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected MessageBoardAttachment
+			testDeleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode_addMessageBoardAttachment()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testGetSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode()
+		throws Exception {
+
+		MessageBoardAttachment postMessageBoardAttachment =
+			testGetSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode_addMessageBoardAttachment();
+
+		MessageBoardAttachment getMessageBoardAttachment =
+			messageBoardAttachmentResource.
+				getSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode(
+					testGetSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode_getSiteId(),
+					testGetSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode_getMessageBoardMessageExternalReferenceCode(),
+					postMessageBoardAttachment.getExternalReferenceCode());
+
+		assertEquals(postMessageBoardAttachment, getMessageBoardAttachment);
+		assertValid(getMessageBoardAttachment);
+	}
+
+	protected Long
+			testGetSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode_getSiteId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected String
+			testGetSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode_getMessageBoardMessageExternalReferenceCode()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected MessageBoardAttachment
+			testGetSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode_addMessageBoardAttachment()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testGraphQLGetSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode()
+		throws Exception {
+
+		MessageBoardAttachment messageBoardAttachment =
+			testGraphQLGetSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode_addMessageBoardAttachment();
+
+		Assert.assertTrue(
+			equals(
+				messageBoardAttachment,
+				MessageBoardAttachmentSerDes.toDTO(
+					JSONUtil.getValueAsString(
+						invokeGraphQLQuery(
+							new GraphQLField(
+								"messageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode",
+								new HashMap<String, Object>() {
+									{
+										put(
+											"siteKey",
+											"\"" +
+												testGraphQLGetSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode_getSiteId() +
+													"\"");
+
+										put(
+											"messageBoardMessageExternalReferenceCode",
+											"\"" +
+												testGraphQLGetSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode_getMessageBoardMessageExternalReferenceCode() +
+													"\"");
+										put(
+											"externalReferenceCode",
+											"\"" +
+												messageBoardAttachment.
+													getExternalReferenceCode() +
+														"\"");
+									}
+								},
+								getGraphQLFields())),
+						"JSONObject/data",
+						"Object/messageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode"))));
+	}
+
+	protected Long
+			testGraphQLGetSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode_getSiteId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected String
+			testGraphQLGetSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode_getMessageBoardMessageExternalReferenceCode()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testGraphQLGetSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCodeNotFound()
+		throws Exception {
+
+		String irrelevantMessageBoardMessageExternalReferenceCode =
+			"\"" + RandomTestUtil.randomString() + "\"";
+		String irrelevantExternalReferenceCode =
+			"\"" + RandomTestUtil.randomString() + "\"";
+
+		Assert.assertEquals(
+			"Not Found",
+			JSONUtil.getValueAsString(
+				invokeGraphQLQuery(
+					new GraphQLField(
+						"messageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode",
+						new HashMap<String, Object>() {
+							{
+								put(
+									"siteKey",
+									"\"" + irrelevantGroup.getGroupId() + "\"");
+								put(
+									"messageBoardMessageExternalReferenceCode",
+									irrelevantMessageBoardMessageExternalReferenceCode);
+								put(
+									"externalReferenceCode",
+									irrelevantExternalReferenceCode);
+							}
+						},
+						getGraphQLFields())),
+				"JSONArray/errors", "Object/0", "JSONObject/extensions",
+				"Object/code"));
+	}
+
+	protected MessageBoardAttachment
+			testGraphQLGetSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode_addMessageBoardAttachment()
+		throws Exception {
+
+		return testGraphQLMessageBoardAttachment_addMessageBoardAttachment();
+	}
+
 	protected MessageBoardAttachment
 			testGraphQLMessageBoardAttachment_addMessageBoardAttachment()
 		throws Exception {
@@ -721,6 +920,16 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 
 			if (Objects.equals("encodingFormat", additionalAssertFieldName)) {
 				if (messageBoardAttachment.getEncodingFormat() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"externalReferenceCode", additionalAssertFieldName)) {
+
+				if (messageBoardAttachment.getExternalReferenceCode() == null) {
 					valid = false;
 				}
 
@@ -881,6 +1090,19 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 				if (!Objects.deepEquals(
 						messageBoardAttachment1.getEncodingFormat(),
 						messageBoardAttachment2.getEncodingFormat())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"externalReferenceCode", additionalAssertFieldName)) {
+
+				if (!Objects.deepEquals(
+						messageBoardAttachment1.getExternalReferenceCode(),
+						messageBoardAttachment2.getExternalReferenceCode())) {
 
 					return false;
 				}
@@ -1055,6 +1277,16 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 			return sb.toString();
 		}
 
+		if (entityFieldName.equals("externalReferenceCode")) {
+			sb.append("'");
+			sb.append(
+				String.valueOf(
+					messageBoardAttachment.getExternalReferenceCode()));
+			sb.append("'");
+
+			return sb.toString();
+		}
+
 		if (entityFieldName.equals("fileExtension")) {
 			sb.append("'");
 			sb.append(
@@ -1138,6 +1370,8 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 				contentValue = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
 				encodingFormat = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				externalReferenceCode = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
 				fileExtension = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/MessageBoardAttachmentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/MessageBoardAttachmentResourceTest.java
@@ -33,6 +33,7 @@ import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
@@ -51,12 +52,56 @@ public class MessageBoardAttachmentResourceTest
 
 		serviceContext.setScopeGroupId(testGroup.getGroupId());
 
-		MBMessage mbMessage = MBTestUtil.addMessage(
-			testGroup.getGroupId(),
-			UserLocalServiceUtil.getDefaultUserId(testGroup.getCompanyId()),
-			RandomTestUtil.randomString(), RandomTestUtil.randomString());
+		MBMessage mbMessage = _addMBMessage();
 
 		_mbThread = mbMessage.getThread();
+	}
+
+	@Override
+	@Test
+	public void testDeleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode()
+		throws Exception {
+
+		super.
+			testDeleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode();
+
+		MessageBoardAttachment messageBoardAttachment =
+			testDeleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode_addMessageBoardAttachment();
+
+		// Nonexistent message board message
+
+		assertHttpResponseStatusCode(
+			404,
+			messageBoardAttachmentResource.
+				deleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCodeHttpResponse(
+					testDeleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode_getSiteId(),
+					RandomTestUtil.randomString(),
+					messageBoardAttachment.getExternalReferenceCode()));
+
+		// Nonexistent message board message attachment
+
+		assertHttpResponseStatusCode(
+			404,
+			messageBoardAttachmentResource.
+				deleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCodeHttpResponse(
+					testDeleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode_getSiteId(),
+					testDeleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode_getMessageBoardMessageExternalReferenceCode(),
+					RandomTestUtil.randomString()));
+
+		// Message board Attachment associated to a different message board
+
+		MBMessage previousMBMessage = _mbMessage;
+
+		MessageBoardAttachment newMessageBoardAttachment =
+			testDeleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode_addMessageBoardAttachment();
+
+		assertHttpResponseStatusCode(
+			404,
+			messageBoardAttachmentResource.
+				deleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCodeHttpResponse(
+					testDeleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode_getSiteId(),
+					previousMBMessage.getExternalReferenceCode(),
+					newMessageBoardAttachment.getExternalReferenceCode()));
 	}
 
 	@Override
@@ -118,6 +163,33 @@ public class MessageBoardAttachmentResourceTest
 				getMultipartFiles());
 	}
 
+	protected MessageBoardAttachment
+			testDeleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode_addMessageBoardAttachment()
+		throws Exception {
+
+		_mbMessage = _addMBMessage();
+
+		return messageBoardAttachmentResource.
+			postMessageBoardMessageMessageBoardAttachment(
+				_mbMessage.getMessageId(), randomMessageBoardAttachment(),
+				getMultipartFiles());
+	}
+
+	protected String
+			testDeleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode_getMessageBoardMessageExternalReferenceCode()
+		throws Exception {
+
+		return _mbMessage.getExternalReferenceCode();
+	}
+
+	@Override
+	protected Long
+			testDeleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode_getSiteId()
+		throws Exception {
+
+		return testGroup.getGroupId();
+	}
+
 	@Override
 	protected MessageBoardAttachment
 			testGetMessageBoardAttachment_addMessageBoardAttachment()
@@ -143,12 +215,67 @@ public class MessageBoardAttachmentResourceTest
 		return _mbThread.getThreadId();
 	}
 
+	protected MessageBoardAttachment
+			testGetSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode_addMessageBoardAttachment()
+		throws Exception {
+
+		_mbMessage = _addMBMessage();
+
+		return messageBoardAttachmentResource.
+			postMessageBoardMessageMessageBoardAttachment(
+				_mbMessage.getMessageId(), randomMessageBoardAttachment(),
+				getMultipartFiles());
+	}
+
+	protected String
+			testGetSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode_getMessageBoardMessageExternalReferenceCode()
+		throws Exception {
+
+		return _mbMessage.getExternalReferenceCode();
+	}
+
+	protected Long
+			testGetSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode_getSiteId()
+		throws Exception {
+
+		return testGroup.getGroupId();
+	}
+
+	@Override
+	protected MessageBoardAttachment
+			testGraphQLGetSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode_addMessageBoardAttachment()
+		throws Exception {
+
+		return testDeleteSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode_addMessageBoardAttachment();
+	}
+
+	protected String
+			testGraphQLGetSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode_getMessageBoardMessageExternalReferenceCode()
+		throws Exception {
+
+		return _mbMessage.getExternalReferenceCode();
+	}
+
+	protected Long
+			testGraphQLGetSiteMessageBoardMessageByExternalReferenceCodeMessageBoardMessageExternalReferenceCodeMessageBoardAttachmentByExternalReferenceCode_getSiteId()
+		throws Exception {
+
+		return testGroup.getGroupId();
+	}
+
 	@Override
 	protected MessageBoardAttachment
 			testGraphQLMessageBoardAttachment_addMessageBoardAttachment()
 		throws Exception {
 
 		return testDeleteMessageBoardAttachment_addMessageBoardAttachment();
+	}
+
+	private MBMessage _addMBMessage() throws Exception {
+		return MBTestUtil.addMessage(
+			testGroup.getGroupId(),
+			UserLocalServiceUtil.getDefaultUserId(testGroup.getCompanyId()),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString());
 	}
 
 	private String _read(String url) throws Exception {
@@ -163,6 +290,7 @@ public class MessageBoardAttachmentResourceTest
 		return httpResponse.getContent();
 	}
 
+	private MBMessage _mbMessage;
 	private MBThread _mbThread;
 	private String _tempFileName;
 

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/model/MBMessage.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/model/MBMessage.java
@@ -74,6 +74,11 @@ public interface MBMessage extends MBMessageModel, PersistedModel, TreeModel {
 	public int getAttachmentsFileEntriesCount()
 		throws com.liferay.portal.kernel.exception.PortalException;
 
+	public com.liferay.portal.kernel.repository.model.FileEntry
+			getAttachmentsFileEntryByExternalReferenceCode(
+				String externalReferenceCode, long groupId)
+		throws com.liferay.portal.kernel.exception.PortalException;
+
 	public long getAttachmentsFolderId()
 		throws com.liferay.portal.kernel.exception.PortalException;
 

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/model/MBMessageWrapper.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/model/MBMessageWrapper.java
@@ -349,6 +349,16 @@ public class MBMessageWrapper
 	}
 
 	@Override
+	public com.liferay.portal.kernel.repository.model.FileEntry
+			getAttachmentsFileEntryByExternalReferenceCode(
+				String externalReferenceCode, long groupId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return model.getAttachmentsFileEntryByExternalReferenceCode(
+			externalReferenceCode, groupId);
+	}
+
+	@Override
 	public long getAttachmentsFolderId()
 		throws com.liferay.portal.kernel.exception.PortalException {
 

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBMessageService.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBMessageService.java
@@ -209,6 +209,11 @@ public interface MBMessageService extends BaseService {
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public MBMessage getMBMessageByExternalReferenceCode(
+			String externalReferenceCode, long groupId)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public MBMessage getMessage(long messageId) throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBMessageServiceUtil.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBMessageServiceUtil.java
@@ -286,6 +286,14 @@ public class MBMessageServiceUtil {
 			entryURL, themeDisplay);
 	}
 
+	public static MBMessage getMBMessageByExternalReferenceCode(
+			String externalReferenceCode, long groupId)
+		throws PortalException {
+
+		return getService().getMBMessageByExternalReferenceCode(
+			externalReferenceCode, groupId);
+	}
+
 	public static MBMessage getMessage(long messageId) throws PortalException {
 		return getService().getMessage(messageId);
 	}

--- a/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBMessageServiceWrapper.java
+++ b/modules/apps/message-boards/message-boards-api/src/main/java/com/liferay/message/boards/service/MBMessageServiceWrapper.java
@@ -311,6 +311,15 @@ public class MBMessageServiceWrapper
 	}
 
 	@Override
+	public MBMessage getMBMessageByExternalReferenceCode(
+			String externalReferenceCode, long groupId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _mbMessageService.getMBMessageByExternalReferenceCode(
+			externalReferenceCode, groupId);
+	}
+
+	@Override
 	public MBMessage getMessage(long messageId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 

--- a/modules/apps/message-boards/message-boards-api/src/main/resources/com/liferay/message/boards/model/packageinfo
+++ b/modules/apps/message-boards/message-boards-api/src/main/resources/com/liferay/message/boards/model/packageinfo
@@ -1,1 +1,1 @@
-version 10.0.0
+version 10.1.0

--- a/modules/apps/message-boards/message-boards-api/src/main/resources/com/liferay/message/boards/service/packageinfo
+++ b/modules/apps/message-boards/message-boards-api/src/main/resources/com/liferay/message/boards/service/packageinfo
@@ -1,1 +1,1 @@
-version 9.0.0
+version 9.1.0

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/model/impl/MBMessageImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/model/impl/MBMessageImpl.java
@@ -15,6 +15,7 @@
 package com.liferay.message.boards.model.impl;
 
 import com.liferay.asset.kernel.service.AssetTagLocalServiceUtil;
+import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.util.comparator.RepositoryModelTitleComparator;
 import com.liferay.message.boards.constants.MBCategoryConstants;
@@ -25,6 +26,7 @@ import com.liferay.message.boards.model.MBMessage;
 import com.liferay.message.boards.model.MBThread;
 import com.liferay.message.boards.service.MBCategoryLocalServiceUtil;
 import com.liferay.message.boards.service.MBThreadLocalServiceUtil;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
@@ -119,6 +121,28 @@ public class MBMessageImpl extends MBMessageBaseImpl {
 		}
 
 		return attachmentsFileEntriesCount;
+	}
+
+	@Override
+	public FileEntry getAttachmentsFileEntryByExternalReferenceCode(
+			String externalReferenceCode, long groupId)
+		throws PortalException {
+
+		FileEntry fileEntry =
+			PortletFileRepositoryUtil.
+				getPortletFileEntryByExternalReferenceCode(
+					externalReferenceCode, groupId);
+
+		long attachmentsFolderId = getAttachmentsFolderId();
+
+		if (attachmentsFolderId == fileEntry.getFolderId()) {
+			return fileEntry;
+		}
+
+		throw new NoSuchFileEntryException(
+			StringBundler.concat(
+				"No FileEntry exists with the key {fileEntryId=",
+				fileEntry.getFileEntryId(), "}"));
 	}
 
 	@Override

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/http/MBMessageServiceHttp.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/http/MBMessageServiceHttp.java
@@ -1043,6 +1043,49 @@ public class MBMessageServiceHttp {
 		}
 	}
 
+	public static com.liferay.message.boards.model.MBMessage
+			getMBMessageByExternalReferenceCode(
+				HttpPrincipal httpPrincipal, String externalReferenceCode,
+				long groupId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				MBMessageServiceUtil.class,
+				"getMBMessageByExternalReferenceCode",
+				_getMBMessageByExternalReferenceCodeParameterTypes24);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, externalReferenceCode, groupId);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.message.boards.model.MBMessage)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	public static com.liferay.message.boards.model.MBMessage getMessage(
 			HttpPrincipal httpPrincipal, long messageId)
 		throws com.liferay.portal.kernel.exception.PortalException {
@@ -1050,7 +1093,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBMessageServiceUtil.class, "getMessage",
-				_getMessageParameterTypes24);
+				_getMessageParameterTypes25);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, messageId);
@@ -1091,7 +1134,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBMessageServiceUtil.class, "getMessageDisplay",
-				_getMessageDisplayParameterTypes25);
+				_getMessageDisplayParameterTypes26);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, messageId, status);
@@ -1131,7 +1174,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBMessageServiceUtil.class, "getTempAttachmentNames",
-				_getTempAttachmentNamesParameterTypes26);
+				_getTempAttachmentNamesParameterTypes27);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderName);
@@ -1171,7 +1214,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBMessageServiceUtil.class, "getThreadAnswersCount",
-				_getThreadAnswersCountParameterTypes27);
+				_getThreadAnswersCountParameterTypes28);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, categoryId, threadId);
@@ -1205,7 +1248,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBMessageServiceUtil.class, "getThreadMessages",
-				_getThreadMessagesParameterTypes28);
+				_getThreadMessagesParameterTypes29);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, categoryId, threadId, status, start, end);
@@ -1239,7 +1282,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBMessageServiceUtil.class, "getThreadMessagesCount",
-				_getThreadMessagesCountParameterTypes29);
+				_getThreadMessagesCountParameterTypes30);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, categoryId, threadId, status);
@@ -1275,7 +1318,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBMessageServiceUtil.class, "getThreadMessagesRSS",
-				_getThreadMessagesRSSParameterTypes30);
+				_getThreadMessagesRSSParameterTypes31);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, threadId, status, max, type, version, displayStyle,
@@ -1316,7 +1359,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBMessageServiceUtil.class, "moveMessageAttachmentToTrash",
-				_moveMessageAttachmentToTrashParameterTypes31);
+				_moveMessageAttachmentToTrashParameterTypes32);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, messageId, fileName);
@@ -1352,7 +1395,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBMessageServiceUtil.class, "restoreMessageAttachmentFromTrash",
-				_restoreMessageAttachmentFromTrashParameterTypes32);
+				_restoreMessageAttachmentFromTrashParameterTypes33);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, messageId, fileName);
@@ -1388,7 +1431,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBMessageServiceUtil.class, "subscribeMessage",
-				_subscribeMessageParameterTypes33);
+				_subscribeMessageParameterTypes34);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, messageId);
@@ -1424,7 +1467,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBMessageServiceUtil.class, "unsubscribeMessage",
-				_unsubscribeMessageParameterTypes34);
+				_unsubscribeMessageParameterTypes35);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, messageId);
@@ -1461,7 +1504,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBMessageServiceUtil.class, "updateAnswer",
-				_updateAnswerParameterTypes35);
+				_updateAnswerParameterTypes36);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, messageId, answer, cascade);
@@ -1504,7 +1547,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBMessageServiceUtil.class, "updateDiscussionMessage",
-				_updateDiscussionMessageParameterTypes36);
+				_updateDiscussionMessageParameterTypes37);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, className, classPK, messageId, subject, body,
@@ -1551,7 +1594,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				MBMessageServiceUtil.class, "updateMessage",
-				_updateMessageParameterTypes37);
+				_updateMessageParameterTypes38);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, messageId, subject, body, inputStreamOVPs, priority,
@@ -1682,47 +1725,51 @@ public class MBMessageServiceHttp {
 			double.class, String.class, String.class, String.class,
 			com.liferay.portal.kernel.theme.ThemeDisplay.class
 		};
-	private static final Class<?>[] _getMessageParameterTypes24 = new Class[] {
+	private static final Class<?>[]
+		_getMBMessageByExternalReferenceCodeParameterTypes24 = new Class[] {
+			String.class, long.class
+		};
+	private static final Class<?>[] _getMessageParameterTypes25 = new Class[] {
 		long.class
 	};
-	private static final Class<?>[] _getMessageDisplayParameterTypes25 =
+	private static final Class<?>[] _getMessageDisplayParameterTypes26 =
 		new Class[] {long.class, int.class};
-	private static final Class<?>[] _getTempAttachmentNamesParameterTypes26 =
+	private static final Class<?>[] _getTempAttachmentNamesParameterTypes27 =
 		new Class[] {long.class, String.class};
-	private static final Class<?>[] _getThreadAnswersCountParameterTypes27 =
+	private static final Class<?>[] _getThreadAnswersCountParameterTypes28 =
 		new Class[] {long.class, long.class, long.class};
-	private static final Class<?>[] _getThreadMessagesParameterTypes28 =
+	private static final Class<?>[] _getThreadMessagesParameterTypes29 =
 		new Class[] {
 			long.class, long.class, long.class, int.class, int.class, int.class
 		};
-	private static final Class<?>[] _getThreadMessagesCountParameterTypes29 =
+	private static final Class<?>[] _getThreadMessagesCountParameterTypes30 =
 		new Class[] {long.class, long.class, long.class, int.class};
-	private static final Class<?>[] _getThreadMessagesRSSParameterTypes30 =
+	private static final Class<?>[] _getThreadMessagesRSSParameterTypes31 =
 		new Class[] {
 			long.class, int.class, int.class, String.class, double.class,
 			String.class, String.class, String.class,
 			com.liferay.portal.kernel.theme.ThemeDisplay.class
 		};
 	private static final Class<?>[]
-		_moveMessageAttachmentToTrashParameterTypes31 = new Class[] {
+		_moveMessageAttachmentToTrashParameterTypes32 = new Class[] {
 			long.class, String.class
 		};
 	private static final Class<?>[]
-		_restoreMessageAttachmentFromTrashParameterTypes32 = new Class[] {
+		_restoreMessageAttachmentFromTrashParameterTypes33 = new Class[] {
 			long.class, String.class
 		};
-	private static final Class<?>[] _subscribeMessageParameterTypes33 =
+	private static final Class<?>[] _subscribeMessageParameterTypes34 =
 		new Class[] {long.class};
-	private static final Class<?>[] _unsubscribeMessageParameterTypes34 =
+	private static final Class<?>[] _unsubscribeMessageParameterTypes35 =
 		new Class[] {long.class};
-	private static final Class<?>[] _updateAnswerParameterTypes35 =
+	private static final Class<?>[] _updateAnswerParameterTypes36 =
 		new Class[] {long.class, boolean.class, boolean.class};
-	private static final Class<?>[] _updateDiscussionMessageParameterTypes36 =
+	private static final Class<?>[] _updateDiscussionMessageParameterTypes37 =
 		new Class[] {
 			String.class, long.class, long.class, String.class, String.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateMessageParameterTypes37 =
+	private static final Class<?>[] _updateMessageParameterTypes38 =
 		new Class[] {
 			long.class, String.class, String.class, java.util.List.class,
 			double.class, boolean.class,

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageServiceImpl.java
@@ -670,6 +670,21 @@ public class MBMessageServiceImpl extends MBMessageServiceBaseImpl {
 	}
 
 	@Override
+	public MBMessage getMBMessageByExternalReferenceCode(
+			String externalReferenceCode, long groupId)
+		throws PortalException {
+
+		MBMessage mbMessage =
+			mbMessageLocalService.getMBMessageByExternalReferenceCode(
+				externalReferenceCode, groupId);
+
+		_messageModelResourcePermission.check(
+			getPermissionChecker(), mbMessage, ActionKeys.VIEW);
+
+		return mbMessage;
+	}
+
+	@Override
 	public MBMessage getMessage(long messageId) throws PortalException {
 		_messageModelResourcePermission.check(
 			getPermissionChecker(), messageId, ActionKeys.VIEW);

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/model/impl/WikiPageImpl.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/model/impl/WikiPageImpl.java
@@ -195,7 +195,7 @@ public class WikiPageImpl extends WikiPageBaseImpl {
 		FileEntry portletFileEntryByExternalReferenceCode =
 			PortletFileRepositoryUtil.
 				getPortletFileEntryByExternalReferenceCode(
-					groupId, externalReferenceCode);
+					externalReferenceCode, groupId);
 
 		long attachmentsFolderId = getAttachmentsFolderId();
 

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/src/main/resources/site-initializer/fragments/group/src/mdf-request-detail-collection/fragments/activities-list-panel/index.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/src/main/resources/site-initializer/fragments/group/src/mdf-request-detail-collection/fragments/activities-list-panel/index.js
@@ -284,8 +284,14 @@ export default function () {
 
 	const [loading, setLoading] = useState(true);
 
+	const findRequestIdUrl = (paramsUrl) => {
+		const splitParamsUrl = paramsUrl.split('?');
+
+		return splitParamsUrl[0];
+	};
+
 	const currentPath = Liferay.currentURL.split('/');
-	const mdfRequestId = +currentPath.at(-1);
+	const mdfRequestId = findRequestIdUrl(currentPath.at(-1));
 
 	useEffect(() => {
 		const getActivities = async () => {
@@ -314,7 +320,7 @@ export default function () {
 			});
 		};
 
-		if (mdfRequestId) {
+		if (!isNaN(mdfRequestId)) {
 			getActivities();
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/portal-kernel/src/com/liferay/portal/kernel/portletfilerepository/PortletFileRepository.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portletfilerepository/PortletFileRepository.java
@@ -153,7 +153,7 @@ public interface PortletFileRepository {
 		throws PortalException;
 
 	public FileEntry getPortletFileEntryByExternalReferenceCode(
-			long groupId, String externalReferenceCode)
+			String externalReferenceCode, long groupId)
 		throws PortalException;
 
 	public String getPortletFileEntryURL(

--- a/portal-kernel/src/com/liferay/portal/kernel/portletfilerepository/PortletFileRepositoryUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portletfilerepository/PortletFileRepositoryUtil.java
@@ -267,12 +267,12 @@ public class PortletFileRepositoryUtil {
 	}
 
 	public static FileEntry getPortletFileEntryByExternalReferenceCode(
-			long groupId, String externalReferenceCode)
+			String externalReferenceCode, long groupId)
 		throws PortalException {
 
 		return _portletFileRepository.
 			getPortletFileEntryByExternalReferenceCode(
-				groupId, externalReferenceCode);
+				externalReferenceCode, groupId);
 	}
 
 	public static String getPortletFileEntryURL(

--- a/portal-kernel/src/com/liferay/portal/kernel/portletfilerepository/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/portletfilerepository/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 5.0.0

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/ClayAlert.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/ClayAlert.path
@@ -25,11 +25,6 @@
 	<td>//div[@class='alert alert-${key_alertType}']//strong[contains(@class,'lead') and contains(text(), '${key_alertBold}')]</td>
 	<td></td>
 </tr>
-<tr>
-	<td>ALERT_TOAST_ICON</td>
-	<td>//*[@id='ToastAlertContainer']//*[@class='lexicon-icon lexicon-icon-${key_icon}']</td>
-	<td></td>
-</tr>
 </tbody>
 </table>
 </body>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/ClayAlert.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/ClayAlert.path
@@ -1,0 +1,36 @@
+<html>
+<head>
+<title>ClayAlert</title>
+</head>
+
+<body>
+<table border="1" cellpadding="1" cellspacing="1">
+<thead>
+<tr><td rowspan="1" colspan="3">ClayAlert</td></tr>
+</thead>
+
+<tbody>
+<tr>
+	<td>ALERT_STATIC</td>
+	<td>//div[@class='alert alert-${key_alertType}']</td>
+	<td></td>
+</tr>
+<tr>
+	<td>ALERT_STATIC_ICON</td>
+	<td>//div[@class='alert alert-${key_alertType}']//*[@class='lexicon-icon lexicon-icon-${key_icon}']</td>
+	<td></td>
+</tr>
+<tr>
+	<td>ALERT_STATIC_BOLD</td>
+	<td>//div[@class='alert alert-${key_alertType}']//strong[contains(@class,'lead') and contains(text(), '${key_alertBold}')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>ALERT_TOAST_ICON</td>
+	<td>//*[@id='ToastAlertContainer']//*[@class='lexicon-icon lexicon-icon-${key_icon}']</td>
+	<td></td>
+</tr>
+</tbody>
+</table>
+</body>
+</html>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/ClayAlertToast.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/ClayAlertToast.path
@@ -1,0 +1,36 @@
+<html>
+<head>
+<title>ClayAlertToast</title>
+</head>
+
+<body>
+<table border="1" cellpadding="1" cellspacing="1">
+<thead>
+<tr><td rowspan="1" colspan="3">ClayAlertToast</td></tr>
+</thead>
+
+<tbody>
+<tr>
+	<td>ALERT_STATIC</td>
+	<td>//div[@class='alert alert-${key_alertType}']</td>
+	<td></td>
+</tr>
+<tr>
+	<td>ALERT_STATIC_ICON</td>
+	<td>//div[@class='alert alert-${key_alertType}']//*[@class='lexicon-icon lexicon-icon-${key_icon}']</td>
+	<td></td>
+</tr>
+<tr>
+	<td>ALERT_STATIC_BOLD</td>
+	<td>//div[@class='alert alert-${key_alertType}']//strong[contains(@class,'lead') and contains(text(), '${key_alertBold}')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>ALERT_TOAST_ICON</td>
+	<td>//*[@id='ToastAlertContainer']//*[@class='lexicon-icon lexicon-icon-${key_icon}']</td>
+	<td></td>
+</tr>
+</tbody>
+</table>
+</body>
+</html>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/ClayAlertToast.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/ClayAlertToast.path
@@ -11,21 +11,6 @@
 
 <tbody>
 <tr>
-	<td>ALERT_STATIC</td>
-	<td>//div[@class='alert alert-${key_alertType}']</td>
-	<td></td>
-</tr>
-<tr>
-	<td>ALERT_STATIC_ICON</td>
-	<td>//div[@class='alert alert-${key_alertType}']//*[@class='lexicon-icon lexicon-icon-${key_icon}']</td>
-	<td></td>
-</tr>
-<tr>
-	<td>ALERT_STATIC_BOLD</td>
-	<td>//div[@class='alert alert-${key_alertType}']//strong[contains(@class,'lead') and contains(text(), '${key_alertBold}')]</td>
-	<td></td>
-</tr>
-<tr>
 	<td>ALERT_TOAST_ICON</td>
 	<td>//*[@id='ToastAlertContainer']//*[@class='lexicon-icon lexicon-icon-${key_icon}']</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
@@ -18,6 +18,11 @@ definition {
 		if ("${testPortalInstance}" == "true") {
 			PortalInstances.tearDownCP();
 		}
+		else {
+			JSONLayout.deletePublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page");
+		}
 	}
 
 	@description = "Verify toast message popup can be closed manually"

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
@@ -46,34 +46,31 @@ definition {
 			Navigator.gotoPage(pageName = "Clay Sample Test Page");
 		}
 
-		task ("When the alert contains all attributes then the alert displays status icon, type text, description text, close icon") {
-			Click(
-				key_text = "Success Submit",
-				locator1 = "Button#ANY");
-
-			AssertElementPresent(locator1 = "//*[@id='ToastAlertContainer']//*[@class='lexicon-icon lexicon-icon-check-circle-full']");
-
-			AssertTextEquals(
-				locator1 = "Message#SUCCESS_DISMISSIBLE",
-				value1 = "Success:Your request completed successfully.");
-
+		task ("When the alert contains all attributes") {
 			AssertElementPresent(
-				locator1 = "Message#SUCCESS_DISMISSIBLE",
-				value1 = "Icon#CLOSE_ALERT");
+				locator1 = "ClayAlertToast#ALERT_STATIC",
+				key_alertType = "success");
+		}
 
-			Click(
-				key_text = "Fail Submit",
-				locator1 = "Button#ANY");
-
-			AssertElementPresent(locator1 = "//*[@id='ToastAlertContainer']//*[@class='lexicon-icon lexicon-icon-exclamation-full']");
-
-			AssertTextEquals(
-				locator1 = "Message#ERROR_DISMISSIBLE",
-				value1 = "Error:An unexpected error occurred.");
-
+		task ("Then the alert displays status icon") {
 			AssertElementPresent(
-				locator1 = "Message#ERROR_DISMISSIBLE",
-				value1 = "Icon#CLOSE_ALERT");
+				locator1 = "ClayAlertToast#ALERT_STATIC_ICON",
+				key_alertType = "success",
+				key_icon = "check-circle-full");
+		}
+
+		task ("And displays type text") {
+			AssertElementPresent(
+				locator1 = "ClayAlertToast#ALERT_STATIC_BOLD",
+				key_alertType = "success",
+				key_alertBold = "Success");
+		}
+
+		task ("And displays description text") {
+			AssertTextEquals(
+				locator1 = "ClayAlertToast#ALERT_STATIC",
+				key_alertType = "success",
+				value1 = "Success:This is a success message.");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
@@ -48,28 +48,28 @@ definition {
 
 		task ("When the alert contains all attributes") {
 			AssertElementPresent(
-				locator1 = "ClayAlertToast#ALERT_STATIC",
-				key_alertType = "success");
+				key_alertType = "success",
+				locator1 = "ClayAlertToast#ALERT_STATIC");
 		}
 
 		task ("Then the alert displays status icon") {
 			AssertElementPresent(
-				locator1 = "ClayAlertToast#ALERT_STATIC_ICON",
 				key_alertType = "success",
-				key_icon = "check-circle-full");
+				key_icon = "check-circle-full",
+				locator1 = "ClayAlertToast#ALERT_STATIC_ICON");
 		}
 
 		task ("And displays type text") {
 			AssertElementPresent(
-				locator1 = "ClayAlertToast#ALERT_STATIC_BOLD",
+				key_alertBold = "Success",
 				key_alertType = "success",
-				key_alertBold = "Success");
+				locator1 = "ClayAlertToast#ALERT_STATIC_BOLD");
 		}
 
 		task ("And displays description text") {
 			AssertTextEquals(
-				locator1 = "ClayAlertToast#ALERT_STATIC",
 				key_alertType = "success",
+				locator1 = "ClayAlertToast#ALERT_STATIC",
 				value1 = "Success:This is a success message.");
 		}
 	}
@@ -97,23 +97,22 @@ definition {
 
 		task ("When alert contains status icon and keyword") {
 			AssertTextEquals(
-				locator1 = "ClayAlertToast#ALERT_STATIC",
 				key_alertType = "success",
+				locator1 = "ClayAlertToast#ALERT_STATIC",
 				value1 = "Success:This is a success message.");
 
 			AssertElementPresent(
-				locator1 = "ClayAlertToast#ALERT_STATIC_ICON",
 				key_alertType = "success",
-				key_icon = "check-circle-full");
+				key_icon = "check-circle-full",
+				locator1 = "ClayAlertToast#ALERT_STATIC_ICON");
 		}
 
 		task ("Then keyword must be semi-bold") {
 			AssertCssValue(
-				locator1 = "ClayAlertToast#ALERT_STATIC",
 				key_alertType = "success",
+				locator1 = "ClayAlertToast#ALERT_STATIC",
 				locator2 = "font-weight",
-				value1 = "400"
-			);
+				value1 = "400");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
@@ -79,4 +79,45 @@ definition {
 		AssertElementNotPresent(locator1 = "Message#SUCCESS_DISMISSIBLE");
 	}
 
+	@description = "Verify if the keyword is semi-bold when alert contains status icon and keyword"
+	@priority = "4"
+	test KeywordCanDisplayInSemibold {
+		task ("Given Clay Sample Portlet") {
+			JSONLayout.addPublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page");
+		
+			JSONLayout.updateLayoutTemplateOfPublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page",
+				layoutTemplate = "1 Column");
+		
+			JSONLayout.addWidgetToPublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page",
+				widgetName = "Clay Sample");
+
+			Navigator.gotoPage(pageName = "Clay Sample Test Page");
+		}
+
+		task ("When alert contains status icon and keyword Then keyword must be semi-bold") {
+			Click(
+				locator1 = "Button#ANY",
+				key_text = "Success Submit");
+
+			AssertCssValue(
+				locator1 = "Message#SUCCESS_DISMISSIBLE",
+				locator2 = "font-weight",
+				value1 = "400");
+			
+			Click(
+				locator1 = "Button#ANY",
+				key_text = "Fail Submit");
+			
+			AssertCssValue(
+				locator1 = "Message#ERROR_DISMISSIBLE",
+				locator2 = "font-weight",
+				value1 = "400");
+		}
+	}
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
@@ -49,27 +49,27 @@ definition {
 		task ("When the alert contains all attributes") {
 			AssertElementPresent(
 				key_alertType = "success",
-				locator1 = "ClayAlertToast#ALERT_STATIC");
+				locator1 = "ClayAlert#ALERT_STATIC");
 		}
 
 		task ("Then the alert displays status icon") {
 			AssertElementPresent(
 				key_alertType = "success",
 				key_icon = "check-circle-full",
-				locator1 = "ClayAlertToast#ALERT_STATIC_ICON");
+				locator1 = "ClayAlert#ALERT_STATIC_ICON");
 		}
 
 		task ("And displays type text") {
 			AssertElementPresent(
 				key_alertBold = "Success",
 				key_alertType = "success",
-				locator1 = "ClayAlertToast#ALERT_STATIC_BOLD");
+				locator1 = "ClayAlert#ALERT_STATIC_BOLD");
 		}
 
 		task ("And displays description text") {
 			AssertTextEquals(
 				key_alertType = "success",
-				locator1 = "ClayAlertToast#ALERT_STATIC",
+				locator1 = "ClayAlert#ALERT_STATIC",
 				value1 = "Success:This is a success message.");
 		}
 	}
@@ -98,19 +98,19 @@ definition {
 		task ("When alert contains status icon and keyword") {
 			AssertTextEquals(
 				key_alertType = "success",
-				locator1 = "ClayAlertToast#ALERT_STATIC",
+				locator1 = "ClayAlert#ALERT_STATIC",
 				value1 = "Success:This is a success message.");
 
 			AssertElementPresent(
 				key_alertType = "success",
 				key_icon = "check-circle-full",
-				locator1 = "ClayAlertToast#ALERT_STATIC_ICON");
+				locator1 = "ClayAlert#ALERT_STATIC_ICON");
 		}
 
 		task ("Then keyword must be semi-bold") {
 			AssertCssValue(
 				key_alertType = "success",
-				locator1 = "ClayAlertToast#ALERT_STATIC",
+				locator1 = "ClayAlert#ALERT_STATIC",
 				locator2 = "font-weight",
 				value1 = "400");
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
@@ -98,24 +98,25 @@ definition {
 			Navigator.gotoPage(pageName = "Clay Sample Test Page");
 		}
 
-		task ("When alert contains status icon and keyword Then keyword must be semi-bold") {
-			Click(
-				key_text = "Success Submit",
-				locator1 = "Button#ANY");
+		task ("When alert contains status icon and keyword") {
+			AssertTextEquals(
+				locator1 = "ClayAlertToast#ALERT_STATIC",
+				key_alertType = "success",
+				value1 = "Success:This is a success message.");
 
+			AssertElementPresent(
+				locator1 = "ClayAlertToast#ALERT_STATIC_ICON",
+				key_alertType = "success",
+				key_icon = "check-circle-full");
+		}
+
+		task ("Then keyword must be semi-bold") {
 			AssertCssValue(
-				locator1 = "Message#SUCCESS_DISMISSIBLE",
+				locator1 = "ClayAlertToast#ALERT_STATIC",
+				key_alertType = "success",
 				locator2 = "font-weight",
-				value1 = "400");
-
-			Click(
-				key_text = "Fail Submit",
-				locator1 = "Button#ANY");
-
-			AssertCssValue(
-				locator1 = "Message#ERROR_DISMISSIBLE",
-				locator2 = "font-weight",
-				value1 = "400");
+				value1 = "400"
+			);
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
@@ -10,24 +10,7 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
-	}
 
-	tearDown {
-		var testPortalInstance = PropsUtil.get("test.portal.instance");
-
-		if ("${testPortalInstance}" == "true") {
-			PortalInstances.tearDownCP();
-		}
-		else {
-			JSONLayout.deletePublicLayout(
-				groupName = "Guest",
-				layoutName = "Clay Sample Test Page");
-		}
-	}
-
-	@description = "Verify if alert contains all attributes: icon, type text, description and close icon"
-	@priority = "5"
-	test CanDisplayAllAttributes {
 		task ("Given Clay Sample Portlet") {
 			JSONLayout.addPublicLayout(
 				groupName = "Guest",
@@ -45,9 +28,26 @@ definition {
 
 			Navigator.gotoPage(pageName = "Clay Sample Test Page");
 		}
+	}
 
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if ("${testPortalInstance}" == "true") {
+			PortalInstances.tearDownCP();
+		}
+		else {
+			JSONLayout.deletePublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page");
+		}
+	}
+
+	@description = "Verify alert contains all required attributes: icon, type text, and description"
+	@priority = "5"
+	test CanDisplayAllAttributes {
 		task ("When the alert contains all attributes") {
-			AssertElementPresent(
+			VerifyElementPresent(
 				key_alertType = "success",
 				locator1 = "ClayAlert#ALERT_STATIC");
 		}
@@ -74,34 +74,16 @@ definition {
 		}
 	}
 
-	@description = "Verify if the keyword is semi-bold when alert contains status icon and keyword"
+	@description = "Verify the keyword is semi-bold when alert contains status icon and keyword"
 	@priority = "4"
 	test KeywordCanDisplayInSemibold {
-		task ("Given Clay Sample Portlet") {
-			JSONLayout.addPublicLayout(
-				groupName = "Guest",
-				layoutName = "Clay Sample Test Page");
-
-			JSONLayout.updateLayoutTemplateOfPublicLayout(
-				groupName = "Guest",
-				layoutName = "Clay Sample Test Page",
-				layoutTemplate = "1 Column");
-
-			JSONLayout.addWidgetToPublicLayout(
-				groupName = "Guest",
-				layoutName = "Clay Sample Test Page",
-				widgetName = "Clay Sample");
-
-			Navigator.gotoPage(pageName = "Clay Sample Test Page");
-		}
-
 		task ("When alert contains status icon and keyword") {
 			AssertTextEquals(
 				key_alertType = "success",
 				locator1 = "ClayAlert#ALERT_STATIC",
 				value1 = "Success:This is a success message.");
 
-			AssertElementPresent(
+			VerifyElementPresent(
 				key_alertType = "success",
 				key_icon = "check-circle-full",
 				locator1 = "ClayAlert#ALERT_STATIC_ICON");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
@@ -25,6 +25,100 @@ definition {
 		}
 	}
 
+	@description = "Verify if alert contains all attributes: icon, type text, description and close icon"
+	@priority = "5"
+	test CanDisplayAllAttributes {
+		task ("Given Clay Sample Portlet") {
+			JSONLayout.addPublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page");
+
+			JSONLayout.updateLayoutTemplateOfPublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page",
+				layoutTemplate = "1 Column");
+
+			JSONLayout.addWidgetToPublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page",
+				widgetName = "Clay Sample");
+
+			Navigator.gotoPage(pageName = "Clay Sample Test Page");
+		}
+
+		task ("When the alert contains all attributes then the alert displays status icon, type text, description text, close icon") {
+			Click(
+				key_text = "Success Submit",
+				locator1 = "Button#ANY");
+
+			AssertElementPresent(locator1 = "//*[@id='ToastAlertContainer']//*[@class='lexicon-icon lexicon-icon-check-circle-full']");
+
+			AssertTextEquals(
+				locator1 = "Message#SUCCESS_DISMISSIBLE",
+				value1 = "Success:Your request completed successfully.");
+
+			AssertElementPresent(
+				locator1 = "Message#SUCCESS_DISMISSIBLE",
+				value1 = "Icon#CLOSE_ALERT");
+
+			Click(
+				key_text = "Fail Submit",
+				locator1 = "Button#ANY");
+
+			AssertElementPresent(locator1 = "//*[@id='ToastAlertContainer']//*[@class='lexicon-icon lexicon-icon-exclamation-full']");
+
+			AssertTextEquals(
+				locator1 = "Message#ERROR_DISMISSIBLE",
+				value1 = "Error:An unexpected error occurred.");
+
+			AssertElementPresent(
+				locator1 = "Message#ERROR_DISMISSIBLE",
+				value1 = "Icon#CLOSE_ALERT");
+		}
+	}
+
+	@description = "Verify if the keyword is semi-bold when alert contains status icon and keyword"
+	@priority = "4"
+	test KeywordCanDisplayInSemibold {
+		task ("Given Clay Sample Portlet") {
+			JSONLayout.addPublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page");
+
+			JSONLayout.updateLayoutTemplateOfPublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page",
+				layoutTemplate = "1 Column");
+
+			JSONLayout.addWidgetToPublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page",
+				widgetName = "Clay Sample");
+
+			Navigator.gotoPage(pageName = "Clay Sample Test Page");
+		}
+
+		task ("When alert contains status icon and keyword Then keyword must be semi-bold") {
+			Click(
+				key_text = "Success Submit",
+				locator1 = "Button#ANY");
+
+			AssertCssValue(
+				locator1 = "Message#SUCCESS_DISMISSIBLE",
+				locator2 = "font-weight",
+				value1 = "400");
+
+			Click(
+				key_text = "Fail Submit",
+				locator1 = "Button#ANY");
+
+			AssertCssValue(
+				locator1 = "Message#ERROR_DISMISSIBLE",
+				locator2 = "font-weight",
+				value1 = "400");
+		}
+	}
+
 	@description = "Verify toast message popup can be closed manually"
 	@priority = "3"
 	@refactordone
@@ -84,97 +178,4 @@ definition {
 		AssertElementNotPresent(locator1 = "Message#SUCCESS_DISMISSIBLE");
 	}
 
-	@description = "Verify if the keyword is semi-bold when alert contains status icon and keyword"
-	@priority = "4"
-	test KeywordCanDisplayInSemibold {
-		task ("Given Clay Sample Portlet") {
-			JSONLayout.addPublicLayout(
-				groupName = "Guest",
-				layoutName = "Clay Sample Test Page");
-		
-			JSONLayout.updateLayoutTemplateOfPublicLayout(
-				groupName = "Guest",
-				layoutName = "Clay Sample Test Page",
-				layoutTemplate = "1 Column");
-		
-			JSONLayout.addWidgetToPublicLayout(
-				groupName = "Guest",
-				layoutName = "Clay Sample Test Page",
-				widgetName = "Clay Sample");
-
-			Navigator.gotoPage(pageName = "Clay Sample Test Page");
-		}
-
-		task ("When alert contains status icon and keyword Then keyword must be semi-bold") {
-			Click(
-				locator1 = "Button#ANY",
-				key_text = "Success Submit");
-
-			AssertCssValue(
-				locator1 = "Message#SUCCESS_DISMISSIBLE",
-				locator2 = "font-weight",
-				value1 = "400");
-			
-			Click(
-				locator1 = "Button#ANY",
-				key_text = "Fail Submit");
-			
-			AssertCssValue(
-				locator1 = "Message#ERROR_DISMISSIBLE",
-				locator2 = "font-weight",
-				value1 = "400");
-		}
-	}
-
-	@description = "Verify if alert contains all attributes: icon, type text, description and close icon"
-	@priority = "5"
-	test CanDisplayAllAttributes {
-		task ("Given Clay Sample Portlet") {
-			JSONLayout.addPublicLayout(
-				groupName = "Guest",
-				layoutName = "Clay Sample Test Page");
-		
-			JSONLayout.updateLayoutTemplateOfPublicLayout(
-				groupName = "Guest",
-				layoutName = "Clay Sample Test Page",
-				layoutTemplate = "1 Column");
-		
-			JSONLayout.addWidgetToPublicLayout(
-				groupName = "Guest",
-				layoutName = "Clay Sample Test Page",
-				widgetName = "Clay Sample");
-
-			Navigator.gotoPage(pageName = "Clay Sample Test Page");
-		}
-
-		task ("When the alert contains all attributes then the alert displays status icon, type text, description text, close icon") {
-			Click(
-				locator1 = "Button#ANY",
-				key_text = "Success Submit");
-			
-			AssertElementPresent(locator1 = "//*[@id='ToastAlertContainer']//*[@class='lexicon-icon lexicon-icon-check-circle-full']");
-			
-			AssertTextEquals(
-				locator1 = "Message#SUCCESS_DISMISSIBLE",
-				value1 = "Success:Your request completed successfully.");
-
-			AssertElementPresent(
-				locator1 = "Message#SUCCESS_DISMISSIBLE",
-				value1 = "Icon#CLOSE_ALERT");
-
-			Click(
-				locator1 = "Button#ANY",
-				key_text = "Fail Submit");
-
-			AssertElementPresent(locator1 = "//*[@id='ToastAlertContainer']//*[@class='lexicon-icon lexicon-icon-exclamation-full']");
-
-			AssertTextEquals(
-				locator1 = "Message#ERROR_DISMISSIBLE",
-				value1 = "Error:An unexpected error occurred.");
-
-			AssertElementPresent(
-				locator1 = "Message#ERROR_DISMISSIBLE",
-				value1 = "Icon#CLOSE_ALERT");
-		}
-	}
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
@@ -120,4 +120,56 @@ definition {
 				value1 = "400");
 		}
 	}
+
+	@description = "Verify if alert contains all attributes: icon, type text, description and close icon"
+	@priority = "5"
+	test CanDisplayAllAttributes {
+		task ("Given Clay Sample Portlet") {
+			JSONLayout.addPublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page");
+		
+			JSONLayout.updateLayoutTemplateOfPublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page",
+				layoutTemplate = "1 Column");
+		
+			JSONLayout.addWidgetToPublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page",
+				widgetName = "Clay Sample");
+
+			Navigator.gotoPage(pageName = "Clay Sample Test Page");
+		}
+
+		task ("When the alert contains all attributes then the alert displays status icon, type text, description text, close icon") {
+			Click(
+				locator1 = "Button#ANY",
+				key_text = "Success Submit");
+			
+			AssertElementPresent(locator1 = "//*[@id='ToastAlertContainer']//*[@class='lexicon-icon lexicon-icon-check-circle-full']");
+			
+			AssertTextEquals(
+				locator1 = "Message#SUCCESS_DISMISSIBLE",
+				value1 = "Success:Your request completed successfully.");
+
+			AssertElementPresent(
+				locator1 = "Message#SUCCESS_DISMISSIBLE",
+				value1 = "Icon#CLOSE_ALERT");
+
+			Click(
+				locator1 = "Button#ANY",
+				key_text = "Fail Submit");
+
+			AssertElementPresent(locator1 = "//*[@id='ToastAlertContainer']//*[@class='lexicon-icon lexicon-icon-exclamation-full']");
+
+			AssertTextEquals(
+				locator1 = "Message#ERROR_DISMISSIBLE",
+				value1 = "Error:An unexpected error occurred.");
+
+			AssertElementPresent(
+				locator1 = "Message#ERROR_DISMISSIBLE",
+				value1 = "Icon#CLOSE_ALERT");
+		}
+	}
 }


### PR DESCRIPTION
## Main Objective
The main of this PR is to expose `externalReferenceCode` in MessageBoardAttachment. For that reason I have made some changes in the service part and in the API part.

**What is new?**
- Expose **External Reference Code** in `MessageBoardAttachment`.
- Endpoint implementation of `GET` and `DELETE` by **External Reference Code**.
- Including some tests in API part.
- Implement new exception: `MessageBoardAttachmentException`.
- Making some change `PortletFileRepository` swapping `groupId` and `exteranlReferenceCode` following the new model of implementation in the same way with entities.
- Create `getAttachmentsFileEntryByExternalReferenceCode` method in MBMessage implementation 
- Brian request changes in https://github.com/brianchandotcom/liferay-portal/pull/127510#issuecomment-1346611861
- Rename `userAccountExternalReferenceCode` in Headless Admin User API just to maintain the homogeneity: https://github.com/brianchandotcom/liferay-portal/pull/127651

## SERVICE
This PR supports the implementation of external reference code in `PortletFileRepository` service to be able to GET and DELETE by external reference code. 


## API
In the API section, this PR contains the new endpoints to operate using the ERC:

![image](https://user-images.githubusercontent.com/44723449/194241440-2961f8ff-cbff-408c-a6ce-3e367902dd9f.png)

To see this new endpoint you have to follow these steps:

1. Deploy `message-board-api` and `message-board-service` in this order. 
2. Deploy `headless-delivery-api` and `headless-delivery-impl` in this order.
3. Go to `/o/api`
4. Go to `MessageBoardAttachment`


**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-164284


 
