### PR TITLE
LPS-170938: Remove duplicate logic in ObjectEntryResourceTest

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -98,323 +98,142 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
-	public void testDeleteManyToManyCustomObjectDefinition1WithCustomObjectDefinition2()
+	public void testDeleteCustomObjectDefinition1WithCustomObjectDefinition2()
 		throws Exception {
 
-		String name = StringUtil.randomId();
+		Long irrelevantCurrentObjectId = RandomTestUtil.randomLong();
 
 		_objectRelationship = _addObjectRelationship(
-			name, _objectEntry1.getPrimaryKey(), _objectEntry2.getPrimaryKey(),
+			StringUtil.randomId(), _objectEntry1.getPrimaryKey(),
+			_objectEntry2.getPrimaryKey(),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
-		JSONObject jsonObject = HTTPTestUtil.invoke(
-			null,
-			com.liferay.petra.string.StringBundler.concat(
-				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
-				_objectEntry1.getPrimaryKey(), StringPool.SLASH,
-				_objectRelationship.getName()),
-			Http.Method.GET);
-
-		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
-
-		Assert.assertEquals(1, itemsJSONArray.length());
-
-		HTTPTestUtil.invoke(
-			null,
+		_testDeleteOneToManyAndManyToManyCustomObjectWithCustomObject(
 			com.liferay.petra.string.StringBundler.concat(
 				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
 				_objectEntry1.getPrimaryKey(), StringPool.SLASH,
 				_objectRelationship.getName(), StringPool.SLASH,
 				_objectEntry2.getPrimaryKey()),
-			Http.Method.DELETE);
-
-		jsonObject = HTTPTestUtil.invoke(
-			null,
 			com.liferay.petra.string.StringBundler.concat(
 				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
 				_objectEntry1.getPrimaryKey(), StringPool.SLASH,
-				_objectRelationship.getName()),
-			Http.Method.GET);
-
-		itemsJSONArray = jsonObject.getJSONArray("items");
-
-		Assert.assertEquals(0, itemsJSONArray.length());
-	}
-
-	@Test
-	public void testDeleteManyToManyCustomObjectDefinition2WithCustomObjectDefinition1()
-		throws Exception {
-
-		String name = StringUtil.randomId();
+				_objectRelationship.getName()));
 
 		_objectRelationship = _addObjectRelationship(
-			name, _objectEntry1.getPrimaryKey(), _objectEntry2.getPrimaryKey(),
+			StringUtil.randomId(), _objectEntry1.getPrimaryKey(),
+			_objectEntry2.getPrimaryKey(),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
-		JSONObject jsonObject = HTTPTestUtil.invoke(
-			null,
-			com.liferay.petra.string.StringBundler.concat(
-				_objectDefinition2.getRESTContextPath(), StringPool.SLASH,
-				_objectEntry2.getPrimaryKey(), StringPool.SLASH,
-				_objectRelationship.getName()),
-			Http.Method.GET);
-
-		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
-
-		Assert.assertEquals(1, itemsJSONArray.length());
-
-		HTTPTestUtil.invoke(
-			null,
+		_testDeleteOneToManyAndManyToManyCustomObjectWithCustomObject(
 			com.liferay.petra.string.StringBundler.concat(
 				_objectDefinition2.getRESTContextPath(), StringPool.SLASH,
 				_objectEntry2.getPrimaryKey(), StringPool.SLASH,
 				_objectRelationship.getName(), StringPool.SLASH,
 				_objectEntry1.getPrimaryKey()),
-			Http.Method.DELETE);
-
-		jsonObject = HTTPTestUtil.invoke(
-			null,
 			com.liferay.petra.string.StringBundler.concat(
 				_objectDefinition2.getRESTContextPath(), StringPool.SLASH,
 				_objectEntry2.getPrimaryKey(), StringPool.SLASH,
-				_objectRelationship.getName()),
-			Http.Method.GET);
-
-		itemsJSONArray = jsonObject.getJSONArray("items");
-
-		Assert.assertEquals(0, itemsJSONArray.length());
-	}
-
-	@Test
-	public void testDeleteManyToManyCustomObjectDefinition2WithCustomObjectDefinition1NotFound()
-		throws Exception {
-
-		Long irrelevantCurrentObjectId = RandomTestUtil.randomLong();
-
-		String name = StringUtil.randomId();
+				_objectRelationship.getName()));
 
 		_objectRelationship = _addObjectRelationship(
-			name, _objectEntry1.getPrimaryKey(), _objectEntry2.getPrimaryKey(),
+			StringUtil.randomId(), _objectEntry1.getPrimaryKey(),
+			_objectEntry2.getPrimaryKey(),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
-		JSONObject jsonObject = HTTPTestUtil.invoke(
-			null,
+		_testDeleteOneToManyAndManyToManyCustomObjectWithCustomObjectNotFound(
 			com.liferay.petra.string.StringBundler.concat(
 				_objectDefinition2.getRESTContextPath(), StringPool.SLASH,
 				irrelevantCurrentObjectId, StringPool.SLASH,
 				_objectRelationship.getName(), StringPool.SLASH,
 				_objectEntry1.getPrimaryKey()),
-			Http.Method.DELETE);
-
-		Assert.assertEquals("NOT_FOUND", jsonObject.getString("status"));
-
-		jsonObject = HTTPTestUtil.invoke(
-			null,
 			com.liferay.petra.string.StringBundler.concat(
 				_objectDefinition2.getRESTContextPath(), StringPool.SLASH,
 				_objectEntry2.getPrimaryKey(), StringPool.SLASH,
 				_objectRelationship.getName(), StringPool.SLASH,
 				irrelevantCurrentObjectId),
-			Http.Method.DELETE);
-
-		Assert.assertEquals("NOT_FOUND", jsonObject.getString("status"));
-
-		jsonObject = HTTPTestUtil.invoke(
-			null,
 			com.liferay.petra.string.StringBundler.concat(
 				_objectDefinition2.getRESTContextPath(), StringPool.SLASH,
 				_objectEntry2.getPrimaryKey(), StringPool.SLASH,
-				_objectRelationship.getName()),
-			Http.Method.GET);
-
-		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
-
-		Assert.assertEquals(1, itemsJSONArray.length());
-	}
-
-	@Test
-	public void testDeleteManyToManyCustomObjectDefinitionWithCustomObjectDefinition2NotFound()
-		throws Exception {
-
-		Long irrelevantCurrentObjectId = RandomTestUtil.randomLong();
-
-		String name = StringUtil.randomId();
+				_objectRelationship.getName()));
 
 		_objectRelationship = _addObjectRelationship(
-			name, _objectEntry1.getPrimaryKey(), _objectEntry2.getPrimaryKey(),
+			StringUtil.randomId(), _objectEntry1.getPrimaryKey(),
+			_objectEntry2.getPrimaryKey(),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
-		JSONObject jsonObject = HTTPTestUtil.invoke(
-			null,
+		_testDeleteOneToManyAndManyToManyCustomObjectWithCustomObjectNotFound(
 			com.liferay.petra.string.StringBundler.concat(
 				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
 				irrelevantCurrentObjectId, StringPool.SLASH,
 				_objectRelationship.getName(), StringPool.SLASH,
 				_objectEntry2.getPrimaryKey()),
-			Http.Method.DELETE);
-
-		Assert.assertEquals("NOT_FOUND", jsonObject.getString("status"));
-
-		jsonObject = HTTPTestUtil.invoke(
-			null,
 			com.liferay.petra.string.StringBundler.concat(
 				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
 				_objectEntry1.getPrimaryKey(), StringPool.SLASH,
 				_objectRelationship.getName(), StringPool.SLASH,
 				irrelevantCurrentObjectId),
-			Http.Method.DELETE);
-
-		Assert.assertEquals("NOT_FOUND", jsonObject.getString("status"));
-
-		jsonObject = HTTPTestUtil.invoke(
-			null,
 			com.liferay.petra.string.StringBundler.concat(
 				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
 				_objectEntry1.getPrimaryKey(), StringPool.SLASH,
-				_objectRelationship.getName()),
-			Http.Method.GET);
-
-		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
-
-		Assert.assertEquals(1, itemsJSONArray.length());
-	}
-
-	@Test
-	public void testDeleteOneToManyCustomObjectDefinition1WithCustomObjectDefinition2()
-		throws Exception {
-
-		String name = StringUtil.randomId();
+				_objectRelationship.getName()));
 
 		_objectRelationship = _addObjectRelationship(
-			name, _objectEntry1.getPrimaryKey(), _objectEntry2.getPrimaryKey(),
+			StringUtil.randomId(), _objectEntry1.getPrimaryKey(),
+			_objectEntry2.getPrimaryKey(),
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
-		JSONObject jsonObject = HTTPTestUtil.invoke(
-			null,
-			com.liferay.petra.string.StringBundler.concat(
-				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
-				_objectEntry1.getPrimaryKey(), StringPool.SLASH,
-				_objectRelationship.getName()),
-			Http.Method.GET);
-
-		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
-
-		Assert.assertEquals(1, itemsJSONArray.length());
-
-		HTTPTestUtil.invoke(
-			null,
+		_testDeleteOneToManyAndManyToManyCustomObjectWithCustomObject(
 			com.liferay.petra.string.StringBundler.concat(
 				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
 				_objectEntry1.getPrimaryKey(), StringPool.SLASH,
 				_objectRelationship.getName(), StringPool.SLASH,
 				_objectEntry2.getPrimaryKey()),
-			Http.Method.DELETE);
-
-		jsonObject = HTTPTestUtil.invoke(
-			null,
 			com.liferay.petra.string.StringBundler.concat(
 				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
 				_objectEntry1.getPrimaryKey(), StringPool.SLASH,
-				_objectRelationship.getName()),
-			Http.Method.GET);
-
-		itemsJSONArray = jsonObject.getJSONArray("items");
-
-		Assert.assertEquals(0, itemsJSONArray.length());
-	}
-
-	@Test
-	public void testDeleteOneToManyCustomObjectDefinition1WithCustomObjectDefinition2NotFound()
-		throws Exception {
-
-		Long irrelevantCurrentObjectId = RandomTestUtil.randomLong();
-
-		String name = StringUtil.randomId();
+				_objectRelationship.getName()));
 
 		_objectRelationship = _addObjectRelationship(
-			name, _objectEntry1.getPrimaryKey(), _objectEntry2.getPrimaryKey(),
+			StringUtil.randomId(), _objectEntry1.getPrimaryKey(),
+			_objectEntry2.getPrimaryKey(),
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
-		JSONObject jsonObject = HTTPTestUtil.invoke(
-			null,
+		_testDeleteOneToManyAndManyToManyCustomObjectWithCustomObjectNotFound(
 			com.liferay.petra.string.StringBundler.concat(
 				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
 				irrelevantCurrentObjectId, StringPool.SLASH,
 				_objectRelationship.getName(), StringPool.SLASH,
 				_objectEntry2.getPrimaryKey()),
-			Http.Method.DELETE);
-
-		Assert.assertEquals("NOT_FOUND", jsonObject.getString("status"));
-
-		jsonObject = HTTPTestUtil.invoke(
-			null,
 			com.liferay.petra.string.StringBundler.concat(
 				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
 				_objectEntry1.getPrimaryKey(), StringPool.SLASH,
 				_objectRelationship.getName(), StringPool.SLASH,
 				irrelevantCurrentObjectId),
-			Http.Method.DELETE);
-
-		Assert.assertEquals("NOT_FOUND", jsonObject.getString("status"));
-
-		jsonObject = HTTPTestUtil.invoke(
-			null,
 			com.liferay.petra.string.StringBundler.concat(
 				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
 				_objectEntry1.getPrimaryKey(), StringPool.SLASH,
-				_objectRelationship.getName()),
-			Http.Method.GET);
-
-		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
-
-		Assert.assertEquals(1, itemsJSONArray.length());
-	}
-
-	@Test
-	public void testDeleteOneToManyCustomObjectDefinition2WithCustomObjectDefinition1NotFound()
-		throws Exception {
-
-		Long irrelevantCurrentObjectId = RandomTestUtil.randomLong();
-
-		String name = StringUtil.randomId();
+				_objectRelationship.getName()));
 
 		_objectRelationship = _addObjectRelationship(
-			name, _objectEntry1.getPrimaryKey(), _objectEntry2.getPrimaryKey(),
+			StringUtil.randomId(), _objectEntry1.getPrimaryKey(),
+			_objectEntry2.getPrimaryKey(),
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
-		JSONObject jsonObject = HTTPTestUtil.invoke(
-			null,
+		_testDeleteOneToManyAndManyToManyCustomObjectWithCustomObjectNotFound(
 			com.liferay.petra.string.StringBundler.concat(
 				_objectDefinition2.getRESTContextPath(), StringPool.SLASH,
 				irrelevantCurrentObjectId, StringPool.SLASH,
 				_objectRelationship.getName(), StringPool.SLASH,
 				_objectEntry1.getPrimaryKey()),
-			Http.Method.DELETE);
-
-		Assert.assertEquals("NOT_FOUND", jsonObject.getString("status"));
-
-		jsonObject = HTTPTestUtil.invoke(
-			null,
 			com.liferay.petra.string.StringBundler.concat(
 				_objectDefinition2.getRESTContextPath(), StringPool.SLASH,
 				_objectEntry2.getPrimaryKey(), StringPool.SLASH,
 				_objectRelationship.getName(), StringPool.SLASH,
 				irrelevantCurrentObjectId),
-			Http.Method.DELETE);
-
-		Assert.assertEquals("NOT_FOUND", jsonObject.getString("status"));
-
-		jsonObject = HTTPTestUtil.invoke(
-			null,
 			com.liferay.petra.string.StringBundler.concat(
 				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
 				_objectEntry1.getPrimaryKey(), StringPool.SLASH,
-				_objectRelationship.getName()),
-			Http.Method.GET);
-
-		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
-
-		Assert.assertEquals(1, itemsJSONArray.length());
+				_objectRelationship.getName()));
 	}
 
 	@Test
@@ -572,6 +391,49 @@ public class ObjectEntryResourceTest {
 			objectRelationship, TestPropsValues.getUserId());
 
 		return objectRelationship;
+	}
+
+	private void _testDeleteOneToManyAndManyToManyCustomObjectWithCustomObject(
+			String deleteEndpoint, String getEndpoint)
+		throws Exception {
+
+		JSONObject jsonObject = HTTPTestUtil.invoke(
+			null, getEndpoint, Http.Method.GET);
+
+		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
+
+		Assert.assertEquals(1, itemsJSONArray.length());
+
+		HTTPTestUtil.invoke(null, deleteEndpoint, Http.Method.DELETE);
+
+		jsonObject = HTTPTestUtil.invoke(null, getEndpoint, Http.Method.GET);
+
+		itemsJSONArray = jsonObject.getJSONArray("items");
+
+		Assert.assertEquals(0, itemsJSONArray.length());
+	}
+
+	private void
+			_testDeleteOneToManyAndManyToManyCustomObjectWithCustomObjectNotFound(
+				String deleteEndpoint1, String deleteEndpoint2,
+				String getEndpoint)
+		throws Exception {
+
+		JSONObject jsonObject = HTTPTestUtil.invoke(
+			null, deleteEndpoint1, Http.Method.DELETE);
+
+		Assert.assertEquals("NOT_FOUND", jsonObject.getString("status"));
+
+		jsonObject = HTTPTestUtil.invoke(
+			null, deleteEndpoint2, Http.Method.DELETE);
+
+		Assert.assertEquals("NOT_FOUND", jsonObject.getString("status"));
+
+		jsonObject = HTTPTestUtil.invoke(null, getEndpoint, Http.Method.GET);
+
+		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
+
+		Assert.assertEquals(1, itemsJSONArray.length());
 	}
 
 	private void _testGetNestedFieldDetailsInOneToManyRelationships(

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/src/main/resources/site-initializer/fragments/group/src/mdf-request-detail-collection/fragments/activities-list-panel/index.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/src/main/resources/site-initializer/fragments/group/src/mdf-request-detail-collection/fragments/activities-list-panel/index.js
@@ -284,8 +284,14 @@ export default function () {
 
 	const [loading, setLoading] = useState(true);
 
+	const findRequestIdUrl = (paramsUrl) => {
+		const splitParamsUrl = paramsUrl.split('?');
+
+		return splitParamsUrl[0];
+	};
+
 	const currentPath = Liferay.currentURL.split('/');
-	const mdfRequestId = +currentPath.at(-1);
+	const mdfRequestId = findRequestIdUrl(currentPath.at(-1));
 
 	useEffect(() => {
 		const getActivities = async () => {
@@ -314,7 +320,7 @@ export default function () {
 			});
 		};
 
-		if (mdfRequestId) {
+		if (!isNaN(mdfRequestId)) {
 			getActivities();
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/ClayAlert.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/ClayAlert.path
@@ -25,11 +25,6 @@
 	<td>//div[@class='alert alert-${key_alertType}']//strong[contains(@class,'lead') and contains(text(), '${key_alertBold}')]</td>
 	<td></td>
 </tr>
-<tr>
-	<td>ALERT_TOAST_ICON</td>
-	<td>//*[@id='ToastAlertContainer']//*[@class='lexicon-icon lexicon-icon-${key_icon}']</td>
-	<td></td>
-</tr>
 </tbody>
 </table>
 </body>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/ClayAlert.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/ClayAlert.path
@@ -1,0 +1,36 @@
+<html>
+<head>
+<title>ClayAlert</title>
+</head>
+
+<body>
+<table border="1" cellpadding="1" cellspacing="1">
+<thead>
+<tr><td rowspan="1" colspan="3">ClayAlert</td></tr>
+</thead>
+
+<tbody>
+<tr>
+	<td>ALERT_STATIC</td>
+	<td>//div[@class='alert alert-${key_alertType}']</td>
+	<td></td>
+</tr>
+<tr>
+	<td>ALERT_STATIC_ICON</td>
+	<td>//div[@class='alert alert-${key_alertType}']//*[@class='lexicon-icon lexicon-icon-${key_icon}']</td>
+	<td></td>
+</tr>
+<tr>
+	<td>ALERT_STATIC_BOLD</td>
+	<td>//div[@class='alert alert-${key_alertType}']//strong[contains(@class,'lead') and contains(text(), '${key_alertBold}')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>ALERT_TOAST_ICON</td>
+	<td>//*[@id='ToastAlertContainer']//*[@class='lexicon-icon lexicon-icon-${key_icon}']</td>
+	<td></td>
+</tr>
+</tbody>
+</table>
+</body>
+</html>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/ClayAlertToast.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/ClayAlertToast.path
@@ -1,0 +1,36 @@
+<html>
+<head>
+<title>ClayAlertToast</title>
+</head>
+
+<body>
+<table border="1" cellpadding="1" cellspacing="1">
+<thead>
+<tr><td rowspan="1" colspan="3">ClayAlertToast</td></tr>
+</thead>
+
+<tbody>
+<tr>
+	<td>ALERT_STATIC</td>
+	<td>//div[@class='alert alert-${key_alertType}']</td>
+	<td></td>
+</tr>
+<tr>
+	<td>ALERT_STATIC_ICON</td>
+	<td>//div[@class='alert alert-${key_alertType}']//*[@class='lexicon-icon lexicon-icon-${key_icon}']</td>
+	<td></td>
+</tr>
+<tr>
+	<td>ALERT_STATIC_BOLD</td>
+	<td>//div[@class='alert alert-${key_alertType}']//strong[contains(@class,'lead') and contains(text(), '${key_alertBold}')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>ALERT_TOAST_ICON</td>
+	<td>//*[@id='ToastAlertContainer']//*[@class='lexicon-icon lexicon-icon-${key_icon}']</td>
+	<td></td>
+</tr>
+</tbody>
+</table>
+</body>
+</html>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/ClayAlertToast.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/ClayAlertToast.path
@@ -11,21 +11,6 @@
 
 <tbody>
 <tr>
-	<td>ALERT_STATIC</td>
-	<td>//div[@class='alert alert-${key_alertType}']</td>
-	<td></td>
-</tr>
-<tr>
-	<td>ALERT_STATIC_ICON</td>
-	<td>//div[@class='alert alert-${key_alertType}']//*[@class='lexicon-icon lexicon-icon-${key_icon}']</td>
-	<td></td>
-</tr>
-<tr>
-	<td>ALERT_STATIC_BOLD</td>
-	<td>//div[@class='alert alert-${key_alertType}']//strong[contains(@class,'lead') and contains(text(), '${key_alertBold}')]</td>
-	<td></td>
-</tr>
-<tr>
 	<td>ALERT_TOAST_ICON</td>
 	<td>//*[@id='ToastAlertContainer']//*[@class='lexicon-icon lexicon-icon-${key_icon}']</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
@@ -18,6 +18,11 @@ definition {
 		if ("${testPortalInstance}" == "true") {
 			PortalInstances.tearDownCP();
 		}
+		else {
+			JSONLayout.deletePublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page");
+		}
 	}
 
 	@description = "Verify toast message popup can be closed manually"

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
@@ -46,34 +46,31 @@ definition {
 			Navigator.gotoPage(pageName = "Clay Sample Test Page");
 		}
 
-		task ("When the alert contains all attributes then the alert displays status icon, type text, description text, close icon") {
-			Click(
-				key_text = "Success Submit",
-				locator1 = "Button#ANY");
-
-			AssertElementPresent(locator1 = "//*[@id='ToastAlertContainer']//*[@class='lexicon-icon lexicon-icon-check-circle-full']");
-
-			AssertTextEquals(
-				locator1 = "Message#SUCCESS_DISMISSIBLE",
-				value1 = "Success:Your request completed successfully.");
-
+		task ("When the alert contains all attributes") {
 			AssertElementPresent(
-				locator1 = "Message#SUCCESS_DISMISSIBLE",
-				value1 = "Icon#CLOSE_ALERT");
+				locator1 = "ClayAlertToast#ALERT_STATIC",
+				key_alertType = "success");
+		}
 
-			Click(
-				key_text = "Fail Submit",
-				locator1 = "Button#ANY");
-
-			AssertElementPresent(locator1 = "//*[@id='ToastAlertContainer']//*[@class='lexicon-icon lexicon-icon-exclamation-full']");
-
-			AssertTextEquals(
-				locator1 = "Message#ERROR_DISMISSIBLE",
-				value1 = "Error:An unexpected error occurred.");
-
+		task ("Then the alert displays status icon") {
 			AssertElementPresent(
-				locator1 = "Message#ERROR_DISMISSIBLE",
-				value1 = "Icon#CLOSE_ALERT");
+				locator1 = "ClayAlertToast#ALERT_STATIC_ICON",
+				key_alertType = "success",
+				key_icon = "check-circle-full");
+		}
+
+		task ("And displays type text") {
+			AssertElementPresent(
+				locator1 = "ClayAlertToast#ALERT_STATIC_BOLD",
+				key_alertType = "success",
+				key_alertBold = "Success");
+		}
+
+		task ("And displays description text") {
+			AssertTextEquals(
+				locator1 = "ClayAlertToast#ALERT_STATIC",
+				key_alertType = "success",
+				value1 = "Success:This is a success message.");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
@@ -48,28 +48,28 @@ definition {
 
 		task ("When the alert contains all attributes") {
 			AssertElementPresent(
-				locator1 = "ClayAlertToast#ALERT_STATIC",
-				key_alertType = "success");
+				key_alertType = "success",
+				locator1 = "ClayAlertToast#ALERT_STATIC");
 		}
 
 		task ("Then the alert displays status icon") {
 			AssertElementPresent(
-				locator1 = "ClayAlertToast#ALERT_STATIC_ICON",
 				key_alertType = "success",
-				key_icon = "check-circle-full");
+				key_icon = "check-circle-full",
+				locator1 = "ClayAlertToast#ALERT_STATIC_ICON");
 		}
 
 		task ("And displays type text") {
 			AssertElementPresent(
-				locator1 = "ClayAlertToast#ALERT_STATIC_BOLD",
+				key_alertBold = "Success",
 				key_alertType = "success",
-				key_alertBold = "Success");
+				locator1 = "ClayAlertToast#ALERT_STATIC_BOLD");
 		}
 
 		task ("And displays description text") {
 			AssertTextEquals(
-				locator1 = "ClayAlertToast#ALERT_STATIC",
 				key_alertType = "success",
+				locator1 = "ClayAlertToast#ALERT_STATIC",
 				value1 = "Success:This is a success message.");
 		}
 	}
@@ -97,23 +97,22 @@ definition {
 
 		task ("When alert contains status icon and keyword") {
 			AssertTextEquals(
-				locator1 = "ClayAlertToast#ALERT_STATIC",
 				key_alertType = "success",
+				locator1 = "ClayAlertToast#ALERT_STATIC",
 				value1 = "Success:This is a success message.");
 
 			AssertElementPresent(
-				locator1 = "ClayAlertToast#ALERT_STATIC_ICON",
 				key_alertType = "success",
-				key_icon = "check-circle-full");
+				key_icon = "check-circle-full",
+				locator1 = "ClayAlertToast#ALERT_STATIC_ICON");
 		}
 
 		task ("Then keyword must be semi-bold") {
 			AssertCssValue(
-				locator1 = "ClayAlertToast#ALERT_STATIC",
 				key_alertType = "success",
+				locator1 = "ClayAlertToast#ALERT_STATIC",
 				locator2 = "font-weight",
-				value1 = "400"
-			);
+				value1 = "400");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
@@ -79,4 +79,45 @@ definition {
 		AssertElementNotPresent(locator1 = "Message#SUCCESS_DISMISSIBLE");
 	}
 
+	@description = "Verify if the keyword is semi-bold when alert contains status icon and keyword"
+	@priority = "4"
+	test KeywordCanDisplayInSemibold {
+		task ("Given Clay Sample Portlet") {
+			JSONLayout.addPublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page");
+		
+			JSONLayout.updateLayoutTemplateOfPublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page",
+				layoutTemplate = "1 Column");
+		
+			JSONLayout.addWidgetToPublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page",
+				widgetName = "Clay Sample");
+
+			Navigator.gotoPage(pageName = "Clay Sample Test Page");
+		}
+
+		task ("When alert contains status icon and keyword Then keyword must be semi-bold") {
+			Click(
+				locator1 = "Button#ANY",
+				key_text = "Success Submit");
+
+			AssertCssValue(
+				locator1 = "Message#SUCCESS_DISMISSIBLE",
+				locator2 = "font-weight",
+				value1 = "400");
+			
+			Click(
+				locator1 = "Button#ANY",
+				key_text = "Fail Submit");
+			
+			AssertCssValue(
+				locator1 = "Message#ERROR_DISMISSIBLE",
+				locator2 = "font-weight",
+				value1 = "400");
+		}
+	}
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
@@ -49,27 +49,27 @@ definition {
 		task ("When the alert contains all attributes") {
 			AssertElementPresent(
 				key_alertType = "success",
-				locator1 = "ClayAlertToast#ALERT_STATIC");
+				locator1 = "ClayAlert#ALERT_STATIC");
 		}
 
 		task ("Then the alert displays status icon") {
 			AssertElementPresent(
 				key_alertType = "success",
 				key_icon = "check-circle-full",
-				locator1 = "ClayAlertToast#ALERT_STATIC_ICON");
+				locator1 = "ClayAlert#ALERT_STATIC_ICON");
 		}
 
 		task ("And displays type text") {
 			AssertElementPresent(
 				key_alertBold = "Success",
 				key_alertType = "success",
-				locator1 = "ClayAlertToast#ALERT_STATIC_BOLD");
+				locator1 = "ClayAlert#ALERT_STATIC_BOLD");
 		}
 
 		task ("And displays description text") {
 			AssertTextEquals(
 				key_alertType = "success",
-				locator1 = "ClayAlertToast#ALERT_STATIC",
+				locator1 = "ClayAlert#ALERT_STATIC",
 				value1 = "Success:This is a success message.");
 		}
 	}
@@ -98,19 +98,19 @@ definition {
 		task ("When alert contains status icon and keyword") {
 			AssertTextEquals(
 				key_alertType = "success",
-				locator1 = "ClayAlertToast#ALERT_STATIC",
+				locator1 = "ClayAlert#ALERT_STATIC",
 				value1 = "Success:This is a success message.");
 
 			AssertElementPresent(
 				key_alertType = "success",
 				key_icon = "check-circle-full",
-				locator1 = "ClayAlertToast#ALERT_STATIC_ICON");
+				locator1 = "ClayAlert#ALERT_STATIC_ICON");
 		}
 
 		task ("Then keyword must be semi-bold") {
 			AssertCssValue(
 				key_alertType = "success",
-				locator1 = "ClayAlertToast#ALERT_STATIC",
+				locator1 = "ClayAlert#ALERT_STATIC",
 				locator2 = "font-weight",
 				value1 = "400");
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
@@ -98,24 +98,25 @@ definition {
 			Navigator.gotoPage(pageName = "Clay Sample Test Page");
 		}
 
-		task ("When alert contains status icon and keyword Then keyword must be semi-bold") {
-			Click(
-				key_text = "Success Submit",
-				locator1 = "Button#ANY");
+		task ("When alert contains status icon and keyword") {
+			AssertTextEquals(
+				locator1 = "ClayAlertToast#ALERT_STATIC",
+				key_alertType = "success",
+				value1 = "Success:This is a success message.");
 
+			AssertElementPresent(
+				locator1 = "ClayAlertToast#ALERT_STATIC_ICON",
+				key_alertType = "success",
+				key_icon = "check-circle-full");
+		}
+
+		task ("Then keyword must be semi-bold") {
 			AssertCssValue(
-				locator1 = "Message#SUCCESS_DISMISSIBLE",
+				locator1 = "ClayAlertToast#ALERT_STATIC",
+				key_alertType = "success",
 				locator2 = "font-weight",
-				value1 = "400");
-
-			Click(
-				key_text = "Fail Submit",
-				locator1 = "Button#ANY");
-
-			AssertCssValue(
-				locator1 = "Message#ERROR_DISMISSIBLE",
-				locator2 = "font-weight",
-				value1 = "400");
+				value1 = "400"
+			);
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
@@ -10,24 +10,7 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
-	}
 
-	tearDown {
-		var testPortalInstance = PropsUtil.get("test.portal.instance");
-
-		if ("${testPortalInstance}" == "true") {
-			PortalInstances.tearDownCP();
-		}
-		else {
-			JSONLayout.deletePublicLayout(
-				groupName = "Guest",
-				layoutName = "Clay Sample Test Page");
-		}
-	}
-
-	@description = "Verify if alert contains all attributes: icon, type text, description and close icon"
-	@priority = "5"
-	test CanDisplayAllAttributes {
 		task ("Given Clay Sample Portlet") {
 			JSONLayout.addPublicLayout(
 				groupName = "Guest",
@@ -45,9 +28,26 @@ definition {
 
 			Navigator.gotoPage(pageName = "Clay Sample Test Page");
 		}
+	}
 
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if ("${testPortalInstance}" == "true") {
+			PortalInstances.tearDownCP();
+		}
+		else {
+			JSONLayout.deletePublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page");
+		}
+	}
+
+	@description = "Verify alert contains all required attributes: icon, type text, and description"
+	@priority = "5"
+	test CanDisplayAllAttributes {
 		task ("When the alert contains all attributes") {
-			AssertElementPresent(
+			VerifyElementPresent(
 				key_alertType = "success",
 				locator1 = "ClayAlert#ALERT_STATIC");
 		}
@@ -74,34 +74,16 @@ definition {
 		}
 	}
 
-	@description = "Verify if the keyword is semi-bold when alert contains status icon and keyword"
+	@description = "Verify the keyword is semi-bold when alert contains status icon and keyword"
 	@priority = "4"
 	test KeywordCanDisplayInSemibold {
-		task ("Given Clay Sample Portlet") {
-			JSONLayout.addPublicLayout(
-				groupName = "Guest",
-				layoutName = "Clay Sample Test Page");
-
-			JSONLayout.updateLayoutTemplateOfPublicLayout(
-				groupName = "Guest",
-				layoutName = "Clay Sample Test Page",
-				layoutTemplate = "1 Column");
-
-			JSONLayout.addWidgetToPublicLayout(
-				groupName = "Guest",
-				layoutName = "Clay Sample Test Page",
-				widgetName = "Clay Sample");
-
-			Navigator.gotoPage(pageName = "Clay Sample Test Page");
-		}
-
 		task ("When alert contains status icon and keyword") {
 			AssertTextEquals(
 				key_alertType = "success",
 				locator1 = "ClayAlert#ALERT_STATIC",
 				value1 = "Success:This is a success message.");
 
-			AssertElementPresent(
+			VerifyElementPresent(
 				key_alertType = "success",
 				key_icon = "check-circle-full",
 				locator1 = "ClayAlert#ALERT_STATIC_ICON");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
@@ -25,6 +25,100 @@ definition {
 		}
 	}
 
+	@description = "Verify if alert contains all attributes: icon, type text, description and close icon"
+	@priority = "5"
+	test CanDisplayAllAttributes {
+		task ("Given Clay Sample Portlet") {
+			JSONLayout.addPublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page");
+
+			JSONLayout.updateLayoutTemplateOfPublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page",
+				layoutTemplate = "1 Column");
+
+			JSONLayout.addWidgetToPublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page",
+				widgetName = "Clay Sample");
+
+			Navigator.gotoPage(pageName = "Clay Sample Test Page");
+		}
+
+		task ("When the alert contains all attributes then the alert displays status icon, type text, description text, close icon") {
+			Click(
+				key_text = "Success Submit",
+				locator1 = "Button#ANY");
+
+			AssertElementPresent(locator1 = "//*[@id='ToastAlertContainer']//*[@class='lexicon-icon lexicon-icon-check-circle-full']");
+
+			AssertTextEquals(
+				locator1 = "Message#SUCCESS_DISMISSIBLE",
+				value1 = "Success:Your request completed successfully.");
+
+			AssertElementPresent(
+				locator1 = "Message#SUCCESS_DISMISSIBLE",
+				value1 = "Icon#CLOSE_ALERT");
+
+			Click(
+				key_text = "Fail Submit",
+				locator1 = "Button#ANY");
+
+			AssertElementPresent(locator1 = "//*[@id='ToastAlertContainer']//*[@class='lexicon-icon lexicon-icon-exclamation-full']");
+
+			AssertTextEquals(
+				locator1 = "Message#ERROR_DISMISSIBLE",
+				value1 = "Error:An unexpected error occurred.");
+
+			AssertElementPresent(
+				locator1 = "Message#ERROR_DISMISSIBLE",
+				value1 = "Icon#CLOSE_ALERT");
+		}
+	}
+
+	@description = "Verify if the keyword is semi-bold when alert contains status icon and keyword"
+	@priority = "4"
+	test KeywordCanDisplayInSemibold {
+		task ("Given Clay Sample Portlet") {
+			JSONLayout.addPublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page");
+
+			JSONLayout.updateLayoutTemplateOfPublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page",
+				layoutTemplate = "1 Column");
+
+			JSONLayout.addWidgetToPublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page",
+				widgetName = "Clay Sample");
+
+			Navigator.gotoPage(pageName = "Clay Sample Test Page");
+		}
+
+		task ("When alert contains status icon and keyword Then keyword must be semi-bold") {
+			Click(
+				key_text = "Success Submit",
+				locator1 = "Button#ANY");
+
+			AssertCssValue(
+				locator1 = "Message#SUCCESS_DISMISSIBLE",
+				locator2 = "font-weight",
+				value1 = "400");
+
+			Click(
+				key_text = "Fail Submit",
+				locator1 = "Button#ANY");
+
+			AssertCssValue(
+				locator1 = "Message#ERROR_DISMISSIBLE",
+				locator2 = "font-weight",
+				value1 = "400");
+		}
+	}
+
 	@description = "Verify toast message popup can be closed manually"
 	@priority = "3"
 	@refactordone
@@ -84,97 +178,4 @@ definition {
 		AssertElementNotPresent(locator1 = "Message#SUCCESS_DISMISSIBLE");
 	}
 
-	@description = "Verify if the keyword is semi-bold when alert contains status icon and keyword"
-	@priority = "4"
-	test KeywordCanDisplayInSemibold {
-		task ("Given Clay Sample Portlet") {
-			JSONLayout.addPublicLayout(
-				groupName = "Guest",
-				layoutName = "Clay Sample Test Page");
-		
-			JSONLayout.updateLayoutTemplateOfPublicLayout(
-				groupName = "Guest",
-				layoutName = "Clay Sample Test Page",
-				layoutTemplate = "1 Column");
-		
-			JSONLayout.addWidgetToPublicLayout(
-				groupName = "Guest",
-				layoutName = "Clay Sample Test Page",
-				widgetName = "Clay Sample");
-
-			Navigator.gotoPage(pageName = "Clay Sample Test Page");
-		}
-
-		task ("When alert contains status icon and keyword Then keyword must be semi-bold") {
-			Click(
-				locator1 = "Button#ANY",
-				key_text = "Success Submit");
-
-			AssertCssValue(
-				locator1 = "Message#SUCCESS_DISMISSIBLE",
-				locator2 = "font-weight",
-				value1 = "400");
-			
-			Click(
-				locator1 = "Button#ANY",
-				key_text = "Fail Submit");
-			
-			AssertCssValue(
-				locator1 = "Message#ERROR_DISMISSIBLE",
-				locator2 = "font-weight",
-				value1 = "400");
-		}
-	}
-
-	@description = "Verify if alert contains all attributes: icon, type text, description and close icon"
-	@priority = "5"
-	test CanDisplayAllAttributes {
-		task ("Given Clay Sample Portlet") {
-			JSONLayout.addPublicLayout(
-				groupName = "Guest",
-				layoutName = "Clay Sample Test Page");
-		
-			JSONLayout.updateLayoutTemplateOfPublicLayout(
-				groupName = "Guest",
-				layoutName = "Clay Sample Test Page",
-				layoutTemplate = "1 Column");
-		
-			JSONLayout.addWidgetToPublicLayout(
-				groupName = "Guest",
-				layoutName = "Clay Sample Test Page",
-				widgetName = "Clay Sample");
-
-			Navigator.gotoPage(pageName = "Clay Sample Test Page");
-		}
-
-		task ("When the alert contains all attributes then the alert displays status icon, type text, description text, close icon") {
-			Click(
-				locator1 = "Button#ANY",
-				key_text = "Success Submit");
-			
-			AssertElementPresent(locator1 = "//*[@id='ToastAlertContainer']//*[@class='lexicon-icon lexicon-icon-check-circle-full']");
-			
-			AssertTextEquals(
-				locator1 = "Message#SUCCESS_DISMISSIBLE",
-				value1 = "Success:Your request completed successfully.");
-
-			AssertElementPresent(
-				locator1 = "Message#SUCCESS_DISMISSIBLE",
-				value1 = "Icon#CLOSE_ALERT");
-
-			Click(
-				locator1 = "Button#ANY",
-				key_text = "Fail Submit");
-
-			AssertElementPresent(locator1 = "//*[@id='ToastAlertContainer']//*[@class='lexicon-icon lexicon-icon-exclamation-full']");
-
-			AssertTextEquals(
-				locator1 = "Message#ERROR_DISMISSIBLE",
-				value1 = "Error:An unexpected error occurred.");
-
-			AssertElementPresent(
-				locator1 = "Message#ERROR_DISMISSIBLE",
-				value1 = "Icon#CLOSE_ALERT");
-		}
-	}
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
@@ -120,4 +120,56 @@ definition {
 				value1 = "400");
 		}
 	}
+
+	@description = "Verify if alert contains all attributes: icon, type text, description and close icon"
+	@priority = "5"
+	test CanDisplayAllAttributes {
+		task ("Given Clay Sample Portlet") {
+			JSONLayout.addPublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page");
+		
+			JSONLayout.updateLayoutTemplateOfPublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page",
+				layoutTemplate = "1 Column");
+		
+			JSONLayout.addWidgetToPublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page",
+				widgetName = "Clay Sample");
+
+			Navigator.gotoPage(pageName = "Clay Sample Test Page");
+		}
+
+		task ("When the alert contains all attributes then the alert displays status icon, type text, description text, close icon") {
+			Click(
+				locator1 = "Button#ANY",
+				key_text = "Success Submit");
+			
+			AssertElementPresent(locator1 = "//*[@id='ToastAlertContainer']//*[@class='lexicon-icon lexicon-icon-check-circle-full']");
+			
+			AssertTextEquals(
+				locator1 = "Message#SUCCESS_DISMISSIBLE",
+				value1 = "Success:Your request completed successfully.");
+
+			AssertElementPresent(
+				locator1 = "Message#SUCCESS_DISMISSIBLE",
+				value1 = "Icon#CLOSE_ALERT");
+
+			Click(
+				locator1 = "Button#ANY",
+				key_text = "Fail Submit");
+
+			AssertElementPresent(locator1 = "//*[@id='ToastAlertContainer']//*[@class='lexicon-icon lexicon-icon-exclamation-full']");
+
+			AssertTextEquals(
+				locator1 = "Message#ERROR_DISMISSIBLE",
+				value1 = "Error:An unexpected error occurred.");
+
+			AssertElementPresent(
+				locator1 = "Message#ERROR_DISMISSIBLE",
+				value1 = "Icon#CLOSE_ALERT");
+		}
+	}
 }


### PR DESCRIPTION
**What is new?**
- Update all test cases related to unlink Object Relationship to remove duplicate logic. Just providing the endpoint in every test case
- Brian requested changes in https://github.com/brianchandotcom/liferay-portal/pull/127857#issuecomment-1358018055

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-170938