### PR TITLE
Lps 171507 Add tests to filter out object APIs from other instances

### DIFF
--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectDefinitionAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectDefinitionAPI.macro
@@ -70,7 +70,16 @@ definition {
 	macro _createObjectDefinition {
 		Variables.assertDefined(parameterList = "${en_US_label},${name},${requiredStringFieldName},${en_US_plural_label}");
 
-		var portalURL = JSONCompany.getPortalURL();
+		if (isSet(virtualHost)) {
+			if (!(isSet(port))) {
+				var port = "8080";
+			}
+
+			var portalURL = "http://${virtualHost}:${port}";
+		}
+		else {
+			var portalURL = JSONCompany.getPortalURL();
+		}
 
 		var curl = '''
 			${portalURL}/o/object-admin/v1.0/object-definitions \
@@ -111,16 +120,31 @@ definition {
 		Variables.assertDefined(parameterList = "${en_US_plural_label},${name}");
 
 		var en_US_plural_label_lowercase = StringUtil.lowerCase("${en_US_plural_label}");
-		var portalURL = JSONCompany.getPortalURL();
 
-		var curl = '''
+		if (isSet(virtualHost)) {
+			if (!(isSet(port))) {
+				var port = "8080";
+			}
+
+			var portalURL = "http://${virtualHost}:${port}";
+		}
+		else {
+			var portalURL = JSONCompany.getPortalURL();
+		}
+
+		var body = '''"name": "${name}"''';
+
+		if (isSet(secondField)) {
+			var body = StringUtil.add("${body},", "\"secondField\":\"${secondFieldValue}\"", "");
+		}
+
+		var curlWithoutBody = '''
 			${portalURL}/o/c/${en_US_plural_label_lowercase} \
 				-u test@liferay.com:test \
 				-H Content-Type: application/json \
-				-d {
-					"name": "${name}"
-				}
 		''';
+
+		var curl = StringUtil.add("${curlWithoutBody}", "-d {${body}}", " ");
 
 		var objectId = JSONCurlUtil.post("${curl}", "$.id");
 
@@ -246,7 +270,16 @@ definition {
 	macro _getObjectDefinitionStatusById {
 		Variables.assertDefined(parameterList = "${objectDefinitionId}");
 
-		var portalURL = JSONCompany.getPortalURL();
+		if (isSet(virtualHost)) {
+			if (!(isSet(port))) {
+				var port = "8080";
+			}
+
+			var portalURL = "http://${virtualHost}:${port}";
+		}
+		else {
+			var portalURL = JSONCompany.getPortalURL();
+		}
 
 		var curl = '''
 			${portalURL}/o/object-admin/v1.0/object-definitions/${objectDefinitionId} \
@@ -262,7 +295,17 @@ definition {
 		Variables.assertDefined(parameterList = "${en_US_plural_label},${objectId}");
 
 		var en_US_plural_label_lowercase = StringUtil.lowerCase("${en_US_plural_label}");
-		var portalURL = JSONCompany.getPortalURL();
+
+		if (isSet(virtualHost)) {
+			if (!(isSet(port))) {
+				var port = "8080";
+			}
+
+			var portalURL = "http://${virtualHost}:${port}";
+		}
+		else {
+			var portalURL = JSONCompany.getPortalURL();
+		}
 
 		var curl = '''
 			${portalURL}/o/c/${en_US_plural_label_lowercase}/${objectId} \
@@ -385,7 +428,16 @@ definition {
 	macro _publishObjectDefinition {
 		Variables.assertDefined(parameterList = "${objectDefinitionId}");
 
-		var portalURL = JSONCompany.getPortalURL();
+		if (isSet(virtualHost)) {
+			if (!(isSet(port))) {
+				var port = "8080";
+			}
+
+			var portalURL = "http://${virtualHost}:${port}";
+		}
+		else {
+			var portalURL = JSONCompany.getPortalURL();
+		}
 
 		var curl = '''
 			${portalURL}/o/object-admin/v1.0/object-definitions/${objectDefinitionId}/publish \
@@ -606,11 +658,16 @@ definition {
 			en_US_label = "${en_US_label}",
 			en_US_plural_label = "${en_US_plural_label}",
 			name = "${name}",
-			requiredStringFieldName = "${requiredStringFieldName}");
+			requiredStringFieldName = "${requiredStringFieldName}",
+			virtualHost = "${virtualHost}");
 
-		ObjectDefinitionAPI._publishObjectDefinition(objectDefinitionId = "${objectDefinitionId}");
+		ObjectDefinitionAPI._publishObjectDefinition(
+			objectDefinitionId = "${objectDefinitionId}",
+			virtualHost = "${virtualHost}");
 
-		var objectDefinitionStatus = ObjectDefinitionAPI._getObjectDefinitionStatusById(objectDefinitionId = "${objectDefinitionId}");
+		var objectDefinitionStatus = ObjectDefinitionAPI._getObjectDefinitionStatusById(
+			objectDefinitionId = "${objectDefinitionId}",
+			virtualHost = "${virtualHost}");
 
 		TestUtils.assertEquals(
 			actual = "${objectDefinitionStatus}",
@@ -648,11 +705,14 @@ definition {
 	macro createObjectEntryWithName {
 		var objectId = ObjectDefinitionAPI._createObjectEntryWithName(
 			en_US_plural_label = "${en_US_plural_label}",
-			name = "${name}");
+			name = "${name}",
+			secondFieldValue = "${secondFieldValue}",
+			virtualHost = "${virtualHost}");
 
 		var actualName = ObjectDefinitionAPI._getObjectEntryNameById(
 			en_US_plural_label = "${en_US_plural_label}",
-			objectId = "${objectId}");
+			objectId = "${objectId}",
+			virtualHost = "${virtualHost}");
 
 		TestUtils.assertEquals(
 			actual = "${actualName}",
@@ -741,7 +801,17 @@ definition {
 		Variables.assertDefined(parameterList = "${en_US_plural_label}");
 
 		var en_US_plural_label_lowercase = StringUtil.lowerCase("${en_US_plural_label}");
-		var portalURL = JSONCompany.getPortalURL();
+
+		if (isSet(virtualHost)) {
+			if (!(isSet(port))) {
+				var port = "8080";
+			}
+
+			var portalURL = "http://${virtualHost}:${port}";
+		}
+		else {
+			var portalURL = JSONCompany.getPortalURL();
+		}
 
 		var curl = '''
 			${portalURL}/o/c/${en_US_plural_label_lowercase}/ \

--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectFieldAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectFieldAPI.macro
@@ -20,13 +20,7 @@ definition {
 		return "${curl}";
 	}
 
-	macro deleteObjectField {
-		var curl = ObjectFieldAPI._curlObjectField(objectFieldId = "${staticObjectFieldId}");
-
-		JSONCurlUtil.delete("${curl}");
-	}
-
-	macro getIdOfCreatedObjectField {
+	macro createObjectFieldByObjectDefinitionId {
 		Variables.assertDefined(parameterList = "${objectDefinitionId},${dbType},${name}");
 
 		var curl = ObjectFieldAPI._curlObjectField(objectDefinitionId = "${objectDefinitionId}");
@@ -49,7 +43,24 @@ definition {
 
 		var curl = StringUtil.add("${curl}", "${body}", " ");
 
-		var objectFieldId = JSONCurlUtil.post("${curl}", "$.id");
+		var response = JSONCurlUtil.post("${curl}");
+
+		return "${response}";
+	}
+
+	macro deleteObjectField {
+		var curl = ObjectFieldAPI._curlObjectField(objectFieldId = "${staticObjectFieldId}");
+
+		JSONCurlUtil.delete("${curl}");
+	}
+
+	macro getIdOfCreatedObjectField {
+		var response = ObjectFieldAPI.createObjectFieldByObjectDefinitionId(
+			dbType = "${dbType}",
+			name = "${name}",
+			objectDefinitionId = "${objectDefinitionId}");
+
+		var objectFieldId = JSONCurlUtil.get("${response}", "$.id");
 
 		return "${objectFieldId}";
 	}

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/FilterObjectAPIsFromOtherInstances.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/FilterObjectAPIsFromOtherInstances.testcase
@@ -1,0 +1,171 @@
+@component-name = "portal-headless"
+definition {
+
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Object";
+	property testray.main.component.name = "Headless";
+
+	setUp {
+		TestCase.setUpPortalInstanceNoSelenium();
+
+		task ("Given two new virtual instances www.able.com and www.baker.com are created") {
+			HeadlessPortalInstanceAPI.addPortalInstance(
+				domain = "liferay.com",
+				portalInstanceId = "www.able.com",
+				virtualHost = "www.able.com");
+
+			HeadlessPortalInstanceAPI.addPortalInstance(
+				domain = "liferay.com",
+				portalInstanceId = "www.baker.com",
+				virtualHost = "www.baker.com");
+		}
+
+		task ("And Given objectDefinition University created and published in www.able.com instance") {
+			ObjectDefinitionAPI.createAndPublishObjectDefinition(
+				en_US_label = "University",
+				en_US_plural_label = "Universities",
+				name = "University",
+				requiredStringFieldName = "firstname",
+				virtualHost = "www.able.com");
+		}
+
+		task ("And Given objectDefinition Subject created and published in www.baker.com instance") {
+			ObjectDefinitionAPI.createAndPublishObjectDefinition(
+				en_US_label = "Subject",
+				en_US_plural_label = "Subjects",
+				name = "Subject",
+				requiredStringFieldName = "name",
+				virtualHost = "www.baker.com");
+		}
+	}
+
+	tearDown {
+		if ("${testPortalInstance}" == "true") {
+			PortalInstances.tearDownCP();
+		}
+		else {
+			ObjectAdmin.deleteObjectViaAPI(objectName = "Subject");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = "3"
+	test CanGetObjectEndponitsFromCurrentInstance {
+		task ("When requesting GET "/o/c/subjects" from www.baker.com instance") {
+			var response = ObjectDefinitionAPI.getObjectEntries(
+				en_US_plural_label = "subjects",
+				virtualHost = "www.baker.com");
+		}
+
+		task ("Then I can get a correct response with www.baker.com:8080/o/c/subjects href in actions") {
+			var actualValue = JSONUtil.getWithJSONPath("${response}", "$.actions.create.href");
+
+			TestUtils.assertEquals(
+				actual = "${actualValue}",
+				expected = "http://www.baker.com:8080/o/c/subjects/");
+		}
+
+		task ("And Then the information of www.baker.com:8080/o/c/univeristies is not found") {
+			var response = ObjectDefinitionAPI.getObjectEntries(
+				en_US_plural_label = "universities",
+				virtualHost = "www.baker.com");
+
+			TestUtils.assertPartialEquals(
+				actual = "${response}",
+				expected = "NOT_FOUND");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = "4"
+	test CannotGetObjectEndponitsFromOtherInstance {
+		property portal.acceptance = "true";
+
+		task ("When requesting GET "/o/c/universities" from www.able.com instance") {
+			var response = ObjectDefinitionAPI.getObjectEntries(
+				en_US_plural_label = "universities",
+				virtualHost = "www.able.com");
+		}
+
+		task ("Then I can get a correct response with www.able.com:8080/o/c/universities href in actions") {
+			var actualValue = JSONUtil.getWithJSONPath("${response}", "$.actions.create.href");
+
+			TestUtils.assertEquals(
+				actual = "${actualValue}",
+				expected = "http://www.able.com:8080/o/c/universities/");
+		}
+
+		task ("And Then the information of www.able.com:8080/o/c/subjects is not found") {
+			var response = ObjectDefinitionAPI.getObjectEntries(
+				en_US_plural_label = "subjects",
+				virtualHost = "www.able.com");
+
+			TestUtils.assertPartialEquals(
+				actual = "${response}",
+				expected = "NOT_FOUND");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = "4"
+	test CannotGetObjectEntryFromOtherInstance {
+		property portal.acceptance = "true";
+
+		task ("And Given objectDefinition Subject created and published with secondField in default instance") {
+			var objectDefinitionId = ObjectDefinitionAPI.createAndPublishObjectDefinition(
+				en_US_label = "Subject",
+				en_US_plural_label = "Subjects",
+				name = "Subject",
+				requiredStringFieldName = "name");
+
+			ObjectFieldAPI.createObjectFieldByObjectDefinitionId(
+				dbType = "String",
+				name = "secondField",
+				objectDefinitionId = "${objectDefinitionId}");
+		}
+
+		task ("And Given Subject entry created in default instance") {
+			ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "subjects",
+				name = "Object Entry in Default Instance",
+				secondFieldValue = "The other field in Default Instance");
+		}
+
+		task ("And Given Subject entry created in www.baker.com instances") {
+			ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "subjects",
+				name = "Object Entry in Second Instance",
+				virtualHost = "www.baker.com");
+		}
+
+		task ("When requesting GET www.baker.com/o/c/subjects") {
+			var response = ObjectDefinitionAPI.getObjectEntries(
+				en_US_plural_label = "subjects",
+				virtualHost = "www.baker.com");
+		}
+
+		task ("Then I can see one Subject entry with its name correctly related") {
+			var actualName = JSONUtil.getWithJSONPath("${response}", "$.items[*].name");
+
+			TestUtils.assertEquals(
+				actual = "${actualName}",
+				expected = "Object Entry in Second Instance");
+
+			var totoalCount = JSONUtil.getWithJSONPath("${response}", "$.totalCount");
+
+			TestUtils.assertEquals(
+				actual = "${totoalCount}",
+				expected = "1");
+		}
+
+		task ("And Then I can not see the Subject entry with secondField in default instance") {
+			var actualSecondFieldValue = JSONUtil.getWithJSONPath("${response}", "$..secondField");
+
+			TestUtils.assertPartialEquals(
+				actual = "${actualSecondFieldValue}",
+				expected = "");
+		}
+	}
+
+}

--- a/modules/apps/object/object-test/src/testFunctional/macros/json/JSONObject.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/json/JSONObject.macro
@@ -447,7 +447,17 @@ definition {
 
 	@summary = "This calls the JSON WS API to delete an object"
 	macro deleteObject {
-		var portalURL = JSONCompany.getPortalURL();
+		if (isSet(virtualHost)) {
+			if (!(isSet(port))) {
+				var port = "8080";
+			}
+
+			var portalURL = "http://${virtualHost}:${port}";
+		}
+		else {
+			var portalURL = JSONCompany.getPortalURL();
+		}
+
 		var objectId = JSONObject.getObjectId(
 			objectName = "${objectName}",
 			userEmailAddress = "${userEmailAddress}",
@@ -598,7 +608,16 @@ definition {
 	}
 
 	macro getObjectEntryId {
-		var portalURL = JSONCompany.getPortalURL();
+		if (isSet(virtualHost)) {
+			if (!(isSet(port))) {
+				var port = "8080";
+			}
+
+			var portalURL = "http://${virtualHost}:${port}";
+		}
+		else {
+			var portalURL = JSONCompany.getPortalURL();
+		}
 
 		if (!(isSet(userEmailAddress))) {
 			var userEmailAddress = "test@liferay.com";


### PR DESCRIPTION
**Background**
- Add tests using curl to filter out object APIs from other virtual instances

**Test Plan**
- Given two new virtual instances www.first.com and www.second.com are created
And Given objectDefinition University created and published in www.first.com instance
And Given objectDefinition Subject created and published in www.second.com instance
When requesting GET "/o/c/universities" from www.first.com instance
Then I can get a correct response with www.first.com:8080/o/c/universities href in actions
And Then the information of www.first.com:8080/o/c/subjects is not found
- Given two new virtual instances www.first.com and www.second.com are created
And Given objectDefinition University created and published in www.first.com instance
And Given objectDefinition Subject created and published in www.second.com instance
When requesting GET "/o/c/subjects" from www.second.com instance
Then I can get a correct response with www.second.com:8080/o/c/subjects href in actions
And Then the information of www.second.com:8080/o/c/univeristies is not found
- Given a new virtual instance www.second.com is created
And Given objectDefinition Subject created and published 
with secondField in default instanceAnd Given objectDefinition Subject created and pusblished in www.second.com instance
And Given Subject entry created in default instance
And Given Subject entry created in www.second.com instances
When requesting GET www.second.com/o/c/subjects
Then I can see one Subject entry with its name correctly related
And Then I can not see the Subject entry with secondField in default instance 

**Jira Ticket**
- https://issues.liferay.com/browse/LPS-171507