### PR TITLE
LPS-171617 Create a VulcanConfiguration scoped by company to manage the excludedOperationIds parameter in Objects

### DIFF
--- a/modules/apps/object/object-rest-impl/build.gradle
+++ b/modules/apps/object/object-rest-impl/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	compileOnly project(":apps:portal-odata:portal-odata-api")
 	compileOnly project(":apps:portal-search:portal-search-api")
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
+	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":core:osgi-service-tracker-collections")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-lang")

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -45,6 +45,8 @@ import com.liferay.object.service.ObjectRelationshipService;
 import com.liferay.object.system.JaxRsApplicationDescriptor;
 import com.liferay.object.system.SystemObjectDefinitionMetadata;
 import com.liferay.object.system.SystemObjectDefinitionMetadataRegistry;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -123,9 +125,9 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 
 			_objectDefinitionsMap.put(
 				objectDefinition.getRESTContextPath(), objectDefinitions);
-
-			_excludeScopedMethods(objectDefinition, objectScopeProvider);
 		}
+
+		_excludeScopedMethods(objectDefinition, objectScopeProvider);
 
 		_initCustomObjectDefinition(objectDefinition);
 
@@ -247,10 +249,11 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		try {
 			String factoryPid =
 				"com.liferay.portal.vulcan.internal.configuration." +
-					"VulcanConfiguration";
+					"VulcanCompanyConfiguration";
 
 			Configuration configuration =
-				_configurationAdmin.createFactoryConfiguration(factoryPid, "?");
+				_configurationAdmin.createFactoryConfiguration(
+					factoryPid, StringPool.QUESTION);
 
 			Method[] methods = BaseObjectEntryResourceImpl.class.getMethods();
 
@@ -278,6 +281,10 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 
 			configuration.update(
 				HashMapDictionaryBuilder.put(
+					ExtendedObjectClassDefinition.Scope.COMPANY.
+						getPropertyKey(),
+					String.valueOf(objectDefinition.getCompanyId())
+				).put(
 					"excludedOperationIds",
 					StringUtil.merge(excludedOperationIds, ",")
 				).put(

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/configuration/VulcanCompanyConfiguration.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/configuration/VulcanCompanyConfiguration.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.internal.configuration;
+
+import aQute.bnd.annotation.metatype.Meta;
+
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+
+/**
+ * @author Carlos Correa
+ */
+@ExtendedObjectClassDefinition(
+	category = "web-api", factoryInstanceLabelAttribute = "path",
+	scope = ExtendedObjectClassDefinition.Scope.COMPANY
+)
+@Meta.OCD(
+	factory = true,
+	id = "com.liferay.portal.vulcan.internal.configuration.VulcanCompanyConfiguration",
+	localization = "content/Language", name = "headless-api-configuration-name"
+)
+public interface VulcanCompanyConfiguration {
+
+	@Meta.AD(deflt = "/api", name = "path")
+	public String path();
+
+	@Meta.AD(deflt = "true", name = "graphql-api", required = false)
+	public boolean graphQLEnabled();
+
+	@Meta.AD(deflt = "true", name = "rest-api", required = false)
+	public boolean restEnabled();
+
+	@Meta.AD(name = "excluded-operation-ids", required = false)
+	public String excludedOperationIds();
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/configuration/persistence/listener/BaseConfigurationModelListener.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/configuration/persistence/listener/BaseConfigurationModelListener.java
@@ -1,0 +1,174 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.internal.configuration.persistence.listener;
+
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+import com.liferay.portal.configuration.persistence.listener.ConfigurationModelListener;
+import com.liferay.portal.configuration.persistence.listener.ConfigurationModelListenerException;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.LocaleThreadLocal;
+import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.vulcan.internal.configuration.VulcanCompanyConfiguration;
+import com.liferay.portal.vulcan.internal.configuration.VulcanConfiguration;
+
+import java.util.Collection;
+import java.util.Dictionary;
+import java.util.Map;
+import java.util.Set;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.osgi.service.component.runtime.ServiceComponentRuntime;
+import org.osgi.service.component.runtime.dto.ComponentDescriptionDTO;
+
+/**
+ * @author Carlos Correa
+ */
+public class BaseConfigurationModelListener
+	implements ConfigurationModelListener {
+
+	@Override
+	public void onAfterSave(String pid, Dictionary<String, Object> dictionary) {
+		Collection<ComponentDescriptionDTO> componentDescriptionDTOs =
+			_serviceComponentRuntime.getComponentDescriptionDTOs(
+				_bundleContext.getBundles());
+
+		for (ComponentDescriptionDTO componentDescriptionDTO :
+				componentDescriptionDTOs) {
+
+			Map<String, Object> properties = componentDescriptionDTO.properties;
+
+			Set<Map.Entry<String, Object>> entries = properties.entrySet();
+
+			for (Map.Entry<String, Object> entry : entries) {
+				String key = entry.getKey();
+
+				Object value = entry.getValue();
+
+				if (key.equals("osgi.jaxrs.application.base") &&
+					value.equals(dictionary.get("path"))) {
+
+					if ((Boolean)dictionary.get("restEnabled")) {
+						_serviceComponentRuntime.enableComponent(
+							componentDescriptionDTO);
+					}
+					else {
+						_serviceComponentRuntime.disableComponent(
+							componentDescriptionDTO);
+					}
+
+					break;
+				}
+			}
+		}
+	}
+
+	@Override
+	public void onBeforeSave(String pid, Dictionary<String, Object> dictionary)
+		throws ConfigurationModelListenerException {
+
+		try {
+			String path = (String)dictionary.get("path");
+
+			_validatePathExists(path);
+
+			_validateUniqueConfiguration(path, dictionary);
+		}
+		catch (Exception exception) {
+			throw new ConfigurationModelListenerException(
+				exception.getMessage(), BaseConfigurationModelListener.class,
+				getClass(), dictionary);
+		}
+	}
+
+	protected void init(
+		BundleContext bundleContext, ConfigurationAdmin configurationAdmin,
+		ServiceComponentRuntime serviceComponentRuntime) {
+
+		_bundleContext = bundleContext;
+		_configurationAdmin = configurationAdmin;
+		_serviceComponentRuntime = serviceComponentRuntime;
+	}
+
+	private void _validatePathExists(String path) throws Exception {
+		if (Validator.isNotNull(path)) {
+			return;
+		}
+
+		throw new Exception(
+			ResourceBundleUtil.getString(
+				ResourceBundleUtil.getBundle(
+					"content.Language",
+					LocaleThreadLocal.getThemeDisplayLocale(), getClass()),
+				"path-cannot-be-empty"));
+	}
+
+	private void _validateUniqueConfiguration(
+			Dictionary<String, Object> dictionary, String filterString)
+		throws Exception {
+
+		Configuration[] configurations = _configurationAdmin.listConfigurations(
+			filterString);
+
+		if (configurations == null) {
+			return;
+		}
+
+		for (Configuration configuration : configurations) {
+			if (configuration == null) {
+				continue;
+			}
+
+			Dictionary<String, Object> properties =
+				configuration.getProperties();
+
+			Object servicePid = properties.get("service.pid");
+
+			if (!servicePid.equals(dictionary.get("service.pid"))) {
+				configuration.delete();
+			}
+		}
+	}
+
+	private void _validateUniqueConfiguration(
+			String path, Dictionary<String, Object> dictionary)
+		throws Exception {
+
+		String filterString = String.format(
+			"(&(path=%s)(service.factoryPid=%s))", path,
+			VulcanConfiguration.class.getName());
+
+		_validateUniqueConfiguration(dictionary, filterString);
+
+		if (dictionary.get("companyId") == null) {
+			return;
+		}
+
+		filterString = String.format(
+			"(&(path=%s)(service.factoryPid=%s)(%s=%d))", path,
+			VulcanCompanyConfiguration.class.getName(),
+			ExtendedObjectClassDefinition.Scope.COMPANY.getPropertyKey(),
+			GetterUtil.getLong(dictionary.get("companyId")));
+
+		_validateUniqueConfiguration(dictionary, filterString);
+	}
+
+	private BundleContext _bundleContext;
+	private ConfigurationAdmin _configurationAdmin;
+	private ServiceComponentRuntime _serviceComponentRuntime;
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/configuration/persistence/listener/VulcanCompanyConfigurationModelListener.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/configuration/persistence/listener/VulcanCompanyConfigurationModelListener.java
@@ -14,28 +14,14 @@
 
 package com.liferay.portal.vulcan.internal.configuration.persistence.listener;
 
-import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
 import com.liferay.portal.configuration.persistence.listener.ConfigurationModelListener;
-import com.liferay.portal.configuration.persistence.listener.ConfigurationModelListenerException;
-import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.LocaleThreadLocal;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
-import com.liferay.portal.kernel.util.Validator;
-import com.liferay.portal.vulcan.internal.configuration.VulcanCompanyConfiguration;
-
-import java.util.Collection;
-import java.util.Dictionary;
-import java.util.Map;
-import java.util.Set;
 
 import org.osgi.framework.BundleContext;
-import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.runtime.ServiceComponentRuntime;
-import org.osgi.service.component.runtime.dto.ComponentDescriptionDTO;
 
 /**
  * @author Carlos Correa
@@ -46,113 +32,12 @@ import org.osgi.service.component.runtime.dto.ComponentDescriptionDTO;
 	service = ConfigurationModelListener.class
 )
 public class VulcanCompanyConfigurationModelListener
-	implements ConfigurationModelListener {
-
-	@Override
-	public void onAfterSave(String pid, Dictionary<String, Object> dictionary) {
-		Collection<ComponentDescriptionDTO> componentDescriptionDTOs =
-			_serviceComponentRuntime.getComponentDescriptionDTOs(
-				_bundleContext.getBundles());
-
-		for (ComponentDescriptionDTO componentDescriptionDTO :
-				componentDescriptionDTOs) {
-
-			Map<String, Object> properties = componentDescriptionDTO.properties;
-
-			Set<Map.Entry<String, Object>> entries = properties.entrySet();
-
-			for (Map.Entry<String, Object> entry : entries) {
-				String key = entry.getKey();
-
-				Object value = entry.getValue();
-
-				if (key.equals("osgi.jaxrs.application.base") &&
-					value.equals(dictionary.get("path"))) {
-
-					if ((Boolean)dictionary.get("restEnabled")) {
-						_serviceComponentRuntime.enableComponent(
-							componentDescriptionDTO);
-					}
-					else {
-						_serviceComponentRuntime.disableComponent(
-							componentDescriptionDTO);
-					}
-
-					break;
-				}
-			}
-		}
-	}
-
-	@Override
-	public void onBeforeSave(String pid, Dictionary<String, Object> dictionary)
-		throws ConfigurationModelListenerException {
-
-		try {
-			String path = (String)dictionary.get("path");
-
-			_validatePathExists(path);
-
-			_validateUniqueConfiguration(path, dictionary);
-		}
-		catch (Exception exception) {
-			throw new ConfigurationModelListenerException(
-				exception.getMessage(),
-				VulcanCompanyConfigurationModelListener.class, getClass(),
-				dictionary);
-		}
-	}
+	extends BaseConfigurationModelListener {
 
 	@Activate
 	protected void activate(BundleContext bundleContext) {
-		_bundleContext = bundleContext;
+		init(bundleContext, _configurationAdmin, _serviceComponentRuntime);
 	}
-
-	private void _validatePathExists(String path) throws Exception {
-		if (Validator.isNotNull(path)) {
-			return;
-		}
-
-		throw new Exception(
-			ResourceBundleUtil.getString(
-				ResourceBundleUtil.getBundle(
-					"content.Language",
-					LocaleThreadLocal.getThemeDisplayLocale(), getClass()),
-				"path-cannot-be-empty"));
-	}
-
-	private void _validateUniqueConfiguration(
-			String path, Dictionary<String, Object> dictionary)
-		throws Exception {
-
-		String filterString = String.format(
-			"(&(path=%s)(service.factoryPid=%s)(%s=%d))", path,
-			VulcanCompanyConfiguration.class.getName(),
-			ExtendedObjectClassDefinition.Scope.COMPANY.getPropertyKey(),
-			GetterUtil.getLong(dictionary.get("companyId")));
-
-		Configuration[] configurations = _configurationAdmin.listConfigurations(
-			filterString);
-
-		if (configurations == null) {
-			return;
-		}
-
-		Configuration configuration = configurations[0];
-
-		if (configuration != null) {
-			Dictionary<String, Object> properties =
-				configuration.getProperties();
-
-			Object servicePid = properties.get("service.pid");
-
-			if (!servicePid.equals(dictionary.get("service.pid"))) {
-				configuration.delete();
-			}
-		}
-	}
-
-	private BundleContext _bundleContext;
 
 	@Reference
 	private ConfigurationAdmin _configurationAdmin;

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/configuration/persistence/listener/VulcanCompanyConfigurationModelListener.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/configuration/persistence/listener/VulcanCompanyConfigurationModelListener.java
@@ -1,0 +1,163 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.internal.configuration.persistence.listener;
+
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+import com.liferay.portal.configuration.persistence.listener.ConfigurationModelListener;
+import com.liferay.portal.configuration.persistence.listener.ConfigurationModelListenerException;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.LocaleThreadLocal;
+import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.vulcan.internal.configuration.VulcanCompanyConfiguration;
+
+import java.util.Collection;
+import java.util.Dictionary;
+import java.util.Map;
+import java.util.Set;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.runtime.ServiceComponentRuntime;
+import org.osgi.service.component.runtime.dto.ComponentDescriptionDTO;
+
+/**
+ * @author Carlos Correa
+ */
+@Component(
+	immediate = true,
+	property = "model.class.name=com.liferay.portal.vulcan.internal.configuration.VulcanCompanyConfiguration",
+	service = ConfigurationModelListener.class
+)
+public class VulcanCompanyConfigurationModelListener
+	implements ConfigurationModelListener {
+
+	@Override
+	public void onAfterSave(String pid, Dictionary<String, Object> dictionary) {
+		Collection<ComponentDescriptionDTO> componentDescriptionDTOs =
+			_serviceComponentRuntime.getComponentDescriptionDTOs(
+				_bundleContext.getBundles());
+
+		for (ComponentDescriptionDTO componentDescriptionDTO :
+				componentDescriptionDTOs) {
+
+			Map<String, Object> properties = componentDescriptionDTO.properties;
+
+			Set<Map.Entry<String, Object>> entries = properties.entrySet();
+
+			for (Map.Entry<String, Object> entry : entries) {
+				String key = entry.getKey();
+
+				Object value = entry.getValue();
+
+				if (key.equals("osgi.jaxrs.application.base") &&
+					value.equals(dictionary.get("path"))) {
+
+					if ((Boolean)dictionary.get("restEnabled")) {
+						_serviceComponentRuntime.enableComponent(
+							componentDescriptionDTO);
+					}
+					else {
+						_serviceComponentRuntime.disableComponent(
+							componentDescriptionDTO);
+					}
+
+					break;
+				}
+			}
+		}
+	}
+
+	@Override
+	public void onBeforeSave(String pid, Dictionary<String, Object> dictionary)
+		throws ConfigurationModelListenerException {
+
+		try {
+			String path = (String)dictionary.get("path");
+
+			_validatePathExists(path);
+
+			_validateUniqueConfiguration(path, dictionary);
+		}
+		catch (Exception exception) {
+			throw new ConfigurationModelListenerException(
+				exception.getMessage(),
+				VulcanCompanyConfigurationModelListener.class, getClass(),
+				dictionary);
+		}
+	}
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_bundleContext = bundleContext;
+	}
+
+	private void _validatePathExists(String path) throws Exception {
+		if (Validator.isNotNull(path)) {
+			return;
+		}
+
+		throw new Exception(
+			ResourceBundleUtil.getString(
+				ResourceBundleUtil.getBundle(
+					"content.Language",
+					LocaleThreadLocal.getThemeDisplayLocale(), getClass()),
+				"path-cannot-be-empty"));
+	}
+
+	private void _validateUniqueConfiguration(
+			String path, Dictionary<String, Object> dictionary)
+		throws Exception {
+
+		String filterString = String.format(
+			"(&(path=%s)(service.factoryPid=%s)(%s=%d))", path,
+			VulcanCompanyConfiguration.class.getName(),
+			ExtendedObjectClassDefinition.Scope.COMPANY.getPropertyKey(),
+			GetterUtil.getLong(dictionary.get("companyId")));
+
+		Configuration[] configurations = _configurationAdmin.listConfigurations(
+			filterString);
+
+		if (configurations == null) {
+			return;
+		}
+
+		Configuration configuration = configurations[0];
+
+		if (configuration != null) {
+			Dictionary<String, Object> properties =
+				configuration.getProperties();
+
+			Object servicePid = properties.get("service.pid");
+
+			if (!servicePid.equals(dictionary.get("service.pid"))) {
+				configuration.delete();
+			}
+		}
+	}
+
+	private BundleContext _bundleContext;
+
+	@Reference
+	private ConfigurationAdmin _configurationAdmin;
+
+	@Reference
+	private ServiceComponentRuntime _serviceComponentRuntime;
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/configuration/persistence/listener/VulcanConfigurationModelListener.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/configuration/persistence/listener/VulcanConfigurationModelListener.java
@@ -15,25 +15,13 @@
 package com.liferay.portal.vulcan.internal.configuration.persistence.listener;
 
 import com.liferay.portal.configuration.persistence.listener.ConfigurationModelListener;
-import com.liferay.portal.configuration.persistence.listener.ConfigurationModelListenerException;
-import com.liferay.portal.kernel.util.LocaleThreadLocal;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
-import com.liferay.portal.kernel.util.Validator;
-import com.liferay.portal.vulcan.internal.configuration.VulcanConfiguration;
-
-import java.util.Collection;
-import java.util.Dictionary;
-import java.util.Map;
-import java.util.Set;
 
 import org.osgi.framework.BundleContext;
-import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.runtime.ServiceComponentRuntime;
-import org.osgi.service.component.runtime.dto.ComponentDescriptionDTO;
 
 /**
  * @author Javier Gamarra
@@ -44,110 +32,12 @@ import org.osgi.service.component.runtime.dto.ComponentDescriptionDTO;
 	service = ConfigurationModelListener.class
 )
 public class VulcanConfigurationModelListener
-	implements ConfigurationModelListener {
-
-	@Override
-	public void onAfterSave(String pid, Dictionary<String, Object> dictionary) {
-		Collection<ComponentDescriptionDTO> componentDescriptionDTOs =
-			_serviceComponentRuntime.getComponentDescriptionDTOs(
-				_bundleContext.getBundles());
-
-		for (ComponentDescriptionDTO componentDescriptionDTO :
-				componentDescriptionDTOs) {
-
-			Map<String, Object> properties = componentDescriptionDTO.properties;
-
-			Set<Map.Entry<String, Object>> entries = properties.entrySet();
-
-			for (Map.Entry<String, Object> entry : entries) {
-				String key = entry.getKey();
-
-				Object value = entry.getValue();
-
-				if (key.equals("osgi.jaxrs.application.base") &&
-					value.equals(dictionary.get("path"))) {
-
-					if ((Boolean)dictionary.get("restEnabled")) {
-						_serviceComponentRuntime.enableComponent(
-							componentDescriptionDTO);
-					}
-					else {
-						_serviceComponentRuntime.disableComponent(
-							componentDescriptionDTO);
-					}
-
-					break;
-				}
-			}
-		}
-	}
-
-	@Override
-	public void onBeforeSave(String pid, Dictionary<String, Object> dictionary)
-		throws ConfigurationModelListenerException {
-
-		try {
-			String path = (String)dictionary.get("path");
-
-			_validatePathExists(path);
-
-			_validateUniqueConfiguration(path, dictionary);
-		}
-		catch (Exception exception) {
-			throw new ConfigurationModelListenerException(
-				exception.getMessage(), VulcanConfigurationModelListener.class,
-				getClass(), dictionary);
-		}
-	}
+	extends BaseConfigurationModelListener {
 
 	@Activate
 	protected void activate(BundleContext bundleContext) {
-		_bundleContext = bundleContext;
+		init(bundleContext, _configurationAdmin, _serviceComponentRuntime);
 	}
-
-	private void _validatePathExists(String path) throws Exception {
-		if (Validator.isNotNull(path)) {
-			return;
-		}
-
-		throw new Exception(
-			ResourceBundleUtil.getString(
-				ResourceBundleUtil.getBundle(
-					"content.Language",
-					LocaleThreadLocal.getThemeDisplayLocale(), getClass()),
-				"path-cannot-be-empty"));
-	}
-
-	private void _validateUniqueConfiguration(
-			String path, Dictionary<String, Object> dictionary)
-		throws Exception {
-
-		String filterString = String.format(
-			"(&(path=%s)(service.factoryPid=%s))", path,
-			VulcanConfiguration.class.getName());
-
-		Configuration[] configurations = _configurationAdmin.listConfigurations(
-			filterString);
-
-		if (configurations == null) {
-			return;
-		}
-
-		Configuration configuration = configurations[0];
-
-		if (configuration != null) {
-			Dictionary<String, Object> properties =
-				configuration.getProperties();
-
-			Object servicePid = properties.get("service.pid");
-
-			if (!servicePid.equals(dictionary.get("service.pid"))) {
-				configuration.delete();
-			}
-		}
-	}
-
-	private BundleContext _bundleContext;
 
 	@Reference
 	private ConfigurationAdmin _configurationAdmin;

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/configuration/util/ConfigurationUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/configuration/util/ConfigurationUtil.java
@@ -14,10 +14,12 @@
 
 package com.liferay.portal.vulcan.internal.configuration.util;
 
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.vulcan.internal.configuration.VulcanCompanyConfiguration;
 import com.liferay.portal.vulcan.internal.configuration.VulcanConfiguration;
 
 import java.util.Dictionary;
@@ -33,12 +35,16 @@ import org.osgi.service.cm.ConfigurationAdmin;
 public class ConfigurationUtil {
 
 	public static Set<String> getExcludedOperationIds(
-		ConfigurationAdmin configurationAdmin, String path) {
+		long companyId, ConfigurationAdmin configurationAdmin, String path) {
 
 		try {
 			String filterString = String.format(
-				"(&(path=%s)(service.factoryPid=%s))", path,
-				VulcanConfiguration.class.getName());
+				"(&(path=%s)(|(service.factoryPid=%s)" +
+					"(&(service.factoryPid=%s)(%s=%d))))",
+				path, VulcanConfiguration.class.getName(),
+				VulcanCompanyConfiguration.class.getName(),
+				ExtendedObjectClassDefinition.Scope.COMPANY.getPropertyKey(),
+				companyId);
 
 			Configuration[] configurations =
 				configurationAdmin.listConfigurations(filterString);

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/container/request/filter/ContextContainerRequestFilter.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/container/request/filter/ContextContainerRequestFilter.java
@@ -108,16 +108,20 @@ public class ContextContainerRequestFilter implements ContainerRequestFilter {
 	}
 
 	private void _filterExcludedOperationIds(
-		ContainerRequestContext containerRequestContext, Message message) {
+			ContainerRequestContext containerRequestContext,
+			HttpServletRequest httpServletRequest, Message message)
+		throws Exception {
 
-		String path = StringUtil.removeSubstring(
+		String path = StringUtil.removeFirst(
 			(String)message.get(Message.BASE_PATH), "/o");
 
 		path = StringUtil.replaceLast(path, '/', "");
 
+		Company company = _portal.getCompany(httpServletRequest);
+
 		Set<String> excludedOperationIds =
 			ConfigurationUtil.getExcludedOperationIds(
-				_configurationAdmin, path);
+				company.getCompanyId(), _configurationAdmin, path);
 
 		Method method = (Method)message.get("org.apache.cxf.resource.method");
 
@@ -144,7 +148,8 @@ public class ContextContainerRequestFilter implements ContainerRequestFilter {
 		HttpServletRequest httpServletRequest =
 			ContextProviderUtil.getHttpServletRequest(message);
 
-		_filterExcludedOperationIds(containerRequestContext, message);
+		_filterExcludedOperationIds(
+			containerRequestContext, httpServletRequest, message);
 
 		Class<?> clazz = instance.getClass();
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/resource/OpenAPIResourceImpl.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/resource/OpenAPIResourceImpl.java
@@ -554,7 +554,7 @@ public class OpenAPIResourceImpl implements OpenAPIResource {
 
 				Set<String> excludedOperationIds =
 					ConfigurationUtil.getExcludedOperationIds(
-						_configurationAdmin,
+						CompanyThreadLocal.getCompanyId(), _configurationAdmin,
 						openAPISchemaFilter.getApplicationPath());
 
 				if (excludedOperationIds.contains(operationId)) {


### PR DESCRIPTION
This pull request contains the code to create a **Vulcan Configuration scoped by company** that lives together with a Vulcan Configuration scoped by system . As it previously existed a `VulcanConfiguration` to manage several parameters, it is now necessary to be able to configure certain endpoints **scoped by company**. The use case is related with Objects, as now, based on the Company, the definition of an object could be different for the different companies, even if they share the same name.

For example, if an Object called `Student` _scoped by company_ is created in one company, and then, another Object called `Student` too _scoped by site_ is created in a different company, then:

- **Before the PR**: One `VulcanConfiguration` is defined with some parameters, including `excludedOperationIds`. That means for the second company, the `VulcanConfiguration` is mistaken, as certain endpoints will be excluded of being invoked based on the first `VulcanConfiguration` defined from the first Object.
- **After the PR:** One `VulcanCompanyConfiguration` is defined for the first Object, and another `VulcanCompanyConfiguration` is defined for the second Object. That means each Object has its own Vulcan Configuration, based on **its REST path** (`/c/students` in both cases) **and its company** (each one with its own companyId parameter).
