### PR TITLE
Lps 172437 Add more tests on expose erc for wikiPageAttachement

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/WikiPageAttachmentAPI.macro
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/WikiPageAttachmentAPI.macro
@@ -39,8 +39,8 @@ definition {
 
 		var curl = '''
 			${portalURL}/o/headless-delivery/v1.0/${api} \
-			-u test@liferay.com:test \
-			-H Content-Type: application/json
+				-u test@liferay.com:test \
+				-H Content-Type: application/json
 		''';
 
 		return "${curl}";

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/WikiPageAttachmentAPI.macro
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/WikiPageAttachmentAPI.macro
@@ -16,6 +16,32 @@ definition {
 		return "${curl}";
 	}
 
+	macro _curlWikiPageAttachments {
+		var portalURL = JSONCompany.getPortalURL();
+
+		if (isSet(wikiPageId)) {
+			var api = "wiki-pages/${wikiPageId}/wiki-page-attachments";
+		}
+		else if (isSet(wikiPageAttachementId)) {
+			var api = "/wiki-page-attachments/${wikiPageAttachementId}";
+		}
+		else {
+			Variables.assertDefined(parameterList = "${groupName},${wikiPageErc},${wikiPageAttachementErc}");
+
+			var siteId = JSONGroupAPI._getSiteIdByGroupKey(groupName = "${groupName}");
+
+			var api = "sites/${siteId}/wiki-pages/by-external-reference-code/${wikiPageErc}/wiki-page-attachments/by-external-reference-code/${wikiPageAttachementErc}";
+		}
+
+		var curl = '''
+			${portalURL}/o/headless-delivery/v1.0/${api} \
+			-u test@liferay.com:test \
+			-H Content-Type: application/json
+		''';
+
+		return "${curl}";
+	}
+
 	macro _getAttachmentById {
 		Variables.assertDefined(parameterList = "${wikiPageAttachmentId}");
 
@@ -31,6 +57,16 @@ definition {
 		var curl = JSONCurlUtil.get("${curl}");
 
 		return "${curl}";
+	}
+
+	macro AssertCorrectErcInResponse {
+		Variables.assertDefined(parameterList = "${responseToParse},${expectedErc}");
+
+		var actualErc = JSONUtil.getWithJSONPath("${responseToParse}", "$..externalReferenceCode");
+
+		TestUtils.assertEquals(
+			actual = "${actualErc}",
+			expected = "${expectedErc}");
 	}
 
 	macro createWikiPageAttachment {
@@ -71,9 +107,23 @@ definition {
 		return "${response}";
 	}
 
+	macro getWikiPageAttachments {
+		var curl = WikiPageAttachmentAPI._curlWikiPageAttachments(
+			groupName = "${groupName}",
+			wikiPageAttachementErc = "${wikiPageAttachementErc}",
+			wikiPageAttachementId = "${wikiPageAttachementId}",
+			wikiPageErc = "${wikiPageErc}",
+			wikiPageId = "${wikiPageId}");
+
+		var response = JSONCurlUtil.get("${curl}");
+
+		return "${response}";
+	}
+
 	macro setupGlobalWikiPageWithAttachment {
 		var wikiPage = JSONWiki.addWikiPage(
 			groupName = "Guest",
+			noSelenium = "true",
 			wikiNodeName = "Main",
 			wikiPageContent = "Wiki Page Content",
 			wikiPageName = "Wiki Page Title");

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/WikiPageAttachmentAPI.macro
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/WikiPageAttachmentAPI.macro
@@ -3,7 +3,9 @@ definition {
 	macro _curlDeleteByErc {
 		Variables.assertDefined(parameterList = "${groupName},${wikiPageAttachmentErc},${wikiPageErc}");
 
-		var siteId = JSONGroupAPI._getSiteIdByGroupKey(groupName = "${groupName}");
+		var siteId = JSONGroupAPI._getGroupIdByNameNoSelenium(
+			groupName = "${groupName}",
+			site = "true");
 		var portalURL = JSONCompany.getPortalURL();
 
 		var curl = '''
@@ -28,7 +30,9 @@ definition {
 		else {
 			Variables.assertDefined(parameterList = "${groupName},${wikiPageErc},${wikiPageAttachementErc}");
 
-			var siteId = JSONGroupAPI._getSiteIdByGroupKey(groupName = "${groupName}");
+			var siteId = JSONGroupAPI._getGroupIdByNameNoSelenium(
+				groupName = "${groupName}",
+				site = "true");
 
 			var api = "sites/${siteId}/wiki-pages/by-external-reference-code/${wikiPageErc}/wiki-page-attachments/by-external-reference-code/${wikiPageAttachementErc}";
 		}

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcInWikiPageAttachment.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcInWikiPageAttachment.testcase
@@ -37,4 +37,52 @@ definition {
 		}
 	}
 
+	@priority = "3"
+	test CanReturenErcWithGetSiteWikiPagesByErc {
+		property portal.acceptance = "true";
+
+		task ("When requesting getSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode") {
+			var response = WikiPageAttachmentAPI.getWikiPageAttachments(
+				groupName = "Guest",
+				wikiPageAttachementErc = "${staticWikiPageAttachmentErc}",
+				wikiPageErc = "${staticWikiPageErc}");
+		}
+
+		task ("Then the payload contains externalReferenceCode") {
+			WikiPageAttachmentAPI.AssertCorrectErcInResponse(
+				expectedErc = "${staticWikiPageAttachmentErc}",
+				responseToParse = "${response}");
+		}
+	}
+
+	@priority = "3"
+	test CanReturenErcWithGetWikiPageAttachmentsByWikiPageId {
+		property portal.acceptance = "true";
+
+		task ("When requesting getWikiPageWikiPageAttachmentsPage") {
+			var response = WikiPageAttachmentAPI.getWikiPageAttachments(wikiPageAttachementId = "${staticWikiPageAttachmentId}");
+		}
+
+		task ("Then the attachment object contains externalReferenceCode") {
+			WikiPageAttachmentAPI.AssertCorrectErcInResponse(
+				expectedErc = "${staticWikiPageAttachmentErc}",
+				responseToParse = "${response}");
+		}
+	}
+
+	@priority = "3"
+	test CanReturenErcWithGetWikiPagesByWikiPageId {
+		property portal.acceptance = "true";
+
+		task ("When requesting getWikiPageAttachment") {
+			var response = WikiPageAttachmentAPI.getWikiPageAttachments(wikiPageId = "${staticWikiPageId}");
+		}
+
+		task ("Then the attachment object contains externalReferenceCode") {
+			WikiPageAttachmentAPI.AssertCorrectErcInResponse(
+				expectedErc = "${staticWikiPageAttachmentErc}",
+				responseToParse = "${response}");
+		}
+	}
+
 }

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcInWikiPageAttachment.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcInWikiPageAttachment.testcase
@@ -17,6 +17,7 @@ definition {
 		JSONWiki.deleteWikiPageById(wikiPageId = "${staticWikiPageId}");
 	}
 
+	@disable-webdriver = "true"
 	@priority = "4"
 	test CanDeleteAttachmentByExternalReferenceCode {
 		property portal.acceptance = "true";
@@ -37,10 +38,9 @@ definition {
 		}
 	}
 
+	@disable-webdriver = "true"
 	@priority = "3"
 	test CanReturenErcWithGetSiteWikiPagesByErc {
-		property portal.acceptance = "true";
-
 		task ("When requesting getSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode") {
 			var response = WikiPageAttachmentAPI.getWikiPageAttachments(
 				groupName = "Guest",
@@ -55,10 +55,9 @@ definition {
 		}
 	}
 
+	@disable-webdriver = "true"
 	@priority = "3"
 	test CanReturenErcWithGetWikiPageAttachmentsByWikiPageId {
-		property portal.acceptance = "true";
-
 		task ("When requesting getWikiPageWikiPageAttachmentsPage") {
 			var response = WikiPageAttachmentAPI.getWikiPageAttachments(wikiPageAttachementId = "${staticWikiPageAttachmentId}");
 		}
@@ -70,10 +69,9 @@ definition {
 		}
 	}
 
+	@disable-webdriver = "true"
 	@priority = "3"
 	test CanReturenErcWithGetWikiPagesByWikiPageId {
-		property portal.acceptance = "true";
-
 		task ("When requesting getWikiPageAttachment") {
 			var response = WikiPageAttachmentAPI.getWikiPageAttachments(wikiPageId = "${staticWikiPageId}");
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/group/JSONGroupAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/group/JSONGroupAPI.macro
@@ -248,7 +248,13 @@ definition {
 			var portalURL = JSONCompany.getPortalURL();
 		}
 
-		var companyId = JSONCompany.getCompanyId(portalURL = "${portalURL}");
+		if (isSet(noSelenium)) {
+			var companyId = JSONCompany.getCompanyIdNoSelenium(portalURL = "${portalURL}");
+		}
+		else {
+			var companyId = JSONCompany.getCompanyId(portalURL = "${portalURL}");
+		}
+
 		var parentGroupId = JSONGroupSetter.setParentGroupId(
 			grandParentGroupName = "${grandParentGroupName}",
 			parentGroupName = "${parentGroupName}");

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/wiki/JSONWiki.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/wiki/JSONWiki.macro
@@ -55,6 +55,7 @@ definition {
 		var nodeId = JSONWikiSetter.setNodeId(
 			groupName = "${groupName}",
 			name = "${wikiNodeName}",
+			noSelenium = "${noSelenium}",
 			site = "${site}");
 
 		var response = JSONWikiAPI._addWikiPage(

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/wiki/JSONWikiSetter.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/wiki/JSONWikiSetter.macro
@@ -23,6 +23,7 @@ definition {
 
 		var groupId = JSONGroupAPI._getGroupIdByName(
 			groupName = "${groupName}",
+			noSelenium = "${noSelenium}",
 			site = "${site}");
 
 		var nodeId = JSONWikiAPI._getNodeIdByName(


### PR DESCRIPTION
**Background**
- Add more tests for story: expose ERC in WikiPageAttachment

**Test Plan**
- Given WikiPage with attachment created
  When requesting getWikiPageAttachment
  Then the attachment object contains externalReferenceCode
- Given WikiPage with attachment created
  When requesting getWikiPageWikiPageAttachmentsPage
  Then the attachment object contains externalReferenceCode | PASSED
- Given WikiPage with attachment created
  When requesting getSiteWikiPageByExternalReferenceCodeWikiPageExternalReferenceCodeWikiPageAttachmentByExternalReferenceCode
  Then the payload contains externalReferenceCode

**Jira Ticket**
- https://issues.liferay.com/browse/LPS-172437
