### PR TITLE
LPS-172369 Fixing filter parameter in Headless API not working with custom object date fields

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/v1_0/ObjectEntryEntityModel.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/v1_0/ObjectEntryEntityModel.java
@@ -32,7 +32,6 @@ import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.odata.entity.BooleanEntityField;
 import com.liferay.portal.odata.entity.CollectionEntityField;
 import com.liferay.portal.odata.entity.ComplexEntityField;
-import com.liferay.portal.odata.entity.DateEntityField;
 import com.liferay.portal.odata.entity.DateTimeEntityField;
 import com.liferay.portal.odata.entity.DoubleEntityField;
 import com.liferay.portal.odata.entity.EntityField;
@@ -146,7 +145,7 @@ public class ObjectEntryEntityModel implements EntityModel {
 					objectField.getDBType(),
 					ObjectFieldConstants.DB_TYPE_DATE)) {
 
-			return new DateEntityField(
+			return new DateTimeEntityField(
 				objectField.getName(), locale -> objectField.getName(),
 				locale -> objectField.getName());
 		}


### PR DESCRIPTION
**What is new?**
-  Change `DateEntityField` by `DateTimeEntityField` in ObjectEntryEntityModel to enable filtering custom object date fields

**How to test it?**
1. Deploy `object-rest-impl`.
2. Create a Custom Object with a custom `Date` field called `issueDate`.
3. Create an Object Entry.
4. Execute a GET request passing a filter parameter like this: `filter=issueDate lt 2023-02-13T12:33:12Z`. Like:
```
curl -X 'GET' \
  'http://localhost:8080/o/c/subjects/?filter=issueDate%20lt%202023-02-13T12%3A33%3A12Z' \
  -H 'accept: application/json' \
  -u 'test@liferay.com:test'
```

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-172369 