### PR TITLE
LPS-172577 Allow filtering by related object's system fields

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -96,6 +96,46 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
+	public void testFilterByRelatedObjectDefinitionSystemObjectFieldInManyToManyRelationship()
+		throws Exception {
+
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-154672", "true"
+			).build());
+
+		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		_testFilterByRelatedObjectDefinitionSystemObjectFieldInBothSides();
+
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-154672", "false"
+			).build());
+	}
+
+	@Test
+	public void testFilterByRelatedObjectDefinitionSystemObjectFieldInOneToManyRelationship()
+		throws Exception {
+
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-154672", "true"
+			).build());
+
+		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		_testFilterByRelatedObjectDefinitionSystemObjectFieldInBothSides();
+
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-154672", "false"
+			).build());
+	}
+
+	@Test
 	public void testGetNestedFieldDetailsInOneToManyRelationships()
 		throws Exception {
 
@@ -229,6 +269,42 @@ public class ObjectEntryResourceTest {
 			objectRelationship, TestPropsValues.getUserId());
 
 		return objectRelationship;
+	}
+
+	private void _testFilterByRelatedObjectDefinitionSystemObjectField(
+			String expectedObjectFieldName, String expectedObjectFieldValue,
+			ObjectDefinition objectDefinition, long relatedObjectEntryId)
+		throws Exception {
+
+		String endpoint = StringBundler.concat(
+			objectDefinition.getRESTContextPath(), "?filter=",
+			_objectRelationship.getName(), "/id%20eq%20'",
+			String.valueOf(relatedObjectEntryId), StringPool.APOSTROPHE);
+
+		JSONObject jsonObject = HTTPTestUtil.invoke(
+			null, endpoint, Http.Method.GET);
+
+		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
+
+		Assert.assertEquals(1, itemsJSONArray.length());
+
+		JSONObject itemJSONObject = itemsJSONArray.getJSONObject(0);
+
+		Assert.assertEquals(
+			expectedObjectFieldValue,
+			itemJSONObject.getString(expectedObjectFieldName));
+	}
+
+	private void _testFilterByRelatedObjectDefinitionSystemObjectFieldInBothSides()
+		throws Exception {
+
+		_testFilterByRelatedObjectDefinitionSystemObjectField(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1, _objectDefinition1,
+			_objectEntry2.getObjectEntryId());
+
+		_testFilterByRelatedObjectDefinitionSystemObjectField(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2, _objectDefinition2,
+			_objectEntry1.getObjectEntryId());
 	}
 
 	private void _testGetNestedFieldDetailsInOneToManyRelationships(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntry1toMObjectRelatedModelsPredicateProviderImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntry1toMObjectRelatedModelsPredicateProviderImpl.java
@@ -17,6 +17,7 @@ package com.liferay.object.internal.related.models;
 import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.internal.petra.sql.dsl.DynamicObjectDefinitionTable;
 import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntryTable;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
 import com.liferay.object.service.ObjectFieldLocalService;
@@ -95,6 +96,11 @@ public class ObjectEntry1toMObjectRelatedModelsPredicateProviderImpl
 				).from(
 					objectDefinition2DynamicObjectDefinitionTable
 				).innerJoinON(
+					ObjectEntryTable.INSTANCE,
+					ObjectEntryTable.INSTANCE.objectEntryId.eq(
+						objectDefinition2DynamicObjectDefinitionTable.
+							getPrimaryKeyColumn())
+				).innerJoinON(
 					objectDefinition2ExtensionDynamicObjectDefinitionTable,
 					objectDefinition2DynamicObjectDefinitionTable.
 						getPrimaryKeyColumn(
@@ -133,6 +139,11 @@ public class ObjectEntry1toMObjectRelatedModelsPredicateProviderImpl
 						objectDefinition1PKObjectFieldColumn
 					).from(
 						objectDefinition1DynamicObjectDefinitionTable
+					).innerJoinON(
+						ObjectEntryTable.INSTANCE,
+						ObjectEntryTable.INSTANCE.objectEntryId.eq(
+							objectDefinition1DynamicObjectDefinitionTable.
+								getPrimaryKeyColumn())
 					).innerJoinON(
 						objectDefinition1ExtensionTable,
 						objectDefinition1DynamicObjectDefinitionTable.

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntryMtoMObjectRelatedModelsPredicateProviderImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntryMtoMObjectRelatedModelsPredicateProviderImpl.java
@@ -18,6 +18,7 @@ import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.internal.petra.sql.dsl.DynamicObjectDefinitionTable;
 import com.liferay.object.internal.petra.sql.dsl.DynamicObjectRelationshipMappingTable;
 import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntryTable;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.relationship.util.ObjectRelationshipUtil;
 import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
@@ -103,6 +104,11 @@ public class ObjectEntryMtoMObjectRelatedModelsPredicateProviderImpl
 							relatedObjectDefinition)
 					).from(
 						relatedDynamicObjectDefinitionTable
+					).innerJoinON(
+						ObjectEntryTable.INSTANCE,
+						ObjectEntryTable.INSTANCE.objectEntryId.eq(
+							relatedDynamicObjectDefinitionTable.
+								getPrimaryKeyColumn())
 					).innerJoinON(
 						relatedObjectDefinitionExtensionTable,
 						relatedDynamicObjectDefinitionTable.getPrimaryKeyColumn(


### PR DESCRIPTION
Related ticker: [LPS-172577](https://issues.liferay.com/browse/LPS-172577)
___
This PR fixes the problem with the filtering by the related object's system fields (more info about the problem is in the ticket)

### How to test it
* Deploy the module `object-service`
* Enable this feature flag: `feature.flag.LPS-154672`

### Steps to reproduce it (from the ticket)
* Create two custom objects
* Relate that custom objects (the relationship could be one-to-many or many-to-many)
* Publish both objects
* Add some entries to both objects and relate those entries (if you create the typical example of subjects and students, relate the created students with a subject)
* Make a request filtering by a system object field. For example:
```
## Get students
curl "http://localhost:8080/o/c/students?filter=studentSubjects/id eq '43968'" \
     -u 'test@liferay.com:test'
```
Being 43968 the id of the subject to filter so we would receive the students that study that subject