### PR TITLE
LRQA-79070 Remove companyId and userId from batch engine

### DIFF
--- a/modules/apps/batch-engine/batch-engine-test/src/testFunctional/macros/BatchEngine.macro
+++ b/modules/apps/batch-engine/batch-engine-test/src/testFunctional/macros/BatchEngine.macro
@@ -53,14 +53,10 @@ definition {
 	}
 
 	macro setUpGlobalIds {
-		var userId = JSONUserAPI._getUserIdByEmailAddress(userEmailAddress = "test@liferay.com");
 		var companyId = JSONCompany.getCompanyIdNoSelenium(portalURL = "${portalURL}");
 		var siteId = JSONGroupAPI._getSiteIdByGroupKey(groupName = "Guest");
-		static var staticUserId = "${userId}";
 		static var staticCompanyId = "${companyId}";
 		static var staticSiteId = "${siteId}";
-
-		return "${staticUserId}";
 
 		return "${staticCompanyId}";
 

--- a/modules/apps/batch-engine/batch-engine-test/src/testFunctional/tests/AutoDeployMultipleEntriesZipFile.testcase
+++ b/modules/apps/batch-engine/batch-engine-test/src/testFunctional/tests/AutoDeployMultipleEntriesZipFile.testcase
@@ -41,8 +41,6 @@ definition {
 
 			FileUtil.replaceStringInFile("${filePath}/batch-engine.json", "20097", "${staticCompanyId}");
 
-			FileUtil.replaceStringInFile("${filePath}/batch-engine.json", "20125", "${staticUserId}");
-
 			FileUtil.replaceStringInFile("${filePath}/batch-engine.json", "20121", "${staticSiteId}");
 
 			var arhivedFilePath = BatchEngine.archiveAndDeleteOriginalFile(
@@ -76,19 +74,13 @@ definition {
 
 			FileUtil.replaceStringInFile("${filePath}/batch-engine.json", "20097", "${staticCompanyId}");
 
-			FileUtil.replaceStringInFile("${filePath}/batch-engine.json", "20125", "${staticUserId}");
-
 			FileUtil.replaceStringInFile("${filePath}/batch-engine.json", "20121", "${staticSiteId}");
 
 			FileUtil.replaceStringInFile("${filePath}/blog/batch-engine.json", "20097", "${staticCompanyId}");
 
-			FileUtil.replaceStringInFile("${filePath}/blog/batch-engine.json", "20125", "${staticUserId}");
-
 			FileUtil.replaceStringInFile("${filePath}/blog/batch-engine.json", "20121", "${staticSiteId}");
 
 			FileUtil.replaceStringInFile("${filePath}/object/objectDefinition/batch-engine.json", "20097", "${staticCompanyId}");
-
-			FileUtil.replaceStringInFile("${filePath}/object/objectDefinition/batch-engine.json", "20125", "${staticUserId}");
 
 			var arhivedFilePath = BatchEngine.archiveAndDeleteOriginalFile(
 				fileNameWithExtension = "multipleElementsParis.zip",
@@ -128,8 +120,6 @@ definition {
 			var filePath = BatchEngine.copyDependenciesDirToFolder(file = "objectDefinition");
 
 			FileUtil.replaceStringInFile("${filePath}/batch-engine.json", "20097", "${staticCompanyId}");
-
-			FileUtil.replaceStringInFile("${filePath}/batch-engine.json", "20125", "${staticUserId}");
 
 			var arhivedFilePath = BatchEngine.archiveAndDeleteOriginalFile(
 				fileNameWithExtension = "objectDefinition.zip",
@@ -181,8 +171,6 @@ definition {
 			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
 
 			FileUtil.replaceStringInFile("${filePath}/batch-engine.json", "20097", "${staticCompanyId}");
-
-			FileUtil.replaceStringInFile("${filePath}/batch-engine.json", "20125", "${staticUserId}");
 
 			FileUtil.replaceStringInFile("${filePath}/batch-engine.json", "20121", "${staticSiteId}");
 

--- a/modules/apps/batch-engine/batch-engine-test/src/testFunctional/tests/dependencies/blogPosting/batch-engine.json
+++ b/modules/apps/batch-engine/batch-engine-test/src/testFunctional/tests/dependencies/blogPosting/batch-engine.json
@@ -6,6 +6,5 @@
 		"createStrategy": "UPSERT",
 		"siteId": 20121
 	},
-	"userId": 20125,
 	"version": "v1.0"
 }

--- a/modules/apps/batch-engine/batch-engine-test/src/testFunctional/tests/dependencies/multipleElementsParis/batch-engine.json
+++ b/modules/apps/batch-engine/batch-engine-test/src/testFunctional/tests/dependencies/multipleElementsParis/batch-engine.json
@@ -6,6 +6,5 @@
 		"createStrategy": "UPSERT",
 		"siteId": 20121
 	},
-	"userId": 20125,
 	"version": "v1.0"
 }

--- a/modules/apps/batch-engine/batch-engine-test/src/testFunctional/tests/dependencies/multipleElementsParis/blog/batch-engine.json
+++ b/modules/apps/batch-engine/batch-engine-test/src/testFunctional/tests/dependencies/multipleElementsParis/blog/batch-engine.json
@@ -6,6 +6,5 @@
 		"createStrategy": "UPSERT",
 		"siteId": 20121
 	},
-	"userId": 20125,
 	"version": "v1.0"
 }

--- a/modules/apps/batch-engine/batch-engine-test/src/testFunctional/tests/dependencies/multipleElementsParis/object/objectDefinition/batch-engine.json
+++ b/modules/apps/batch-engine/batch-engine-test/src/testFunctional/tests/dependencies/multipleElementsParis/object/objectDefinition/batch-engine.json
@@ -3,6 +3,5 @@
 	"className": "com.liferay.object.admin.rest.dto.v1_0.ObjectDefinition",
 	"companyId": 20097,
 	"parameters": null,
-	"userId": 20125,
 	"version": "v1.0"
 }

--- a/modules/apps/batch-engine/batch-engine-test/src/testFunctional/tests/dependencies/objectDefinition/batch-engine.json
+++ b/modules/apps/batch-engine/batch-engine-test/src/testFunctional/tests/dependencies/objectDefinition/batch-engine.json
@@ -3,6 +3,5 @@
 	"className": "com.liferay.object.admin.rest.dto.v1_0.ObjectDefinition",
 	"companyId": 20097,
 	"parameters": null,
-	"userId": 20125,
 	"version": "v1.0"
 }

--- a/modules/apps/batch-engine/batch-engine-test/src/testFunctional/tests/dependencies/structuredContent/batch-engine.json
+++ b/modules/apps/batch-engine/batch-engine-test/src/testFunctional/tests/dependencies/structuredContent/batch-engine.json
@@ -6,6 +6,5 @@
 		"createStrategy": "UPSERT",
 		"siteId": 20121
 	},
-	"userId": 20125,
 	"version": "v1.0"
 }


### PR DESCRIPTION
Background:
- According to the document https://liferay.atlassian.net/wiki/spaces/COMMERCE/pages/1736409287/Batch+Engine, batch engine will get default companyId and userId

Test Plan:
- Remove companyId and userId from batch engine tests since batch engine can read from conf files for default ones

Jira Ticket:
- https://issues.liferay.com/browse/LRQA-79070