### PR TITLE
LPS-172699 batch-planner-web - JS - fix bug - put no enclosing charac…

### DIFF
--- a/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/constants.js
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/constants.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-export const CSV_ENCLOSING_CHARACTERS = ['"', "'"];
+export const CSV_ENCLOSING_CHARACTERS = ['', '"', "'"];
 export const CSV_FORMAT = 'csv';
 export const EXPORT_FILE_NAME = 'Export.zip';
 export const FILE_EXTENSION_INPUT_PARTIAL_NAME = 'externalType';


### PR DESCRIPTION
In Import/Export Centar - Import View - some cool dev guy removed option to NOT HAVE ENCLOSING CHARACTER
maybe it was me, maybe not...
I'm putting it back