### PR TITLE
LPS-173173 It's not possible to create a Patch by External Reference Code in object-rest-impl

### DIFF
--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -317,7 +317,11 @@ public abstract class Base${schemaName}ResourceImpl
 				/>
 
 				<#if javaMethodSignature.methodName?contains("ByExternalReferenceCode")>
-					${javaDataType} existing${schemaName} = get${schemaName}ByExternalReferenceCode(${firstJavaMethodParameter.parameterName});
+					<#if configYAML.forcePredictableOperationId>
+						${javaDataType} existing${schemaName} = getByExternalReferenceCode(${firstJavaMethodParameter.parameterName});
+					<#else>
+						${javaDataType} existing${schemaName} = get${schemaName}ByExternalReferenceCode(${firstJavaMethodParameter.parameterName});
+					</#if>
 				<#else>
 					${javaDataType} existing${schemaName} = get${schemaName}(${firstJavaMethodParameter.parameterName});
 				</#if>
@@ -335,7 +339,11 @@ public abstract class Base${schemaName}ResourceImpl
 				preparePatch(${schemaVarName}, existing${schemaName});
 
 				<#if javaMethodSignature.methodName?contains("ByExternalReferenceCode")>
-					return put${schemaName}ByExternalReferenceCode(${firstJavaMethodParameter.parameterName}, existing${schemaName});
+					<#if configYAML.forcePredictableOperationId>
+						return putByExternalReferenceCode(${firstJavaMethodParameter.parameterName}, existing${schemaName});
+					<#else>
+						return put${schemaName}ByExternalReferenceCode(${firstJavaMethodParameter.parameterName}, existing${schemaName});
+					</#if>
 				<#else>
 					return put${schemaName}(${firstJavaMethodParameter.parameterName}, existing${schemaName});
 				</#if>


### PR DESCRIPTION
- LPS-173173 Adding the breaking method
- LPS-173173 buildREST
- LPS-173173 Manual fix
- LPS-173173 Ommiting schema name when forcePredictableOperationId = true
- PS-173173 Removing the breaking method
- LPS-173173 buildREST
