### PR TITLE
LPS-163251 Scroll bar disappears when user finish importing in import/export center

### DIFF
--- a/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/import/ImportModal.js
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/import/ImportModal.js
@@ -92,8 +92,8 @@ const ImportModal = ({closeModal, formDataQuerySelector, formImportURL}) => {
 			<ClayModal.Footer
 				last={
 					<ClayButton.Group spaced>
-						<ClayButton displayType={null} onClick={onClose}>
-							{Liferay.Language.get('back-to-the-list')}
+						<ClayButton displayType="secondary" onClick={onClose}>
+							{Liferay.Language.get('close')}
 						</ClayButton>
 
 						{modalStatus === 'danger' && !!externalReferenceCode && (

--- a/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/import/ImportPreviewModal.js
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/import/ImportPreviewModal.js
@@ -13,11 +13,11 @@
  */
 
 import ClayButton from '@clayui/button';
-import ClayModal from '@clayui/modal';
+import ClayModal, {useModal} from '@clayui/modal';
 import ClayTable from '@clayui/table';
 import React from 'react';
 
-const ImportPreviewModalBody = ({
+const ImportPreviewModal = ({
 	closeModal,
 	fieldsSelections,
 	fileContent,
@@ -25,8 +25,14 @@ const ImportPreviewModalBody = ({
 }) => {
 	const dbFieldsSelected = Object.keys(fieldsSelections).sort();
 
+	const {observer, onClose} = useModal({
+		onClose: () => {
+			closeModal();
+		},
+	});
+
 	return (
-		<>
+		<ClayModal observer={observer} size="lg">
 			<ClayModal.Header>
 				{Liferay.Language.get('preview')}
 			</ClayModal.Header>
@@ -69,10 +75,7 @@ const ImportPreviewModalBody = ({
 			<ClayModal.Footer
 				last={
 					<ClayButton.Group spaced>
-						<ClayButton
-							displayType="secondary"
-							onClick={closeModal}
-						>
+						<ClayButton displayType="secondary" onClick={onClose}>
 							{Liferay.Language.get('cancel')}
 						</ClayButton>
 
@@ -87,8 +90,8 @@ const ImportPreviewModalBody = ({
 					</ClayButton.Group>
 				}
 			/>
-		</>
+		</ClayModal>
 	);
 };
 
-export default ImportPreviewModalBody;
+export default ImportPreviewModal;

--- a/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/import/ImportSubmit.js
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/import/ImportSubmit.js
@@ -13,12 +13,11 @@
  */
 
 import ClayButton from '@clayui/button';
-import ClayModal, {useModal} from '@clayui/modal';
 import PropTypes from 'prop-types';
 import React, {useCallback, useState} from 'react';
 
 import ImportModal from './ImportModal';
-import ImportPreviewModalBody from './ImportPreviewModalBody';
+import ImportPreviewModal from './ImportPreviewModal';
 
 function ImportSubmit({
 	evaluateForm,
@@ -30,14 +29,6 @@ function ImportSubmit({
 }) {
 	const [modalVisibile, setModalVisibile] = useState(false);
 	const [stage, setStage] = useState('preview');
-
-	const {observer, onClose} = useModal({
-		onClose: () => {
-			setStage('preview');
-
-			setModalVisibile(false);
-		},
-	});
 
 	const showPreviewModal = useCallback(() => {
 		evaluateForm();
@@ -58,19 +49,20 @@ function ImportSubmit({
 			</ClayButton>
 
 			{modalVisibile && stage === 'preview' && (
-				<ClayModal observer={observer} size="lg">
-					<ImportPreviewModalBody
-						closeModal={onClose}
-						fieldsSelections={fieldsSelections}
-						fileContent={fileContent}
-						startImport={() => setStage('import')}
-					/>
-				</ClayModal>
+				<ImportPreviewModal
+					closeModal={() => setModalVisibile(false)}
+					fieldsSelections={fieldsSelections}
+					fileContent={fileContent}
+					startImport={() => setStage('import')}
+				/>
 			)}
 
 			{modalVisibile && stage === 'import' && (
 				<ImportModal
-					closeModal={onClose}
+					closeModal={() => {
+						setModalVisibile(false);
+						setStage('preview');
+					}}
 					formDataQuerySelector={formDataQuerySelector}
 					formImportURL={formImportURL}
 				/>

--- a/modules/apps/batch-planner/batch-planner-web/test/components/Import/ImportSubmit.js
+++ b/modules/apps/batch-planner/batch-planner-web/test/components/Import/ImportSubmit.js
@@ -32,6 +32,8 @@ import ImportSubmit from '../../../src/main/resources/META-INF/resources/js/impo
 
 const BASE_PROPS = {
 	evaluateForm: () => {},
+	fieldsSelections: {},
+	fileContent: [],
 	formDataQuerySelector: 'form',
 	formImportURL: 'https://formUrl.test',
 	formIsValid: true,


### PR DESCRIPTION
useModal was being used twice, so there was a ghost modal blocking the
whole page after the import modal was being closed.

Now each modal uses it's own hook so they are properly closed.
