### PR TITLE
LPS-173905 Add reference in Portlet as the onAfterSave method of the listener is not called until the configuration is saved for the second time

### DIFF
--- a/modules/apps/questions/questions-web/src/main/java/com/liferay/questions/web/internal/configuration/persistence/listener/QuestionsConfigurationModelListener.java
+++ b/modules/apps/questions/questions-web/src/main/java/com/liferay/questions/web/internal/configuration/persistence/listener/QuestionsConfigurationModelListener.java
@@ -48,7 +48,6 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
@@ -57,8 +56,6 @@ import org.osgi.service.component.annotations.Reference;
  * @author Javier Gamarra
  */
 @Component(
-	configurationPid = "com.liferay.questions.web.internal.configuration.QuestionsConfiguration",
-	configurationPolicy = ConfigurationPolicy.REQUIRE,
 	property = "model.class.name=com.liferay.questions.web.internal.configuration.QuestionsConfiguration",
 	service = ConfigurationModelListener.class
 )

--- a/modules/apps/questions/questions-web/src/main/java/com/liferay/questions/web/internal/portlet/QuestionsPortlet.java
+++ b/modules/apps/questions/questions-web/src/main/java/com/liferay/questions/web/internal/portlet/QuestionsPortlet.java
@@ -24,6 +24,7 @@ import com.liferay.item.selector.criteria.image.criterion.ImageItemSelectorCrite
 import com.liferay.message.boards.moderation.configuration.MBModerationGroupConfiguration;
 import com.liferay.message.boards.service.MBStatsUserLocalService;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
+import com.liferay.portal.configuration.persistence.listener.ConfigurationModelListener;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
@@ -264,6 +265,11 @@ public class QuestionsPortlet extends MVCPortlet {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		QuestionsPortlet.class);
+
+	@Reference(
+		target = "(model.class.name=com.liferay.questions.web.internal.configuration.QuestionsConfiguration)"
+	)
+	private ConfigurationModelListener _configurationModelListener;
 
 	@Reference
 	private ConfigurationProvider _configurationProvider;


### PR DESCRIPTION
This PR contains the code to fix [this bug](https://issues.liferay.com/browse/LPS-173905).

The point is, for the first time the Configuration is created/saved, the `@Activate` annotated method is executed, but then, the code of the afterSave method is not executed until it is saved for the second time.

With the current code, when the configuration is created, the listener has been already injected, and then, it is ensuring that the listener is already listening for saving events