### PR TITLE
LPS-172142: POST JSON call response's body is not correctly parsed

### DIFF
--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/dto/v1_0/Account.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/dto/v1_0/Account.java
@@ -41,8 +41,8 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMax;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -277,7 +277,7 @@ public class Account implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Date dateModified;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "10130")
 	public Long getDefaultBillingAccountAddressId() {
 		return defaultBillingAccountAddressId;
@@ -310,7 +310,7 @@ public class Account implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long defaultBillingAccountAddressId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "10131")
 	public Long getDefaultShippingAccountAddressId() {
 		return defaultShippingAccountAddressId;
@@ -402,7 +402,7 @@ public class Account implements Serializable {
 	@NotEmpty
 	protected String externalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;
@@ -429,7 +429,7 @@ public class Account implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long id;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "20078")
 	public Long getLogoId() {
 		return logoId;
@@ -567,8 +567,8 @@ public class Account implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String taxId;
 
-	@DecimalMax("2")
-	@DecimalMin("0")
+	@Max(2)
+	@Min(0)
 	@Schema(example = "1")
 	public Integer getType() {
 		return type;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/dto/v1_0/AccountAddress.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/dto/v1_0/AccountAddress.java
@@ -36,8 +36,8 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
-import javax.validation.constraints.DecimalMax;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -229,7 +229,7 @@ public class AccountAddress implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String externalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "31130")
 	public Long getId() {
 		return id;
@@ -480,8 +480,8 @@ public class AccountAddress implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String street3;
 
-	@DecimalMax("3")
-	@DecimalMin("1")
+	@Max(3)
+	@Min(1)
 	@Schema(example = "1")
 	public Integer getType() {
 		return type;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/dto/v1_0/AccountChannelShippingOption.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/dto/v1_0/AccountChannelShippingOption.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -93,7 +93,7 @@ public class AccountChannelShippingOption implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String accountExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getAccountId() {
 		return accountId;
@@ -212,7 +212,7 @@ public class AccountChannelShippingOption implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long channelId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30324")
 	public Long getId() {
 		return id;
@@ -239,7 +239,7 @@ public class AccountChannelShippingOption implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long id;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30324")
 	public Long getShippingMethodId() {
 		return shippingMethodId;
@@ -296,7 +296,7 @@ public class AccountChannelShippingOption implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String shippingMethodKey;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30324")
 	public Long getShippingOptionId() {
 		return shippingOptionId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/dto/v1_0/AccountGroup.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/dto/v1_0/AccountGroup.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -118,7 +118,7 @@ public class AccountGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String externalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/dto/v1_0/AccountMember.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/dto/v1_0/AccountMember.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -61,7 +61,7 @@ public class AccountMember implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(AccountMember.class, json);
 	}
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getAccountId() {
 		return accountId;
@@ -234,7 +234,7 @@ public class AccountMember implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String userExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30002")
 	public Long getUserId() {
 		return userId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/dto/v1_0/AccountOrganization.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/dto/v1_0/AccountOrganization.java
@@ -36,7 +36,7 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -59,7 +59,7 @@ public class AccountOrganization implements Serializable {
 			AccountOrganization.class, json);
 	}
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getAccountId() {
 		return accountId;
@@ -147,7 +147,7 @@ public class AccountOrganization implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String organizationExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30002")
 	public Long getOrganizationId() {
 		return organizationId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/dto/v1_0/AccountRole.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/dto/v1_0/AccountRole.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -120,7 +120,7 @@ public class AccountRole implements Serializable {
 	@NotEmpty
 	protected String name;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getRoleId() {
 		return roleId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/dto/v1_0/User.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/dto/v1_0/User.java
@@ -36,7 +36,7 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -146,7 +146,7 @@ public class User implements Serializable {
 	@NotEmpty
 	protected String firstName;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/resources/com/liferay/headless/commerce/admin/account/dto/v1_0/packageinfo
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/resources/com/liferay/headless/commerce/admin/account/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 6.4.0
+version 6.4.1

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Attachment.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Attachment.java
@@ -41,7 +41,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -288,7 +288,7 @@ public class Attachment implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String externalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/AttachmentBase64.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/AttachmentBase64.java
@@ -41,7 +41,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -232,7 +232,7 @@ public class AttachmentBase64 implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String externalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/AttachmentUrl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/AttachmentUrl.java
@@ -41,7 +41,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -204,7 +204,7 @@ public class AttachmentUrl implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String externalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Catalog.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Catalog.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -175,7 +175,7 @@ public class Catalog implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String externalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Category.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Category.java
@@ -36,7 +36,7 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -88,7 +88,7 @@ public class Category implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String externalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Diagram.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Diagram.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -117,7 +117,7 @@ public class Diagram implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String color;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "31130")
 	public Long getId() {
 		return id;
@@ -144,7 +144,7 @@ public class Diagram implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long id;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "33132")
 	public Long getImageId() {
 		return imageId;
@@ -233,7 +233,7 @@ public class Diagram implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String productExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "33131")
 	public Long getProductId() {
 		return productId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/GroupedProduct.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/GroupedProduct.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -92,7 +92,7 @@ public class GroupedProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String entryProductExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "33131")
 	public Long getEntryProductId() {
 		return entryProductId;
@@ -153,7 +153,7 @@ public class GroupedProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Map<String, String> entryProductName;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "33130")
 	public Long getId() {
 		return id;
@@ -240,7 +240,7 @@ public class GroupedProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String productExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "33131")
 	public Long getProductId() {
 		return productId;
@@ -301,7 +301,7 @@ public class GroupedProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Map<String, String> productName;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "1")
 	public Integer getQuantity() {
 		return quantity;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/MappedProduct.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/MappedProduct.java
@@ -39,7 +39,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -120,7 +120,7 @@ public class MappedProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected CustomField[] customFields;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "33130")
 	public Long getId() {
 		return id;
@@ -179,7 +179,7 @@ public class MappedProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String productExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "33131")
 	public Long getProductId() {
 		return productId;
@@ -240,7 +240,7 @@ public class MappedProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Map<String, String> productName;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "1")
 	public Integer getQuantity() {
 		return quantity;
@@ -353,7 +353,7 @@ public class MappedProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String skuExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "33135")
 	public Long getSkuId() {
 		return skuId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Option.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Option.java
@@ -39,7 +39,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
@@ -249,7 +249,7 @@ public class Option implements Serializable {
 	@NotNull
 	protected FieldType fieldType;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/OptionCategory.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/OptionCategory.java
@@ -38,6 +38,7 @@ import javax.annotation.Generated;
 
 import javax.validation.Valid;
 import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
@@ -92,7 +93,7 @@ public class OptionCategory implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Map<String, String> description;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "31130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/OptionValue.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/OptionValue.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
@@ -120,7 +120,7 @@ public class OptionValue implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String externalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Pin.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Pin.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -59,7 +59,7 @@ public class Pin implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(Pin.class, json);
 	}
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "33130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Product.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Product.java
@@ -41,7 +41,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
@@ -183,7 +183,7 @@ public class Product implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Catalog catalog;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30054")
 	public Long getCatalogId() {
 		return catalogId;
@@ -531,7 +531,7 @@ public class Product implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String externalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/ProductAccountGroup.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/ProductAccountGroup.java
@@ -36,7 +36,7 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -61,7 +61,7 @@ public class ProductAccountGroup implements Serializable {
 			ProductAccountGroup.class, json);
 	}
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "31130")
 	public Long getAccountGroupId() {
 		return accountGroupId;
@@ -118,7 +118,7 @@ public class ProductAccountGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String externalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "31130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/ProductChannel.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/ProductChannel.java
@@ -36,7 +36,7 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -60,7 +60,7 @@ public class ProductChannel implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(ProductChannel.class, json);
 	}
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "31130")
 	public Long getChannelId() {
 		return channelId;
@@ -145,7 +145,7 @@ public class ProductChannel implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String externalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "31130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/ProductGroup.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/ProductGroup.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -148,7 +148,7 @@ public class ProductGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String externalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;
@@ -205,7 +205,7 @@ public class ProductGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected ProductGroupProduct[] products;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "20")
 	public Integer getProductsCount() {
 		return productsCount;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/ProductGroupProduct.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/ProductGroupProduct.java
@@ -36,7 +36,7 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -59,7 +59,7 @@ public class ProductGroupProduct implements Serializable {
 			ProductGroupProduct.class, json);
 	}
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;
@@ -151,7 +151,7 @@ public class ProductGroupProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String productGroupExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30324")
 	public Long getProductGroupId() {
 		return productGroupId;
@@ -180,7 +180,7 @@ public class ProductGroupProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long productGroupId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getProductId() {
 		return productId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/ProductOption.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/ProductOption.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
@@ -181,7 +181,7 @@ public class ProductOption implements Serializable {
 	@NotEmpty
 	protected String fieldType;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;
@@ -265,7 +265,7 @@ public class ProductOption implements Serializable {
 	@NotNull
 	protected Map<String, String> name;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30080")
 	public Long getOptionId() {
 		return optionId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/ProductOptionValue.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/ProductOptionValue.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
@@ -62,7 +62,7 @@ public class ProductOptionValue implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(ProductOptionValue.class, json);
 	}
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/ProductSpecification.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/ProductSpecification.java
@@ -38,6 +38,7 @@ import javax.annotation.Generated;
 
 import javax.validation.Valid;
 import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
@@ -63,7 +64,7 @@ public class ProductSpecification implements Serializable {
 			ProductSpecification.class, json);
 	}
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "31130")
 	public Long getId() {
 		return id;
@@ -121,7 +122,7 @@ public class ProductSpecification implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Map<String, String> label;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30129")
 	public Long getOptionCategoryId() {
 		return optionCategoryId;
@@ -179,7 +180,7 @@ public class ProductSpecification implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Double priority;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30129")
 	public Long getProductId() {
 		return productId;
@@ -208,7 +209,7 @@ public class ProductSpecification implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long productId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30129")
 	public Long getSpecificationId() {
 		return specificationId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/ProductTaxConfiguration.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/ProductTaxConfiguration.java
@@ -36,7 +36,7 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -59,7 +59,7 @@ public class ProductTaxConfiguration implements Serializable {
 			ProductTaxConfiguration.class, json);
 	}
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/RelatedProduct.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/RelatedProduct.java
@@ -36,7 +36,7 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
@@ -61,7 +61,7 @@ public class RelatedProduct implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(RelatedProduct.class, json);
 	}
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;
@@ -148,7 +148,7 @@ public class RelatedProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String productExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30129")
 	public Long getProductId() {
 		return productId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Sku.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Sku.java
@@ -44,6 +44,7 @@ import javax.annotation.Generated;
 
 import javax.validation.Valid;
 import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -321,7 +322,7 @@ public class Sku implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Double height;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;
@@ -463,7 +464,7 @@ public class Sku implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected BigDecimal price;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30129")
 	public Long getProductId() {
 		return productId;
@@ -641,7 +642,7 @@ public class Sku implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String replacementSkuExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "33135")
 	public Long getReplacementSkuId() {
 		return replacementSkuId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/SkuOption.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/SkuOption.java
@@ -36,7 +36,7 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -58,7 +58,7 @@ public class SkuOption implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(SkuOption.class, json);
 	}
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "31130")
 	public Long getKey() {
 		return key;
@@ -85,7 +85,7 @@ public class SkuOption implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long key;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "31130")
 	public Long getValue() {
 		return value;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Specification.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Specification.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
@@ -120,7 +120,7 @@ public class Specification implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean facetable;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "31130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/resources/com/liferay/headless/commerce/admin/catalog/dto/v1_0/packageinfo
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/resources/com/liferay/headless/commerce/admin/catalog/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 12.1.0
+version 12.1.1

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/dto/v1_0/OrderType.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/dto/v1_0/OrderType.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -59,7 +59,7 @@ public class OrderType implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(OrderType.class, json);
 	}
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/dto/v1_0/PaymentMethodGroupRelOrderType.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/dto/v1_0/PaymentMethodGroupRelOrderType.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -154,7 +154,7 @@ public class PaymentMethodGroupRelOrderType implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String orderTypeExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30324")
 	public Long getOrderTypeId() {
 		return orderTypeId;
@@ -184,7 +184,7 @@ public class PaymentMethodGroupRelOrderType implements Serializable {
 	@NotNull
 	protected Long orderTypeId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getPaymentMethodGroupRelId() {
 		return paymentMethodGroupRelId;
@@ -215,7 +215,7 @@ public class PaymentMethodGroupRelOrderType implements Serializable {
 	@NotNull
 	protected Long paymentMethodGroupRelId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30643")
 	public Long getPaymentMethodGroupRelOrderTypeId() {
 		return paymentMethodGroupRelOrderTypeId;
@@ -249,7 +249,7 @@ public class PaymentMethodGroupRelOrderType implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long paymentMethodGroupRelOrderTypeId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "1")
 	public Integer getPriority() {
 		return priority;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/dto/v1_0/PaymentMethodGroupRelTerm.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/dto/v1_0/PaymentMethodGroupRelTerm.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -93,7 +93,7 @@ public class PaymentMethodGroupRelTerm implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Map<String, Map<String, String>> actions;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30324")
 	public Long getPaymentMethodGroupRelId() {
 		return paymentMethodGroupRelId;
@@ -124,7 +124,7 @@ public class PaymentMethodGroupRelTerm implements Serializable {
 	@NotNull
 	protected Long paymentMethodGroupRelId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30643")
 	public Long getPaymentMethodGroupRelTermId() {
 		return paymentMethodGroupRelTermId;
@@ -214,7 +214,7 @@ public class PaymentMethodGroupRelTerm implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String termExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getTermId() {
 		return termId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/dto/v1_0/ShippingFixedOptionOrderType.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/dto/v1_0/ShippingFixedOptionOrderType.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -154,7 +154,7 @@ public class ShippingFixedOptionOrderType implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String orderTypeExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30324")
 	public Long getOrderTypeId() {
 		return orderTypeId;
@@ -184,7 +184,7 @@ public class ShippingFixedOptionOrderType implements Serializable {
 	@NotNull
 	protected Long orderTypeId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "1")
 	public Integer getPriority() {
 		return priority;
@@ -213,7 +213,7 @@ public class ShippingFixedOptionOrderType implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Integer priority;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getShippingFixedOptionId() {
 		return shippingFixedOptionId;
@@ -243,7 +243,7 @@ public class ShippingFixedOptionOrderType implements Serializable {
 	@NotNull
 	protected Long shippingFixedOptionId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30643")
 	public Long getShippingFixedOptionOrderTypeId() {
 		return shippingFixedOptionOrderTypeId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/dto/v1_0/ShippingFixedOptionTerm.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/dto/v1_0/ShippingFixedOptionTerm.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -92,7 +92,7 @@ public class ShippingFixedOptionTerm implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Map<String, Map<String, String>> actions;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30324")
 	public Long getShippingFixedOptionId() {
 		return shippingFixedOptionId;
@@ -122,7 +122,7 @@ public class ShippingFixedOptionTerm implements Serializable {
 	@NotNull
 	protected Long shippingFixedOptionId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30643")
 	public Long getShippingFixedOptionTermId() {
 		return shippingFixedOptionTermId;
@@ -210,7 +210,7 @@ public class ShippingFixedOptionTerm implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String termExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getTermId() {
 		return termId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/dto/v1_0/ShippingMethod.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/dto/v1_0/ShippingMethod.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -147,7 +147,7 @@ public class ShippingMethod implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String engineKey;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30324")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/dto/v1_0/ShippingOption.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/dto/v1_0/ShippingOption.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -147,7 +147,7 @@ public class ShippingOption implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Map<String, String> description;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30324")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/dto/v1_0/TaxCategory.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/dto/v1_0/TaxCategory.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -91,7 +91,7 @@ public class TaxCategory implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Map<String, String> description;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "23130")
 	public Long getGroupId() {
 		return groupId;
@@ -120,7 +120,7 @@ public class TaxCategory implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long groupId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/dto/v1_0/Term.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/dto/v1_0/Term.java
@@ -36,7 +36,7 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -58,7 +58,7 @@ public class Term implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(Term.class, json);
 	}
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/resources/com/liferay/headless/commerce/admin/channel/dto/v1_0/packageinfo
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/resources/com/liferay/headless/commerce/admin/channel/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 3.1.0
+version 3.1.1

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-api/src/main/java/com/liferay/headless/commerce/admin/inventory/dto/v1_0/OrderType.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-api/src/main/java/com/liferay/headless/commerce/admin/inventory/dto/v1_0/OrderType.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -59,7 +59,7 @@ public class OrderType implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(OrderType.class, json);
 	}
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-api/src/main/java/com/liferay/headless/commerce/admin/inventory/dto/v1_0/Warehouse.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-api/src/main/java/com/liferay/headless/commerce/admin/inventory/dto/v1_0/Warehouse.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -231,7 +231,7 @@ public class Warehouse implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String externalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-api/src/main/java/com/liferay/headless/commerce/admin/inventory/dto/v1_0/WarehouseChannel.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-api/src/main/java/com/liferay/headless/commerce/admin/inventory/dto/v1_0/WarehouseChannel.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -152,7 +152,7 @@ public class WarehouseChannel implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String channelExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getChannelId() {
 		return channelId;
@@ -182,7 +182,7 @@ public class WarehouseChannel implements Serializable {
 	@NotNull
 	protected Long channelId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30643")
 	public Long getWarehouseChannelId() {
 		return warehouseChannelId;
@@ -243,7 +243,7 @@ public class WarehouseChannel implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String warehouseExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30324")
 	public Long getWarehouseId() {
 		return warehouseId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-api/src/main/java/com/liferay/headless/commerce/admin/inventory/dto/v1_0/WarehouseItem.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-api/src/main/java/com/liferay/headless/commerce/admin/inventory/dto/v1_0/WarehouseItem.java
@@ -40,7 +40,7 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -90,7 +90,7 @@ public class WarehouseItem implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String externalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;
@@ -145,7 +145,7 @@ public class WarehouseItem implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date modifiedDate;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "1")
 	public Integer getQuantity() {
 		return quantity;
@@ -174,7 +174,7 @@ public class WarehouseItem implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Integer quantity;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "2")
 	public Integer getReservedQuantity() {
 		return reservedQuantity;
@@ -261,7 +261,7 @@ public class WarehouseItem implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String warehouseExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30030")
 	public Long getWarehouseId() {
 		return warehouseId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-api/src/main/java/com/liferay/headless/commerce/admin/inventory/dto/v1_0/WarehouseOrderType.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-api/src/main/java/com/liferay/headless/commerce/admin/inventory/dto/v1_0/WarehouseOrderType.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -152,7 +152,7 @@ public class WarehouseOrderType implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String orderTypeExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30324")
 	public Long getOrderTypeId() {
 		return orderTypeId;
@@ -182,7 +182,7 @@ public class WarehouseOrderType implements Serializable {
 	@NotNull
 	protected Long orderTypeId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "1")
 	public Integer getPriority() {
 		return priority;
@@ -243,7 +243,7 @@ public class WarehouseOrderType implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String warehouseExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getWarehouseId() {
 		return warehouseId;
@@ -273,7 +273,7 @@ public class WarehouseOrderType implements Serializable {
 	@NotNull
 	protected Long warehouseId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30643")
 	public Long getWarehouseOrderTypeId() {
 		return warehouseOrderTypeId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-api/src/main/resources/com/liferay/headless/commerce/admin/inventory/dto/v1_0/packageinfo
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-api/src/main/resources/com/liferay/headless/commerce/admin/inventory/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 5.0.0
+version 5.0.1

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/Account.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/Account.java
@@ -37,8 +37,8 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMax;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -145,7 +145,7 @@ public class Account implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String externalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;
@@ -172,7 +172,7 @@ public class Account implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long id;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "20078")
 	public Long getLogoId() {
 		return logoId;
@@ -281,8 +281,8 @@ public class Account implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String taxId;
 
-	@DecimalMax("2")
-	@DecimalMin("0")
+	@Max(2)
+	@Min(0)
 	@Schema(example = "1")
 	public Integer getType() {
 		return type;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/AccountGroup.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/AccountGroup.java
@@ -36,7 +36,7 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -58,7 +58,7 @@ public class AccountGroup implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(AccountGroup.class, json);
 	}
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/BillingAddress.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/BillingAddress.java
@@ -36,7 +36,7 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -172,7 +172,7 @@ public class BillingAddress implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String externalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "31130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/Channel.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/Channel.java
@@ -36,7 +36,7 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -114,7 +114,7 @@ public class Channel implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String externalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "31130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/Order.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/Order.java
@@ -44,6 +44,7 @@ import javax.annotation.Generated;
 
 import javax.validation.Valid;
 import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
@@ -129,7 +130,7 @@ public class Order implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String accountExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getAccountId() {
 		return accountId;
@@ -246,7 +247,7 @@ public class Order implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected BillingAddress billingAddress;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "31130")
 	public Long getBillingAddressId() {
 		return billingAddressId;
@@ -336,7 +337,7 @@ public class Order implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String channelExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getChannelId() {
 		return channelId;
@@ -510,7 +511,7 @@ public class Order implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String deliveryTermDescription;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getDeliveryTermId() {
 		return deliveryTermId;
@@ -595,7 +596,7 @@ public class Order implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String externalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;
@@ -735,7 +736,7 @@ public class Order implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected OrderItem[] orderItems;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "0")
 	public Integer getOrderStatus() {
 		return orderStatus;
@@ -825,7 +826,7 @@ public class Order implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String orderTypeExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getOrderTypeId() {
 		return orderTypeId;
@@ -882,7 +883,7 @@ public class Order implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String paymentMethod;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "0")
 	public Integer getPaymentStatus() {
 		return paymentStatus;
@@ -969,7 +970,7 @@ public class Order implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String paymentTermDescription;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getPaymentTermId() {
 		return paymentTermId;
@@ -1140,7 +1141,7 @@ public class Order implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected ShippingAddress shippingAddress;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "31130")
 	public Long getShippingAddressId() {
 		return shippingAddressId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/OrderItem.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/OrderItem.java
@@ -44,6 +44,7 @@ import javax.annotation.Generated;
 
 import javax.validation.Valid;
 import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -65,7 +66,7 @@ public class OrderItem implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(OrderItem.class, json);
 	}
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "32144")
 	public Long getBookedQuantityId() {
 		return bookedQuantityId;
@@ -666,7 +667,7 @@ public class OrderItem implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String formattedQuantity;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;
@@ -784,7 +785,7 @@ public class OrderItem implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String orderExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30128")
 	public Long getOrderId() {
 		return orderId;
@@ -932,7 +933,7 @@ public class OrderItem implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected BigDecimal promoPriceWithTaxAmount;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "2")
 	public Integer getQuantity() {
 		return quantity;
@@ -989,7 +990,7 @@ public class OrderItem implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date requestedDeliveryDate;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "1")
 	public Integer getShippedQuantity() {
 		return shippedQuantity;
@@ -1048,7 +1049,7 @@ public class OrderItem implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected ShippingAddress shippingAddress;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "31130")
 	public Long getShippingAddressId() {
 		return shippingAddressId;
@@ -1133,7 +1134,7 @@ public class OrderItem implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String skuExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30128")
 	public Long getSkuId() {
 		return skuId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/OrderNote.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/OrderNote.java
@@ -36,7 +36,7 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -142,7 +142,7 @@ public class OrderNote implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String externalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;
@@ -201,7 +201,7 @@ public class OrderNote implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String orderExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30128")
 	public Long getOrderId() {
 		return orderId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/OrderRule.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/OrderRule.java
@@ -41,7 +41,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -291,7 +291,7 @@ public class OrderRule implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String externalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/OrderRuleAccount.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/OrderRuleAccount.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -122,7 +122,7 @@ public class OrderRuleAccount implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String accountExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30324")
 	public Long getAccountId() {
 		return accountId;
@@ -182,7 +182,7 @@ public class OrderRuleAccount implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Map<String, Map<String, String>> actions;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30643")
 	public Long getOrderRuleAccountId() {
 		return orderRuleAccountId;
@@ -243,7 +243,7 @@ public class OrderRuleAccount implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String orderRuleExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getOrderRuleId() {
 		return orderRuleId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/OrderRuleAccountGroup.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/OrderRuleAccountGroup.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -124,7 +124,7 @@ public class OrderRuleAccountGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String accountGroupExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30324")
 	public Long getAccountGroupId() {
 		return accountGroupId;
@@ -184,7 +184,7 @@ public class OrderRuleAccountGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Map<String, Map<String, String>> actions;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30643")
 	public Long getOrderRuleAccountGroupId() {
 		return orderRuleAccountGroupId;
@@ -246,7 +246,7 @@ public class OrderRuleAccountGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String orderRuleExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getOrderRuleId() {
 		return orderRuleId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/OrderRuleChannel.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/OrderRuleChannel.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -152,7 +152,7 @@ public class OrderRuleChannel implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String channelExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30324")
 	public Long getChannelId() {
 		return channelId;
@@ -182,7 +182,7 @@ public class OrderRuleChannel implements Serializable {
 	@NotNull
 	protected Long channelId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30643")
 	public Long getOrderRuleChannelId() {
 		return orderRuleChannelId;
@@ -243,7 +243,7 @@ public class OrderRuleChannel implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String orderRuleExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getOrderRuleId() {
 		return orderRuleId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/OrderRuleOrderType.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/OrderRuleOrderType.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -123,7 +123,7 @@ public class OrderRuleOrderType implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String orderRuleExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getOrderRuleId() {
 		return orderRuleId;
@@ -153,7 +153,7 @@ public class OrderRuleOrderType implements Serializable {
 	@NotNull
 	protected Long orderRuleId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30643")
 	public Long getOrderRuleOrderTypeId() {
 		return orderRuleOrderTypeId;
@@ -243,7 +243,7 @@ public class OrderRuleOrderType implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String orderTypeExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30324")
 	public Long getOrderTypeId() {
 		return orderTypeId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/OrderType.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/OrderType.java
@@ -41,7 +41,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -210,7 +210,7 @@ public class OrderType implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date displayDate;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "1")
 	public Integer getDisplayOrder() {
 		return displayOrder;
@@ -295,7 +295,7 @@ public class OrderType implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String externalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/OrderTypeChannel.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/OrderTypeChannel.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -152,7 +152,7 @@ public class OrderTypeChannel implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String channelExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getChannelId() {
 		return channelId;
@@ -182,7 +182,7 @@ public class OrderTypeChannel implements Serializable {
 	@NotNull
 	protected Long channelId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30643")
 	public Long getOrderTypeChannelId() {
 		return orderTypeChannelId;
@@ -243,7 +243,7 @@ public class OrderTypeChannel implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String orderTypeExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30324")
 	public Long getOrderTypeId() {
 		return orderTypeId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/ShippingAddress.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/ShippingAddress.java
@@ -36,7 +36,7 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -172,7 +172,7 @@ public class ShippingAddress implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String externalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "31130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/Term.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/Term.java
@@ -41,7 +41,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -267,7 +267,7 @@ public class Term implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String externalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/TermOrderType.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/TermOrderType.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -152,7 +152,7 @@ public class TermOrderType implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String orderTypeExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30324")
 	public Long getOrderTypeId() {
 		return orderTypeId;
@@ -212,7 +212,7 @@ public class TermOrderType implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String termExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getTermId() {
 		return termId;
@@ -242,7 +242,7 @@ public class TermOrderType implements Serializable {
 	@NotNull
 	protected Long termId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30643")
 	public Long getTermOrderTypeId() {
 		return termOrderTypeId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/resources/com/liferay/headless/commerce/admin/order/dto/v1_0/packageinfo
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/resources/com/liferay/headless/commerce/admin/order/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 12.0.0
+version 12.0.1

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v1_0/Discount.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v1_0/Discount.java
@@ -44,6 +44,7 @@ import javax.annotation.Generated;
 
 import javax.validation.Valid;
 import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -357,7 +358,7 @@ public class Discount implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String externalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;
@@ -384,7 +385,7 @@ public class Discount implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long id;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "0")
 	public Integer getLimitationTimes() {
 		return limitationTimes;
@@ -501,7 +502,7 @@ public class Discount implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean neverExpire;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "5")
 	public Integer getNumberOfUse() {
 		return numberOfUse;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v1_0/DiscountAccountGroup.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v1_0/DiscountAccountGroup.java
@@ -36,7 +36,7 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -92,7 +92,7 @@ public class DiscountAccountGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String accountGroupExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getAccountGroupId() {
 		return accountGroupId;
@@ -153,7 +153,7 @@ public class DiscountAccountGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String discountExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30324")
 	public Long getDiscountId() {
 		return discountId;
@@ -182,7 +182,7 @@ public class DiscountAccountGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long discountId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30643")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v1_0/DiscountCategory.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v1_0/DiscountCategory.java
@@ -36,7 +36,7 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -90,7 +90,7 @@ public class DiscountCategory implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String categoryExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getCategoryId() {
 		return categoryId;
@@ -151,7 +151,7 @@ public class DiscountCategory implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String discountExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30324")
 	public Long getDiscountId() {
 		return discountId;
@@ -180,7 +180,7 @@ public class DiscountCategory implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long discountId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30643")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v1_0/DiscountProduct.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v1_0/DiscountProduct.java
@@ -36,7 +36,7 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -90,7 +90,7 @@ public class DiscountProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String discountExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30324")
 	public Long getDiscountId() {
 		return discountId;
@@ -119,7 +119,7 @@ public class DiscountProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long discountId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30643")
 	public Long getId() {
 		return id;
@@ -178,7 +178,7 @@ public class DiscountProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String productExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getProductId() {
 		return productId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v1_0/DiscountRule.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v1_0/DiscountRule.java
@@ -36,7 +36,7 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -60,7 +60,7 @@ public class DiscountRule implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(DiscountRule.class, json);
 	}
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30324")
 	public Long getDiscountId() {
 		return discountId;
@@ -89,7 +89,7 @@ public class DiscountRule implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long discountId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30643")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v1_0/PriceEntry.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v1_0/PriceEntry.java
@@ -40,6 +40,7 @@ import javax.annotation.Generated;
 
 import javax.validation.Valid;
 import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -148,7 +149,7 @@ public class PriceEntry implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean hasTierPrice;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;
@@ -238,7 +239,7 @@ public class PriceEntry implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String priceListExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "20078")
 	public Long getPriceListId() {
 		return priceListId;
@@ -353,7 +354,7 @@ public class PriceEntry implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String skuExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getSkuId() {
 		return skuId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v1_0/PriceList.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v1_0/PriceList.java
@@ -41,7 +41,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -93,7 +93,7 @@ public class PriceList implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean active;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "23130")
 	public Long getCatalogId() {
 		return catalogId;
@@ -264,7 +264,7 @@ public class PriceList implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String externalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v1_0/PriceListAccountGroup.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v1_0/PriceListAccountGroup.java
@@ -36,7 +36,7 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -92,7 +92,7 @@ public class PriceListAccountGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String accountGroupExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30324")
 	public Long getAccountGroupId() {
 		return accountGroupId;
@@ -121,7 +121,7 @@ public class PriceListAccountGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long accountGroupId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30643")
 	public Long getId() {
 		return id;
@@ -148,7 +148,7 @@ public class PriceListAccountGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "1")
 	public Integer getOrder() {
 		return order;
@@ -209,7 +209,7 @@ public class PriceListAccountGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String priceListExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getPriceListId() {
 		return priceListId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v1_0/TierPrice.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v1_0/TierPrice.java
@@ -40,6 +40,7 @@ import javax.annotation.Generated;
 
 import javax.validation.Valid;
 import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -118,7 +119,7 @@ public class TierPrice implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String externalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "31130")
 	public Long getId() {
 		return id;
@@ -145,7 +146,7 @@ public class TierPrice implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long id;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "5")
 	public Integer getMinimumQuantity() {
 		return minimumQuantity;
@@ -236,7 +237,7 @@ public class TierPrice implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String priceEntryExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getPriceEntryId() {
 		return priceEntryId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/Account.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/Account.java
@@ -36,7 +36,7 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -58,7 +58,7 @@ public class Account implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(Account.class, json);
 	}
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;
@@ -85,7 +85,7 @@ public class Account implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long id;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "20078")
 	public Long getLogoId() {
 		return logoId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/AccountGroup.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/AccountGroup.java
@@ -36,7 +36,7 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -58,7 +58,7 @@ public class AccountGroup implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(AccountGroup.class, json);
 	}
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/Category.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/Category.java
@@ -36,7 +36,7 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -58,7 +58,7 @@ public class Category implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(Category.class, json);
 	}
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/Discount.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/Discount.java
@@ -44,6 +44,7 @@ import javax.annotation.Generated;
 
 import javax.validation.Valid;
 import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
@@ -542,7 +543,7 @@ public class Discount implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String externalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;
@@ -598,7 +599,7 @@ public class Discount implements Serializable {
 	@NotEmpty
 	protected String level;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "0")
 	public Integer getLimitationTimes() {
 		return limitationTimes;
@@ -627,7 +628,7 @@ public class Discount implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Integer limitationTimes;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "0")
 	public Integer getLimitationTimesPerAccount() {
 		return limitationTimesPerAccount;
@@ -748,7 +749,7 @@ public class Discount implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean neverExpire;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "5")
 	public Integer getNumberOfUse() {
 		return numberOfUse;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/DiscountAccount.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/DiscountAccount.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -122,7 +122,7 @@ public class DiscountAccount implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String accountExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getAccountId() {
 		return accountId;
@@ -182,7 +182,7 @@ public class DiscountAccount implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Map<String, Map<String, String>> actions;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30643")
 	public Long getDiscountAccountId() {
 		return discountAccountId;
@@ -243,7 +243,7 @@ public class DiscountAccount implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String discountExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30324")
 	public Long getDiscountId() {
 		return discountId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/DiscountAccountGroup.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/DiscountAccountGroup.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -124,7 +124,7 @@ public class DiscountAccountGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String accountGroupExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getAccountGroupId() {
 		return accountGroupId;
@@ -184,7 +184,7 @@ public class DiscountAccountGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Map<String, Map<String, String>> actions;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30643")
 	public Long getDiscountAccountGroupId() {
 		return discountAccountGroupId;
@@ -245,7 +245,7 @@ public class DiscountAccountGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String discountExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30324")
 	public Long getDiscountId() {
 		return discountId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/DiscountCategory.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/DiscountCategory.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -152,7 +152,7 @@ public class DiscountCategory implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String categoryExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getCategoryId() {
 		return categoryId;
@@ -182,7 +182,7 @@ public class DiscountCategory implements Serializable {
 	@NotNull
 	protected Long categoryId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30643")
 	public Long getDiscountCategoryId() {
 		return discountCategoryId;
@@ -243,7 +243,7 @@ public class DiscountCategory implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String discountExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30324")
 	public Long getDiscountId() {
 		return discountId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/DiscountChannel.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/DiscountChannel.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -152,7 +152,7 @@ public class DiscountChannel implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String channelExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getChannelId() {
 		return channelId;
@@ -182,7 +182,7 @@ public class DiscountChannel implements Serializable {
 	@NotNull
 	protected Long channelId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30643")
 	public Long getDiscountChannelId() {
 		return discountChannelId;
@@ -243,7 +243,7 @@ public class DiscountChannel implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String discountExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30324")
 	public Long getDiscountId() {
 		return discountId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/DiscountOrderType.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/DiscountOrderType.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -123,7 +123,7 @@ public class DiscountOrderType implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String discountExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getDiscountId() {
 		return discountId;
@@ -152,7 +152,7 @@ public class DiscountOrderType implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long discountId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30643")
 	public Long getDiscountOrderTypeId() {
 		return discountOrderTypeId;
@@ -242,7 +242,7 @@ public class DiscountOrderType implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String orderTypeExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30324")
 	public Long getOrderTypeId() {
 		return orderTypeId;
@@ -272,7 +272,7 @@ public class DiscountOrderType implements Serializable {
 	@NotNull
 	protected Long orderTypeId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "1")
 	public Integer getPriority() {
 		return priority;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/DiscountProduct.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/DiscountProduct.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -123,7 +123,7 @@ public class DiscountProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String discountExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30324")
 	public Long getDiscountId() {
 		return discountId;
@@ -152,7 +152,7 @@ public class DiscountProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long discountId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30643")
 	public Long getDiscountProductId() {
 		return discountProductId;
@@ -242,7 +242,7 @@ public class DiscountProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String productExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getProductId() {
 		return productId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/DiscountProductGroup.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/DiscountProductGroup.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -124,7 +124,7 @@ public class DiscountProductGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String discountExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30324")
 	public Long getDiscountId() {
 		return discountId;
@@ -153,7 +153,7 @@ public class DiscountProductGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long discountId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30643")
 	public Long getDiscountProductGroupId() {
 		return discountProductGroupId;
@@ -244,7 +244,7 @@ public class DiscountProductGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String productGroupExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getProductGroupId() {
 		return productGroupId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/DiscountRule.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/DiscountRule.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -91,7 +91,7 @@ public class DiscountRule implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Map<String, Map<String, String>> actions;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30324")
 	public Long getDiscountId() {
 		return discountId;
@@ -120,7 +120,7 @@ public class DiscountRule implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long discountId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30643")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/DiscountSku.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/DiscountSku.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -123,7 +123,7 @@ public class DiscountSku implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String discountExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30324")
 	public Long getDiscountId() {
 		return discountId;
@@ -152,7 +152,7 @@ public class DiscountSku implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long discountId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30643")
 	public Long getDiscountSkuId() {
 		return discountSkuId;
@@ -181,7 +181,7 @@ public class DiscountSku implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long discountSkuId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30324")
 	public Long getProductId() {
 		return productId;
@@ -299,7 +299,7 @@ public class DiscountSku implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String skuExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getSkuId() {
 		return skuId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/OrderType.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/OrderType.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -59,7 +59,7 @@ public class OrderType implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(OrderType.class, json);
 	}
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceEntry.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceEntry.java
@@ -44,6 +44,7 @@ import javax.annotation.Generated;
 
 import javax.validation.Valid;
 import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -529,7 +530,7 @@ public class PriceEntry implements Serializable {
 	@NotNull
 	protected Double price;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getPriceEntryId() {
 		return priceEntryId;
@@ -618,7 +619,7 @@ public class PriceEntry implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String priceListExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "20078")
 	public Long getPriceListId() {
 		return priceListId;
@@ -734,7 +735,7 @@ public class PriceEntry implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String skuExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getSkuId() {
 		return skuId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceList.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceList.java
@@ -43,7 +43,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
@@ -182,7 +182,7 @@ public class PriceList implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean catalogBasePriceList;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "23130")
 	public Long getCatalogId() {
 		return catalogId;
@@ -410,7 +410,7 @@ public class PriceList implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String externalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;
@@ -520,7 +520,7 @@ public class PriceList implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean neverExpire;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getParentPriceListId() {
 		return parentPriceListId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceListAccount.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceListAccount.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -122,7 +122,7 @@ public class PriceListAccount implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String accountExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30324")
 	public Long getAccountId() {
 		return accountId;
@@ -182,7 +182,7 @@ public class PriceListAccount implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Map<String, Map<String, String>> actions;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "1")
 	public Integer getOrder() {
 		return order;
@@ -211,7 +211,7 @@ public class PriceListAccount implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Integer order;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30643")
 	public Long getPriceListAccountId() {
 		return priceListAccountId;
@@ -272,7 +272,7 @@ public class PriceListAccount implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String priceListExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getPriceListId() {
 		return priceListId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceListAccountGroup.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceListAccountGroup.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -124,7 +124,7 @@ public class PriceListAccountGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String accountGroupExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30324")
 	public Long getAccountGroupId() {
 		return accountGroupId;
@@ -184,7 +184,7 @@ public class PriceListAccountGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Map<String, Map<String, String>> actions;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "1")
 	public Integer getOrder() {
 		return order;
@@ -213,7 +213,7 @@ public class PriceListAccountGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Integer order;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30643")
 	public Long getPriceListAccountGroupId() {
 		return priceListAccountGroupId;
@@ -275,7 +275,7 @@ public class PriceListAccountGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String priceListExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getPriceListId() {
 		return priceListId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceListChannel.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceListChannel.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -152,7 +152,7 @@ public class PriceListChannel implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String channelExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30324")
 	public Long getChannelId() {
 		return channelId;
@@ -182,7 +182,7 @@ public class PriceListChannel implements Serializable {
 	@NotNull
 	protected Long channelId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "1")
 	public Integer getOrder() {
 		return order;
@@ -211,7 +211,7 @@ public class PriceListChannel implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Integer order;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30643")
 	public Long getPriceListChannelId() {
 		return priceListChannelId;
@@ -272,7 +272,7 @@ public class PriceListChannel implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String priceListExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getPriceListId() {
 		return priceListId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceListDiscount.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceListDiscount.java
@@ -36,7 +36,7 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -92,7 +92,7 @@ public class PriceListDiscount implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String discountExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30324")
 	public Long getDiscountId() {
 		return discountId;
@@ -150,7 +150,7 @@ public class PriceListDiscount implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String discountName;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "1")
 	public Integer getOrder() {
 		return order;
@@ -179,7 +179,7 @@ public class PriceListDiscount implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Integer order;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30643")
 	public Long getPriceListDiscountId() {
 		return priceListDiscountId;
@@ -240,7 +240,7 @@ public class PriceListDiscount implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String priceListExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getPriceListId() {
 		return priceListId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceListOrderType.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceListOrderType.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -152,7 +152,7 @@ public class PriceListOrderType implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String orderTypeExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30324")
 	public Long getOrderTypeId() {
 		return orderTypeId;
@@ -214,7 +214,7 @@ public class PriceListOrderType implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String priceListExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getPriceListId() {
 		return priceListId;
@@ -244,7 +244,7 @@ public class PriceListOrderType implements Serializable {
 	@NotNull
 	protected Long priceListId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30643")
 	public Long getPriceListOrderTypeId() {
 		return priceListOrderTypeId;
@@ -273,7 +273,7 @@ public class PriceListOrderType implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long priceListOrderTypeId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "1")
 	public Integer getPriority() {
 		return priority;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceModifier.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceModifier.java
@@ -43,7 +43,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
@@ -212,7 +212,7 @@ public class PriceModifier implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String externalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;
@@ -358,7 +358,7 @@ public class PriceModifier implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String priceListExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "20078")
 	public Long getPriceListId() {
 		return priceListId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceModifierCategory.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceModifierCategory.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -153,7 +153,7 @@ public class PriceModifierCategory implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String categoryExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getCategoryId() {
 		return categoryId;
@@ -183,7 +183,7 @@ public class PriceModifierCategory implements Serializable {
 	@NotNull
 	protected Long categoryId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30643")
 	public Long getPriceModifierCategoryId() {
 		return priceModifierCategoryId;
@@ -246,7 +246,7 @@ public class PriceModifierCategory implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String priceModifierExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30324")
 	public Long getPriceModifierId() {
 		return priceModifierId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceModifierProduct.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceModifierProduct.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -125,7 +125,7 @@ public class PriceModifierProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String priceModifierExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30324")
 	public Long getPriceModifierId() {
 		return priceModifierId;
@@ -155,7 +155,7 @@ public class PriceModifierProduct implements Serializable {
 	@NotNull
 	protected Long priceModifierId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30643")
 	public Long getPriceModifierProductId() {
 		return priceModifierProductId;
@@ -245,7 +245,7 @@ public class PriceModifierProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String productExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getProductId() {
 		return productId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceModifierProductGroup.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceModifierProductGroup.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -126,7 +126,7 @@ public class PriceModifierProductGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String priceModifierExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30324")
 	public Long getPriceModifierId() {
 		return priceModifierId;
@@ -156,7 +156,7 @@ public class PriceModifierProductGroup implements Serializable {
 	@NotNull
 	protected Long priceModifierId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30643")
 	public Long getPriceModifierProductGroupId() {
 		return priceModifierProductGroupId;
@@ -251,7 +251,7 @@ public class PriceModifierProductGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String productGroupExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getProductGroupId() {
 		return productGroupId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/Product.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/Product.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -59,7 +59,7 @@ public class Product implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(Product.class, json);
 	}
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/ProductGroup.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/ProductGroup.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -59,7 +59,7 @@ public class ProductGroup implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(ProductGroup.class, json);
 	}
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;
@@ -86,7 +86,7 @@ public class ProductGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long id;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "20")
 	public Integer getProductsCount() {
 		return productsCount;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/Sku.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/Sku.java
@@ -36,7 +36,7 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -172,7 +172,7 @@ public class Sku implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String basePromoPriceFormatted;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/TierPrice.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/TierPrice.java
@@ -44,6 +44,7 @@ import javax.annotation.Generated;
 
 import javax.validation.Valid;
 import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -386,7 +387,7 @@ public class TierPrice implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String externalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "31130")
 	public Long getId() {
 		return id;
@@ -413,7 +414,7 @@ public class TierPrice implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long id;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "5")
 	public Integer getMinimumQuantity() {
 		return minimumQuantity;
@@ -532,7 +533,7 @@ public class TierPrice implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String priceEntryExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getPriceEntryId() {
 		return priceEntryId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/resources/com/liferay/headless/commerce/admin/pricing/dto/v1_0/packageinfo
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/resources/com/liferay/headless/commerce/admin/pricing/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 5.3.1
+version 5.3.2

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/resources/com/liferay/headless/commerce/admin/pricing/dto/v2_0/packageinfo
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/resources/com/liferay/headless/commerce/admin/pricing/dto/v2_0/packageinfo
@@ -1,1 +1,1 @@
-version 8.1.0
+version 8.1.1

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-api/src/main/java/com/liferay/headless/commerce/admin/shipment/dto/v1_0/Shipment.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-api/src/main/java/com/liferay/headless/commerce/admin/shipment/dto/v1_0/Shipment.java
@@ -41,7 +41,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -63,7 +63,7 @@ public class Shipment implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(Shipment.class, json);
 	}
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getAccountId() {
 		return accountId;
@@ -263,7 +263,7 @@ public class Shipment implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String externalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;
@@ -318,7 +318,7 @@ public class Shipment implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Date modifiedDate;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getOrderId() {
 		return orderId;
@@ -406,7 +406,7 @@ public class Shipment implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected ShippingAddress shippingAddress;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "31130")
 	public Long getShippingAddressId() {
 		return shippingAddressId;
@@ -463,7 +463,7 @@ public class Shipment implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date shippingDate;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getShippingMethodId() {
 		return shippingMethodId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-api/src/main/java/com/liferay/headless/commerce/admin/shipment/dto/v1_0/ShipmentItem.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-api/src/main/java/com/liferay/headless/commerce/admin/shipment/dto/v1_0/ShipmentItem.java
@@ -41,7 +41,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -151,7 +151,7 @@ public class ShipmentItem implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String externalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;
@@ -206,7 +206,7 @@ public class ShipmentItem implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Date modifiedDate;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getOrderItemId() {
 		return orderItemId;
@@ -236,7 +236,7 @@ public class ShipmentItem implements Serializable {
 	@NotNull
 	protected Long orderItemId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "1")
 	public Integer getQuantity() {
 		return quantity;
@@ -298,7 +298,7 @@ public class ShipmentItem implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String shipmentExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getShipmentId() {
 		return shipmentId;
@@ -383,7 +383,7 @@ public class ShipmentItem implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean validateInventory;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getWarehouseId() {
 		return warehouseId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-api/src/main/java/com/liferay/headless/commerce/admin/shipment/dto/v1_0/ShippingAddress.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-api/src/main/java/com/liferay/headless/commerce/admin/shipment/dto/v1_0/ShippingAddress.java
@@ -36,7 +36,7 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -172,7 +172,7 @@ public class ShippingAddress implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String externalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "31130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-api/src/main/resources/com/liferay/headless/commerce/admin/shipment/dto/v1_0/packageinfo
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-api/src/main/resources/com/liferay/headless/commerce/admin/shipment/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.5.0
+version 1.5.1

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-api/src/main/java/com/liferay/headless/commerce/admin/site/setting/dto/v1_0/AvailabilityEstimate.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-api/src/main/java/com/liferay/headless/commerce/admin/site/setting/dto/v1_0/AvailabilityEstimate.java
@@ -38,6 +38,7 @@ import javax.annotation.Generated;
 
 import javax.validation.Valid;
 import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -62,7 +63,7 @@ public class AvailabilityEstimate implements Serializable {
 			AvailabilityEstimate.class, json);
 	}
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "23130")
 	public Long getGroupId() {
 		return groupId;
@@ -91,7 +92,7 @@ public class AvailabilityEstimate implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long groupId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-api/src/main/java/com/liferay/headless/commerce/admin/site/setting/dto/v1_0/MeasurementUnit.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-api/src/main/java/com/liferay/headless/commerce/admin/site/setting/dto/v1_0/MeasurementUnit.java
@@ -38,6 +38,7 @@ import javax.annotation.Generated;
 
 import javax.validation.Valid;
 import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
@@ -62,7 +63,7 @@ public class MeasurementUnit implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(MeasurementUnit.class, json);
 	}
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getCompanyId() {
 		return companyId;
@@ -119,7 +120,7 @@ public class MeasurementUnit implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String externalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-api/src/main/java/com/liferay/headless/commerce/admin/site/setting/dto/v1_0/TaxCategory.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-api/src/main/java/com/liferay/headless/commerce/admin/site/setting/dto/v1_0/TaxCategory.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -91,7 +91,7 @@ public class TaxCategory implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Map<String, String> description;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "23130")
 	public Long getGroupId() {
 		return groupId;
@@ -120,7 +120,7 @@ public class TaxCategory implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long groupId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-api/src/main/java/com/liferay/headless/commerce/admin/site/setting/dto/v1_0/Warehouse.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-api/src/main/java/com/liferay/headless/commerce/admin/site/setting/dto/v1_0/Warehouse.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -115,7 +115,7 @@ public class Warehouse implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String city;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getCommerceCountryId() {
 		return commerceCountryId;
@@ -145,7 +145,7 @@ public class Warehouse implements Serializable {
 	@NotNull
 	protected Long commerceCountryId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30234")
 	public Long getCommerceRegionId() {
 		return commerceRegionId;
@@ -206,7 +206,7 @@ public class Warehouse implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Map<String, String> description;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "23130")
 	public Long getGroupId() {
 		return groupId;
@@ -235,7 +235,7 @@ public class Warehouse implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long groupId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-api/src/main/resources/com/liferay/headless/commerce/admin/site/setting/dto/v1_0/packageinfo
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-api/src/main/resources/com/liferay/headless/commerce/admin/site/setting/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 6.0.0
+version 6.0.1

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/Attachment.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/Attachment.java
@@ -41,7 +41,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -148,7 +148,7 @@ public class Attachment implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date expirationDate;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/Category.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/Category.java
@@ -36,7 +36,7 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -58,7 +58,7 @@ public class Category implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(Category.class, json);
 	}
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/MappedProduct.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/MappedProduct.java
@@ -39,7 +39,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -154,7 +154,7 @@ public class MappedProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected MappedProduct firstAvailableReplacementMappedProduct;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "33130")
 	public Long getId() {
 		return id;
@@ -272,7 +272,7 @@ public class MappedProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String productExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "33131")
 	public Long getProductId() {
 		return productId;
@@ -391,7 +391,7 @@ public class MappedProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Boolean purchasable;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "1")
 	public Integer getQuantity() {
 		return quantity;
@@ -565,7 +565,7 @@ public class MappedProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String skuExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "33135")
 	public Long getSkuId() {
 		return skuId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/Pin.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/Pin.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -59,7 +59,7 @@ public class Pin implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(Pin.class, json);
 	}
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "33130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/Product.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/Product.java
@@ -41,7 +41,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -234,7 +234,7 @@ public class Product implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String externalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/ProductOption.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/ProductOption.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -143,7 +143,7 @@ public class ProductOption implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String fieldType;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;
@@ -222,7 +222,7 @@ public class ProductOption implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String name;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30080")
 	public Long getOptionId() {
 		return optionId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/ProductOptionValue.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/ProductOptionValue.java
@@ -36,7 +36,7 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -58,7 +58,7 @@ public class ProductOptionValue implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(ProductOptionValue.class, json);
 	}
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/ProductSpecification.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/ProductSpecification.java
@@ -37,6 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -59,7 +60,7 @@ public class ProductSpecification implements Serializable {
 			ProductSpecification.class, json);
 	}
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "31130")
 	public Long getId() {
 		return id;
@@ -86,7 +87,7 @@ public class ProductSpecification implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long id;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30129")
 	public Long getOptionCategoryId() {
 		return optionCategoryId;
@@ -144,7 +145,7 @@ public class ProductSpecification implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Double priority;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30129")
 	public Long getProductId() {
 		return productId;
@@ -173,7 +174,7 @@ public class ProductSpecification implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long productId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30129")
 	public Long getSpecificationId() {
 		return specificationId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/RelatedProduct.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/RelatedProduct.java
@@ -36,7 +36,7 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -58,7 +58,7 @@ public class RelatedProduct implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(RelatedProduct.class, json);
 	}
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;
@@ -113,7 +113,7 @@ public class RelatedProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Double priority;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30129")
 	public Long getProductId() {
 		return productId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/Sku.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/Sku.java
@@ -42,6 +42,7 @@ import javax.annotation.Generated;
 
 import javax.validation.Valid;
 import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -261,7 +262,7 @@ public class Sku implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Double height;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/SkuOption.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/SkuOption.java
@@ -36,7 +36,7 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -58,7 +58,7 @@ public class SkuOption implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(SkuOption.class, json);
 	}
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "31130")
 	public Long getKey() {
 		return key;
@@ -85,7 +85,7 @@ public class SkuOption implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long key;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "31130")
 	public Long getValue() {
 		return value;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/resources/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/packageinfo
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/resources/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 5.2.0
+version 5.2.1

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-api/src/main/java/com/liferay/headless/commerce/delivery/order/dto/v1_0/PlacedOrderItemShipment.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-api/src/main/java/com/liferay/headless/commerce/delivery/order/dto/v1_0/PlacedOrderItemShipment.java
@@ -41,7 +41,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -64,7 +64,7 @@ public class PlacedOrderItemShipment implements Serializable {
 			PlacedOrderItemShipment.class, json);
 	}
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getAccountId() {
 		return accountId;
@@ -233,7 +233,7 @@ public class PlacedOrderItemShipment implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Date estimatedShippingDate;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;
@@ -288,7 +288,7 @@ public class PlacedOrderItemShipment implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Date modifiedDate;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getOrderId() {
 		return orderId;
@@ -345,7 +345,7 @@ public class PlacedOrderItemShipment implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Integer quantity;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "31130")
 	public Long getShippingAddressId() {
 		return shippingAddressId;
@@ -374,7 +374,7 @@ public class PlacedOrderItemShipment implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long shippingAddressId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getShippingMethodId() {
 		return shippingMethodId;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-api/src/main/resources/com/liferay/headless/commerce/delivery/order/dto/v1_0/packageinfo
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-api/src/main/resources/com/liferay/headless/commerce/delivery/order/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.0.1

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-api/src/main/java/com/liferay/headless/batch/engine/dto/v1_0/ExportTask.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-api/src/main/java/com/liferay/headless/batch/engine/dto/v1_0/ExportTask.java
@@ -43,7 +43,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -259,7 +259,7 @@ public class ExportTask implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String externalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(description = "The task's ID.", example = "30130")
 	public Long getId() {
 		return id;
@@ -286,7 +286,7 @@ public class ExportTask implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long id;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(
 		description = "Number of items processed by export task opeartion.",
 		example = "100"
@@ -351,7 +351,7 @@ public class ExportTask implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date startTime;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(
 		description = "Total number of items that will be processed by export task operation.",
 		example = "1000"

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-api/src/main/java/com/liferay/headless/batch/engine/dto/v1_0/ImportTask.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-api/src/main/java/com/liferay/headless/batch/engine/dto/v1_0/ImportTask.java
@@ -43,7 +43,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -288,7 +288,7 @@ public class ImportTask implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected FailedItem[] failedItems;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(description = "The task's ID.", example = "30130")
 	public Long getId() {
 		return id;
@@ -396,7 +396,7 @@ public class ImportTask implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Operation operation;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(
 		description = "Number of items processed by import task opeartion.",
 		example = "100"
@@ -461,7 +461,7 @@ public class ImportTask implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date startTime;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(
 		description = "Total number of items that will be processed by import task operation.",
 		example = "1000"

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-api/src/main/resources/com/liferay/headless/batch/engine/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-api/src/main/resources/com/liferay/headless/batch/engine/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 3.1.0
+version 3.1.1

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/ColumnViewportDefinition.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/ColumnViewportDefinition.java
@@ -36,8 +36,8 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
-import javax.validation.constraints.DecimalMax;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -60,8 +60,8 @@ public class ColumnViewportDefinition implements Serializable {
 			ColumnViewportDefinition.class, json);
 	}
 
-	@DecimalMax("12")
-	@DecimalMin("1")
+	@Max(12)
+	@Min(1)
 	@Schema
 	public Integer getSize() {
 		return size;

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/PageColumnDefinition.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/PageColumnDefinition.java
@@ -37,8 +37,8 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMax;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -136,8 +136,8 @@ public class PageColumnDefinition implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected ColumnViewport[] columnViewports;
 
-	@DecimalMax("12")
-	@DecimalMin("1")
+	@Max(12)
+	@Min(1)
 	@Schema(description = "The page column's size.")
 	public Integer getSize() {
 		return size;

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 31.4.0
+version 31.4.1

--- a/modules/dxp/apps/commerce-punchout/headless/headless-commerce-punchout-api/src/main/java/com/liferay/headless/commerce/punchout/dto/v1_0/CartItem.java
+++ b/modules/dxp/apps/commerce-punchout/headless/headless-commerce-punchout-api/src/main/java/com/liferay/headless/commerce/punchout/dto/v1_0/CartItem.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -308,7 +308,7 @@ public class CartItem implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Settings settings;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "1")
 	public Integer getShippedQuantity() {
 		return shippedQuantity;

--- a/modules/dxp/apps/commerce-punchout/headless/headless-commerce-punchout-api/src/main/java/com/liferay/headless/commerce/punchout/dto/v1_0/User.java
+++ b/modules/dxp/apps/commerce-punchout/headless/headless-commerce-punchout-api/src/main/java/com/liferay/headless/commerce/punchout/dto/v1_0/User.java
@@ -36,7 +36,7 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -145,7 +145,7 @@ public class User implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String firstName;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;

--- a/modules/dxp/apps/commerce-punchout/headless/headless-commerce-punchout-api/src/main/resources/com/liferay/headless/commerce/punchout/dto/v1_0/packageinfo
+++ b/modules/dxp/apps/commerce-punchout/headless/headless-commerce-punchout-api/src/main/resources/com/liferay/headless/commerce/punchout/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 2.2.5
+version 2.2.6

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/Category.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/Category.java
@@ -36,7 +36,7 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -88,7 +88,7 @@ public class Category implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String externalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/Order.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/Order.java
@@ -44,6 +44,7 @@ import javax.annotation.Generated;
 
 import javax.validation.Valid;
 import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
@@ -68,7 +69,7 @@ public class Order implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(Order.class, json);
 	}
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getAccountId() {
 		return accountId;
@@ -97,7 +98,7 @@ public class Order implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long accountId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getChannelId() {
 		return channelId;
@@ -241,7 +242,7 @@ public class Order implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String externalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;
@@ -353,7 +354,7 @@ public class Order implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected OrderItem[] orderItems;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "0")
 	public Integer getOrderStatus() {
 		return orderStatus;
@@ -414,7 +415,7 @@ public class Order implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String orderTypeExternalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getOrderTypeId() {
 		return orderTypeId;
@@ -471,7 +472,7 @@ public class Order implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String paymentMethod;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "0")
 	public Integer getPaymentStatus() {
 		return paymentStatus;

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/OrderItem.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/OrderItem.java
@@ -44,6 +44,7 @@ import javax.annotation.Generated;
 
 import javax.validation.Valid;
 import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -208,7 +209,7 @@ public class OrderItem implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected BigDecimal finalPrice;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;
@@ -322,7 +323,7 @@ public class OrderItem implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String options;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30128")
 	public Long getOrderId() {
 		return orderId;
@@ -351,7 +352,7 @@ public class OrderItem implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long orderId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30128")
 	public Long getParentOrderItemId() {
 		return parentOrderItemId;
@@ -380,7 +381,7 @@ public class OrderItem implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long parentOrderItemId;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "2")
 	public Integer getQuantity() {
 		return quantity;

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/Product.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/Product.java
@@ -41,7 +41,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
@@ -66,7 +66,7 @@ public class Product implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(Product.class, json);
 	}
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30054")
 	public Long getCatalogId() {
 		return catalogId;
@@ -297,7 +297,7 @@ public class Product implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String externalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/ProductChannel.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/ProductChannel.java
@@ -36,7 +36,7 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -116,7 +116,7 @@ public class ProductChannel implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String externalReferenceCode;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema
 	public Long getId() {
 		return id;

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/ProductSpecification.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/ProductSpecification.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
@@ -63,7 +63,7 @@ public class ProductSpecification implements Serializable {
 			ProductSpecification.class, json);
 	}
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "31130")
 	public Long getId() {
 		return id;
@@ -90,7 +90,7 @@ public class ProductSpecification implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long id;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30129")
 	public Long getOptionCategoryId() {
 		return optionCategoryId;

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/Sku.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/Sku.java
@@ -44,6 +44,7 @@ import javax.annotation.Generated;
 
 import javax.validation.Valid;
 import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -235,7 +236,7 @@ public class Sku implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String gtin;
 
-	@DecimalMin("0")
+	@Min(0)
 	@Schema(example = "30130")
 	public Long getId() {
 		return id;

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/resources/com/liferay/headless/commerce/machine/learning/dto/v1_0/packageinfo
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/resources/com/liferay/headless/commerce/machine/learning/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 2.1.1

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/dto.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/dto.ftl
@@ -49,6 +49,8 @@ import javax.annotation.Generated;
 import javax.validation.Valid;
 import javax.validation.constraints.DecimalMax;
 import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
@@ -138,11 +140,19 @@ public class ${schemaName} <#if dtoParentClassName?has_content>extends ${dtoPare
 		/>
 
 		<#if propertySchema.maximum??>
-			@DecimalMax("${propertySchema.maximum}")
+			<#if stringUtil.equals(propertyType, "Integer") || stringUtil.equals(propertyType, "Long")>
+				@Max(${propertySchema.maximum})
+			<#else>
+				@DecimalMax("${propertySchema.maximum}")
+			</#if>
 		</#if>
 
 		<#if propertySchema.minimum??>
-			@DecimalMin("${propertySchema.minimum}")
+			<#if stringUtil.equals(propertyType, "Integer") || stringUtil.equals(propertyType, "Long")>
+				@Min(${propertySchema.minimum})
+			<#else>
+				@DecimalMin("${propertySchema.minimum}")
+			</#if>
 		</#if>
 
 		<#if propertySchema.jsonMap>


### PR DESCRIPTION
**What is new?**
- Changes in `dto.ftl`, checking if `parameterType` is `Long` or `Integer`, it will use the `@Min` and `@Max` annotations. For BigDecimals and Double `parameterType` it will maintain the `@DecimalMin` and `@DecimalMax` annotation.
- `buildREST` in `modules/apps` and `modules/dxp/apps`.

**Before PR**
![image](https://user-images.githubusercontent.com/44723449/215778891-95948c50-bc62-4936-8ae6-d2af1650f832.png)

**After PR**
![image](https://user-images.githubusercontent.com/44723449/215779040-af95a283-4323-43f9-a3a2-1922f94ff457.png)

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-172142