### PR TITLE
LPS-173133 Return proper resource for Nested Fields

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/jaxrs/constants/JaxRsConstants.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/jaxrs/constants/JaxRsConstants.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.jaxrs.constants;
+
+/**
+ * @author Luis Miguel Barcos
+ */
+public class JaxRsConstants {
+
+	public static final String LAST_SERVICE_OBJECT =
+		"org.apache.cxf.service.object.last";
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/ContextProviderUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/ContextProviderUtil.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.vulcan.internal.jaxrs.context.provider;
 
 import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.vulcan.jaxrs.constants.JaxRsConstants;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 
 import java.util.Arrays;
@@ -66,10 +67,12 @@ public class ContextProviderUtil {
 	public static Object getMatchedResource(Message message) {
 		Exchange exchange = message.getExchange();
 
-		Object root = exchange.get(JAXRSUtils.ROOT_INSTANCE);
+		Object resource = _fetchExistingResource(
+			exchange, JAXRSUtils.ROOT_INSTANCE,
+			JaxRsConstants.LAST_SERVICE_OBJECT);
 
-		if (root != null) {
-			return root;
+		if (resource != null) {
+			return resource;
 		}
 
 		OperationResourceInfo operationResourceInfo = exchange.get(
@@ -111,6 +114,20 @@ public class ContextProviderUtil {
 				}
 			}
 		};
+	}
+
+	private static Object _fetchExistingResource(
+		Exchange exchange, String... messageKeys) {
+
+		Object resource = null;
+		int i = 0;
+
+		while ((i < messageKeys.length) && (resource == null)) {
+			resource = exchange.get(messageKeys[i]);
+			i++;
+		}
+
+		return resource;
 	}
 
 	private static MultivaluedMap<String, String> _getPathParameters(

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/message/exchange/ExchangeWrapper.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/message/exchange/ExchangeWrapper.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.internal.jaxrs.message.exchange;
+
+import com.liferay.portal.vulcan.jaxrs.constants.JaxRsConstants;
+
+import org.apache.cxf.message.Exchange;
+import org.apache.cxf.message.ExchangeImpl;
+
+/**
+ * @author Luis Miguel Barcos
+ */
+public class ExchangeWrapper extends ExchangeImpl {
+
+	public ExchangeWrapper(Exchange exchange, Object resource) {
+		super((ExchangeImpl)exchange);
+
+		_exchange = exchange;
+		_resource = resource;
+	}
+
+	@Override
+	public Object get(Object key) {
+		if (key.equals(JaxRsConstants.LAST_SERVICE_OBJECT)) {
+			return _resource;
+		}
+
+		return super.get(key);
+	}
+
+	public Exchange getExchange() {
+		return _exchange;
+	}
+
+	public Object getResource() {
+		return _resource;
+	}
+
+	private final Exchange _exchange;
+	private final Object _resource;
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/jaxrs/writer/interceptor/NestedFieldsWriterInterceptorTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/jaxrs/writer/interceptor/NestedFieldsWriterInterceptorTest.java
@@ -50,6 +50,7 @@ import javax.ws.rs.ext.WriterInterceptorContext;
 import org.apache.cxf.Bus;
 import org.apache.cxf.jaxrs.ext.ContextProvider;
 import org.apache.cxf.jaxrs.provider.ProviderFactory;
+import org.apache.cxf.message.ExchangeImpl;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.message.MessageImpl;
 
@@ -178,7 +179,7 @@ public class NestedFieldsWriterInterceptorTest {
 
 		NestedFieldsContextThreadLocal.setNestedFieldsContext(
 			new NestedFieldsContext(
-				Arrays.asList("productOptions", "skus"), new MessageImpl(),
+				Arrays.asList("productOptions", "skus"), _getMessageImpl(),
 				new MultivaluedHashMap<>(), "v1.0",
 				new MultivaluedHashMap<>()));
 
@@ -215,7 +216,7 @@ public class NestedFieldsWriterInterceptorTest {
 
 		NestedFieldsContextThreadLocal.setNestedFieldsContext(
 			new NestedFieldsContext(
-				Arrays.asList("productOptions", "skus"), new MessageImpl(),
+				Arrays.asList("productOptions", "skus"), _getMessageImpl(),
 				_getPathParameters(), "v1.0", new MultivaluedHashMap<>()));
 
 		_nestedFieldsWriterInterceptor.aroundWriteTo(_writerInterceptorContext);
@@ -254,7 +255,7 @@ public class NestedFieldsWriterInterceptorTest {
 			new NestedFieldsContext(
 				Arrays.asList(
 					"productOptions", "productOptions.productOptionValues"),
-				new MessageImpl(), _getPathParameters(), "v1.0",
+				_getMessageImpl(), _getPathParameters(), "v1.0",
 				new MultivaluedHashMap<>()));
 
 		_nestedFieldsWriterInterceptor.aroundWriteTo(_writerInterceptorContext);
@@ -305,7 +306,7 @@ public class NestedFieldsWriterInterceptorTest {
 
 		NestedFieldsContextThreadLocal.setNestedFieldsContext(
 			new NestedFieldsContext(
-				Collections.singletonList("categories"), new MessageImpl(),
+				Collections.singletonList("categories"), _getMessageImpl(),
 				_getPathParameters(), "v1.0", new MultivaluedHashMap<>()));
 
 		_nestedFieldsWriterInterceptor.aroundWriteTo(_writerInterceptorContext);
@@ -316,7 +317,7 @@ public class NestedFieldsWriterInterceptorTest {
 
 		NestedFieldsContextThreadLocal.setNestedFieldsContext(
 			new NestedFieldsContext(
-				Collections.singletonList("categories"), new MessageImpl(),
+				Collections.singletonList("categories"), _getMessageImpl(),
 				_getPathParameters(), "v2.0", new MultivaluedHashMap<>()));
 
 		_nestedFieldsWriterInterceptor.aroundWriteTo(_writerInterceptorContext);
@@ -338,7 +339,7 @@ public class NestedFieldsWriterInterceptorTest {
 
 		NestedFieldsContextThreadLocal.setNestedFieldsContext(
 			new NestedFieldsContext(
-				Collections.emptyList(), new MessageImpl(),
+				Collections.emptyList(), _getMessageImpl(),
 				_getPathParameters(), "v1.0", new MultivaluedHashMap<>()));
 
 		_nestedFieldsWriterInterceptor.aroundWriteTo(_writerInterceptorContext);
@@ -347,7 +348,7 @@ public class NestedFieldsWriterInterceptorTest {
 
 		NestedFieldsContextThreadLocal.setNestedFieldsContext(
 			new NestedFieldsContext(
-				Collections.singletonList("nonexistent"), new MessageImpl(),
+				Collections.singletonList("nonexistent"), _getMessageImpl(),
 				_getPathParameters(), "v1.0", new MultivaluedHashMap<>()));
 
 		_nestedFieldsWriterInterceptor.aroundWriteTo(_writerInterceptorContext);
@@ -376,7 +377,7 @@ public class NestedFieldsWriterInterceptorTest {
 
 		NestedFieldsContextThreadLocal.setNestedFieldsContext(
 			new NestedFieldsContext(
-				Arrays.asList("productOptions", "skus"), new MessageImpl(),
+				Arrays.asList("productOptions", "skus"), _getMessageImpl(),
 				_getPathParameters(), "v1.0", new MultivaluedHashMap<>()));
 
 		Assert.assertNull(_productResource_v1_0_Impl.contextThemeDisplay);
@@ -416,7 +417,7 @@ public class NestedFieldsWriterInterceptorTest {
 
 		NestedFieldsContextThreadLocal.setNestedFieldsContext(
 			new NestedFieldsContext(
-				Collections.singletonList("externalCode"), new MessageImpl(),
+				Collections.singletonList("externalCode"), _getMessageImpl(),
 				_getPathParameters(), "v1.0", queryParameters));
 
 		_nestedFieldsWriterInterceptor.aroundWriteTo(_writerInterceptorContext);
@@ -447,7 +448,7 @@ public class NestedFieldsWriterInterceptorTest {
 
 		NestedFieldsContextThreadLocal.setNestedFieldsContext(
 			new NestedFieldsContext(
-				Collections.singletonList("skus"), new MessageImpl(),
+				Collections.singletonList("skus"), _getMessageImpl(),
 				_getPathParameters(), "v1.0", new MultivaluedHashMap<>()));
 
 		_nestedFieldsWriterInterceptor.aroundWriteTo(_writerInterceptorContext);
@@ -488,7 +489,7 @@ public class NestedFieldsWriterInterceptorTest {
 
 		NestedFieldsContextThreadLocal.setNestedFieldsContext(
 			new NestedFieldsContext(
-				Collections.singletonList("productOptions"), new MessageImpl(),
+				Collections.singletonList("productOptions"), _getMessageImpl(),
 				_getPathParameters(), "v1.0", queryParameters));
 
 		_nestedFieldsWriterInterceptor.aroundWriteTo(_writerInterceptorContext);
@@ -524,7 +525,7 @@ public class NestedFieldsWriterInterceptorTest {
 
 		NestedFieldsContextThreadLocal.setNestedFieldsContext(
 			new NestedFieldsContext(
-				Collections.singletonList("skus"), new MessageImpl(),
+				Collections.singletonList("skus"), _getMessageImpl(),
 				_getPathParameters(), "v2.0", new MultivaluedHashMap<>()));
 
 		_nestedFieldsWriterInterceptor.aroundWriteTo(_writerInterceptorContext);
@@ -555,7 +556,7 @@ public class NestedFieldsWriterInterceptorTest {
 
 		NestedFieldsContextThreadLocal.setNestedFieldsContext(
 			new NestedFieldsContext(
-				Collections.singletonList("skus"), new MessageImpl(),
+				Collections.singletonList("skus"), _getMessageImpl(),
 				_getPathParameters(), "v2.0", new MultivaluedHashMap<>()));
 
 		_nestedFieldsWriterInterceptor.aroundWriteTo(_writerInterceptorContext);
@@ -586,7 +587,7 @@ public class NestedFieldsWriterInterceptorTest {
 
 		NestedFieldsContextThreadLocal.setNestedFieldsContext(
 			new NestedFieldsContext(
-				Arrays.asList("productOptions", "skus"), new MessageImpl(),
+				Arrays.asList("productOptions", "skus"), _getMessageImpl(),
 				_getPathParameters(), "v1.0", new MultivaluedHashMap<>()));
 
 		Assert.assertNull(_productResource_v1_0_Impl.themeDisplay);
@@ -636,6 +637,14 @@ public class NestedFieldsWriterInterceptorTest {
 		sku.setId(id);
 
 		return sku;
+	}
+
+	private MessageImpl _getMessageImpl() {
+		MessageImpl messageImpl = new MessageImpl();
+
+		messageImpl.setExchange(new ExchangeImpl());
+
+		return messageImpl;
 	}
 
 	private MultivaluedHashMap<String, String> _getPathParameters() {


### PR DESCRIPTION
Related JIRA Ticket: https://issues.liferay.com/browse/LPS-173133
___
### Explanation of what this PR fixes
There is some special case where the use of nested fields ends in a NullPointerException.
This case is:
* Declaring a nested field with `@NestedField` annotation
* The method of the nested field has some special attributes (like Sort[])

The problem was that when creating the context for the special attributes, we rely on the proper ContextProvider (like SortContextProvider). Context providers need to calculate the EntityModel of the resource and the resource contained wasn't the correct one, but the "parent class" resource, which is not the correct one. 

It was working because most of the time when calculating the EntityModel (which is not also the correct one) the resource wasn't using the context properties of the resource. But in the case of the ticket, the parent resource is calculating the entityModel using `contextCompany` which is not injected by Vulcan.

### What does the PR do?
With this PR, in case of the request comes with nestedFields, we are adding nested field information in the request message to be able to get the resource associated with the nested field by the `@NestedField` annotation.
That resource will have injected all the context parameters and will calculate the proper EntityModel

### How to test it?
* Stop Liferay portal
* Deploy the following modules:
    * `portal-vulcan-api`
    * `portal-vulcan-impl`

_NOTE: The steps to reproduce the bug and to ensure that it is no longer happening are in the JIRA Ticket attached at the beginning._

