### PR TITLE
LPS-174611 Add createBatch action in getListTypeDefinitionListTypeEntriesPage method

### DIFF
--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-api/src/main/resources/com/liferay/headless/admin/list/type/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-api/src/main/resources/com/liferay/headless/admin/list/type/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.3.0
+version 1.3.1

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/ListTypeEntryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/ListTypeEntryResourceImpl.java
@@ -83,6 +83,14 @@ public class ListTypeEntryResourceImpl
 						getName(),
 					listTypeDefinitionId)
 			).put(
+				"createBatch",
+				addAction(
+					ActionKeys.UPDATE,
+					"postListTypeDefinitionListTypeEntryBatch",
+					com.liferay.list.type.model.ListTypeDefinition.class.
+						getName(),
+					listTypeDefinitionId)
+			).put(
 				"get",
 				addAction(
 					ActionKeys.VIEW, "getListTypeDefinitionListTypeEntriesPage",


### PR DESCRIPTION
**What is new?**
- Add `createBatch` action in `getListTypeDefinitionListTypeEntriesPage` method from `headless-admin-list-type`

![image](https://user-images.githubusercontent.com/44723449/217008589-52fbb4e3-69bb-4d9d-9d4c-147daf14cd93.png)

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-174611