### PR TITLE
LPS-172142 Change MessageInterpolator as ParameterMessageInterpolator does not parse expression language constraint errors

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/validation/ValidatorFactory.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/validation/ValidatorFactory.java
@@ -24,7 +24,7 @@ import javax.validation.spi.ValidationProvider;
 
 import org.hibernate.validator.HibernateValidator;
 import org.hibernate.validator.HibernateValidatorConfiguration;
-import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
+import org.hibernate.validator.messageinterpolation.ResourceBundleMessageInterpolator;
 
 /**
  * @author Javier Gamarra
@@ -46,7 +46,7 @@ public class ValidatorFactory {
 			allowOverridingMethodAlterParameterConstraint(true);
 
 		hibernateValidatorConfiguration.messageInterpolator(
-			new ParameterMessageInterpolator());
+			new ResourceBundleMessageInterpolator());
 
 		javax.validation.ValidatorFactory validatorFactory =
 			hibernateValidatorConfiguration.buildValidatorFactory();


### PR DESCRIPTION
This PR contains the code to use another implementation of `MessageInterpolator` as the old one, the `ParameterMessageInterpolator`, does not interpolate Expression Language and then, the errors returned by the 
`Validator` is not properly parsed when it does includes EL expressions.

**Before the PR:**

![image](https://user-images.githubusercontent.com/32699538/217277982-b52ce57e-3c30-4300-b79a-ef1d0f2e7e1b.png)

**After the PR:**

![image](https://user-images.githubusercontent.com/32699538/217278052-d475c012-f562-4152-bcf8-1074027eec39.png)
