### PR TITLE
LPS-174933 | Break a relationship between a custom object and a system object

### DIFF
--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectDefinitionAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectDefinitionAPI.macro
@@ -460,9 +460,7 @@ definition {
 				-u test@liferay.com:test
 		''';
 
-		var response = JSONCurlUtil.put(${curl});
-
-		return ${response};
+		return ${curl};
 	}
 
 	macro _updateEmployee {
@@ -651,6 +649,16 @@ definition {
 		TestUtils.assertEquals(
 			actual = ${actual},
 			expected = ${expectedValue});
+	}
+
+	macro breakRelationshipBetweenEntries {
+		var curl = ObjectDefinitionAPI._relateObjectEntries(
+			en_US_plural_label = ${en_US_plural_label},
+			objectEntry1 = ${objectEntry1},
+			objectEntry2 = ${objectEntry2},
+			relationshipName = ${relationshipName});
+
+		JSONCurlUtil.delete(${curl});
 	}
 
 	macro createAndPublishObjectDefinition {
@@ -859,11 +867,13 @@ definition {
 	}
 
 	macro relateObjectEntries {
-		var response = ObjectDefinitionAPI._relateObjectEntries(
+		var curl = ObjectDefinitionAPI._relateObjectEntries(
 			en_US_plural_label = ${en_US_plural_label},
 			objectEntry1 = ${objectEntry1},
 			objectEntry2 = ${objectEntry2},
 			relationshipName = ${relationshipName});
+
+		var response = JSONCurlUtil.put(${curl});
 
 		return ${response};
 	}

--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectDefinitionAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectDefinitionAPI.macro
@@ -176,6 +176,20 @@ definition {
 		return ${relationshipId};
 	}
 
+	macro _curlObjectEntriesRelationship {
+		Variables.assertDefined(parameterList = "${en_US_plural_label},${objectEntry1},${objectEntry2},${relationshipName}");
+
+		var portalURL = JSONCompany.getPortalURL();
+		var en_US_plural_label_lowercase = StringUtil.lowerCase(${en_US_plural_label});
+
+		var curl = '''
+			${portalURL}/o/c/${en_US_plural_label_lowercase}/${objectEntry1}/${relationshipName}/${objectEntry2} \
+				-u test@liferay.com:test
+		''';
+
+		return ${curl};
+	}
+
 	macro _deleteEmployee {
 		Variables.assertDefined(parameterList = ${employeeId});
 
@@ -449,20 +463,6 @@ definition {
 		return ${json};
 	}
 
-	macro _relateObjectEntries {
-		Variables.assertDefined(parameterList = "${en_US_plural_label},${objectEntry1},${objectEntry2},${relationshipName}");
-
-		var portalURL = JSONCompany.getPortalURL();
-		var en_US_plural_label_lowercase = StringUtil.lowerCase(${en_US_plural_label});
-
-		var curl = '''
-			${portalURL}/o/c/${en_US_plural_label_lowercase}/${objectEntry1}/${relationshipName}/${objectEntry2} \
-				-u test@liferay.com:test
-		''';
-
-		return ${curl};
-	}
-
 	macro _updateEmployee {
 		Variables.assertDefined(parameterList = "${employeeId},${firstname},${managerId}");
 
@@ -652,7 +652,7 @@ definition {
 	}
 
 	macro breakRelationshipBetweenEntries {
-		var curl = ObjectDefinitionAPI._relateObjectEntries(
+		var curl = ObjectDefinitionAPI._curlObjectEntriesRelationship(
 			en_US_plural_label = ${en_US_plural_label},
 			objectEntry1 = ${objectEntry1},
 			objectEntry2 = ${objectEntry2},
@@ -867,7 +867,7 @@ definition {
 	}
 
 	macro relateObjectEntries {
-		var curl = ObjectDefinitionAPI._relateObjectEntries(
+		var curl = ObjectDefinitionAPI._curlObjectEntriesRelationship(
 			en_US_plural_label = ${en_US_plural_label},
 			objectEntry1 = ${objectEntry1},
 			objectEntry2 = ${objectEntry2},

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/BreakRelationshipBetweenCustomAndSystemObjects.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/BreakRelationshipBetweenCustomAndSystemObjects.testcase
@@ -1,0 +1,189 @@
+@component-name = "portal-headless"
+definition {
+
+	property custom.properties = "feature.flag.LPS-153324=true${line.separator}feature.flag.LPS-162966=true";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Object";
+	property testray.main.component.name = "Headless";
+
+	setUp {
+		TestCase.setUpPortalInstanceNoSelenium();
+
+		task ("Given a foundation object") {
+			var customObjectDefinitionId1 = ObjectDefinitionAPI.createAndPublishObjectDefinition(
+				en_US_label = "foundation",
+				en_US_plural_label = "foundations",
+				name = "Foundation",
+				requiredStringFieldName = "name");
+		}
+
+		task ("Given a secondFoundation object") {
+			var customObjectDefinitionId2 = ObjectDefinitionAPI.createAndPublishObjectDefinition(
+				en_US_label = "secondFoundation",
+				en_US_plural_label = "secondFoundations",
+				name = "SecondFoundation",
+				requiredStringFieldName = "name");
+		}
+
+		task ("Given oneToMany relationship secondFoundationOfUsers created") {
+			ObjectDefinitionAPI.setUpGlobalObjectDefinitionIdWithName(objectName = "User");
+
+			var relationshipName = ObjectDefinitionAPI.createRelationship(
+				deletionType = "cascade",
+				en_US_label = "SecondFoundationOfUsers",
+				name = "secondFoundationOfUsers",
+				objectDefinitionId1 = ${customObjectDefinitionId2},
+				objectDefinitionId2 = ${staticObjectId},
+				type = "oneToMany");
+		}
+
+		task ("Given manyToMany relationship foundationsOfUsers created") {
+			var relationshipName = ObjectDefinitionAPI.createRelationship(
+				deletionType = "cascade",
+				en_US_label = "FoundationsOfUsers",
+				name = "foundationsOfUsers",
+				objectDefinitionId1 = ${customObjectDefinitionId1},
+				objectDefinitionId2 = ${staticObjectId},
+				type = "manyToMany");
+		}
+
+		task ("Given object entries created") {
+			ObjectDefinitionAPI.setUpGlobalObjectEntryId();
+		}
+
+		task ("Given userAccount entry created") {
+			UserAccountAPI.setUpGlobalUserAccountIds(
+				alternateName1 = "user1",
+				alternateName2 = "user2",
+				emailAddress1 = "user1@liferay.com",
+				emailAddress2 = "user2@liferay.com",
+				familyName1 = "userfn1",
+				familyName2 = "userfn2",
+				givenName1 = "usergn1",
+				givenName2 = "usergn2");
+		}
+	}
+
+	tearDown {
+		for (var objectName : list "Foundation,SecondFoundation") {
+			ObjectAdmin.deleteObjectViaAPI(objectName = ${objectName});
+		}
+
+		for (var userId : list "${staticUserAccountId1},${staticUserAccountId2}") {
+			JSONUser.deleteUserByUserId(userId = ${userId});
+		}
+
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if (${testPortalInstance} == "true") {
+			PortalInstances.tearDownCPNoSelenium();
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 4
+	test CanBreakManyToManyRelationshipWithCustomObjectAsParent {
+		property portal.acceptance = "true";
+		property test.name.skip.portal.instance = "BreakRelationshipBetweenCustomAndSystemObjects#CanBreakManyToManyRelationshipWithCustomObjectAsParent";
+
+		task ("Given I relate the userAccount entry with the foundation entry through the foundation PUT endpoint") {
+			ObjectDefinitionAPI.relateObjectEntries(
+				en_US_plural_label = "foundations",
+				objectEntry1 = ${staticObjectEntryId1},
+				objectEntry2 = ${staticUserAccountId1},
+				relationshipName = "foundationsOfUsers");
+		}
+
+		task ("When using the delete request deleteFoundation{relationshipName}") {
+			ObjectDefinitionAPI.breakRelationshipBetweenEntries(
+				en_US_plural_label = "foundations",
+				objectEntry1 = ${staticObjectEntryId1},
+				objectEntry2 = ${staticUserAccountId1},
+				relationshipName = "foundationsOfUsers");
+		}
+
+		task ("Then I can see no one entry correctly related in GET request response with the relationshipName=foundationsOfUsers") {
+			var response = ObjectDefinitionAPI.getObjectEntryRelation(
+				en_US_plural_label = "foundations",
+				objectId = ${staticObjectEntryId1},
+				relationshipName = "foundationsOfUsers");
+
+			ObjectDefinitionAPI.assertNoItemsInResponse(responseToParse = ${response});
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 4
+	test CanBreakOneToManyRelationshipKeepingOtherEntriesRelated {
+		property portal.acceptance = "true";
+		property test.name.skip.portal.instance = "BreakRelationshipBetweenCustomAndSystemObjects#CanBreakOneToManyRelationshipKeepingOtherEntriesRelated";
+
+		task ("Given all userAccounts are related to the secondFoundation through the secondFoundation PUT endpoint") {
+			ObjectDefinitionAPI.relateObjectEntries(
+				en_US_plural_label = "secondFoundations",
+				objectEntry1 = ${staticObjectEntryId3},
+				objectEntry2 = ${staticUserAccountId1},
+				relationshipName = "secondFoundationOfUsers");
+
+			ObjectDefinitionAPI.relateObjectEntries(
+				en_US_plural_label = "secondFoundations",
+				objectEntry1 = ${staticObjectEntryId3},
+				objectEntry2 = ${staticUserAccountId2},
+				relationshipName = "secondFoundationOfUsers");
+		}
+
+		task ("When breaking one of the userAccount entries") {
+			ObjectDefinitionAPI.breakRelationshipBetweenEntries(
+				en_US_plural_label = "secondFoundations",
+				objectEntry1 = ${staticObjectEntryId3},
+				objectEntry2 = ${staticUserAccountId1},
+				relationshipName = "secondFoundationOfUsers");
+		}
+
+		task ("Then I can see only one entry correctly related in GET request response") {
+			var response = ObjectDefinitionAPI.getObjectEntryRelation(
+				en_US_plural_label = "secondFoundations",
+				objectId = ${staticObjectEntryId3},
+				relationshipName = "secondFoundationOfUsers");
+
+			ObjectDefinitionAPI.assertResponseHasCorrectObjectEntryName(
+				expectedValue = "usergn2 userfn2",
+				objectEntryId = ${staticUserAccountId2},
+				responseToParse = ${response});
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 4
+	test CanBreakOneToManyRelationshipWithCustomObjectAsParent {
+		property portal.acceptance = "true";
+		property test.name.skip.portal.instance = "BreakRelationshipBetweenCustomAndSystemObjects#CanBreakOneToManyRelationshipWithCustomObjectAsParent";
+
+		task ("Given I relate the userAccount entry with the secondFoundation entry through the secondFoundation PUT endpoint") {
+			ObjectDefinitionAPI.relateObjectEntries(
+				en_US_plural_label = "secondFoundations",
+				objectEntry1 = ${staticObjectEntryId3},
+				objectEntry2 = ${staticUserAccountId1},
+				relationshipName = "secondFoundationOfUsers");
+		}
+
+		task ("When using the delete request deleteSecondFoundation{relationshipName}") {
+			ObjectDefinitionAPI.breakRelationshipBetweenEntries(
+				en_US_plural_label = "secondFoundations",
+				objectEntry1 = ${staticObjectEntryId3},
+				objectEntry2 = ${staticUserAccountId1},
+				relationshipName = "secondFoundationOfUsers");
+		}
+
+		task ("Then I can see no one entry correctly related in GET request response with the relationshipName=secondFoundationOfUsers") {
+			var response = ObjectDefinitionAPI.getObjectEntryRelation(
+				en_US_plural_label = "secondFoundations",
+				objectId = ${staticObjectEntryId3},
+				relationshipName = "secondFoundationOfUsers");
+
+			ObjectDefinitionAPI.assertNoItemsInResponse(responseToParse = ${response});
+		}
+	}
+
+}


### PR DESCRIPTION
**Background**
Add a testcase to break a relationship between a custom object and a system object

**Test Plan**
Background Steps:
Given a foundation object
Given a secondFoundation object
Given oneToMany relationship secondFoundationOfUsers created
Given manyToMany relationship foundationsOfUsers created
Given object entries created
Given userAccount entry created

CanBreakManyToManyRelationshipWithCustomObjectAsParent
Given I relate the userAccount entry with the foundation entry through the foundation PUT endpoint
When using the delete request deleteFoundation{relationshipName}
Then I can see no one entry correctly related in GET request response with the relationshipName=foundationsOfUsers

CanBreakOneToManyRelationshipKeepingOtherEntriesRelated
Given all userAccounts are related to the secondFoundation through the secondFoundation PUT endpoint
When breaking one of the userAccount entries
Then I can see only one entry correctly related in GET request response

CanBreakOneToManyRelationshipWithCustomObjectAsParent
Given I relate the userAccount entry with the secondFoundation entry through the secondFoundation PUT endpoint
When using the delete request deleteSecondFoundation{relationshipName}
Then I can see no one entry correctly related in GET request response with the relationshipName=secondFoundationOfUsers

**JIRA Link:**
https://issues.liferay.com/browse/LPS-174933