### PR TITLE
LPS-174410 Add test to load open api profile for all APIs in the system

### DIFF
--- a/modules/apps/headless/headless-discovery/headless-discovery-test/src/testFunctional/tests/OpenAPIProfile.testcase
+++ b/modules/apps/headless/headless-discovery/headless-discovery-test/src/testFunctional/tests/OpenAPIProfile.testcase
@@ -1,0 +1,44 @@
+@component-name = "portal-headless"
+definition {
+
+	property custom.properties = "feature.flag.LPS-166216=true";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.main.component.name = "Headless";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if ("${testPortalInstance}" == "true") {
+			PortalInstances.tearDownCP();
+		}
+	}
+
+	@priority = "4"
+	test CanLoadOpenAPIProfileWithoutErrors {
+		property portal.acceptance = "true";
+
+		task ("When navigate to /o/openapi/openapi.json endpoint") {
+			APIExplorer.navigateToOpenAPI(
+				api = "openapi",
+				version = "");
+		}
+
+		task ("Then global rest api loaded without errors") {
+			var portalURL = PropsUtil.get("portal.url");
+
+			AssertTextEquals(
+				locator1 = "Select#HEADLESS_SERVERS",
+				value1 = "${portalURL}/o");
+
+			AssertConsoleTextNotPresent(value1 = "Failed to load Global REST API");
+		}
+	}
+
+}


### PR DESCRIPTION
**Background**
Add test to make sure the new openapi load without errors

**Test Plan**
When navigate to /o/openapi/openapi.json endpoint
Then global rest api loaded without errors

**JIRA Link:**
https://issues.liferay.com/browse/LPS-174410