### PR TITLE
Lps 175231 | Master

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/MessageBoardAttachmentAPI.macro
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/MessageBoardAttachmentAPI.macro
@@ -89,16 +89,28 @@ definition {
 		return ${response};
 	}
 
-	macro getMessageBoardAttachmentIdByMbMessageErcAndMbAttachmentErc {
+	macro deleteMessageBoardAttachmentByMbMessageErcAndMbAttachmentErc {
 		Variables.assertDefined(parameterList = "${messageBoardMessageErc},${messageBoardAttachmentErc}");
 
 		var curl = MessageBoardAttachmentAPI._curlMessageBoardAttachment(
 			messageBoardAttachmentErc = ${messageBoardAttachmentErc},
 			messageBoardMessageErc = ${messageBoardMessageErc});
 
-		var mbAttachmentId = JSONCurlUtil.get(${curl}, "$.id");
+		var response = JSONCurlUtil.delete(${curl});
 
-		return ${mbAttachmentId};
+		return ${response};
+	}
+
+	macro getMessageBoardAttachmentByMbMessageErcAndMbAttachmentErc {
+		Variables.assertDefined(parameterList = "${messageBoardMessageErc},${messageBoardAttachmentErc}");
+
+		var curl = MessageBoardAttachmentAPI._curlMessageBoardAttachment(
+			messageBoardAttachmentErc = ${messageBoardAttachmentErc},
+			messageBoardMessageErc = ${messageBoardMessageErc});
+
+		var response = JSONCurlUtil.get(${curl});
+
+		return ${response};
 	}
 
 }

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/MessageBoardAttachmentAPI.macro
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/MessageBoardAttachmentAPI.macro
@@ -20,61 +20,85 @@ definition {
 			var curl = StringUtil.add("${portalURL}/o/headless-delivery/v1.0/${api}/message-board-attachments", "\ ${command}", "");
 		}
 		else {
-			var curl = '''
-				${portalURL}/o/headless-delivery/v1.0/message-board-attachments/${messageBoardAttachmentId} \
-					-u test@liferay.com:test \
-					-H Content-Type: application/json
+			if (isSet(messageBoardAttachmentId)) {
+				var api = "message-board-attachments/${messageBoardAttachmentId}";
+			}
+			else {
+				var siteId = JSONGroupAPI._getGroupIdByNameNoSelenium(
+					groupName = "Guest",
+					site = "true");
+
+				var api = "sites/${siteId}/message-board-messages/by-external-reference-code/${messageBoardMessageErc}/message-board-attachments/by-external-reference-code/${messageBoardAttachmentErc}";
+			}
+
+			var command = '''
+				-u test@liferay.com:test \
+				-H Content-Type: application/json
 			''';
+
+			var curl = StringUtil.add("${portalURL}/o/headless-delivery/v1.0/${api}", "\ ${command}", "");
 		}
 
-		return "${curl}";
+		return ${curl};
 	}
 
 	macro _getErcOfMessageBoardAttchment {
-		Variables.assertDefined(parameterList = "${messageBoardAttachmentId}");
+		Variables.assertDefined(parameterList = ${messageBoardAttachmentId});
 
-		var curl = MessageBoardAttachmentAPI._curlMessageBoardAttachment(messageBoardAttachmentId = "${messageBoardAttachmentId}");
+		var curl = MessageBoardAttachmentAPI._curlMessageBoardAttachment(messageBoardAttachmentId = ${messageBoardAttachmentId});
 
-		var mbAttachmentErc = JSONCurlUtil.get("${curl}", "$.externalReferenceCode");
+		var mbAttachmentErc = JSONCurlUtil.get(${curl}, "$.externalReferenceCode");
 
-		return "${mbAttachmentErc}";
+		return ${mbAttachmentErc};
 	}
 
 	macro assertCorrectErcInResponse {
-		Variables.assertDefined(parameterList = "${response}");
+		Variables.assertDefined(parameterList = ${response});
 
-		var mbAttachmentId = JSONUtil.getWithJSONPath("${response}", "$.id");
+		var mbAttachmentId = JSONUtil.getWithJSONPath(${response}, "$.id");
 
-		var expectedErc = MessageBoardAttachmentAPI._getErcOfMessageBoardAttchment(messageBoardAttachmentId = "${mbAttachmentId}");
-		var mbAttachmentErc = JSONUtil.getWithJSONPath("${response}", "$.externalReferenceCode");
+		var expectedErc = MessageBoardAttachmentAPI._getErcOfMessageBoardAttchment(messageBoardAttachmentId = ${mbAttachmentId});
+		var mbAttachmentErc = JSONUtil.getWithJSONPath(${response}, "$.externalReferenceCode");
 
 		TestUtils.assertEquals(
-			actual = "${mbAttachmentErc}",
-			expected = "${expectedErc}");
+			actual = ${mbAttachmentErc},
+			expected = ${expectedErc});
 	}
 
 	macro createMessageBoardMessageMessageBoardAttachment {
 		Variables.assertDefined(parameterList = "${messageBoardMessageId},${attachmentPath}");
 
 		var curl = MessageBoardAttachmentAPI._curlMessageBoardAttachment(
-			attachmentPath = "${attachmentPath}",
-			messageBoardMessageId = "${messageBoardMessageId}");
+			attachmentPath = ${attachmentPath},
+			messageBoardMessageId = ${messageBoardMessageId});
 
-		var response = JSONCurlUtil.post("${curl}");
+		var response = JSONCurlUtil.post(${curl});
 
-		return "${response}";
+		return ${response};
 	}
 
 	macro createMessageBoardThreadMessageBoardAttachment {
 		Variables.assertDefined(parameterList = "${messageBoardThreadId},${attachmentPath}");
 
 		var curl = MessageBoardAttachmentAPI._curlMessageBoardAttachment(
-			attachmentPath = "${attachmentPath}",
-			messageBoardThreadId = "${messageBoardThreadId}");
+			attachmentPath = ${attachmentPath},
+			messageBoardThreadId = ${messageBoardThreadId});
 
-		var response = JSONCurlUtil.post("${curl}");
+		var response = JSONCurlUtil.post(${curl});
 
-		return "${response}";
+		return ${response};
+	}
+
+	macro getMessageBoardAttachmentIdByMbMessageErcAndMbAttachmentErc {
+		Variables.assertDefined(parameterList = "${messageBoardMessageErc},${messageBoardAttachmentErc}");
+
+		var curl = MessageBoardAttachmentAPI._curlMessageBoardAttachment(
+			messageBoardAttachmentErc = ${messageBoardAttachmentErc},
+			messageBoardMessageErc = ${messageBoardMessageErc});
+
+		var mbAttachmentId = JSONCurlUtil.get(${curl}, "$.id");
+
+		return ${mbAttachmentId};
 	}
 
 }

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/MessageBoardAttachmentAPI.macro
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/MessageBoardAttachmentAPI.macro
@@ -41,12 +41,12 @@ definition {
 	macro assertCorrectErcInResponse {
 		Variables.assertDefined(parameterList = ${response});
 
-		var messageBoardAttachmentErc = JSONResponseUtil.getRootExternalReferenceCodeFromResponse(response = ${response});
-		var messageBoardAttachmentId = JSONResponseUtil.getRootIdFromResponse(response = ${response});
+		var messageBoardAttachmentErc = JSONUtil.getWithJSONPath(${response}, "$.externalReferenceCode");
+		var messageBoardAttachmentId = JSONUtil.getWithJSONPath(${response}, "$.id");
 
 		var responseFromGet = MessageBoardAttachmentAPI.getMessageBoardAttachment(messageBoardAttachmentId = ${messageBoardAttachmentId});
 
-		var expectedErc = JSONResponseUtil.getRootExternalReferenceCodeFromResponse(response = ${responseFromGet});
+		var expectedErc = JSONUtil.getWithJSONPath(${responseFromGet}, "$.externalReferenceCode");
 
 		TestUtils.assertEquals(
 			actual = ${messageBoardAttachmentErc},

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/MessageBoardAttachmentAPI.macro
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/MessageBoardAttachmentAPI.macro
@@ -1,0 +1,80 @@
+definition {
+
+	macro _curlMessageBoardAttachment {
+		var portalURL = JSONCompany.getPortalURL();
+
+		if (isSet(attachmentPath)) {
+			if (isSet(messageBoardThreadId)) {
+				var api = "message-board-threads/${messageBoardThreadId}";
+			}
+			else {
+				var api = "/message-board-messages/${messageBoardMessageId}";
+			}
+
+			var command = '''
+				-u test@liferay.com:test \
+				-H Content-Type: multipart/form-data \
+				-F file=@${attachmentPath}
+			''';
+
+			var curl = StringUtil.add("${portalURL}/o/headless-delivery/v1.0/${api}/message-board-attachments", "\ ${command}", "");
+		}
+		else {
+			var curl = '''
+				${portalURL}/o/headless-delivery/v1.0/message-board-attachments/${messageBoardAttachmentId} \
+					-u test@liferay.com:test \
+					-H Content-Type: application/json
+			''';
+		}
+
+		return "${curl}";
+	}
+
+	macro _getErcOfMessageBoardAttchment {
+		Variables.assertDefined(parameterList = "${messageBoardAttachmentId}");
+
+		var curl = MessageBoardAttachmentAPI._curlMessageBoardAttachment(messageBoardAttachmentId = "${messageBoardAttachmentId}");
+
+		var mbAttachmentErc = JSONCurlUtil.get("${curl}", "$.externalReferenceCode");
+
+		return "${mbAttachmentErc}";
+	}
+
+	macro assertCorrectErcInResponse {
+		Variables.assertDefined(parameterList = "${response}");
+
+		var mbAttachmentId = JSONUtil.getWithJSONPath("${response}", "$.id");
+
+		var expectedErc = MessageBoardAttachmentAPI._getErcOfMessageBoardAttchment(messageBoardAttachmentId = "${mbAttachmentId}");
+		var mbAttachmentErc = JSONUtil.getWithJSONPath("${response}", "$.externalReferenceCode");
+
+		TestUtils.assertEquals(
+			actual = "${mbAttachmentErc}",
+			expected = "${expectedErc}");
+	}
+
+	macro createMessageBoardMessageMessageBoardAttachment {
+		Variables.assertDefined(parameterList = "${messageBoardMessageId},${attachmentPath}");
+
+		var curl = MessageBoardAttachmentAPI._curlMessageBoardAttachment(
+			attachmentPath = "${attachmentPath}",
+			messageBoardMessageId = "${messageBoardMessageId}");
+
+		var response = JSONCurlUtil.post("${curl}");
+
+		return "${response}";
+	}
+
+	macro createMessageBoardThreadMessageBoardAttachment {
+		Variables.assertDefined(parameterList = "${messageBoardThreadId},${attachmentPath}");
+
+		var curl = MessageBoardAttachmentAPI._curlMessageBoardAttachment(
+			attachmentPath = "${attachmentPath}",
+			messageBoardThreadId = "${messageBoardThreadId}");
+
+		var response = JSONCurlUtil.post("${curl}");
+
+		return "${response}";
+	}
+
+}

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/MessageBoardAttachmentAPI.macro
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/MessageBoardAttachmentAPI.macro
@@ -38,26 +38,18 @@ definition {
 		return ${curl};
 	}
 
-	macro _getErcOfMessageBoardAttchment {
-		Variables.assertDefined(parameterList = ${messageBoardAttachmentId});
-
-		var curl = MessageBoardAttachmentAPI._curlMessageBoardAttachment(messageBoardAttachmentId = ${messageBoardAttachmentId});
-
-		var mbAttachmentErc = JSONCurlUtil.get(${curl}, "$.externalReferenceCode");
-
-		return ${mbAttachmentErc};
-	}
-
 	macro assertCorrectErcInResponse {
 		Variables.assertDefined(parameterList = ${response});
 
-		var mbAttachmentId = JSONUtil.getWithJSONPath(${response}, "$.id");
+		var messageBoardAttachmentErc = JSONResponseUtil.getRootExternalReferenceCodeFromResponse(response = ${response});
+		var messageBoardAttachmentId = JSONResponseUtil.getRootIdFromResponse(response = ${response});
 
-		var expectedErc = MessageBoardAttachmentAPI._getErcOfMessageBoardAttchment(messageBoardAttachmentId = ${mbAttachmentId});
-		var mbAttachmentErc = JSONUtil.getWithJSONPath(${response}, "$.externalReferenceCode");
+		var responseFromGet = MessageBoardAttachmentAPI.getMessageBoardAttachment(messageBoardAttachmentId = ${messageBoardAttachmentId});
+
+		var expectedErc = JSONResponseUtil.getRootExternalReferenceCodeFromResponse(response = ${responseFromGet});
 
 		TestUtils.assertEquals(
-			actual = ${mbAttachmentErc},
+			actual = ${messageBoardAttachmentErc},
 			expected = ${expectedErc});
 	}
 
@@ -93,6 +85,16 @@ definition {
 			messageBoardMessageErc = ${messageBoardMessageErc});
 
 		var response = JSONCurlUtil.delete(${curl});
+
+		return ${response};
+	}
+
+	macro getMessageBoardAttachment {
+		Variables.assertDefined(parameterList = ${messageBoardAttachmentId});
+
+		var curl = MessageBoardAttachmentAPI._curlMessageBoardAttachment(messageBoardAttachmentId = ${messageBoardAttachmentId});
+
+		var response = JSONCurlUtil.get(${curl});
 
 		return ${response};
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/MessageBoardAttachmentAPI.macro
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/MessageBoardAttachmentAPI.macro
@@ -3,41 +3,37 @@ definition {
 	macro _curlMessageBoardAttachment {
 		var portalURL = JSONCompany.getPortalURL();
 
-		if (isSet(attachmentPath)) {
-			if (isSet(messageBoardThreadId)) {
-				var api = "message-board-threads/${messageBoardThreadId}";
-			}
-			else {
-				var api = "/message-board-messages/${messageBoardMessageId}";
-			}
+		if (isSet(messageBoardThreadId)) {
+			var api = "message-board-threads/${messageBoardThreadId}/message-board-attachments";
+		}
+		else if (isSet(messageBoardMessageId)) {
+			var api = "message-board-messages/${messageBoardMessageId}/message-board-attachments";
+		}
+		else if (isSet(messageBoardAttachmentId)) {
+			var api = "message-board-attachments/${messageBoardAttachmentId}";
+		}
+		else {
+			var siteId = JSONGroupAPI._getGroupIdByNameNoSelenium(
+				groupName = "Guest",
+				site = "true");
 
-			var command = '''
-				-u test@liferay.com:test \
+			var api = "sites/${siteId}/message-board-messages/by-external-reference-code/${messageBoardMessageErc}/message-board-attachments/by-external-reference-code/${messageBoardAttachmentErc}";
+		}
+
+		var command = '''
+				-u test@liferay.com:test
+			''';
+
+		if (isSet(attachmentPath)) {
+			var body = '''
 				-H Content-Type: multipart/form-data \
 				-F file=@${attachmentPath}
 			''';
 
-			var curl = StringUtil.add("${portalURL}/o/headless-delivery/v1.0/${api}/message-board-attachments", "\ ${command}", "");
+			var command = StringUtil.add(${command}, " \ ${body}", "");
 		}
-		else {
-			if (isSet(messageBoardAttachmentId)) {
-				var api = "message-board-attachments/${messageBoardAttachmentId}";
-			}
-			else {
-				var siteId = JSONGroupAPI._getGroupIdByNameNoSelenium(
-					groupName = "Guest",
-					site = "true");
 
-				var api = "sites/${siteId}/message-board-messages/by-external-reference-code/${messageBoardMessageErc}/message-board-attachments/by-external-reference-code/${messageBoardAttachmentErc}";
-			}
-
-			var command = '''
-				-u test@liferay.com:test \
-				-H Content-Type: application/json
-			''';
-
-			var curl = StringUtil.add("${portalURL}/o/headless-delivery/v1.0/${api}", "\ ${command}", "");
-		}
+		var curl = StringUtil.add("${portalURL}/o/headless-delivery/v1.0/${api}", "\ ${command}", "");
 
 		return ${curl};
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/MessageBoardMessageAPI.macro
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/MessageBoardMessageAPI.macro
@@ -1,0 +1,52 @@
+definition {
+
+	macro _curlMessageBoardMessage {
+		Variables.assertDefined(parameterList = "${headline}");
+
+		var portalURL = JSONCompany.getPortalURL();
+
+		if (isSet(messageBoardThreadId)) {
+			var api = "message-board-threads/${messageBoardThreadId}";
+		}
+		else {
+			var api = "message-board-messages/${parentMessageBoardMessageId}";
+		}
+
+		var command = '''
+				-u test@liferay.com:test \
+				-H Content-Type: application/json \
+				-d {
+					"headline": "${headline}"
+				}
+		''';
+
+		var curl = StringUtil.add("${portalURL}/o/headless-delivery/v1.0/${api}/message-board-messages", "\ ${command}", "");
+
+		return "${curl}";
+	}
+
+	macro getIdOfCreatedChildMbMessageByMbMessageId {
+		Variables.assertDefined(parameterList = "${parentMessageBoardMessageId}");
+
+		var curl = MessageBoardMessageAPI._curlMessageBoardMessage(
+			headline = "${headline}",
+			parentMessageBoardMessageId = "${parentMessageBoardMessageId}");
+
+		var mbMessageId = JSONCurlUtil.post("${curl}", "$.id");
+
+		return "${mbMessageId}";
+	}
+
+	macro getIdOfCreatedMbMessageByMbThreadId {
+		Variables.assertDefined(parameterList = "${messageBoardThreadId}");
+
+		var curl = MessageBoardMessageAPI._curlMessageBoardMessage(
+			headline = "${headline}",
+			messageBoardThreadId = "${messageBoardThreadId}");
+
+		var mbMessageId = JSONCurlUtil.post("${curl}", "$.id");
+
+		return "${mbMessageId}";
+	}
+
+}

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/MessageBoardMessageAPI.macro
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/MessageBoardMessageAPI.macro
@@ -33,38 +33,56 @@ definition {
 		return ${curl};
 	}
 
-	macro getIdOfCreatedChildMbMessageByMbMessageId {
+	macro createChildMbMessageByMbMessageId {
 		Variables.assertDefined(parameterList = "${headline},${parentMessageBoardMessageId}");
 
 		var curl = MessageBoardMessageAPI._curlMessageBoardMessage(
 			headline = ${headline},
 			parentMessageBoardMessageId = ${parentMessageBoardMessageId});
 
-		var mbMessageId = JSONCurlUtil.post(${curl}, "$.id");
+		var response = JSONCurlUtil.post(${curl});
 
-		return ${mbMessageId};
+		return ${response};
 	}
 
-	macro getIdOfCreatedMbMessageByMbThreadId {
+	macro createMbMessageByMbThreadId {
 		Variables.assertDefined(parameterList = "${headline},${messageBoardThreadId}");
 
 		var curl = MessageBoardMessageAPI._curlMessageBoardMessage(
 			headline = ${headline},
 			messageBoardThreadId = ${messageBoardThreadId});
 
-		var mbMessageId = JSONCurlUtil.post(${curl}, "$.id");
+		var response = JSONCurlUtil.post(${curl});
 
-		return ${mbMessageId};
+		return ${response};
 	}
 
-	macro getMbMessageErcByMbMessageId {
+	macro getIdOfCreatedMbMessageByMbThreadId {
+		var response = MessageBoardMessageAPI.createMbMessageByMbThreadId(
+			headline = ${headline},
+			messageBoardThreadId = ${messageBoardThreadId});
+
+		var messageboardMessageId = JSONResponseUtil.getRootIdFromResponse(response = ${response});
+
+		return ${messageboardMessageId};
+	}
+
+	macro getMbMessageByMbMessageId {
 		Variables.assertDefined(parameterList = ${messageBoardMessageId});
 
 		var curl = MessageBoardMessageAPI._curlMessageBoardMessage(messageBoardMessageId = ${messageBoardMessageId});
 
-		var mbMessageErc = JSONCurlUtil.get(${curl}, "$.externalReferenceCode");
+		var response = JSONCurlUtil.get(${curl});
 
-		return ${mbMessageErc};
+		return ${response};
+	}
+
+	macro getMbMessageErcByMbMessageId {
+		var response = MessageBoardMessageAPI.getMbMessageByMbMessageId(messageBoardMessageId = ${messageBoardMessageId});
+
+		var messageBoardMessageErc = JSONResponseUtil.getRootExternalReferenceCodeFromResponse(response = ${response});
+
+		return ${messageBoardMessageErc};
 	}
 
 }

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/MessageBoardMessageAPI.macro
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/MessageBoardMessageAPI.macro
@@ -1,52 +1,70 @@
 definition {
 
 	macro _curlMessageBoardMessage {
-		Variables.assertDefined(parameterList = "${headline}");
-
 		var portalURL = JSONCompany.getPortalURL();
 
 		if (isSet(messageBoardThreadId)) {
-			var api = "message-board-threads/${messageBoardThreadId}";
+			var api = "message-board-threads/${messageBoardThreadId}/message-board-messages";
+		}
+		else if (isSet(messageBoardMessageId)) {
+			var api = "message-board-messages/${messageBoardMessageId}";
 		}
 		else {
-			var api = "message-board-messages/${parentMessageBoardMessageId}";
+			var api = "message-board-messages/${parentMessageBoardMessageId}/message-board-messages";
 		}
 
 		var command = '''
 				-u test@liferay.com:test \
-				-H Content-Type: application/json \
+				-H Content-Type: application/json
+		''';
+
+		if (isSet(headline)) {
+			var body = '''
 				-d {
 					"headline": "${headline}"
 				}
-		''';
+			''';
 
-		var curl = StringUtil.add("${portalURL}/o/headless-delivery/v1.0/${api}/message-board-messages", "\ ${command}", "");
+			var command = StringUtil.add(${command}, " \ ${body}", "");
+		}
 
-		return "${curl}";
+		var curl = StringUtil.add("${portalURL}/o/headless-delivery/v1.0/${api}", "\ ${command}", "");
+
+		return ${curl};
 	}
 
 	macro getIdOfCreatedChildMbMessageByMbMessageId {
-		Variables.assertDefined(parameterList = "${parentMessageBoardMessageId}");
+		Variables.assertDefined(parameterList = "${headline},${parentMessageBoardMessageId}");
 
 		var curl = MessageBoardMessageAPI._curlMessageBoardMessage(
-			headline = "${headline}",
-			parentMessageBoardMessageId = "${parentMessageBoardMessageId}");
+			headline = ${headline},
+			parentMessageBoardMessageId = ${parentMessageBoardMessageId});
 
-		var mbMessageId = JSONCurlUtil.post("${curl}", "$.id");
+		var mbMessageId = JSONCurlUtil.post(${curl}, "$.id");
 
-		return "${mbMessageId}";
+		return ${mbMessageId};
 	}
 
 	macro getIdOfCreatedMbMessageByMbThreadId {
-		Variables.assertDefined(parameterList = "${messageBoardThreadId}");
+		Variables.assertDefined(parameterList = "${headline},${messageBoardThreadId}");
 
 		var curl = MessageBoardMessageAPI._curlMessageBoardMessage(
-			headline = "${headline}",
-			messageBoardThreadId = "${messageBoardThreadId}");
+			headline = ${headline},
+			messageBoardThreadId = ${messageBoardThreadId});
 
-		var mbMessageId = JSONCurlUtil.post("${curl}", "$.id");
+		var mbMessageId = JSONCurlUtil.post(${curl}, "$.id");
 
-		return "${mbMessageId}";
+		return ${mbMessageId};
+	}
+
+	macro getMbMessageErcByMbMessageId {
+		Variables.assertDefined(parameterList = ${messageBoardMessageId});
+
+		var curl = MessageBoardMessageAPI._curlMessageBoardMessage(messageBoardMessageId = ${messageBoardMessageId});
+
+		var mbMessageErc = JSONCurlUtil.get(${curl}, "$.externalReferenceCode");
+
+		return ${mbMessageErc};
 	}
 
 }

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/MessageBoardMessageAPI.macro
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/MessageBoardMessageAPI.macro
@@ -62,7 +62,7 @@ definition {
 			headline = ${headline},
 			messageBoardThreadId = ${messageBoardThreadId});
 
-		var messageboardMessageId = JSONResponseUtil.getRootIdFromResponse(response = ${response});
+		var messageboardMessageId = JSONUtil.getWithJSONPath(${response}, "$.id");
 
 		return ${messageboardMessageId};
 	}
@@ -80,7 +80,7 @@ definition {
 	macro getMbMessageErcByMbMessageId {
 		var response = MessageBoardMessageAPI.getMbMessageByMbMessageId(messageBoardMessageId = ${messageBoardMessageId});
 
-		var messageBoardMessageErc = JSONResponseUtil.getRootExternalReferenceCodeFromResponse(response = ${response});
+		var messageBoardMessageErc = JSONUtil.getWithJSONPath(${response}, "$.externalReferenceCode");
 
 		return ${messageBoardMessageErc};
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/MessageBoardSectionAPI.macro
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/MessageBoardSectionAPI.macro
@@ -27,24 +27,24 @@ definition {
 		return ${curl};
 	}
 
-	macro getIdOfChildMessageBoardSection {
+	macro createChildMessageBoardSection {
 		Variables.assertDefined(parameterList = "${title},${parentMessageBoardSectionId}");
 
 		var curl = MessageBoardSectionAPI._curlMessageBoardSection(title = ${title});
 
-		var mbSectionId = JSONCurlUtil.post(${curl}, "$.id");
+		var response = JSONCurlUtil.post(${curl});
 
-		return ${mbSectionId};
+		return ${response};
 	}
 
-	macro getIdOfCreatedMessageBoardSection {
+	macro createMessageBoardSection {
 		Variables.assertDefined(parameterList = ${title});
 
 		var curl = MessageBoardSectionAPI._curlMessageBoardSection(title = ${title});
 
-		var mbSectionId = JSONCurlUtil.post(${curl}, "$.id");
+		var response = JSONCurlUtil.post(${curl});
 
-		return ${mbSectionId};
+		return ${response};
 	}
 
 }

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/MessageBoardSectionAPI.macro
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/MessageBoardSectionAPI.macro
@@ -1,0 +1,50 @@
+definition {
+
+	macro _curlMessageBoardSection {
+		var portalURL = JSONCompany.getPortalURL();
+
+		if (isSet(parentMessageBoardSectionId)) {
+			var api = "message-board-sections/${parentMessageBoardSectionId}";
+		}
+		else {
+			var siteId = JSONGroupAPI._getGroupIdByNameNoSelenium(
+				groupName = "Guest",
+				site = "true");
+
+			var api = "sites/${siteId}";
+		}
+
+		var command = '''
+			-u test@liferay.com:test \
+			-H Content-Type: application/json \
+			-d {
+				"title": "${title}"
+			}
+		''';
+
+		var curl = StringUtil.add("${portalURL}/o/headless-delivery/v1.0/${api}/message-board-sections", "\ ${command}", "");
+
+		return ${curl};
+	}
+
+	macro getIdOfChildMessageBoardSection {
+		Variables.assertDefined(parameterList = "${title},${parentMessageBoardSectionId}");
+
+		var curl = MessageBoardSectionAPI._curlMessageBoardSection(title = ${title});
+
+		var mbSectionId = JSONCurlUtil.post(${curl}, "$.id");
+
+		return ${mbSectionId};
+	}
+
+	macro getIdOfCreatedMessageBoardSection {
+		Variables.assertDefined(parameterList = ${title});
+
+		var curl = MessageBoardSectionAPI._curlMessageBoardSection(title = ${title});
+
+		var mbSectionId = JSONCurlUtil.post(${curl}, "$.id");
+
+		return ${mbSectionId};
+	}
+
+}

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/MessageBoardThreadAPI.macro
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/MessageBoardThreadAPI.macro
@@ -64,9 +64,9 @@ definition {
 
 		var messageBoardThreadId = JSONCurlUtil.post(${curl}, "$.['id']");
 
-		static var staticMbThreadId = ${messageBoardThreadId};
+		static var staticMessageBoardThreadId = ${messageBoardThreadId};
 
-		return ${staticMbThreadId};
+		return ${staticMessageBoardThreadId};
 	}
 
 }

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/MessageBoardThreadAPI.macro
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/MessageBoardThreadAPI.macro
@@ -1,0 +1,52 @@
+definition {
+
+	macro _curlMessageBoardThread {
+		var portalURL = JSONCompany.getPortalURL();
+		var siteId = JSONGroupAPI._getGroupIdByNameNoSelenium(
+			groupName = "Guest",
+			site = "true");
+
+		if (isSet(headline)) {
+			var curl = '''
+				${portalURL}/o/headless-delivery/v1.0/sites/${siteId}/message-board-threads \
+					-u test@liferay.com:test \
+					-H Content-Type: application/json \
+					-d {
+						"headline": "${headline}"
+					}
+			''';
+		}
+		else {
+			var curl = '''
+				${portalURL}/o/headless-delivery/v1.0/message-board-threads/${messageBoardThreadId} \
+					-u test@liferay.com:test \
+					-H Content-Type: application/json
+			''';
+		}
+
+		return "${curl}";
+	}
+
+	macro deleteMessageBoardThreadByThreadId {
+		Variables.assertDefined(parameterList = "${messageBoardThreadId}");
+
+		var curl = MessageBoardThreadAPI._curlMessageBoardThread(messageBoardThreadId = "${messageBoardThreadId}");
+
+		JSONCurlUtil.delete("${curl}");
+	}
+
+	macro setUpGlobalMessageBoardThreadId {
+		Variables.assertDefined(parameterList = "${headline}");
+
+		var curl = MessageBoardThreadAPI._curlMessageBoardThread(headline = "${headline}");
+
+		var response = JSONCurlUtil.post("${curl}");
+
+		var messageBoardThreadId = JSONUtil.getWithJSONPath("${response}", "$.['id']");
+
+		static var staticMbThreadId = "${messageBoardThreadId}";
+
+		return "${staticMbThreadId}";
+	}
+
+}

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/MessageBoardThreadAPI.macro
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/MessageBoardThreadAPI.macro
@@ -3,35 +3,36 @@ definition {
 	macro _curlMessageBoardThread {
 		var portalURL = JSONCompany.getPortalURL();
 
-		if (isSet(headline)) {
-			if (isSet(messageBoardSectionId)) {
-				var api = "message-board-sections/${messageBoardSectionId}";
-			}
-			else {
-				var siteId = JSONGroupAPI._getGroupIdByNameNoSelenium(
-					groupName = "Guest",
-					site = "true");
-
-				var api = "sites/${siteId}";
-			}
-
-			var command = '''
-					-u test@liferay.com:test \
-					-H Content-Type: application/json \
-					-d {
-						"headline": "${headline}"
-					}
-			''';
-
-			var curl = StringUtil.add("${portalURL}/o/headless-delivery/v1.0/${api}/message-board-threads", "\ ${command}", "");
+		if (isSet(messageBoardSectionId)) {
+			var api = "message-board-sections/${messageBoardSectionId}/message-board-threads";
+		}
+		else if (isSet(messageBoardThreadId)) {
+			var api = "message-board-threads/${messageBoardThreadId}";
 		}
 		else {
-			var curl = '''
-				${portalURL}/o/headless-delivery/v1.0/message-board-threads/${messageBoardThreadId} \
-					-u test@liferay.com:test \
-					-H Content-Type: application/json
-			''';
+			var siteId = JSONGroupAPI._getGroupIdByNameNoSelenium(
+				groupName = "Guest",
+				site = "true");
+
+			var api = "sites/${siteId}/message-board-threads";
 		}
+
+		var command = '''
+			-u test@liferay.com:test \
+			-H Content-Type: application/json
+		''';
+
+		if (isSet(headline)) {
+			var body = '''
+				-d {
+					"headline": "${headline}"
+				}
+			''';
+
+			var command = StringUtil.add(${command}, " \ ${body}", "");
+		}
+
+		var curl = StringUtil.add("${portalURL}/o/headless-delivery/v1.0/${api}", "\ ${command}", "");
 
 		return ${curl};
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/MessageBoardThreadAPI.macro
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/MessageBoardThreadAPI.macro
@@ -2,19 +2,28 @@ definition {
 
 	macro _curlMessageBoardThread {
 		var portalURL = JSONCompany.getPortalURL();
-		var siteId = JSONGroupAPI._getGroupIdByNameNoSelenium(
-			groupName = "Guest",
-			site = "true");
 
 		if (isSet(headline)) {
-			var curl = '''
-				${portalURL}/o/headless-delivery/v1.0/sites/${siteId}/message-board-threads \
+			if (isSet(messageBoardSectionId)) {
+				var api = "message-board-sections/${messageBoardSectionId}";
+			}
+			else {
+				var siteId = JSONGroupAPI._getGroupIdByNameNoSelenium(
+					groupName = "Guest",
+					site = "true");
+
+				var api = "sites/${siteId}";
+			}
+
+			var command = '''
 					-u test@liferay.com:test \
 					-H Content-Type: application/json \
 					-d {
 						"headline": "${headline}"
 					}
 			''';
+
+			var curl = StringUtil.add("${portalURL}/o/headless-delivery/v1.0/${api}/message-board-threads", "\ ${command}", "");
 		}
 		else {
 			var curl = '''
@@ -24,29 +33,39 @@ definition {
 			''';
 		}
 
-		return "${curl}";
+		return ${curl};
+	}
+
+	macro createMessageThreadInMessageBoardSection {
+		Variables.assertDefined(parameterList = "${headline},${messageBoardSectionId}");
+
+		var curl = MessageBoardThreadAPI._curlMessageBoardThread(
+			headline = ${headline},
+			messageBoardSectionId = ${messageBoardSectionId});
+
+		var response = JSONCurlUtil.post(${curl});
+
+		return ${response};
 	}
 
 	macro deleteMessageBoardThreadByThreadId {
-		Variables.assertDefined(parameterList = "${messageBoardThreadId}");
+		Variables.assertDefined(parameterList = ${messageBoardThreadId});
 
-		var curl = MessageBoardThreadAPI._curlMessageBoardThread(messageBoardThreadId = "${messageBoardThreadId}");
+		var curl = MessageBoardThreadAPI._curlMessageBoardThread(messageBoardThreadId = ${messageBoardThreadId});
 
-		JSONCurlUtil.delete("${curl}");
+		JSONCurlUtil.delete(${curl});
 	}
 
 	macro setUpGlobalMessageBoardThreadId {
-		Variables.assertDefined(parameterList = "${headline}");
+		Variables.assertDefined(parameterList = ${headline});
 
-		var curl = MessageBoardThreadAPI._curlMessageBoardThread(headline = "${headline}");
+		var curl = MessageBoardThreadAPI._curlMessageBoardThread(headline = ${headline});
 
-		var response = JSONCurlUtil.post("${curl}");
+		var messageBoardThreadId = JSONCurlUtil.post(${curl}, "$.['id']");
 
-		var messageBoardThreadId = JSONUtil.getWithJSONPath("${response}", "$.['id']");
+		static var staticMbThreadId = ${messageBoardThreadId};
 
-		static var staticMbThreadId = "${messageBoardThreadId}";
-
-		return "${staticMbThreadId}";
+		return ${staticMbThreadId};
 	}
 
 }

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcForMessageBoardAttachment.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcForMessageBoardAttachment.testcase
@@ -1,0 +1,87 @@
+@component-name = "portal-headless"
+definition {
+
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.main.component.name = "Headless";
+
+	setUp {
+		TestCase.setUpPortalInstanceNoSelenium();
+
+		MessageBoardThreadAPI.setUpGlobalMessageBoardThreadId(headline = "This is the mb thread");
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		MessageBoardThreadAPI.deleteMessageBoardThreadByThreadId(messageBoardThreadId = "${staticMbThreadId}");
+
+		if ("${testPortalInstance}" == "true") {
+			PortalInstances.tearDownCPNoSelenium();
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = "4"
+	test CanCreateChildMessageBoardMessageMessageBoardAttachementWithErc {
+		property portal.acceptance = "true";
+
+		task ("Given with postMessageBoardThreadMessageBoardMessage and messageBoardThreadId to create a message board message") {
+			var mbMessageId = MessageBoardMessageAPI.getIdOfCreatedMbMessageByMbThreadId(
+				headline = "This is the parent mb message",
+				messageBoardThreadId = "${staticMbThreadId}");
+		}
+
+		task ("And Given with postMessageBoardMessageMessageBoardMessage and parentMessageBoardMessageId to create a child message board message") {
+			var childMbMessageId = MessageBoardMessageAPI.getIdOfCreatedChildMbMessageByMbMessageId(
+				headline = "This is the child mb message",
+				parentMessageBoardMessageId = "${mbMessageId}");
+		}
+
+		task ("When with postMessageBoardMessageMessageBoardAttachmentsPage and messageBoardMessageId to create an attachment for child message board message") {
+			var attachmentPath = TestCase.getDependenciesDirPath(fileName = "Document_4.jpg");
+
+			var response = MessageBoardAttachmentAPI.createMessageBoardMessageMessageBoardAttachment(
+				attachmentPath = "${attachmentPath}",
+				messageBoardMessageId = "${childMbMessageId}");
+		}
+
+		task ("Then I can see external reference code equals to uuid in the response") {
+			MessageBoardAttachmentAPI.assertCorrectErcInResponse(response = "${response}");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = "4"
+	test CanCreateMessageBoardAttachementForMessageBoardMessageInSectionWithErc {
+		property portal.acceptance = "true";
+
+		task ("Given with postSiteMessageBoardSection and siteId to create a message board section") {
+			var mbMessageId = MessageBoardMessageAPI.getIdOfCreatedMbMessageByMbThreadId(
+				headline = "This is the parent mb message",
+				messageBoardThreadId = "${staticMbThreadId}");
+		}
+
+		task ("And Given with postMessageBoardSectionMessageBoardThread and messageBoardSectionId to create a message board thread") {
+			var childMbMessageId = MessageBoardMessageAPI.getIdOfCreatedChildMbMessageByMbMessageId(
+				headline = "This is the child mb message",
+				parentMessageBoardMessageId = "${mbMessageId}");
+		}
+
+		task ("And Given with postMessageBoardThreadMessageBoardMessage and messageBoardThreadId to create a message board message") {
+			var attachmentPath = TestCase.getDependenciesDirPath(fileName = "Document_4.jpg");
+
+			var response = MessageBoardAttachmentAPI.createMessageBoardMessageMessageBoardAttachment(
+				attachmentPath = "${attachmentPath}",
+				messageBoardMessageId = "${childMbMessageId}");
+		}
+
+		task ("When with postMessageBoardMessageMessageBoardAttachmentsPage and messageBoardMessageId to create an attachment for message board message") {
+		}
+
+		task ("Then I can see external reference code equals to uuid in the response") {
+			MessageBoardAttachmentAPI.assertCorrectErcInResponse(response = "${response}");
+		}
+	}
+
+}

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcForMessageBoardAttachment.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcForMessageBoardAttachment.testcase
@@ -11,13 +11,13 @@ definition {
 		MessageBoardThreadAPI.setUpGlobalMessageBoardThreadId(headline = "This is the mb thread");
 	}
 
-	//tearDown {
-	//	var testPortalInstance = PropsUtil.get("test.portal.instance");
-	//	MessageBoardThreadAPI.deleteMessageBoardThreadByThreadId(messageBoardThreadId = ${staticMbThreadId});
-	//	if (${testPortalInstance} == "true") {
-	//		PortalInstances.tearDownCPNoSelenium();
-	//}
-	//}
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+		MessageBoardThreadAPI.deleteMessageBoardThreadByThreadId(messageBoardThreadId = ${staticMbThreadId});
+		if (${testPortalInstance} == "true") {
+			PortalInstances.tearDownCPNoSelenium();
+	}
+	}
 
 	@disable-webdriver = "true"
 	@priority = 4
@@ -30,7 +30,7 @@ definition {
 				messageBoardThreadId = ${staticMbThreadId});
 		}
 
-		task ("And Given with postMessageBoardMessageMessageBoardMessage and parentMessageBoardMessageId to create a child message board message") {
+		task ("Given with postMessageBoardMessageMessageBoardMessage and parentMessageBoardMessageId to create a child message board message") {
 			var childMbMessageId = MessageBoardMessageAPI.getIdOfCreatedChildMbMessageByMbMessageId(
 				headline = "This is the child mb message",
 				parentMessageBoardMessageId = ${mbMessageId});
@@ -159,17 +159,76 @@ definition {
 			var mbMessageErc = MessageBoardMessageAPI.getMbMessageErcByMbMessageId(messageBoardMessageId = ${mbMessageId});
 			var mbAttachmentErc = JSONUtil.getWithJSONPath(${responseToParse}, "$.externalReferenceCode");
 
-			var mbAttachmentId = MessageBoardAttachmentAPI.getMessageBoardAttachmentIdByMbMessageErcAndMbAttachmentErc(
+			var response = MessageBoardAttachmentAPI.getMessageBoardAttachmentByMbMessageErcAndMbAttachmentErc(
 				messageBoardAttachmentErc = ${mbAttachmentErc},
 				messageBoardMessageErc = ${mbMessageErc});
 		}
 
 		task ("Then I can see the correct details of message board message attachment") {
 			var expectId = JSONUtil.getWithJSONPath(${responseToParse}, "$.id");
+			var mbAttachmentId = JSONUtil.getWithJSONPath(${response}, "$.id");
 
 			TestUtils.assertEquals(
 				actual = ${mbAttachmentId},
 				expected = ${expectId});
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 3
+	test CanReturnMessageBoardNotExistsWithDeleteMessageBoardAttachmentByNonexistentMessageBoardMessageErc {
+		task ("When with DELETE request, siteId, message board message's and message board attachment's external reference codes to delete the message board attachment") {
+			var response = MessageBoardAttachmentAPI.deleteMessageBoardAttachmentByMbMessageErcAndMbAttachmentErc(
+				messageBoardAttachmentErc = "nonexistent-attachment-erc",
+				messageBoardMessageErc = "nonexistent-attachment-erc");
+		}
+
+		task ("Then it will show user that there is no message board message exists") {
+			TestUtils.assertPartialEquals(
+				actual = ${response},
+				expected = "No MBMessage exists with the key");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 4
+	test CanReturnMessageBoardNotExistsWithGetMessageBoardAttachmentByNonexistentErc {
+		property portal.acceptance = "true";
+
+		task ("When with GET request, siteId, nonexistent message board message's and message board attachment's external reference codes to retrieve the message board attachment") {
+			var response = MessageBoardAttachmentAPI.getMessageBoardAttachmentByMbMessageErcAndMbAttachmentErc(
+				messageBoardAttachmentErc = "nonexistent-attachment-erc",
+				messageBoardMessageErc = "nonexistent-message-erc");
+		}
+
+		task ("Then it will show user that there is no message board message exists") {
+			TestUtils.assertPartialEquals(
+				actual = ${response},
+				expected = "No MBMessage exists with the key");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 3
+	test CanReturnNoFileExistsWithGetMessageBoardAttachmentByNonexistentMessageBoardMessageAttachmentErc {
+		task ("Given with postMessageBoardThreadMessageBoardMessage and messageBoardThreadId to create a message board message") {
+			var mbMessageId = MessageBoardMessageAPI.getIdOfCreatedMbMessageByMbThreadId(
+				headline = "This is the mb message",
+				messageBoardThreadId = ${staticMbThreadId});
+		}
+
+		task ("When with GET request, siteId, message board message's erc and nonexistent message board attachment's erc to retrieve the message board attachment") {
+			var mbMessageErc = MessageBoardMessageAPI.getMbMessageErcByMbMessageId(messageBoardMessageId = ${mbMessageId});
+
+			var response = MessageBoardAttachmentAPI.getMessageBoardAttachmentByMbMessageErcAndMbAttachmentErc(
+				messageBoardAttachmentErc = "nonexistent-attachment-erc",
+				messageBoardMessageErc = ${mbMessageErc});
+		}
+
+		task ("Then it will show user that there is no file exists") {
+			TestUtils.assertPartialEquals(
+				actual = ${response},
+				expected = "No DLFileEntry exists with the key");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcForMessageBoardAttachment.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcForMessageBoardAttachment.testcase
@@ -40,7 +40,7 @@ definition {
 				headline = "This is the child mb message",
 				parentMessageBoardMessageId = ${messageBoardMessageId});
 
-			var childMessageBoardMessageId = JSONResponseUtil.getRootIdFromResponse(response = ${response});
+			var childMessageBoardMessageId = JSONUtil.getWithJSONPath(${response}, "$.id");
 		}
 
 		task ("When with postMessageBoardMessageMessageBoardAttachmentsPage and messageBoardMessageId to create an attachment for child message board message") {
@@ -64,7 +64,7 @@ definition {
 		task ("Given with postSiteMessageBoardSection and siteId to create a message board section") {
 			var response = MessageBoardSectionAPI.createMessageBoardSection(title = "mb section");
 
-			var messageBoardSectionId = JSONResponseUtil.getRootIdFromResponse(response = ${response});
+			var messageBoardSectionId = JSONUtil.getWithJSONPath(${response}, "$.id");
 		}
 
 		task ("And Given with postMessageBoardSectionMessageBoardThread and messageBoardSectionId to create a message board thread") {
@@ -72,7 +72,7 @@ definition {
 				headline = "This is the mb thread in section",
 				messageBoardSectionId = ${messageBoardSectionId});
 
-			var messageBoardThreadId = JSONResponseUtil.getRootIdFromResponse(response = ${response});
+			var messageBoardThreadId = JSONUtil.getWithJSONPath(${response}, "$.id");
 		}
 
 		task ("And Given with postMessageBoardThreadMessageBoardMessage and messageBoardThreadId to create a message board message") {
@@ -148,7 +148,7 @@ definition {
 				headline = "This is the child mb message",
 				parentMessageBoardMessageId = ${messageBoardMessageId});
 
-			var childMessageBoardMessageId = JSONResponseUtil.getRootIdFromResponse(response = ${response});
+			var childMessageBoardMessageId = JSONUtil.getWithJSONPath(${response}, "$.id");
 		}
 
 		task ("And Given with postMessageBoardMessageMessageBoardAttachmentsPage and messageBoardMessageId to create an attachment for child message board message") {
@@ -161,7 +161,7 @@ definition {
 
 		task ("When with DELETE request, siteId, child message board message's and child message board attachment's external reference codes to delete the message board attachment") {
 			var messageBoardMessageErc = MessageBoardMessageAPI.getMbMessageErcByMbMessageId(messageBoardMessageId = ${childMessageBoardMessageId});
-			var messageBoardAttachmentErc = JSONResponseUtil.getRootExternalReferenceCodeFromResponse(response = ${response});
+			var messageBoardAttachmentErc = JSONUtil.getWithJSONPath(${response}, "$.externalReferenceCode");
 
 			MessageBoardAttachmentAPI.deleteMessageBoardAttachmentByMbMessageErcAndMbAttachmentErc(
 				messageBoardAttachmentErc = ${messageBoardAttachmentErc},
@@ -187,7 +187,7 @@ definition {
 		task ("Given with postSiteMessageBoardSection and siteId to create a message board section") {
 			var response = MessageBoardSectionAPI.createMessageBoardSection(title = "mb section");
 
-			var messageBoardSectionId = JSONResponseUtil.getRootIdFromResponse(response = ${response});
+			var messageBoardSectionId = JSONUtil.getWithJSONPath(${response}, "$.id");
 		}
 
 		task ("And Given with postMessageBoardSectionMessageBoardSection and parentMessageBoardSectionId to create a child message board section") {
@@ -195,7 +195,7 @@ definition {
 				parentMessageBoardSectionId = ${messageBoardSectionId},
 				title = "child mb section");
 
-			var childMessageBoardSectionId = JSONResponseUtil.getRootIdFromResponse(response = ${response});
+			var childMessageBoardSectionId = JSONUtil.getWithJSONPath(${response}, "$.id");
 		}
 
 		task ("And Given with postMessageBoardSectionMessageBoardThread and messageBoardSectionId to create a message board thread") {
@@ -215,7 +215,7 @@ definition {
 		}
 
 		task ("When with DELETE request, siteId, message board message's and message board attachment's external reference codes to delete the message board attachment") {
-			var messageBoardAttachmentErc = JSONResponseUtil.getRootExternalReferenceCodeFromResponse(response = ${response});
+			var messageBoardAttachmentErc = JSONUtil.getWithJSONPath(${response}, "$.externalReferenceCode");
 			var messageBoardMessageErc = MessageBoardMessageAPI.getMbMessageErcByMbMessageId(messageBoardMessageId = ${messageBoardMessageId});
 
 			var response = MessageBoardAttachmentAPI.deleteMessageBoardAttachmentByMbMessageErcAndMbAttachmentErc(
@@ -242,7 +242,7 @@ definition {
 		task ("Given with postSiteMessageBoardSection and siteId to create a message board section") {
 			var response = MessageBoardSectionAPI.createMessageBoardSection(title = "mb section");
 
-			var messageBoardSectionId = JSONResponseUtil.getRootIdFromResponse(response = ${response});
+			var messageBoardSectionId = JSONUtil.getWithJSONPath(${response}, "$.id");
 		}
 
 		task ("And Given with postMessageBoardSectionMessageBoardSection and parentMessageBoardSectionId to create a child message board section") {
@@ -250,7 +250,7 @@ definition {
 				parentMessageBoardSectionId = ${messageBoardSectionId},
 				title = "child mb section");
 
-			var childMessageBoardSectionId = JSONResponseUtil.getRootIdFromResponse(response = ${response});
+			var childMessageBoardSectionId = JSONUtil.getWithJSONPath(${response}, "$.id");
 		}
 
 		task ("And Given with postMessageBoardSectionMessageBoardThread and messageBoardSectionId to create a message board thread") {
@@ -258,7 +258,7 @@ definition {
 				headline = "This is the mb thread in child section",
 				messageBoardSectionId = ${childMessageBoardSectionId});
 
-			var messageBoardThreadId = JSONResponseUtil.getRootIdFromResponse(response = ${response});
+			var messageBoardThreadId = JSONUtil.getWithJSONPath(${response}, "$.id");
 			var messageBoardMessageId = JSONUtil.getWithJSONPath(${response}, "$.messageBoardRootMessageId");
 		}
 
@@ -272,7 +272,7 @@ definition {
 
 		task ("When with GET request, siteId, message board message's and message board attachment's external reference codes to retrieve the message board attachment") {
 			var messageBoardMessageErc = MessageBoardMessageAPI.getMbMessageErcByMbMessageId(messageBoardMessageId = ${messageBoardMessageId});
-			var messageBoardbAttachmentErc = JSONResponseUtil.getRootExternalReferenceCodeFromResponse(response = ${responseToParse});
+			var messageBoardbAttachmentErc = JSONUtil.getWithJSONPath(${responseToParse}, "$.externalReferenceCode");
 
 			var response = MessageBoardAttachmentAPI.getMessageBoardAttachmentByMbMessageErcAndMbAttachmentErc(
 				messageBoardAttachmentErc = ${messageBoardbAttachmentErc},
@@ -280,8 +280,8 @@ definition {
 		}
 
 		task ("Then I can see the correct details of message board message attachment") {
-			var expectId = JSONResponseUtil.getRootIdFromResponse(response = ${responseToParse});
-			var messageBoardAttachmentId = JSONResponseUtil.getRootIdFromResponse(response = ${response});
+			var expectId = JSONUtil.getWithJSONPath(${responseToParse}, "$.id");
+			var messageBoardAttachmentId = JSONUtil.getWithJSONPath(${response}, "$.id");
 
 			TestUtils.assertEquals(
 				actual = ${messageBoardAttachmentId},

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcForMessageBoardAttachment.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcForMessageBoardAttachment.testcase
@@ -13,10 +13,13 @@ definition {
 
 	tearDown {
 		var testPortalInstance = PropsUtil.get("test.portal.instance");
-		MessageBoardThreadAPI.deleteMessageBoardThreadByThreadId(messageBoardThreadId = ${staticMbThreadId});
+
 		if (${testPortalInstance} == "true") {
 			PortalInstances.tearDownCPNoSelenium();
-	}
+		}
+		else {
+			MessageBoardThreadAPI.deleteMessageBoardThreadByThreadId(messageBoardThreadId = ${staticMbThreadId});
+		}
 	}
 
 	@disable-webdriver = "true"
@@ -125,6 +128,100 @@ definition {
 
 	@disable-webdriver = "true"
 	@priority = 4
+	test CanDeleteMessageBoardAttachmentByMessageBoardMessageErcAndMessageBoardAttachmentErc {
+		property portal.acceptance = "true";
+
+		task ("Given with postMessageBoardMessageMessageBoardMessage and parentMessageBoardMessageId to create a child message board message") {
+			var mbMessageId = MessageBoardMessageAPI.getIdOfCreatedMbMessageByMbThreadId(
+				headline = "This is the parent mb message",
+				messageBoardThreadId = ${staticMbThreadId});
+
+			var childMbMessageId = MessageBoardMessageAPI.getIdOfCreatedChildMbMessageByMbMessageId(
+				headline = "This is the child mb message",
+				parentMessageBoardMessageId = ${mbMessageId});
+		}
+
+		task ("And Given with postMessageBoardMessageMessageBoardAttachmentsPage and messageBoardMessageId to create an attachment for child message board message") {
+			var attachmentPath = TestCase.getDependenciesDirPath(fileName = "Document_4.jpg");
+
+			var response = MessageBoardAttachmentAPI.createMessageBoardMessageMessageBoardAttachment(
+				attachmentPath = ${attachmentPath},
+				messageBoardMessageId = ${childMbMessageId});
+		}
+
+		task ("When with DELETE request, siteId, child message board message's and child message board attachment's external reference codes to delete the message board attachment") {
+			var mbMessageErc = MessageBoardMessageAPI.getMbMessageErcByMbMessageId(messageBoardMessageId = ${childMbMessageId});
+			var mbAttachmentErc = JSONUtil.getWithJSONPath(${response}, "$.externalReferenceCode");
+
+			MessageBoardAttachmentAPI.deleteMessageBoardAttachmentByMbMessageErcAndMbAttachmentErc(
+				messageBoardAttachmentErc = ${mbAttachmentErc},
+				messageBoardMessageErc = ${mbMessageErc});
+		}
+
+		task ("Then the message board message attachment is deleted") {
+			var response = MessageBoardAttachmentAPI.getMessageBoardAttachmentByMbMessageErcAndMbAttachmentErc(
+				messageBoardAttachmentErc = ${mbAttachmentErc},
+				messageBoardMessageErc = ${mbMessageErc});
+
+			TestUtils.assertPartialEquals(
+				actual = ${response},
+				expected = "No DLFileEntry exists with the key");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 4
+	test CanDeleteMessageBoardAttachmentInSectionByMessageBoardMessageErcAndMessageBoardAttachmentErc {
+		property portal.acceptance = "true";
+
+		task ("Given with postSiteMessageBoardSection and siteId to create a message board section") {
+			var mbSectionId = MessageBoardSectionAPI.getIdOfCreatedMessageBoardSection(title = "mb section");
+		}
+
+		task ("And Given with postMessageBoardSectionMessageBoardSection and parentMessageBoardSectionId to create a child message board section") {
+			var childMbSectionId = MessageBoardSectionAPI.getIdOfChildMessageBoardSection(
+				parentMessageBoardSectionId = ${mbSectionId},
+				title = "child mb section");
+		}
+
+		task ("And Given with postMessageBoardSectionMessageBoardThread and messageBoardSectionId to create a message board thread") {
+			var response = MessageBoardThreadAPI.createMessageThreadInMessageBoardSection(
+				headline = "This is the mb thread in section",
+				messageBoardSectionId = ${mbSectionId});
+
+			var mbMessageId = JSONUtil.getWithJSONPath(${response}, "$.messageBoardRootMessageId");
+		}
+
+		task ("And Given with postMessageBoardThreadMessageBoardAttachment and messageBoardThreadId to create an attachment for message board thread") {
+			var attachmentPath = TestCase.getDependenciesDirPath(fileName = "Document_4.jpg");
+
+			var response = MessageBoardAttachmentAPI.createMessageBoardThreadMessageBoardAttachment(
+				attachmentPath = ${attachmentPath},
+				messageBoardThreadId = ${staticMbThreadId});
+		}
+
+		task ("When with DELETE request, siteId, message board message's and message board attachment's external reference codes to delete the message board attachment") {
+			var mbAttachmentErc = JSONUtil.getWithJSONPath(${response}, "$.externalReferenceCode");
+			var mbMessageErc = MessageBoardMessageAPI.getMbMessageErcByMbMessageId(messageBoardMessageId = ${mbMessageId});
+
+			var response = MessageBoardAttachmentAPI.deleteMessageBoardAttachmentByMbMessageErcAndMbAttachmentErc(
+				messageBoardAttachmentErc = ${mbAttachmentErc},
+				messageBoardMessageErc = ${mbMessageErc});
+		}
+
+		task ("Then the message board message attachment is deleted") {
+			var response = MessageBoardAttachmentAPI.getMessageBoardAttachmentByMbMessageErcAndMbAttachmentErc(
+				messageBoardAttachmentErc = ${mbAttachmentErc},
+				messageBoardMessageErc = ${mbMessageErc});
+
+			TestUtils.assertPartialEquals(
+				actual = ${response},
+				expected = "No DLFileEntry exists with the key");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 4
 	test CanGetMessageBoardAttachementForMessageBoardMessageInChildSectionByErcs {
 		property portal.acceptance = "true";
 
@@ -205,6 +302,32 @@ definition {
 			TestUtils.assertPartialEquals(
 				actual = ${response},
 				expected = "No MBMessage exists with the key");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 4
+	test CanReturnNoFileExistsWithDeleteMessgeBoardAttachmentByNonexistentMessageBoardAttachmentErc {
+		property portal.acceptance = "true";
+
+		task ("Given with postMessageBoardThreadMessageBoardMessage and messageBoardThreadId to create a message board message") {
+			var mbMessageId = MessageBoardMessageAPI.getIdOfCreatedMbMessageByMbThreadId(
+				headline = "This is the parent mb message",
+				messageBoardThreadId = ${staticMbThreadId});
+		}
+
+		task ("When with DELETE request, siteId, message board message's erc and nonexistent message board attachment's erc to retrieve the message board attachment") {
+			var mbMessageErc = MessageBoardMessageAPI.getMbMessageErcByMbMessageId(messageBoardMessageId = ${mbMessageId});
+
+			var response = MessageBoardAttachmentAPI.deleteMessageBoardAttachmentByMbMessageErcAndMbAttachmentErc(
+				messageBoardAttachmentErc = "nonexistent-attachment-erc",
+				messageBoardMessageErc = ${mbMessageErc});
+		}
+
+		task ("Then it will show user that there is no file exists") {
+			TestUtils.assertPartialEquals(
+				actual = ${response},
+				expected = "No DLFileEntry exists with the key");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcForMessageBoardAttachment.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcForMessageBoardAttachment.testcase
@@ -1,9 +1,9 @@
-@component-name = "portal-headless"
+@component-name = "portal-lima"
 definition {
 
 	property portal.release = "true";
 	property portal.upstream = "true";
-	property testray.main.component.name = "Headless";
+	property testray.main.component.name = "Lima Headless";
 
 	setUp {
 		TestCase.setUpPortalInstanceNoSelenium();
@@ -11,76 +11,165 @@ definition {
 		MessageBoardThreadAPI.setUpGlobalMessageBoardThreadId(headline = "This is the mb thread");
 	}
 
-	tearDown {
-		var testPortalInstance = PropsUtil.get("test.portal.instance");
-
-		MessageBoardThreadAPI.deleteMessageBoardThreadByThreadId(messageBoardThreadId = "${staticMbThreadId}");
-
-		if ("${testPortalInstance}" == "true") {
-			PortalInstances.tearDownCPNoSelenium();
-		}
-	}
+	//tearDown {
+	//	var testPortalInstance = PropsUtil.get("test.portal.instance");
+	//	MessageBoardThreadAPI.deleteMessageBoardThreadByThreadId(messageBoardThreadId = ${staticMbThreadId});
+	//	if (${testPortalInstance} == "true") {
+	//		PortalInstances.tearDownCPNoSelenium();
+	//}
+	//}
 
 	@disable-webdriver = "true"
-	@priority = "4"
+	@priority = 4
 	test CanCreateChildMessageBoardMessageMessageBoardAttachementWithErc {
 		property portal.acceptance = "true";
 
 		task ("Given with postMessageBoardThreadMessageBoardMessage and messageBoardThreadId to create a message board message") {
 			var mbMessageId = MessageBoardMessageAPI.getIdOfCreatedMbMessageByMbThreadId(
 				headline = "This is the parent mb message",
-				messageBoardThreadId = "${staticMbThreadId}");
+				messageBoardThreadId = ${staticMbThreadId});
 		}
 
 		task ("And Given with postMessageBoardMessageMessageBoardMessage and parentMessageBoardMessageId to create a child message board message") {
 			var childMbMessageId = MessageBoardMessageAPI.getIdOfCreatedChildMbMessageByMbMessageId(
 				headline = "This is the child mb message",
-				parentMessageBoardMessageId = "${mbMessageId}");
+				parentMessageBoardMessageId = ${mbMessageId});
 		}
 
 		task ("When with postMessageBoardMessageMessageBoardAttachmentsPage and messageBoardMessageId to create an attachment for child message board message") {
 			var attachmentPath = TestCase.getDependenciesDirPath(fileName = "Document_4.jpg");
 
 			var response = MessageBoardAttachmentAPI.createMessageBoardMessageMessageBoardAttachment(
-				attachmentPath = "${attachmentPath}",
-				messageBoardMessageId = "${childMbMessageId}");
+				attachmentPath = ${attachmentPath},
+				messageBoardMessageId = ${childMbMessageId});
 		}
 
 		task ("Then I can see external reference code equals to uuid in the response") {
-			MessageBoardAttachmentAPI.assertCorrectErcInResponse(response = "${response}");
+			MessageBoardAttachmentAPI.assertCorrectErcInResponse(response = ${response});
 		}
 	}
 
 	@disable-webdriver = "true"
-	@priority = "4"
+	@priority = 4
 	test CanCreateMessageBoardAttachementForMessageBoardMessageInSectionWithErc {
 		property portal.acceptance = "true";
 
 		task ("Given with postSiteMessageBoardSection and siteId to create a message board section") {
-			var mbMessageId = MessageBoardMessageAPI.getIdOfCreatedMbMessageByMbThreadId(
-				headline = "This is the parent mb message",
-				messageBoardThreadId = "${staticMbThreadId}");
+			var mbSectionId = MessageBoardSectionAPI.getIdOfCreatedMessageBoardSection(title = "mb section");
 		}
 
 		task ("And Given with postMessageBoardSectionMessageBoardThread and messageBoardSectionId to create a message board thread") {
-			var childMbMessageId = MessageBoardMessageAPI.getIdOfCreatedChildMbMessageByMbMessageId(
-				headline = "This is the child mb message",
-				parentMessageBoardMessageId = "${mbMessageId}");
+			var mbThreadId = MessageBoardThreadAPI.getIdOfCreatedMessageThreadInMessageBoardSection(
+				headline = "This is the mb thread in section",
+				messageBoardSectionId = ${mbSectionId});
 		}
 
 		task ("And Given with postMessageBoardThreadMessageBoardMessage and messageBoardThreadId to create a message board message") {
-			var attachmentPath = TestCase.getDependenciesDirPath(fileName = "Document_4.jpg");
-
-			var response = MessageBoardAttachmentAPI.createMessageBoardMessageMessageBoardAttachment(
-				attachmentPath = "${attachmentPath}",
-				messageBoardMessageId = "${childMbMessageId}");
+			var mbMessageId = MessageBoardMessageAPI.getIdOfCreatedMbMessageByMbThreadId(
+				headline = "This is the mb message",
+				messageBoardThreadId = ${mbThreadId});
 		}
 
 		task ("When with postMessageBoardMessageMessageBoardAttachmentsPage and messageBoardMessageId to create an attachment for message board message") {
+			var attachmentPath = TestCase.getDependenciesDirPath(fileName = "Document_4.jpg");
+
+			var response = MessageBoardAttachmentAPI.createMessageBoardMessageMessageBoardAttachment(
+				attachmentPath = ${attachmentPath},
+				messageBoardMessageId = ${mbMessageId});
 		}
 
 		task ("Then I can see external reference code equals to uuid in the response") {
-			MessageBoardAttachmentAPI.assertCorrectErcInResponse(response = "${response}");
+			MessageBoardAttachmentAPI.assertCorrectErcInResponse(response = ${response});
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 3
+	test CanCreateMessageBoardMessageMessageBoardAttachementWithErc {
+		task ("Given with postMessageBoardThreadMessageBoardMessage and messageBoardThreadId to create a message board message") {
+			var mbMessageId = MessageBoardMessageAPI.getIdOfCreatedMbMessageByMbThreadId(
+				headline = "This is the mb message",
+				messageBoardThreadId = ${staticMbThreadId});
+		}
+
+		task ("When with postMessageBoardMessageMessageBoardAttachmentsPage and messageBoardMessageId to create an attachment for message board message") {
+			var attachmentPath = TestCase.getDependenciesDirPath(fileName = "Document_4.jpg");
+
+			var response = MessageBoardAttachmentAPI.createMessageBoardMessageMessageBoardAttachment(
+				attachmentPath = ${attachmentPath},
+				messageBoardMessageId = ${mbMessageId});
+		}
+
+		task ("Then I can see external reference code in the response") {
+			MessageBoardAttachmentAPI.assertCorrectErcInResponse(response = ${response});
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 4
+	test CanCreateMessageBoardThreadMessageBoardAttachmentWithErc {
+		property portal.acceptance = "true";
+
+		task ("When with postMessageBoardThreadMessageBoardAttachment and messageBoardThreadId to create an attachment for message board thread") {
+			var attachmentPath = TestCase.getDependenciesDirPath(fileName = "Document_4.jpg");
+
+			var response = MessageBoardAttachmentAPI.createMessageBoardThreadMessageBoardAttachment(
+				attachmentPath = ${attachmentPath},
+				messageBoardThreadId = ${staticMbThreadId});
+		}
+
+		task ("Then I can see the external reference code in the response") {
+			MessageBoardAttachmentAPI.assertCorrectErcInResponse(response = ${response});
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 4
+	test CanGetMessageBoardAttachementForMessageBoardMessageInChildSectionByErcs {
+		property portal.acceptance = "true";
+
+		task ("Given with postSiteMessageBoardSection and siteId to create a message board section") {
+			var mbSectionId = MessageBoardSectionAPI.getIdOfCreatedMessageBoardSection(title = "mb section");
+		}
+
+		task ("And Given with postMessageBoardSectionMessageBoardSection and parentMessageBoardSectionId to create a child message board section") {
+			var childMbSectionId = MessageBoardSectionAPI.getIdOfChildMessageBoardSection(
+				parentMessageBoardSectionId = ${mbSectionId},
+				title = "child mb section");
+		}
+
+		task ("And Given with postMessageBoardSectionMessageBoardThread and messageBoardSectionId to create a message board thread") {
+			var response = MessageBoardThreadAPI.createMessageThreadInMessageBoardSection(
+				headline = "This is the mb thread in section",
+				messageBoardSectionId = ${childMbSectionId});
+
+			var mbThreadId = JSONUtil.getWithJSONPath(${response}, "$.id");
+			var mbMessageId = JSONUtil.getWithJSONPath(${response}, "$.messageBoardRootMessageId");
+		}
+
+		task ("And Given with postMessageBoardThreadMessageBoardAttachment and messageBoardThreadId to create an attachment for message board thread") {
+			var attachmentPath = TestCase.getDependenciesDirPath(fileName = "Document_4.jpg");
+
+			var responseToParse = MessageBoardAttachmentAPI.createMessageBoardThreadMessageBoardAttachment(
+				attachmentPath = ${attachmentPath},
+				messageBoardThreadId = ${mbThreadId});
+		}
+
+		task ("When with GET request, siteId, message board message's and message board attachment's external reference codes to retrieve the message board attachment") {
+			var mbMessageErc = MessageBoardMessageAPI.getMbMessageErcByMbMessageId(messageBoardMessageId = ${mbMessageId});
+			var mbAttachmentErc = JSONUtil.getWithJSONPath(${responseToParse}, "$.externalReferenceCode");
+
+			var mbAttachmentId = MessageBoardAttachmentAPI.getMessageBoardAttachmentIdByMbMessageErcAndMbAttachmentErc(
+				messageBoardAttachmentErc = ${mbAttachmentErc},
+				messageBoardMessageErc = ${mbMessageErc});
+		}
+
+		task ("Then I can see the correct details of message board message attachment") {
+			var expectId = JSONUtil.getWithJSONPath(${responseToParse}, "$.id");
+
+			TestUtils.assertEquals(
+				actual = ${mbAttachmentId},
+				expected = ${expectId});
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcForMessageBoardAttachment.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcForMessageBoardAttachment.testcase
@@ -62,9 +62,11 @@ definition {
 		}
 
 		task ("And Given with postMessageBoardSectionMessageBoardThread and messageBoardSectionId to create a message board thread") {
-			var mbThreadId = MessageBoardThreadAPI.getIdOfCreatedMessageThreadInMessageBoardSection(
+			var response = MessageBoardThreadAPI.createMessageThreadInMessageBoardSection(
 				headline = "This is the mb thread in section",
 				messageBoardSectionId = ${mbSectionId});
+
+			var mbThreadId = JSONUtil.getWithJSONPath(${response}, "$.id");
 		}
 
 		task ("And Given with postMessageBoardThreadMessageBoardMessage and messageBoardThreadId to create a message board message") {
@@ -216,7 +218,7 @@ definition {
 
 			TestUtils.assertPartialEquals(
 				actual = ${response},
-				expected = "No DLFileEntry exists with the key");
+				expected = "No FileEntry exists with the key");
 		}
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcForMessageBoardAttachment.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcForMessageBoardAttachment.testcase
@@ -8,7 +8,9 @@ definition {
 	setUp {
 		TestCase.setUpPortalInstanceNoSelenium();
 
-		MessageBoardThreadAPI.setUpGlobalMessageBoardThreadId(headline = "This is the mb thread");
+		task ("Given with postSiteMessageBoardThread and siteId to create a message board thread") {
+			MessageBoardThreadAPI.setUpGlobalMessageBoardThreadId(headline = "This is the mb thread");
+		}
 	}
 
 	tearDown {
@@ -18,7 +20,7 @@ definition {
 			PortalInstances.tearDownCPNoSelenium();
 		}
 		else {
-			MessageBoardThreadAPI.deleteMessageBoardThreadByThreadId(messageBoardThreadId = ${staticMbThreadId});
+			MessageBoardThreadAPI.deleteMessageBoardThreadByThreadId(messageBoardThreadId = ${staticMessageBoardThreadId});
 		}
 	}
 
@@ -28,15 +30,17 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given with postMessageBoardThreadMessageBoardMessage and messageBoardThreadId to create a message board message") {
-			var mbMessageId = MessageBoardMessageAPI.getIdOfCreatedMbMessageByMbThreadId(
+			var messageBoardMessageId = MessageBoardMessageAPI.getIdOfCreatedMbMessageByMbThreadId(
 				headline = "This is the parent mb message",
-				messageBoardThreadId = ${staticMbThreadId});
+				messageBoardThreadId = ${staticMessageBoardThreadId});
 		}
 
-		task ("Given with postMessageBoardMessageMessageBoardMessage and parentMessageBoardMessageId to create a child message board message") {
-			var childMbMessageId = MessageBoardMessageAPI.getIdOfCreatedChildMbMessageByMbMessageId(
+		task ("And Given with postMessageBoardMessageMessageBoardMessage and parentMessageBoardMessageId to create a child message board message") {
+			var response = MessageBoardMessageAPI.createChildMbMessageByMbMessageId(
 				headline = "This is the child mb message",
-				parentMessageBoardMessageId = ${mbMessageId});
+				parentMessageBoardMessageId = ${messageBoardMessageId});
+
+			var childMessageBoardMessageId = JSONResponseUtil.getRootIdFromResponse(response = ${response});
 		}
 
 		task ("When with postMessageBoardMessageMessageBoardAttachmentsPage and messageBoardMessageId to create an attachment for child message board message") {
@@ -44,7 +48,7 @@ definition {
 
 			var response = MessageBoardAttachmentAPI.createMessageBoardMessageMessageBoardAttachment(
 				attachmentPath = ${attachmentPath},
-				messageBoardMessageId = ${childMbMessageId});
+				messageBoardMessageId = ${childMessageBoardMessageId});
 		}
 
 		task ("Then I can see external reference code equals to uuid in the response") {
@@ -58,21 +62,23 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given with postSiteMessageBoardSection and siteId to create a message board section") {
-			var mbSectionId = MessageBoardSectionAPI.getIdOfCreatedMessageBoardSection(title = "mb section");
+			var response = MessageBoardSectionAPI.createMessageBoardSection(title = "mb section");
+
+			var messageBoardSectionId = JSONResponseUtil.getRootIdFromResponse(response = ${response});
 		}
 
 		task ("And Given with postMessageBoardSectionMessageBoardThread and messageBoardSectionId to create a message board thread") {
 			var response = MessageBoardThreadAPI.createMessageThreadInMessageBoardSection(
 				headline = "This is the mb thread in section",
-				messageBoardSectionId = ${mbSectionId});
+				messageBoardSectionId = ${messageBoardSectionId});
 
-			var mbThreadId = JSONUtil.getWithJSONPath(${response}, "$.id");
+			var messageBoardThreadId = JSONResponseUtil.getRootIdFromResponse(response = ${response});
 		}
 
 		task ("And Given with postMessageBoardThreadMessageBoardMessage and messageBoardThreadId to create a message board message") {
-			var mbMessageId = MessageBoardMessageAPI.getIdOfCreatedMbMessageByMbThreadId(
+			var messageBoardMessageId = MessageBoardMessageAPI.getIdOfCreatedMbMessageByMbThreadId(
 				headline = "This is the mb message",
-				messageBoardThreadId = ${mbThreadId});
+				messageBoardThreadId = ${messageBoardThreadId});
 		}
 
 		task ("When with postMessageBoardMessageMessageBoardAttachmentsPage and messageBoardMessageId to create an attachment for message board message") {
@@ -80,7 +86,7 @@ definition {
 
 			var response = MessageBoardAttachmentAPI.createMessageBoardMessageMessageBoardAttachment(
 				attachmentPath = ${attachmentPath},
-				messageBoardMessageId = ${mbMessageId});
+				messageBoardMessageId = ${messageBoardMessageId});
 		}
 
 		task ("Then I can see external reference code equals to uuid in the response") {
@@ -92,9 +98,9 @@ definition {
 	@priority = 3
 	test CanCreateMessageBoardMessageMessageBoardAttachementWithErc {
 		task ("Given with postMessageBoardThreadMessageBoardMessage and messageBoardThreadId to create a message board message") {
-			var mbMessageId = MessageBoardMessageAPI.getIdOfCreatedMbMessageByMbThreadId(
+			var messageBoardMessageId = MessageBoardMessageAPI.getIdOfCreatedMbMessageByMbThreadId(
 				headline = "This is the mb message",
-				messageBoardThreadId = ${staticMbThreadId});
+				messageBoardThreadId = ${staticMessageBoardThreadId});
 		}
 
 		task ("When with postMessageBoardMessageMessageBoardAttachmentsPage and messageBoardMessageId to create an attachment for message board message") {
@@ -102,7 +108,7 @@ definition {
 
 			var response = MessageBoardAttachmentAPI.createMessageBoardMessageMessageBoardAttachment(
 				attachmentPath = ${attachmentPath},
-				messageBoardMessageId = ${mbMessageId});
+				messageBoardMessageId = ${messageBoardMessageId});
 		}
 
 		task ("Then I can see external reference code in the response") {
@@ -120,7 +126,7 @@ definition {
 
 			var response = MessageBoardAttachmentAPI.createMessageBoardThreadMessageBoardAttachment(
 				attachmentPath = ${attachmentPath},
-				messageBoardThreadId = ${staticMbThreadId});
+				messageBoardThreadId = ${staticMessageBoardThreadId});
 		}
 
 		task ("Then I can see the external reference code in the response") {
@@ -134,13 +140,15 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given with postMessageBoardMessageMessageBoardMessage and parentMessageBoardMessageId to create a child message board message") {
-			var mbMessageId = MessageBoardMessageAPI.getIdOfCreatedMbMessageByMbThreadId(
+			var messageBoardMessageId = MessageBoardMessageAPI.getIdOfCreatedMbMessageByMbThreadId(
 				headline = "This is the parent mb message",
-				messageBoardThreadId = ${staticMbThreadId});
+				messageBoardThreadId = ${staticMessageBoardThreadId});
 
-			var childMbMessageId = MessageBoardMessageAPI.getIdOfCreatedChildMbMessageByMbMessageId(
+			var response = MessageBoardMessageAPI.createChildMbMessageByMbMessageId(
 				headline = "This is the child mb message",
-				parentMessageBoardMessageId = ${mbMessageId});
+				parentMessageBoardMessageId = ${messageBoardMessageId});
+
+			var childMessageBoardMessageId = JSONResponseUtil.getRootIdFromResponse(response = ${response});
 		}
 
 		task ("And Given with postMessageBoardMessageMessageBoardAttachmentsPage and messageBoardMessageId to create an attachment for child message board message") {
@@ -148,22 +156,22 @@ definition {
 
 			var response = MessageBoardAttachmentAPI.createMessageBoardMessageMessageBoardAttachment(
 				attachmentPath = ${attachmentPath},
-				messageBoardMessageId = ${childMbMessageId});
+				messageBoardMessageId = ${childMessageBoardMessageId});
 		}
 
 		task ("When with DELETE request, siteId, child message board message's and child message board attachment's external reference codes to delete the message board attachment") {
-			var mbMessageErc = MessageBoardMessageAPI.getMbMessageErcByMbMessageId(messageBoardMessageId = ${childMbMessageId});
-			var mbAttachmentErc = JSONUtil.getWithJSONPath(${response}, "$.externalReferenceCode");
+			var messageBoardMessageErc = MessageBoardMessageAPI.getMbMessageErcByMbMessageId(messageBoardMessageId = ${childMessageBoardMessageId});
+			var messageBoardAttachmentErc = JSONResponseUtil.getRootExternalReferenceCodeFromResponse(response = ${response});
 
 			MessageBoardAttachmentAPI.deleteMessageBoardAttachmentByMbMessageErcAndMbAttachmentErc(
-				messageBoardAttachmentErc = ${mbAttachmentErc},
-				messageBoardMessageErc = ${mbMessageErc});
+				messageBoardAttachmentErc = ${messageBoardAttachmentErc},
+				messageBoardMessageErc = ${messageBoardMessageErc});
 		}
 
 		task ("Then the message board message attachment is deleted") {
 			var response = MessageBoardAttachmentAPI.getMessageBoardAttachmentByMbMessageErcAndMbAttachmentErc(
-				messageBoardAttachmentErc = ${mbAttachmentErc},
-				messageBoardMessageErc = ${mbMessageErc});
+				messageBoardAttachmentErc = ${messageBoardAttachmentErc},
+				messageBoardMessageErc = ${messageBoardMessageErc});
 
 			TestUtils.assertPartialEquals(
 				actual = ${response},
@@ -177,21 +185,25 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given with postSiteMessageBoardSection and siteId to create a message board section") {
-			var mbSectionId = MessageBoardSectionAPI.getIdOfCreatedMessageBoardSection(title = "mb section");
+			var response = MessageBoardSectionAPI.createMessageBoardSection(title = "mb section");
+
+			var messageBoardSectionId = JSONResponseUtil.getRootIdFromResponse(response = ${response});
 		}
 
 		task ("And Given with postMessageBoardSectionMessageBoardSection and parentMessageBoardSectionId to create a child message board section") {
-			var childMbSectionId = MessageBoardSectionAPI.getIdOfChildMessageBoardSection(
-				parentMessageBoardSectionId = ${mbSectionId},
+			var response = MessageBoardSectionAPI.createChildMessageBoardSection(
+				parentMessageBoardSectionId = ${messageBoardSectionId},
 				title = "child mb section");
+
+			var childMessageBoardSectionId = JSONResponseUtil.getRootIdFromResponse(response = ${response});
 		}
 
 		task ("And Given with postMessageBoardSectionMessageBoardThread and messageBoardSectionId to create a message board thread") {
 			var response = MessageBoardThreadAPI.createMessageThreadInMessageBoardSection(
-				headline = "This is the mb thread in section",
-				messageBoardSectionId = ${mbSectionId});
+				headline = "This is the mb thread in child section",
+				messageBoardSectionId = ${childMessageBoardSectionId});
 
-			var mbMessageId = JSONUtil.getWithJSONPath(${response}, "$.messageBoardRootMessageId");
+			var messageBoardMessageId = JSONUtil.getWithJSONPath(${response}, "$.messageBoardRootMessageId");
 		}
 
 		task ("And Given with postMessageBoardThreadMessageBoardAttachment and messageBoardThreadId to create an attachment for message board thread") {
@@ -199,22 +211,22 @@ definition {
 
 			var response = MessageBoardAttachmentAPI.createMessageBoardThreadMessageBoardAttachment(
 				attachmentPath = ${attachmentPath},
-				messageBoardThreadId = ${staticMbThreadId});
+				messageBoardThreadId = ${staticMessageBoardThreadId});
 		}
 
 		task ("When with DELETE request, siteId, message board message's and message board attachment's external reference codes to delete the message board attachment") {
-			var mbAttachmentErc = JSONUtil.getWithJSONPath(${response}, "$.externalReferenceCode");
-			var mbMessageErc = MessageBoardMessageAPI.getMbMessageErcByMbMessageId(messageBoardMessageId = ${mbMessageId});
+			var messageBoardAttachmentErc = JSONResponseUtil.getRootExternalReferenceCodeFromResponse(response = ${response});
+			var messageBoardMessageErc = MessageBoardMessageAPI.getMbMessageErcByMbMessageId(messageBoardMessageId = ${messageBoardMessageId});
 
 			var response = MessageBoardAttachmentAPI.deleteMessageBoardAttachmentByMbMessageErcAndMbAttachmentErc(
-				messageBoardAttachmentErc = ${mbAttachmentErc},
-				messageBoardMessageErc = ${mbMessageErc});
+				messageBoardAttachmentErc = ${messageBoardAttachmentErc},
+				messageBoardMessageErc = ${messageBoardMessageErc});
 		}
 
 		task ("Then the message board message attachment is deleted") {
 			var response = MessageBoardAttachmentAPI.getMessageBoardAttachmentByMbMessageErcAndMbAttachmentErc(
-				messageBoardAttachmentErc = ${mbAttachmentErc},
-				messageBoardMessageErc = ${mbMessageErc});
+				messageBoardAttachmentErc = ${messageBoardAttachmentErc},
+				messageBoardMessageErc = ${messageBoardMessageErc});
 
 			TestUtils.assertPartialEquals(
 				actual = ${response},
@@ -228,22 +240,26 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given with postSiteMessageBoardSection and siteId to create a message board section") {
-			var mbSectionId = MessageBoardSectionAPI.getIdOfCreatedMessageBoardSection(title = "mb section");
+			var response = MessageBoardSectionAPI.createMessageBoardSection(title = "mb section");
+
+			var messageBoardSectionId = JSONResponseUtil.getRootIdFromResponse(response = ${response});
 		}
 
 		task ("And Given with postMessageBoardSectionMessageBoardSection and parentMessageBoardSectionId to create a child message board section") {
-			var childMbSectionId = MessageBoardSectionAPI.getIdOfChildMessageBoardSection(
-				parentMessageBoardSectionId = ${mbSectionId},
+			var response = MessageBoardSectionAPI.createChildMessageBoardSection(
+				parentMessageBoardSectionId = ${messageBoardSectionId},
 				title = "child mb section");
+
+			var childMessageBoardSectionId = JSONResponseUtil.getRootIdFromResponse(response = ${response});
 		}
 
 		task ("And Given with postMessageBoardSectionMessageBoardThread and messageBoardSectionId to create a message board thread") {
 			var response = MessageBoardThreadAPI.createMessageThreadInMessageBoardSection(
-				headline = "This is the mb thread in section",
-				messageBoardSectionId = ${childMbSectionId});
+				headline = "This is the mb thread in child section",
+				messageBoardSectionId = ${childMessageBoardSectionId});
 
-			var mbThreadId = JSONUtil.getWithJSONPath(${response}, "$.id");
-			var mbMessageId = JSONUtil.getWithJSONPath(${response}, "$.messageBoardRootMessageId");
+			var messageBoardThreadId = JSONResponseUtil.getRootIdFromResponse(response = ${response});
+			var messageBoardMessageId = JSONUtil.getWithJSONPath(${response}, "$.messageBoardRootMessageId");
 		}
 
 		task ("And Given with postMessageBoardThreadMessageBoardAttachment and messageBoardThreadId to create an attachment for message board thread") {
@@ -251,24 +267,24 @@ definition {
 
 			var responseToParse = MessageBoardAttachmentAPI.createMessageBoardThreadMessageBoardAttachment(
 				attachmentPath = ${attachmentPath},
-				messageBoardThreadId = ${mbThreadId});
+				messageBoardThreadId = ${messageBoardThreadId});
 		}
 
 		task ("When with GET request, siteId, message board message's and message board attachment's external reference codes to retrieve the message board attachment") {
-			var mbMessageErc = MessageBoardMessageAPI.getMbMessageErcByMbMessageId(messageBoardMessageId = ${mbMessageId});
-			var mbAttachmentErc = JSONUtil.getWithJSONPath(${responseToParse}, "$.externalReferenceCode");
+			var messageBoardMessageErc = MessageBoardMessageAPI.getMbMessageErcByMbMessageId(messageBoardMessageId = ${messageBoardMessageId});
+			var messageBoardbAttachmentErc = JSONResponseUtil.getRootExternalReferenceCodeFromResponse(response = ${responseToParse});
 
 			var response = MessageBoardAttachmentAPI.getMessageBoardAttachmentByMbMessageErcAndMbAttachmentErc(
-				messageBoardAttachmentErc = ${mbAttachmentErc},
-				messageBoardMessageErc = ${mbMessageErc});
+				messageBoardAttachmentErc = ${messageBoardbAttachmentErc},
+				messageBoardMessageErc = ${messageBoardMessageErc});
 		}
 
 		task ("Then I can see the correct details of message board message attachment") {
-			var expectId = JSONUtil.getWithJSONPath(${responseToParse}, "$.id");
-			var mbAttachmentId = JSONUtil.getWithJSONPath(${response}, "$.id");
+			var expectId = JSONResponseUtil.getRootIdFromResponse(response = ${responseToParse});
+			var messageBoardAttachmentId = JSONResponseUtil.getRootIdFromResponse(response = ${response});
 
 			TestUtils.assertEquals(
-				actual = ${mbAttachmentId},
+				actual = ${messageBoardAttachmentId},
 				expected = ${expectId});
 		}
 	}
@@ -313,17 +329,17 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given with postMessageBoardThreadMessageBoardMessage and messageBoardThreadId to create a message board message") {
-			var mbMessageId = MessageBoardMessageAPI.getIdOfCreatedMbMessageByMbThreadId(
+			var messageBoardMessageId = MessageBoardMessageAPI.getIdOfCreatedMbMessageByMbThreadId(
 				headline = "This is the parent mb message",
-				messageBoardThreadId = ${staticMbThreadId});
+				messageBoardThreadId = ${staticMessageBoardThreadId});
 		}
 
 		task ("When with DELETE request, siteId, message board message's erc and nonexistent message board attachment's erc to retrieve the message board attachment") {
-			var mbMessageErc = MessageBoardMessageAPI.getMbMessageErcByMbMessageId(messageBoardMessageId = ${mbMessageId});
+			var messageBoardMessageErc = MessageBoardMessageAPI.getMbMessageErcByMbMessageId(messageBoardMessageId = ${messageBoardMessageId});
 
 			var response = MessageBoardAttachmentAPI.deleteMessageBoardAttachmentByMbMessageErcAndMbAttachmentErc(
 				messageBoardAttachmentErc = "nonexistent-attachment-erc",
-				messageBoardMessageErc = ${mbMessageErc});
+				messageBoardMessageErc = ${messageBoardMessageErc});
 		}
 
 		task ("Then it will show user that there is no file exists") {
@@ -337,17 +353,17 @@ definition {
 	@priority = 3
 	test CanReturnNoFileExistsWithGetMessageBoardAttachmentByNonexistentMessageBoardMessageAttachmentErc {
 		task ("Given with postMessageBoardThreadMessageBoardMessage and messageBoardThreadId to create a message board message") {
-			var mbMessageId = MessageBoardMessageAPI.getIdOfCreatedMbMessageByMbThreadId(
+			var messageBoardMessageId = MessageBoardMessageAPI.getIdOfCreatedMbMessageByMbThreadId(
 				headline = "This is the mb message",
-				messageBoardThreadId = ${staticMbThreadId});
+				messageBoardThreadId = ${staticMessageBoardThreadId});
 		}
 
 		task ("When with GET request, siteId, message board message's erc and nonexistent message board attachment's erc to retrieve the message board attachment") {
-			var mbMessageErc = MessageBoardMessageAPI.getMbMessageErcByMbMessageId(messageBoardMessageId = ${mbMessageId});
+			var messageBoardMessageErc = MessageBoardMessageAPI.getMbMessageErcByMbMessageId(messageBoardMessageId = ${messageBoardMessageId});
 
 			var response = MessageBoardAttachmentAPI.getMessageBoardAttachmentByMbMessageErcAndMbAttachmentErc(
 				messageBoardAttachmentErc = "nonexistent-attachment-erc",
-				messageBoardMessageErc = ${mbMessageErc});
+				messageBoardMessageErc = ${messageBoardMessageErc});
 		}
 
 		task ("Then it will show user that there is no file exists") {


### PR DESCRIPTION
**Background:**
- Add tests on expose external reference code for message board attachment

**Test Plan:**
- Given with postSiteMessageBoardThread and siteId to create a message board thread
When with postMessageBoardThreadMessageBoardAttachment and messageBoardThreadId to create an attachment for message board thread
Then I can see the external reference code equals to uuid in the response
- Given with postSiteMessageBoardThread and siteId to create a message board thread
And Given with postMessageBoardThreadMessageBoardMessage and messageBoardThreadId to create a message board message
When with postMessageBoardMessageMessageBoardAttachmentsPage and messageBoardMessageId to create an attachment for message board message
Then I can see external reference code in the response
- Given with postSiteMessageBoardThread and siteId to create a message board thread
And Given with postMessageBoardThreadMessageBoardMessage and messageBoardThreadId to create a message board message
And Given with postMessageBoardMessageMessageBoardMessage and parentMessageBoardMessageId to create a child message board message
When with postMessageBoardMessageMessageBoardAttachmentsPage and messageBoardMessageId to create an attachment for child message board message
Then I can see external reference code equals to uuid in the response
- Given with postSiteMessageBoardSection and siteId to create a message board section
And Given with postMessageBoardSectionMessageBoardThread and messageBoardSectionId to create a message board thread
And Given with postMessageBoardThreadMessageBoardMessage and messageBoardThreadId to create a message board message
When with postMessageBoardMessageMessageBoardAttachmentsPage and messageBoardMessageId to create an attachment for message board message
Then I can see external reference code equals to uuid in the response
- Given with postSiteMessageBoardSection and siteId to create a message board section
And Given with postMessageBoardSectionMessageBoardSection and parentMessageBoardSectionId to create a child message board section
And Given with postMessageBoardSectionMessageBoardThread and messageBoardSectionId to create a message board thread
And Given with postMessageBoardThreadMessageBoardAttachment and messageBoardThreadId to create an attachment for message board thread
When with GET request, siteId, message board message's and message board attachment's external reference codes to retrieve the message board attachment
Then I can see the correct details of message board message attachment
- When with GET request, siteId, nonexistent message board message's and message board attachment's external reference codes to retrieve the message board attachment
Then it will show user that there is no message board message exists 
- Given with postSiteMessageBoardThread and siteId to create a message board thread
And Given with postMessageBoardThreadMessageBoardMessage and messageBoardThreadId to create a message board message
When with GET request, siteId, message board message's erc and nonexistent message board attachment's erc to retrieve the message board attachment
Then it will show user that there is no file exists
- When with DELETE request, siteId, message board message's and message board attachment's external reference codes to delete the message board attachment
Then it will show user that there is no message board message exists 
- Given with postSiteMessageBoardThread and siteId to create a message board thread
And Given with postMessageBoardThreadMessageBoardMessage and messageBoardThreadId to create a message board message
When with DELETE request, siteId, message board message's erc and nonexistent message board attachment's erc to retrieve the message board attachment
Then it will show user that there is no file exists
- Given with postSiteMessageBoardThread and siteId to create a message board thread
And Given with postMessageBoardMessageMessageBoardMessage and parentMessageBoardMessageId to create a child message board message
And Given with postMessageBoardMessageMessageBoardAttachmentsPage and messageBoardMessageId to create an attachment for child message board message
When with DELETE request, siteId, child message board message's and child message board attachment's external reference codes to delete the message board attachment
Then the message board message attachment is deleted
- Given with postSiteMessageBoardSection and siteId to create a message board section
And Given with postMessageBoardSectionMessageBoardSection and parentMessageBoardSectionId to create a child message board section
And Given with postMessageBoardSectionMessageBoardThread and messageBoardSectionId to create a message board thread
And Given with postMessageBoardThreadMessageBoardAttachment and messageBoardThreadId to create an attachment for message board thread 
When with DELETE request, siteId, message board message's and message board attachment's external reference codes to delete the message board attachment
Then the message board message attachment is deleted

**Jira Ticket:**
- https://issues.liferay.com/browse/LPS-175231