### PR TITLE
LPS-175558: Expose and add nested entities to OpenAPI schema

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -396,6 +396,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 								_bundleContext, _dtoConverterRegistry,
 								_objectActionLocalService, objectDefinition,
 								_objectDefinitionLocalService,
+								_objectEntryOpenAPIResourceProvider,
 								_objectFieldLocalService,
 								_objectRelationshipLocalService,
 								_openAPIResource,

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/openapi/v1_0/ObjectEntryOpenAPIResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/openapi/v1_0/ObjectEntryOpenAPIResourceImpl.java
@@ -20,6 +20,7 @@ import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.field.setting.util.ObjectFieldSettingUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectField;
+import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.rest.dto.v1_0.FileEntry;
 import com.liferay.object.rest.dto.v1_0.ListEntry;
 import com.liferay.object.rest.internal.resource.v1_0.ObjectEntryRelatedObjectsResourceImpl;
@@ -27,6 +28,7 @@ import com.liferay.object.rest.internal.resource.v1_0.ObjectEntryResourceImpl;
 import com.liferay.object.rest.internal.resource.v1_0.OpenAPIResourceImpl;
 import com.liferay.object.rest.internal.vulcan.openapi.contributor.ObjectEntryOpenAPIContributor;
 import com.liferay.object.rest.openapi.v1_0.ObjectEntryOpenAPIResource;
+import com.liferay.object.rest.openapi.v1_0.ObjectEntryOpenAPIResourceProvider;
 import com.liferay.object.service.ObjectActionLocalService;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
@@ -71,6 +73,7 @@ public class ObjectEntryOpenAPIResourceImpl
 		ObjectActionLocalService objectActionLocalService,
 		ObjectDefinition objectDefinition,
 		ObjectDefinitionLocalService objectDefinitionLocalService,
+		ObjectEntryOpenAPIResourceProvider objectEntryOpenAPIResourceProvider,
 		ObjectFieldLocalService objectFieldLocalService,
 		ObjectRelationshipLocalService objectRelationshipLocalService,
 		OpenAPIResource openAPIResource,
@@ -82,6 +85,8 @@ public class ObjectEntryOpenAPIResourceImpl
 		_objectActionLocalService = objectActionLocalService;
 		_objectDefinition = objectDefinition;
 		_objectDefinitionLocalService = objectDefinitionLocalService;
+		_objectEntryOpenAPIResourceProvider =
+			objectEntryOpenAPIResourceProvider;
 		_objectFieldLocalService = objectFieldLocalService;
 		_objectRelationshipLocalService = objectRelationshipLocalService;
 		_openAPIResource = openAPIResource;
@@ -215,6 +220,7 @@ public class ObjectEntryOpenAPIResourceImpl
 				addRelatedSchemas, _bundleContext, _dtoConverterRegistry,
 				_objectActionLocalService, _objectDefinition,
 				_objectDefinitionLocalService, this,
+				_objectEntryOpenAPIResourceProvider,
 				_objectRelationshipLocalService, _openAPIResource,
 				_systemObjectDefinitionMetadataRegistry),
 			_getOpenAPISchemaFilter(_objectDefinition),
@@ -250,6 +256,22 @@ public class ObjectEntryOpenAPIResourceImpl
 			if (Objects.equals(
 					objectField.getRelationshipType(),
 					ObjectRelationshipConstants.TYPE_ONE_TO_MANY)) {
+
+				ObjectRelationship objectRelationship =
+					_objectRelationshipLocalService.
+						fetchObjectRelationshipByObjectFieldId2(
+							objectField.getObjectFieldId());
+
+				dtoProperties.add(
+					new DTOProperty(
+						Collections.singletonMap("x-parent-map", "properties"),
+						objectRelationship.getName(),
+						String.class.getSimpleName()) {
+
+						{
+							setRequired(objectField.isRequired());
+						}
+					});
 
 				dtoProperties.add(
 					new DTOProperty(
@@ -315,6 +337,8 @@ public class ObjectEntryOpenAPIResourceImpl
 	private final ObjectActionLocalService _objectActionLocalService;
 	private final ObjectDefinition _objectDefinition;
 	private final ObjectDefinitionLocalService _objectDefinitionLocalService;
+	private final ObjectEntryOpenAPIResourceProvider
+		_objectEntryOpenAPIResourceProvider;
 	private final ObjectFieldLocalService _objectFieldLocalService;
 	private final ObjectRelationshipLocalService
 		_objectRelationshipLocalService;

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/openapi/contributor/ObjectEntryOpenAPIContributor.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/openapi/contributor/ObjectEntryOpenAPIContributor.java
@@ -153,7 +153,7 @@ public class ObjectEntryOpenAPIContributor extends BaseOpenAPIContributor {
 						}
 					}
 
-					if (_addRelatedSchemas) {
+					if (_addRelatedSchemas && (relatedSchemaName != null)) {
 						_setSchemaDescription(
 							objectRelationship, openAPI, relatedSchemaName);
 
@@ -512,16 +512,16 @@ public class ObjectEntryOpenAPIContributor extends BaseOpenAPIContributor {
 			"Information about the relationship ", objectRelationship.getName(),
 			" can be embedded with \"nestedFields\".");
 
-		schema.setDescription(description);
-
 		schema.set$ref(schemaName);
 
-		if (((objectRelationship.getObjectDefinitionId1() ==
-				_objectDefinition.getObjectDefinitionId()) ||
-			 Objects.equals(
-				 objectRelationship.getType(),
-				 ObjectRelationshipConstants.TYPE_MANY_TO_MANY)) &&
-			(schemaName != null)) {
+		if (Objects.equals(
+				objectRelationship.getType(),
+				ObjectRelationshipConstants.TYPE_MANY_TO_MANY) ||
+			(Objects.equals(
+				objectRelationship.getType(),
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY) &&
+			 (objectRelationship.getObjectDefinitionId1() ==
+				 _objectDefinition.getObjectDefinitionId()))) {
 
 			ArraySchema arraySchema = new ArraySchema();
 
@@ -531,6 +531,8 @@ public class ObjectEntryOpenAPIContributor extends BaseOpenAPIContributor {
 
 			return arraySchema;
 		}
+
+		schema.setDescription(description);
 
 		return schema;
 	}


### PR DESCRIPTION
**What is new?**
- Add `objectRelationshipName` as a property in all 1-M relationships to show the nested entity.
- Display at level 1 all nested entities in OpenAPI schemas.
- These changes support nested entities for Custom and System Object Definitions. 

**NOTE:** All schemas will contain the `objectRelationshipName` as nested entities for M-M and 1-M relationship

**How to reproduce this?**
1. Deploy `object-rest-impl`
2. Create two Custom Objects, like Student and Subject, and relate them with a M-M relationship, `studentSubject`.
3. Go to `/o/api/subjects` and see Subject's schema:

![image](https://user-images.githubusercontent.com/44723449/212719054-4c48cf55-0d39-4093-a4b5-ff93eccaf90f.png)

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-175558

