### PR TITLE
LPS-175821 create a new paramConverter to check if the scopeKey is valid

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/feature/VulcanFeature.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/feature/VulcanFeature.java
@@ -68,6 +68,7 @@ import com.liferay.portal.vulcan.internal.jaxrs.message.body.JSONMessageBodyWrit
 import com.liferay.portal.vulcan.internal.jaxrs.message.body.MultipartBodyMessageBodyReader;
 import com.liferay.portal.vulcan.internal.jaxrs.message.body.XMLMessageBodyReader;
 import com.liferay.portal.vulcan.internal.jaxrs.message.body.XMLMessageBodyWriter;
+import com.liferay.portal.vulcan.internal.jaxrs.param.converter.provider.ScopeKeyParamConverterProvider;
 import com.liferay.portal.vulcan.internal.jaxrs.param.converter.provider.SiteParamConverterProvider;
 import com.liferay.portal.vulcan.internal.jaxrs.validation.BeanValidationInterceptor;
 import com.liferay.portal.vulcan.internal.jaxrs.writer.interceptor.EntityExtensionWriterInterceptor;
@@ -174,6 +175,8 @@ public class VulcanFeature implements Feature {
 		featureContext.register(
 			new SiteParamConverterProvider(
 				_depotEntryLocalService, _groupLocalService));
+		featureContext.register(
+			new ScopeKeyParamConverterProvider(_groupLocalService));
 		featureContext.register(
 			new SortContextProvider(_language, _portal, _sortParserProvider));
 		featureContext.register(new UserContextProvider(_portal));

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/param/converter/provider/ScopeKeyParamConverterProvider.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/param/converter/provider/ScopeKeyParamConverterProvider.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.internal.jaxrs.param.converter.provider;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.vulcan.util.GroupUtil;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.ext.ParamConverter;
+import javax.ws.rs.ext.ParamConverterProvider;
+import javax.ws.rs.ext.Provider;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.cxf.jaxrs.utils.AnnotationUtils;
+
+/**
+ * @author Javier Gamarra
+ */
+@Provider
+public class ScopeKeyParamConverterProvider
+	implements ParamConverter<String>, ParamConverterProvider {
+
+	public ScopeKeyParamConverterProvider(GroupLocalService groupLocalService) {
+		_groupLocalService = groupLocalService;
+	}
+
+	@Override
+	public String fromString(String parameter) {
+		MultivaluedMap<String, String> multivaluedMap =
+			_uriInfo.getPathParameters();
+
+		String scopeKey = getGroupId(
+			_company.getCompanyId(), multivaluedMap.getFirst("scopeKey"));
+
+		if (scopeKey != null) {
+			return scopeKey;
+		}
+
+		StringBundler sb = new StringBundler(2);
+
+		sb.append("Unable to get a valid scopeKey with name ");
+		sb.append(parameter);
+
+		throw new NotFoundException(sb.toString());
+	}
+
+	@Override
+	public <T> ParamConverter<T> getConverter(
+		Class<T> clazz, Type type, Annotation[] annotations) {
+
+		if (String.class.equals(clazz) && _hasScopeKeyAnnotation(annotations)) {
+			return (ParamConverter<T>)this;
+		}
+
+		return null;
+	}
+
+	public String getGroupId(long companyId, String scopeKey) {
+		if (scopeKey == null) {
+			return null;
+		}
+
+		Long groupId = GroupUtil.getGroupId(
+			companyId, scopeKey, _groupLocalService);
+
+		if (groupId == null) {
+			return null;
+		}
+
+		return String.valueOf(groupId);
+	}
+
+	@Override
+	public String toString(String parameter) {
+		return String.valueOf(parameter);
+	}
+
+	private boolean _hasScopeKeyAnnotation(Annotation[] annotations) {
+		for (Annotation annotation : annotations) {
+			if ((annotation.annotationType() == PathParam.class) &&
+				StringUtils.equalsAny(
+					AnnotationUtils.getAnnotationValue(annotation),
+					"scopeKey")) {
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	@Context
+	private Company _company;
+
+	private final GroupLocalService _groupLocalService;
+
+	@Context
+	private UriInfo _uriInfo;
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/param/converter/provider/ScopeKeyParamConverterProvider.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/param/converter/provider/ScopeKeyParamConverterProvider.java
@@ -35,7 +35,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.cxf.jaxrs.utils.AnnotationUtils;
 
 /**
- * @author Javier Gamarra
+ * @author Jorge García Jiménez
  */
 @Provider
 public class ScopeKeyParamConverterProvider


### PR DESCRIPTION
Hi Team.

This PR aims to solve [LPS-175821](https://issues.liferay.com/browse/LPS-175821).
The problem is  doing a request for a object entry with site scope, via  /scopes/{scopeKey} method  doesn't return a 404 is the scopeKey param is invalid.

I don't know if adding a new ParamConverter is too much or if this should be handled in a different layer, please tell me what do you think and if I have to do any change for this solution.

Thanks in advance.