### PR TITLE
LPS-175919 Add more tests on open API profile

### DIFF
--- a/modules/apps/headless/headless-discovery/headless-discovery-test/src/testFunctional/macros/OpenAPIProfile.macro
+++ b/modules/apps/headless/headless-discovery/headless-discovery-test/src/testFunctional/macros/OpenAPIProfile.macro
@@ -1,0 +1,26 @@
+definition {
+
+	macro assertEndpointsInResponse {
+		Variables.assertDefined(parameterList = "${responseToParse},${attributesList}");
+
+		for (var attribute : list ${attributesList}) {
+			TestUtils.assertPartialEquals(
+				actual = ${responseToParse},
+				expected = ${attribute});
+		}
+	}
+
+	macro getOpenApiProfile {
+		var portalURL = JSONCompany.getPortalURL();
+
+		var curl = '''
+			${portalURL}/o/openapi/openapi.json \
+				-u test@liferay.com:test
+		''';
+
+		var response = JSONCurlUtil.get(${curl});
+
+		return ${response};
+	}
+
+}

--- a/modules/apps/headless/headless-discovery/headless-discovery-test/src/testFunctional/tests/OpenAPIProfile.testcase
+++ b/modules/apps/headless/headless-discovery/headless-discovery-test/src/testFunctional/tests/OpenAPIProfile.testcase
@@ -41,4 +41,47 @@ definition {
 		}
 	}
 
+	@priority = 4
+	test CanRetrieveHeadlessAdminWorkflowGetOpenAPI {
+		property portal.acceptance = "true";
+
+		task ("Given navigate to /o/openapi/openapi.json endpoint") {
+			APIExplorer.navigateToOpenAPI(
+				api = "openapi",
+				version = "");
+		}
+
+		task ("When executing HeadlessAdminWorkflow.v1.0.getOpenAPI") {
+			APIExplorer.executeAPIMethodWithParameters(
+				method = "HeadlessAdminWorkflow\.v1\.0\.getOpenAPI",
+				parameter = "type",
+				service = "default",
+				value = "json");
+		}
+
+		task ("Then the shown response code is 200") {
+			AssertTextEquals(
+				locator1 = "OpenAPI#RESPONSE_CODE",
+				method = "HeadlessAdminWorkflow\.v1\.0\.getOpenAPI",
+				value1 = 200);
+		}
+	}
+
+	@priority = 4
+	test CanReturnDetailsOfAPIsInTheSystem {
+		property portal.acceptance = "true";
+
+		task ("When with get request to retrieve /o/openapi/openapi.json") {
+			var response = OpenAPIProfile.getOpenApiProfile();
+		}
+
+		task ("Then I can see details of all the APIs in the system") {
+			var attributesList = "application/json,application/xml,#/components/schemas/";
+
+			OpenAPIProfile.assertEndpointsInResponse(
+				attributesList = ${attributesList},
+				responseToParse = ${response});
+		}
+	}
+
 }


### PR DESCRIPTION
**Background:**
- Add more tests for system APIs in open api profile

**Test Plan:**
- When with get request to retrieve /o/openapi/openapi.json
Then I can see details of all the APIs in the system
- Given navigate to /o/openapi/openapi.json endpoint
When executing HeadlessAdminWorkflow.v1.0.getOpenAPI
Then the shown response code is 200

**Jira Ticket:**
- https://issues.liferay.com/browse/LPS-175919