### PR TITLE
LPS-176172 Set HTTPS scheme only if `Portal.isSecure` method returns true, otherwise the value keeps unaltered from the getBaseUriBuilder method

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/resource/OpenAPIResourceImpl.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/resource/OpenAPIResourceImpl.java
@@ -518,19 +518,13 @@ public class OpenAPIResourceImpl implements OpenAPIResource {
 			return UriInfoUtil.getBasePath(uriInfo);
 		}
 
-		String scheme = Http.HTTP;
-
-		if (_portal.isSecure(httpServletRequest)) {
-			scheme = Http.HTTPS;
-		}
-
 		UriBuilder uriBuilder = UriInfoUtil.getBaseUriBuilder(uriInfo);
 
-		uriBuilder.host(
-			_portal.getForwardedHost(httpServletRequest)
-		).scheme(
-			scheme
-		);
+		uriBuilder.host(_portal.getForwardedHost(httpServletRequest));
+
+		if (_portal.isSecure(httpServletRequest)) {
+			uriBuilder.scheme(Http.HTTPS);
+		}
 
 		return String.valueOf(uriBuilder.build());
 	}

--- a/modules/apps/portal-vulcan/portal-vulcan-test/build.gradle
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	testIntegrationCompile group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.13.4"
+	testIntegrationCompile group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.13.4.2"
 	testIntegrationCompile group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"
 	testIntegrationCompile group: "org.apache.cxf", name: "cxf-core", version: "3.4.10"
 	testIntegrationCompile group: "org.apache.cxf", name: "cxf-rt-frontend-jaxrs", version: "3.4.10"

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/resource/test/OpenAPIResourceTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/resource/test/OpenAPIResourceTest.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.internal.resource.test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.vulcan.internal.test.util.URLConnectionUtil;
+
+import java.io.InputStream;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Carlos Correa
+ */
+@RunWith(Arquillian.class)
+public class OpenAPIResourceTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testGetOpenAPIServerURL() throws Exception {
+		InputStream inputStream = URLConnectionUtil.getInputStream(
+			"http://localhost:8080/o/headless-delivery/v1.0/openapi.json");
+
+		String path = _getPath(inputStream, "/servers/0/url");
+
+		Assert.assertTrue(path.startsWith("http://localhost:8080/"));
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"WEB_SERVER_PROTOCOL", "https")) {
+
+			inputStream = URLConnectionUtil.getInputStream(
+				"http://localhost:8080/o/headless-delivery/v1.0/openapi.json");
+
+			path = _getPath(inputStream, "/servers/0/url");
+
+			Assert.assertTrue(path.startsWith("https://localhost:8080/"));
+		}
+	}
+
+	private String _getPath(InputStream inputStream, String path)
+		throws Exception {
+
+		JsonNode jsonNode = _objectMapper.readTree(inputStream);
+
+		jsonNode = jsonNode.at(path);
+
+		return jsonNode.asText();
+	}
+
+	private final ObjectMapper _objectMapper = new ObjectMapper();
+
+}


### PR DESCRIPTION
This PR contains the code to fix the regression bug https://issues.liferay.com/browse/LPS-176172.

The value of the UriBuilder from the invocation `UriInfoUtil.getBaseUriBuilder(uriInfo)` already contains the scheme set to `HTTPS` if one of the properties `portal.instance.protocol` or `web.server.protocol` are set to `true`.

