### PR TITLE
LPS-169912 Only allow operations over an active related Object Definition

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/RelatedObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/RelatedObjectEntryResourceImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.object.rest.internal.resource.v1_0;
 
+import com.liferay.object.exception.NoSuchObjectDefinitionException;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.related.models.ObjectRelatedModelsProvider;
@@ -240,15 +241,28 @@ public class RelatedObjectEntryResourceImpl
 			ObjectRelationship objectRelationship)
 		throws Exception {
 
-		long objectDefinitionId1 = objectRelationship.getObjectDefinitionId1();
+		ObjectDefinition relatedObjectDefinition = null;
 
-		if (objectDefinitionId1 != objectDefinition.getObjectDefinitionId()) {
-			return _objectDefinitionLocalService.getObjectDefinition(
-				objectRelationship.getObjectDefinitionId1());
+		if (objectRelationship.getObjectDefinitionId1() !=
+				objectDefinition.getObjectDefinitionId()) {
+
+			relatedObjectDefinition =
+				_objectDefinitionLocalService.getObjectDefinition(
+					objectRelationship.getObjectDefinitionId1());
+		}
+		else {
+			relatedObjectDefinition =
+				_objectDefinitionLocalService.getObjectDefinition(
+					objectRelationship.getObjectDefinitionId2());
 		}
 
-		return _objectDefinitionLocalService.getObjectDefinition(
-			objectRelationship.getObjectDefinitionId2());
+		if (!relatedObjectDefinition.isActive()) {
+			throw new NoSuchObjectDefinitionException(
+				"No active object definition found for the relationship " +
+					objectRelationship.getName());
+		}
+
+		return relatedObjectDefinition;
 	}
 
 	private ObjectEntry _getRelatedObjectEntry(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/ObjectRelationshipExtensionProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/ObjectRelationshipExtensionProvider.java
@@ -134,7 +134,9 @@ public class ObjectRelationshipExtensionProvider
 				_getRelatedObjectDefinition(
 					objectDefinition, objectRelationship);
 
-			if (relatedObjectDefinition.isSystem()) {
+			if (!relatedObjectDefinition.isActive() ||
+				relatedObjectDefinition.isSystem()) {
+
 				continue;
 			}
 
@@ -214,7 +216,9 @@ public class ObjectRelationshipExtensionProvider
 				_getRelatedObjectDefinition(
 					objectDefinition, objectRelationship);
 
-			if (relatedObjectDefinition.isSystem()) {
+			if (!relatedObjectDefinition.isActive() ||
+				relatedObjectDefinition.isSystem()) {
+
 				continue;
 			}
 

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/openapi/contributor/RelatedObjectEntryOpenAPIContributor.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/openapi/contributor/RelatedObjectEntryOpenAPIContributor.java
@@ -124,10 +124,14 @@ public class RelatedObjectEntryOpenAPIContributor
 			ObjectRelationship systemObjectRelationship, String version)
 		throws Exception {
 
-		Paths paths = openAPI.getPaths();
-
 		ObjectDefinition relatedObjectDefinition = _getRelatedObjectDefinition(
 			systemObjectDefinition, systemObjectRelationship);
+
+		if (!relatedObjectDefinition.isActive()) {
+			return;
+		}
+
+		Paths paths = openAPI.getPaths();
 
 		String relatedSchemaName = getSchemaName(relatedObjectDefinition);
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/RelatedObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/RelatedObjectEntryResourceTest.java
@@ -241,6 +241,23 @@ public class RelatedObjectEntryResourceTest {
 		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
 
 		Assert.assertEquals(1, itemsJSONArray.length());
+
+		// Inactive Object Definition
+
+		_objectDefinition.setActive(false);
+
+		_objectDefinitionLocalService.updateObjectDefinition(_objectDefinition);
+
+		jsonObject = HTTPTestUtil.invoke(
+			null,
+			StringBundler.concat(
+				jaxRsApplicationDescriptor.getRESTContextPath(),
+				StringPool.SLASH, _user.getUserId(), StringPool.SLASH,
+				_objectRelationship.getName(), StringPool.SLASH,
+				_objectEntry.getPrimaryKey()),
+			Http.Method.DELETE);
+
+		Assert.assertEquals("NOT_FOUND", jsonObject.getString("status"));
 	}
 
 	@Test
@@ -282,6 +299,23 @@ public class RelatedObjectEntryResourceTest {
 		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
 
 		Assert.assertEquals(1, itemsJSONArray.length());
+
+		// Inactive Object Definition
+
+		_objectDefinition.setActive(false);
+
+		_objectDefinitionLocalService.updateObjectDefinition(_objectDefinition);
+
+		jsonObject = HTTPTestUtil.invoke(
+			null,
+			StringBundler.concat(
+				jaxRsApplicationDescriptor.getRESTContextPath(),
+				StringPool.SLASH, _user.getUserId(), StringPool.SLASH,
+				_objectRelationship.getName(), StringPool.SLASH,
+				_objectEntry.getPrimaryKey()),
+			Http.Method.DELETE);
+
+		Assert.assertEquals("NOT_FOUND", jsonObject.getString("status"));
 	}
 
 	@Test
@@ -372,6 +406,28 @@ public class RelatedObjectEntryResourceTest {
 		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
 
 		Assert.assertEquals(1, itemsJSONArray.length());
+
+		// Inactive Object Definition
+
+		_objectRelationship = _addObjectRelationship(
+			StringUtil.randomId(), _objectDefinition.getObjectDefinitionId(),
+			_userSystemObjectDefinition.getObjectDefinitionId(),
+			_objectEntry.getPrimaryKey(), _user.getUserId(),
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		_objectDefinition.setActive(false);
+
+		_objectDefinitionLocalService.updateObjectDefinition(_objectDefinition);
+
+		jsonObject = HTTPTestUtil.invoke(
+			null,
+			StringBundler.concat(
+				jaxRsApplicationDescriptor.getRESTContextPath(),
+				StringPool.SLASH, _user.getUserId(), StringPool.SLASH,
+				_objectRelationship.getName()),
+			Http.Method.GET);
+
+		Assert.assertEquals("NOT_FOUND", jsonObject.getString("status"));
 	}
 
 	@Test
@@ -510,6 +566,28 @@ public class RelatedObjectEntryResourceTest {
 		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
 
 		Assert.assertEquals(1, itemsJSONArray.length());
+
+		// Inactive Object Definition
+
+		String objectFieldValue = RandomTestUtil.randomString();
+
+		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
+			_objectDefinition, _OBJECT_FIELD_NAME, objectFieldValue);
+
+		_objectDefinition.setActive(false);
+
+		_objectDefinitionLocalService.updateObjectDefinition(_objectDefinition);
+
+		jsonObject = HTTPTestUtil.invoke(
+			null,
+			StringBundler.concat(
+				jaxRsApplicationDescriptor.getRESTContextPath(),
+				StringPool.SLASH, _user.getUserId(), StringPool.SLASH,
+				_objectRelationship.getName(), StringPool.SLASH,
+				objectEntry.getPrimaryKey()),
+			Http.Method.PUT);
+
+		Assert.assertEquals("NOT_FOUND", jsonObject.getString("status"));
 	}
 
 	private ObjectRelationship _addObjectRelationship(


### PR DESCRIPTION
This PR contains the code to fix this bug: https://issues.liferay.com/browse/LPS-169912

New validations have been included to avoid inactive related Object Definition. That will avoid the following use cases for inactive Object Definitions:

- Getting the related entries of a System Object that belongs to an inactive Object Definition
- Relate a System Object Entry to a Custom Object whose Object Definition is inactive
- Unrelate a System Object Entry to a Custom Object whose Object Definition is inactive
- Include in the System Object Definition's OpenAPI the endpoints and the schema of the relationships with an inactive Object Definition.
- Include in the System Object Entries returned the related Object Entries if the related Object Definition is inactive