### PR TITLE
LPS-171173 Call undeploy method of a removed ObjectDefinitionDeployer with all the existing Objects

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -176,6 +176,25 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 
 	@Override
 	public synchronized void undeploy(ObjectDefinition objectDefinition) {
+		if (objectDefinition.isSystem()) {
+			SystemObjectDefinitionMetadata systemObjectDefinitionMetadata =
+				_systemObjectDefinitionMetadataRegistry.
+					getSystemObjectDefinitionMetadata(
+						objectDefinition.getName());
+
+			if (systemObjectDefinitionMetadata == null) {
+				return;
+			}
+
+			JaxRsApplicationDescriptor jaxRsApplicationDescriptor =
+				systemObjectDefinitionMetadata.getJaxRsApplicationDescriptor();
+
+			_disposeComponentInstances(
+				jaxRsApplicationDescriptor.getRESTContextPath());
+
+			return;
+		}
+
 		String restContextPath = objectDefinition.getRESTContextPath();
 
 		Map<Long, ObjectDefinition> objectDefinitions =
@@ -235,14 +254,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 			return;
 		}
 
-		List<ComponentInstance> componentInstances =
-			_componentInstancesMap.remove(restContextPath);
-
-		if (componentInstances != null) {
-			for (ComponentInstance componentInstance : componentInstances) {
-				componentInstance.dispose();
-			}
-		}
+		_disposeComponentInstances(restContextPath);
 
 		ServiceRegistration<?> serviceRegistration1 =
 			_applicationServiceRegistrations.remove(restContextPath);
@@ -275,6 +287,17 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 			_objectFieldLocalService, _objectRelationshipService,
 			_objectScopeProviderRegistry,
 			_systemObjectDefinitionMetadataRegistry);
+	}
+
+	private void _disposeComponentInstances(String restContextPath) {
+		List<ComponentInstance> componentInstances =
+			_componentInstancesMap.remove(restContextPath);
+
+		if (componentInstances != null) {
+			for (ComponentInstance componentInstance : componentInstances) {
+				componentInstance.dispose();
+			}
+		}
 	}
 
 	private void _excludeScopedMethods(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -641,6 +641,12 @@ public class ObjectDefinitionLocalServiceImpl
 					ServiceReference<ObjectDefinitionDeployer> serviceReference,
 					ObjectDefinitionDeployer objectDefinitionDeployer) {
 
+					for (ObjectDefinition objectDefinition :
+							_getObjectDefinitions()) {
+
+						objectDefinitionDeployer.undeploy(objectDefinition);
+					}
+
 					Map<Long, List<ServiceRegistration<?>>>
 						serviceRegistrationsMap =
 							_serviceRegistrationsMaps.remove(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -126,6 +126,7 @@ import com.liferay.portal.search.spi.model.registrar.ModelSearchRegistrarHelper;
 import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -800,18 +801,11 @@ public class ObjectDefinitionLocalServiceImpl
 		Map<Long, List<ServiceRegistration<?>>> serviceRegistrationsMap =
 			new ConcurrentHashMap<>();
 
-		_companyLocalService.forEachCompanyId(
-			companyId -> {
-				List<ObjectDefinition> objectDefinitions =
-					objectDefinitionLocalService.getObjectDefinitions(
-						companyId, true, WorkflowConstants.STATUS_APPROVED);
-
-				for (ObjectDefinition objectDefinition : objectDefinitions) {
-					serviceRegistrationsMap.put(
-						objectDefinition.getObjectDefinitionId(),
-						objectDefinitionDeployer.deploy(objectDefinition));
-				}
-			});
+		for (ObjectDefinition objectDefinition : _getObjectDefinitions()) {
+			serviceRegistrationsMap.put(
+				objectDefinition.getObjectDefinitionId(),
+				objectDefinitionDeployer.deploy(objectDefinition));
+		}
 
 		_serviceRegistrationsMaps.put(
 			objectDefinitionDeployer, serviceRegistrationsMap);
@@ -1068,6 +1062,17 @@ public class ObjectDefinitionLocalServiceImpl
 		}
 
 		return name;
+	}
+
+	private List<ObjectDefinition> _getObjectDefinitions() {
+		List<ObjectDefinition> objectDefinitions = new ArrayList<>();
+
+		_companyLocalService.forEachCompanyId(
+			companyId -> objectDefinitions.addAll(
+				objectDefinitionLocalService.getObjectDefinitions(
+					companyId, true, WorkflowConstants.STATUS_APPROVED)));
+
+		return objectDefinitions;
 	}
 
 	private String _getPKObjectFieldDBColumnName(


### PR DESCRIPTION
This PR is created to fix this bug: https://issues.liferay.com/browse/LPS-171173

When `portal-vulcan-impl` module is restarted, the `com.liferay.object.rest.internal.deployer.ObjectDefinitionDeployerImpl` class is redeployed as it has dependencies with certain classes of portal-vulcan, causing that all the Objects REST API components that have been registered in OSGi keep unaltered, the references to the registrations are lost as they were kept in private maps, and then, the `_objectDefinitionDeployerServiceTracker` of the class `com.liferay.object.service.impl.ObjectDefinitionLocalServiceImpl` invokes for each ObjectDefinition the method `deploy` once the `ObjectDefinitionDeployerImpl` has been registered, causing that several components are registered as many times as the `ObjectDefinitionDeployerImpl` is redeployed.

To avoid that, apart from calling the `deploy` method for each Object Definition in the Service Tracker of the `ObjectDefinitionLocalServiceImpl` when an `ObjectDefinitionDeployer` has been added, the method `undeploy` will be invoked for each Object Definition in the Service Tracker of the same class when an `ObjectDefinitionDeployer` has been removed.