### PR TITLE
LPS-173250 Handle collection property in a complex property

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -349,6 +349,8 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 			HashMapDictionaryBuilder.<String, Object>put(
 				"companyId", companyIds
 			).put(
+				"liferay.filter.disabled", true
+			).put(
 				"liferay.jackson", false
 			).put(
 				"liferay.objects", true

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/petra/sql/dsl/expression/FilterPredicateFactoryImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/petra/sql/dsl/expression/FilterPredicateFactoryImpl.java
@@ -21,14 +21,16 @@ import com.liferay.object.rest.internal.odata.filter.expression.PredicateExpress
 import com.liferay.object.rest.petra.sql.dsl.expression.FilterPredicateFactory;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.petra.sql.dsl.expression.Predicate;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.Filter;
 import com.liferay.portal.odata.filter.FilterParser;
 import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.filter.InvalidFilterException;
 import com.liferay.portal.odata.filter.expression.Expression;
+import com.liferay.portal.odata.filter.expression.ExpressionVisitException;
+
+import javax.ws.rs.ServerErrorException;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -62,11 +64,17 @@ public class FilterPredicateFactoryImpl implements FilterPredicateFactory {
 					_objectFieldBusinessTypeRegistry, _objectFieldLocalService,
 					_objectRelatedModelsPredicateProviderRegistry));
 		}
-		catch (Exception exception) {
-			_log.error(exception);
+		catch (ExpressionVisitException expressionVisitException) {
+			throw new InvalidFilterException(
+				expressionVisitException.getMessage(),
+				expressionVisitException);
 		}
-
-		return null;
+		catch (InvalidFilterException invalidFilterException) {
+			throw invalidFilterException;
+		}
+		catch (Exception exception) {
+			throw new ServerErrorException(500, exception);
+		}
 	}
 
 	@Override
@@ -76,9 +84,6 @@ public class FilterPredicateFactoryImpl implements FilterPredicateFactory {
 
 		return create(entityModel, filterString, objectDefinitionId);
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		FilterPredicateFactoryImpl.class);
 
 	@Reference
 	private FilterParserProvider _filterParserProvider;

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/feature/VulcanFeature.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/feature/VulcanFeature.java
@@ -43,7 +43,6 @@ import com.liferay.portal.vulcan.internal.jaxrs.context.provider.AcceptLanguageC
 import com.liferay.portal.vulcan.internal.jaxrs.context.provider.AggregationContextProvider;
 import com.liferay.portal.vulcan.internal.jaxrs.context.provider.CompanyContextProvider;
 import com.liferay.portal.vulcan.internal.jaxrs.context.provider.FieldsQueryParamContextProvider;
-import com.liferay.portal.vulcan.internal.jaxrs.context.provider.FilterContextProvider;
 import com.liferay.portal.vulcan.internal.jaxrs.context.provider.PaginationContextProvider;
 import com.liferay.portal.vulcan.internal.jaxrs.context.provider.RestrictFieldsQueryParamContextProvider;
 import com.liferay.portal.vulcan.internal.jaxrs.context.provider.SortContextProvider;
@@ -157,9 +156,6 @@ public class VulcanFeature implements Feature {
 		featureContext.register(
 			new EntityExtensionHandlerContextResolver(
 				_extensionProviderRegistry));
-		featureContext.register(
-			new FilterContextProvider(
-				_expressionConvert, _filterParserProvider, _language, _portal));
 		featureContext.register(
 			new MultipartBodyMessageBodyReader(
 				_dlValidator.getMaxAllowableSize(

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/feature/VulcanFilterFeature.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/feature/VulcanFilterFeature.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.internal.jaxrs.feature;
+
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.vulcan.internal.jaxrs.context.provider.FilterContextProvider;
+
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ServiceScope;
+import org.osgi.service.jaxrs.whiteboard.JaxrsWhiteboardConstants;
+
+/**
+ * @author Luis Miguel Barcos
+ */
+@Component(
+	property = {
+		JaxrsWhiteboardConstants.JAX_RS_APPLICATION_SELECT + "=(|(!(liferay.filter.disabled=*))(liferay.filter.disabled=false))",
+		JaxrsWhiteboardConstants.JAX_RS_EXTENSION + "=true",
+		JaxrsWhiteboardConstants.JAX_RS_NAME + "=Liferay.Vulcan.Filter"
+	},
+	scope = ServiceScope.PROTOTYPE, service = Feature.class
+)
+public class VulcanFilterFeature implements Feature {
+
+	@Override
+	public boolean configure(FeatureContext featureContext) {
+		featureContext.register(
+			new FilterContextProvider(
+				_expressionConvert, _filterParserProvider, _language, _portal));
+
+		return false;
+	}
+
+	@Reference(
+		target = "(result.class.name=com.liferay.portal.kernel.search.filter.Filter)"
+	)
+	private ExpressionConvert<Filter> _expressionConvert;
+
+	@Reference
+	private FilterParserProvider _filterParserProvider;
+
+	@Reference
+	private Language _language;
+
+	@Reference
+	private Portal _portal;
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/test/FilterContextProviderTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/test/FilterContextProviderTest.java
@@ -118,7 +118,7 @@ public class FilterContextProviderTest {
 	private ContextProvider<Filter> _contextProvider;
 
 	@Inject(
-		filter = "component.name=com.liferay.portal.vulcan.internal.jaxrs.feature.VulcanFeature"
+		filter = "component.name=com.liferay.portal.vulcan.internal.jaxrs.feature.VulcanFilterFeature"
 	)
 	private Feature _feature;
 


### PR DESCRIPTION
Related ticket [LPS-173250](https://issues.liferay.com/browse/LPS-173250)
____
## Purpose of the PR
Before the PR there was no way to filter by a `multipicklist` field of a related object. This PR is to support that case.
The related ticket example is perfect for explaining this behavior.
Now, with the objects and relationships described on the ticket, when a user types this filter
`(studentSubjects/multi/any(k:k eq 'name3')) and (studentSubjects/multi/any(k:k eq 'name4'))` he should receive the subjects of the students that meet this condition.

_IMPORTANT: Note that the filter differs from the filter used in the ticket at the moment of the creation of this PR_

## How to test it
Deploy the following modules:
* portal-vulcan-impl
* object-rest-impl
* Follow the instructions from the ticket except the last one. Instead of that filter, use the filter above.