### PR TITLE
LPS-163008 Fix creating entities with same externalReferenceCode in Liferay Portal 7.3.x

### DIFF
--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_impl.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_impl.ftl
@@ -819,9 +819,13 @@ public class ${entity.name}PersistenceImpl extends BasePersistenceImpl<${entity.
 				</#if>
 			}
 
-			<#if serviceBuilder.isVersionGTE_7_4_0() && entity.hasExternalReferenceCode()>
+			<#if serviceBuilder.isVersionGTE_7_3_0() && entity.hasExternalReferenceCode()>
 				else {
-					${entity.name} erc${entity.name} = fetchByERC_${entity.externalReferenceCode?cap_first[0..0]}(${entity.variableName}.getExternalReferenceCode(), ${entity.variableName}.get${entity.externalReferenceCode?cap_first}Id());
+					<#if serviceBuilder.isVersionGTE_7_4_0()>
+						${entity.name} erc${entity.name} = fetchByERC_${entity.externalReferenceCode?cap_first[0..0]}(${entity.variableName}.getExternalReferenceCode(), ${entity.variableName}.get${entity.externalReferenceCode?cap_first}Id());
+					<#else>
+						${entity.name} erc${entity.name} = fetchBy${entity.externalReferenceCode?cap_first[0..0]}_ERC(${entity.variableName}.get${entity.externalReferenceCode?cap_first}Id(), ${entity.variableName}.getExternalReferenceCode());
+					</#if>
 
 					if (isNew) {
 						if (erc${entity.name} != null) {


### PR DESCRIPTION
**What is new?**
- Update condition in the `persistance.ftl` to add in their related Persistance class to throw a `DuplicateExternalReferenceCodeException` in Liferay Portal with version greater and equals than 7.3.x
  
**JIRA Related Tickets**
https://issues.liferay.com/browse/LPS-173548
https://issues.liferay.com/browse/LPS-170268
