### PR TITLE
LPS-173450 Fix the auto-generated PATCH method when the GET by externalReferenceCode method has more than one parameter

### DIFF
--- a/modules/apps/digital-signature/digital-signature-rest-impl/rest-openapi.yaml
+++ b/modules/apps/digital-signature/digital-signature-rest-impl/rest-openapi.yaml
@@ -85,7 +85,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.digital.signature.rest.client', and version '1.0.11'."
+        'com.liferay.digital.signature.rest.client', and version '1.0.12'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/digital-signature/digital-signature-rest-impl/src/main/java/com/liferay/digital/signature/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/digital-signature/digital-signature-rest-impl/src/main/java/com/liferay/digital/signature/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.digital.signature.rest.client', and version '1.0.11'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.digital.signature.rest.client', and version '1.0.12'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryResourceImpl.java
@@ -516,7 +516,9 @@ public abstract class BaseObjectEntryResourceImpl
 			ObjectEntry objectEntry)
 		throws Exception {
 
-		ObjectEntry existingObjectEntry = getByExternalReferenceCode(scopeKey);
+		ObjectEntry existingObjectEntry =
+			getScopeScopeKeyByExternalReferenceCode(
+				scopeKey, externalReferenceCode);
 
 		if (objectEntry.getActions() != null) {
 			existingObjectEntry.setActions(objectEntry.getActions());
@@ -545,7 +547,8 @@ public abstract class BaseObjectEntryResourceImpl
 
 		preparePatch(objectEntry, existingObjectEntry);
 
-		return putByExternalReferenceCode(scopeKey, existingObjectEntry);
+		return putScopeScopeKeyByExternalReferenceCode(
+			scopeKey, externalReferenceCode, existingObjectEntry);
 	}
 
 	@io.swagger.v3.oas.annotations.Parameters(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
@@ -268,47 +268,6 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 	}
 
 	@Override
-	public ObjectEntry patchScopeScopeKeyByExternalReferenceCode(
-			String scopeKey, String externalReferenceCode,
-			ObjectEntry objectEntry)
-		throws Exception {
-
-		ObjectEntry existingObjectEntry =
-			getScopeScopeKeyByExternalReferenceCode(
-				scopeKey, externalReferenceCode);
-
-		if (objectEntry.getActions() != null) {
-			existingObjectEntry.setActions(objectEntry.getActions());
-		}
-
-		if (objectEntry.getDateCreated() != null) {
-			existingObjectEntry.setDateCreated(objectEntry.getDateCreated());
-		}
-
-		if (objectEntry.getDateModified() != null) {
-			existingObjectEntry.setDateModified(objectEntry.getDateModified());
-		}
-
-		if (objectEntry.getExternalReferenceCode() != null) {
-			existingObjectEntry.setExternalReferenceCode(
-				objectEntry.getExternalReferenceCode());
-		}
-
-		if (objectEntry.getProperties() != null) {
-			existingObjectEntry.setProperties(objectEntry.getProperties());
-		}
-
-		if (objectEntry.getScopeKey() != null) {
-			existingObjectEntry.setScopeKey(objectEntry.getScopeKey());
-		}
-
-		preparePatch(objectEntry, existingObjectEntry);
-
-		return putScopeScopeKeyByExternalReferenceCode(
-			scopeKey, externalReferenceCode, existingObjectEntry);
-	}
-
-	@Override
 	public ObjectEntry postObjectEntry(ObjectEntry objectEntry)
 		throws Exception {
 

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -325,18 +325,22 @@ public abstract class Base${schemaName}ResourceImpl
 			<#elseif freeMarkerTool.hasHTTPMethod(javaMethodSignature, "patch") && freeMarkerTool.hasJavaMethodSignature(javaMethodSignatures, "get" + javaMethodSignature.methodName?remove_beginning("patch")) && freeMarkerTool.hasJavaMethodSignature(javaMethodSignatures, "put" + javaMethodSignature.methodName?remove_beginning("patch")) && !javaMethodSignature.operation.requestBody.content?keys?seq_contains("multipart/form-data")>
 				<#assign
 					generatePatchMethods = true
-					firstJavaMethodParameter = javaMethodSignature.javaMethodParameters[0]
+					javaMethodParameters = javaMethodSignature.javaMethodParameters[0..javaMethodSignature.javaMethodParameters?size-2]
+					javaMethodParameterName = ""
 				/>
 
 				<#if javaMethodSignature.methodName?contains("ByExternalReferenceCode")>
-					<#if configYAML.forcePredictableOperationId>
-						${javaDataType} existing${schemaName} = getByExternalReferenceCode(${firstJavaMethodParameter.parameterName});
-					<#else>
-						${javaDataType} existing${schemaName} = get${schemaName}ByExternalReferenceCode(${firstJavaMethodParameter.parameterName});
-					</#if>
+					<#assign javaMethodParameterName = javaMethodSignature.methodName?replace("patch", "get") />
 				<#else>
-					${javaDataType} existing${schemaName} = get${schemaName}(${firstJavaMethodParameter.parameterName});
+					<#assign javaMethodParameterName = "get" + schemaName />
 				</#if>
+
+				${javaDataType} existing${schemaName} = ${javaMethodParameterName}(
+					<#list javaMethodParameters as javaMethodParameter>
+						${javaMethodParameter.parameterName}
+						<#sep>, </#sep>
+					</#list>
+				);
 
 				<#assign properties = freeMarkerTool.getDTOProperties(configYAML, openAPIYAML, schema) />
 
@@ -351,14 +355,18 @@ public abstract class Base${schemaName}ResourceImpl
 				preparePatch(${schemaVarName}, existing${schemaName});
 
 				<#if javaMethodSignature.methodName?contains("ByExternalReferenceCode")>
-					<#if configYAML.forcePredictableOperationId>
-						return putByExternalReferenceCode(${firstJavaMethodParameter.parameterName}, existing${schemaName});
-					<#else>
-						return put${schemaName}ByExternalReferenceCode(${firstJavaMethodParameter.parameterName}, existing${schemaName});
-					</#if>
+					<#assign javaMethodParameterName = javaMethodSignature.methodName?replace("patch", "put") />
 				<#else>
-					return put${schemaName}(${firstJavaMethodParameter.parameterName}, existing${schemaName});
+					<#assign javaMethodParameterName = "put" + schemaName />
 				</#if>
+
+				return ${javaMethodParameterName}(
+					<#list javaMethodParameters as javaMethodParameter>
+						${javaMethodParameter.parameterName}
+						<#sep>, </#sep>
+					</#list>
+					, existing${schemaName}
+				);
 			<#else>
 				return new ${javaMethodSignature.returnType}();
 			</#if>


### PR DESCRIPTION
This PR contains the code to fix this bug: https://issues.liferay.com/browse/LPS-173450

Now, the `get` and `put` methods name come from the `patch` method name just by replacing the substring `patch` for `get` or `put` instead of calculating it based on the `forcePredictableOperationId` configuration parameter.

Furthermore, instead of just adding the first java method parameter name, all of them except the last one are used.

cc/ @4lejandrito as I rollback part of the code that was included in [this commit](https://github.com/liferay/liferay-portal/commit/ba509dfe7c4274565b27076e82b887b576d65f33)