### PR TITLE
LPS-176501 | Can load API Explorer from custom context

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -14616,7 +14616,7 @@ mail.send.blacklist=</echo>
 						<replace
 							file="${app.server.dir}/conf/catalina.properties"
 							token="common.loader=&quot;${catalina.home}/webapps/ROOT/WEB-INF/lib/support-tomcat.jar&quot;"
-							value="common.loader=&quot;${catalina.home}/webapps/liferay/WEB-INF/lib/support-tomcat.jar&quot;"
+							value="common.loader=&quot;${catalina.home}/webapps/${portal.context}/WEB-INF/lib/support-tomcat.jar&quot;"
 						/>
 					</then>
 					<else>

--- a/modules/apps/headless/headless-discovery/headless-discovery-test/src/testFunctional/macros/APIExplorer.macro
+++ b/modules/apps/headless/headless-discovery/headless-discovery-test/src/testFunctional/macros/APIExplorer.macro
@@ -81,11 +81,14 @@ definition {
 	}
 
 	macro navigateToOpenAPI {
-		Variables.assertDefined(parameterList = "${api},${version}");
-
 		var portalURL = JSONCompany.getPortalURL();
 
-		Navigator.openSpecificURL(url = "${portalURL}/o/api?endpoint=${portalURL}/o/${api}/${version}/openapi.json");
+		if (isSet(api)) {
+			Navigator.openSpecificURL(url = "${portalURL}/o/api?endpoint=${portalURL}/o/${api}/${version}/openapi.json");
+		}
+		else {
+			Navigator.openSpecificURL(url = "${portalURL}/o/api");
+		}
 	}
 
 }

--- a/modules/apps/headless/headless-discovery/headless-discovery-test/src/testFunctional/tests/HeadlessDiscovery.testcase
+++ b/modules/apps/headless/headless-discovery/headless-discovery-test/src/testFunctional/tests/HeadlessDiscovery.testcase
@@ -125,6 +125,28 @@ definition {
 	}
 
 	@priority = 5
+	test CanLoadAPIExplorerFromCustomContext {
+		property portal.acceptance = "true";
+		property portal.context = "world";
+		property skip.clean-app-server-deploy-dir = "true";
+		property test.name.skip.portal.instance = "HeadlessDiscovery#CanLoadAPIExplorerFromCustomContext";
+
+		task ("When I navigate to localhost:8080/world/o/api") {
+			var portalURL = PropsUtil.get("portal.url");
+
+			APIExplorer.navigateToOpenAPI();
+		}
+
+		task ("Then Liferay API Explorer loads correctly") {
+			var api = "headless-delivery";
+
+			AssertTextEquals(
+				locator1 = "Select#HEADLESS_SERVERS",
+				value1 = "${portalURL}/o/${api}/");
+		}
+	}
+
+	@priority = 5
 	test CanLoadHeadlessAdminContentOpenAPI {
 		property portal.acceptance = "true";
 


### PR DESCRIPTION
**Background**
Add a test case to load API Explorer from custom context

**Test Plan**
Given ROOT context changed to 'liferay'

When I navigate to localhost:8080/liferay/o/api

Then Liferay API Explorer loads correctly

**JIRA Link:**
https://issues.liferay.com/browse/LPS-176501