### PR TITLE
LPS-176796 Delete isSanitize method because it will be always false

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Vulcan API
 Bundle-SymbolicName: com.liferay.portal.vulcan.api
-Bundle-Version: 30.0.2
+Bundle-Version: 31.0.0
 Export-Package:\
 	com.liferay.portal.vulcan.accept.language,\
 	com.liferay.portal.vulcan.aggregation,\

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/jaxrs/exception/mapper/BaseExceptionMapper.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/jaxrs/exception/mapper/BaseExceptionMapper.java
@@ -14,9 +14,6 @@
 
 package com.liferay.portal.vulcan.jaxrs.exception.mapper;
 
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
-
 import java.util.List;
 
 import javax.ws.rs.core.Context;
@@ -33,14 +30,7 @@ public abstract class BaseExceptionMapper<T extends Throwable>
 
 	@Override
 	public Response toResponse(T exception) {
-		Problem problem = null;
-
-		if (isSanitize()) {
-			problem = _getSanitizedProblem(exception);
-		}
-		else {
-			problem = getProblem(exception);
-		}
+		Problem problem = getProblem(exception);
 
 		return Response.status(
 			problem.getStatus()
@@ -67,27 +57,7 @@ public abstract class BaseExceptionMapper<T extends Throwable>
 
 	protected abstract Problem getProblem(T exception);
 
-	protected boolean isSanitize() {
-		return false;
-	}
-
 	@Context
 	protected HttpHeaders httpHeaders;
-
-	private Problem _getSanitizedProblem(T exception) {
-		Problem problem = getProblem(exception);
-
-		if (_log.isWarnEnabled()) {
-			_log.warn("Problem " + problem, exception);
-		}
-
-		problem.setDetail(null);
-		problem.setTitle(null);
-
-		return problem;
-	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		BaseExceptionMapper.class);
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/jaxrs/exception/mapper/packageinfo
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/jaxrs/exception/mapper/packageinfo
@@ -1,1 +1,1 @@
-version 3.2.0
+version 4.0.0


### PR DESCRIPTION
**What is new?**
- Delete `isSanitize` method, because there isn't any ExcpetionMapper that uses it.

**JIRA Tikcet**
https://issues.liferay.com/browse/LPS-176796