### PR TITLE
Lps 171717 | Add tests for Object REST API with different scopes in an LXC environment

### DIFF
--- a/modules/apps/headless/headless-discovery/headless-discovery-test/src/testFunctional/macros/APIExplorer.macro
+++ b/modules/apps/headless/headless-discovery/headless-discovery-test/src/testFunctional/macros/APIExplorer.macro
@@ -81,7 +81,16 @@ definition {
 	}
 
 	macro navigateToOpenAPI {
-		var portalURL = JSONCompany.getPortalURL();
+		if (isSet(virtualHost)) {
+			if (!(isSet(port))) {
+				var port = 8080;
+			}
+
+			var portalURL = "http://${virtualHost}:${port}";
+		}
+		else {
+			var portalURL = JSONCompany.getPortalURL();
+		}
 
 		if (isSet(api)) {
 			Navigator.openSpecificURL(url = "${portalURL}/o/api?endpoint=${portalURL}/o/${api}/${version}/openapi.json");

--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/OAuth2ForObject.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/OAuth2ForObject.macro
@@ -1,0 +1,55 @@
+definition {
+
+	macro addAuth2Application {
+		if (isSet(baseURL)) {
+			SignIn.signInSpecificURL(url = ${baseURL});
+		}
+		else {
+			var baseURL = PropsUtil.get("portal.url");
+		}
+
+		OAuth2.openOAuth2Admin(baseURL = ${baseURL});
+
+		OAuth2.addApplication(
+			applicationName = "OAuth Application",
+			checkboxUncheckList = "Authorization Code");
+
+		OAuth2.inputApplicationValues(
+			clientId = "myApplication",
+			clientSecret = "mySecret");
+	}
+
+	macro createTokenWithOAuth2Scopes {
+		Variables.assertDefined(parameterList = ${resourceCheckList});
+
+		if (!(isSet(baseURL))) {
+			var baseURL = PropsUtil.get("portal.url");
+		}
+
+		OAuth2.openOAuth2Admin(baseURL = ${baseURL});
+
+		OAuth2.editScopes(
+			applicationName = "OAuth Application",
+			resourceCheckList = ${resourceCheckList},
+			resourcePanels = ${resourcePanels});
+
+		var accessToken = OAuth2.getAccessToken(
+			client_id = "myApplication",
+			client_secret = "mySecret",
+			grantFlow = "clientCredentials",
+			portalURL = ${baseURL});
+
+		return ${accessToken};
+	}
+
+	macro setUpGlobalTokenForDefaultInstance {
+		var defaultInstanceToken = OAuth2ForObject.createTokenWithOAuth2Scopes(
+			resourceCheckList = "Liferay.Headless.Portal.Instances.everything,Liferay.Object.Admin.REST.everything",
+			resourcePanels = "Liferay.Headless.Portal.Instances,Liferay.Object.Admin.REST");
+
+		static var staticDefaultInstanceToken = ${defaultInstanceToken};
+
+		return ${staticDefaultInstanceToken};
+	}
+
+}

--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/OAuth2ForObject.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/OAuth2ForObject.macro
@@ -1,6 +1,6 @@
 definition {
 
-	macro addAuth2Application {
+	macro addOAuth2Application {
 		if (isSet(baseURL)) {
 			SignIn.signInSpecificURL(url = ${baseURL});
 		}
@@ -40,16 +40,6 @@ definition {
 			portalURL = ${baseURL});
 
 		return ${accessToken};
-	}
-
-	macro setUpGlobalTokenForDefaultInstance {
-		var defaultInstanceToken = OAuth2ForObject.createTokenWithOAuth2Scopes(
-			resourceCheckList = "Liferay.Headless.Portal.Instances.everything,Liferay.Object.Admin.REST.everything",
-			resourcePanels = "Liferay.Headless.Portal.Instances,Liferay.Object.Admin.REST");
-
-		static var staticDefaultInstanceToken = ${defaultInstanceToken};
-
-		return ${staticDefaultInstanceToken};
 	}
 
 }

--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectDefinitionAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectDefinitionAPI.macro
@@ -125,7 +125,7 @@ definition {
 			fieldValue = ${name},
 			token = ${token});
 
-		var objectId = JSONUtil.getWithJSONPath(${response}, "$.id");
+		var objectId = JSONPathUtil.getIdValue(response = ${response});
 
 		return ${objectId};
 	}
@@ -285,38 +285,11 @@ definition {
 				-u test@liferay.com:test
 		''';
 
-<<<<<<< HEAD
-		var response = JSONCurlUtil.get(${curl});
-=======
 		if (isSet(token)) {
 			var curl = StringUtil.add(${curl}, " -H 'Authorization: Bearer ${token}'", "");
 		}
 
 		var response = JSONCurlUtil.get(${curl});
-
-		return ${response};
-	}
-
-	macro _getObjectEntryRelation {
-		Variables.assertDefined(parameterList = "${en_US_plural_label},${objectId},${relationshipName}");
-
-		var en_US_plural_label_lowercase = StringUtil.lowerCase(${en_US_plural_label});
-		var portalURL = JSONCompany.getPortalURL();
-
-		var curl = '''
-			${portalURL}/o/c/${en_US_plural_label_lowercase}/${objectId}/${relationshipName} \
-				-H accept: application/json \
-				-u test@liferay.com:test
-		''';
-
-		var json = JSONCurlUtil.get(${curl});
-
-		return ${json};
-	}
-
-	macro _getObjectFirstnameById {
-		var objectFirstname = JSONUtil.getWithJSONPath(${responseToParse}, "$.items[?(@.id==${objectId})].firstname");
->>>>>>> LPS-171717 Add object tests with different scopes in multiple portal instances
 
 		return ${response};
 	}

--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectDefinitionAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectDefinitionAPI.macro
@@ -73,6 +73,10 @@ definition {
 			var portalURL = JSONCompany.getPortalURL();
 		}
 
+		if (!(isSet(scope))) {
+			var scope = "company";
+		}
+
 		var curl = '''
 			${portalURL}/o/object-admin/v1.0/object-definitions \
 				-u test@liferay.com:test \
@@ -99,9 +103,13 @@ definition {
 						"en_US": "${en_US_plural_label}"
 					},
 					"portlet": true,
-					"scope": "company"
+					"scope": "${scope}"
 				}
 		''';
+
+		if (isSet(token)) {
+			var curl = StringUtil.add(${curl}, " -H 'Authorization: Bearer ${token}'", "");
+		}
 
 		var objectDefinitionId = JSONCurlUtil.post(${curl}, "$.id");
 
@@ -109,36 +117,15 @@ definition {
 	}
 
 	macro _createObjectEntryWithName {
-		Variables.assertDefined(parameterList = "${en_US_plural_label},${name}");
+		Variables.assertDefined(parameterList = ${name});
 
-		var en_US_plural_label_lowercase = StringUtil.lowerCase(${en_US_plural_label});
+		var response = ObjectDefinitionAPI.createObjectEntryWithField(
+			en_US_plural_label = ${en_US_plural_label},
+			fieldName = "name",
+			fieldValue = ${name},
+			token = ${token});
 
-		if (isSet(virtualHost)) {
-			if (!(isSet(port))) {
-				var port = 8080;
-			}
-
-			var portalURL = "http://${virtualHost}:${port}";
-		}
-		else {
-			var portalURL = JSONCompany.getPortalURL();
-		}
-
-		var body = '''"name": "${name}"''';
-
-		if (isSet(secondField)) {
-			var body = StringUtil.add("${body},", "\"secondField\":\"${secondFieldValue}\"", "");
-		}
-
-		var curlWithoutBody = '''
-			${portalURL}/o/c/${en_US_plural_label_lowercase} \
-				-u test@liferay.com:test \
-				-H Content-Type: application/json \
-		''';
-
-		var curl = StringUtil.add(${curlWithoutBody}, "-d {${body}}", " ");
-
-		var objectId = JSONCurlUtil.post(${curl}, "$.id");
+		var objectId = JSONUtil.getWithJSONPath(${response}, "$.id");
 
 		return ${objectId};
 	}
@@ -162,6 +149,10 @@ definition {
 					"type": "${type}"
 				}
 		''';
+
+		if (isSet(token)) {
+			var curl = StringUtil.add(${curl}, " -H 'Authorization: Bearer ${token}'", "");
+		}
 
 		var relationshipId = JSONCurlUtil.post(${curl}, "$.id");
 
@@ -264,6 +255,10 @@ definition {
 				-u test@liferay.com:test
 		''';
 
+		if (isSet(token)) {
+			var curl = StringUtil.add(${curl}, " -H 'Authorization: Bearer ${token}'", "");
+		}
+
 		var objectDefinitionStatus = JSONCurlUtil.get(${curl}, "$.active");
 
 		return ${objectDefinitionStatus};
@@ -290,7 +285,38 @@ definition {
 				-u test@liferay.com:test
 		''';
 
+<<<<<<< HEAD
 		var response = JSONCurlUtil.get(${curl});
+=======
+		if (isSet(token)) {
+			var curl = StringUtil.add(${curl}, " -H 'Authorization: Bearer ${token}'", "");
+		}
+
+		var response = JSONCurlUtil.get(${curl});
+
+		return ${response};
+	}
+
+	macro _getObjectEntryRelation {
+		Variables.assertDefined(parameterList = "${en_US_plural_label},${objectId},${relationshipName}");
+
+		var en_US_plural_label_lowercase = StringUtil.lowerCase(${en_US_plural_label});
+		var portalURL = JSONCompany.getPortalURL();
+
+		var curl = '''
+			${portalURL}/o/c/${en_US_plural_label_lowercase}/${objectId}/${relationshipName} \
+				-H accept: application/json \
+				-u test@liferay.com:test
+		''';
+
+		var json = JSONCurlUtil.get(${curl});
+
+		return ${json};
+	}
+
+	macro _getObjectFirstnameById {
+		var objectFirstname = JSONUtil.getWithJSONPath(${responseToParse}, "$.items[?(@.id==${objectId})].firstname");
+>>>>>>> LPS-171717 Add object tests with different scopes in multiple portal instances
 
 		return ${response};
 	}
@@ -398,6 +424,10 @@ definition {
 			${portalURL}/o/object-admin/v1.0/object-definitions/${objectDefinitionId}/publish \
 				-u test@liferay.com:test
 		''';
+
+		if (isSet(token)) {
+			var curl = StringUtil.add(${curl}, " -H 'Authorization: Bearer ${token}'", "");
+		}
 
 		var json = JSONCurlUtil.post(${curl});
 
@@ -608,14 +638,17 @@ definition {
 			en_US_plural_label = ${en_US_plural_label},
 			name = ${name},
 			requiredStringFieldName = ${requiredStringFieldName},
+			token = ${token},
 			virtualHost = ${virtualHost});
 
 		ObjectDefinitionAPI._publishObjectDefinition(
 			objectDefinitionId = ${objectDefinitionId},
+			token = ${token},
 			virtualHost = ${virtualHost});
 
 		var objectDefinitionStatus = ObjectDefinitionAPI._getObjectDefinitionStatusById(
 			objectDefinitionId = ${objectDefinitionId},
+			token = ${token},
 			virtualHost = ${virtualHost});
 
 		TestUtils.assertEquals(
@@ -651,16 +684,67 @@ definition {
 		return ${managerId};
 	}
 
+	macro createObjectEntryWithField {
+		Variables.assertDefined(parameterList = "${en_US_plural_label},${fieldName},${fieldValue}");
+
+		var en_US_plural_label_lowercase = StringUtil.lowerCase(${en_US_plural_label});
+
+		if (isSet(virtualHost)) {
+			if (!(isSet(port))) {
+				var port = 8080;
+			}
+
+			var portalURL = "http://${virtualHost}:${port}";
+		}
+		else {
+			var portalURL = JSONCompany.getPortalURL();
+		}
+
+		var body = '''"${fieldName}": "${fieldValue}"''';
+
+		if (isSet(secondField)) {
+			var body = StringUtil.add("${body},", "\"secondField\":\"${secondFieldValue}\"", "");
+		}
+
+		var api = ${en_US_plural_label_lowercase};
+
+		if (isSet(scopeKey)) {
+			var scopeKey = JSONGroupAPI._getGroupIdByNameNoSelenium(
+				groupName = "Guest",
+				site = "true");
+
+			var api = StringUtil.add(${api}, "/scopes/${scopeKey}", "");
+		}
+
+		var curlWithoutBody = '''
+			${portalURL}/o/c/${api} \
+				-u test@liferay.com:test \
+				-H Content-Type: application/json \
+		''';
+
+		var curl = StringUtil.add(${curlWithoutBody}, "-d {${body}}", " ");
+
+		if (isSet(token)) {
+			var curl = StringUtil.add(${curl}, " -H 'Authorization: Bearer ${token}'", "");
+		}
+
+		var response = JSONCurlUtil.post(${curl});
+
+		return ${response};
+	}
+
 	macro createObjectEntryWithName {
 		var objectId = ObjectDefinitionAPI._createObjectEntryWithName(
 			en_US_plural_label = ${en_US_plural_label},
 			name = ${name},
 			secondFieldValue = ${secondFieldValue},
+			token = ${token},
 			virtualHost = ${virtualHost});
 
 		var response = ObjectDefinitionAPI._getObjectEntryById(
 			en_US_plural_label = ${en_US_plural_label},
 			objectId = ${objectId},
+			token = ${token},
 			virtualHost = ${virtualHost});
 
 		var actualName = JSONUtil.getWithJSONPath(${response}, "$.name");
@@ -764,6 +848,10 @@ definition {
 			${portalURL}/o/c/${en_US_plural_label_lowercase}/ \
 				-u test@liferay.com:test
 		''';
+
+		if (isSet(token)) {
+			var curl = StringUtil.add(${curl}, " -H 'Authorization: Bearer ${token}'", "");
+		}
 
 		var response = JSONCurlUtil.get(${curl});
 

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/ScopeObjectAPIsForDifferentInstances.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/ScopeObjectAPIsForDifferentInstances.testcase
@@ -72,6 +72,8 @@ definition {
 		}
 	}
 
+	@description = "Ignore tests since Oauth scopes problems in LPS-169916"
+	@ignore = "true"
 	@priority = 4
 	test CanCreateObjectEntryByScopeKey {
 		property portal.acceptance = "true";
@@ -101,6 +103,8 @@ definition {
 		}
 	}
 
+	@description = "Ignore tests since Oauth scopes problems in LPS-169916"
+	@ignore = "true"
 	@priority = 4
 	test CanCreateObjectEntryInVirtualInstance {
 		property portal.acceptance = "true";
@@ -132,6 +136,8 @@ definition {
 		}
 	}
 
+	@description = "Ignore tests since Oauth scopes problems in LPS-169916"
+	@ignore = "true"
 	@priority = 4
 	test CanIncludeObjectFieldInAPIExplorer {
 		property portal.acceptance = "true";

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/ScopeObjectAPIsForDifferentInstances.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/ScopeObjectAPIsForDifferentInstances.testcase
@@ -10,7 +10,7 @@ definition {
 		User.firstLoginUI();
 
 		task ("Given an OAuth application with headless scopes is created on default instance") {
-			OAuth2ForObject.addAuth2Application();
+			OAuth2ForObject.addOAuth2Application();
 
 			var defaultInstanceToken = OAuth2ForObject.createTokenWithOAuth2Scopes(
 				resourceCheckList = "Liferay.Headless.Portal.Instances.everything,Liferay.Object.Admin.REST.everything",
@@ -26,7 +26,7 @@ definition {
 		}
 
 		task ("And Given an OAuth application with headless scopes is created on www.able.com") {
-			OAuth2ForObject.addAuth2Application(baseURL = "http://www.able.com:8080");
+			OAuth2ForObject.addOAuth2Application(baseURL = "http://www.able.com:8080");
 
 			var virtualInstanceToken = OAuth2ForObject.createTokenWithOAuth2Scopes(
 				baseURL = "http://www.able.com:8080",

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/ScopeObjectAPIsForDifferentInstances.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/ScopeObjectAPIsForDifferentInstances.testcase
@@ -1,0 +1,168 @@
+@component-name = "portal-headless"
+definition {
+
+	property custom.properties = "include-and-override=portal-liferay-online.properties";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.main.component.name = "Headless";
+
+	setUp {
+		User.firstLoginUI();
+
+		task ("Given an OAuth application with headless scopes is created on default instance") {
+			OAuth2ForObject.addAuth2Application();
+
+			var defaultInstanceToken = OAuth2ForObject.createTokenWithOAuth2Scopes(
+				resourceCheckList = "Liferay.Headless.Portal.Instances.everything,Liferay.Object.Admin.REST.everything",
+				resourcePanels = "Liferay.Headless.Portal.Instances,Liferay.Object.Admin.REST");
+		}
+
+		task ("And Given a new virtual instances www.able.com is created") {
+			HeadlessPortalInstanceAPI.addPortalInstance(
+				domain = "liferay.com",
+				portalInstanceId = "www.able.com",
+				token = ${defaultInstanceToken},
+				virtualHost = "www.able.com");
+		}
+
+		task ("And Given an OAuth application with headless scopes is created on www.able.com") {
+			OAuth2ForObject.addAuth2Application(baseURL = "http://www.able.com:8080");
+
+			var virtualInstanceToken = OAuth2ForObject.createTokenWithOAuth2Scopes(
+				baseURL = "http://www.able.com:8080",
+				resourceCheckList = "Liferay.Headless.Portal.Instances.everything,Liferay.Object.Admin.REST.everything");
+		}
+
+		task ("And Given objectDefinition Test with site scope and new field name is created and published in default instance") {
+			ObjectDefinitionAPI.createAndPublishObjectDefinition(
+				en_US_label = "Test",
+				en_US_plural_label = "Tests",
+				name = "Test",
+				requiredStringFieldName = "name",
+				scope = "site",
+				token = ${defaultInstanceToken});
+		}
+
+		task ("And Given objectDefinition University with default company scope and new field location is created and published in www.able.com") {
+			ObjectDefinitionAPI.createAndPublishObjectDefinition(
+				en_US_label = "Test",
+				en_US_plural_label = "Tests",
+				name = "Test",
+				requiredStringFieldName = "location",
+				token = ${virtualInstanceToken},
+				virtualHost = "www.able.com");
+		}
+	}
+
+	tearDown {
+		var defaultInstanceToken = OAuth2ForObject.createTokenWithOAuth2Scopes(
+			resourceCheckList = "Liferay.Headless.Portal.Instances.everything,Liferay.Object.Admin.REST.everything",
+			resourcePanels = "Liferay.Headless.Portal.Instances,Liferay.Object.Admin.REST");
+
+		ObjectAdmin.deleteObjectViaAPI(
+			objectName = "Test",
+			token = ${defaultInstanceToken});
+
+		OAuth2.deleteApplication(applicationName = "OAuth Application");
+
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if (${testPortalInstance} == "true") {
+			PortalInstances.tearDownCP();
+		}
+	}
+
+	@priority = 4
+	test CanCreateObjectEntryByScopeKey {
+		property portal.acceptance = "true";
+
+		task ("When I use postScopeScopeKey and scopeKey to create an object entry in default instance") {
+			var defaultInstanceToken = OAuth2ForObject.createTokenWithOAuth2Scopes(
+				resourceCheckList = "C_Test.everything",
+				resourcePanels = "C_Test");
+
+			ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "tests",
+				name = "Object Entry in Default Instance",
+				scopeKey = "true",
+				token = ${defaultInstanceToken});
+		}
+
+		task ("Then the object entry created successfully") {
+			var responseToParse = ObjectDefinitionAPI.getObjectEntries(
+				en_US_plural_label = "tests",
+				token = ${defaultInstanceToken});
+
+			var actualValue = JSONUtil.getWithJSONPath(${responseToParse}, "$.totalCount");
+
+			TestUtils.assertEquals(
+				actual = ${actualValue},
+				expected = 1);
+		}
+	}
+
+	@priority = 4
+	test CanCreateObjectEntryInVirtualInstance {
+		property portal.acceptance = "true";
+
+		task ("When I use postTest to create an object entry in www.able.com instance") {
+			var virtualInstanceToken = OAuth2ForObject.createTokenWithOAuth2Scopes(
+				baseURL = "http://www.able.com:8080",
+				resourceCheckList = "C_Test.everything");
+
+			ObjectDefinitionAPI.createObjectEntryWithField(
+				en_US_plural_label = "tests",
+				fieldName = "location",
+				fieldValue = "Object Entry in Virtual Instance",
+				token = ${virtualInstanceToken},
+				virtualHost = "www.able.com");
+		}
+
+		task ("Then the object entry with location created successfully") {
+			var responseToParse = ObjectDefinitionAPI.getObjectEntries(
+				en_US_plural_label = "tests",
+				token = ${virtualInstanceToken},
+				virtualHost = "www.able.com");
+
+			var actualValue = JSONUtil.getWithJSONPath(${responseToParse}, "$.items[*].location");
+
+			TestUtils.assertEquals(
+				actual = ${actualValue},
+				expected = "Object Entry in Virtual Instance");
+		}
+	}
+
+	@priority = 4
+	test CanIncludeObjectFieldInAPIExplorer {
+		property portal.acceptance = "true";
+
+		task ("Given navigate to www.able.com:8080/o/c/tests") {
+			APIExplorer.navigateToOpenAPI(
+				api = "c",
+				version = "tests",
+				virtualHost = "www.able.com");
+		}
+
+		task ("When expand postTest") {
+			Click(
+				locator1 = "OpenAPI#API_METHOD",
+				method = "postTest",
+				service = "Test");
+		}
+
+		task ("Then location field exists and name does not exist in postTest body") {
+			AssertTextEquals.assertPartialText(
+				locator1 = "OpenAPI#REQUEST_BODY",
+				method = "postTest",
+				value1 = "\"location\":");
+		}
+
+		task ("And Then location field exists and name does not exist in Test schema") {
+			IsTextNotEqual(
+				locator1 = "OpenAPI#REQUEST_BODY",
+				method = "postTest",
+				value1 = "\"name\":");
+		}
+	}
+
+}

--- a/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
@@ -816,6 +816,7 @@ definition {
 	macro deleteObjectViaAPI {
 		JSONObject.deleteObject(
 			objectName = ${objectName},
+			token = ${token},
 			userEmailAddress = ${userEmailAddress},
 			userPassword = ${userPassword});
 	}

--- a/modules/apps/object/object-test/src/testFunctional/macros/json/JSONObject.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/json/JSONObject.macro
@@ -460,6 +460,7 @@ definition {
 
 		var objectId = JSONObject.getObjectId(
 			objectName = ${objectName},
+			token = ${token},
 			userEmailAddress = ${userEmailAddress},
 			userPassword = ${userPassword});
 
@@ -475,6 +476,10 @@ definition {
 			${portalURL}/o/object-admin/v1.0/object-definitions/${objectId} \
 				-u ${userEmailAddress}:${userPassword}
 		''';
+
+		if (isSet(token)) {
+			var curl = StringUtil.add(${curl}, " -H 'Authorization: Bearer ${token}'", "");
+		}
 
 		JSONCurlUtil.delete(${curl});
 	}
@@ -654,6 +659,10 @@ definition {
 			${portalURL}/o/object-admin/v1.0/object-definitions \
 				-u ${userEmailAddress}:${userPassword}
 		''';
+
+		if (isSet(token)) {
+			var curl = StringUtil.add(${curl}, " -H 'Authorization: Bearer ${token}'", "");
+		}
 
 		var objectId = JSONCurlUtil.get(${curl}, "$.items[?(@['name'] == '${objectName}')]['id']");
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/OAuth2.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/OAuth2.macro
@@ -361,8 +361,10 @@ definition {
 				Navigator.gotoNavUnderline(navUnderline = "Resource scopes");
 			}
 
-			for (var resourcePanel : list ${resourcePanels}) {
-				OAuth2.expandResourcePanel(resourcePanel = ${resourcePanel});
+			if (isSet(resourcePanels) && (${resourcePanels} != "")) {
+				for (var resourcePanel : list ${resourcePanels}) {
+					OAuth2.expandResourcePanel(resourcePanel = ${resourcePanel});
+				}
 			}
 
 			if (isSet(checkGlobalScopesViaModal)) {
@@ -439,7 +441,9 @@ definition {
 	}
 
 	macro getAccessToken {
-		var portalURL = PropsUtil.get("portal.url");
+		if (!(isSet(portalURL))) {
+			var portalURL = PropsUtil.get("portal.url");
+		}
 
 		if (${grantFlow} == "clientCredentials") {
 			var tokenCurl = '''

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/portalinstance/HeadlessPortalInstanceAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/portalinstance/HeadlessPortalInstanceAPI.macro
@@ -56,6 +56,10 @@ definition {
 				-H Content-Type: application/json
 		''';
 
+		if (isSet(token)) {
+			var curl = StringUtil.add(${curl}, " -H 'Authorization: Bearer ${token}'", "");
+		}
+
 		JSONCurlUtil.post(${curl});
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/oauth2/OAuth2.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/oauth2/OAuth2.path
@@ -115,7 +115,7 @@
 </tr>
 <tr>
 	<td>ADMIN_RESOURCE_SCOPE_CHECKBOX</td>
-	<td>//input[contains(@value,'${key_scopeName}')]</td>
+	<td>//input[@value='${key_scopeName}']</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
**Background:**
- set include-and-override=portal-liferay-online.properties in portal-ext.properties
- Given an OAuth application with headless scopes is created on default instance
- And Given a new virtual instances www.able.com is created
- And Given an OAuth application with headless scopes is created on www.able.com
- And Given objectDefinition University with site scope and new field name is created and published in default instance
- And Given objectDefinition University with default company scope and new field location is created and published in www.able.com

**Test Plan:**
- When I use postScopeScopeKey and scopeKey to create an object entry in default instance
Then the object entry created successfully 
- When I use postTest to create an object entry in www.able.com instance
Then the object entry with location created successfully
- When navigate to www.able.com:8080/o/c/tests
Then location field exists and name doesn't exist in postTest body
And Then location field exists and name doesn't exist in Test schema

**Ticket:**
- https://issues.liferay.com/browse/LPS-171717