### PR TITLE
Lps 175093 | Improve tests on using private methods and reduce some test codes

### DIFF
--- a/modules/apps/batch-engine/batch-engine-test/src/testFunctional/tests/AutoDeployMultipleEntriesZipFile.testcase
+++ b/modules/apps/batch-engine/batch-engine-test/src/testFunctional/tests/AutoDeployMultipleEntriesZipFile.testcase
@@ -102,9 +102,7 @@ definition {
 				actual = ${blogTotalCount},
 				expected = 2);
 
-			var objectStatus = ObjectDefinitionAPI.getObjectDefinitionStatusByName(
-				name = "TestObject",
-				objectDefinitionId = ${objectDefinitionId});
+			var objectStatus = ObjectDefinitionAPI.getObjectDefinitionStatusByName(name = "TestObject");
 
 			TestUtils.assertEquals(
 				actual = ${objectStatus},
@@ -133,12 +131,8 @@ definition {
 		}
 
 		task ("Then all object definitions are imported") {
-			var objectStatus1 = ObjectDefinitionAPI.getObjectDefinitionStatusByName(
-				name = "TestObject",
-				objectDefinitionId = ${objectDefinitionId1});
-			var objectStatus2 = ObjectDefinitionAPI.getObjectDefinitionStatusByName(
-				name = "Coupon",
-				objectDefinitionId = ${objectDefinitionId2});
+			var objectStatus1 = ObjectDefinitionAPI.getObjectDefinitionStatusByName(name = "TestObject");
+			var objectStatus2 = ObjectDefinitionAPI.getObjectDefinitionStatusByName(name = "Coupon");
 
 			TestUtils.assertEquals(
 				actual = ${objectStatus1},

--- a/modules/apps/batch-engine/batch-engine-test/src/testFunctional/tests/AutoDeployMultipleEntriesZipFile.testcase
+++ b/modules/apps/batch-engine/batch-engine-test/src/testFunctional/tests/AutoDeployMultipleEntriesZipFile.testcase
@@ -102,9 +102,9 @@ definition {
 				actual = ${blogTotalCount},
 				expected = 2);
 
-			var objectDefinitionId = ObjectDefinitionAPI.getObjectDefinitionIdByName(name = "TestObject");
-
-			var objectStatus = ObjectDefinitionAPI._getObjectDefinitionStatusById(objectDefinitionId = ${objectDefinitionId});
+			var objectStatus = ObjectDefinitionAPI.getObjectDefinitionStatusByName(
+				name = "TestObject",
+				objectDefinitionId = ${objectDefinitionId});
 
 			TestUtils.assertEquals(
 				actual = ${objectStatus},
@@ -133,10 +133,12 @@ definition {
 		}
 
 		task ("Then all object definitions are imported") {
-			var objectDefinitionId1 = ObjectDefinitionAPI.getObjectDefinitionIdByName(name = "TestObject");
-			var objectDefinitionId2 = ObjectDefinitionAPI.getObjectDefinitionIdByName(name = "Coupon");
-			var objectStatus1 = ObjectDefinitionAPI._getObjectDefinitionStatusById(objectDefinitionId = ${objectDefinitionId1});
-			var objectStatus2 = ObjectDefinitionAPI._getObjectDefinitionStatusById(objectDefinitionId = ${objectDefinitionId2});
+			var objectStatus1 = ObjectDefinitionAPI.getObjectDefinitionStatusByName(
+				name = "TestObject",
+				objectDefinitionId = ${objectDefinitionId1});
+			var objectStatus2 = ObjectDefinitionAPI.getObjectDefinitionStatusByName(
+				name = "Coupon",
+				objectDefinitionId = ${objectDefinitionId2});
 
 			TestUtils.assertEquals(
 				actual = ${objectStatus1},

--- a/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/ImportExport.testcase
+++ b/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/ImportExport.testcase
@@ -808,9 +808,9 @@ definition {
 		}
 
 		task ("And Then the status of the imported objectDefinition is approved") {
-			var objectDefinitionId = ObjectDefinitionAPI.getObjectDefinitionIdByName(name = "Coupon");
-
-			var objectDefinitionStatus = ObjectDefinitionAPI._getObjectDefinitionStatusById(objectDefinitionId = ${objectDefinitionId});
+			var objectStatus2 = ObjectDefinitionAPI.getObjectDefinitionStatusByName(
+				name = "Coupon",
+				objectDefinitionId = ${objectDefinitionId});
 
 			TestUtils.assertEquals(
 				actual = ${objectDefinitionStatus},
@@ -851,9 +851,9 @@ definition {
 		}
 
 		task ("And Then the status of the imported objectDefinition is Draft") {
-			var objectDefinitionId = ObjectDefinitionAPI.getObjectDefinitionIdByName(name = "Coupon");
-
-			var objectDefinitionStatus = ObjectDefinitionAPI._getObjectDefinitionStatusById(objectDefinitionId = ${objectDefinitionId});
+			var objectStatus2 = ObjectDefinitionAPI.getObjectDefinitionStatusByName(
+				name = "Coupon",
+				objectDefinitionId = ${objectDefinitionId});
 
 			TestUtils.assertEquals(
 				actual = ${objectDefinitionStatus},

--- a/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/ImportExport.testcase
+++ b/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/ImportExport.testcase
@@ -808,9 +808,7 @@ definition {
 		}
 
 		task ("And Then the status of the imported objectDefinition is approved") {
-			var objectDefinitionStatus = ObjectDefinitionAPI.getObjectDefinitionStatusByName(
-				name = "Coupon",
-				objectDefinitionId = ${objectDefinitionId});
+			var objectDefinitionStatus = ObjectDefinitionAPI.getObjectDefinitionStatusByName(name = "Coupon");
 
 			TestUtils.assertEquals(
 				actual = ${objectDefinitionStatus},
@@ -851,9 +849,7 @@ definition {
 		}
 
 		task ("And Then the status of the imported objectDefinition is Draft") {
-			var objectDefinitionStatus = ObjectDefinitionAPI.getObjectDefinitionStatusByName(
-				name = "Coupon",
-				objectDefinitionId = ${objectDefinitionId});
+			var objectDefinitionStatus = ObjectDefinitionAPI.getObjectDefinitionStatusByName(name = "Coupon");
 
 			TestUtils.assertEquals(
 				actual = ${objectDefinitionStatus},

--- a/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/ImportExport.testcase
+++ b/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/ImportExport.testcase
@@ -808,7 +808,7 @@ definition {
 		}
 
 		task ("And Then the status of the imported objectDefinition is approved") {
-			var objectStatus2 = ObjectDefinitionAPI.getObjectDefinitionStatusByName(
+			var objectDefinitionStatus = ObjectDefinitionAPI.getObjectDefinitionStatusByName(
 				name = "Coupon",
 				objectDefinitionId = ${objectDefinitionId});
 
@@ -851,7 +851,7 @@ definition {
 		}
 
 		task ("And Then the status of the imported objectDefinition is Draft") {
-			var objectStatus2 = ObjectDefinitionAPI.getObjectDefinitionStatusByName(
+			var objectDefinitionStatus = ObjectDefinitionAPI.getObjectDefinitionStatusByName(
 				name = "Coupon",
 				objectDefinitionId = ${objectDefinitionId});
 

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testFunctional/tests/ExposeStructuredContentFolderIdInHeadlessAdminContent.testcase
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testFunctional/tests/ExposeStructuredContentFolderIdInHeadlessAdminContent.testcase
@@ -14,9 +14,7 @@ definition {
 		task ("Given a content structure is created in an asset library") {
 			JSONDepot.addDepot(depotName = "Test Depot Name");
 
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-
-			WebContentNavigator.openWebContentStructuresAdminInAssetLibrary(depotId = ${assetLibraryId});
+			WebContentNavigator.openWebContentStructuresAdmin(depotName = "Test Depot Name");
 
 			WebContentStructures.addCP(structureName = "content-structure");
 
@@ -29,7 +27,7 @@ definition {
 
 		task ("And Given a structured content folder is created with POST request in the asset library") {
 			HeadlessWebcontentFolderAPI.createStructuredContentFolderInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				name = "Test Folder",
 				setUpGlobalFolderId = "true");
 		}
@@ -117,10 +115,8 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("And Given another structured content folder is created with POST request in the asset library") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-
 			var response = HeadlessWebcontentFolderAPI.createStructuredContentFolderInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				name = "Second Folder");
 
 			var idOfSecondStructuredContentFolder = JSONPathUtil.getIdValue(response = ${response});
@@ -140,9 +136,9 @@ definition {
 		}
 
 		task ("And Given the structured content is moved into another folder through UI") {
-			Navigator.openWithAppendToBaseURL(
-				baseURL = ${baseURL},
-				urlAppend = "group/asset-library-${assetLibraryId}/~/control_panel/manage?p_p_id=com_liferay_journal_web_portlet_JournalPortlet&_com_liferay_journal_web_portlet_JournalPortlet_folderId=${staticStructuredContentFolderId}");
+			WebContentNavigator.openFolderInWebContentAdmin(
+				depotName = "Test Depot Name",
+				folderId = ${staticStructuredContentFolderId});
 
 			WebContent.moveToFolderCP(
 				folderName = "Second Folder",

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testFunctional/tests/HeadlessAdminContentSupprotDifferentParameters.testcase
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testFunctional/tests/HeadlessAdminContentSupprotDifferentParameters.testcase
@@ -82,14 +82,13 @@ definition {
 
 		task ("Given a web content created") {
 			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
-			var siteId = JSONGroupAPI._getSiteIdByGroupKey(groupName = "Test Site Name");
 
 			var responseFromCreate = HeadlessWebcontentAPI.createStructuredContent(
 				data = "<p>My content</p>",
 				ddmStructureId = ${ddmStructureId},
+				groupName = "Test Site Name",
 				label = "Text",
 				name = "Text",
-				siteId = ${siteId},
 				title = "WC WebContent Title");
 		}
 
@@ -163,14 +162,13 @@ definition {
 
 		task ("Given a web content created") {
 			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
-			var siteId = JSONGroupAPI._getSiteIdByGroupKey(groupName = "Test Site Name");
 
 			var responseFromCreate = HeadlessWebcontentAPI.createStructuredContent(
 				data = "<p>My content</p>",
 				ddmStructureId = ${ddmStructureId},
+				groupName = "Test Site Name",
 				label = "Text",
 				name = "Text",
-				siteId = ${siteId},
 				title = "WC WebContent Title");
 		}
 
@@ -214,14 +212,13 @@ definition {
 
 		task ("And Given web content created") {
 			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
-			var siteId = JSONGroupAPI._getSiteIdByGroupKey(groupName = "Test Site Name");
 
 			var responseFromCreate = HeadlessWebcontentAPI.createStructuredContent(
 				data = "<p>My content</p>",
 				ddmStructureId = ${ddmStructureId},
+				groupName = "Test Site Name",
 				label = "Text",
 				name = "Text",
-				siteId = ${siteId},
 				title = "WC WebContent Title");
 		}
 
@@ -264,14 +261,13 @@ definition {
 
 		task ("And Given web content created") {
 			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
-			var siteId = JSONGroupAPI._getSiteIdByGroupKey(groupName = "Test Site Name");
 
 			var responseFromCreate = HeadlessWebcontentAPI.createStructuredContent(
 				data = "<p>My content</p>",
 				ddmStructureId = ${ddmStructureId},
+				groupName = "Test Site Name",
 				label = "Text",
 				name = "Text",
-				siteId = ${siteId},
 				title = "WC WebContent Title");
 		}
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testFunctional/macros/TaxonomyCategoryAPI.macro
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testFunctional/macros/TaxonomyCategoryAPI.macro
@@ -95,6 +95,7 @@ definition {
 
 		var response = TaxonomyVocabularyAPI.createTaxonomyVocabulary(
 			assetLibraryId = ${assetLibraryId},
+			groupName = "Guest",
 			name = "Vocabulary Name");
 
 		static var responseOfCreated = ${response};

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testFunctional/macros/TaxonomyVocabularyAPI.macro
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testFunctional/macros/TaxonomyVocabularyAPI.macro
@@ -102,7 +102,9 @@ definition {
 				var method = "POST";
 
 				if (isSet(depotName)) {
-					var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = ${depotName});
+					var assetLibraryId = JSONGroupAPI._getDepotIdByName(
+						depotName = ${depotName},
+						noSelenium = "true");
 
 					var href = "${portalURL}/o/headless-admin-taxonomy/v1.0/asset-libraries/${assetLibraryId}/taxonomy-vocabularies/batch";
 				}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testFunctional/macros/TaxonomyVocabularyAPI.macro
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testFunctional/macros/TaxonomyVocabularyAPI.macro
@@ -3,7 +3,9 @@ definition {
 	macro _curlTaxonomyKeywords {
 		var portalURL = JSONCompany.getPortalURL();
 
-		if (isSet(assetLibraryId)) {
+		if (isSet(depotName)) {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = ${depotName});
+
 			var api = "asset-libraries/${assetLibraryId}/keywords";
 		}
 		else if (isSet(keywordId)) {
@@ -31,7 +33,11 @@ definition {
 	macro _curlTaxonomyVocabulary {
 		var portalURL = JSONCompany.getPortalURL();
 
-		if (isSet(assetLibraryId)) {
+		if (isSet(depotName)) {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(
+				depotName = ${depotName},
+				noSelenium = "true");
+
 			var api = "asset-libraries/${assetLibraryId}/taxonomy-vocabularies";
 		}
 		else {
@@ -95,7 +101,9 @@ definition {
 			else {
 				var method = "POST";
 
-				if (isSet(assetLibraryId)) {
+				if (isSet(depotName)) {
+					var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = ${depotName});
+
 					var href = "${portalURL}/o/headless-admin-taxonomy/v1.0/asset-libraries/${assetLibraryId}/taxonomy-vocabularies/batch";
 				}
 				else {
@@ -119,7 +127,7 @@ definition {
 		Variables.assertDefined(parameterList = ${expectedTotalCount});
 
 		var response = TaxonomyVocabularyAPI.filterTaxonomyVocabulary(
-			assetLibraryId = ${assetLibraryId},
+			depotName = ${depotName},
 			filterValue = ${filterValue});
 
 		var actualTotalCount = TaxonomyVocabularyAPI.getElementOfCreatedVocabulary(
@@ -140,9 +148,9 @@ definition {
 	}
 
 	macro createAssetLibraryWithKeyWords {
-		Variables.assertDefined(parameterList = "${assetLibraryId},${name}");
+		Variables.assertDefined(parameterList = "${depotName},${name}");
 
-		var curl = TaxonomyVocabularyAPI._curlTaxonomyKeywords(assetLibraryId = ${assetLibraryId});
+		var curl = TaxonomyVocabularyAPI._curlTaxonomyKeywords(depotName = ${depotName});
 		var body = '''-d {"name": "${name}"}''';
 
 		var curl = StringUtil.add(${curl}, ${body}, " ");
@@ -160,7 +168,7 @@ definition {
 		}
 
 		var curl = TaxonomyVocabularyAPI._curlTaxonomyVocabulary(
-			assetLibraryId = ${assetLibraryId},
+			depotName = ${depotName},
 			groupName = ${groupName});
 		var body = '''-d {
 				"name": "${name}",
@@ -178,7 +186,7 @@ definition {
 		Variables.assertDefined(parameterList = ${externalReferenceCode});
 
 		var curl = TaxonomyVocabularyAPI._curlTaxonomyVocabulary(
-			assetLibraryId = ${assetLibraryId},
+			depotName = ${depotName},
 			externalReferenceCode = ${externalReferenceCode},
 			groupName = ${groupName});
 
@@ -189,7 +197,7 @@ definition {
 		Variables.assertDefined(parameterList = ${filterValue});
 
 		var curl = TaxonomyVocabularyAPI._curlTaxonomyVocabulary(
-			assetLibraryId = ${assetLibraryId},
+			depotName = ${depotName},
 			filterValue = ${filterValue},
 			groupName = ${groupName});
 
@@ -200,7 +208,7 @@ definition {
 
 	macro getAssetLibraryKeywordsWithDifferentParameters {
 		var curl = TaxonomyVocabularyAPI._curlTaxonomyKeywords(
-			assetLibraryId = ${assetLibraryId},
+			depotName = ${depotName},
 			keywordId = ${keywordId},
 			parameter = ${parameter},
 			parameterValue = ${parameterValue});
@@ -222,7 +230,7 @@ definition {
 		Variables.assertDefined(parameterList = ${externalReferenceCode});
 
 		var curl = TaxonomyVocabularyAPI._curlTaxonomyVocabulary(
-			assetLibraryId = ${assetLibraryId},
+			depotName = ${depotName},
 			externalReferenceCode = ${externalReferenceCode},
 			groupName = ${groupName});
 
@@ -233,7 +241,7 @@ definition {
 
 	macro getTaxonomyVocabularyWithDifferentParameters {
 		var curl = TaxonomyVocabularyAPI._curlTaxonomyVocabulary(
-			assetLibraryId = ${assetLibraryId},
+			depotName = ${depotName},
 			groupName = ${groupName},
 			parameter = ${parameter},
 			parameterValue = ${parameterValue});
@@ -253,7 +261,7 @@ definition {
 		}
 
 		var curl = TaxonomyVocabularyAPI._curlTaxonomyVocabulary(
-			assetLibraryId = ${assetLibraryId},
+			depotName = ${depotName},
 			externalReferenceCode = ${externalReferenceCode},
 			groupName = ${groupName});
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testFunctional/tests/ExposeBatchActionForHeadlessAdminTaxonomyAPI.testcase
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testFunctional/tests/ExposeBatchActionForHeadlessAdminTaxonomyAPI.testcase
@@ -24,18 +24,14 @@ definition {
 			JSONDepot.addDepot(depotName = "Test Depot Name");
 		}
 
-		task ("When with get request and siteId to retrieve taxonomy vocabularies") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(
-				depotName = "Test Depot Name",
-				noSelenium = "true");
-
-			var response = TaxonomyVocabularyAPI.getTaxonomyVocabularyWithDifferentParameters(assetLibraryId = ${assetLibraryId});
+		task ("When with get request and assetLibraryId to retrieve taxonomy vocabularies") {
+			var response = TaxonomyVocabularyAPI.getTaxonomyVocabularyWithDifferentParameters(depotName = "Test Depot Name");
 		}
 
 		task ("Then I can see details of updateBatch, createBatch and deleteBatch inside of action block in response") {
 			TaxonomyVocabularyAPI.assertProperBatchInActionBlock(
-				assetLibraryId = ${assetLibraryId},
 				batchActions = "createBatch,updateBatch,deleteBatch",
+				depotName = "Test Depot Name",
 				responseToParse = ${response});
 		}
 	}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testFunctional/tests/ExposeErcFromAssetLibrariesForVocabularies.testcase
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testFunctional/tests/ExposeErcFromAssetLibrariesForVocabularies.testcase
@@ -31,10 +31,8 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("When user makes a PUT request to create a vocabulary with assetLibraryId and a custom ERC") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-
 			var response = TaxonomyVocabularyAPI.updateTaxonomyVocabularyByErc(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				externalReferenceCodeInBody = "erc-in-body",
 				name = "Vocabulary Name");
@@ -54,10 +52,8 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("When user makes a PUT request to create a vocabulary with assetLibraryId and no ERC specified in the body") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-
 			var response = TaxonomyVocabularyAPI.updateTaxonomyVocabularyByErc(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "nonexistent-erc",
 				name = "Vocabulary Name");
 		}
@@ -76,23 +72,21 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given an existing vocabulary with ERC") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-
 			TaxonomyVocabularyAPI.createTaxonomyVocabulary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				name = "Vocabulary Name");
 		}
 
 		task ("When user makes a DELETE request to delete the vocabulary with ERC") {
 			TaxonomyVocabularyAPI.deleteTaxonomyVocabularyByErc(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc");
 		}
 
 		task ("Then the vocabulary is deleted") {
 			TaxonomyVocabularyAPI.assertProperVocabularyTotalCount(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				expectedTotalCount = 0,
 				filterValue = "name%20eq%20%27Vocabulary%20Name%27");
 		}
@@ -103,17 +97,15 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given an existing vocabulary with ERC") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-
 			TaxonomyVocabularyAPI.createTaxonomyVocabulary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				name = "Vocabulary Name");
 		}
 
 		task ("When user makes a GET request to retrieve the vocabulary with assetLibraryId and ERC") {
 			var response = TaxonomyVocabularyAPI.getTaxonomyVocabularyByErc(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc");
 		}
 
@@ -133,23 +125,21 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given an existing vocabulary with ERC") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-
 			TaxonomyVocabularyAPI.createTaxonomyVocabulary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				name = "Vocabulary Name");
 		}
 
 		task ("When user makes a DELETE request to delete the vocabulary with a nonexisting ERC") {
 			TaxonomyVocabularyAPI.deleteTaxonomyVocabularyByErc(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "nonexistent-erc");
 		}
 
 		task ("Then existing vocabularies are still present") {
 			TaxonomyVocabularyAPI.assertProperVocabularyTotalCount(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				expectedTotalCount = 1,
 				filterValue = "name%20eq%20%27Vocabulary%20Name%27");
 		}
@@ -160,10 +150,8 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("When user makes a GET request to retrieve the vocabulary with assetLibraryId and a nonexisting ERC") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-
 			var response = TaxonomyVocabularyAPI.getTaxonomyVocabularyByErc(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "nonexistent-erc");
 		}
 
@@ -179,17 +167,15 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given an existing vocabulary") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-
 			TaxonomyVocabularyAPI.createTaxonomyVocabulary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				name = "Vocabulary Name");
 		}
 
 		task ("When user makes a PUT request to update the vocabulary name with assetLibraryId and ERC") {
 			var response = TaxonomyVocabularyAPI.updateTaxonomyVocabularyByErc(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				name = "Update Vocabulary Name");
 		}
@@ -206,7 +192,7 @@ definition {
 
 		task ("And Then the previous vocabulary name is not present") {
 			TaxonomyVocabularyAPI.assertProperVocabularyTotalCount(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				expectedTotalCount = 0,
 				filterValue = "name%20eq%20%27Vocabulary%20Name%27");
 		}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testFunctional/tests/HeadlessAdminTaxonomySupportDifferentParameters.testcase
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testFunctional/tests/HeadlessAdminTaxonomySupportDifferentParameters.testcase
@@ -27,19 +27,17 @@ definition {
 	test CanReceiveABodyWithNameOnlyInResponse {
 		property portal.acceptance = "true";
 
-		task ("Given a AssetLibrary with keyword created") {
+		task ("Given an AssetLibrary with keyword created") {
 			JSONDepot.addDepot(depotName = "Test Depot Name");
 
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-
 			TaxonomyVocabularyAPI.createAssetLibraryWithKeyWords(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				name = "Liferay");
 		}
 
 		task ("When with curl I request getAssetLibraryKeywordsPage with fields=name") {
 			var response = TaxonomyVocabularyAPI.getAssetLibraryKeywordsWithDifferentParameters(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				parameter = "fields",
 				parameterValue = "name");
 
@@ -92,10 +90,8 @@ definition {
 		task ("Given a AssetLibrary with keyword created") {
 			JSONDepot.addDepot(depotName = "Test Depot Name");
 
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-
 			var responseFromCreate = TaxonomyVocabularyAPI.createAssetLibraryWithKeyWords(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				name = "liferay");
 		}
 
@@ -124,17 +120,15 @@ definition {
 		task ("Given a Taxonomy Vocabulary with assetLibrary") {
 			JSONDepot.addDepot(depotName = "Test Depot Name");
 
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-
 			TaxonomyVocabularyAPI.createTaxonomyVocabulary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				name = "Vocabulary Name");
 		}
 
 		task ("When with curl I request getAssetLibraryTaxonomyVocabulariesPage with restrictFields equal all fields except name field") {
 			var response = TaxonomyVocabularyAPI.getTaxonomyVocabularyWithDifferentParameters(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				parameter = "restrictFields",
 				parameterValue = "actions,assetLibraryKey,assetTypes,availableLanguages,creator,dateCreated,dateModified,description,externalReferenceCode,id,numberOfTaxonomyCategories");
 
@@ -155,10 +149,8 @@ definition {
 		task ("Given a AssetLibrary with keyword created") {
 			JSONDepot.addDepot(depotName = "Test Depot Name");
 
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-
 			var responseFromCreate = TaxonomyVocabularyAPI.createAssetLibraryWithKeyWords(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				name = "liferay");
 		}
 

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-test/src/testFunctional/tests/HeadlessDeliveryBatchMode.testcase
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-test/src/testFunctional/tests/HeadlessDeliveryBatchMode.testcase
@@ -434,9 +434,7 @@ definition {
 		task ("And Then the blog article body is updated") {
 			var response = BlogPostingAPI.getBlogPostings();
 
-			var blogPostingHeadline = BlogPostingAPI._getFieldValueOfExistingBlogPosting(
-				fieldName = "headline",
-				response = ${response});
+			var blogPostingHeadline = JSONUtil.getWithJSONPath(${response}, "$.items.[0].headline");
 
 			TestUtils.assertEquals(
 				actual = ${blogPostingHeadline},

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/ContentElementAPI.macro
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/ContentElementAPI.macro
@@ -1,9 +1,10 @@
 definition {
 
 	macro _getAssetLibraryContentElementsByDifferentParameters {
-		Variables.assertDefined(parameterList = "${assetLibraryId},${parameter}");
+		Variables.assertDefined(parameterList = "${depotName},${parameter},${fieldValue}");
 
 		var portalURL = JSONCompany.getPortalURL();
+		var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = ${depotName});
 
 		var curl = '''
 			${portalURL}/o/headless-delivery/v1.0/asset-libraries/${assetLibraryId}/content-elements?${parameter}=${fieldValue} \
@@ -26,7 +27,7 @@ definition {
 
 	macro getAssetLibraryContentElementsByDifferentParameters {
 		ContentElementAPI._getAssetLibraryContentElementsByDifferentParameters(
-			assetLibraryId = ${assetLibraryId},
+			depotName = ${depotName},
 			fieldValue = ${fieldValue},
 			parameter = ${parameter});
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/DocumentAPI.macro
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/DocumentAPI.macro
@@ -5,7 +5,9 @@ definition {
 
 		var portalURL = JSONCompany.getPortalURL();
 
-		if (isSet(assetLibraryId)) {
+		if (isSet(depotName)) {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = ${depotName});
+
 			var api = "asset-libraries/${assetLibraryId}/documents";
 		}
 		else {
@@ -34,7 +36,9 @@ definition {
 
 		var portalURL = JSONCompany.getPortalURL();
 
-		if (isSet(assetLibraryId)) {
+		if (isSet(depotName)) {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = ${depotName});
+
 			var api = "asset-libraries/${assetLibraryId}/documents/by-external-reference-code/${externalReferenceCode}";
 		}
 		else {
@@ -53,8 +57,9 @@ definition {
 	}
 
 	macro _filterDocumentInAssetLibrary {
-		Variables.assertDefined(parameterList = "${assetLibraryId},${filtervalue}");
+		Variables.assertDefined(parameterList = "${depotName},${filtervalue}");
 
+		var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = ${depotName});
 		var portalURL = JSONCompany.getPortalURL();
 
 		var curl = '''
@@ -92,9 +97,13 @@ definition {
 	}
 
 	macro _getDocumentsByErcInAssetLibrary {
-		Variables.assertDefined(parameterList = "${assetLibraryId},${externalReferenceCode}");
+		Variables.assertDefined(parameterList = ${externalReferenceCode});
 
 		var portalURL = JSONCompany.getPortalURL();
+
+		if (!(isSet(assetLibraryId))) {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = ${depotName});
+		}
 
 		var curl = '''
 			${portalURL}/o/headless-delivery/v1.0/asset-libraries/${assetLibraryId}/documents/by-external-reference-code/${externalReferenceCode} \
@@ -114,7 +123,9 @@ definition {
 			TestUtils.fail(message = "Please set at least one property to update the document.");
 		}
 
-		if (isSet(assetLibraryId)) {
+		if (isSet(depotName)) {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = ${depotName});
+
 			var api = "asset-libraries/${assetLibraryId}/documents/by-external-reference-code/${externalReferenceCode}";
 		}
 		else {
@@ -163,10 +174,10 @@ definition {
 	}
 
 	macro addDocumentInAssetLibraryByUploadFile {
-		Variables.assertDefined(parameterList = "${assetLibraryId},${filePath}");
+		Variables.assertDefined(parameterList = "${depotName},${filePath}");
 
 		var response = DocumentAPI._addDocument(
-			assetLibraryId = ${assetLibraryId},
+			depotName = ${depotName},
 			externalReferenceCode = ${externalReferenceCode},
 			filePath = ${filePath});
 
@@ -189,7 +200,7 @@ definition {
 		Variables.assertDefined(parameterList = ${expectedDocumentTotalCount});
 
 		var response = DocumentAPI._filterDocumentInAssetLibrary(
-			assetLibraryId = ${assetLibraryId},
+			depotName = ${depotName},
 			filtervalue = ${filtervalue});
 
 		var actualDocumentTotalCount = JSONUtil.getWithJSONPath(${response}, "$..['totalCount']");
@@ -200,7 +211,7 @@ definition {
 	}
 
 	macro deleteDocumentInAssetLibrary {
-		Variables.assertDefined(parameterList = ${assetLibraryId});
+		Variables.assertDefined(parameterList = ${depotName});
 
 		if (!(isSet(externalReferenceCode))) {
 			Variables.assertDefined(parameterList = ${responseToParse});
@@ -209,7 +220,7 @@ definition {
 		}
 
 		DocumentAPI._deleteDocumentsByErcInAssetLibrary(
-			assetLibraryId = ${assetLibraryId},
+			depotName = ${depotName},
 			externalReferenceCode = ${externalReferenceCode});
 	}
 
@@ -225,6 +236,7 @@ definition {
 	macro getDocumentsByErcInAssetLibrary {
 		var response = DocumentAPI._getDocumentsByErcInAssetLibrary(
 			assetLibraryId = ${assetLibraryId},
+			depotName = ${depotName},
 			externalReferenceCode = ${externalReferenceCode});
 
 		return ${response};
@@ -232,7 +244,7 @@ definition {
 
 	macro getIdOfCreatedDocument {
 		var response = DocumentAPI.addDocumentInAssetLibraryByUploadFile(
-			assetLibraryId = ${assetLibraryId},
+			depotName = ${depotName},
 			externalReferenceCode = ${externalReferenceCode},
 			filePath = ${filePath});
 
@@ -260,10 +272,10 @@ definition {
 	}
 
 	macro updateDocumentByErcInAssetLibrary {
-		Variables.assertDefined(parameterList = ${assetLibraryId});
+		Variables.assertDefined(parameterList = ${depotName});
 
 		var response = DocumentAPI._updateDocumentByErc(
-			assetLibraryId = ${assetLibraryId},
+			depotName = ${depotName},
 			externalReferenceCode = ${externalReferenceCode},
 			filePath = ${filePath},
 			title = ${title},

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/DocumentFolderAPI.macro
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/DocumentFolderAPI.macro
@@ -3,7 +3,11 @@ definition {
 	macro _curlDocumentFolders {
 		var portalURL = JSONCompany.getPortalURL();
 
-		if (isSet(assetLibraryId)) {
+		if (isSet(depotName)) {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(
+				depotName = ${depotName},
+				noSelenium = "true");
+
 			var api = "asset-libraries/${assetLibraryId}";
 		}
 		else {
@@ -40,7 +44,9 @@ definition {
 			else {
 				var actualHref = JSONUtil.getWithJSONPath(${responseToParse}, "$.actions.createBatch[?(@.method == 'POST')].href");
 
-				if (isSet(assetLibraryId)) {
+				if (isSet(depotName)) {
+					var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = ${depotName});
+
 					var expectedHref = "${portalURL}/o/headless-delivery/v1.0/asset-libraries/${assetLibraryId}/document-folders/batch";
 				}
 				else {
@@ -60,7 +66,7 @@ definition {
 
 	macro getDocumentFolders {
 		var curl = DocumentFolderAPI._curlDocumentFolders(
-			assetLibraryId = ${assetLibraryId},
+			depotName = ${depotName},
 			groupName = ${groupName});
 
 		var response = JSONCurlUtil.get(${curl});

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/DocumentFolderAPI.macro
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/DocumentFolderAPI.macro
@@ -45,7 +45,9 @@ definition {
 				var actualHref = JSONUtil.getWithJSONPath(${responseToParse}, "$.actions.createBatch[?(@.method == 'POST')].href");
 
 				if (isSet(depotName)) {
-					var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = ${depotName});
+					var assetLibraryId = JSONGroupAPI._getDepotIdByName(
+						depotName = ${depotName},
+						noSelenium = "true");
 
 					var expectedHref = "${portalURL}/o/headless-delivery/v1.0/asset-libraries/${assetLibraryId}/document-folders/batch";
 				}

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/HeadlessWebcontentAPI.macro
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/HeadlessWebcontentAPI.macro
@@ -124,7 +124,9 @@ definition {
 		if (isSet(structuredContentFolderId)) {
 			var api = "structured-content-folders/${structuredContentFolderId}";
 		}
-		else if (isSet(assetLibraryId)) {
+		else if (isSet(depotName)) {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = ${depotName});
+
 			var api = "asset-libraries/${assetLibraryId}/";
 		}
 		else {
@@ -219,7 +221,9 @@ definition {
 
 		var portalURL = JSONCompany.getPortalURL();
 
-		if (isSet(assetLibraryId)) {
+		if (isSet(depotName)) {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = ${depotName});
+
 			var api = "asset-libraries/${assetLibraryId}/structured-contents/by-external-reference-code/${externalReferenceCode}";
 		}
 		else {
@@ -329,9 +333,10 @@ definition {
 	}
 
 	macro _filterStructuredContentInAssetLibrary {
-		Variables.assertDefined(parameterList = ${filtervalue});
+		Variables.assertDefined(parameterList = "${depotName},${filtervalue}");
 
 		var portalURL = JSONCompany.getPortalURL();
+		var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = ${depotName});
 
 		var curl = '''
 			${portalURL}/o/headless-delivery/v1.0/asset-libraries/${assetLibraryId}/structured-contents?filter=${filtervalue} \
@@ -345,9 +350,13 @@ definition {
 	}
 
 	macro _getStructuredContentsByErcInAssetLibrary {
-		Variables.assertDefined(parameterList = "${assetLibraryId},${externalReferenceCode}");
+		Variables.assertDefined(parameterList = ${externalReferenceCode});
 
 		var portalURL = JSONCompany.getPortalURL();
+
+		if (!(isSet(assetLibraryId))) {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = ${depotName});
+		}
 
 		var curl = '''
 			${portalURL}/o/headless-delivery/v1.0/asset-libraries/${assetLibraryId}/structured-contents/by-external-reference-code/${externalReferenceCode} \
@@ -414,9 +423,10 @@ definition {
 	}
 
 	macro _updateStructuredContentByErcInAssetLibrary {
-		Variables.assertDefined(parameterList = "${assetLibraryId},${externalReferenceCode},${data},${label},${name},${ddmStructureId},${title},${updateExternalReferenceCode}");
+		Variables.assertDefined(parameterList = "${depotName},${externalReferenceCode},${data},${label},${name},${ddmStructureId},${title},${updateExternalReferenceCode}");
 
 		var portalURL = JSONCompany.getPortalURL();
+		var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = ${depotName});
 
 		var curl = '''
 			${portalURL}/o/headless-delivery/v1.0/asset-libraries/${assetLibraryId}/structured-contents/by-external-reference-code/${externalReferenceCode} \
@@ -532,10 +542,16 @@ definition {
 	}
 
 	macro createStructuredContent {
+		if (!(isSet(groupName))) {
+			var groupName = "Guest";
+		}
+
+		var siteId = JSONGroupAPI._getSiteIdByGroupKey(groupName = ${groupName});
+
 		var response = HeadlessWebcontentAPI._createStructuredContent(
-			assetLibraryId = ${assetLibraryId},
 			data = ${data},
 			ddmStructureId = ${ddmStructureId},
+			depotName = ${depotName},
 			externalReferenceCode = ${externalReferenceCode},
 			label = ${label},
 			name = ${name},
@@ -578,10 +594,10 @@ definition {
 	}
 
 	macro deleteStructuredContentInAssetLibrary {
-		Variables.assertDefined(parameterList = "${assetLibraryId},${externalReferenceCode}");
+		Variables.assertDefined(parameterList = "${depotName},${externalReferenceCode}");
 
 		HeadlessWebcontentAPI._deleteStructuredContentByExternalReferenceCode(
-			assetLibraryId = ${assetLibraryId},
+			depotName = ${depotName},
 			externalReferenceCode = ${externalReferenceCode});
 	}
 
@@ -628,7 +644,7 @@ definition {
 
 	macro filterStructuredContentInAssetLibrary {
 		var response = HeadlessWebcontentAPI._filterStructuredContentInAssetLibrary(
-			assetLibraryId = ${assetLibraryId},
+			depotName = ${depotName},
 			filtervalue = ${filtervalue});
 
 		return ${response};
@@ -645,10 +661,9 @@ definition {
 	}
 
 	macro getStructuredContentsByErcInAssetLibrary {
-		Variables.assertDefined(parameterList = "${assetLibraryId},${externalReferenceCode}");
-
 		var response = HeadlessWebcontentAPI._getStructuredContentsByErcInAssetLibrary(
 			assetLibraryId = ${assetLibraryId},
+			depotName = ${depotName},
 			externalReferenceCode = ${externalReferenceCode});
 
 		return ${response};
@@ -719,16 +734,14 @@ definition {
 	}
 
 	macro updateStructuredContentByErcInAssetLibrary {
-		Variables.assertDefined(parameterList = "${assetLibraryId},${externalReferenceCode},${data},${label},${name},${ddmStructureId},${title}");
-
 		if (!(isSet(updateExternalReferenceCode))) {
 			var updateExternalReferenceCode = "";
 		}
 
 		var response = HeadlessWebcontentAPI._updateStructuredContentByErcInAssetLibrary(
-			assetLibraryId = ${assetLibraryId},
 			data = ${data},
 			ddmStructureId = ${ddmStructureId},
+			depotName = ${depotName},
 			externalReferenceCode = ${externalReferenceCode},
 			label = ${label},
 			name = ${name},

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/HeadlessWebcontentFolderAPI.macro
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/HeadlessWebcontentFolderAPI.macro
@@ -50,7 +50,9 @@ definition {
 			var externalReferenceCode = "";
 		}
 
-		if (isSet(assetLibraryId)) {
+		if (isSet(depotName)) {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = ${depotName});
+
 			var api = "asset-libraries/${assetLibraryId}/structured-content-folders";
 		}
 		else {
@@ -100,7 +102,9 @@ definition {
 
 		var portalURL = JSONCompany.getPortalURL();
 
-		if (isSet(assetLibraryId)) {
+		if (isSet(depotName)) {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = ${depotName});
+
 			var api = "asset-libraries/${assetLibraryId}/structured-content-folders/by-external-reference-code/${externalReferenceCode}";
 		}
 		else {
@@ -121,7 +125,9 @@ definition {
 	macro _filterStructuredContentFolders {
 		Variables.assertDefined(parameterList = ${filterValue});
 
-		if (isSet(assetLibraryId)) {
+		if (isSet(depotName)) {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = ${depotName});
+
 			var api = "asset-libraries/${assetLibraryId}/structured-content-folders";
 		}
 		else {
@@ -174,9 +180,13 @@ definition {
 	}
 
 	macro _getStructuredContentFoldersByErcInAssetLibrary {
-		Variables.assertDefined(parameterList = "${assetLibraryId},${externalReferenceCode}");
+		Variables.assertDefined(parameterList = ${externalReferenceCode});
 
 		var portalURL = JSONCompany.getPortalURL();
+
+		if (!(isSet(assetLibraryId))) {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = ${depotName});
+		}
 
 		var curl = '''
 			${portalURL}/o/headless-delivery/v1.0/asset-libraries/${assetLibraryId}/structured-content-folders/by-external-reference-code/${externalReferenceCode} \
@@ -191,6 +201,8 @@ definition {
 
 	macro _getStructuredContentFoldersWithDifferentParameters {
 		var portalURL = JSONCompany.getPortalURL();
+		var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = ${depotName});
+
 		var api = "asset-libraries/${assetLibraryId}/structured-content-folders";
 
 		if (isSet(parameter)) {
@@ -227,7 +239,9 @@ definition {
 
 		var portalURL = JSONCompany.getPortalURL();
 
-		if (isSet(assetLibraryId)) {
+		if (isSet(depotName)) {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = ${depotName});
+
 			var api = "asset-libraries/${assetLibraryId}/structured-content-folders/by-external-reference-code/${externalReferenceCode}";
 		}
 		else {
@@ -264,10 +278,10 @@ definition {
 	}
 
 	macro assertProperTotalCountOfStructuredContentFoldersInAssetLibrary {
-		Variables.assertDefined(parameterList = "${assetLibraryId},${expectedStructuredContentFolderTotalCount}");
+		Variables.assertDefined(parameterList = "${depotName},${expectedStructuredContentFolderTotalCount}");
 
 		var response = HeadlessWebcontentFolderAPI._filterStructuredContentFolders(
-			assetLibraryId = ${assetLibraryId},
+			depotName = ${depotName},
 			filterValue = ${filterValue});
 
 		var actualTotalCount = JSONUtil.getWithJSONPath(${response}, "$..['totalCount']");
@@ -341,10 +355,10 @@ definition {
 	}
 
 	macro createStructuredContentFolderInAssetLibrary {
-		Variables.assertDefined(parameterList = "${assetLibraryId},${name}");
+		Variables.assertDefined(parameterList = "${depotName},${name}");
 
 		var response = HeadlessWebcontentFolderAPI._addWebcontentFolder(
-			assetLibraryId = ${assetLibraryId},
+			depotName = ${depotName},
 			description = ${description},
 			externalReferenceCode = ${externalReferenceCode},
 			name = ${name},
@@ -394,10 +408,10 @@ definition {
 	}
 
 	macro deleteStructuredContentFolderByErcInAssetLibrary {
-		Variables.assertDefined(parameterList = ${assetLibraryId});
+		Variables.assertDefined(parameterList = ${depotName});
 
 		HeadlessWebcontentFolderAPI._deleteStructuredContentFolderByErc(
-			assetLibraryId = ${assetLibraryId},
+			depotName = ${depotName},
 			externalReferenceCode = ${externalReferenceCode});
 	}
 
@@ -432,20 +446,21 @@ definition {
 	}
 
 	macro getStructuredContentFoldersByErcInAssetLibrary {
-		Variables.assertDefined(parameterList = "${assetLibraryId},${externalReferenceCode}");
+		Variables.assertDefined(parameterList = ${externalReferenceCode});
 
 		var response = HeadlessWebcontentFolderAPI._getStructuredContentFoldersByErcInAssetLibrary(
 			assetLibraryId = ${assetLibraryId},
+			depotName = ${depotName},
 			externalReferenceCode = ${externalReferenceCode});
 
 		return ${response};
 	}
 
 	macro getStructuredContentFoldersWithDifferentParameters {
-		Variables.assertDefined(parameterList = ${assetLibraryId});
+		Variables.assertDefined(parameterList = ${depotName});
 
 		var response = HeadlessWebcontentFolderAPI._getStructuredContentFoldersWithDifferentParameters(
-			assetLibraryId = ${assetLibraryId},
+			depotName = ${depotName},
 			parameter = ${parameter},
 			parameterValue = ${parameterValue});
 
@@ -463,10 +478,10 @@ definition {
 	}
 
 	macro updateStructureContentFolderByErcInAssetLibrary {
-		Variables.assertDefined(parameterList = ${assetLibraryId});
+		Variables.assertDefined(parameterList = ${depotName});
 
 		var response = HeadlessWebcontentFolderAPI._updateStructureContentFolderByErc(
-			assetLibraryId = ${assetLibraryId},
+			depotName = ${depotName},
 			externalReferenceCode = ${externalReferenceCode},
 			externalReferenceCodeInBody = ${externalReferenceCodeInBody},
 			name = ${name});

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/LanguageAPI.macro
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/LanguageAPI.macro
@@ -3,7 +3,9 @@ definition {
 	macro _getLanguages {
 		var portalURL = JSONCompany.getPortalURL();
 
-		if (isSet(assetLibraryId)) {
+		if (isSet(depotName)) {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = ${depotName});
+
 			var api = "asset-libraries/${assetLibraryId}";
 		}
 		else {
@@ -22,13 +24,17 @@ definition {
 	}
 
 	macro getAssetLibraryLanguages {
-		Variables.assertDefined(parameterList = ${assetLibraryId});
+		Variables.assertDefined(parameterList = ${depotName});
 
-		LanguageAPI._getLanguages(assetLibraryId = ${assetLibraryId});
+		LanguageAPI._getLanguages(depotName = ${depotName});
 	}
 
 	macro getSiteLanguages {
-		Variables.assertDefined(parameterList = ${siteId});
+		Variables.assertDefined(parameterList = ${groupName});
+
+		var siteId = JSONGroupAPI._getGroupIdByNameNoSelenium(
+			groupName = ${groupName},
+			site = "true");
 
 		LanguageAPI._getLanguages(siteId = ${siteId});
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/NavigationMenuAPI.macro
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/NavigationMenuAPI.macro
@@ -24,7 +24,7 @@ definition {
 
 		NavigationMenuAPI._assertResponseIncludeCorrectElement(
 			element = "contentURL",
-			expectedElement = ${expectedURL},
+			expectedElement = ${expectedContentURL},
 			responseFromSite = ${responseFromSite},
 			responseToParse = ${responseToParse});
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/NavigationMenuAPI.macro
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/NavigationMenuAPI.macro
@@ -18,6 +18,10 @@ definition {
 	macro assertResponseHasCorrectInformations {
 		Variables.assertDefined(parameterList = "${expectedURL},${expectedType},${expectedUseCustomName},${responseToParse}");
 
+		var portalURL = JSONCompany.getPortalURL();
+
+		var expectedContentURL = "${portalURL}/${expectedURL}";
+
 		NavigationMenuAPI._assertResponseIncludeCorrectElement(
 			element = "contentURL",
 			expectedElement = ${expectedURL},
@@ -44,6 +48,10 @@ definition {
 			var api = "navigation-menus/${navigationMenuId}";
 		}
 		else {
+			var siteId = JSONGroupAPI._getGroupIdByNameNoSelenium(
+				groupName = ${groupName},
+				site = "true");
+
 			var api = "sites/${siteId}/navigation-menus/";
 		}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeBatchActionForHeadlessDeliveryAPI.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeBatchActionForHeadlessDeliveryAPI.testcase
@@ -25,17 +25,13 @@ definition {
 		}
 
 		task ("When with get request and assetLibraryId to retrieve document folders") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(
-				depotName = "Test Depot Name",
-				noSelenium = "true");
-
-			var response = DocumentFolderAPI.getDocumentFolders(assetLibraryId = ${assetLibraryId});
+			var response = DocumentFolderAPI.getDocumentFolders(depotName = "Test Depot Name");
 		}
 
 		task ("Then I can see details of updateBatch, createBatch and deleteBatch inside of action block in response") {
 			DocumentFolderAPI.assertProperBatchInActionBlock(
-				assetLibraryId = ${assetLibraryId},
 				batchActions = "createBatch,updateBatch,deleteBatch",
+				depotName = "Test Depot Name",
 				responseToParse = ${response});
 		}
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcFromAssetLibraryForDocument.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcFromAssetLibraryForDocument.testcase
@@ -32,24 +32,23 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given a document with a custom erc is created with a POST request in asset library") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
 			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");
 
 			DocumentAPI.addDocumentInAssetLibraryByUploadFile(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				filePath = ${filePath});
 		}
 
 		task ("When I make a DELETE request by assetLibraryId and custom erc") {
 			DocumentAPI.deleteDocumentInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc");
 		}
 
 		task ("Then the document is correctly deleted") {
 			DocumentAPI.assertProperDocumentTotalCount(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				expectedDocumentTotalCount = 0,
 				filtervalue = "title%20eq%20%27Document_1.txt%27");
 		}
@@ -61,23 +60,22 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given a document without custom erc is created with a POST request in asset library") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
 			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");
 
 			var response = DocumentAPI.addDocumentInAssetLibraryByUploadFile(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				filePath = ${filePath});
 		}
 
 		task ("When I make a DELETE request by assetLibraryId and UUID as the erc") {
 			DocumentAPI.deleteDocumentInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				responseToParse = ${response});
 		}
 
 		task ("Then the document is correctly deleted") {
 			DocumentAPI.assertProperDocumentTotalCount(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				expectedDocumentTotalCount = 0,
 				filtervalue = "title%20eq%20%27Document_1.txt%27");
 		}
@@ -89,18 +87,17 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given a document with a custom erc is created with a POST request in asset library") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
 			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");
 
 			DocumentAPI.addDocumentInAssetLibraryByUploadFile(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				filePath = ${filePath});
 		}
 
 		task ("When I make a GET request by assetLibraryId and erc") {
 			var response = DocumentAPI.getDocumentsByErcInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc");
 		}
 
@@ -117,11 +114,10 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given a document without a custom erc is created with a POST request in asset library") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
 			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");
 
 			var response = DocumentAPI.addDocumentInAssetLibraryByUploadFile(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				filePath = ${filePath});
 		}
 
@@ -129,7 +125,7 @@ definition {
 			var documentUuid = DocumentAPI.getUuidOfCreatedDocument(responseToParse = ${response});
 
 			var response = DocumentAPI.getDocumentsByErcInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = ${documentUuid});
 		}
 
@@ -146,11 +142,10 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given a document with a custom erc is created with a POST request in asset library") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
 			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");
 
 			DocumentAPI.addDocumentInAssetLibraryByUploadFile(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				filePath = ${filePath});
 		}
@@ -159,7 +154,7 @@ definition {
 			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_2.txt");
 
 			var response = DocumentAPI.addDocumentInAssetLibraryByUploadFile(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				filePath = ${filePath});
 		}
@@ -172,7 +167,7 @@ definition {
 
 		task ("And Then another document with same erc is not being created") {
 			DocumentAPI.assertProperDocumentTotalCount(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				expectedDocumentTotalCount = 0,
 				filtervalue = "title%20eq%20%27Document_2.txt%27");
 		}
@@ -184,18 +179,17 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given a document with a custom erc is created in asset library with a POST request") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
 			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");
 
 			DocumentAPI.addDocumentInAssetLibraryByUploadFile(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				filePath = ${filePath});
 		}
 
 		task ("When I make a PUT request by assetLibraryId and erc with an erc modified in the body") {
 			var response = DocumentAPI.updateDocumentByErcInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				title = "title",
 				updateExternalReferenceCode = "update-erc");
@@ -209,7 +203,7 @@ definition {
 
 		task ("And Then another document with an erc being the modified value is not being created") {
 			DocumentAPI.assertProperDocumentTotalCount(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				expectedDocumentTotalCount = 1,
 				filtervalue = "title%20eq%20%27title%27");
 		}
@@ -243,10 +237,8 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("When I make a GET request by assetLibraryID and non-existent erc") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-
 			var response = DocumentAPI.getDocumentsByErcInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "nonexistent-erc");
 		}
 
@@ -263,18 +255,17 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given a document with a custom erc is created in asset library with a POST request") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
 			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");
 
 			DocumentAPI.addDocumentInAssetLibraryByUploadFile(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				filePath = ${filePath});
 		}
 
 		task ("When I make a PUT request by assetLibraryId and erc") {
 			var response = DocumentAPI.updateDocumentByErcInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				title = "updated title");
 		}
@@ -289,7 +280,7 @@ definition {
 
 		task ("And Then the document is correctly updated") {
 			DocumentAPI.assertProperDocumentTotalCount(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				expectedDocumentTotalCount = 1,
 				filtervalue = "title%20eq%20%27updated%20title%27");
 		}
@@ -301,24 +292,23 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given a document with a custom erc is created with a POST request in asset library") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
 			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");
 
 			var documentId = DocumentAPI.getIdOfCreatedDocument(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				filePath = ${filePath});
 		}
 
 		task ("When I make a DELETE request by assetLibraryId and use internal ID as erc") {
 			DocumentAPI.deleteDocumentInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = ${documentId});
 		}
 
 		task ("Then the document with a custom erc created earlier still exists") {
 			DocumentAPI.assertProperDocumentTotalCount(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				expectedDocumentTotalCount = 1,
 				filtervalue = "title%20eq%20%27Document_1.txt%27");
 		}
@@ -330,11 +320,10 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("When I make a PUT request by assetLibraryId and a non-existent erc") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
 			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");
 
 			var response = DocumentAPI.updateDocumentByErcInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "nonexistent-erc",
 				filePath = ${filePath});
 		}
@@ -347,7 +336,7 @@ definition {
 
 		task ("And Then a document is being created") {
 			DocumentAPI.assertProperDocumentTotalCount(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				expectedDocumentTotalCount = 1,
 				filtervalue = "title%20eq%20%27Document_1.txt%27");
 		}
@@ -359,11 +348,10 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given a document with a custom erc is created in asset library with a POST request") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
 			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");
 
 			DocumentAPI.addDocumentInAssetLibraryByUploadFile(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				filePath = ${filePath});
 		}
@@ -372,7 +360,7 @@ definition {
 			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_2.txt");
 
 			var response = DocumentAPI.updateDocumentByErcInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "nonexistent-erc",
 				filePath = ${filePath},
 				title = "Document_2.txt",
@@ -387,7 +375,7 @@ definition {
 
 		task ("And Then a document is being created") {
 			DocumentAPI.assertProperDocumentTotalCount(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				expectedDocumentTotalCount = 1,
 				filtervalue = "title%20eq%20%27Document_2.txt%27");
 		}
@@ -399,11 +387,10 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("When with POST request I create a new document with a custom erc in asset library") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
 			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");
 
 			var response = DocumentAPI.addDocumentInAssetLibraryByUploadFile(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				filePath = ${filePath});
 		}
@@ -421,11 +408,10 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given a document with a custom erc is created with a POST request in asset library") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
 			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");
 
 			var documentId = DocumentAPI.getIdOfCreatedDocument(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				filePath = ${filePath});
 		}
@@ -434,7 +420,7 @@ definition {
 			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_2.txt");
 
 			var response = DocumentAPI.addDocumentInAssetLibraryByUploadFile(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = ${documentId},
 				filePath = ${filePath});
 		}
@@ -447,7 +433,7 @@ definition {
 
 		task ("And Then the document is created properly") {
 			DocumentAPI.assertProperDocumentTotalCount(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				expectedDocumentTotalCount = 1,
 				filtervalue = "title%20eq%20%27Document_2.txt%27");
 		}
@@ -459,11 +445,10 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("When with POST request I create a new document without a custom erc") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
 			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");
 
 			var response = DocumentAPI.addDocumentInAssetLibraryByUploadFile(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				filePath = ${filePath});
 		}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcFromAssetLibraryForStructuredContentFolders.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcFromAssetLibraryForStructuredContentFolders.testcase
@@ -32,23 +32,21 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given a structured content folder with a custom erc is created with a POST request") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-
 			HeadlessWebcontentFolderAPI.createStructuredContentFolderInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				name = "Test Folder");
 		}
 
 		task ("When I make a DELETE request by erc") {
 			var response = HeadlessWebcontentFolderAPI.deleteStructuredContentFolderByErcInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc");
 		}
 
 		task ("Then the structured content folder is correctly deleted") {
 			HeadlessWebcontentFolderAPI.assertProperTotalCountOfStructuredContentFoldersInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				expectedStructuredContentFolderTotalCount = 0,
 				filterValue = "name%20eq%20%27Test%20Folder%27");
 		}
@@ -60,10 +58,8 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given a structured content folder without a custom erc is created with a POST request") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-
 			var response = HeadlessWebcontentFolderAPI.createStructuredContentFolderInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				name = "Test Folder");
 		}
 
@@ -74,13 +70,13 @@ definition {
 				site = "false");
 
 			var response = HeadlessWebcontentFolderAPI.deleteStructuredContentFolderByErcInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = ${folderUuid});
 		}
 
 		task ("Then the structured content folder is correctly deleted") {
 			HeadlessWebcontentFolderAPI.assertProperTotalCountOfStructuredContentFoldersInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				expectedStructuredContentFolderTotalCount = 0,
 				filterValue = "name%20eq%20%27Test%20Folder%27");
 		}
@@ -92,10 +88,8 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given a structured content folder with a custom erc is created with a POST request") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-
 			var response = HeadlessWebcontentFolderAPI.createStructuredContentFolderInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				name = "Test Folder");
 		}
@@ -113,7 +107,7 @@ definition {
 
 		task ("When I make a GET request by the erc of the parent structured content folder") {
 			var response = HeadlessWebcontentFolderAPI.getStructuredContentFoldersByErcInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc");
 		}
 
@@ -130,17 +124,15 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given a structured content folder with a custom erc is created with a POST request") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-
 			HeadlessWebcontentFolderAPI.createStructuredContentFolderInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				name = "Test Folder");
 		}
 
 		task ("When I make a GET request by assetLibraryId and erc") {
 			var response = HeadlessWebcontentFolderAPI.getStructuredContentFoldersByErcInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc");
 		}
 
@@ -157,10 +149,8 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given a structured content folder without a custom erc is created with a POST request") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-
 			var response = HeadlessWebcontentFolderAPI.createStructuredContentFolderInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				name = "Test Folder");
 		}
 
@@ -171,7 +161,7 @@ definition {
 				site = "false");
 
 			var response = HeadlessWebcontentFolderAPI.getStructuredContentFoldersByErcInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = ${folderUuid});
 		}
 
@@ -188,10 +178,8 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given a structured content folder with a custom erc is created with a POST request") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-
 			var response = HeadlessWebcontentFolderAPI.createStructuredContentFolderInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				name = "Test Folder");
 		}
@@ -209,7 +197,7 @@ definition {
 
 		task ("When I make a GET request by the erc of subfolder") {
 			var response = HeadlessWebcontentFolderAPI.getStructuredContentFoldersByErcInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "subfolder-erc");
 		}
 
@@ -236,17 +224,15 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given a structured content folder with a custom erc is created with POST request") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-
 			HeadlessWebcontentFolderAPI.createStructuredContentFolderInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				name = "Test Folder");
 		}
 
 		task ("When with POST request I create a structured content folder with an already existing custom erc") {
 			var response = HeadlessWebcontentFolderAPI.createStructuredContentFolderInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				name = "Second Folder");
 		}
@@ -259,7 +245,7 @@ definition {
 
 		task ("And Then another folder with same erc is not being created") {
 			HeadlessWebcontentFolderAPI.assertProperTotalCountOfStructuredContentFoldersInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				expectedStructuredContentFolderTotalCount = 0,
 				filterValue = "name%20eq%20%27Second%20Folder%27");
 		}
@@ -271,17 +257,15 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given a structured content folder with a custom erc is created with a POST request") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-
 			HeadlessWebcontentFolderAPI.createStructuredContentFolderInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				name = "Test Folder");
 		}
 
 		task ("When I make a PUT request by previous custom erc and updated erc in body") {
 			var response = HeadlessWebcontentFolderAPI.updateStructureContentFolderByErcInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				externalReferenceCodeInBody = "update-erc",
 				name = "Update Test Folder");
@@ -295,7 +279,7 @@ definition {
 
 		task ("And Then another folder with updated erc is not being created") {
 			var response = HeadlessWebcontentFolderAPI.getStructuredContentFoldersByErcInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "update-erc");
 
 			TestUtils.assertPartialEquals(
@@ -332,10 +316,8 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("When I make a GET request by assetLibraryID and non-existent erc") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-
 			var response = HeadlessWebcontentFolderAPI.getStructuredContentFoldersByErcInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "nonexistent-erc");
 		}
 
@@ -352,17 +334,15 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given a structured content folder with a custom erc is created with a POST request") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-
 			HeadlessWebcontentFolderAPI.createStructuredContentFolderInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				name = "Test Folder");
 		}
 
 		task ("When I make a PUT request by erc to update folder name") {
 			var response = HeadlessWebcontentFolderAPI.updateStructureContentFolderByErcInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				name = "Update Test Folder");
 		}
@@ -379,7 +359,7 @@ definition {
 
 		task ("And Then the structured content folder is correctly updated") {
 			HeadlessWebcontentFolderAPI.assertProperTotalCountOfStructuredContentFoldersInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				expectedStructuredContentFolderTotalCount = 1,
 				filterValue = "name%20eq%20%27Update%20Test%20Folder%27");
 		}
@@ -391,10 +371,8 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given a structured content folder with a custom erc is created with a POST request") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-
 			var response = HeadlessWebcontentFolderAPI.createStructuredContentFolderInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				name = "Test Folder");
 		}
@@ -412,7 +390,7 @@ definition {
 
 		task ("When I make a PUT request by subfolder erc and a new subfolder name in the body") {
 			var response = HeadlessWebcontentFolderAPI.updateStructureContentFolderByErcInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "subfolder-erc",
 				name = "Update Sub Folder");
 		}
@@ -434,10 +412,8 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given a structured content folder with a custom erc is created with a POST request") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-
 			var response = HeadlessWebcontentFolderAPI.createStructuredContentFolderInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				name = "Test Folder");
 		}
@@ -455,13 +431,13 @@ definition {
 
 		task ("Given I make a DELETE request by erc of subfolder") {
 			HeadlessWebcontentFolderAPI.deleteStructuredContentFolderByErcInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "subfolder-erc");
 		}
 
 		task ("When I make a GET request by parent erc") {
 			var response = HeadlessWebcontentFolderAPI.getStructuredContentFoldersByErcInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc");
 		}
 
@@ -482,23 +458,21 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given a structured content folder with a custom erc is created with a POST request") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-
 			HeadlessWebcontentFolderAPI.createStructuredContentFolderInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				name = "Test Folder");
 		}
 
 		task ("When I make a DELETE request by a non-existent erc") {
 			HeadlessWebcontentFolderAPI.deleteStructuredContentFolderByErcInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "nonexistent-erc");
 		}
 
 		task ("Then the structured content folder with erc created earlier still exists") {
 			HeadlessWebcontentFolderAPI.assertProperTotalCountOfStructuredContentFoldersInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				expectedStructuredContentFolderTotalCount = 1,
 				filterValue = "name%20eq%20%27Test%20Folder%27");
 		}
@@ -510,10 +484,8 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("When with POST request I create a structured content folder without a custom erc") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-
 			var response = HeadlessWebcontentFolderAPI.createStructuredContentFolderInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				name = "Test Folder");
 		}
@@ -531,10 +503,8 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("When with POST request I create a structured content folder without a custom erc") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-
 			var response = HeadlessWebcontentFolderAPI.createStructuredContentFolderInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				name = "Test Folder");
 		}
 
@@ -556,10 +526,8 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given a structured content folder with a custom erc is created with a POST request") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-
 			var response = HeadlessWebcontentFolderAPI.createStructuredContentFolderInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				name = "Test Folder");
 		}
@@ -577,14 +545,14 @@ definition {
 
 		task ("When I make a PUT request by nonexistent erc with subfolder name in the body") {
 			var response = HeadlessWebcontentFolderAPI.updateStructureContentFolderByErcInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "nonexistent-erc",
 				name = "Sub Folder");
 		}
 
 		task ("And Then a new structured content folder is created") {
 			HeadlessWebcontentFolderAPI.assertProperTotalCountOfStructuredContentFoldersInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				expectedStructuredContentFolderTotalCount = 1,
 				filterValue = "name%20eq%20%27Sub%20Folder%27");
 		}
@@ -596,10 +564,8 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given a structured content folder with a custom erc is created with POST request") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-
 			var response = HeadlessWebcontentFolderAPI.createStructuredContentFolderInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				name = "Test Folder");
 		}
@@ -623,7 +589,7 @@ definition {
 
 		task ("And Then a child folder is being created properly") {
 			var response = HeadlessWebcontentFolderAPI.getStructuredContentFoldersByErcInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc");
 
 			HeadlessWebcontentFolderAPI.assetProperNumberOfStructuredContentFolders(
@@ -638,10 +604,8 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given a structured content folder with a custom erc is created with POST request") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-
 			var response = HeadlessWebcontentFolderAPI.createStructuredContentFolderInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				name = "Test Folder");
 		}
@@ -669,7 +633,7 @@ definition {
 
 		task ("And Then a child folder is being created properly") {
 			var response = HeadlessWebcontentFolderAPI.getStructuredContentFoldersByErcInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc");
 
 			HeadlessWebcontentFolderAPI.assetProperNumberOfStructuredContentFolders(
@@ -684,10 +648,8 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given a structured content folder with a custom erc is created with a POST request") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-
 			var response = HeadlessWebcontentFolderAPI.createStructuredContentFolderInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				name = "Test Folder");
 		}
@@ -705,13 +667,13 @@ definition {
 
 		task ("When I make a DELETE request by erc of parent folder") {
 			HeadlessWebcontentFolderAPI.deleteStructuredContentFolderByErcInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc");
 		}
 
 		task ("Then both parent and sub structured content folders are deleted") {
 			var response = HeadlessWebcontentFolderAPI.getStructuredContentFoldersByErcInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "subfolder-erc");
 
 			ObjectDefinitionAPI.assertStatusInResponse(
@@ -719,7 +681,7 @@ definition {
 				responseToParse = ${response});
 
 			HeadlessWebcontentFolderAPI.assertProperTotalCountOfStructuredContentFoldersInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				expectedStructuredContentFolderTotalCount = 0,
 				filterValue = "name%20eq%20%27Test%20Folder%27");
 		}

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcFromAssetLibraryForStructuredContents.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcFromAssetLibraryForStructuredContents.testcase
@@ -15,9 +15,7 @@ definition {
 		}
 
 		task ("Given a content structure created in asset library") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-
-			WebContentNavigator.openWebContentStructuresAdminInAssetLibrary(depotId = ${assetLibraryId});
+			WebContentNavigator.openWebContentStructuresAdmin(depotName = "Test Depot Name");
 
 			WebContentStructures.addCP(structureName = "content-structure");
 
@@ -46,13 +44,12 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given a structured content with a custom erc is created with a POST request in asset library") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
 			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
 
 			HeadlessWebcontentAPI.createStructuredContent(
-				assetLibraryId = ${assetLibraryId},
 				data = "<p>My content</p>",
 				ddmStructureId = ${ddmStructureId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				label = "Text",
 				name = "Text",
@@ -61,13 +58,13 @@ definition {
 
 		task ("When I make a DELETE request by assetLibraryId and the custom erc") {
 			HeadlessWebcontentAPI.deleteStructuredContentInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc");
 		}
 
 		task ("Then the structured content is correctly deleted") {
 			var response = HeadlessWebcontentAPI.filterStructuredContentInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				filtervalue = "title%20eq%20%27WC%20WebContent%20Title%27");
 
 			HeadlessWebcontentAPI.assertProperNumberOfItems(
@@ -82,13 +79,12 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given a structured content without custom erc is created with a POST request in asset library") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
 			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
 
 			var response = HeadlessWebcontentAPI.createStructuredContent(
-				assetLibraryId = ${assetLibraryId},
 				data = "<p>My content</p>",
 				ddmStructureId = ${ddmStructureId},
+				depotName = "Test Depot Name",
 				label = "Text",
 				name = "Text",
 				title = "WC WebContent Title");
@@ -98,13 +94,13 @@ definition {
 			var structuredContentUuid = HeadlessWebcontentAPI.getUuidOfStructuredContent(responseToParse = ${response});
 
 			HeadlessWebcontentAPI.deleteStructuredContentInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = ${structuredContentUuid});
 		}
 
 		task ("Then the structured content is correctly deleted") {
 			var response = HeadlessWebcontentAPI.filterStructuredContentInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				filtervalue = "title%20eq%20%27WC%20WebContent%20Title%27");
 
 			HeadlessWebcontentAPI.assertProperNumberOfItems(
@@ -119,13 +115,12 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given a structured content with a custom erc is created with a POST request in asset library") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
 			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
 
 			var response = HeadlessWebcontentAPI.createStructuredContent(
-				assetLibraryId = ${assetLibraryId},
 				data = "<p>My content</p>",
 				ddmStructureId = ${ddmStructureId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				label = "Text",
 				name = "Text",
@@ -134,7 +129,7 @@ definition {
 
 		task ("When I make a GET request by assetLibraryId and erc") {
 			var response = HeadlessWebcontentAPI.getStructuredContentsByErcInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc");
 		}
 
@@ -151,13 +146,12 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given a structured content without a custom erc is created with a POST request in asset library") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
 			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
 
 			var response = HeadlessWebcontentAPI.createStructuredContent(
-				assetLibraryId = ${assetLibraryId},
 				data = "<p>My content</p>",
 				ddmStructureId = ${ddmStructureId},
+				depotName = "Test Depot Name",
 				label = "Text",
 				name = "Text",
 				title = "WC WebContent Title");
@@ -167,7 +161,7 @@ definition {
 			var structuredContentUuid = HeadlessWebcontentAPI.getUuidOfStructuredContent(responseToParse = ${response});
 
 			var response = HeadlessWebcontentAPI.getStructuredContentsByErcInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = ${structuredContentUuid});
 		}
 
@@ -184,13 +178,12 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given a structured content with a custom erc is created with a POST request in asset library") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
 			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
 
 			HeadlessWebcontentAPI.createStructuredContent(
-				assetLibraryId = ${assetLibraryId},
 				data = "<p>My content</p>",
 				ddmStructureId = ${ddmStructureId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				label = "Text",
 				name = "Text",
@@ -199,9 +192,9 @@ definition {
 
 		task ("When with POST I create a structured content with an existing erc") {
 			var response = HeadlessWebcontentAPI.createStructuredContent(
-				assetLibraryId = ${assetLibraryId},
 				data = "<p>My content</p>",
 				ddmStructureId = ${ddmStructureId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				label = "Text",
 				name = "Text",
@@ -216,7 +209,7 @@ definition {
 
 		task ("And Then another structured content with same erc is not being created") {
 			var response = HeadlessWebcontentAPI.filterStructuredContentInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				filtervalue = "title%20eq%20%27WC%20Second%20WebContent%20Title%27");
 
 			HeadlessWebcontentAPI.assertProperNumberOfItems(
@@ -231,13 +224,12 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given a structured content with a custom erc is created with a POST request in asset library") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
 			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
 
 			HeadlessWebcontentAPI.updateStructuredContentByErcInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
 				data = "<p>My content</p>",
 				ddmStructureId = ${ddmStructureId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				label = "Text",
 				name = "Text",
@@ -246,9 +238,9 @@ definition {
 
 		task ("When I make a PUT request by assetLibraryId and erc with an erc modified in the body") {
 			var response = HeadlessWebcontentAPI.updateStructuredContentByErcInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
 				data = "<p>My content</p>",
 				ddmStructureId = ${ddmStructureId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				label = "Text",
 				name = "Text",
@@ -264,7 +256,7 @@ definition {
 
 		task ("And Then another structured content with an erc being the modified value is not being created") {
 			var response = HeadlessWebcontentAPI.getStructuredContentsByErcInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc-update");
 
 			TestUtils.assertPartialEquals(
@@ -301,10 +293,8 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("When I make a GET request by assetLibraryID and nonexistent erc") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-
 			var response = HeadlessWebcontentAPI.getStructuredContentsByErcInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "nonexistent-erc");
 		}
 
@@ -321,13 +311,12 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given a structured content with a custom erc is created with a POST request in asset library") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
 			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
 
 			var response = HeadlessWebcontentAPI.createStructuredContent(
-				assetLibraryId = ${assetLibraryId},
 				data = "<p>My content</p>",
 				ddmStructureId = ${ddmStructureId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				label = "Text",
 				name = "Text",
@@ -336,9 +325,9 @@ definition {
 
 		task ("When I make a PUT request by assetLibraryId and erc") {
 			var response = HeadlessWebcontentAPI.updateStructuredContentByErcInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
 				data = "<p>My content</p>",
 				ddmStructureId = ${ddmStructureId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				label = "Text",
 				name = "Text",
@@ -355,7 +344,7 @@ definition {
 
 		task ("And Then the structured content is correctly updated") {
 			var response = HeadlessWebcontentAPI.filterStructuredContentInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				filtervalue = "title%20eq%20%27WC%20WebContent%20Title%20Updated%27");
 
 			HeadlessWebcontentAPI.assertProperNumberOfItems(
@@ -370,13 +359,12 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given a structured content with custom erc is created with a POST request in asset library") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
 			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
 
 			HeadlessWebcontentAPI.createStructuredContent(
-				assetLibraryId = ${assetLibraryId},
 				data = "<p>My content</p>",
 				ddmStructureId = ${ddmStructureId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				label = "Text",
 				name = "Text",
@@ -385,13 +373,13 @@ definition {
 
 		task ("When I make a DELETE request by assetLibraryId and a non-existent erc") {
 			HeadlessWebcontentAPI.deleteStructuredContentInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "nonexistent-erc");
 		}
 
 		task ("Then the structured content with a custom erc created earlier still exists") {
 			var response = HeadlessWebcontentAPI.filterStructuredContentInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				filtervalue = "title%20eq%20%27WC%20WebContent%20Title%27");
 
 			HeadlessWebcontentAPI.assertExternalReferenceCodeWithCorrectValue(
@@ -410,13 +398,12 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("When I make a PUT request by assetLibraryId and a non-existent erc without erc in the body") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
 			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
 
 			var response = HeadlessWebcontentAPI.updateStructuredContentByErcInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
 				data = "<p>My content</p>",
 				ddmStructureId = ${ddmStructureId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "nonexistent-erc",
 				label = "Text",
 				name = "Text",
@@ -431,7 +418,7 @@ definition {
 
 		task ("And Then a new structured content is created properly") {
 			var response = HeadlessWebcontentAPI.filterStructuredContentInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				filtervalue = "title%20eq%20%27WC%20WebContent%20Title%27");
 
 			HeadlessWebcontentAPI.assertProperNumberOfItems(
@@ -446,13 +433,12 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given a structured content with a custom erc is created with a POST request in asset library") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
 			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
 
 			HeadlessWebcontentAPI.updateStructuredContentByErcInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
 				data = "<p>My content</p>",
 				ddmStructureId = ${ddmStructureId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				label = "Text",
 				name = "Text",
@@ -461,9 +447,9 @@ definition {
 
 		task ("When I make a PUT request by assetLibraryId and a non-existent erc with exsiting erc in the body") {
 			var response = HeadlessWebcontentAPI.updateStructuredContentByErcInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
 				data = "<p>My content update</p>",
 				ddmStructureId = ${ddmStructureId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "nonexistent-erc",
 				label = "Text",
 				name = "Text",
@@ -479,7 +465,7 @@ definition {
 
 		task ("And Then a new structured content is created properly") {
 			var response = HeadlessWebcontentAPI.filterStructuredContentInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				filtervalue = "title%20eq%20%27WC%20WebContent%20Title%27");
 
 			HeadlessWebcontentAPI.assertProperNumberOfItems(
@@ -494,13 +480,12 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("When with POST request I create a structured content with a custom erc in asset library") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
 			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
 
 			var response = HeadlessWebcontentAPI.createStructuredContent(
-				assetLibraryId = ${assetLibraryId},
 				data = "<p>My content</p>",
 				ddmStructureId = ${ddmStructureId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				label = "Text",
 				name = "Text",
@@ -515,7 +500,7 @@ definition {
 
 		task ("And Then structured content is created properly") {
 			var response = HeadlessWebcontentAPI.filterStructuredContentInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				filtervalue = "title%20eq%20%27WC%20WebContent%20Title%27");
 
 			HeadlessWebcontentAPI.assertProperNumberOfItems(
@@ -530,13 +515,12 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("When with POST request I create a structured content without erc in asset library") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
 			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
 
 			var response = HeadlessWebcontentAPI.createStructuredContent(
-				assetLibraryId = ${assetLibraryId},
 				data = "<p>My content</p>",
 				ddmStructureId = ${ddmStructureId},
+				depotName = "Test Depot Name",
 				label = "Text",
 				name = "Text",
 				title = "WC WebContent Title");
@@ -548,7 +532,7 @@ definition {
 
 		task ("And Then the structured content is created properly") {
 			var response = HeadlessWebcontentAPI.filterStructuredContentInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				filtervalue = "title%20eq%20%27WC%20WebContent%20Title%27");
 
 			HeadlessWebcontentAPI.assertProperNumberOfItems(
@@ -563,13 +547,12 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given a structured content with custom erc is created with a POST request in asset library") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
 			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
 
 			var response = HeadlessWebcontentAPI.createStructuredContent(
-				assetLibraryId = ${assetLibraryId},
 				data = "<p>My content</p>",
 				ddmStructureId = ${ddmStructureId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				label = "Text",
 				name = "Text",
@@ -579,9 +562,9 @@ definition {
 		task ("When with POST request I create a structured content with erc equals to the internal id of the previously created structured content") {
 			var structuredContentId = HeadlessWebcontentAPI.getWebContentIdFromResponse(responseToParse = ${response});
 			var response = HeadlessWebcontentAPI.createStructuredContent(
-				assetLibraryId = ${assetLibraryId},
 				data = "<p>My content</p>",
 				ddmStructureId = ${ddmStructureId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = ${customErc},
 				label = "Text",
 				name = "Text",
@@ -596,7 +579,7 @@ definition {
 
 		task ("Then structured content is created properly") {
 			var response = HeadlessWebcontentAPI.filterStructuredContentInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				filtervalue = "title%20eq%20%27WC%20WebContent%20Title%27");
 
 			HeadlessWebcontentAPI.assertProperNumberOfItems(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeInformationInNavigationMenus.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeInformationInNavigationMenus.testcase
@@ -55,11 +55,10 @@ definition {
 		}
 
 		task ("And Given a document is uploaded with post request in asset library") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
 			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");
 
 			var documentId = DocumentAPI.getIdOfCreatedDocument(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				filePath = ${filePath});
 		}
@@ -76,9 +75,7 @@ definition {
 		}
 
 		task ("When with get request and siteId to retrieve the navigation menu") {
-			var siteId = JSONGroupAPI._getSiteIdByGroupKey(groupName = "Guest");
-
-			var response = NavigationMenuAPI.getNavigationMenu(siteId = ${siteId});
+			var response = NavigationMenuAPI.getNavigationMenu(groupName = ${groupName});
 		}
 
 		task ("Then I can see values of useCustomName is false, contentURL equals to document endpoint and type equals to document") {
@@ -106,11 +103,10 @@ definition {
 		}
 
 		task ("And Given a document is uploaded with post request in asset library") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
 			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");
 
 			var documentId = DocumentAPI.getIdOfCreatedDocument(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				filePath = ${filePath});
 		}
@@ -139,11 +135,9 @@ definition {
 		}
 
 		task ("Then I can see values of useCustomName equals to true, contentURL equals to document endpoint and type equals to document") {
-			var portalURL = JSONCompany.getPortalURL();
-
 			NavigationMenuAPI.assertResponseHasCorrectInformations(
 				expectedType = "document",
-				expectedURL = "${portalURL}/o/headless-delivery/v1.0/documents/${documentId}",
+				expectedURL = "o/headless-delivery/v1.0/documents/${documentId}",
 				expectedUseCustomName = "true",
 				responseToParse = ${response});
 		}
@@ -162,9 +156,7 @@ definition {
 		}
 
 		task ("And Given a content structure created in asset library") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-
-			WebContentNavigator.openWebContentStructuresAdminInAssetLibrary(depotId = ${assetLibraryId});
+			WebContentNavigator.openWebContentStructuresAdmin(depotName = "Test Depot Name");
 
 			WebContentStructures.addCP(structureName = "content-structure");
 
@@ -176,13 +168,12 @@ definition {
 		}
 
 		task ("And Given a web content article is created in asset Library") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
 			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
 
 			var responseFromCreate = HeadlessWebcontentAPI.createStructuredContent(
-				assetLibraryId = ${assetLibraryId},
 				data = "<p>My content</p>",
 				ddmStructureId = ${ddmStructureId},
+				depotName = "Test Depot Name",
 				label = "Text",
 				name = "Text",
 				title = "Web Content Title");
@@ -204,18 +195,15 @@ definition {
 		}
 
 		task ("When with get request and siteId to retrieve the navigation menu") {
-			var siteId = JSONGroupAPI._getSiteIdByGroupKey(groupName = "Guest");
-
-			var response = NavigationMenuAPI.getNavigationMenu(siteId = ${siteId});
+			var response = NavigationMenuAPI.getNavigationMenu(groupName = "Guest");
 		}
 
 		task ("Then I can see values of useCustomName equals to true, contentURL equals to webcontent endpoint and type equals to structuredContent") {
-			var portalURL = JSONCompany.getPortalURL();
 			var structuredContentId = HeadlessWebcontentAPI.getWebContentIdFromResponse(responseToParse = ${responseFromCreate});
 
 			NavigationMenuAPI.assertResponseHasCorrectInformations(
 				expectedType = "structuredContent",
-				expectedURL = "${portalURL}/o/headless-delivery/v1.0/structured-contents/${structuredContentId}",
+				expectedURL = "o/headless-delivery/v1.0/structured-contents/${structuredContentId}",
 				expectedUseCustomName = "true",
 				responseFromSite = "true",
 				responseToParse = ${response});
@@ -235,9 +223,7 @@ definition {
 		}
 
 		task ("And Given a content structure created in asset library") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-
-			WebContentNavigator.openWebContentStructuresAdminInAssetLibrary(depotId = ${assetLibraryId});
+			WebContentNavigator.openWebContentStructuresAdmin(depotName = "Test Depot Name");
 
 			WebContentStructures.addCP(structureName = "content-structure");
 
@@ -249,13 +235,12 @@ definition {
 		}
 
 		task ("And Given a web content article is created in asset Library") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
 			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
 
 			var responseFromCreate = HeadlessWebcontentAPI.createStructuredContent(
-				assetLibraryId = ${assetLibraryId},
 				data = "<p>My content</p>",
 				ddmStructureId = ${ddmStructureId},
+				depotName = "Test Depot Name",
 				label = "Text",
 				name = "Text",
 				title = "Web Content Title");
@@ -281,12 +266,11 @@ definition {
 		}
 
 		task ("Then I can see values of useCustomName is false, contentURL equals to webcontent endpoint and type equals to structuredContent") {
-			var portalURL = JSONCompany.getPortalURL();
 			var structuredContentId = HeadlessWebcontentAPI.getWebContentIdFromResponse(responseToParse = ${responseFromCreate});
 
 			NavigationMenuAPI.assertResponseHasCorrectInformations(
 				expectedType = "structuredContent",
-				expectedURL = "${portalURL}/o/headless-delivery/v1.0/structured-contents/${structuredContentId}",
+				expectedURL = "o/headless-delivery/v1.0/structured-contents/${structuredContentId}",
 				expectedUseCustomName = "false",
 				responseToParse = ${response});
 		}
@@ -321,11 +305,9 @@ definition {
 		}
 
 		task ("Then I can see values of useCustomName is false, contentURL equals to blog endpoint and type equals to blogPosting") {
-			var portalURL = JSONCompany.getPortalURL();
-
 			NavigationMenuAPI.assertResponseHasCorrectInformations(
 				expectedType = "blogPosting",
-				expectedURL = "${portalURL}/o/headless-delivery/v1.0/blog-postings/${blogPostingId}",
+				expectedURL = "o/headless-delivery/v1.0/blog-postings/${blogPostingId}",
 				expectedUseCustomName = "false",
 				responseToParse = ${response});
 		}
@@ -356,17 +338,13 @@ definition {
 		}
 
 		task ("When with get request to retrieve the navigation menu with siteId") {
-			var siteId = JSONGroupAPI._getSiteIdByGroupKey(groupName = "Guest");
-
-			var response = NavigationMenuAPI.getNavigationMenu(siteId = ${siteId});
+			var response = NavigationMenuAPI.getNavigationMenu(groupName = "Guest");
 		}
 
 		task ("Then I can see values of useCustomName is true, contentURL equals to blog endpoint and type equals to blogPosting") {
-			var portalURL = JSONCompany.getPortalURL();
-
 			NavigationMenuAPI.assertResponseHasCorrectInformations(
 				expectedType = "blogPosting",
-				expectedURL = "${portalURL}/o/headless-delivery/v1.0/blog-postings/${blogPostingId}",
+				expectedURL = "o/headless-delivery/v1.0/blog-postings/${blogPostingId}",
 				expectedUseCustomName = "true",
 				responseFromSite = "true",
 				responseToParse = ${response});
@@ -396,20 +374,17 @@ definition {
 		}
 
 		task ("When with get request and siteId to retrieve the navigation menu") {
-			var siteId = JSONGroupAPI._getSiteIdByGroupKey(groupName = "Guest");
-
-			var response = NavigationMenuAPI.getNavigationMenu(siteId = ${siteId});
+			var response = NavigationMenuAPI.getNavigationMenu(groupName = "Guest");
 		}
 
 		task ("Then I can see values of useCustomName is false, contentURL equals to document endpoint and type equals to document") {
-			var portalURL = JSONCompany.getPortalURL();
 			var documentId = JSONDocument.getFileEntryId(
 				dmDocumentTitle = "Document_1.txt",
 				groupName = "Guest");
 
 			NavigationMenuAPI.assertResponseHasCorrectInformations(
 				expectedType = "document",
-				expectedURL = "${portalURL}/o/headless-delivery/v1.0/documents/${documentId}",
+				expectedURL = "o/headless-delivery/v1.0/documents/${documentId}",
 				expectedUseCustomName = "false",
 				responseFromSite = "true",
 				responseToParse = ${response});
@@ -451,14 +426,13 @@ definition {
 		}
 
 		task ("Then I can see values of useCustomName equals to true, contentURL equals to document endpoint and type equals to document") {
-			var portalURL = JSONCompany.getPortalURL();
 			var documentId = JSONDocument.getFileEntryId(
 				dmDocumentTitle = "Document_1.txt",
 				groupName = "Guest");
 
 			NavigationMenuAPI.assertResponseHasCorrectInformations(
 				expectedType = "document",
-				expectedURL = "${portalURL}/o/headless-delivery/v1.0/documents/${documentId}",
+				expectedURL = "o/headless-delivery/v1.0/documents/${documentId}",
 				expectedUseCustomName = "true",
 				responseToParse = ${response});
 		}
@@ -490,18 +464,15 @@ definition {
 		}
 
 		task ("When with get request and siteId to retrieve the navigation menu") {
-			var siteId = JSONGroupAPI._getSiteIdByGroupKey(groupName = "Guest");
-
-			var response = NavigationMenuAPI.getNavigationMenu(siteId = ${siteId});
+			var response = NavigationMenuAPI.getNavigationMenu(groupName = "Guest");
 		}
 
 		task ("Then I can see values of useCustomName equals to true, contentURL equals to webcontent endpoint and type equals to structuredContent") {
-			var portalURL = JSONCompany.getPortalURL();
 			var structuredContentId = HeadlessWebcontentAPI.getStructuredContentIdByTitle(title = "Web Content Title");
 
 			NavigationMenuAPI.assertResponseHasCorrectInformations(
 				expectedType = "structuredContent",
-				expectedURL = "${portalURL}/o/headless-delivery/v1.0/structured-contents/${structuredContentId}",
+				expectedURL = "o/headless-delivery/v1.0/structured-contents/${structuredContentId}",
 				expectedUseCustomName = "true",
 				responseFromSite = "true",
 				responseToParse = ${response});
@@ -538,12 +509,11 @@ definition {
 		}
 
 		task ("Then I can see values of useCustomName is false, contentURL equals to webcontent endpoint and type equals to structuredContent") {
-			var portalURL = JSONCompany.getPortalURL();
 			var structuredContentId = HeadlessWebcontentAPI.getStructuredContentIdByTitle(title = "Web Content Title");
 
 			NavigationMenuAPI.assertResponseHasCorrectInformations(
 				expectedType = "structuredContent",
-				expectedURL = "${portalURL}/o/headless-delivery/v1.0/structured-contents/${structuredContentId}",
+				expectedURL = "o/headless-delivery/v1.0/structured-contents/${structuredContentId}",
 				expectedUseCustomName = "false",
 				responseToParse = ${response});
 		}

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeInformationInNavigationMenus.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeInformationInNavigationMenus.testcase
@@ -75,15 +75,13 @@ definition {
 		}
 
 		task ("When with get request and siteId to retrieve the navigation menu") {
-			var response = NavigationMenuAPI.getNavigationMenu(groupName = ${groupName});
+			var response = NavigationMenuAPI.getNavigationMenu(groupName = "Guest");
 		}
 
 		task ("Then I can see values of useCustomName is false, contentURL equals to document endpoint and type equals to document") {
-			var portalURL = JSONCompany.getPortalURL();
-
 			NavigationMenuAPI.assertResponseHasCorrectInformations(
 				expectedType = "document",
-				expectedURL = "${portalURL}/o/headless-delivery/v1.0/documents/${documentId}",
+				expectedURL = "o/headless-delivery/v1.0/documents/${documentId}",
 				expectedUseCustomName = "false",
 				responseFromSite = "true",
 				responseToParse = ${response});

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeLanguagesFromAssetLibraryAndSite.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeLanguagesFromAssetLibraryAndSite.testcase
@@ -47,9 +47,7 @@ definition {
 		}
 
 		task ("When a user makes a query to getAssetLibraryLanguagesPage") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-
-			var response = LanguageAPI.getAssetLibraryLanguages(assetLibraryId = ${assetLibraryId});
+			var response = LanguageAPI.getAssetLibraryLanguages(depotName = "Test Depot Name");
 		}
 
 		task ("Then the response returns the configured languages for the AssetLibrary") {
@@ -74,9 +72,7 @@ definition {
 		}
 
 		task ("When a user makes a query to getSiteLanguagesPage") {
-			var siteId = JSONGroupAPI._getSiteIdByGroupKey(groupName = "Guest");
-
-			var response = LanguageAPI.getSiteLanguages(siteId = ${siteId});
+			var response = LanguageAPI.getSiteLanguages(groupName = "Guest");
 		}
 
 		task ("Then the response returns the configured languages for the site") {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeStructuredContentFolderIdInHeadlessDelivery.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeStructuredContentFolderIdInHeadlessDelivery.testcase
@@ -14,9 +14,7 @@ definition {
 		task ("Given a content structure is created in an asset library") {
 			JSONDepot.addDepot(depotName = "Test Depot Name");
 
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-
-			WebContentNavigator.openWebContentStructuresAdminInAssetLibrary(depotId = ${assetLibraryId});
+			WebContentNavigator.openWebContentStructuresAdmin(depotName = "Test Depot Name");
 
 			WebContentStructures.addCP(structureName = "content-structure");
 
@@ -29,7 +27,7 @@ definition {
 
 		task ("And Given a structured content folder is created with POST request in the asset library") {
 			HeadlessWebcontentFolderAPI.createStructuredContentFolderInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				name = "Test Folder",
 				setUpGlobalFolderId = "true");
 		}
@@ -127,10 +125,8 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("And Given another structured content folder is created with POST request in the asset library") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-
 			var response = HeadlessWebcontentFolderAPI.createStructuredContentFolderInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				name = "Second Folder");
 
 			var idOfSecondStructuredContentFolder = JSONPathUtil.getIdValue(response = ${response});
@@ -150,9 +146,9 @@ definition {
 		}
 
 		task ("And Given the structured content is moved into another folder through UI") {
-			Navigator.openWithAppendToBaseURL(
-				baseURL = ${baseURL},
-				urlAppend = "group/asset-library-${assetLibraryId}/~/control_panel/manage?p_p_id=com_liferay_journal_web_portlet_JournalPortlet&_com_liferay_journal_web_portlet_JournalPortlet_folderId=${staticStructuredContentFolderId}");
+			WebContentNavigator.openFolderInWebContentAdmin(
+				depotName = "Test Depot Name",
+				folderId = ${staticStructuredContentFolderId});
 
 			WebContent.moveToFolderCP(
 				folderName = "Second Folder",

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/HeadlessDeliverySupportDifferentParameters.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/HeadlessDeliverySupportDifferentParameters.testcase
@@ -30,9 +30,7 @@ definition {
 		}
 
 		task ("Given a content structure created in asset library") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-
-			WebContentNavigator.openWebContentStructuresAdminInAssetLibrary(depotId = ${assetLibraryId});
+			WebContentNavigator.openWebContentStructuresAdmin(depotName = "Test Depot Name");
 
 			WebContentStructures.addCP(structureName = "content-structure");
 
@@ -44,13 +42,12 @@ definition {
 		}
 
 		task ("Given a structured content is created with a POST request in asset library") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
 			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
 
 			HeadlessWebcontentAPI.createStructuredContent(
-				assetLibraryId = ${assetLibraryId},
 				data = "<p>My content</p>",
 				ddmStructureId = ${ddmStructureId},
+				depotName = "Test Depot Name",
 				label = "Text",
 				name = "Text",
 				title = "WC WebContent Title");
@@ -58,7 +55,7 @@ definition {
 
 		task ("When with curl I request GET getAssetLibraryContentElementsPage with assetLibraryId and fields=content.assetLibraryKey") {
 			var response = ContentElementAPI.getAssetLibraryContentElementsByDifferentParameters(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				fieldValue = "content.assetLibraryKey",
 				parameter = "fields");
 		}
@@ -79,17 +76,15 @@ definition {
 		}
 
 		task ("Given a Web Content Folder created") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-
 			HeadlessWebcontentFolderAPI.createStructuredContentFolderInAssetLibrary(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				name = "Test Folder");
 		}
 
 		task ("When with curl I request GET getAssetLibraryStructuredContentFoldersPage with assetLibraryId and nestedFields = profileURL") {
 			var response = HeadlessWebcontentFolderAPI.getStructuredContentFoldersWithDifferentParameters(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				parameter = "nestedFields",
 				parameterValue = "profileURL");
 		}

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/HeadlessDeliverySupportDifferentParametersDM.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/HeadlessDeliverySupportDifferentParametersDM.testcase
@@ -9,6 +9,8 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		JSONDepot.addDepot(depotName = "Test Depot Name");
 	}
 
 	tearDown {
@@ -25,14 +27,11 @@ definition {
 	test CanReceiveIdFieldValuesOnlyInResponseForIndividualElement {
 		property portal.acceptance = "true";
 
-		task ("Given a document of a site") {
-			JSONDepot.addDepot(depotName = "Test Depot Name");
-
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+		task ("Given a document of an asset library") {
 			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");
 
 			var documentId = DocumentAPI.getIdOfCreatedDocument(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				filePath = ${filePath});
 		}
@@ -57,14 +56,11 @@ definition {
 	test CanReceiveTitleFieldValuesOnlyInResponseForIndividualElement {
 		property portal.acceptance = "true";
 
-		task ("Given a document of a site") {
-			JSONDepot.addDepot(depotName = "Test Depot Name");
-
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+		task ("Given a document of an asset library") {
 			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");
 
 			var documentId = DocumentAPI.getIdOfCreatedDocument(
-				assetLibraryId = ${assetLibraryId},
+				depotName = "Test Depot Name",
 				externalReferenceCode = "erc",
 				filePath = ${filePath});
 		}

--- a/modules/apps/headless/headless-discovery/headless-discovery-test/src/testFunctional/tests/HeadlessDiscovery.testcase
+++ b/modules/apps/headless/headless-discovery/headless-discovery-test/src/testFunctional/tests/HeadlessDiscovery.testcase
@@ -48,9 +48,7 @@ definition {
 		}
 
 		task ("When executing query structured content title") {
-			var siteId = JSONGroupAPI._getGroupIdByNameNoSelenium(
-				groupName = "Guest",
-				site = "true");
+			var siteId = JSONGroupSetter.setGroupId(groupName = "Guest");
 
 			APIExplorer.executeGraphqlQuery(query = "query {structuredContents(siteKey:\"${siteId}\"){items{title}}}");
 		}
@@ -79,9 +77,7 @@ definition {
 		}
 
 		task ("When executing query taxonomy vocabulary name") {
-			var siteId = JSONGroupAPI._getGroupIdByNameNoSelenium(
-				groupName = "Guest",
-				site = "true");
+			var siteId = JSONGroupSetter.setGroupId(groupName = "Guest");
 
 			APIExplorer.executeGraphqlQuery(query = "query{taxonomyVocabularies(siteKey:\"${siteId}\"){items{name}}}");
 		}
@@ -110,9 +106,7 @@ definition {
 		}
 
 		task ("When executing query blog headline") {
-			var siteId = JSONGroupAPI._getGroupIdByNameNoSelenium(
-				groupName = "Guest",
-				site = "true");
+			var siteId = JSONGroupSetter.setGroupId(groupName = "Guest");
 
 			APIExplorer.executeGraphqlQuery(query = "query{blogPostings(siteKey:\"${siteId}\"){items{headline}}}");
 		}
@@ -225,10 +219,6 @@ definition {
 		}
 
 		task ("When executing getSiteBlogPosingPage with siteID as the parameter") {
-			var siteId = JSONGroupAPI._getGroupIdByNameNoSelenium(
-				groupName = "Guest",
-				site = "true");
-
 			APIExplorer.executeAPIMethodWithParameters(
 				method = "getSiteBlogPostingsPage",
 				parameter = "siteId",
@@ -254,10 +244,6 @@ definition {
 		}
 
 		task ("When executing getSiteKeywordsPage with siteID as the parameter") {
-			var siteId = JSONGroupAPI._getGroupIdByNameNoSelenium(
-				groupName = "Guest",
-				site = "true");
-
 			APIExplorer.executeAPIMethodWithParameters(
 				method = "getSiteKeywordsPage",
 				parameter = "siteId",
@@ -283,10 +269,6 @@ definition {
 		}
 
 		task ("When executing getSiteStructuredContentsPage with siteID as the parameter") {
-			var siteId = JSONGroupAPI._getGroupIdByNameNoSelenium(
-				groupName = "Guest",
-				site = "true");
-
 			APIExplorer.executeAPIMethodWithParameters(
 				method = "getSiteStructuredContentsPage",
 				parameter = "siteId",
@@ -318,9 +300,6 @@ definition {
 		}
 
 		task ("When executing postSiteTaxonomyVocabulary with siteID as the parameter") {
-			var siteId = JSONGroupAPI._getGroupIdByNameNoSelenium(
-				groupName = "Guest",
-				site = "true");
 			var requestBody = '''{"name": "Vocubulary Name"}''';
 
 			APIExplorer.executeAPIMethodWithParameters(
@@ -388,9 +367,6 @@ definition {
 		}
 
 		task ("When executing postSiteStructuredContentDraft with siteID as the parameter and structuredId in the body") {
-			var siteId = JSONGroupAPI._getGroupIdByNameNoSelenium(
-				groupName = "Guest",
-				site = "true");
 			var requestBody = '''
 				{
 					"contentStructureId": ${ddmStructureId},
@@ -463,9 +439,6 @@ definition {
 		}
 
 		task ("When executing postSiteStructuredContent with siteID as the parameter and structuredId in the body") {
-			var siteId = JSONGroupAPI._getGroupIdByNameNoSelenium(
-				groupName = "Guest",
-				site = "true");
 			var requestBody = '''
 				{
 					"contentStructureId": ${ddmStructureId},
@@ -529,10 +502,6 @@ definition {
 		}
 
 		task ("When executing getSiteStructuredContentsPage with siteID as the parameter") {
-			var siteId = JSONGroupAPI._getGroupIdByNameNoSelenium(
-				groupName = "Guest",
-				site = "true");
-
 			APIExplorer.executeAPIMethodWithParameters(
 				method = "getSiteStructuredContentsPage",
 				parameter = "siteId",
@@ -578,10 +547,6 @@ definition {
 		}
 
 		task ("When executing getSiteTaxonomyVocabulariesPage with siteID as the parameter") {
-			var siteId = JSONGroupAPI._getGroupIdByNameNoSelenium(
-				groupName = "Guest",
-				site = "true");
-
 			APIExplorer.executeAPIMethodWithParameters(
 				method = "getSiteTaxonomyVocabulariesPage",
 				parameter = "siteId",
@@ -628,10 +593,6 @@ definition {
 		}
 
 		task ("When executing getSiteStructuredContentsPage with siteID as the parameter") {
-			var siteId = JSONGroupAPI._getGroupIdByNameNoSelenium(
-				groupName = "Guest",
-				site = "true");
-
 			APIExplorer.executeAPIMethodWithParameters(
 				method = "getSiteStructuredContentsPage",
 				parameter = "siteId",

--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectDefinitionAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectDefinitionAPI.macro
@@ -744,6 +744,14 @@ definition {
 		return ${response};
 	}
 
+	macro getObjectDefinitionStatusByName {
+		var objectDefinitionId = ObjectDefinitionAPI.getObjectDefinitionIdByName(name = ${name});
+
+		var objectDefinitionStatus = ObjectDefinitionAPI._getObjectDefinitionStatusById(objectDefinitionId = ${objectDefinitionId});
+
+		return ${objectDefinitionStatus};
+	}
+
 	macro getObjectEntries {
 		Variables.assertDefined(parameterList = ${en_US_plural_label});
 

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/BreakRelationshipBetweenSystemAndCustonObjects.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/BreakRelationshipBetweenSystemAndCustonObjects.testcase
@@ -82,10 +82,6 @@ definition {
 		property test.name.skip.portal.instance = "BreakRelationshipBetweenSystemAndCustonObjects#CanBreakManyToManyRelationship";
 
 		task ("Given I relate the custom object entry with the userAccount entry through the userAccount PUT endpoint") {
-			var response = ObjectDefinitionAPI._getRelationshipId(
-				objectDefinitionId = ${staticObjectId},
-				relationshipName = "usersSecondFoundations");
-
 			UserAccountAPI.relateObjectEntries(
 				customObjectId = ${staticObjectEntryId3},
 				relationshipName = "usersSecondFoundations",

--- a/portal-web/test/functional/com/liferay/portalweb/macros/journal/WebContentNavigator.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/journal/WebContentNavigator.macro
@@ -152,6 +152,14 @@ definition {
 			value1 = ${templateName});
 	}
 
+	macro openFolderInWebContentAdmin {
+		var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = ${depotName});
+
+		Navigator.openWithAppendToBaseURL(
+			baseURL = ${baseURL},
+			urlAppend = "group/asset-library-${assetLibraryId}/~/control_panel/manage?p_p_id=com_liferay_journal_web_portlet_JournalPortlet&_com_liferay_journal_web_portlet_JournalPortlet_folderId=${folderId}");
+	}
+
 	// You can use this navigation when you need to access the configuration quickly without checking the UI.
 
 	macro openToAddBasicArticle {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/journal/WebContentNavigator.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/journal/WebContentNavigator.macro
@@ -239,15 +239,18 @@ definition {
 	}
 
 	macro openWebContentStructuresAdmin {
-		Navigator.openWithAppendToBaseURL(
-			baseURL = ${baseURL},
-			urlAppend = "group/${siteURLKey}/~/control_panel/manage?p_p_id=com_liferay_journal_web_portlet_JournalPortlet&_com_liferay_journal_web_portlet_JournalPortlet_mvcPath=%2Fview_ddm_structures.jsp&p_p_auth=sNIcMAzl");
-	}
+		if (isSet(depotName)) {
+			var depotId = JSONGroupAPI._getDepotIdByName(depotName = ${depotName});
 
-	macro openWebContentStructuresAdminInAssetLibrary {
+			var urlKey = "asset-library-${depotId}";
+		}
+		else {
+			var urlKey = ${siteURLKey};
+		}
+
 		Navigator.openWithAppendToBaseURL(
 			baseURL = ${baseURL},
-			urlAppend = "group/asset-library-${depotId}/~/control_panel/manage?p_p_id=com_liferay_journal_web_portlet_JournalPortlet&_com_liferay_journal_web_portlet_JournalPortlet_mvcPath=%2Fview_ddm_structures.jsp");
+			urlAppend = "group/${urlKey}/~/control_panel/manage?p_p_id=com_liferay_journal_web_portlet_JournalPortlet&_com_liferay_journal_web_portlet_JournalPortlet_mvcPath=%2Fview_ddm_structures.jsp&p_p_auth=sNIcMAzl");
 	}
 
 	macro openWebContentTemplatesAdmin {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/group/JSONGroupAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/group/JSONGroupAPI.macro
@@ -159,7 +159,7 @@ definition {
 			var portalURL = JSONCompany.getPortalURL();
 		}
 
-		if (isSet(noSelenium)) {
+		if (${noSelenium} == "true") {
 			var companyId = JSONCompany.getCompanyIdNoSelenium(portalURL = ${portalURL});
 		}
 		else {


### PR DESCRIPTION
**Background:**
- Check all the underscored methods, verify whether they're internal methods and update tests

**Jira Ticket:**
- https://issues.liferay.com/browse/LPS-175093

**Key Changes:**
- add getObjectDefinitionStatusByName in ObjectDefinitionAPI.macro to reduce testing codes with getId and getStatus in tests
- remove unused siteId and use JSONGroupSetter.setGroupId instead of using JSONGroupAPI._getGroupIdX in tests
- reduce get assetLibraryId in tests by passing methods depotName parameter in macro files 
- combine openWebContentStructuresAdmin() and openWebContentStructuresAdminInAssetLibrary() in macro and update test
- add openFolderInWebContentAdmin in WebContentNavigator.macro to reduce codes in related tests