### PR TITLE
LPS-175920 | Can break oneToMany relationship with custom object as parent in virtual instance

### DIFF
--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectDefinitionAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectDefinitionAPI.macro
@@ -134,7 +134,16 @@ definition {
 	macro _createRelationship {
 		Variables.assertDefined(parameterList = "${deletionType},${en_US_label},${name},${objectDefinitionId1},${objectDefinitionId2},${type}");
 
-		var portalURL = JSONCompany.getPortalURL();
+		if (isSet(virtualHost)) {
+			if (!(isSet(port))) {
+				var port = 8080;
+			}
+
+			var portalURL = "http://${virtualHost}:${port}";
+		}
+		else {
+			var portalURL = JSONCompany.getPortalURL();
+		}
 
 		var curl = '''
 			${portalURL}/o/object-admin/v1.0/object-definitions/${objectDefinitionId1}/object-relationships \
@@ -163,7 +172,17 @@ definition {
 	macro _curlObjectEntriesRelationship {
 		Variables.assertDefined(parameterList = "${en_US_plural_label},${objectEntry1},${objectEntry2},${relationshipName}");
 
-		var portalURL = JSONCompany.getPortalURL();
+		if (isSet(virtualHost)) {
+			if (!(isSet(port))) {
+				var port = 8080;
+			}
+
+			var portalURL = "http://${virtualHost}:${port}";
+		}
+		else {
+			var portalURL = JSONCompany.getPortalURL();
+		}
+
 		var en_US_plural_label_lowercase = StringUtil.lowerCase(${en_US_plural_label});
 
 		var curl = '''
@@ -348,7 +367,16 @@ definition {
 	macro _getRelationshipNameById {
 		Variables.assertDefined(parameterList = ${relationshipId});
 
-		var portalURL = JSONCompany.getPortalURL();
+		if (isSet(virtualHost)) {
+			if (!(isSet(port))) {
+				var port = 8080;
+			}
+
+			var portalURL = "http://${virtualHost}:${port}";
+		}
+		else {
+			var portalURL = JSONCompany.getPortalURL();
+		}
 
 		var curl = '''
 			${portalURL}/o/object-admin/v1.0/object-relationships/${relationshipId} \
@@ -601,7 +629,8 @@ definition {
 			en_US_plural_label = ${en_US_plural_label},
 			objectEntry1 = ${objectEntry1},
 			objectEntry2 = ${objectEntry2},
-			relationshipName = ${relationshipName});
+			relationshipName = ${relationshipName},
+			virtualHost = ${virtualHost});
 
 		JSONCurlUtil.delete(${curl});
 	}
@@ -737,9 +766,12 @@ definition {
 			name = ${name},
 			objectDefinitionId1 = ${objectDefinitionId1},
 			objectDefinitionId2 = ${objectDefinitionId2},
-			type = ${type});
+			type = ${type},
+			virtualHost = ${virtualHost});
 
-		var relationshipName = ObjectDefinitionAPI._getRelationshipNameById(relationshipId = ${relationshipId});
+		var relationshipName = ObjectDefinitionAPI._getRelationshipNameById(
+			relationshipId = ${relationshipId},
+			virtualHost = ${virtualHost});
 
 		TestUtils.assertEquals(
 			actual = ${relationshipName},
@@ -775,7 +807,16 @@ definition {
 	macro getObjectDefinitionIdByName {
 		Variables.assertDefined(parameterList = ${name});
 
-		var portalURL = JSONCompany.getPortalURL();
+		if (isSet(virtualHost)) {
+			if (!(isSet(port))) {
+				var port = 8080;
+			}
+
+			var portalURL = "http://${virtualHost}:${port}";
+		}
+		else {
+			var portalURL = JSONCompany.getPortalURL();
+		}
 
 		var curl = '''
 			${portalURL}/o/object-admin/v1.0/object-definitions?filter=name%20eq%20%27${name}%27 \
@@ -843,8 +884,18 @@ definition {
 	macro getObjectEntryRelationship {
 		Variables.assertDefined(parameterList = "${en_US_plural_label},${objectId},${relationshipName}");
 
+		if (isSet(virtualHost)) {
+			if (!(isSet(port))) {
+				var port = 8080;
+			}
+
+			var portalURL = "http://${virtualHost}:${port}";
+		}
+		else {
+			var portalURL = JSONCompany.getPortalURL();
+		}
+
 		var en_US_plural_label_lowercase = StringUtil.lowerCase(${en_US_plural_label});
-		var portalURL = JSONCompany.getPortalURL();
 
 		var curl = '''
 			${portalURL}/o/c/${en_US_plural_label_lowercase}/${objectId}/${relationshipName} \
@@ -888,7 +939,8 @@ definition {
 			en_US_plural_label = ${en_US_plural_label},
 			objectEntry1 = ${objectEntry1},
 			objectEntry2 = ${objectEntry2},
-			relationshipName = ${relationshipName});
+			relationshipName = ${relationshipName},
+			virtualHost = ${virtualHost});
 
 		var response = JSONCurlUtil.put(${curl});
 
@@ -898,7 +950,9 @@ definition {
 	macro setUpGlobalObjectDefinitionIdWithName {
 		Variables.assertDefined(parameterList = ${objectName});
 
-		var objectId = ObjectDefinitionAPI.getObjectDefinitionIdByName(name = ${objectName});
+		var objectId = ObjectDefinitionAPI.getObjectDefinitionIdByName(
+			name = ${objectName},
+			virtualHost = ${virtualHost});
 
 		static var staticObjectId = ${objectId};
 
@@ -908,28 +962,49 @@ definition {
 	macro setUpGlobalObjectEntryId {
 		var objectEntryId1 = ObjectDefinitionAPI.createObjectEntryWithName(
 			en_US_plural_label = "foundations",
-			name = "Foundation First");
+			name = "Foundation First",
+			virtualHost = ${virtualHost});
 		var objectEntryId2 = ObjectDefinitionAPI.createObjectEntryWithName(
 			en_US_plural_label = "foundations",
-			name = "Foundation Second");
+			name = "Foundation Second",
+			virtualHost = ${virtualHost});
 		var objectEntryId3 = ObjectDefinitionAPI.createObjectEntryWithName(
 			en_US_plural_label = "secondFoundations",
-			name = "Foundation First-1");
+			name = "Foundation First-1",
+			virtualHost = ${virtualHost});
 		var objectEntryId4 = ObjectDefinitionAPI.createObjectEntryWithName(
 			en_US_plural_label = "secondFoundations",
-			name = "Foundation Second-1");
-		static var staticObjectEntryId1 = ${objectEntryId1};
-		static var staticObjectEntryId2 = ${objectEntryId2};
-		static var staticObjectEntryId3 = ${objectEntryId3};
-		static var staticObjectEntryId4 = ${objectEntryId4};
+			name = "Foundation Second-1",
+			virtualHost = ${virtualHost});
 
-		return ${staticObjectEntryId1};
+		if (isSet(virtualHost)) {
+			static var staticObjectEntryId5 = ${objectEntryId1};
+			static var staticObjectEntryId6 = ${objectEntryId2};
+			static var staticObjectEntryId7 = ${objectEntryId3};
+			static var staticObjectEntryId8 = ${objectEntryId4};
 
-		return ${staticObjectEntryId2};
+			return ${staticObjectEntryId5};
 
-		return ${staticObjectEntryId3};
+			return ${staticObjectEntryId6};
 
-		return ${staticObjectEntryId4};
+			return ${staticObjectEntryId7};
+
+			return ${staticObjectEntryId8};
+		}
+		else {
+			static var staticObjectEntryId1 = ${objectEntryId1};
+			static var staticObjectEntryId2 = ${objectEntryId2};
+			static var staticObjectEntryId3 = ${objectEntryId3};
+			static var staticObjectEntryId4 = ${objectEntryId4};
+
+			return ${staticObjectEntryId1};
+
+			return ${staticObjectEntryId2};
+
+			return ${staticObjectEntryId3};
+
+			return ${staticObjectEntryId4};
+		}
 	}
 
 	macro setUpGlobalUniversityId {

--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/UserAccountAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/UserAccountAPI.macro
@@ -1,7 +1,16 @@
 definition {
 
 	macro _curlUserAccount {
-		var portalURL = JSONCompany.getPortalURL();
+		if (isSet(virtualHost)) {
+			if (!(isSet(port))) {
+				var port = 8080;
+			}
+
+			var portalURL = "http://${virtualHost}:${port}";
+		}
+		else {
+			var portalURL = JSONCompany.getPortalURL();
+		}
 
 		if (isSet(userAccountId)) {
 			var api = "user-accounts/${userAccountId}";
@@ -59,7 +68,7 @@ definition {
 	macro createUserAccount {
 		Variables.assertDefined(parameterList = "${alternateName},${emailAddress},${familyName},${givenName}");
 
-		var curl = UserAccountAPI._curlUserAccount();
+		var curl = UserAccountAPI._curlUserAccount(virtualHost = ${virtualHost});
 		var body = '''"alternateName": "${alternateName}","emailAddress": "${emailAddress}","familyName": "${familyName}","givenName": "${givenName}"''';
 
 		if (isSet(fieldName) && isSet(fieldValue)) {
@@ -236,20 +245,33 @@ definition {
 			alternateName = ${alternateName1},
 			emailAddress = ${emailAddress1},
 			familyName = ${familyName1},
-			givenName = ${givenName1});
+			givenName = ${givenName1},
+			virtualHost = ${virtualHost});
 		var response2 = UserAccountAPI.createUserAccount(
 			alternateName = ${alternateName2},
 			emailAddress = ${emailAddress2},
 			familyName = ${familyName2},
-			givenName = ${givenName2});
+			givenName = ${givenName2},
+			virtualHost = ${virtualHost});
 		var userAccountId1 = JSONPathUtil.getIdValue(response = ${response1});
 		var userAccountId2 = JSONPathUtil.getIdValue(response = ${response2});
-		static var staticUserAccountId1 = ${userAccountId1};
-		static var staticUserAccountId2 = ${userAccountId2};
 
-		return ${staticUserAccountId1};
+		if (isSet(virtualHost)) {
+			static var staticUserAccountId3 = ${userAccountId1};
+			static var staticUserAccountId4 = ${userAccountId2};
 
-		return ${staticUserAccountId2};
+			return ${staticUserAccountId3};
+
+			return ${staticUserAccountId4};
+		}
+		else {
+			static var staticUserAccountId1 = ${userAccountId1};
+			static var staticUserAccountId2 = ${userAccountId2};
+
+			return ${staticUserAccountId1};
+
+			return ${staticUserAccountId2};
+		}
 	}
 
 }

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/BreakRelationshipBetweenCustomAndSystemObjects.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/BreakRelationshipBetweenCustomAndSystemObjects.testcase
@@ -10,12 +10,25 @@ definition {
 	setUp {
 		TestCase.setUpPortalInstanceNoSelenium();
 
+		task ("Given a virtual Instance") {
+			HeadlessPortalInstanceAPI.addPortalInstance(
+				domain = "liferay.com",
+				portalInstanceId = "www.able.com",
+				virtualHost = "www.able.com");
+		}
+
 		task ("Given a foundation object") {
 			var customObjectDefinitionId1 = ObjectDefinitionAPI.createAndPublishObjectDefinition(
 				en_US_label = "foundation",
 				en_US_plural_label = "foundations",
 				name = "Foundation",
 				requiredStringFieldName = "name");
+			var customObjectDefinitionId3 = ObjectDefinitionAPI.createAndPublishObjectDefinition(
+				en_US_label = "foundation",
+				en_US_plural_label = "foundations",
+				name = "Foundation",
+				requiredStringFieldName = "name",
+				virtualHost = "www.able.com");
 		}
 
 		task ("Given a secondFoundation object") {
@@ -24,32 +37,61 @@ definition {
 				en_US_plural_label = "secondFoundations",
 				name = "SecondFoundation",
 				requiredStringFieldName = "name");
+			var customObjectDefinitionId4 = ObjectDefinitionAPI.createAndPublishObjectDefinition(
+				en_US_label = "secondFoundation",
+				en_US_plural_label = "secondFoundations",
+				name = "SecondFoundation",
+				requiredStringFieldName = "name",
+				virtualHost = "www.able.com");
 		}
 
 		task ("Given oneToMany relationship secondFoundationOfUsers created") {
-			ObjectDefinitionAPI.setUpGlobalObjectDefinitionIdWithName(objectName = "User");
+			var systemObjectDefinitionId1 = ObjectDefinitionAPI.setUpGlobalObjectDefinitionIdWithName(objectName = "User");
+			var systemObjectDefinitionId2 = ObjectDefinitionAPI.setUpGlobalObjectDefinitionIdWithName(
+				objectName = "User",
+				virtualHost = "www.able.com");
 
-			var relationshipName = ObjectDefinitionAPI.createRelationship(
+			ObjectDefinitionAPI.createRelationship(
 				deletionType = "cascade",
 				en_US_label = "SecondFoundationOfUsers",
 				name = "secondFoundationOfUsers",
 				objectDefinitionId1 = ${customObjectDefinitionId2},
-				objectDefinitionId2 = ${staticObjectId},
+				objectDefinitionId2 = ${systemObjectDefinitionId1},
 				type = "oneToMany");
+
+			ObjectDefinitionAPI.createRelationship(
+				deletionType = "cascade",
+				en_US_label = "SecondFoundationOfUsers",
+				name = "secondFoundationOfUsers",
+				objectDefinitionId1 = ${customObjectDefinitionId4},
+				objectDefinitionId2 = ${systemObjectDefinitionId2},
+				type = "oneToMany",
+				virtualHost = "www.able.com");
 		}
 
 		task ("Given manyToMany relationship foundationsOfUsers created") {
-			var relationshipName = ObjectDefinitionAPI.createRelationship(
+			ObjectDefinitionAPI.createRelationship(
 				deletionType = "cascade",
 				en_US_label = "FoundationsOfUsers",
 				name = "foundationsOfUsers",
 				objectDefinitionId1 = ${customObjectDefinitionId1},
-				objectDefinitionId2 = ${staticObjectId},
+				objectDefinitionId2 = ${systemObjectDefinitionId1},
 				type = "manyToMany");
+
+			ObjectDefinitionAPI.createRelationship(
+				deletionType = "cascade",
+				en_US_label = "FoundationsOfUsers",
+				name = "foundationsOfUsers",
+				objectDefinitionId1 = ${customObjectDefinitionId3},
+				objectDefinitionId2 = ${systemObjectDefinitionId2},
+				type = "manyToMany",
+				virtualHost = "www.able.com");
 		}
 
 		task ("Given object entries created") {
 			ObjectDefinitionAPI.setUpGlobalObjectEntryId();
+
+			ObjectDefinitionAPI.setUpGlobalObjectEntryId(virtualHost = "www.able.com");
 		}
 
 		task ("Given userAccount entry created") {
@@ -62,11 +104,24 @@ definition {
 				familyName2 = "userfn2",
 				givenName1 = "usergn1",
 				givenName2 = "usergn2");
+
+			UserAccountAPI.setUpGlobalUserAccountIds(
+				alternateName1 = "user1",
+				alternateName2 = "user2",
+				emailAddress1 = "user1@liferay.com",
+				emailAddress2 = "user2@liferay.com",
+				familyName1 = "userfn1",
+				familyName2 = "userfn2",
+				givenName1 = "usergn1",
+				givenName2 = "usergn2",
+				virtualHost = "www.able.com");
 		}
 	}
 
 	tearDown {
 		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		HeadlessPortalInstanceAPI.cleanAllPortalInstances();
 
 		ObjectAdmin.deleteAllCustomObjectsViaAPI();
 
@@ -104,6 +159,41 @@ definition {
 				en_US_plural_label = "foundations",
 				objectId = ${staticObjectEntryId1},
 				relationshipName = "foundationsOfUsers");
+
+			ObjectDefinitionAPI.assertNoItemsInResponse(responseToParse = ${response});
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 4
+	test CanBreakManyToManyRelationshipWithSystemObjectAsParentInVirtualInstance {
+		property portal.acceptance = "true";
+		property test.name.skip.portal.instance = "BreakRelationshipBetweenCustomAndSystemObjects#CanBreakManyToManyRelationshipWithSystemObjectAsParentInVirtualInstance";
+
+		task ("Given I relate the userAccount entry with the foundation entry through the foundation PUT endpoint") {
+			ObjectDefinitionAPI.relateObjectEntries(
+				en_US_plural_label = "foundations",
+				objectEntry1 = ${staticObjectEntryId5},
+				objectEntry2 = ${staticUserAccountId3},
+				relationshipName = "foundationsOfUsers",
+				virtualHost = "www.able.com");
+		}
+
+		task ("When using the delete request deleteFoundation{relationshipName}") {
+			ObjectDefinitionAPI.breakRelationshipBetweenEntries(
+				en_US_plural_label = "foundations",
+				objectEntry1 = ${staticObjectEntryId5},
+				objectEntry2 = ${staticUserAccountId3},
+				relationshipName = "foundationsOfUsers",
+				virtualHost = "www.able.com");
+		}
+
+		task ("Then I can see no one entry correctly related in GET request response with the relationshipName=foundationsOfUsers") {
+			var response = ObjectDefinitionAPI.getObjectEntryRelationship(
+				en_US_plural_label = "foundations",
+				objectId = ${staticObjectEntryId5},
+				relationshipName = "foundationsOfUsers",
+				virtualHost = "www.able.com");
 
 			ObjectDefinitionAPI.assertNoItemsInResponse(responseToParse = ${response});
 		}
@@ -179,6 +269,51 @@ definition {
 				relationshipName = "secondFoundationOfUsers");
 
 			ObjectDefinitionAPI.assertNoItemsInResponse(responseToParse = ${response});
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 4
+	test CanBreakOneToManyRelationshipWithCustomObjectAsParentInVirtualInstance {
+		property portal.acceptance = "true";
+		property test.name.skip.portal.instance = "BreakRelationshipBetweenCustomAndSystemObjects#CanBreakOneToManyRelationshipWithCustomObjectAsParentInVirtualInstance";
+
+		task ("Given all userAccounts are related to the secondFoundation through the secondFoundation PUT endpoint") {
+			ObjectDefinitionAPI.relateObjectEntries(
+				en_US_plural_label = "secondFoundations",
+				objectEntry1 = ${staticObjectEntryId7},
+				objectEntry2 = ${staticUserAccountId3},
+				relationshipName = "secondFoundationOfUsers",
+				virtualHost = "www.able.com");
+
+			ObjectDefinitionAPI.relateObjectEntries(
+				en_US_plural_label = "secondFoundations",
+				objectEntry1 = ${staticObjectEntryId7},
+				objectEntry2 = ${staticUserAccountId4},
+				relationshipName = "secondFoundationOfUsers",
+				virtualHost = "www.able.com");
+		}
+
+		task ("When deleting one of the userAccount entries") {
+			ObjectDefinitionAPI.breakRelationshipBetweenEntries(
+				en_US_plural_label = "secondFoundations",
+				objectEntry1 = ${staticObjectEntryId7},
+				objectEntry2 = ${staticUserAccountId3},
+				relationshipName = "secondFoundationOfUsers",
+				virtualHost = "www.able.com");
+		}
+
+		task ("Then I can see only one entry correctly related in GET request response") {
+			var response = ObjectDefinitionAPI.getObjectEntryRelationship(
+				en_US_plural_label = "secondFoundations",
+				objectId = ${staticObjectEntryId7},
+				relationshipName = "secondFoundationOfUsers",
+				virtualHost = "www.able.com");
+
+			ObjectDefinitionAPI.assertResponseHasCorrectObjectEntryName(
+				expectedValue = "usergn2 userfn2",
+				objectEntryId = ${staticUserAccountId4},
+				responseToParse = ${response});
 		}
 	}
 

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/BreakRelationshipBetweenCustomAndSystemObjects.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/BreakRelationshipBetweenCustomAndSystemObjects.testcase
@@ -18,12 +18,12 @@ definition {
 		}
 
 		task ("Given a foundation object") {
-			var customObjectDefinitionId1 = ObjectDefinitionAPI.createAndPublishObjectDefinition(
+			var foundationObjectDefinitionId = ObjectDefinitionAPI.createAndPublishObjectDefinition(
 				en_US_label = "foundation",
 				en_US_plural_label = "foundations",
 				name = "Foundation",
 				requiredStringFieldName = "name");
-			var customObjectDefinitionId3 = ObjectDefinitionAPI.createAndPublishObjectDefinition(
+			var foundationObjectDefinitionIdInVirtualInstance = ObjectDefinitionAPI.createAndPublishObjectDefinition(
 				en_US_label = "foundation",
 				en_US_plural_label = "foundations",
 				name = "Foundation",
@@ -32,12 +32,12 @@ definition {
 		}
 
 		task ("Given a secondFoundation object") {
-			var customObjectDefinitionId2 = ObjectDefinitionAPI.createAndPublishObjectDefinition(
+			var secondFoundationObjectDefinitionId = ObjectDefinitionAPI.createAndPublishObjectDefinition(
 				en_US_label = "secondFoundation",
 				en_US_plural_label = "secondFoundations",
 				name = "SecondFoundation",
 				requiredStringFieldName = "name");
-			var customObjectDefinitionId4 = ObjectDefinitionAPI.createAndPublishObjectDefinition(
+			var secondFoundationObjectDefinitionIdInVirtualInstance = ObjectDefinitionAPI.createAndPublishObjectDefinition(
 				en_US_label = "secondFoundation",
 				en_US_plural_label = "secondFoundations",
 				name = "SecondFoundation",
@@ -55,7 +55,7 @@ definition {
 				deletionType = "cascade",
 				en_US_label = "SecondFoundationOfUsers",
 				name = "secondFoundationOfUsers",
-				objectDefinitionId1 = ${customObjectDefinitionId2},
+				objectDefinitionId1 = ${secondFoundationObjectDefinitionId},
 				objectDefinitionId2 = ${systemObjectDefinitionId1},
 				type = "oneToMany");
 
@@ -63,7 +63,7 @@ definition {
 				deletionType = "cascade",
 				en_US_label = "SecondFoundationOfUsers",
 				name = "secondFoundationOfUsers",
-				objectDefinitionId1 = ${customObjectDefinitionId4},
+				objectDefinitionId1 = ${secondFoundationObjectDefinitionIdInVirtualInstance},
 				objectDefinitionId2 = ${systemObjectDefinitionId2},
 				type = "oneToMany",
 				virtualHost = "www.able.com");
@@ -74,7 +74,7 @@ definition {
 				deletionType = "cascade",
 				en_US_label = "FoundationsOfUsers",
 				name = "foundationsOfUsers",
-				objectDefinitionId1 = ${customObjectDefinitionId1},
+				objectDefinitionId1 = ${foundationObjectDefinitionId},
 				objectDefinitionId2 = ${systemObjectDefinitionId1},
 				type = "manyToMany");
 
@@ -82,7 +82,7 @@ definition {
 				deletionType = "cascade",
 				en_US_label = "FoundationsOfUsers",
 				name = "foundationsOfUsers",
-				objectDefinitionId1 = ${customObjectDefinitionId3},
+				objectDefinitionId1 = ${foundationObjectDefinitionIdInVirtualInstance},
 				objectDefinitionId2 = ${systemObjectDefinitionId2},
 				type = "manyToMany",
 				virtualHost = "www.able.com");


### PR DESCRIPTION
**Background**
Add a test case to break oneToMany relationship with custom object as parent in virtual instance

**Test Plan**
CanBreakManyToManyRelationshipWithSystemObjectAsParentInVirtualInstance
Given a virtual Instance
Given login with the new virtual Instance
Given a foundation object
Given manyToMany relationship foundationsOfUsers created
Given one foundation entry created
Given one userAccount entry created
Given I relate the userAccount entry with the foundation entry through the foundation PUT endpoint
When using the delete request deleteFoundation{relationshipName}
Then I can see no one entry correctly related in GET request response with the relationshipName=foundationsOfUsers

CanBreakOneToManyRelationshipWithCustomObjectAsParentInVirtualInstance
Given a virtual Instance
Given login with the new virtual Instance
Given a secondFoundation object
Given oneToMany relationship secondFoundationOfUsers created
Given one secondFoundation entries created
Given two userAccount entry created
Given all userAccounts are related to the secondFoundation through the secondFoundation PUT endpoint
When deleting one of the userAccount entries
Then I can see only one entry correctly related in GET request response

**JIRA Link:**
https://issues.liferay.com/browse/LPS-175920