### PR TITLE
Remove from headless test suites the integration tests for modules that do not belong to headless anymore

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -4667,9 +4667,6 @@
         **/batch-engine/**/*Test.java,\
         **/batch-planner/**/*Test.java,\
         **/dispatch/**/*Test.java,\
-        **/headless/headless-admin-content/**/*Test.java,\
-        **/headless/headless-admin-taxonomy/**/*Test.java,\
-        **/headless/headless-delivery/**/*Test.java,\
         **/portal-tools-rest-builder/**/*Test.java,\
         **/portal-vulcan/**/*Test.java
 
@@ -4697,9 +4694,6 @@
         **/batch-engine/**/*Test.java,\
         **/batch-planner/**/*Test.java,\
         **/dispatch/**/*Test.java,\
-        **/headless/headless-admin-content/**/*Test.java,\
-        **/headless/headless-admin-taxonomy/**/*Test.java,\
-        **/headless/headless-delivery/**/*Test.java,\
         **/portal-tools-rest-builder/**/*Test.java,\
         **/portal-vulcan/**/*Test.java,\
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-177594