### PR TITLE
PTR-3697 Headless API returns [Bad Request Error] when friendlyUrl includes /

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-api/bnd.bnd
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Delivery API
 Bundle-SymbolicName: com.liferay.headless.delivery.api
-Bundle-Version: 46.5.1
+Bundle-Version: 46.6.0
 Export-Package:\
 	com.liferay.headless.delivery.dto.v1_0,\
 	com.liferay.headless.delivery.dto.v1_0.util,\

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/BlogPostingResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/BlogPostingResource.java
@@ -112,6 +112,18 @@ public interface BlogPostingResource {
 			Long siteId, String callbackURL, Object object)
 		throws Exception;
 
+	public void deleteSiteBlogPostingByExternalReferenceCodeQueryParam(
+			Long siteId, String externalReferenceCode)
+		throws Exception;
+
+	public BlogPosting getSiteBlogPostingByExternalReferenceCodeQueryParam(
+			Long siteId, String externalReferenceCode)
+		throws Exception;
+
+	public BlogPosting putSiteBlogPostingByExternalReferenceCodeQueryParam(
+			Long siteId, String externalReferenceCode, BlogPosting blogPosting)
+		throws Exception;
+
 	public void deleteSiteBlogPostingByExternalReferenceCode(
 			Long siteId, String externalReferenceCode)
 		throws Exception;

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 17.3.0
+version 17.4.0

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/BlogPostingResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/BlogPostingResource.java
@@ -164,6 +164,34 @@ public interface BlogPostingResource {
 			Long siteId, String callbackURL, Object object)
 		throws Exception;
 
+	public void deleteSiteBlogPostingByExternalReferenceCodeQueryParam(
+			Long siteId, String externalReferenceCode)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			deleteSiteBlogPostingByExternalReferenceCodeQueryParamHttpResponse(
+				Long siteId, String externalReferenceCode)
+		throws Exception;
+
+	public BlogPosting getSiteBlogPostingByExternalReferenceCodeQueryParam(
+			Long siteId, String externalReferenceCode)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			getSiteBlogPostingByExternalReferenceCodeQueryParamHttpResponse(
+				Long siteId, String externalReferenceCode)
+		throws Exception;
+
+	public BlogPosting putSiteBlogPostingByExternalReferenceCodeQueryParam(
+			Long siteId, String externalReferenceCode, BlogPosting blogPosting)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			putSiteBlogPostingByExternalReferenceCodeQueryParamHttpResponse(
+				Long siteId, String externalReferenceCode,
+				BlogPosting blogPosting)
+		throws Exception;
+
 	public void deleteSiteBlogPostingByExternalReferenceCode(
 			Long siteId, String externalReferenceCode)
 		throws Exception;
@@ -1630,6 +1658,283 @@ public interface BlogPostingResource {
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
 						"/o/headless-delivery/v1.0/sites/{siteId}/blog-postings/batch");
+
+			httpInvoker.path("siteId", siteId);
+
+			httpInvoker.userNameAndPassword(
+				_builder._login + ":" + _builder._password);
+
+			return httpInvoker.invoke();
+		}
+
+		public void deleteSiteBlogPostingByExternalReferenceCodeQueryParam(
+				Long siteId, String externalReferenceCode)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				deleteSiteBlogPostingByExternalReferenceCodeQueryParamHttpResponse(
+					siteId, externalReferenceCode);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return;
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				deleteSiteBlogPostingByExternalReferenceCodeQueryParamHttpResponse(
+					Long siteId, String externalReferenceCode)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(
+				externalReferenceCode.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.DELETE);
+
+			if (externalReferenceCode != null) {
+				httpInvoker.parameter(
+					"externalReferenceCode",
+					String.valueOf(externalReferenceCode));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-delivery/v1.0/sites/{siteId}/blog-postings/by-external-reference-code-query-param");
+
+			httpInvoker.path("siteId", siteId);
+
+			httpInvoker.userNameAndPassword(
+				_builder._login + ":" + _builder._password);
+
+			return httpInvoker.invoke();
+		}
+
+		public BlogPosting getSiteBlogPostingByExternalReferenceCodeQueryParam(
+				Long siteId, String externalReferenceCode)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getSiteBlogPostingByExternalReferenceCodeQueryParamHttpResponse(
+					siteId, externalReferenceCode);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return BlogPostingSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				getSiteBlogPostingByExternalReferenceCodeQueryParamHttpResponse(
+					Long siteId, String externalReferenceCode)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			if (externalReferenceCode != null) {
+				httpInvoker.parameter(
+					"externalReferenceCode",
+					String.valueOf(externalReferenceCode));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-delivery/v1.0/sites/{siteId}/blog-postings/by-external-reference-code-query-param");
+
+			httpInvoker.path("siteId", siteId);
+
+			httpInvoker.userNameAndPassword(
+				_builder._login + ":" + _builder._password);
+
+			return httpInvoker.invoke();
+		}
+
+		public BlogPosting putSiteBlogPostingByExternalReferenceCodeQueryParam(
+				Long siteId, String externalReferenceCode,
+				BlogPosting blogPosting)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				putSiteBlogPostingByExternalReferenceCodeQueryParamHttpResponse(
+					siteId, externalReferenceCode, blogPosting);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return BlogPostingSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				putSiteBlogPostingByExternalReferenceCodeQueryParamHttpResponse(
+					Long siteId, String externalReferenceCode,
+					BlogPosting blogPosting)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(blogPosting.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.PUT);
+
+			if (externalReferenceCode != null) {
+				httpInvoker.parameter(
+					"externalReferenceCode",
+					String.valueOf(externalReferenceCode));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-delivery/v1.0/sites/{siteId}/blog-postings/by-external-reference-code-query-param");
 
 			httpInvoker.path("siteId", siteId);
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -10809,6 +10809,104 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/BlogPosting"
             tags: ["BlogPosting"]
+    "/sites/{siteId}/blog-postings/by-external-reference-code-query-param":
+        delete:
+            # @review
+            description:
+                Deletes the blog post by external reference code.
+            operationId: deleteSiteBlogPostingByExternalReferenceCodeQueryParam
+            parameters:
+                - in: path
+                  name: siteId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+                - in: query
+                  name: externalReferenceCode
+                  required: true
+                  schema:
+                      type: string
+            responses:
+                204:
+                    content:
+                        application/json: {}
+                        application/xml: {}
+            tags: ["BlogPosting"]
+        get:
+            # @review
+            description:
+                Retrieves the site's blog post by external reference code.
+            operationId: getSiteBlogPostingByExternalReferenceCodeQueryParam
+            parameters:
+                - in: path
+                  name: siteId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+                - in: query
+                  name: externalReferenceCode
+                  required: true
+                  schema:
+                      type: string
+                - in: query
+                  name: fields
+                  schema:
+                      type: string
+                - in: query
+                  name: nestedFields
+                  schema:
+                      type: string
+                - in: query
+                  name: restrictFields
+                  schema:
+                      type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/BlogPosting"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/BlogPosting"
+            tags: ["BlogPosting"]
+        put:
+            # @review
+            description:
+                Updates the site's blog post with the given external reference code, or creates it if it not exists.
+            operationId: putSiteBlogPostingByExternalReferenceCodeQueryParam
+            parameters:
+                - in: path
+                  name: siteId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+                - in: query
+                  name: externalReferenceCode
+                  required: true
+                  schema:
+                      type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/BlogPosting"
+                    application/xml:
+                        schema:
+                            $ref: "#/components/schemas/BlogPosting"
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/BlogPosting"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/BlogPosting"
+            tags: ["BlogPosting"]
     "/sites/{siteId}/blog-postings/by-external-reference-code/{blogPostingExternalReferenceCode}/comments/by-external-reference-code/{externalReferenceCode}":
         delete:
             # @review

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/mutation/v1_0/Mutation.java
@@ -408,6 +408,44 @@ public class Mutation {
 	@GraphQLField(
 		description = "Deletes the blog post by external reference code."
 	)
+	public boolean deleteSiteBlogPostingByExternalReferenceCodeQueryParam(
+			@GraphQLName("siteKey") @NotEmpty String siteKey,
+			@GraphQLName("externalReferenceCode") String externalReferenceCode)
+		throws Exception {
+
+		_applyVoidComponentServiceObjects(
+			_blogPostingResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			blogPostingResource ->
+				blogPostingResource.
+					deleteSiteBlogPostingByExternalReferenceCodeQueryParam(
+						Long.valueOf(siteKey), externalReferenceCode));
+
+		return true;
+	}
+
+	@GraphQLField(
+		description = "Updates the site's blog post with the given external reference code, or creates it if it not exists."
+	)
+	public BlogPosting updateSiteBlogPostingByExternalReferenceCodeQueryParam(
+			@GraphQLName("siteKey") @NotEmpty String siteKey,
+			@GraphQLName("externalReferenceCode") String externalReferenceCode,
+			@GraphQLName("blogPosting") BlogPosting blogPosting)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_blogPostingResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			blogPostingResource ->
+				blogPostingResource.
+					putSiteBlogPostingByExternalReferenceCodeQueryParam(
+						Long.valueOf(siteKey), externalReferenceCode,
+						blogPosting));
+	}
+
+	@GraphQLField(
+		description = "Deletes the blog post by external reference code."
+	)
 	public boolean deleteSiteBlogPostingByExternalReferenceCode(
 			@GraphQLName("siteKey") @NotEmpty String siteKey,
 			@GraphQLName("externalReferenceCode") String externalReferenceCode)

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/query/v1_0/Query.java
@@ -407,6 +407,28 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {blogPostingByExternalReferenceCodeQueryParam(externalReferenceCode: ___, siteKey: ___){actions, aggregateRating, alternativeHeadline, articleBody, creator, customFields, dateCreated, dateModified, datePublished, description, encodingFormat, externalReferenceCode, friendlyUrlPath, headline, id, image, keywords, numberOfComments, relatedContents, renderedContents, siteId, taxonomyCategoryBriefs, taxonomyCategoryIds, viewableBy}}"}' -u 'test@liferay.com:test'
+	 */
+	@GraphQLField(
+		description = "Retrieves the site's blog post by external reference code."
+	)
+	public BlogPosting blogPostingByExternalReferenceCodeQueryParam(
+			@GraphQLName("siteKey") @NotEmpty String siteKey,
+			@GraphQLName("externalReferenceCode") String externalReferenceCode)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_blogPostingResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			blogPostingResource ->
+				blogPostingResource.
+					getSiteBlogPostingByExternalReferenceCodeQueryParam(
+						Long.valueOf(siteKey), externalReferenceCode));
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
 	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {blogPostingByExternalReferenceCode(externalReferenceCode: ___, siteKey: ___){actions, aggregateRating, alternativeHeadline, articleBody, creator, customFields, dateCreated, dateModified, datePublished, description, encodingFormat, externalReferenceCode, friendlyUrlPath, headline, id, image, keywords, numberOfComments, relatedContents, renderedContents, siteId, taxonomyCategoryBriefs, taxonomyCategoryIds, viewableBy}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -266,6 +266,16 @@ public class ServletDataImpl implements ServletData {
 							BlogPostingResourceImpl.class,
 							"postSiteBlogPostingBatch"));
 					put(
+						"mutation#deleteSiteBlogPostingByExternalReferenceCodeQueryParam",
+						new ObjectValuePair<>(
+							BlogPostingResourceImpl.class,
+							"deleteSiteBlogPostingByExternalReferenceCodeQueryParam"));
+					put(
+						"mutation#updateSiteBlogPostingByExternalReferenceCodeQueryParam",
+						new ObjectValuePair<>(
+							BlogPostingResourceImpl.class,
+							"putSiteBlogPostingByExternalReferenceCodeQueryParam"));
+					put(
 						"mutation#deleteSiteBlogPostingByExternalReferenceCode",
 						new ObjectValuePair<>(
 							BlogPostingResourceImpl.class,
@@ -1453,6 +1463,11 @@ public class ServletDataImpl implements ServletData {
 						new ObjectValuePair<>(
 							BlogPostingResourceImpl.class,
 							"getSiteBlogPostingsPage"));
+					put(
+						"query#blogPostingByExternalReferenceCodeQueryParam",
+						new ObjectValuePair<>(
+							BlogPostingResourceImpl.class,
+							"getSiteBlogPostingByExternalReferenceCodeQueryParam"));
 					put(
 						"query#blogPostingByExternalReferenceCode",
 						new ObjectValuePair<>(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingResourceImpl.java
@@ -897,6 +897,147 @@ public abstract class BaseBlogPostingResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
+	 * curl -X 'DELETE' 'http://localhost:8080/o/headless-delivery/v1.0/sites/{siteId}/blog-postings/by-external-reference-code-query-param'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Deletes the blog post by external reference code."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "siteId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "externalReferenceCode"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "BlogPosting")}
+	)
+	@javax.ws.rs.DELETE
+	@javax.ws.rs.Path(
+		"/sites/{siteId}/blog-postings/by-external-reference-code-query-param"
+	)
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public void deleteSiteBlogPostingByExternalReferenceCodeQueryParam(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("siteId")
+			Long siteId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.QueryParam("externalReferenceCode")
+			String externalReferenceCode)
+		throws Exception {
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/headless-delivery/v1.0/sites/{siteId}/blog-postings/by-external-reference-code-query-param'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Retrieves the site's blog post by external reference code."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "siteId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "externalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "fields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "nestedFields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "restrictFields"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "BlogPosting")}
+	)
+	@javax.ws.rs.GET
+	@javax.ws.rs.Path(
+		"/sites/{siteId}/blog-postings/by-external-reference-code-query-param"
+	)
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public BlogPosting getSiteBlogPostingByExternalReferenceCodeQueryParam(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("siteId")
+			Long siteId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.QueryParam("externalReferenceCode")
+			String externalReferenceCode)
+		throws Exception {
+
+		return new BlogPosting();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'PUT' 'http://localhost:8080/o/headless-delivery/v1.0/sites/{siteId}/blog-postings/by-external-reference-code-query-param' -d $'{"alternativeHeadline": ___, "articleBody": ___, "customFields": ___, "datePublished": ___, "description": ___, "externalReferenceCode": ___, "friendlyUrlPath": ___, "headline": ___, "image": ___, "keywords": ___, "taxonomyCategoryIds": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Updates the site's blog post with the given external reference code, or creates it if it not exists."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "siteId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "externalReferenceCode"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "BlogPosting")}
+	)
+	@javax.ws.rs.Consumes({"application/json", "application/xml"})
+	@javax.ws.rs.Path(
+		"/sites/{siteId}/blog-postings/by-external-reference-code-query-param"
+	)
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@javax.ws.rs.PUT
+	@Override
+	public BlogPosting putSiteBlogPostingByExternalReferenceCodeQueryParam(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("siteId")
+			Long siteId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.QueryParam("externalReferenceCode")
+			String externalReferenceCode,
+			BlogPosting blogPosting)
+		throws Exception {
+
+		return new BlogPosting();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
 	 * curl -X 'DELETE' 'http://localhost:8080/o/headless-delivery/v1.0/sites/{siteId}/blog-postings/by-external-reference-code/{externalReferenceCode}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BlogPostingResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BlogPostingResourceImpl.java
@@ -110,6 +110,15 @@ public class BlogPostingResourceImpl extends BaseBlogPostingResourceImpl {
 	}
 
 	@Override
+	public void deleteSiteBlogPostingByExternalReferenceCodeQueryParam(
+			Long siteId, String externalReferenceCode)
+		throws Exception {
+
+		deleteSiteBlogPostingByExternalReferenceCode(
+			siteId, externalReferenceCode);
+	}
+
+	@Override
 	public BlogPosting getBlogPosting(Long blogPostingId) throws Exception {
 		BlogsEntry blogsEntry = _blogsEntryService.getEntry(blogPostingId);
 
@@ -155,6 +164,15 @@ public class BlogPostingResourceImpl extends BaseBlogPostingResourceImpl {
 		return _toBlogPosting(
 			_blogsEntryService.getBlogsEntryByExternalReferenceCode(
 				siteId, externalReferenceCode));
+	}
+
+	@Override
+	public BlogPosting getSiteBlogPostingByExternalReferenceCodeQueryParam(
+			Long siteId, String externalReferenceCode)
+		throws Exception {
+
+		return getSiteBlogPostingByExternalReferenceCode(
+			siteId, externalReferenceCode);
 	}
 
 	@Override
@@ -265,6 +283,15 @@ public class BlogPostingResourceImpl extends BaseBlogPostingResourceImpl {
 		}
 
 		return _addBlogPosting(externalReferenceCode, siteId, blogPosting);
+	}
+
+	@Override
+	public BlogPosting putSiteBlogPostingByExternalReferenceCodeQueryParam(
+			Long siteId, String externalReferenceCode, BlogPosting blogPosting)
+		throws Exception {
+
+		return putSiteBlogPostingByExternalReferenceCode(
+			siteId, externalReferenceCode, blogPosting);
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingResourceTestCase.java
@@ -922,6 +922,217 @@ public abstract class BaseBlogPostingResourceTestCase {
 	}
 
 	@Test
+	public void testDeleteSiteBlogPostingByExternalReferenceCodeQueryParam()
+		throws Exception {
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		BlogPosting blogPosting =
+			testDeleteSiteBlogPostingByExternalReferenceCodeQueryParam_addBlogPosting();
+
+		assertHttpResponseStatusCode(
+			204,
+			blogPostingResource.
+				deleteSiteBlogPostingByExternalReferenceCodeQueryParamHttpResponse(
+					testDeleteSiteBlogPostingByExternalReferenceCodeQueryParam_getSiteId(
+						blogPosting),
+					null));
+
+		assertHttpResponseStatusCode(
+			404,
+			blogPostingResource.
+				getSiteBlogPostingByExternalReferenceCodeQueryParamHttpResponse(
+					testDeleteSiteBlogPostingByExternalReferenceCodeQueryParam_getSiteId(
+						blogPosting),
+					testDeleteSiteBlogPostingByExternalReferenceCodeQueryParam_getExternalReferenceCode()));
+
+		assertHttpResponseStatusCode(
+			404,
+			blogPostingResource.
+				getSiteBlogPostingByExternalReferenceCodeQueryParamHttpResponse(
+					testDeleteSiteBlogPostingByExternalReferenceCodeQueryParam_getSiteId(
+						blogPosting),
+					testDeleteSiteBlogPostingByExternalReferenceCodeQueryParam_getExternalReferenceCode()));
+	}
+
+	protected Long
+			testDeleteSiteBlogPostingByExternalReferenceCodeQueryParam_getSiteId(
+				BlogPosting blogPosting)
+		throws Exception {
+
+		return blogPosting.getSiteId();
+	}
+
+	protected String
+			testDeleteSiteBlogPostingByExternalReferenceCodeQueryParam_getExternalReferenceCode(
+				BlogPosting blogPosting)
+		throws Exception {
+
+		return blogPosting.getExternalReferenceCode();
+	}
+
+	protected BlogPosting
+			testDeleteSiteBlogPostingByExternalReferenceCodeQueryParam_addBlogPosting()
+		throws Exception {
+
+		return blogPostingResource.postSiteBlogPosting(
+			testGroup.getGroupId(), randomBlogPosting());
+	}
+
+	@Test
+	public void testGetSiteBlogPostingByExternalReferenceCodeQueryParam()
+		throws Exception {
+
+		BlogPosting postBlogPosting =
+			testGetSiteBlogPostingByExternalReferenceCodeQueryParam_addBlogPosting();
+
+		BlogPosting getBlogPosting =
+			blogPostingResource.
+				getSiteBlogPostingByExternalReferenceCodeQueryParam(
+					testGetSiteBlogPostingByExternalReferenceCodeQueryParam_getSiteId(
+						postBlogPosting),
+					null);
+
+		assertEquals(postBlogPosting, getBlogPosting);
+		assertValid(getBlogPosting);
+	}
+
+	protected Long
+			testGetSiteBlogPostingByExternalReferenceCodeQueryParam_getSiteId(
+				BlogPosting blogPosting)
+		throws Exception {
+
+		return blogPosting.getSiteId();
+	}
+
+	protected BlogPosting
+			testGetSiteBlogPostingByExternalReferenceCodeQueryParam_addBlogPosting()
+		throws Exception {
+
+		return blogPostingResource.postSiteBlogPosting(
+			testGroup.getGroupId(), randomBlogPosting());
+	}
+
+	@Test
+	public void testGraphQLGetSiteBlogPostingByExternalReferenceCodeQueryParam()
+		throws Exception {
+
+		BlogPosting blogPosting =
+			testGraphQLGetSiteBlogPostingByExternalReferenceCodeQueryParam_addBlogPosting();
+
+		Assert.assertTrue(
+			equals(
+				blogPosting,
+				BlogPostingSerDes.toDTO(
+					JSONUtil.getValueAsString(
+						invokeGraphQLQuery(
+							new GraphQLField(
+								"blogPostingByExternalReferenceCodeQueryParam",
+								new HashMap<String, Object>() {
+									{
+										put(
+											"siteKey",
+											"\"" +
+												testGraphQLGetSiteBlogPostingByExternalReferenceCodeQueryParam_getSiteId(
+													blogPosting) + "\"");
+									}
+								},
+								getGraphQLFields())),
+						"JSONObject/data",
+						"Object/blogPostingByExternalReferenceCodeQueryParam"))));
+	}
+
+	protected Long
+			testGraphQLGetSiteBlogPostingByExternalReferenceCodeQueryParam_getSiteId(
+				BlogPosting blogPosting)
+		throws Exception {
+
+		return blogPosting.getSiteId();
+	}
+
+	@Test
+	public void testGraphQLGetSiteBlogPostingByExternalReferenceCodeQueryParamNotFound()
+		throws Exception {
+
+		Assert.assertEquals(
+			"Not Found",
+			JSONUtil.getValueAsString(
+				invokeGraphQLQuery(
+					new GraphQLField(
+						"blogPostingByExternalReferenceCodeQueryParam",
+						new HashMap<String, Object>() {
+							{
+								put(
+									"siteKey",
+									"\"" + irrelevantGroup.getGroupId() + "\"");
+							}
+						},
+						getGraphQLFields())),
+				"JSONArray/errors", "Object/0", "JSONObject/extensions",
+				"Object/code"));
+	}
+
+	protected BlogPosting
+			testGraphQLGetSiteBlogPostingByExternalReferenceCodeQueryParam_addBlogPosting()
+		throws Exception {
+
+		return testGraphQLBlogPosting_addBlogPosting();
+	}
+
+	@Test
+	public void testPutSiteBlogPostingByExternalReferenceCodeQueryParam()
+		throws Exception {
+
+		BlogPosting postBlogPosting =
+			testPutSiteBlogPostingByExternalReferenceCodeQueryParam_addBlogPosting();
+
+		BlogPosting randomBlogPosting = randomBlogPosting();
+
+		BlogPosting putBlogPosting =
+			blogPostingResource.
+				putSiteBlogPostingByExternalReferenceCodeQueryParam(
+					testPutSiteBlogPostingByExternalReferenceCodeQueryParam_getSiteId(
+						postBlogPosting),
+					testPutSiteBlogPostingByExternalReferenceCodeQueryParam_getExternalReferenceCode(),
+					randomBlogPosting);
+
+		assertEquals(randomBlogPosting, putBlogPosting);
+		assertValid(putBlogPosting);
+
+		BlogPosting getBlogPosting =
+			blogPostingResource.
+				getSiteBlogPostingByExternalReferenceCodeQueryParam(
+					testPutSiteBlogPostingByExternalReferenceCodeQueryParam_getSiteId(
+						putBlogPosting));
+
+		assertEquals(randomBlogPosting, getBlogPosting);
+		assertValid(getBlogPosting);
+	}
+
+	protected Long
+			testPutSiteBlogPostingByExternalReferenceCodeQueryParam_getSiteId(
+				BlogPosting blogPosting)
+		throws Exception {
+
+		return blogPosting.getSiteId();
+	}
+
+	protected String
+			testPutSiteBlogPostingByExternalReferenceCodeQueryParam_getExternalReferenceCode(
+				BlogPosting blogPosting)
+		throws Exception {
+
+		return blogPosting.getExternalReferenceCode();
+	}
+
+	protected BlogPosting
+			testPutSiteBlogPostingByExternalReferenceCodeQueryParam_addBlogPosting()
+		throws Exception {
+
+		return blogPostingResource.postSiteBlogPosting(
+			testGroup.getGroupId(), randomBlogPosting());
+	}
+
+	@Test
 	public void testDeleteSiteBlogPostingByExternalReferenceCode()
 		throws Exception {
 


### PR DESCRIPTION
Hi Team!

In the context of this [PTR](https://issues.liferay.com/browse/PTR-3697), we are trying to find a solution for making endpoints work when identifiers (currently within the URL path) may contain slashes.

Since this may affect not only the endpoint reported on the PTR, which uses the Page Friendly URL as a path parameter, but also other endpoints, as the ones using externalReferenceCode as path parameter, which currently may contain slashes too, we'd like to bring it up here so we ensure that a common solution is applied, and consistency across different endpoints is thus preserved.

This PR contains a possible implementation, consisting on offering an additional endpoint which does not expect externalReferenceCode as path parameter but rather as query parameter.
The Blogs REST API has been modified to verify this approach.

It adds endpoint "/sites/{siteId}/blog-postings/by-external-reference-code-query-param", with REST methods expecting externalReferenceCode as required query parameter.

Several details to note:
1. In my opinion naming the endpoint path "/sites/{siteId}/blog-postings/by-external-reference-code" would be cleaner, but it currently results in duplicated methods in the java generated code.
2. The generated test classes fail to compile, since the required query parameter is not passed in the method call.

When you have a chance, can you take a look and share your thoughts on how to best solve this issue? 
Thank you!