### PR TITLE
LPS-175235 "fields" query parameter does not work when it is executedover a System Object 

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/extension/ExtendedEntity.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/extension/ExtendedEntity.java
@@ -41,7 +41,7 @@ public class ExtendedEntity {
 
 	public static ExtendedEntity extend(
 		Object entity, Map<String, Serializable> extendedProperties,
-		Set<String> filteredPropertyKeys) {
+		Set<String> fieldsQueryParam, Set<String> filteredPropertyKeys) {
 
 		if (extendedProperties == null) {
 			extendedProperties = Collections.emptyMap();
@@ -51,8 +51,12 @@ public class ExtendedEntity {
 			filteredPropertyKeys = Collections.emptySet();
 		}
 
+		if (fieldsQueryParam == null) {
+			fieldsQueryParam = Collections.emptySet();
+		}
+
 		return new ExtendedEntity(
-			entity, extendedProperties, filteredPropertyKeys);
+			entity, extendedProperties, fieldsQueryParam, filteredPropertyKeys);
 	}
 
 	@JsonUnwrapped
@@ -67,7 +71,7 @@ public class ExtendedEntity {
 
 	private ExtendedEntity(
 		Object entity, Map<String, Serializable> extendedProperties,
-		Set<String> filteredPropertyNames) {
+		Set<String> fieldsQueryParam, Set<String> filteredPropertyNames) {
 
 		_entity = entity;
 
@@ -79,18 +83,27 @@ public class ExtendedEntity {
 
 		for (String key : filteredPropertyNames) {
 			_extendedProperties.put(key, null);
+			fieldsQueryParam.remove(key);
 		}
 
 		for (Field field : _getAllFields()) {
-			if (_extendedProperties.containsKey(field.getName())) {
-				try {
+			try {
+				if (_extendedProperties.containsKey(field.getName())) {
 					field.setAccessible(true);
 					field.set(_entity, null);
 				}
-				catch (Exception exception) {
-					if (_log.isDebugEnabled()) {
-						_log.debug(exception);
-					}
+				else if (fieldsQueryParam.contains(field.getName())) {
+					field.setAccessible(true);
+
+					_extendedProperties.put(
+						field.getName(), (Serializable)field.get(entity));
+
+					field.set(_entity, null);
+				}
+			}
+			catch (Exception exception) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(exception);
 				}
 			}
 		}

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/writer/interceptor/EntityExtensionWriterInterceptor.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/writer/interceptor/EntityExtensionWriterInterceptor.java
@@ -17,10 +17,17 @@ package com.liferay.portal.vulcan.internal.jaxrs.writer.interceptor;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.vulcan.fields.FieldsQueryParam;
+import com.liferay.portal.vulcan.fields.RestrictFieldsQueryParam;
 import com.liferay.portal.vulcan.internal.extension.EntityExtensionHandler;
 import com.liferay.portal.vulcan.internal.jaxrs.extension.ExtendedEntity;
 
 import java.io.IOException;
+import java.io.Serializable;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
@@ -58,15 +65,26 @@ public class EntityExtensionWriterInterceptor implements WriterInterceptor {
 		throws IOException {
 
 		try {
+			Map<String, Serializable> extendedProperties =
+				entityExtensionHandler.getExtendedProperties(
+					_company.getCompanyId(),
+					writerInterceptorContext.getEntity());
+
+			Set<String> filteredPropertyNames =
+				entityExtensionHandler.getFilteredPropertyNames(
+					_company.getCompanyId(),
+					writerInterceptorContext.getEntity());
+
+			Optional.ofNullable(
+				_restrictFieldsQueryParam.getRestrictFieldNames()
+			).ifPresent(
+				filteredPropertyNames::addAll
+			);
+
 			writerInterceptorContext.setEntity(
 				ExtendedEntity.extend(
-					writerInterceptorContext.getEntity(),
-					entityExtensionHandler.getExtendedProperties(
-						_company.getCompanyId(),
-						writerInterceptorContext.getEntity()),
-					entityExtensionHandler.getFilteredPropertyNames(
-						_company.getCompanyId(),
-						writerInterceptorContext.getEntity())));
+					writerInterceptorContext.getEntity(), extendedProperties,
+					_fieldsQueryParam.getFieldNames(), filteredPropertyNames));
 
 			writerInterceptorContext.setGenericType(ExtendedEntity.class);
 		}
@@ -98,6 +116,12 @@ public class EntityExtensionWriterInterceptor implements WriterInterceptor {
 	private Company _company;
 
 	@Context
+	private FieldsQueryParam _fieldsQueryParam;
+
+	@Context
 	private Providers _providers;
+
+	@Context
+	private RestrictFieldsQueryParam _restrictFieldsQueryParam;
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/writer/interceptor/PageEntityExtensionWriterInterceptor.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/writer/interceptor/PageEntityExtensionWriterInterceptor.java
@@ -85,6 +85,7 @@ public class PageEntityExtensionWriterInterceptor implements WriterInterceptor {
 						item,
 						entityExtensionHandler.getExtendedProperties(
 							_company.getCompanyId(), item),
+						null,
 						entityExtensionHandler.getFilteredPropertyNames(
 							_company.getCompanyId(), item)));
 			}

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/jaxrs/writer/interceptor/EntityExtensionWriterInterceptorTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/jaxrs/writer/interceptor/EntityExtensionWriterInterceptorTest.java
@@ -19,11 +19,15 @@ import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.portal.vulcan.extension.EntityExtensionThreadLocal;
+import com.liferay.portal.vulcan.fields.FieldsQueryParam;
+import com.liferay.portal.vulcan.fields.RestrictFieldsQueryParam;
 import com.liferay.portal.vulcan.internal.extension.EntityExtensionHandler;
 import com.liferay.portal.vulcan.internal.jaxrs.context.resolver.EntityExtensionHandlerContextResolver;
 import com.liferay.portal.vulcan.internal.jaxrs.extension.ExtendedEntity;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.ext.Providers;
@@ -53,7 +57,13 @@ public class EntityExtensionWriterInterceptorTest {
 		ReflectionTestUtil.setFieldValue(
 			_entityExtensionWriterInterceptor, "_company", _company);
 		ReflectionTestUtil.setFieldValue(
+			_entityExtensionWriterInterceptor, "_fieldsQueryParam",
+			_fieldsQueryParam);
+		ReflectionTestUtil.setFieldValue(
 			_entityExtensionWriterInterceptor, "_providers", _providers);
+		ReflectionTestUtil.setFieldValue(
+			_entityExtensionWriterInterceptor, "_restrictFieldsQueryParam",
+			_restrictFieldsQueryParam);
 	}
 
 	@Test
@@ -75,11 +85,23 @@ public class EntityExtensionWriterInterceptorTest {
 		);
 
 		Mockito.when(
+			_fieldsQueryParam.getFieldNames()
+		).thenReturn(
+			new HashSet<>(Arrays.asList("userName"))
+		);
+
+		Mockito.when(
 			_providers.getContextResolver(
 				Mockito.eq(EntityExtensionHandler.class),
 				Mockito.any(MediaType.class))
 		).thenReturn(
 			_entityExtensionHandlerContextResolver
+		);
+
+		Mockito.when(
+			_restrictFieldsQueryParam.getRestrictFieldNames()
+		).thenReturn(
+			new HashSet<>(Arrays.asList("userId"))
 		);
 
 		Mockito.when(
@@ -190,12 +212,25 @@ public class EntityExtensionWriterInterceptorTest {
 		);
 
 		Mockito.when(
+			_fieldsQueryParam.getFieldNames()
+		).thenReturn(
+			new HashSet<>(Arrays.asList("userName"))
+		);
+
+		Mockito.when(
 			_providers.getContextResolver(
 				Mockito.eq(EntityExtensionHandler.class),
 				Mockito.any(MediaType.class))
 		).thenReturn(
 			_entityExtensionHandlerContextResolver
 		);
+
+		Mockito.when(
+			_restrictFieldsQueryParam.getRestrictFieldNames()
+		).thenReturn(
+			new HashSet<>(Arrays.asList("userId"))
+		);
+
 		Mockito.when(
 			_writerInterceptorContext.getEntity()
 		).thenReturn(
@@ -272,7 +307,11 @@ public class EntityExtensionWriterInterceptorTest {
 	private final EntityExtensionWriterInterceptor
 		_entityExtensionWriterInterceptor =
 			new EntityExtensionWriterInterceptor();
+	private final FieldsQueryParam _fieldsQueryParam = Mockito.mock(
+		FieldsQueryParam.class);
 	private final Providers _providers = Mockito.mock(Providers.class);
+	private final RestrictFieldsQueryParam _restrictFieldsQueryParam =
+		Mockito.mock(RestrictFieldsQueryParam.class);
 	private final WriterInterceptorContext _writerInterceptorContext =
 		Mockito.mock(WriterInterceptorContext.class);
 


### PR DESCRIPTION
Motivation
=======

This work solves the problem reported in the ticket https://issues.liferay.com/browse/LPS-175235 .
Previous PR: https://github.com/liferay-core-infra/liferay-portal/pull/3547

Proposed Solution
========

- Cause:
   When we perform any request GET (by id) any objects are considered a System Object, the entry will be put into an ExtendedEntity instance (see [EntityExtensionWriterInterceptor#_extendEntity](https://github.com/liferay-core-infra/liferay-portal/blob/master/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/writer/interceptor/EntityExtensionWriterInterceptor.java#L55))
as field  `entity`. If we perform request Get with `filter` (ex: ?filter=externalReferenceCode), the VulcanPropertyFilter#serializeAsField would ignore `entity` property and cound not "see" `externalReferenceCode`
The result would be empty json: `{}`

- What we did to solve this problem:
At class EntityExtensionWriterInterceptor, we get Fields Query Param and Restrict Fields Query Param from the context and pass them to ExtendedEntity.
And we process them, then put field name and field value of the entity to `_extendedProperties`

Steps to Verify
========

- Perform the following request (replace the id 20124 with an existing one): 
`curl -X GET -u 'test@liferay.com:test' http://localhost:8080/o/headless-admin-user/v1.0/user-accounts/20124`
- The response should be something like:
<details>
<summary>
Json string:
</summary>
<p>

```yaml
{
  "accountBriefs" : [ ],
  "actions" : {
    "get-user-account-by-external-reference-code" : {
      "method" : "GET",
      "href" : "http://localhost:8080/o/headless-admin-user/v1.0/user-accounts/by-external-reference-code/20124"
    },
    "put-user-account" : {
      "method" : "PUT",
      "href" : "http://localhost:8080/o/headless-admin-user/v1.0/user-accounts/20124"
    },
    "delete-user-account" : {
      "method" : "DELETE",
      "href" : "http://localhost:8080/o/headless-admin-user/v1.0/user-accounts/20124"
    },
    "get-user-account" : {
      "method" : "GET",
      "href" : "http://localhost:8080/o/headless-admin-user/v1.0/user-accounts/20124"
    },
    "delete-user-account-by-external-reference-code" : {
      "method" : "DELETE",
      "href" : "http://localhost:8080/o/headless-admin-user/v1.0/user-accounts/by-external-reference-code/20124"
    },
    "put-user-account-by-external-reference-code" : {
      "method" : "PUT",
      "href" : "http://localhost:8080/o/headless-admin-user/v1.0/user-accounts/by-external-reference-code/20124"
    },
    "get-my-user-account" : {
      "method" : "GET",
      "href" : "http://localhost:8080/o/headless-admin-user/v1.0/my-user-account"
    },
    "patch-user-account" : {
      "method" : "PATCH",
      "href" : "http://localhost:8080/o/headless-admin-user/v1.0/user-accounts/20124"
    }
  },
  "additionalName" : "",
  "alternateName" : "test",
  "birthDate" : "1970-01-01T00:00:00Z",
  "customFields" : [ ],
  "dashboardURL" : "/user/test",
  "dateCreated" : "2023-02-08T10:01:13Z",
  "dateModified" : "2023-02-09T08:22:45Z",
  "emailAddress" : "test@liferay.com",
  "externalReferenceCode" : "8b8b59b0-0362-70e1-3b2d-98fd3454ed84",
  "familyName" : "Test",
  "givenName" : "Test",
  "id" : 20124,
  "jobTitle" : "",
  "keywords" : [ ],
  "lastLoginDate" : "2023-02-08T16:08:12Z",
  "name" : "Test Test",
  "organizationBriefs" : [ ],
  "profileURL" : "/web/test",
  "roleBriefs" : [ {
    "id" : 20102,
    "name" : "Administrator"
  }, {
    "id" : 20106,
    "name" : "Power User"
  }, {
    "id" : 20108,
    "name" : "User"
  } ],
  "siteBriefs" : [ {
    "descriptiveName" : "Global",
    "id" : 20122,
    "name" : "Global"
  }, {
    "descriptiveName" : "Liferay DXP",
    "id" : 20120,
    "name" : "Guest"
  } ],
  "userAccountContactInformation" : {
    "emailAddresses" : [ ],
    "facebook" : "",
    "jabber" : "",
    "postalAddresses" : [ ],
    "skype" : "",
    "sms" : "",
    "telephones" : [ ],
    "twitter" : "",
    "webUrls" : [ ]
  },
  "userGroupBriefs" : [ ]
}
```

</p>
</details>

- Perform the following request including the `fields` query parameter with an existing field:
`curl -X GET -u 'test@liferay.com:test' http://localhost:8080/o/headless-admin-user/v1.0/user-accounts/20124?fields=externalReferenceCode`

** Expected behaviour:
- The response should contain only the `externalReferenceCode` field:
`{
  "externalReferenceCode" : "8b8b59b0-0362-70e1-3b2d-98fd3454ed84"
}`

** Current behaviour:

- The response is an empty JSON:
`{ }`
