### PR TITLE
LPS-177271 | Expose ERC in document folder

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/DocumentAPI.macro
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/DocumentAPI.macro
@@ -10,6 +10,9 @@ definition {
 
 			var api = "asset-libraries/${assetLibraryId}/documents";
 		}
+		else if (isSet(documentFolderId)) {
+			var api = "document-folders/${documentFolderId}/documents";
+		}
 		else {
 			var api = "sites/${siteId}/documents";
 		}
@@ -178,6 +181,17 @@ definition {
 
 		var response = DocumentAPI._addDocument(
 			depotName = ${depotName},
+			externalReferenceCode = ${externalReferenceCode},
+			filePath = ${filePath});
+
+		return ${response};
+	}
+
+	macro addDocumentWithFileInDocumentFolder {
+		Variables.assertDefined(parameterList = "${documentFolderId},${filePath}");
+
+		var response = DocumentAPI._addDocument(
+			documentFolderId = ${documentFolderId},
 			externalReferenceCode = ${externalReferenceCode},
 			filePath = ${filePath});
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/DocumentFolderAPI.macro
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/DocumentFolderAPI.macro
@@ -10,21 +10,56 @@ definition {
 
 			var api = "asset-libraries/${assetLibraryId}";
 		}
+		else if (isSet(documentFolderId)) {
+			var api = "document-folders/${documentFolderId}";
+		}
+		else if (isSet(parentDocumentFolderId)) {
+			var api = "document-folders/${parentDocumentFolderId}/document-folders";
+		}
 		else {
 			var siteId = JSONGroupAPI._getGroupIdByNameNoSelenium(
 				groupName = ${groupName},
 				site = "true");
 
-			var api = "sites/${siteId}";
+			if (isSet(externalReferenceCode)) {
+				var api = "sites/${siteId}/documents-folder/by-external-reference-code/${externalReferenceCode}";
+			}
+			else {
+				var api = "sites/${siteId}/document-folders";
+			}
+		}
+
+		if (isSet(parameter)) {
+			var api = StringUtil.add(${api}, "?${parameter}=${parameterValue}", "");
 		}
 
 		var curl = '''
-			${portalURL}/o/headless-delivery/v1.0/${api}/document-folders \
+			${portalURL}/o/headless-delivery/v1.0/${api} \
 				-u test@liferay.com:test \
 				-H Content-Type: application/json \
 		''';
 
 		return ${curl};
+	}
+
+	macro addDocumentFolder {
+		Variables.assertDefined(parameterList = ${name});
+
+		var body = '''"name": "${name}"''';
+
+		if (isSet(externalReferenceCode)) {
+			var body = '''"name": "${name}","externalReferenceCode": "${externalReferenceCode}"''';
+		}
+
+		var curlWithoutBody = DocumentFolderAPI._curlDocumentFolders(
+			groupName = ${groupName},
+			parentDocumentFolderId = ${parentDocumentFolderId});
+
+		var curl = StringUtil.add(${curlWithoutBody}, "-d {${body}}", " ");
+
+		var response = JSONCurlUtil.post(${curl});
+
+		return ${response};
 	}
 
 	macro assertProperBatchInActionBlock {
@@ -66,12 +101,112 @@ definition {
 		}
 	}
 
+	macro assertProperDocumentFolderTotalCount {
+		Variables.assertDefined(parameterList = "${expectedDocumentTotalCount},${groupName},${parameter},${parameterValue}");
+
+		var response = DocumentFolderAPI.getDocumentFoldersWithDifferentPameter(
+			groupName = ${groupName},
+			parameter = ${parameter},
+			parameterValue = ${parameterValue});
+
+		var actualDocumentTotalCount = JSONUtil.getWithJSONPath(${response}, "$..['totalCount']");
+
+		TestUtils.assertEquals(
+			actual = ${actualDocumentTotalCount},
+			expected = ${expectedDocumentTotalCount});
+	}
+
+	macro deleteDocumentFolderByName {
+		Variables.assertDefined(parameterList = "${documentFolderName},${groupName}");
+
+		var response = DocumentFolderAPI.getDocumentFoldersWithDifferentPameter(
+			groupName = ${groupName},
+			parameter = "filter",
+			parameterValue = "name%20eq%20%27${documentFolderName}%27");
+
+		var documentFolderId = JSONPathUtil.getProperty(
+			property = "$..items[0].id",
+			response = ${response});
+
+		var curl = DocumentFolderAPI._curlDocumentFolders(documentFolderId = ${documentFolderId});
+
+		JSONCurlUtil.delete(${curl});
+	}
+
+	macro deleteDocumentFolderBySiteIdAndErc {
+		Variables.assertDefined(parameterList = "${externalReferenceCode},${groupName}");
+
+		var curl = DocumentFolderAPI._curlDocumentFolders(
+			externalReferenceCode = ${externalReferenceCode},
+			groupName = ${groupName});
+
+		JSONCurlUtil.delete(${curl});
+	}
+
+	macro getDocumentFolderBySiteIdAndErc {
+		Variables.assertDefined(parameterList = "${externalReferenceCode},${groupName}");
+
+		var curl = DocumentFolderAPI._curlDocumentFolders(
+			externalReferenceCode = ${externalReferenceCode},
+			groupName = ${groupName});
+
+		var response = JSONCurlUtil.get(${curl});
+
+		return ${response};
+	}
+
 	macro getDocumentFolders {
 		var curl = DocumentFolderAPI._curlDocumentFolders(
 			depotName = ${depotName},
 			groupName = ${groupName});
 
 		var response = JSONCurlUtil.get(${curl});
+
+		return ${response};
+	}
+
+	macro getDocumentFoldersWithDifferentPameter {
+		var curl = DocumentFolderAPI._curlDocumentFolders(
+			groupName = ${groupName},
+			parameter = ${parameter},
+			parameterValue = ${parameterValue});
+
+		var response = JSONCurlUtil.get(${curl});
+
+		return ${response};
+	}
+
+	macro staticDoucmentFolderErc {
+		Variables.assertDefined(parameterList = ${response});
+
+		var externalReferenceCode = JSONPathUtil.getErcValue(response = ${response});
+
+		static var staticDoucmentFolderErc = ${externalReferenceCode};
+
+		return ${staticDoucmentFolderErc};
+	}
+
+	macro staticDoucmentFolderId {
+		Variables.assertDefined(parameterList = ${response});
+
+		var documentFolderId = JSONPathUtil.getIdValue(response = ${response});
+
+		static var staticDoucmentFolderId = ${documentFolderId};
+
+		return ${staticDoucmentFolderId};
+	}
+
+	macro updateDocumentFolderBySiteIdAndErc {
+		Variables.assertDefined(parameterList = "${groupName},${externalReferenceCode}");
+
+		var curlWithoutBody = DocumentFolderAPI._curlDocumentFolders(
+			externalReferenceCode = ${externalReferenceCode},
+			groupName = ${groupName});
+		var body = '''"name": "${name}","externalReferenceCode": "${externalReferenceCodeInBody}"''';
+
+		var curl = StringUtil.add(${curlWithoutBody}, "-d {${body}}", " ");
+
+		var response = JSONCurlUtil.put(${curl});
 
 		return ${response};
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcInDocumentFolder.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcInDocumentFolder.testcase
@@ -1,0 +1,378 @@
+@component-name = "portal-lima"
+definition {
+
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.main.component.name = "Lima Headless";
+
+	setUp {
+		TestCase.setUpPortalInstanceNoSelenium();
+
+		task ("Given with postSiteDocumentFolder and siteId to create a document folder") {
+			var response = DocumentFolderAPI.addDocumentFolder(
+				groupName = "Guest",
+				name = "Document Folder Name");
+
+			DocumentFolderAPI.staticDoucmentFolderId(response = ${response});
+
+			DocumentFolderAPI.staticDoucmentFolderErc(response = ${response});
+		}
+	}
+
+	tearDown {
+		for (var documentFolderName : list "Document%20Folder%20Name,Document%20Folder%20Name_1") {
+			DocumentFolderAPI.deleteDocumentFolderByName(
+				documentFolderName = ${documentFolderName},
+				groupName = "Guest");
+		}
+
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if (${testPortalInstance} == "true") {
+			PortalInstances.tearDownCPNoSelenium();
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 4
+	test CanCreateDocumentFolderByPutNonexistentErc {
+		property portal.acceptance = "true";
+
+		task ("When I make a PUT request by siteId and nonexistent erc with a name and another erc in the body") {
+			var response = DocumentFolderAPI.updateDocumentFolderBySiteIdAndErc(
+				externalReferenceCode = "customErc",
+				externalReferenceCodeInBody = "customErcInBody",
+				groupName = "Guest",
+				name = "Document Folder Name_1");
+		}
+
+		task ("Then its erc equals to the value of the nonexistent one") {
+			var actualExternalReferenceCode = JSONPathUtil.getErcValue(response = ${response});
+
+			TestUtils.assertEquals(
+				actual = ${actualExternalReferenceCode},
+				expected = "customErc");
+		}
+
+		task ("And Then a document folder is being created") {
+			DocumentFolderAPI.assertProperDocumentFolderTotalCount(
+				expectedDocumentTotalCount = 1,
+				groupName = "Guest",
+				parameter = "filter",
+				parameterValue = "name%20eq%20%27Document%20Folder%20Name_1%27");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 4
+	test CanCreateDocumentFolderWithCustomErcInAnotherDocumentFolder {
+		property portal.acceptance = "true";
+
+		task ("When with postDocumentFolderDocumentFolder and parentDocumentFolderId to create a new folder with a custom erc") {
+			var response = DocumentFolderAPI.addDocumentFolder(
+				externalReferenceCode = "customErc",
+				name = "Document Sub Folder Name",
+				parentDocumentFolderId = ${staticDoucmentFolderId});
+		}
+
+		task ("Then I can see the custom external reference code in response") {
+			var actualExternalReferenceCode = JSONPathUtil.getErcValue(response = ${response});
+
+			TestUtils.assertEquals(
+				actual = ${actualExternalReferenceCode},
+				expected = "customErc");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 4
+	test CanCreateDocumentFolderWithErcWithoutErcInTheBody {
+		property portal.acceptance = "true";
+
+		task ("Then I can see external reference code in response") {
+			var response = DocumentFolderAPI.getDocumentFolders(groupName = "Guest");
+
+			var expectExternalReferenceCode = JSONUtil.getWithJSONPath(${response}, "$.items[?(@.name=='Document Folder Name')].externalReferenceCode");
+
+			TestUtils.assertEquals(
+				actual = ${expectExternalReferenceCode},
+				expected = ${staticDoucmentFolderErc});
+		}
+	}
+
+	@priority = 4
+	test CanDeleteChildDocumentFolderByErc {
+		property portal.acceptance = "true";
+
+		task ("And Given with postDocumentFolderDocumentFolder and parentDocumentFolderId to create a new folder with a custom erc") {
+			var response = DocumentFolderAPI.addDocumentFolder(
+				externalReferenceCode = "customErc",
+				name = "Document Sub Folder Name",
+				parentDocumentFolderId = ${staticDoucmentFolderId});
+		}
+
+		task ("And Given with postDocumentFolderDocument and documentFolderId to create a document in the child document folder") {
+			var documentFolderId = JSONPathUtil.getIdValue(response = ${response});
+			var externalReferenceCode = JSONPathUtil.getErcValue(response = ${response});
+			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");
+
+			DocumentAPI.addDocumentWithFileInDocumentFolder(
+				documentFolderId = ${documentFolderId},
+				filePath = ${filePath});
+		}
+
+		task ("When I make a DELETE request by siteId and erc of the child document folder") {
+			DocumentFolderAPI.deleteDocumentFolderBySiteIdAndErc(
+				externalReferenceCode = ${externalReferenceCode},
+				groupName = "Guest");
+		}
+
+		task ("Then the child document folder is deleted successfully") {
+			DocumentFolderAPI.assertProperDocumentFolderTotalCount(
+				expectedDocumentTotalCount = 0,
+				groupName = "Guest",
+				parameter = "filter",
+				parameterValue = "name%20eq%20%27Document%20Sub%20Folder%20Name%27");
+		}
+
+		task ("And Then the parent document folder still exists") {
+			DocumentFolderAPI.assertProperDocumentFolderTotalCount(
+				expectedDocumentTotalCount = 1,
+				groupName = "Guest",
+				parameter = "filter",
+				parameterValue = "name%20eq%20%27Document%20Folder%20Name%27");
+		}
+	}
+
+	@priority = 3
+	test CanDeleteParentDocumentFolderByErc {
+		property portal.acceptance = "true";
+
+		task ("And Given with postDocumentFolderDocumentFolder and parentDocumentFolderId to create a new folder with a custom erc") {
+			var response = DocumentFolderAPI.addDocumentFolder(
+				externalReferenceCode = "customErc",
+				name = "Document Sub Folder Name",
+				parentDocumentFolderId = ${staticDoucmentFolderId});
+		}
+
+		task ("And Given with postDocumentFolderDocument and documentFolderId to create a document in the child document folder") {
+			var documentFolderId = JSONPathUtil.getIdValue(response = ${response});
+			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");
+
+			var responseToParse = DocumentAPI.addDocumentWithFileInDocumentFolder(
+				documentFolderId = ${documentFolderId},
+				filePath = ${filePath});
+
+			var documentId = JSONPathUtil.getIdValue(response = ${responseToParse});
+		}
+
+		task ("When I make a DELETE request by siteId and erc of the parent document folder") {
+			DocumentFolderAPI.deleteDocumentFolderBySiteIdAndErc(
+				externalReferenceCode = ${staticDoucmentFolderErc},
+				groupName = "Guest");
+		}
+
+		task ("Then the document folders are deleted successfully") {
+			DocumentFolderAPI.assertProperDocumentFolderTotalCount(
+				expectedDocumentTotalCount = 0,
+				groupName = "Guest",
+				parameter = "filter",
+				parameterValue = "name%20eq%20%27Document%20Folder%20Name%27");
+		}
+
+		task ("And Then the document in the document folder is deleted") {
+			var response = DocumentAPI.getDocumentsByDifferentParameters(documentId = ${documentId});
+
+			var actualMessage = JSONUtil.getWithJSONPath(${response}, "$.title");
+
+			TestUtils.assertPartialEquals(
+				actual = ${actualMessage},
+				expected = "No FileEntry exists with the key");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 3
+	test CanGetDocumentFolderByErc {
+		property portal.acceptance = "true";
+
+		task ("When with GET request, siteId and external reference code to retrieve the document folder") {
+			var response = DocumentFolderAPI.getDocumentFolderBySiteIdAndErc(
+				externalReferenceCode = ${staticDoucmentFolderErc},
+				groupName = "Guest");
+		}
+
+		task ("Then I can see the correct details of the document folder") {
+			var actualExternalReferenceCode = JSONPathUtil.getErcValue(response = ${response});
+			var actualDoucmentFolderId = JSONPathUtil.getIdValue(response = ${response});
+
+			TestUtils.assertEquals(
+				actual = ${actualDoucmentFolderId},
+				expected = ${staticDoucmentFolderId});
+
+			TestUtils.assertEquals(
+				actual = ${actualExternalReferenceCode},
+				expected = ${staticDoucmentFolderErc});
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 4
+	test CanGetDocumentFolderInAntoherFolderByErc {
+		property portal.acceptance = "true";
+
+		task ("And Given with postDocumentFolderDocumentFolder and parentDocumentFolderId to create a new folder with a custom erc") {
+			var responseFromPost = DocumentFolderAPI.addDocumentFolder(
+				externalReferenceCode = "customErc",
+				name = "Document Sub Folder Name",
+				parentDocumentFolderId = ${staticDoucmentFolderId});
+		}
+
+		task ("When with GET request, siteId and external reference code to retrieve the document folder") {
+			var responseFromGet = DocumentFolderAPI.getDocumentFolderBySiteIdAndErc(
+				externalReferenceCode = "customErc",
+				groupName = "Guest");
+		}
+
+		task ("Then I can see the correct details of the document folder") {
+			var actualExternalReferenceCode = JSONPathUtil.getErcValue(response = ${responseFromGet});
+			var actualDoucmentFolderId = JSONPathUtil.getIdValue(response = ${responseFromGet});
+			var expectedDoucmentFolderId = JSONPathUtil.getIdValue(response = ${responseFromPost});
+
+			TestUtils.assertEquals(
+				actual = ${actualDoucmentFolderId},
+				expected = ${expectedDoucmentFolderId});
+
+			TestUtils.assertEquals(
+				actual = ${actualExternalReferenceCode},
+				expected = "customErc");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 4
+	test CannotCreateDocumentFolderWithExistingErc {
+		property portal.acceptance = "true";
+
+		task ("When with postSiteDocumentFolder and siteId to create a document folder with an existing erc") {
+			var actualMessage = DocumentFolderAPI.addDocumentFolder(
+				externalReferenceCode = ${staticDoucmentFolderErc},
+				groupName = "Guest",
+				name = "Document Folder Name_1");
+		}
+
+		task ("Then I receive duplicate external reference code response") {
+			TestUtils.assertPartialEquals(
+				actual = ${actualMessage},
+				expected = "Duplicate document library folder with external reference code ${staticDoucmentFolderErc}");
+		}
+
+		task ("And Then another folder with same erc is not being created") {
+			DocumentFolderAPI.assertProperDocumentFolderTotalCount(
+				expectedDocumentTotalCount = 0,
+				groupName = "Guest",
+				parameter = "filter",
+				parameterValue = "name%20eq%20%27Document%20Folder%20Name_1%27");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 4
+	test CannotUpdateDocumentFolderErcByErc {
+		property portal.acceptance = "true";
+
+		task ("When I make a PUT request by siteId and erc with a erc modified in the body") {
+			var response = DocumentFolderAPI.updateDocumentFolderBySiteIdAndErc(
+				externalReferenceCode = ${staticDoucmentFolderErc},
+				externalReferenceCodeInBody = "customErc",
+				groupName = "Guest",
+				name = "Document Folder Name");
+		}
+
+		task ("Then the erc in the response body is not changed") {
+			var actualExternalReferenceCode = JSONPathUtil.getErcValue(response = ${response});
+
+			TestUtils.assertEquals(
+				actual = ${actualExternalReferenceCode},
+				expected = ${staticDoucmentFolderErc});
+		}
+
+		task ("And Then another document folder with an erc being the modified value is not being created") {
+			DocumentFolderAPI.assertProperDocumentFolderTotalCount(
+				expectedDocumentTotalCount = 1,
+				groupName = "Guest",
+				parameter = "filter",
+				parameterValue = "name%20eq%20%27Document%20Folder%20Name%27");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 3
+	test CanReturnErrorWithGetDocumentFolderByNonexistentErc {
+		property portal.acceptance = "true";
+
+		task ("When with GET request, siteId and nonexistent external reference code to retrieve the document folder") {
+			var response = DocumentFolderAPI.getDocumentFolderBySiteIdAndErc(
+				externalReferenceCode = "customErc",
+				groupName = "Guest");
+		}
+
+		task ("Then I receive no DLFolder exists error message in response") {
+			var actualMessage = JSONUtil.getWithJSONPath(${response}, "$.title");
+
+			TestUtils.assertPartialEquals(
+				actual = ${actualMessage},
+				expected = "No DLFolder exists with the key");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 4
+	test CanUpdateDocumentFolderNameByErc {
+		property portal.acceptance = "true";
+
+		task ("When I make a PUT request by siteId and erc with a name modified in the body") {
+			var response = DocumentFolderAPI.updateDocumentFolderBySiteIdAndErc(
+				externalReferenceCode = ${staticDoucmentFolderErc},
+				groupName = "Guest",
+				name = "Document Folder Name_1");
+		}
+
+		task ("Then I receive a correct body response with updated name") {
+			var actualName = JSONUtil.getWithJSONPath(${response}, "$.name");
+
+			TestUtils.assertEquals(
+				actual = ${actualName},
+				expected = "Document Folder Name_1");
+		}
+
+		task ("And Then the document folder is correctly updated") {
+			DocumentFolderAPI.assertProperDocumentFolderTotalCount(
+				expectedDocumentTotalCount = 1,
+				groupName = "Guest",
+				parameter = "filter",
+				parameterValue = "name%20eq%20%27Document%20Folder%20Name_1%27");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 3
+	test DocumentFolderDeletionImpossibleByNonexistentErc {
+		property portal.acceptance = "true";
+
+		task ("When I make a DELETE request by siteId and on-existent erc") {
+			DocumentFolderAPI.deleteDocumentFolderBySiteIdAndErc(
+				externalReferenceCode = "customErc",
+				groupName = "Guest");
+		}
+
+		task ("Then the document folder created earlier still exists") {
+			DocumentFolderAPI.assertProperDocumentFolderTotalCount(
+				expectedDocumentTotalCount = 1,
+				groupName = "Guest",
+				parameter = "filter",
+				parameterValue = "name%20eq%20%27Document%20Folder%20Name%27");
+		}
+	}
+
+}


### PR DESCRIPTION
**Background**
Add a test case to expose ERC in document folder

**Test Plan**
CanCreateDocumentFolderWithErcWithoutErcInTheBody
When with postSiteDocumentFolder and siteId to create a document folder
Then I can see external reference code in response

CanCreateDocumentFolderWithCustomErcInAnotherDocumentFolder
Given with postSiteDocumentFolder and siteId to create a document folder
When with postDocumentFolderDocumentFolder and parentDocumentFolderId to create a new folder with a custom erc
Then I can see the custom external reference code in response

CannotCreateDocumentFolderWithExistingErc
Given with postSiteDocumentFolder and siteId to create a document folder
When with postSiteDocumentFolder and siteId to create a document folder with an existing erc
Then I receive duplicate external reference code response
And Then another folder with same erc is not being created

CanReturnErrorWithGetDocumentFolderByNonexistentErc
When with GET request, siteId and nonexistent external reference code to retrieve the document folder
Then I receive no DLFolder exists error message in response

CanGetDocumentFolderByErc
Given with postSiteDocumentFolder and siteId to create a document folder
When with GET request, siteId and external reference code to retrieve the document folder
Then I can see the correct details of the document folder

CanGetDocumentFolderInAntoherFolderByErc
Given with postSiteDocumentFolder and siteId to create a document folder
And Given with postDocumentFolderDocumentFolder and parentDocumentFolderId to create a new folder with a custom erc
When with GET request, siteId and external reference code to retrieve the document folder
Then I can see the correct details of the document folder

CanCreateDocumentFolderByPutNonexistentErc
When I make a PUT request by siteId and nonexistent erc with a name and another erc in the body
Then its erc equals to the value of the nonexistent one
And Then a document folder is being created

CanUpdateDocumentFolderNameByErc
Given with postSiteDocumentFolder and siteId to create a document folder
When I make a PUT request by siteId and erc with a name modified in the body
Then I receive a correct body response with updated name
And Then the document folder is correctly updated

CannotUpdateDocumentFolderErcByErc
Given with postSiteDocumentFolder and siteId to create a document folder
When I make a PUT request by siteId and erc with a erc modified in the body
Then the erc in the response body is not changed
And Then another document folder with an erc being the modified value is not being created

CanDeleteParentDocumentFolderByErc
Given with postSiteDocumentFolder and siteId to create a document folder
And Given with postDocumentFolderDocumentFolder and parentDocumentFolderId to create a new folder with a custom erc
And Given with postDocumentFolderDocument and documentFolderId to create a document in the child document folder
When I make a DELETE request by siteId and erc of the parent document folder
Then the document folders are deleted successfully
And Then the document in the document folder is deleted

CanDeleteChildDocumentFolderByErc
Given with postSiteDocumentFolder and siteId to create a document folder
And Given with postDocumentFolderDocumentFolder and parentDocumentFolderId to create a new folder with a custom erc
And Given with postDocumentFolderDocument and documentFolderId to create a document in the child document folder
When I make a DELETE request by siteId and erc of the child document folder
Then the child document folder is deleted successfully
And Then the parent document folder still exists

DocumentFolderDeletionImpossibleByNonexistentErc
Given with postSiteDocumentFolder and siteId to create a document folder
When I make a DELETE request by siteId and on-existent erc
Then the document folder created earlier still exists

**JIRA Link:**
https://issues.liferay.com/browse/LPS-177271