### PR TITLE
LPS-176653 Allow developers to filter over fields of multiple levels of relationships of custom objects using comparison operators

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -22,6 +22,7 @@ import com.liferay.object.rest.dto.v1_0.ObjectEntry;
 import com.liferay.object.rest.internal.graphql.dto.v1_0.ObjectDefinitionGraphQLDTOContributor;
 import com.liferay.object.rest.internal.jaxrs.application.ObjectEntryApplication;
 import com.liferay.object.rest.internal.jaxrs.context.provider.ObjectDefinitionContextProvider;
+import com.liferay.object.rest.internal.jaxrs.context.provider.PredicateContextProvider;
 import com.liferay.object.rest.internal.jaxrs.exception.mapper.ObjectEntryManagerHttpExceptionMapper;
 import com.liferay.object.rest.internal.jaxrs.exception.mapper.ObjectEntryValuesExceptionMapper;
 import com.liferay.object.rest.internal.jaxrs.exception.mapper.ObjectValidationRuleEngineExceptionMapper;
@@ -454,6 +455,22 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 						"osgi.jaxrs.name",
 						objectDefinition.getOSGiJaxRsName(
 							"ObjectDefinitionContextProvider")
+					).build()),
+				_bundleContext.registerService(
+					ContextProvider.class,
+					new PredicateContextProvider(
+						_filterPredicateFactory, this, _portal),
+					HashMapDictionaryBuilder.<String, Object>put(
+						"enabled", "false"
+					).put(
+						"osgi.jaxrs.application.select",
+						"(osgi.jaxrs.name=" + osgiJaxRsName + ")"
+					).put(
+						"osgi.jaxrs.extension", "true"
+					).put(
+						"osgi.jaxrs.name",
+						objectDefinition.getOSGiJaxRsName(
+							"PredicateContextProvider")
 					).build()),
 				_bundleContext.registerService(
 					ExceptionMapper.class,

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -274,10 +274,9 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 
 	private ObjectEntryResourceImpl _createObjectEntryResourceImpl() {
 		return new ObjectEntryResourceImpl(
-			_filterPredicateFactory, _objectDefinitionLocalService,
-			_objectEntryLocalService, _objectEntryManagerRegistry,
-			_objectFieldLocalService, _objectRelationshipService,
-			_objectScopeProviderRegistry,
+			_objectDefinitionLocalService, _objectEntryLocalService,
+			_objectEntryManagerRegistry, _objectFieldLocalService,
+			_objectRelationshipService, _objectScopeProviderRegistry,
 			_systemObjectDefinitionMetadataRegistry);
 	}
 

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/context/provider/ObjectDefinitionContextProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/context/provider/ObjectDefinitionContextProvider.java
@@ -16,12 +16,8 @@ package com.liferay.object.rest.internal.jaxrs.context.provider;
 
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.rest.internal.deployer.ObjectDefinitionDeployerImpl;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.object.rest.internal.jaxrs.context.provider.util.ObjectsContextProviderUtil;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.StringUtil;
-
-import javax.servlet.http.HttpServletRequest;
 
 import javax.ws.rs.ext.Provider;
 
@@ -45,33 +41,9 @@ public class ObjectDefinitionContextProvider
 
 	@Override
 	public ObjectDefinition createContext(Message message) {
-		long companyId = _portal.getCompanyId(
-			(HttpServletRequest)message.getContextualProperty("HTTP.REQUEST"));
-
-		String restContextPath = (String)message.getContextualProperty(
-			"org.apache.cxf.message.Message.BASE_PATH");
-
-		restContextPath = restContextPath.substring(
-			restContextPath.indexOf("/o/"));
-
-		restContextPath = StringUtil.removeFirst(restContextPath, "/o");
-		restContextPath = StringUtil.replaceLast(restContextPath, '/', "");
-
-		try {
-			return _objectDefinitionDeployerImpl.getObjectDefinition(
-				companyId, restContextPath);
-		}
-		catch (Exception exception) {
-			if (_log.isWarnEnabled()) {
-				_log.warn(exception);
-			}
-
-			throw new RuntimeException(exception);
-		}
+		return ObjectsContextProviderUtil.getObjectDefinition(
+			message, _objectDefinitionDeployerImpl, _portal);
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		ObjectDefinitionContextProvider.class);
 
 	private final ObjectDefinitionDeployerImpl _objectDefinitionDeployerImpl;
 	private final Portal _portal;

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/context/provider/PredicateContextProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/context/provider/PredicateContextProvider.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.rest.internal.jaxrs.context.provider;
+
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.rest.internal.deployer.ObjectDefinitionDeployerImpl;
+import com.liferay.object.rest.internal.jaxrs.context.provider.util.ObjectsContextProviderUtil;
+import com.liferay.object.rest.petra.sql.dsl.expression.FilterPredicateFactory;
+import com.liferay.petra.sql.dsl.expression.Predicate;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.Validator;
+
+import javax.ws.rs.ext.Provider;
+
+import org.apache.cxf.jaxrs.ext.ContextProvider;
+import org.apache.cxf.message.Message;
+
+/**
+ * @author Luis Miguel Barcos
+ */
+@Provider
+public class PredicateContextProvider implements ContextProvider<Predicate> {
+
+	public PredicateContextProvider(
+		FilterPredicateFactory filterPredicateFactory,
+		ObjectDefinitionDeployerImpl objectDefinitionDeployerImpl,
+		Portal portal) {
+
+		_filterPredicateFactory = filterPredicateFactory;
+		_objectDefinitionDeployerImpl = objectDefinitionDeployerImpl;
+		_portal = portal;
+	}
+
+	@Override
+	public Predicate createContext(Message message) {
+		String filter = ParamUtil.getString(
+			ObjectsContextProviderUtil.getHttpServletRequest(message),
+			"filter");
+
+		Predicate predicate = null;
+
+		if (Validator.isNotNull(filter)) {
+			ObjectDefinition objectDefinition =
+				ObjectsContextProviderUtil.getObjectDefinition(
+					message, _objectDefinitionDeployerImpl, _portal);
+
+			predicate = _filterPredicateFactory.create(
+				filter, objectDefinition.getObjectDefinitionId());
+		}
+
+		return predicate;
+	}
+
+	private final FilterPredicateFactory _filterPredicateFactory;
+	private final ObjectDefinitionDeployerImpl _objectDefinitionDeployerImpl;
+	private final Portal _portal;
+
+}

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/context/provider/util/ObjectsContextProviderUtil.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/context/provider/util/ObjectsContextProviderUtil.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.rest.internal.jaxrs.context.provider.util;
+
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.rest.internal.deployer.ObjectDefinitionDeployerImpl;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.cxf.message.Message;
+
+/**
+ * @author Luis Miguel Barcos
+ */
+public class ObjectsContextProviderUtil {
+
+	public static HttpServletRequest getHttpServletRequest(Message message) {
+		return (HttpServletRequest)message.getContextualProperty(
+			"HTTP.REQUEST");
+	}
+
+	public static ObjectDefinition getObjectDefinition(
+		Message message,
+		ObjectDefinitionDeployerImpl objectDefinitionDeployerImpl,
+		Portal portal) {
+
+		long companyId = portal.getCompanyId(getHttpServletRequest(message));
+
+		String restContextPath = (String)message.getContextualProperty(
+			"org.apache.cxf.message.Message.BASE_PATH");
+
+		restContextPath = restContextPath.substring(
+			restContextPath.indexOf("/o/"));
+
+		restContextPath = StringUtil.removeFirst(restContextPath, "/o");
+		restContextPath = StringUtil.replaceLast(restContextPath, '/', "");
+
+		try {
+			return objectDefinitionDeployerImpl.getObjectDefinition(
+				companyId, restContextPath);
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(exception);
+			}
+
+			throw new RuntimeException(exception);
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		ObjectsContextProviderUtil.class);
+
+}

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/BaseObjectRelationshipElementsParserImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/BaseObjectRelationshipElementsParserImpl.java
@@ -22,6 +22,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import javax.ws.rs.BadRequestException;
+
 /**
  * @author Carlos Correa
  * @author Sergio Jimenez del Coso
@@ -41,6 +43,11 @@ public abstract class BaseObjectRelationshipElementsParserImpl<T>
 	}
 
 	protected List<T> parseMany(Object object) {
+		if (!(object instanceof List)) {
+			throw new BadRequestException(
+				"Unable to create nested object entries");
+		}
+
 		List<T> list = new ArrayList<>();
 
 		for (Object curObject : (List<?>)object) {
@@ -63,6 +70,13 @@ public abstract class BaseObjectRelationshipElementsParserImpl<T>
 		objectEntry.setProperties(nestedObjectEntryProperties);
 
 		return objectEntry;
+	}
+
+	protected void validateOne(Object object) {
+		if (!(object instanceof Map)) {
+			throw new BadRequestException(
+				"Unable to create nested object entries");
+		}
 	}
 
 	protected ObjectDefinition objectDefinition;

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/ObjectEntry1toMObjectRelationshipElementsParserImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/ObjectEntry1toMObjectRelationshipElementsParserImpl.java
@@ -57,6 +57,8 @@ public class ObjectEntry1toMObjectRelationshipElementsParserImpl
 
 	@Override
 	protected ObjectEntry parseOne(Object object) {
+		validateOne(object);
+
 		return toObjectEntry((Map<String, Object>)object);
 	}
 

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/ObjectEntryMtoMObjectRelationshipElementsParserImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/ObjectEntryMtoMObjectRelationshipElementsParserImpl.java
@@ -50,6 +50,8 @@ public class ObjectEntryMtoMObjectRelationshipElementsParserImpl
 
 	@Override
 	protected ObjectEntry parseOne(Object object) {
+		validateOne(object);
+
 		return toObjectEntry((Map<String, Object>)object);
 	}
 

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/v1_0/ObjectEntryEntityModel.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/v1_0/ObjectEntryEntityModel.java
@@ -59,7 +59,7 @@ public class ObjectEntryEntityModel implements EntityModel {
 	}
 
 	public ObjectEntryEntityModel(
-			ObjectDefinition objectDefinition, List<ObjectField> objectFields)
+			long objectDefinitionId, List<ObjectField> objectFields)
 		throws Exception {
 
 		_entityFieldsMap = _getStringEntityFieldMap(objectFields);
@@ -67,6 +67,10 @@ public class ObjectEntryEntityModel implements EntityModel {
 		if (!FeatureFlagManagerUtil.isEnabled("LPS-154672")) {
 			return;
 		}
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionLocalServiceUtil.getObjectDefinition(
+				objectDefinitionId);
 
 		List<ObjectRelationship> objectRelationships =
 			ObjectRelationshipLocalServiceUtil.getAllObjectRelationships(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
@@ -378,8 +378,7 @@ public class PredicateExpressionVisitorImpl
 	private EntityModel _createEntityModel(long objectDefinitionId) {
 		try {
 			return new ObjectEntryEntityModel(
-				ObjectDefinitionLocalServiceUtil.getObjectDefinition(
-					objectDefinitionId),
+				objectDefinitionId,
 				_objectFieldLocalService.getObjectFields(objectDefinitionId));
 		}
 		catch (Exception exception) {

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/petra/sql/dsl/expression/FilterPredicateFactoryImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/petra/sql/dsl/expression/FilterPredicateFactoryImpl.java
@@ -86,6 +86,14 @@ public class FilterPredicateFactoryImpl implements FilterPredicateFactory {
 
 			return create(entityModel, filterString, objectDefinitionId);
 		}
+		catch (ExpressionVisitException expressionVisitException) {
+			throw new InvalidFilterException(
+				expressionVisitException.getMessage(),
+				expressionVisitException);
+		}
+		catch (InvalidFilterException invalidFilterException) {
+			throw invalidFilterException;
+		}
 		catch (Exception exception) {
 			throw new ServerErrorException(500, exception);
 		}

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/petra/sql/dsl/expression/FilterPredicateFactoryImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/petra/sql/dsl/expression/FilterPredicateFactoryImpl.java
@@ -15,12 +15,10 @@
 package com.liferay.object.rest.internal.petra.sql.dsl.expression;
 
 import com.liferay.object.field.business.type.ObjectFieldBusinessTypeRegistry;
-import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.related.models.ObjectRelatedModelsPredicateProviderRegistry;
 import com.liferay.object.rest.internal.odata.entity.v1_0.ObjectEntryEntityModel;
 import com.liferay.object.rest.internal.odata.filter.expression.PredicateExpressionVisitorImpl;
 import com.liferay.object.rest.petra.sql.dsl.expression.FilterPredicateFactory;
-import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.portal.kernel.util.Validator;
@@ -82,12 +80,8 @@ public class FilterPredicateFactoryImpl implements FilterPredicateFactory {
 	@Override
 	public Predicate create(String filterString, long objectDefinitionId) {
 		try {
-			ObjectDefinition objectDefinition =
-				ObjectDefinitionLocalServiceUtil.getObjectDefinition(
-					objectDefinitionId);
-
 			EntityModel entityModel = new ObjectEntryEntityModel(
-				objectDefinition,
+				objectDefinitionId,
 				_objectFieldLocalService.getObjectFields(objectDefinitionId));
 
 			return create(entityModel, filterString, objectDefinitionId);

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/petra/sql/dsl/expression/FilterPredicateFactoryImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/petra/sql/dsl/expression/FilterPredicateFactoryImpl.java
@@ -15,10 +15,12 @@
 package com.liferay.object.rest.internal.petra.sql.dsl.expression;
 
 import com.liferay.object.field.business.type.ObjectFieldBusinessTypeRegistry;
+import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.related.models.ObjectRelatedModelsPredicateProviderRegistry;
 import com.liferay.object.rest.internal.odata.entity.v1_0.ObjectEntryEntityModel;
 import com.liferay.object.rest.internal.odata.filter.expression.PredicateExpressionVisitorImpl;
 import com.liferay.object.rest.petra.sql.dsl.expression.FilterPredicateFactory;
+import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.portal.kernel.util.Validator;
@@ -79,10 +81,20 @@ public class FilterPredicateFactoryImpl implements FilterPredicateFactory {
 
 	@Override
 	public Predicate create(String filterString, long objectDefinitionId) {
-		EntityModel entityModel = new ObjectEntryEntityModel(
-			_objectFieldLocalService.getObjectFields(objectDefinitionId));
+		try {
+			ObjectDefinition objectDefinition =
+				ObjectDefinitionLocalServiceUtil.getObjectDefinition(
+					objectDefinitionId);
 
-		return create(entityModel, filterString, objectDefinitionId);
+			EntityModel entityModel = new ObjectEntryEntityModel(
+				objectDefinition,
+				_objectFieldLocalService.getObjectFields(objectDefinitionId));
+
+			return create(entityModel, filterString, objectDefinitionId);
+		}
+		catch (Exception exception) {
+			throw new ServerErrorException(500, exception);
+		}
 	}
 
 	@Reference

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
@@ -187,7 +187,7 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 		throws Exception {
 
 		return new ObjectEntryEntityModel(
-			_objectDefinition,
+			_objectDefinition.getObjectDefinitionId(),
 			_objectFieldLocalService.getObjectFields(
 				_objectDefinition.getObjectDefinitionId()));
 	}

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
@@ -20,7 +20,6 @@ import com.liferay.object.rest.dto.v1_0.ObjectEntry;
 import com.liferay.object.rest.internal.odata.entity.v1_0.ObjectEntryEntityModel;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManagerRegistry;
-import com.liferay.object.rest.petra.sql.dsl.expression.FilterPredicateFactory;
 import com.liferay.object.scope.ObjectScopeProvider;
 import com.liferay.object.scope.ObjectScopeProviderRegistry;
 import com.liferay.object.service.ObjectDefinitionLocalService;
@@ -35,7 +34,6 @@ import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -52,7 +50,6 @@ import java.util.Map;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 
 /**
@@ -61,7 +58,6 @@ import javax.ws.rs.core.MultivaluedMap;
 public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 
 	public ObjectEntryResourceImpl(
-		FilterPredicateFactory filterPredicateFactory,
 		ObjectDefinitionLocalService objectDefinitionLocalService,
 		ObjectEntryLocalService objectEntryLocalService,
 		ObjectEntryManagerRegistry objectEntryManagerRegistry,
@@ -71,7 +67,6 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 		SystemObjectDefinitionMetadataRegistry
 			systemObjectDefinitionMetadataRegistry) {
 
-		_filterPredicateFactory = filterPredicateFactory;
 		_objectDefinitionLocalService = objectDefinitionLocalService;
 		_objectEntryLocalService = objectEntryLocalService;
 		_objectEntryManagerRegistry = objectEntryManagerRegistry;
@@ -207,18 +202,9 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 			_objectEntryManagerRegistry.getObjectEntryManager(
 				_objectDefinition.getStorageType());
 
-		Predicate predicate = null;
-
-		if (contextHttpServletRequest != null) {
-			predicate = _filterPredicateFactory.create(
-				getEntityModel(new MultivaluedHashMap<String, Object>()),
-				ParamUtil.getString(contextHttpServletRequest, "filter"),
-				_objectDefinition.getObjectDefinitionId());
-		}
-
 		return objectEntryManager.getObjectEntries(
 			contextCompany.getCompanyId(), _objectDefinition, null, aggregation,
-			_getDTOConverterContext(null), pagination, predicate, search,
+			_getDTOConverterContext(null), pagination, _predicate, search,
 			sorts);
 	}
 
@@ -260,10 +246,7 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 
 		return objectEntryManager.getObjectEntries(
 			contextCompany.getCompanyId(), _objectDefinition, scopeKey,
-			aggregation, _getDTOConverterContext(null), pagination,
-			_filterPredicateFactory.create(
-				ParamUtil.getString(contextHttpServletRequest, "filter"),
-				_objectDefinition.getObjectDefinitionId()),
+			aggregation, _getDTOConverterContext(null), pagination, _predicate,
 			search, sorts);
 	}
 
@@ -596,8 +579,6 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 		throw new NotFoundException("Missing parameter \"objectDefinitionId\"");
 	}
 
-	private final FilterPredicateFactory _filterPredicateFactory;
-
 	@Context
 	private ObjectDefinition _objectDefinition;
 
@@ -607,6 +588,10 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 	private final ObjectFieldLocalService _objectFieldLocalService;
 	private final ObjectRelationshipService _objectRelationshipService;
 	private final ObjectScopeProviderRegistry _objectScopeProviderRegistry;
+
+	@Context
+	private Predicate _predicate;
+
 	private final SystemObjectDefinitionMetadataRegistry
 		_systemObjectDefinitionMetadataRegistry;
 

--- a/modules/apps/portal-odata/portal-odata-impl/src/main/java/com/liferay/portal/odata/internal/filter/EntityModelSchemaBasedEdmProvider.java
+++ b/modules/apps/portal-odata/portal-odata-impl/src/main/java/com/liferay/portal/odata/internal/filter/EntityModelSchemaBasedEdmProvider.java
@@ -75,7 +75,8 @@ public class EntityModelSchemaBasedEdmProvider extends SchemaBasedEdmProvider {
 	}
 
 	private CsdlComplexType _createCsdlComplexType(
-		String namespace, EntityField entityField) {
+		String namespace, EntityField entityField,
+		List<CsdlComplexType> csdlComplexTypes) {
 
 		if (!Objects.equals(entityField.getType(), EntityField.Type.COMPLEX)) {
 			return null;
@@ -99,6 +100,13 @@ public class EntityModelSchemaBasedEdmProvider extends SchemaBasedEdmProvider {
 
 			if (csdlProperty != null) {
 				csdlProperties.add(csdlProperty);
+
+				if (Objects.equals(
+						curEntityField.getType(), EntityField.Type.COMPLEX)) {
+
+					csdlComplexTypes.addAll(
+						_createCsdlComplexTypes(_NAMESPACE, entityFieldsMap));
+				}
 			}
 		}
 
@@ -115,7 +123,7 @@ public class EntityModelSchemaBasedEdmProvider extends SchemaBasedEdmProvider {
 
 		for (EntityField entityField : entityFieldsMap.values()) {
 			CsdlComplexType csdlComplexType = _createCsdlComplexType(
-				namespace, entityField);
+				namespace, entityField, csdlComplexTypes);
 
 			if (csdlComplexType != null) {
 				csdlComplexTypes.add(csdlComplexType);


### PR DESCRIPTION
Related ticket [LPS-176653](https://issues.liferay.com/browse/LPS-176653)
____
### Purpose and scope of this PR
First PR to introduce the functionality to filter over fields of multiple levels of relationships.
This PR is to introduce this to:
* **Custom objects** and **relationships among custom objects**
* Using **just** the **comparision operators**. See more information in [this documentation](https://learn.liferay.com/dxp/latest/en/headless-delivery/consuming-apis/api-query-parameters.html#filter-parameter)

This PR does not contain the tests as the infrastructure for testing will be a little complex. In order to facilitate the review, the test will be sent along with [this other ticket](https://issues.liferay.com/browse/LPS-177830).

### How to test this PR
Deploy the following modules:
* `object-rest-impl`
* `portal-odata-impl`

There is an example in the related ticket.

_NOTE: This PR also contains a revert of a commit that was causing troubles with the tests. That revert is to throw the proper exception in some validations. It was also failing on the master branch_

_UPDATE: Forgot to mention that it is necessary to set the feature flag `LPS-154672` to true_
