### PR TITLE
LPS-175904 Headless API returns [Bad Request Error] when friendlyUrl includes "/"

### DIFF
--- a/modules/apps/bulk/bulk-rest-impl/rest-openapi.yaml
+++ b/modules/apps/bulk/bulk-rest-impl/rest-openapi.yaml
@@ -89,7 +89,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.bulk.rest.client', and version '3.0.15'."
+        'com.liferay.bulk.rest.client', and version '3.0.16'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.bulk.rest.client', and version '3.0.15'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.bulk.rest.client', and version '3.0.16'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/rest-openapi.yaml
@@ -566,7 +566,7 @@ info:
         name: Commerce Team
     description:
         "Liferay Commerce Admin Account API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.admin.account.client', and version '4.0.22'."
+        artifact ID 'com.liferay.headless.commerce.admin.account.client', and version '4.0.23'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce Admin Account API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.account.client', and version '4.0.22'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Account API", version = "v1.0")
+	info = @Info(description = "Liferay Commerce Admin Account API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.account.client', and version '4.0.23'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Account API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/rest-openapi.yaml
@@ -1652,7 +1652,7 @@ info:
         name: Commerce Team
     description:
         "Liferay Commerce Admin Catalog API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.admin.catalog.client', and version '4.0.29'."
+        artifact ID 'com.liferay.headless.commerce.admin.catalog.client', and version '4.0.30'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce Admin Catalog API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.catalog.client', and version '4.0.29'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Catalog API", version = "v1.0")
+	info = @Info(description = "Liferay Commerce Admin Catalog API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.catalog.client', and version '4.0.30'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Catalog API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/rest-openapi.yaml
@@ -361,7 +361,7 @@ components:
 info:
     description:
         "Liferay Commerce Admin Channel API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.admin.channel.client', and version '4.0.20'."
+        artifact ID 'com.liferay.headless.commerce.admin.channel.client', and version '4.0.21'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce Admin Channel API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.channel.client', and version '4.0.20'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Channel API", version = "v1.0")
+	info = @Info(description = "Liferay Commerce Admin Channel API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.channel.client', and version '4.0.21'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Channel API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/rest-openapi.yaml
@@ -298,7 +298,7 @@ info:
         name: "Commerce Team"
     description:
         "Liferay Commerce Admin Inventory API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.admin.inventory.client', and version '4.0.20'."
+        artifact ID 'com.liferay.headless.commerce.admin.inventory.client', and version '4.0.21'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce Admin Inventory API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.inventory.client', and version '4.0.20'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Inventory API", version = "v1.0")
+	info = @Info(description = "Liferay Commerce Admin Inventory API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.inventory.client', and version '4.0.21'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Inventory API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/rest-openapi.yaml
@@ -1368,7 +1368,7 @@ info:
         name: Commerce Team
     description:
         "Liferay Commerce Admin Order API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.admin.order.client', and version '4.0.27'."
+        artifact ID 'com.liferay.headless.commerce.admin.order.client', and version '4.0.28'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce Admin Order API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.order.client', and version '4.0.27'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Order API", version = "v1.0")
+	info = @Info(description = "Liferay Commerce Admin Order API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.order.client', and version '4.0.28'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Order API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/rest-openapi-v2.0.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/rest-openapi-v2.0.yaml
@@ -1467,7 +1467,7 @@ info:
         name: Commerce Team
     description:
         "Liferay Commerce Admin Pricing API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.admin.pricing.client', and version '4.0.20'."
+        artifact ID 'com.liferay.headless.commerce.admin.pricing.client', and version '4.0.21'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/rest-openapi.yaml
@@ -484,7 +484,7 @@ info:
         name: Commerce Team
     description:
         "Liferay Commerce Admin Pricing API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.admin.pricing.client', and version '4.0.20'."
+        artifact ID 'com.liferay.headless.commerce.admin.pricing.client', and version '4.0.21'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce Admin Pricing API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.pricing.client', and version '4.0.20'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Pricing API", version = "v1.0")
+	info = @Info(description = "Liferay Commerce Admin Pricing API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.pricing.client', and version '4.0.21'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Pricing API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce Admin Pricing API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.pricing.client', and version '4.0.20'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Pricing API", version = "v2.0")
+	info = @Info(description = "Liferay Commerce Admin Pricing API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.pricing.client', and version '4.0.21'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Pricing API", version = "v2.0")
 )
 @Path("/v2.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/rest-openapi.yaml
@@ -350,7 +350,7 @@ info:
         name: Commerce Team
     description:
         "Liferay Commerce Admin Admin Shipment API. A Java client JAR is available for use with the group ID
-        'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.shipment.client', and version '1.0.20'."
+        'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.shipment.client', and version '1.0.21'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce Admin Admin Shipment API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.shipment.client', and version '1.0.20'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Admin Shipment API", version = "v1.0")
+	info = @Info(description = "Liferay Commerce Admin Admin Shipment API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.shipment.client', and version '1.0.21'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Admin Shipment API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/rest-openapi.yaml
@@ -326,7 +326,7 @@ info:
         name: Commerce Team
     description:
         "Liferay Commerce Admin Site Setting API. A Java client JAR is available for use with the group ID
-        'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.site.setting.client', and version '4.0.20'."
+        'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.site.setting.client', and version '4.0.21'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce Admin Site Setting API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.site.setting.client', and version '4.0.20'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Site Setting API", version = "v1.0")
+	info = @Info(description = "Liferay Commerce Admin Site Setting API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.site.setting.client', and version '4.0.21'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Site Setting API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/rest-openapi.yaml
@@ -504,7 +504,7 @@ components:
 info:
     description:
         "Headless Delivery Commerce Cart API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.delivery.cart.client', and version '4.0.22'."
+        artifact ID 'com.liferay.headless.commerce.delivery.cart.client', and version '4.0.23'."
     license:
         name: Apache 2.0
         url: http://www.apache.org/licenses/LICENSE-2.0.html

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Headless Delivery Commerce Cart API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.delivery.cart.client', and version '4.0.22'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery Commerce Cart API", version = "v1.0")
+	info = @Info(description = "Headless Delivery Commerce Cart API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.delivery.cart.client', and version '4.0.23'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery Commerce Cart API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/rest-openapi.yaml
@@ -704,7 +704,7 @@ components:
 info:
     description:
         "Headless Commerce Delivery Catalog API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.delivery.catalog.client', and version '4.0.28'."
+        artifact ID 'com.liferay.headless.commerce.delivery.catalog.client', and version '4.0.29'."
     license:
         name: Apache 2.0
         url: http://www.apache.org/licenses/LICENSE-2.0.html

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Headless Commerce Delivery Catalog API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.delivery.catalog.client', and version '4.0.28'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Commerce Delivery Catalog API", version = "v1.0")
+	info = @Info(description = "Headless Commerce Delivery Catalog API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.delivery.catalog.client', and version '4.0.29'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Commerce Delivery Catalog API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/rest-openapi.yaml
@@ -599,7 +599,7 @@ components:
 info:
     description:
         "Headless Delivery Commerce Order API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.delivery.order.client', and version '1.0.5'."
+        artifact ID 'com.liferay.headless.commerce.delivery.order.client', and version '1.0.6'."
     license:
         name: Apache 2.0
         url: http://www.apache.org/licenses/LICENSE-2.0.html

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Headless Delivery Commerce Order API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.delivery.order.client', and version '1.0.5'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery Commerce Order API", version = "v1.0")
+	info = @Info(description = "Headless Delivery Commerce Order API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.delivery.order.client', and version '1.0.6'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery Commerce Order API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/data-engine/data-engine-rest-impl/rest-openapi.yaml
+++ b/modules/apps/data-engine/data-engine-rest-impl/rest-openapi.yaml
@@ -329,7 +329,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.data.engine.rest.client', and version '3.0.18'."
+        'com.liferay.data.engine.rest.client', and version '3.0.19'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/OpenAPIResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.data.engine.rest.client', and version '3.0.18'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Data Engine", version = "v2.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.data.engine.rest.client', and version '3.0.19'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Data Engine", version = "v2.0")
 )
 @Path("/v2.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/digital-signature/digital-signature-rest-impl/rest-openapi.yaml
+++ b/modules/apps/digital-signature/digital-signature-rest-impl/rest-openapi.yaml
@@ -85,7 +85,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.digital.signature.rest.client', and version '1.0.13'."
+        'com.liferay.digital.signature.rest.client', and version '1.0.14'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/digital-signature/digital-signature-rest-impl/src/main/java/com/liferay/digital/signature/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/digital-signature/digital-signature-rest-impl/src/main/java/com/liferay/digital/signature/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.digital.signature.rest.client', and version '1.0.13'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.digital.signature.rest.client', and version '1.0.14'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-impl/rest-openapi.yaml
@@ -86,7 +86,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.admin.address.client', and version '1.0.8'."
+        'com.liferay.headless.admin.address.client', and version '1.0.9'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.address.client', and version '1.0.8'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin Address", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.address.client', and version '1.0.9'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin Address", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/rest-openapi.yaml
@@ -186,7 +186,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.admin.content.client', and version '2.0.19'."
+        'com.liferay.headless.admin.content.client', and version '2.0.20'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.content.client', and version '2.0.19'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin Content", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.content.client', and version '2.0.20'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin Content", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/rest-openapi.yaml
@@ -71,7 +71,7 @@ info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
         'om.liferay.headless.admin.list.type.client', and version '1.0.0'.. A Java client JAR is available for use with
-        the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.list.type.client', and version '1.0.15'."
+        the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.list.type.client', and version '1.0.16'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'om.liferay.headless.admin.list.type.client', and version '1.0.0'.. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.list.type.client', and version '1.0.15'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "List Type", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'om.liferay.headless.admin.list.type.client', and version '1.0.0'.. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.list.type.client', and version '1.0.16'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "List Type", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/rest-openapi.yaml
@@ -362,7 +362,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.admin.taxonomy.client', and version '4.0.18'."
+        'com.liferay.headless.admin.taxonomy.client', and version '4.0.19'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.taxonomy.client', and version '4.0.18'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin Taxonomy", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.taxonomy.client', and version '4.0.19'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin Taxonomy", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
@@ -1097,7 +1097,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.admin.user.client', and version '4.0.38'."
+        'com.liferay.headless.admin.user.client', and version '4.0.39'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSiteResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSiteResourceImpl.java
@@ -136,7 +136,7 @@ public abstract class BaseSiteResourceImpl
 		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Site")}
 	)
 	@javax.ws.rs.GET
-	@javax.ws.rs.Path("/sites/by-friendly-url-path/{friendlyUrlPath}")
+	@javax.ws.rs.Path("/sites/by-friendly-url-path/{friendlyUrlPath : .+}")
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
 	public Site getSiteByFriendlyUrlPath(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.user.client', and version '4.0.38'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin User", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.user.client', and version '4.0.39'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin User", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/rest-openapi.yaml
@@ -650,7 +650,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.admin.workflow.client', and version '4.0.17'."
+        'com.liferay.headless.admin.workflow.client', and version '4.0.18'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.workflow.client', and version '4.0.17'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin Workflow", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.workflow.client', and version '4.0.18'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin Workflow", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/rest-openapi.yaml
@@ -155,7 +155,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.batch.engine.client', and version '1.0.12'."
+        'com.liferay.headless.batch.engine.client', and version '1.0.13'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.batch.engine.client', and version '1.0.12'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Batch Engine", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.batch.engine.client', and version '1.0.13'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Batch Engine", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -5399,7 +5399,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.delivery.client', and version '4.0.49'."
+        'com.liferay.headless.delivery.client', and version '4.0.50'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardMessageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardMessageResourceImpl.java
@@ -1447,7 +1447,7 @@ public abstract class BaseMessageBoardMessageResourceImpl
 	)
 	@javax.ws.rs.GET
 	@javax.ws.rs.Path(
-		"/sites/{siteId}/message-board-messages/by-friendly-url-path/{friendlyUrlPath}"
+		"/sites/{siteId}/message-board-messages/by-friendly-url-path/{friendlyUrlPath : .+}"
 	)
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardThreadResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardThreadResourceImpl.java
@@ -1282,7 +1282,7 @@ public abstract class BaseMessageBoardThreadResourceImpl
 	)
 	@javax.ws.rs.GET
 	@javax.ws.rs.Path(
-		"/sites/{siteId}/message-board-threads/by-friendly-url-path/{friendlyUrlPath}"
+		"/sites/{siteId}/message-board-threads/by-friendly-url-path/{friendlyUrlPath : .+}"
 	)
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseSitePageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseSitePageResourceImpl.java
@@ -202,7 +202,7 @@ public abstract class BaseSitePageResourceImpl
 		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "SitePage")}
 	)
 	@javax.ws.rs.GET
-	@javax.ws.rs.Path("/sites/{siteId}/site-pages/{friendlyUrlPath}")
+	@javax.ws.rs.Path("/sites/{siteId}/site-pages/{friendlyUrlPath : .+}")
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
 	public SitePage getSiteSitePage(
@@ -256,7 +256,7 @@ public abstract class BaseSitePageResourceImpl
 	)
 	@javax.ws.rs.GET
 	@javax.ws.rs.Path(
-		"/sites/{siteId}/site-pages/{friendlyUrlPath}/experiences"
+		"/sites/{siteId}/site-pages/{friendlyUrlPath : .+}/experiences"
 	)
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
@@ -315,7 +315,7 @@ public abstract class BaseSitePageResourceImpl
 	)
 	@javax.ws.rs.GET
 	@javax.ws.rs.Path(
-		"/sites/{siteId}/site-pages/{friendlyUrlPath}/experiences/{experienceKey}"
+		"/sites/{siteId}/site-pages/{friendlyUrlPath : .+}/experiences/{experienceKey}"
 	)
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
@@ -378,7 +378,7 @@ public abstract class BaseSitePageResourceImpl
 	)
 	@javax.ws.rs.GET
 	@javax.ws.rs.Path(
-		"/sites/{siteId}/site-pages/{friendlyUrlPath}/experiences/{experienceKey}/rendered-page"
+		"/sites/{siteId}/site-pages/{friendlyUrlPath : .+}/experiences/{experienceKey}/rendered-page"
 	)
 	@javax.ws.rs.Produces("text/html")
 	@Override
@@ -437,7 +437,7 @@ public abstract class BaseSitePageResourceImpl
 	)
 	@javax.ws.rs.GET
 	@javax.ws.rs.Path(
-		"/sites/{siteId}/site-pages/{friendlyUrlPath}/rendered-page"
+		"/sites/{siteId}/site-pages/{friendlyUrlPath : .+}/rendered-page"
 	)
 	@javax.ws.rs.Produces("text/html")
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.delivery.client', and version '4.0.49'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.delivery.client', and version '4.0.50'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-form/headless-form-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-form/headless-form-impl/rest-openapi.yaml
@@ -432,7 +432,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.form.client', and version '4.0.15'."
+        'com.liferay.headless.form.client', and version '4.0.16'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.form.client', and version '4.0.15'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Form", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.form.client', and version '4.0.16'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Form", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/rest-openapi.yaml
@@ -58,7 +58,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.portal.instances.client', and version '1.0.10'."
+        'com.liferay.headless.portal.instances.client', and version '1.0.11'."
     license:
         name: Apache 2.0
         url: http://www.apache.org/licenses/LICENSE-2.0.html

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.portal.instances.client', and version '1.0.10'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Portal Instances Headless API", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.portal.instances.client', and version '1.0.11'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Portal Instances Headless API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-user-notification/headless-user-notification-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-user-notification/headless-user-notification-impl/rest-openapi.yaml
@@ -49,7 +49,7 @@ components:
 info:
     description:
         "Headless User Notification REST API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.user.notification.client', and version '1.0.3'."
+        artifact ID 'com.liferay.headless.user.notification.client', and version '1.0.4'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-user-notification/headless-user-notification-impl/src/main/java/com/liferay/headless/user/notification/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-user-notification/headless-user-notification-impl/src/main/java/com/liferay/headless/user/notification/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Headless User Notification REST API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.user.notification.client', and version '1.0.3'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "HeadlessUserNotification", version = "v1.0")
+	info = @Info(description = "Headless User Notification REST API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.user.notification.client', and version '1.0.4'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "HeadlessUserNotification", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/notification/notification-rest-impl/rest-openapi.yaml
+++ b/modules/apps/notification/notification-rest-impl/rest-openapi.yaml
@@ -112,7 +112,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.notification.rest.client', and version '1.0.15'."
+        'com.liferay.notification.rest.client', and version '1.0.16'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/notification/notification-rest-impl/src/main/java/com/liferay/notification/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/notification/notification-rest-impl/src/main/java/com/liferay/notification/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.notification.rest.client', and version '1.0.15'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.notification.rest.client', and version '1.0.16'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/portal-search/portal-search-rest-impl/rest-openapi.yaml
+++ b/modules/apps/portal-search/portal-search-rest-impl/rest-openapi.yaml
@@ -35,7 +35,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.portal.search.rest.client', and version '1.0.6'."
+        'com.liferay.portal.search.rest.client', and version '1.0.7'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.portal.search.rest.client', and version '1.0.6'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.portal.search.rest.client', and version '1.0.7'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/rest-openapi.yaml
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/rest-openapi.yaml
@@ -720,7 +720,7 @@ info:
         name: Commerce Team
     description:
         "Liferay Commerce ML API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.commerce.machine.learning.client', and version '1.0.14'."
+        'com.liferay.headless.commerce.machine.learning.client', and version '1.0.15'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce ML API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.machine.learning.client', and version '1.0.14'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce ML API", version = "v1.0")
+	info = @Info(description = "Liferay Commerce ML API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.machine.learning.client', and version '1.0.15'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce ML API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/rest-openapi.yaml
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/rest-openapi.yaml
@@ -570,7 +570,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.portal.workflow.metrics.rest.client', and version '3.0.20'."
+        'com.liferay.portal.workflow.metrics.rest.client', and version '3.0.21'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.portal.workflow.metrics.rest.client', and version '3.0.20'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.portal.workflow.metrics.rest.client', and version '3.0.21'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/rest-openapi.yaml
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/rest-openapi.yaml
@@ -561,7 +561,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.search.experiences.rest.client', and version '3.0.12'."
+        'com.liferay.search.experiences.rest.client', and version '3.0.13'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.search.experiences.rest.client', and version '3.0.12'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.search.experiences.rest.client', and version '3.0.13'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/dxp/apps/segments/segments-asah-rest-impl/rest-openapi.yaml
+++ b/modules/dxp/apps/segments/segments-asah-rest-impl/rest-openapi.yaml
@@ -69,7 +69,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.segments.asah.rest.client', and version '3.0.16'."
+        'com.liferay.segments.asah.rest.client', and version '3.0.17'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.segments.asah.rest.client', and version '3.0.16'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Segments Asah", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.segments.asah.rest.client', and version '3.0.17'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Segments Asah", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
@@ -190,6 +190,22 @@ public class ResourceOpenAPIParser {
 					"})");
 		}
 
+		for (JavaMethodParameter pathJavaMethodParameter :
+				javaMethodSignature.getPathJavaMethodParameters()) {
+
+			String parameterName = pathJavaMethodParameter.getParameterName();
+
+			if (parameterName.endsWith("Path") &&
+				Objects.equals(
+					pathJavaMethodParameter.getParameterType(),
+					"java.lang.String")) {
+
+				path = StringUtil.replace(
+					path, "{" + parameterName + "}",
+					"{" + parameterName + " : .+}");
+			}
+		}
+
 		methodAnnotations.add("@javax.ws.rs.Path(\"" + path + "\")");
 
 		String annotationString = StringUtil.toUpperCase(


### PR DESCRIPTION
- Initial solution to allow `/` in path parameters. It is automatic and is only applied to parameters that end with `Path`.
- We should consider applying the OpenAPI `pattern` attribute as described in https://swagger.io/docs/specification/data-models/data-types/. But this would force developers to explicitly add it to their OpenAPI files.
