### PR TITLE
LPS-178304 | Can import JSON file with create strategy create only

### DIFF
--- a/modules/apps/batch-planner/batch-planner-test/src/testFunctional/macros/ImportExport.macro
+++ b/modules/apps/batch-planner/batch-planner-test/src/testFunctional/macros/ImportExport.macro
@@ -394,4 +394,12 @@ definition {
 			value1 = ${entityType});
 	}
 
+	macro selectImportStrategy {
+		WaitForElementPresent(locator1 = "ImportExport#IMPORT_STRATEGY");
+
+		Select(
+			locator1 = "ImportExport#IMPORT_STRATEGY",
+			value1 = ${strategyType});
+	}
+
 }

--- a/modules/apps/batch-planner/batch-planner-test/src/testFunctional/paths/ImportExport.path
+++ b/modules/apps/batch-planner/batch-planner-test/src/testFunctional/paths/ImportExport.path
@@ -56,6 +56,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>IMPORT_STRATEGY</td>
+	<td>//div[not(contains(@class,'hide'))]/div[label[contains(.,'Import Strategy')]]/select[not(@disabled)]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>OPTIONAL_IMPORT_FIELD</td>
 	<td>//select[contains(@aria-required,'false')][contains(@id,'${key_destinationField}')]</td>
 	<td></td>

--- a/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/ImportExport.testcase
+++ b/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/ImportExport.testcase
@@ -728,6 +728,58 @@ definition {
 		}
 	}
 
+	@description = "Verify users can import JSON file with create strategy create only"
+	@priority = 3
+	test CanImportJSONFileWithCreateStrategyCreateOnly {
+		property portal.acceptance = "true";
+
+		task ("Given the user is importing a JSON file") {
+			ImportExport.openImportExportAdmin();
+
+			ImportExport.gotoImport();
+
+			UploadDependencyFile.uploadFile(fileName = "json_account_import.json");
+
+			ImportExport.selectEntity(entityType = "Account (v1_0 - Liferay Headless Admin User)");
+		}
+
+		task ("When choosing Only Add New Records as Import Strategy and importing the file") {
+			ImportExport.selectImportStrategy(strategyType = "Only Add New Records");
+
+			Button.click(button = "Next");
+
+			Button.click(button = "Start Import");
+		}
+
+		task ("Then the import process should complete successfully") {
+			WaitForElementPresent(locator1 = "ImportExport#EXECUTION_SUCCESS");
+
+			Account.openAccountsAdmin();
+
+			Account.viewAccountDetails(
+				accountDescription = "Test Business Account Description",
+				accountName = "Test Business Account",
+				accountType = "Business",
+				externalReferenceCode = 101);
+
+			Navigator.gotoBack();
+
+			Account.viewAccountDetails(
+				accountDescription = "Test Guest Account Description",
+				accountName = "Test Guest Account",
+				accountType = "Guest",
+				externalReferenceCode = 102);
+
+			Navigator.gotoBack();
+
+			Account.viewAccountDetails(
+				accountDescription = "Test Person Account Description",
+				accountName = "Test Person Account",
+				accountType = "Person",
+				externalReferenceCode = 103);
+		}
+	}
+
 	@description = "Verify users can import entities via JSONL files"
 	@priority = 3
 	test CanImportJSONLFiles {


### PR DESCRIPTION
**Background**
Add a test case to import JSON file with create strategy create only

**Test Plan**
Given the user is importing a JSON file
When choosing Only Add New Records as Import Strategy and importing the file
Then the import process should complete successfully

**JIRA Link:**
https://issues.liferay.com/browse/LPS-172141