### PR TITLE
LPS 177979

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-api/build.gradle
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 	compileOnly project(":apps:portal-search:portal-search-api")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-lang")
+	compileOnly project(":core:petra:petra-reflect")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")
 

--- a/modules/apps/portal-vulcan/portal-vulcan-api/build.gradle
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/build.gradle
@@ -26,6 +26,6 @@ dependencies {
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")
 
-	testCompile group: "org.glassfish.jersey.core", name: "jersey-common", version: "2.26"
+	testCompile group: "org.apache.cxf", name: "cxf-rt-frontend-jaxrs", version: "3.4.10"
 	testCompile group: "org.hamcrest", name: "hamcrest-all", version: "1.3"
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/UriInfoUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/UriInfoUtil.java
@@ -14,11 +14,14 @@
 
 package com.liferay.portal.vulcan.util;
 
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.Validator;
+
+import java.lang.reflect.Field;
 
 import java.net.URI;
 
@@ -27,6 +30,7 @@ import javax.ws.rs.core.UriInfo;
 
 /**
  * @author Javier Gamarra
+ * @author Raymond Augé
  */
 public class UriInfoUtil {
 
@@ -39,6 +43,20 @@ public class UriInfoUtil {
 
 	public static UriBuilder getBaseUriBuilder(UriInfo uriInfo) {
 		return _updateUriBuilder(uriInfo.getBaseUriBuilder());
+	}
+
+	private static String _getHost(UriBuilder uriBuilder) {
+		try {
+			if (_uriBuilderHostField == null) {
+				_uriBuilderHostField = ReflectionUtil.getDeclaredField(
+					uriBuilder.getClass(), "host");
+			}
+
+			return (String)_uriBuilderHostField.get(uriBuilder);
+		}
+		catch (Exception exception) {
+			return ReflectionUtil.throwException(exception);
+		}
 	}
 
 	private static boolean _isHttpsEnabled() {
@@ -59,11 +77,13 @@ public class UriInfoUtil {
 			uriBuilder.replacePath(PortalUtil.getPathContext(uri.getPath()));
 		}
 
-		if (_isHttpsEnabled()) {
+		if (Validator.isNotNull(_getHost(uriBuilder)) && _isHttpsEnabled()) {
 			uriBuilder.scheme(Http.HTTPS);
 		}
 
 		return uriBuilder;
 	}
+
+	private static volatile Field _uriBuilderHostField;
 
 }


### PR DESCRIPTION
- Revert "LPS-178020 Modify cases to adapt new behavior"
- LPS-176015 Modify case to make it stable
- LPS-176224 Remove Optional usage in method body from DLOpenerGoogleDriveManager
- LPS-176224 Remove Optional usage in return value in OAuth2StateUtil and rename
- LPS-176224 Apply
- LPS-176223 Remove Stream usage in static field in DLOpenerMimeTypes
- LPS-176222 Remove stream usage in method body from SamlIdpSpSessionLocalServiceImpl
- LPS-176222 Remove stream usage in method body from SamlSpSessionLocalServiceImpl
- LPS-176222 Simplify, no need to create the list for SamlPeerBinding
- LPS-176222 SF
- LPS-178114 WebSphere issue, make sure to use the same Writer when rendering com.liferay.taglib.ui.IconTag. When rendering com.liferay.taglib.ui.IconTag, we use requestDispatcher.include(ServletRequest, ServletResponse), this api iconTag.doTagAsString(PageContext) can't use the original writer(in the ProductNavigationControlMenuTagDisplayContext#_writeProductNavigationControlMenuEntry()). So the issue happened. When rendering the other icons, for example, the Simulation icon. This tag is com.liferay.taglib.aui.IconTag and its content can be directly returned by iconTag.doTagAsString(), and then directly used by the original writer to write. So the issue didn't happen in the icon
- LPS-178114 SF, use the same httpServletResponse in the same request.
- LPS-178114 Like this
- LPS-176129 Remove stream usage in method body from BaseDB
- LPS-176129 Remove stream usage in method body from UpgradeOrganization
- LPS-176129 Remove stream usage in method body from SearchContainerTest
- LPS-176129 Remove stream usage in method body from JSONUtilTest by using JSONUtil.toJSONArray()
- LPS-176129 Remove stream usage in method body from ServiceXMLTest
- LPS-176129 SF, no need to be static methods
- LPS-176129 Remove Stream usages from UserGroupLocalServiceImpl
- LPS-176129 SF, inline more
- LPS-176129 SF, use TransformerUtil
- LPS-176129 Rename
- LPS-178146 Remove stream usages
- LPS-176122 Add integration test to Segments Vocabulary Configuration's Listener
- LPS-176122 Inline
- LPS-176122 Not needed
- LPS-176122 SF
- LPS-176122 reset, we could do it with a try/finally or with a setUp/tearDown
- LPS-176897 Create input clear button
- LPS-176897 Add translate and SF
- LPS-175838 'createBatch' missing in actions node of getKnowledgeBaseArticleKnowledgeBaseAttachmentsPage
- LRQA-29748 Add Autom. SPAInfrastructure#SetTimeout test
- LRQA-29748 SF
- LRQA-29748 move SPANotificationSetTimeout testcase and fix for working on CI
- LRQA-29748 SF
- LRQA-29748 Removes unnecessary property and code
- COMMERCE-11023 Update the locator to assert the pagination
- LPS-178075 Suport adding event criteria to existing segment
- LPS-178075 Fix delete event criteria
- LPS-178160 Set portal.acceptance property for tests related to the oldValue function
- LPS-176973 Create basic structure
- LPS-176973  page-definition updated
- LPS-176073 SF
- LPS-173096 Fix removeDuplicatedFieldsGroup Macro
- LPS-176550 feature-flag-web: removes feature flag for LPS-167698
- LPS-178148 Adding keywords to the object entry entity model
- LPS-178148 Implementing filter eq operation
- LPS-178148 Implementing ne, gt, ge, lt, le operators
- LPS-178148 Implementing startswith
- LPS-178148 Reusing query
- LPS-178148 Hiding behind feature flag
- LPS-178148 Using same pattern
- LPS-178148 Avoiding duplication
- LPS-178148 Unifying condition
- LPS-178148 Implementing contains
- LPS-178148 Implementing in
- LPS-175187 (headless-admin-user-impl) Create schema for Image
- LPS-175187 (headless-admin-user-impl) Add post endpoint
- LPS-175187 (headless-admin-user) autogenerated: buildRest
- LPS-175187 (headless-admin-user-impl) Add postUserAccountImage method
- LPS-175187 headless-admin-user-test: implement test case to assert that the user now has an image
- LPS-175187 headless-admin-user-impl: adds multiple responses to force a Response method return type
- LPS-175187 (headless-admin-user) autogenerated: buildRest
- LPS-175187 headless-admin-user-impl: update implementation to match new method signature
- LPS-175187 match generated BaseUserAccountResourceImpl.java
- LPS-176815 Adds relationships to form provider. We namespace them differently so the don't collide with fields of the same name for the definition
- LPS-176815 Avoid iterating twice over the fields
- LPS-176815 Extract method
- LPS-176815 Match with _getInfoFieldValuesByDefaultStorageType
- LPS-176815 Add RelatedObjectEntryFieldValues to the list of values
- LPS-176815 Namespace through relationship
- LPS-176815 Get parents' info field set
- LPS-176815 SF
- LPS-176478 batch-engine - convert to builder pattern (rename) and change
- LPS-176478 batch-engine - pass field names that should be included in procession
- LPS-176478 batch-engine - simplify - this has same effect and can be easily used for import too
- LPS-176478 batch-engine - prevent unwanted fields
- LPS-176478 batch-engine - clean code - remove irrelevant argument and fix dependent code
- LPS-176478 batch-engine-service - fieldNameMappings can be null
- LPS-176478 SF
- LPS-176478 SF
- LPS-178251 feature-flag-web: disables the toggle switch on click until the request completes
- LPS-177203 Check for existing default entries shouldn't be done during staging process
- LPS-177203 Use the service to set the default utility page, otherwise we will encounter inconsistencies in the database
- LPS-177203 Refactor test in preparation for future tests
- LPS-177203 Adds integration test for changing the default utility page entry
- LPS-177203 Adds integration test for changing the default display page, by copying and adapting the code from utility pages
- LPS-177203 Is this OK?
- LPS-177979 Batch API Fails with "[https:///headless-batch-engine] is not a valid HTTP URL" when HTTPS server protocol is enabled
- LPS-177979 tests
