### PR TITLE
LPS-175667 Add tests on expose permissions for individual object entry

### DIFF
--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/CustomObjectAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/CustomObjectAPI.macro
@@ -1,0 +1,65 @@
+definition {
+
+	macro _curlObjectPermissions {
+		Variables.assertDefined(parameterList = "${en_US_plural_label},${objectEntryId}");
+
+		var en_US_plural_label_lowercase = StringUtil.lowerCase(${en_US_plural_label});
+		var portalURL = JSONCompany.getPortalURL();
+		var headerAndType = '''
+ 			-u test@liferay.com:test \
+			-H Content-Type: application/json \
+		''';
+		var api = "${portalURL}/o/c/${en_US_plural_label_lowercase}/${objectEntryId}/permissions";
+
+		if (isSet(roleNames)) {
+			var api = StringUtil.add(${curl}, "?roleNames=${roleNames}", "");
+		}
+
+		var curl = StringUtil.add(${api}, " \ ${headerAndType}", "");
+
+		return ${curl};
+	}
+
+	macro getObjectPermissions {
+		Variables.assertDefined(parameterList = "${en_US_plural_label},${objectEntryId}");
+
+		var curl = CustomObjectAPI._curlObjectPermissions(
+			en_US_plural_label = ${en_US_plural_label},
+			objectEntryId = ${objectEntryId});
+
+		var response = JSONCurlUtil.get(${curl});
+
+		return ${response};
+	}
+
+	macro staticObjectEntryId {
+		Variables.assertDefined(parameterList = ${objectEntryId});
+
+		static var staticObjectId = ${objectEntryId};
+
+		return ${staticObjectId};
+	}
+
+	macro updateObjectPermissions {
+		Variables.assertDefined(parameterList = "${en_US_plural_label},${objectEntryId},${actionIds},${roleName}");
+
+		var curl = CustomObjectAPI._curlObjectPermissions(
+			en_US_plural_label = ${en_US_plural_label},
+			objectEntryId = ${objectEntryId});
+		var body = '''
+			-d [{
+				"actionIds": [
+					${actionIds}
+				],
+				"roleName": "${roleName}"
+			}]
+		''';
+
+		var curl = StringUtil.add(${curl}, " \ ${body}", "");
+
+		var response = JSONCurlUtil.put(${curl});
+
+		return ${response};
+	}
+
+}

--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/CustomObjectAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/CustomObjectAPI.macro
@@ -5,7 +5,7 @@ definition {
 
 		var en_US_plural_label_lowercase = StringUtil.lowerCase(${en_US_plural_label});
 		var portalURL = JSONCompany.getPortalURL();
-		var headerAndType = '''
+		var headers = '''
  			-u test@liferay.com:test \
 			-H Content-Type: application/json \
 		''';
@@ -15,7 +15,7 @@ definition {
 			var api = StringUtil.add(${curl}, "?roleNames=${roleNames}", "");
 		}
 
-		var curl = StringUtil.add(${api}, " \ ${headerAndType}", "");
+		var curl = StringUtil.add(${api}, " \ ${headers}", "");
 
 		return ${curl};
 	}

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/ExposePermissionsForIndividualObjectEntries.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/ExposePermissionsForIndividualObjectEntries.testcase
@@ -1,0 +1,149 @@
+@component-name = "portal-headless"
+definition {
+
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Object";
+	property testray.main.component.name = "Headless";
+
+	setUp {
+		TestCase.setUpPortalInstanceNoSelenium();
+
+		task ("Given Object Definition student created") {
+			var objectDefinitionId = ObjectDefinitionAPI.createAndPublishObjectDefinition(
+				en_US_label = "student",
+				en_US_plural_label = "students",
+				name = "Student",
+				requiredStringFieldName = "name");
+		}
+
+		task ("And Given student entry created") {
+			var studentEntryId = ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "students",
+				name = "Able");
+
+			CustomObjectAPI.staticObjectEntryId(objectEntryId = ${studentEntryId});
+		}
+
+		task ("And Given new role "Test" with permissions created") {
+			JSONRole.addRegularRole(
+				roleKey = "Test",
+				roleTitle = "Test");
+		}
+
+		task ("And Given the role "Test" assigned to student entry") {
+			Permissions.definePermissionViaJSONAPI(
+				resourceAction = "VIEW",
+				resourceName = "com.liferay.object.model.ObjectDefinition#${objectDefinitionId}",
+				roleTitle = "Test",
+				roleType = "regular");
+		}
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if (${testPortalInstance} == "true") {
+			PortalInstances.tearDownCPNoSelenium();
+		}
+		else {
+			ObjectAdmin.deleteObjectViaAPI(objectName = "Student");
+		}
+	}
+
+	@description = "Ignore tests until LPS-177115 fixed"
+	@disable-webdriver = "true"
+	@ignore = "true"
+	@priority = 5
+	test CanChangePermissionsAssignedToObjectEntry {
+		property portal.acceptance = "true";
+
+		task ("When requesting putStudentPermissionsPage with created {studentId} to update actionIds of Owner") {
+			var response = CustomObjectAPI.updateObjectPermissions(
+				actionIds = "\"UPDATE\",\"VIEW\"",
+				en_US_plural_label = "students",
+				objectEntryId = ${staticObjectId},
+				roleName = "Owner");
+		}
+
+		task ("Then I can see Owner actionIds are updated") {
+			var actualPermissions = JSONUtil.getWithJSONPath(${response}, "$.items[?(@.roleName == 'Owner')].actionIds");
+
+			TestUtils.assertEquals(
+				actual = ${actualPermissions},
+				expected = "[\"UPDATE\",\"VIEW\"]");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 4
+	test CanEmptyPermissionsOfNewRoleAssignedToObjectEntry {
+		property portal.acceptance = "true";
+
+		task ("And Given with putStudentPermissionsPage I update "Test" role with no actionIds") {
+			CustomObjectAPI.updateObjectPermissions(
+				actionIds = "",
+				en_US_plural_label = "students",
+				objectEntryId = ${staticObjectId},
+				roleName = "Test");
+		}
+
+		task ("When requesting getStudentPermissionsPage with created {studentId}") {
+			var response = CustomObjectAPI.getObjectPermissions(
+				en_US_plural_label = "students",
+				objectEntryId = ${staticObjectId});
+		}
+
+		task ("Then I can see "Owner" as a unique assigned role") {
+			var actualRole = JSONUtil.getWithJSONPath(${response}, "$.items[*].roleName");
+
+			TestUtils.assertEquals(
+				actual = ${actualRole},
+				expected = "Owner");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 5
+	test CanGetPermissionsAssignedToObjectEntry {
+		property portal.acceptance = "true";
+
+		task ("When requesting getStudentPermissionsPage with created {studentId}") {
+			var response = CustomObjectAPI.getObjectPermissions(
+				en_US_plural_label = "students",
+				objectEntryId = ${staticObjectId});
+		}
+
+		task ("Then I can see roles with permissions assigned to the student entry") {
+			var actualPermissions = JSONUtil.getWithJSONPath(${response}, "$.items[?(@.roleName == 'Owner')].actionIds");
+
+			TestUtils.assertEquals(
+				actual = ${actualPermissions},
+				expected = "[\"DELETE\",\"PERMISSIONS\",\"UPDATE\",\"VIEW\"]");
+		}
+	}
+
+	@description = "Ignore tests until LPS-177115 fixed"
+	@disable-webdriver = "true"
+	@ignore = "true"
+	@priority = 4
+	test CanGetPermissionsOfNewRoleAssignedToObjectEntry {
+		property portal.acceptance = "true";
+
+		task ("When requesting getStudentPermissionsPage with created {studentId} and roleNames as "Test"") {
+			var response = CustomObjectAPI.getObjectPermissions(
+				en_US_plural_label = "students",
+				objectEntryId = ${staticObjectId},
+				roleNames = "Test");
+		}
+
+		task ("Then I can see roles with permissions assigned to the student entry") {
+			var actualPermissions = JSONUtil.getWithJSONPath(${response}, "$.items[?(@.roleName == 'Test')].actionIds");
+
+			TestUtils.assertEquals(
+				actual = ${actualPermissions},
+				expected = "[\"VIEW\"]");
+		}
+	}
+
+}

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/permission/JSONPermission.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/permission/JSONPermission.macro
@@ -3,7 +3,9 @@ definition {
 	macro addPermission {
 		Variables.assertDefined(parameterList = "${actionId},${name},${roleTitle}");
 
-		var groupId = JSONPermissionSetter.setGroupId(groupName = ${groupName});
+		var groupId = JSONPermissionSetter.setGroupId(
+			groupName = ${groupName},
+			noSelenium = "true");
 		var roleType = JSONPermissionSetter.setRoleType(roleType = ${roleType});
 
 		var primKey = JSONPermissionSetter.setPrimKey(roleType = ${roleType});

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/permission/JSONPermissionAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/permission/JSONPermissionAPI.macro
@@ -4,7 +4,7 @@ definition {
 		Variables.assertDefined(parameterList = "${groupId},${name},${scope},${primKey},${roleId},${actionId}");
 
 		var portalURL = JSONCompany.getPortalURL();
-		var companyId = JSONCompany.getCompanyId();
+		var companyId = JSONCompany.getCompanyIdNoSelenium();
 
 		var curl = '''
 			${portalURL}/api/jsonws/resourcepermission/add-resource-permission \

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/permission/JSONPermissionSetter.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/permission/JSONPermissionSetter.macro
@@ -11,6 +11,7 @@ definition {
 
 		var groupId = JSONGroupAPI._getGroupIdByName(
 			groupName = ${groupName},
+			noSelenium = ${noSelenium},
 			site = ${site});
 
 		return ${groupId};
@@ -20,7 +21,7 @@ definition {
 		JSONPermissionValidator.validateRoleType(roleType = ${roleType});
 
 		if (${roleType} == "regular") {
-			var primKey = JSONCompany.getCompanyId();
+			var primKey = JSONCompany.getCompanyIdNoSelenium();
 		}
 		else if ((${roleType} == "site") || (${roleType} == "organization") || (${roleType} == "asset library") || (${roleType} == "account")) {
 			var primKey = 0;

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/roles/JSONRoleAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/roles/JSONRoleAPI.macro
@@ -119,7 +119,7 @@ definition {
 	macro _getRoleIdByName {
 		Variables.assertDefined(parameterList = ${name});
 
-		var companyId = JSONCompany.getCompanyId();
+		var companyId = JSONCompany.getCompanyIdNoSelenium();
 		var portalURL = JSONCompany.getPortalURL();
 
 		var curl = '''


### PR DESCRIPTION
**Background:**
- Add tests for LPS-162878 Expose permissions for individual object entries

**Test Plan**
- Given Object Definition student created
And Given student entry created
When requesting getStudentPermissionsPage with created {studentId}
Then I can see roles with permissions assigned to the student entry
- Given Object Definition student created
And Given student entry created
When requesting putStudentPermissionsPage with created {studentId} to update actionIds of "Owner"
Then I can see "Owner" actionIds are updated
- Given Object Definition student created
And Given student entry created
And Given new role "Test" with permissions created
And Given the role "Test" assigned to student entry
When requesting getStudentPermissionsPage with created {studentId} and roleNames as "Test"
Then I can see roles with permissions assigned to the student entry
- Given Object Definition student created
And Given student entry created
And Given new role "Test" with permissions created
And Given the role "Test" assigned to student entry
And Given with putStudentPermissionsPage I update "Test" role with no actionIds
When requesting getStudentPermissionsPage with created {studentId}
Then I can see "Owner" as a unique assigned role

**Jira Ticket:**
- https://issues.liferay.com/browse/LPS-175667