### PR TITLE
LPS-175235 Delete non-necessary JsonFilter annotation

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/extension/ExtendedEntity.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/extension/ExtendedEntity.java
@@ -15,7 +15,6 @@
 package com.liferay.portal.vulcan.internal.jaxrs.extension;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
-import com.fasterxml.jackson.annotation.JsonFilter;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 
 import com.liferay.portal.kernel.log.Log;
@@ -36,7 +35,6 @@ import java.util.Set;
 /**
  * @author Javier de Arcos
  */
-@JsonFilter("Liferay.Vulcan")
 public class ExtendedEntity {
 
 	public static ExtendedEntity extend(


### PR DESCRIPTION
Follow-up pr from https://github.com/liferay-headless/liferay-portal/pull/1068
Original description:

Motivation
=======

This work solves the problem reported in the ticket https://issues.liferay.com/browse/LPS-175235 .
Previous PR: https://github.com/liferay-core-infra/liferay-portal/pull/3547

Steps to Verify
========

- Perform the following request (replace the id 20124 with an existing one): 
`curl -X GET -u 'test@liferay.com:test' http://localhost:8080/o/headless-admin-user/v1.0/user-accounts/20124`
- The response should be something like:
<details>
<summary>
Json string:
</summary>
<p>

```yaml
{
  "accountBriefs" : [ ],
  "actions" : {
    "get-user-account-by-external-reference-code" : {
      "method" : "GET",
      "href" : "http://localhost:8080/o/headless-admin-user/v1.0/user-accounts/by-external-reference-code/20124"
    },
    "put-user-account" : {
      "method" : "PUT",
      "href" : "http://localhost:8080/o/headless-admin-user/v1.0/user-accounts/20124"
    },
    "delete-user-account" : {
      "method" : "DELETE",
      "href" : "http://localhost:8080/o/headless-admin-user/v1.0/user-accounts/20124"
    },
    "get-user-account" : {
      "method" : "GET",
      "href" : "http://localhost:8080/o/headless-admin-user/v1.0/user-accounts/20124"
    },
    "delete-user-account-by-external-reference-code" : {
      "method" : "DELETE",
      "href" : "http://localhost:8080/o/headless-admin-user/v1.0/user-accounts/by-external-reference-code/20124"
    },
    "put-user-account-by-external-reference-code" : {
      "method" : "PUT",
      "href" : "http://localhost:8080/o/headless-admin-user/v1.0/user-accounts/by-external-reference-code/20124"
    },
    "get-my-user-account" : {
      "method" : "GET",
      "href" : "http://localhost:8080/o/headless-admin-user/v1.0/my-user-account"
    },
    "patch-user-account" : {
      "method" : "PATCH",
      "href" : "http://localhost:8080/o/headless-admin-user/v1.0/user-accounts/20124"
    }
  },
  "additionalName" : "",
  "alternateName" : "test",
  "birthDate" : "1970-01-01T00:00:00Z",
  "customFields" : [ ],
  "dashboardURL" : "/user/test",
  "dateCreated" : "2023-02-08T10:01:13Z",
  "dateModified" : "2023-02-09T08:22:45Z",
  "emailAddress" : "test@liferay.com",
  "externalReferenceCode" : "8b8b59b0-0362-70e1-3b2d-98fd3454ed84",
  "familyName" : "Test",
  "givenName" : "Test",
  "id" : 20124,
  "jobTitle" : "",
  "keywords" : [ ],
  "lastLoginDate" : "2023-02-08T16:08:12Z",
  "name" : "Test Test",
  "organizationBriefs" : [ ],
  "profileURL" : "/web/test",
  "roleBriefs" : [ {
    "id" : 20102,
    "name" : "Administrator"
  }, {
    "id" : 20106,
    "name" : "Power User"
  }, {
    "id" : 20108,
    "name" : "User"
  } ],
  "siteBriefs" : [ {
    "descriptiveName" : "Global",
    "id" : 20122,
    "name" : "Global"
  }, {
    "descriptiveName" : "Liferay DXP",
    "id" : 20120,
    "name" : "Guest"
  } ],
  "userAccountContactInformation" : {
    "emailAddresses" : [ ],
    "facebook" : "",
    "jabber" : "",
    "postalAddresses" : [ ],
    "skype" : "",
    "sms" : "",
    "telephones" : [ ],
    "twitter" : "",
    "webUrls" : [ ]
  },
  "userGroupBriefs" : [ ]
}
```

</p>
</details>

- Perform the following request including the `fields` query parameter with an existing field:
`curl -X GET -u 'test@liferay.com:test' http://localhost:8080/o/headless-admin-user/v1.0/user-accounts/20124?fields=externalReferenceCode`

** Expected behaviour:
- The response should contain only the `externalReferenceCode` field:
`{
  "externalReferenceCode" : "8b8b59b0-0362-70e1-3b2d-98fd3454ed84"
}`

** Current behaviour:

- The response is an empty JSON:
`{ }`
