### PR TITLE
LPS-178464 Add test for logical operators

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -28,6 +28,7 @@ import com.liferay.object.rest.internal.resource.v1_0.test.util.ObjectRelationsh
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
@@ -38,7 +39,6 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.MapUtil;
-import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.URLCodec;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
@@ -50,6 +50,7 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.util.PropsUtil;
 
 import java.util.Collections;
+import java.io.Serializable;
 
 import javax.ws.rs.NotSupportedException;
 
@@ -422,8 +423,7 @@ public class ObjectEntryResourceTest {
 			objectEntryJSONObject.toString(),
 			StringBundler.concat(
 				_siteScopedObjectDefinition1.getRESTContextPath(), "/scopes/",
-				String.valueOf(TestPropsValues.getGroupId()),
-				"/by-external-reference-code/",
+				TestPropsValues.getGroupId(), "/by-external-reference-code/",
 				_siteScopedObjectEntry1.getExternalReferenceCode()),
 			Http.Method.PATCH);
 
@@ -636,7 +636,7 @@ public class ObjectEntryResourceTest {
 			_objectEntry2.getExternalReferenceCode(),
 			jsonObject.getString("externalReferenceCode"));
 		Assert.assertEquals(
-			_OBJECT_FIELD_VALUE_2, jsonObject.getString(_OBJECT_FIELD_NAME_2));
+			_OBJECT_FIELD_VALUE_2, jsonObject.getInt(_OBJECT_FIELD_NAME_2));
 
 		jsonObject = HTTPTestUtil.invoke(
 			null,
@@ -652,7 +652,7 @@ public class ObjectEntryResourceTest {
 			_objectEntry1.getExternalReferenceCode(),
 			jsonObject.getString("externalReferenceCode"));
 		Assert.assertEquals(
-			_OBJECT_FIELD_VALUE_1, jsonObject.getString(_OBJECT_FIELD_NAME_1));
+			_OBJECT_FIELD_VALUE_1, jsonObject.getInt(_OBJECT_FIELD_NAME_1));
 
 		jsonObject = HTTPTestUtil.invoke(
 			null,
@@ -699,7 +699,7 @@ public class ObjectEntryResourceTest {
 
 		JSONObject jsonObject = HTTPTestUtil.invoke(
 			newObjectEntryJSONObject.toString(),
-			com.liferay.petra.string.StringBundler.concat(
+			StringBundler.concat(
 				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
 				_objectEntry1.getPrimaryKey()),
 			Http.Method.PUT);
@@ -714,7 +714,7 @@ public class ObjectEntryResourceTest {
 
 		jsonObject = HTTPTestUtil.invoke(
 			null,
-			com.liferay.petra.string.StringBundler.concat(
+			StringBundler.concat(
 				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
 				_objectEntry1.getPrimaryKey(), "?nestedFields=",
 				_objectRelationship.getName()),
@@ -767,7 +767,7 @@ public class ObjectEntryResourceTest {
 
 		jsonObject = HTTPTestUtil.invoke(
 			newObjectEntryJSONObject.toString(),
-			com.liferay.petra.string.StringBundler.concat(
+			StringBundler.concat(
 				_objectDefinition2.getRESTContextPath(), StringPool.SLASH,
 				objectEntryId),
 			Http.Method.PUT);
@@ -830,7 +830,7 @@ public class ObjectEntryResourceTest {
 
 		JSONObject jsonObject = HTTPTestUtil.invoke(
 			newObjectEntryJSONObject.toString(),
-			com.liferay.petra.string.StringBundler.concat(
+			StringBundler.concat(
 				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
 				_objectEntry1.getPrimaryKey()),
 			Http.Method.PUT);
@@ -845,7 +845,7 @@ public class ObjectEntryResourceTest {
 
 		jsonObject = HTTPTestUtil.invoke(
 			null,
-			com.liferay.petra.string.StringBundler.concat(
+			StringBundler.concat(
 				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
 				_objectEntry1.getPrimaryKey(), "?nestedFields=",
 				_objectRelationship.getName()),
@@ -959,7 +959,8 @@ public class ObjectEntryResourceTest {
 	}
 
 	private void _testFilterByRelatedObjectDefinitionSystemObjectField(
-			String expectedObjectFieldName, String expectedObjectFieldValue,
+			String expectedObjectFieldName,
+			Serializable expectedObjectFieldValue,
 			FilterOperator filterOperator, ObjectDefinition objectDefinition,
 			ObjectRelationship objectRelationship, long relatedObjectEntryId)
 		throws Exception {
@@ -967,8 +968,7 @@ public class ObjectEntryResourceTest {
 		String endpoint = StringBundler.concat(
 			objectDefinition.getRESTContextPath(), "?filter=",
 			objectRelationship.getName(), "/id%20", filterOperator.getValue(),
-			"%20'", String.valueOf(relatedObjectEntryId),
-			StringPool.APOSTROPHE);
+			"%20'", relatedObjectEntryId, StringPool.APOSTROPHE);
 
 		_testFilterObjectEntriesByRelatedObjectEntriesUsingAFilterOperator(
 			endpoint, expectedObjectFieldName, expectedObjectFieldValue);
@@ -1015,23 +1015,28 @@ public class ObjectEntryResourceTest {
 
 	private void
 			_testFilterObjectEntriesByRelatedObjectEntriesUsingAFilterOperator(
-				String expectedObjectFieldName, String expectedObjectFieldValue,
+				String expectedObjectFieldName,
+				Serializable expectedObjectFieldValue,
 				FilterOperator filterOperator,
 				ObjectDefinition objectDefinition,
 				ObjectRelationship objectRelationship,
-				String relatedObjectFieldName, String relatedObjectFieldValue)
+				String relatedObjectFieldName,
+				Serializable relatedObjectFieldValue)
 		throws Exception {
 
 		String endpoint = objectDefinition.getRESTContextPath() + "?filter=";
 
 		if (filterOperator == FilterOperator.CONTAINS) {
+			String relatedObjectFieldString = String.valueOf(
+				relatedObjectFieldValue);
+
 			endpoint = endpoint.concat(
 				StringBundler.concat(
 					filterOperator.getValue(), StringPool.OPEN_PARENTHESIS,
 					objectRelationship.getName(), StringPool.SLASH,
 					relatedObjectFieldName, StringPool.COMMA,
 					StringPool.APOSTROPHE,
-					relatedObjectFieldValue.substring(1, 2),
+					relatedObjectFieldString.substring(1, 2),
 					StringPool.APOSTROPHE, StringPool.CLOSE_PARENTHESIS));
 		}
 		else if (filterOperator == FilterOperator.EQ) {
@@ -1055,13 +1060,16 @@ public class ObjectEntryResourceTest {
 					StringPool.APOSTROPHE, StringPool.CLOSE_PARENTHESIS));
 		}
 		else if (filterOperator == FilterOperator.STARTS_WITH) {
+			String relatedObjectFieldString = String.valueOf(
+				relatedObjectFieldValue);
+
 			endpoint = endpoint.concat(
 				StringBundler.concat(
 					filterOperator.getValue(), StringPool.OPEN_PARENTHESIS,
 					objectRelationship.getName(), StringPool.SLASH,
 					relatedObjectFieldName, StringPool.COMMA,
 					StringPool.APOSTROPHE,
-					relatedObjectFieldValue.substring(0, 1),
+					relatedObjectFieldString.substring(0, 1),
 					StringPool.APOSTROPHE, StringPool.CLOSE_PARENTHESIS));
 		}
 		else {
@@ -1076,7 +1084,7 @@ public class ObjectEntryResourceTest {
 	private void
 			_testFilterObjectEntriesByRelatedObjectEntriesUsingAFilterOperator(
 				String endpoint, String expectedObjectFieldName,
-				String expectedObjectFieldValue)
+				Serializable expectedObjectFieldValue)
 		throws Exception {
 
 		JSONObject jsonObject = HTTPTestUtil.invoke(
@@ -1090,7 +1098,7 @@ public class ObjectEntryResourceTest {
 
 		Assert.assertEquals(
 			expectedObjectFieldValue,
-			itemJSONObject.getString(expectedObjectFieldName));
+			itemJSONObject.getInt(expectedObjectFieldName));
 	}
 
 	private void _testGetNestedFieldDetailsInOneToManyRelationships(
@@ -1107,15 +1115,14 @@ public class ObjectEntryResourceTest {
 		JSONObject itemJSONObject = itemsJSONArray.getJSONObject(0);
 
 		Assert.assertEquals(
-			_OBJECT_FIELD_VALUE_2,
-			itemJSONObject.getString(_OBJECT_FIELD_NAME_2));
+			_OBJECT_FIELD_VALUE_2, itemJSONObject.getInt(_OBJECT_FIELD_NAME_2));
 
 		JSONObject relatedObjectJSONObject = itemJSONObject.getJSONObject(
 			expectedFieldName);
 
 		Assert.assertEquals(
 			_OBJECT_FIELD_VALUE_1,
-			relatedObjectJSONObject.getString(_OBJECT_FIELD_NAME_1));
+			relatedObjectJSONObject.getInt(_OBJECT_FIELD_NAME_1));
 	}
 
 	private void
@@ -1199,11 +1206,9 @@ public class ObjectEntryResourceTest {
 	private static final String _OBJECT_FIELD_NAME_2 =
 		"x" + RandomTestUtil.randomString();
 
-	private static final String _OBJECT_FIELD_VALUE_1 =
-		RandomTestUtil.randomString();
+	private static final int _OBJECT_FIELD_VALUE_1 = RandomTestUtil.randomInt();
 
-	private static final String _OBJECT_FIELD_VALUE_2 =
-		RandomTestUtil.randomString();
+	private static final int _OBJECT_FIELD_VALUE_2 = RandomTestUtil.randomInt();
 
 	private ObjectDefinition _objectDefinition1;
 	private ObjectDefinition _objectDefinition2;

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -548,6 +548,266 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
+	public void testFilterByLogicalOperatorsObjectEntriesByRelatesObjectEntriesFields()
+		throws Exception {
+
+		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		// Custom field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s le '%s' and %s/%s gt '%s'",
+					_objectRelationship.getName(), _OBJECT_FIELD_NAME_2,
+					_OBJECT_FIELD_VALUE_2, _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2 - 1)),
+			_objectDefinition1);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s le '%s' or %s/%s gt '%s'",
+					_objectRelationship.getName(), _OBJECT_FIELD_NAME_2,
+					_OBJECT_FIELD_VALUE_2, _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2 - 1)),
+			_objectDefinition1);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"not (%s/%s ge '%s')", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2 + 1)),
+			_objectDefinition1);
+
+		// System field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/id le '%s' and %s/id gt '%s'",
+					_objectRelationship.getName(),
+					_objectEntry2.getObjectEntryId(),
+					_objectRelationship.getName(),
+					_objectEntry2.getObjectEntryId() - 1)),
+			_objectDefinition1);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/id le '%s' or %s/id gt '%s'",
+					_objectRelationship.getName(), _OBJECT_FIELD_VALUE_2,
+					_objectRelationship.getName(),
+					_objectEntry2.getObjectEntryId() - 1)),
+			_objectDefinition1);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"not (%s/id ge '%s')", _objectRelationship.getName(),
+					_objectEntry2.getObjectEntryId() + 1)),
+			_objectDefinition1);
+
+		// Other side of the relationship
+		// Custom field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/%s le '%s' and %s/%s gt '%s'",
+					_objectRelationship.getName(), _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1, _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1 - 1)),
+			_objectDefinition2);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/%s le '%s' or %s/%s gt '%s'",
+					_objectRelationship.getName(), _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1, _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1 - 1)),
+			_objectDefinition2);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"not (%s/%s ge '%s')", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1 + 1)),
+			_objectDefinition2);
+
+		// System field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/id le '%s' and %s/id gt '%s'",
+					_objectRelationship.getName(),
+					_objectEntry1.getObjectEntryId(),
+					_objectRelationship.getName(),
+					_objectEntry1.getObjectEntryId() - 1)),
+			_objectDefinition2);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/id le '%s' or %s/id gt '%s'",
+					_objectRelationship.getName(), _OBJECT_FIELD_VALUE_1,
+					_objectRelationship.getName(),
+					_objectEntry1.getObjectEntryId() - 1)),
+			_objectDefinition2);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"not (%s/id ge '%s')", _objectRelationship.getName(),
+					_objectEntry1.getObjectEntryId() + 1)),
+			_objectDefinition2);
+
+		_objectRelationshipLocalService.deleteObjectRelationship(
+			_objectRelationship);
+
+		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		// Custom field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s le '%s' and %s/%s gt '%s'",
+					_objectRelationship.getName(), _OBJECT_FIELD_NAME_2,
+					_OBJECT_FIELD_VALUE_2, _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2 - 1)),
+			_objectDefinition1);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s le '%s' or %s/%s gt '%s'",
+					_objectRelationship.getName(), _OBJECT_FIELD_NAME_2,
+					_OBJECT_FIELD_VALUE_2, _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2 - 1)),
+			_objectDefinition1);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"not (%s/%s ge '%s')", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2 + 1)),
+			_objectDefinition1);
+
+		// System field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/id le '%s' and %s/id gt '%s'",
+					_objectRelationship.getName(),
+					_objectEntry2.getObjectEntryId(),
+					_objectRelationship.getName(),
+					_objectEntry2.getObjectEntryId() - 1)),
+			_objectDefinition1);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/id le '%s' or %s/id gt '%s'",
+					_objectRelationship.getName(), _OBJECT_FIELD_VALUE_2,
+					_objectRelationship.getName(),
+					_objectEntry2.getObjectEntryId() - 1)),
+			_objectDefinition1);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"not (%s/id ge '%s')", _objectRelationship.getName(),
+					_objectEntry2.getObjectEntryId() + 1)),
+			_objectDefinition1);
+
+		// Other side of the relationship
+		// Custom field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/%s le '%s' and %s/%s gt '%s'",
+					_objectRelationship.getName(), _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1, _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1 - 1)),
+			_objectDefinition2);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/%s le '%s' or %s/%s gt '%s'",
+					_objectRelationship.getName(), _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1, _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1 - 1)),
+			_objectDefinition2);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"not (%s/%s ge '%s')", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1 + 1)),
+			_objectDefinition2);
+
+		// System field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/id le '%s' and %s/id gt '%s'",
+					_objectRelationship.getName(),
+					_objectEntry1.getObjectEntryId(),
+					_objectRelationship.getName(),
+					_objectEntry1.getObjectEntryId() - 1)),
+			_objectDefinition2);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/id le '%s' or %s/id gt '%s'",
+					_objectRelationship.getName(), _OBJECT_FIELD_VALUE_1,
+					_objectRelationship.getName(),
+					_objectEntry1.getObjectEntryId() - 1)),
+			_objectDefinition2);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"not (%s/id ge '%s')", _objectRelationship.getName(),
+					_objectEntry1.getObjectEntryId() + 1)),
+			_objectDefinition2);
+	}
+
+	@Test
 	public void testFilterByStringOperatorsObjectEntriesByRelatesObjectEntriesFields()
 		throws Exception {
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -49,8 +49,9 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.util.PropsUtil;
 
-import java.util.Collections;
 import java.io.Serializable;
+
+import java.util.Collections;
 
 import javax.ws.rs.NotSupportedException;
 
@@ -87,6 +88,10 @@ public class ObjectEntryResourceTest {
 			).build());
 		PropsUtil.addProperties(
 			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-154672", "true"
+			).build());
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
 				"feature.flag.LPS-164801", "true"
 			).build());
 		PropsUtil.addProperties(
@@ -100,6 +105,10 @@ public class ObjectEntryResourceTest {
 		PropsUtil.addProperties(
 			UnicodePropertiesBuilder.setProperty(
 				"feature.flag.LPS-153117", "false"
+			).build());
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-154672", "false"
 			).build());
 		PropsUtil.addProperties(
 			UnicodePropertiesBuilder.setProperty(
@@ -160,6 +169,382 @@ public class ObjectEntryResourceTest {
 			_objectDefinition2);
 		_objectDefinitionLocalService.deleteObjectDefinition(
 			_siteScopedObjectDefinition1);
+	}
+
+	@Test
+	public void testFilterByComparisonOperatorsObjectEntriesByRelatesObjectEntriesFields()
+		throws Exception {
+
+		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		// Custom field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s eq '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2)),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s ge '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2)),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s gt '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2 - 1)),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s le '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2)),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s lt '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2 + 1)),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s ne '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2 - 1)),
+			_objectDefinition1);
+
+		// System field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/id eq '%s'", _objectRelationship.getName(),
+					_objectEntry2.getObjectEntryId())),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/id ge '%s'", _objectRelationship.getName(),
+					_objectEntry2.getObjectEntryId())),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/id gt '%s'", _objectRelationship.getName(),
+					_objectEntry2.getObjectEntryId() - 1)),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/id le '%s'", _objectRelationship.getName(),
+					_objectEntry2.getObjectEntryId())),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/id lt '%s'", _objectRelationship.getName(),
+					_objectEntry2.getObjectEntryId() + 1)),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/id ne '%s'", _objectRelationship.getName(),
+					_objectEntry2.getObjectEntryId() - 1)),
+			_objectDefinition1);
+
+		// Other side of the relationship
+		// Custom field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/%s eq '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1)),
+			_objectDefinition2);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/%s ge '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1)),
+			_objectDefinition2);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/%s gt '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1 - 1)),
+			_objectDefinition2);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/%s le '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1)),
+			_objectDefinition2);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/%s lt '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1 + 1)),
+			_objectDefinition2);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/%s ne '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1 - 1)),
+			_objectDefinition2);
+
+		// System field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/id eq '%s'", _objectRelationship.getName(),
+					_objectEntry1.getObjectEntryId())),
+			_objectDefinition2);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/id ge '%s'", _objectRelationship.getName(),
+					_objectEntry1.getObjectEntryId())),
+			_objectDefinition2);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/id gt '%s'", _objectRelationship.getName(),
+					_objectEntry1.getObjectEntryId() - 1)),
+			_objectDefinition2);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/id le '%s'", _objectRelationship.getName(),
+					_objectEntry1.getObjectEntryId())),
+			_objectDefinition2);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/id lt '%s'", _objectRelationship.getName(),
+					_objectEntry1.getObjectEntryId() + 1)),
+			_objectDefinition2);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/id ne '%s'", _objectRelationship.getName(),
+					_objectEntry1.getObjectEntryId() - 1)),
+			_objectDefinition2);
+
+		_objectRelationshipLocalService.deleteObjectRelationship(
+			_objectRelationship);
+
+		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		// Custom field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s eq '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2)),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s ge '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2)),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s gt '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2 - 1)),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s le '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2)),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s lt '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2 + 1)),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s ne '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2 - 1)),
+			_objectDefinition1);
+
+		// System field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/id eq '%s'", _objectRelationship.getName(),
+					_objectEntry2.getObjectEntryId())),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/id ge '%s'", _objectRelationship.getName(),
+					_objectEntry2.getObjectEntryId())),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/id gt '%s'", _objectRelationship.getName(),
+					_objectEntry2.getObjectEntryId() - 1)),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/id le '%s'", _objectRelationship.getName(),
+					_objectEntry2.getObjectEntryId())),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/id lt '%s'", _objectRelationship.getName(),
+					_objectEntry2.getObjectEntryId() + 1)),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/id ne '%s'", _objectRelationship.getName(),
+					_objectEntry2.getObjectEntryId() - 1)),
+			_objectDefinition1);
+
+		// Other side of the relationship
+		// Custom field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/%s eq '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1)),
+			_objectDefinition2);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/%s ge '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1)),
+			_objectDefinition2);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/%s gt '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1 - 1)),
+			_objectDefinition2);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/%s le '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1)),
+			_objectDefinition2);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/%s lt '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1 + 1)),
+			_objectDefinition2);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/%s ne '%s'", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1 - 1)),
+			_objectDefinition2);
+
+		// System field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/id eq '%s'", _objectRelationship.getName(),
+					_objectEntry1.getObjectEntryId())),
+			_objectDefinition2);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/id ge '%s'", _objectRelationship.getName(),
+					_objectEntry1.getObjectEntryId())),
+			_objectDefinition2);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/id gt '%s'", _objectRelationship.getName(),
+					_objectEntry1.getObjectEntryId() - 1)),
+			_objectDefinition2);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/id le '%s'", _objectRelationship.getName(),
+					_objectEntry1.getObjectEntryId())),
+			_objectDefinition2);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/id lt '%s'", _objectRelationship.getName(),
+					_objectEntry1.getObjectEntryId() + 1)),
+			_objectDefinition2);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/id ne '%s'", _objectRelationship.getName(),
+					_objectEntry1.getObjectEntryId() - 1)),
+			_objectDefinition2);
 	}
 
 	@Test
@@ -880,6 +1265,29 @@ public class ObjectEntryResourceTest {
 		return objectRelationship;
 	}
 
+	private void _assertFilter(
+			String expectedObjectFieldName,
+			Serializable expectedObjectFieldValue, String filter,
+			ObjectDefinition objectDefinition)
+		throws Exception {
+
+		String endpoint =
+			objectDefinition.getRESTContextPath() + "?filter=" + filter;
+
+		JSONObject jsonObject = HTTPTestUtil.invoke(
+			null, endpoint, Http.Method.GET);
+
+		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
+
+		Assert.assertEquals(1, itemsJSONArray.length());
+
+		JSONObject itemJSONObject = itemsJSONArray.getJSONObject(0);
+
+		Assert.assertEquals(
+			String.valueOf(expectedObjectFieldValue),
+			String.valueOf(itemJSONObject.get(expectedObjectFieldName)));
+	}
+
 	private void _assertFilteredObjectEntries(
 			int expectedObjectEntryCount, String filter)
 		throws Exception {
@@ -928,6 +1336,10 @@ public class ObjectEntryResourceTest {
 		}
 
 		return jsonArray;
+	}
+
+	private String _escape(String string) {
+		return URLCodec.encodeURL(string);
 	}
 
 	private void _postObjectEntryWithKeywords(String... keywords)

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -53,8 +53,6 @@ import java.io.Serializable;
 
 import java.util.Collections;
 
-import javax.ws.rs.NotSupportedException;
-
 import org.hamcrest.CoreMatchers;
 
 import org.junit.After;
@@ -1085,23 +1083,6 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
-	public void testFilterObjectEntriesByRelatedObjectEntries()
-		throws Exception {
-
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-154672", "true"
-			).build());
-
-		_testFilterObjectEntriesByRelatedObjectEntries();
-
-		PropsUtil.addProperties(
-			UnicodePropertiesBuilder.setProperty(
-				"feature.flag.LPS-154672", "false"
-			).build());
-	}
-
-	@Test
 	public void testGetNestedFieldDetailsInOneToManyRelationships()
 		throws Exception {
 
@@ -1891,165 +1872,6 @@ public class ObjectEntryResourceTest {
 			_objectDefinition1.getRESTContextPath(), Http.Method.POST);
 	}
 
-	private void _testFilterByRelatedObjectDefinitionSystemObjectField(
-			FilterOperator filterOperator,
-			ObjectRelationship objectRelationship)
-		throws Exception {
-
-		_testFilterByRelatedObjectDefinitionSystemObjectField(
-			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1, filterOperator,
-			_objectDefinition1, objectRelationship,
-			_objectEntry2.getObjectEntryId());
-
-		_testFilterByRelatedObjectDefinitionSystemObjectField(
-			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2, filterOperator,
-			_objectDefinition2, objectRelationship,
-			_objectEntry1.getObjectEntryId());
-	}
-
-	private void _testFilterByRelatedObjectDefinitionSystemObjectField(
-			String expectedObjectFieldName,
-			Serializable expectedObjectFieldValue,
-			FilterOperator filterOperator, ObjectDefinition objectDefinition,
-			ObjectRelationship objectRelationship, long relatedObjectEntryId)
-		throws Exception {
-
-		String endpoint = StringBundler.concat(
-			objectDefinition.getRESTContextPath(), "?filter=",
-			objectRelationship.getName(), "/id%20", filterOperator.getValue(),
-			"%20'", relatedObjectEntryId, StringPool.APOSTROPHE);
-
-		_testFilterObjectEntriesByRelatedObjectEntriesUsingAFilterOperator(
-			endpoint, expectedObjectFieldName, expectedObjectFieldValue);
-	}
-
-	private void _testFilterObjectEntriesByRelatedObjectEntries()
-		throws Exception {
-
-		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
-			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
-
-		for (FilterOperator filterOperator : FilterOperator.values()) {
-			_testFilterObjectEntriesByRelatedObjectEntriesInBothSidesOfRelationship(
-				_objectRelationship, filterOperator);
-		}
-
-		_objectRelationshipLocalService.deleteObjectRelationship(
-			_objectRelationship);
-
-		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
-			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
-
-		for (FilterOperator filterOperator : FilterOperator.values()) {
-			_testFilterObjectEntriesByRelatedObjectEntriesInBothSidesOfRelationship(
-				_objectRelationship, filterOperator);
-		}
-	}
-
-	private void
-			_testFilterObjectEntriesByRelatedObjectEntriesInBothSidesOfRelationship(
-				ObjectRelationship objectRelationship,
-				FilterOperator filterOperator)
-		throws Exception {
-
-		_testFilterObjectEntriesByRelatedObjectEntriesUsingAFilterOperator(
-			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1, filterOperator,
-			_objectDefinition1, objectRelationship, _OBJECT_FIELD_NAME_2,
-			_OBJECT_FIELD_VALUE_2);
-		_testFilterObjectEntriesByRelatedObjectEntriesUsingAFilterOperator(
-			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2, filterOperator,
-			_objectDefinition2, objectRelationship, _OBJECT_FIELD_NAME_1,
-			_OBJECT_FIELD_VALUE_1);
-	}
-
-	private void
-			_testFilterObjectEntriesByRelatedObjectEntriesUsingAFilterOperator(
-				String expectedObjectFieldName,
-				Serializable expectedObjectFieldValue,
-				FilterOperator filterOperator,
-				ObjectDefinition objectDefinition,
-				ObjectRelationship objectRelationship,
-				String relatedObjectFieldName,
-				Serializable relatedObjectFieldValue)
-		throws Exception {
-
-		String endpoint = objectDefinition.getRESTContextPath() + "?filter=";
-
-		if (filterOperator == FilterOperator.CONTAINS) {
-			String relatedObjectFieldString = String.valueOf(
-				relatedObjectFieldValue);
-
-			endpoint = endpoint.concat(
-				StringBundler.concat(
-					filterOperator.getValue(), StringPool.OPEN_PARENTHESIS,
-					objectRelationship.getName(), StringPool.SLASH,
-					relatedObjectFieldName, StringPool.COMMA,
-					StringPool.APOSTROPHE,
-					relatedObjectFieldString.substring(1, 2),
-					StringPool.APOSTROPHE, StringPool.CLOSE_PARENTHESIS));
-		}
-		else if (filterOperator == FilterOperator.EQ) {
-			_testFilterByRelatedObjectDefinitionSystemObjectField(
-				filterOperator, objectRelationship);
-
-			endpoint = endpoint.concat(
-				StringBundler.concat(
-					objectRelationship.getName(), StringPool.SLASH,
-					relatedObjectFieldName, "%20", filterOperator.getValue(),
-					"%20'", relatedObjectFieldValue, StringPool.APOSTROPHE));
-		}
-		else if (filterOperator == FilterOperator.IN) {
-			endpoint = endpoint.concat(
-				StringBundler.concat(
-					objectRelationship.getName(), StringPool.SLASH,
-					relatedObjectFieldName, "%20", filterOperator.getValue(),
-					"%20('", RandomTestUtil.randomString(),
-					StringPool.APOSTROPHE, StringPool.COMMA,
-					StringPool.APOSTROPHE, relatedObjectFieldValue,
-					StringPool.APOSTROPHE, StringPool.CLOSE_PARENTHESIS));
-		}
-		else if (filterOperator == FilterOperator.STARTS_WITH) {
-			String relatedObjectFieldString = String.valueOf(
-				relatedObjectFieldValue);
-
-			endpoint = endpoint.concat(
-				StringBundler.concat(
-					filterOperator.getValue(), StringPool.OPEN_PARENTHESIS,
-					objectRelationship.getName(), StringPool.SLASH,
-					relatedObjectFieldName, StringPool.COMMA,
-					StringPool.APOSTROPHE,
-					relatedObjectFieldString.substring(0, 1),
-					StringPool.APOSTROPHE, StringPool.CLOSE_PARENTHESIS));
-		}
-		else {
-			throw new NotSupportedException(
-				"Filter " + filterOperator.name() + " is not supported");
-		}
-
-		_testFilterObjectEntriesByRelatedObjectEntriesUsingAFilterOperator(
-			endpoint, expectedObjectFieldName, expectedObjectFieldValue);
-	}
-
-	private void
-			_testFilterObjectEntriesByRelatedObjectEntriesUsingAFilterOperator(
-				String endpoint, String expectedObjectFieldName,
-				Serializable expectedObjectFieldValue)
-		throws Exception {
-
-		JSONObject jsonObject = HTTPTestUtil.invoke(
-			null, endpoint, Http.Method.GET);
-
-		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
-
-		Assert.assertEquals(1, itemsJSONArray.length());
-
-		JSONObject itemJSONObject = itemsJSONArray.getJSONObject(0);
-
-		Assert.assertEquals(
-			expectedObjectFieldValue,
-			itemJSONObject.getInt(expectedObjectFieldName));
-	}
-
 	private void _testGetNestedFieldDetailsInOneToManyRelationships(
 			String endpoint, String expectedFieldName)
 		throws Exception {
@@ -2178,21 +2000,5 @@ public class ObjectEntryResourceTest {
 
 	private ObjectDefinition _siteScopedObjectDefinition1;
 	private ObjectEntry _siteScopedObjectEntry1;
-
-	private enum FilterOperator {
-
-		CONTAINS("contains"), EQ("eq"), IN("in"), STARTS_WITH("startswith");
-
-		public String getValue() {
-			return _value;
-		}
-
-		private FilterOperator(String value) {
-			_value = value;
-		}
-
-		private final String _value;
-
-	}
 
 }

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -548,6 +548,179 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
+	public void testFilterByStringOperatorsObjectEntriesByRelatesObjectEntriesFields()
+		throws Exception {
+
+		String objectFieldValue1 = String.valueOf(_OBJECT_FIELD_VALUE_1);
+		String objectFieldValue2 = String.valueOf(_OBJECT_FIELD_VALUE_2);
+
+		_objectEntry1 = ObjectEntryTestUtil.addObjectEntry(
+			_objectDefinition1, _OBJECT_FIELD_NAME_1, objectFieldValue1);
+
+		_objectEntry2 = ObjectEntryTestUtil.addObjectEntry(
+			_objectDefinition2, _OBJECT_FIELD_NAME_2, objectFieldValue2);
+
+		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		// Custom fields
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			String.format(
+				"contains(%s/%s,'%s')", _objectRelationship.getName(),
+				_OBJECT_FIELD_NAME_2, objectFieldValue2.substring(1)),
+			_objectDefinition1);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			String.format(
+				"startswith(%s/%s,'%s')", _objectRelationship.getName(),
+				_OBJECT_FIELD_NAME_2, objectFieldValue2.substring(0, 2)),
+			_objectDefinition1);
+
+		// System field
+
+		String objectEntry2externalReferenceCode =
+			_objectEntry2.getExternalReferenceCode();
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			String.format(
+				"contains(%s/externalReferenceCode,'%s')",
+				_objectRelationship.getName(),
+				objectEntry2externalReferenceCode.substring(1)),
+			_objectDefinition1);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			String.format(
+				"startswith(%s/externalReferenceCode,'%s')",
+				_objectRelationship.getName(),
+				objectEntry2externalReferenceCode.substring(0, 2)),
+			_objectDefinition1);
+
+		// Other side of the relationship
+		// Custom field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			String.format(
+				"contains(%s/%s,'%s')", _objectRelationship.getName(),
+				_OBJECT_FIELD_NAME_1, objectFieldValue1.substring(1)),
+			_objectDefinition2);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			String.format(
+				"startswith(%s/%s,'%s')", _objectRelationship.getName(),
+				_OBJECT_FIELD_NAME_1, objectFieldValue1.substring(0, 2)),
+			_objectDefinition2);
+
+		// System field
+
+		String objectEntry1externalReferenceCode =
+			_objectEntry1.getExternalReferenceCode();
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			String.format(
+				"contains(%s/externalReferenceCode,'%s')",
+				_objectRelationship.getName(),
+				objectEntry1externalReferenceCode.substring(1)),
+			_objectDefinition2);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			String.format(
+				"startswith(%s/externalReferenceCode,'%s')",
+				_objectRelationship.getName(),
+				objectEntry1externalReferenceCode.substring(0, 2)),
+			_objectDefinition2);
+
+		_objectRelationshipLocalService.deleteObjectRelationship(
+			_objectRelationship);
+
+		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		// Custom fields
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			String.format(
+				"contains(%s/%s,'%s')", _objectRelationship.getName(),
+				_OBJECT_FIELD_NAME_2, objectFieldValue2.substring(1)),
+			_objectDefinition1);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			String.format(
+				"startswith(%s/%s,'%s')", _objectRelationship.getName(),
+				_OBJECT_FIELD_NAME_2, objectFieldValue2.substring(0, 2)),
+			_objectDefinition1);
+
+		// System field
+
+		objectEntry2externalReferenceCode =
+			_objectEntry2.getExternalReferenceCode();
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			String.format(
+				"contains(%s/externalReferenceCode,'%s')",
+				_objectRelationship.getName(),
+				objectEntry2externalReferenceCode.substring(1)),
+			_objectDefinition1);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			String.format(
+				"startswith(%s/externalReferenceCode,'%s')",
+				_objectRelationship.getName(),
+				objectEntry2externalReferenceCode.substring(0, 2)),
+			_objectDefinition1);
+
+		// Other side of the relationship
+		// Custom field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			String.format(
+				"contains(%s/%s,'%s')", _objectRelationship.getName(),
+				_OBJECT_FIELD_NAME_1, objectFieldValue1.substring(1)),
+			_objectDefinition2);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			String.format(
+				"startswith(%s/%s,'%s')", _objectRelationship.getName(),
+				_OBJECT_FIELD_NAME_1, objectFieldValue1.substring(0, 2)),
+			_objectDefinition2);
+
+		// System field
+
+		objectEntry1externalReferenceCode =
+			_objectEntry1.getExternalReferenceCode();
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			String.format(
+				"contains(%s/externalReferenceCode,'%s')",
+				_objectRelationship.getName(),
+				objectEntry1externalReferenceCode.substring(1)),
+			_objectDefinition2);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			String.format(
+				"startswith(%s/externalReferenceCode,'%s')",
+				_objectRelationship.getName(),
+				objectEntry1externalReferenceCode.substring(0, 2)),
+			_objectDefinition2);
+	}
+
+	@Test
 	public void testFilterObjectEntriesByRelatedObjectEntries()
 		throws Exception {
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -548,6 +548,110 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
+	public void testFilterByListOperatorsObjectEntriesByRelatesObjectEntriesFields()
+		throws Exception {
+
+		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		// Custom field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s in ('%s', '%s')", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+					RandomTestUtil.randomInt())),
+			_objectDefinition1);
+
+		// System field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/id in ('%s', '%s')", _objectRelationship.getName(),
+					_objectEntry2.getObjectEntryId(),
+					RandomTestUtil.randomInt())),
+			_objectDefinition1);
+
+		// Other side of the relationship
+		// Custom field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/%s in ('%s', '%s')", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+					RandomTestUtil.randomInt())),
+			_objectDefinition2);
+
+		// System field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/id in ('%s', '%s')", _objectRelationship.getName(),
+					_objectEntry1.getObjectEntryId(),
+					RandomTestUtil.randomInt())),
+			_objectDefinition2);
+
+		_objectRelationshipLocalService.deleteObjectRelationship(
+			_objectRelationship);
+
+		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		// Custom field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s in ('%s', '%s')", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+					RandomTestUtil.randomInt())),
+			_objectDefinition1);
+
+		// System field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/id in ('%s', '%s')", _objectRelationship.getName(),
+					_objectEntry2.getObjectEntryId(),
+					RandomTestUtil.randomInt())),
+			_objectDefinition1);
+
+		// Other side of the relationship
+		// Custom field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/%s in ('%s', '%s')", _objectRelationship.getName(),
+					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+					RandomTestUtil.randomInt())),
+			_objectDefinition2);
+
+		// System field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/id in ('%s', '%s')", _objectRelationship.getName(),
+					_objectEntry1.getObjectEntryId(),
+					RandomTestUtil.randomInt())),
+			_objectDefinition2);
+	}
+
+	@Test
 	public void testFilterByLogicalOperatorsObjectEntriesByRelatesObjectEntriesFields()
 		throws Exception {
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -140,6 +140,16 @@ public class ObjectEntryResourceTest {
 		_objectEntry2 = ObjectEntryTestUtil.addObjectEntry(
 			_objectDefinition2, _OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2);
 
+		_objectDefinition3 = ObjectDefinitionTestUtil.publishObjectDefinition(
+			Collections.singletonList(
+				ObjectFieldUtil.createObjectField(
+					"Text", "String", true, true, null,
+					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME_3,
+					false)));
+
+		_objectEntry3 = ObjectEntryTestUtil.addObjectEntry(
+			_objectDefinition3, _OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3);
+
 		_siteScopedObjectDefinition1 =
 			ObjectDefinitionTestUtil.publishObjectDefinition(
 				Collections.singletonList(
@@ -156,15 +166,22 @@ public class ObjectEntryResourceTest {
 
 	@After
 	public void tearDown() throws Exception {
-		if (_objectRelationship != null) {
+		if (_objectRelationship1 != null) {
 			_objectRelationshipLocalService.deleteObjectRelationship(
-				_objectRelationship);
+				_objectRelationship1);
+		}
+
+		if (_objectRelationship2 != null) {
+			_objectRelationshipLocalService.deleteObjectRelationship(
+				_objectRelationship2);
 		}
 
 		_objectDefinitionLocalService.deleteObjectDefinition(
 			_objectDefinition1);
 		_objectDefinitionLocalService.deleteObjectDefinition(
 			_objectDefinition2);
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			_objectDefinition3);
 		_objectDefinitionLocalService.deleteObjectDefinition(
 			_siteScopedObjectDefinition1);
 	}
@@ -173,7 +190,7 @@ public class ObjectEntryResourceTest {
 	public void testFilterByComparisonOperatorsObjectEntriesByRelatesObjectEntriesFields()
 		throws Exception {
 
-		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+		_objectRelationship1 = _addObjectRelationshipAndRelateObjectsEntries(
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		// Custom field
@@ -182,42 +199,42 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
-					"%s/%s eq '%s'", _objectRelationship.getName(),
+					"%s/%s eq '%s'", _objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2)),
 			_objectDefinition1);
 		_assertFilter(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
-					"%s/%s ge '%s'", _objectRelationship.getName(),
+					"%s/%s ge '%s'", _objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2)),
 			_objectDefinition1);
 		_assertFilter(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
-					"%s/%s gt '%s'", _objectRelationship.getName(),
+					"%s/%s gt '%s'", _objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2 - 1)),
 			_objectDefinition1);
 		_assertFilter(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
-					"%s/%s le '%s'", _objectRelationship.getName(),
+					"%s/%s le '%s'", _objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2)),
 			_objectDefinition1);
 		_assertFilter(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
-					"%s/%s lt '%s'", _objectRelationship.getName(),
+					"%s/%s lt '%s'", _objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2 + 1)),
 			_objectDefinition1);
 		_assertFilter(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
-					"%s/%s ne '%s'", _objectRelationship.getName(),
+					"%s/%s ne '%s'", _objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2 - 1)),
 			_objectDefinition1);
 
@@ -227,42 +244,42 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
-					"%s/id eq '%s'", _objectRelationship.getName(),
+					"%s/id eq '%s'", _objectRelationship1.getName(),
 					_objectEntry2.getObjectEntryId())),
 			_objectDefinition1);
 		_assertFilter(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
-					"%s/id ge '%s'", _objectRelationship.getName(),
+					"%s/id ge '%s'", _objectRelationship1.getName(),
 					_objectEntry2.getObjectEntryId())),
 			_objectDefinition1);
 		_assertFilter(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
-					"%s/id gt '%s'", _objectRelationship.getName(),
+					"%s/id gt '%s'", _objectRelationship1.getName(),
 					_objectEntry2.getObjectEntryId() - 1)),
 			_objectDefinition1);
 		_assertFilter(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
-					"%s/id le '%s'", _objectRelationship.getName(),
+					"%s/id le '%s'", _objectRelationship1.getName(),
 					_objectEntry2.getObjectEntryId())),
 			_objectDefinition1);
 		_assertFilter(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
-					"%s/id lt '%s'", _objectRelationship.getName(),
+					"%s/id lt '%s'", _objectRelationship1.getName(),
 					_objectEntry2.getObjectEntryId() + 1)),
 			_objectDefinition1);
 		_assertFilter(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
-					"%s/id ne '%s'", _objectRelationship.getName(),
+					"%s/id ne '%s'", _objectRelationship1.getName(),
 					_objectEntry2.getObjectEntryId() - 1)),
 			_objectDefinition1);
 
@@ -273,42 +290,42 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
 			_escape(
 				String.format(
-					"%s/%s eq '%s'", _objectRelationship.getName(),
+					"%s/%s eq '%s'", _objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1)),
 			_objectDefinition2);
 		_assertFilter(
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
 			_escape(
 				String.format(
-					"%s/%s ge '%s'", _objectRelationship.getName(),
+					"%s/%s ge '%s'", _objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1)),
 			_objectDefinition2);
 		_assertFilter(
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
 			_escape(
 				String.format(
-					"%s/%s gt '%s'", _objectRelationship.getName(),
+					"%s/%s gt '%s'", _objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1 - 1)),
 			_objectDefinition2);
 		_assertFilter(
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
 			_escape(
 				String.format(
-					"%s/%s le '%s'", _objectRelationship.getName(),
+					"%s/%s le '%s'", _objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1)),
 			_objectDefinition2);
 		_assertFilter(
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
 			_escape(
 				String.format(
-					"%s/%s lt '%s'", _objectRelationship.getName(),
+					"%s/%s lt '%s'", _objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1 + 1)),
 			_objectDefinition2);
 		_assertFilter(
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
 			_escape(
 				String.format(
-					"%s/%s ne '%s'", _objectRelationship.getName(),
+					"%s/%s ne '%s'", _objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1 - 1)),
 			_objectDefinition2);
 
@@ -318,49 +335,49 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
 			_escape(
 				String.format(
-					"%s/id eq '%s'", _objectRelationship.getName(),
+					"%s/id eq '%s'", _objectRelationship1.getName(),
 					_objectEntry1.getObjectEntryId())),
 			_objectDefinition2);
 		_assertFilter(
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
 			_escape(
 				String.format(
-					"%s/id ge '%s'", _objectRelationship.getName(),
+					"%s/id ge '%s'", _objectRelationship1.getName(),
 					_objectEntry1.getObjectEntryId())),
 			_objectDefinition2);
 		_assertFilter(
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
 			_escape(
 				String.format(
-					"%s/id gt '%s'", _objectRelationship.getName(),
+					"%s/id gt '%s'", _objectRelationship1.getName(),
 					_objectEntry1.getObjectEntryId() - 1)),
 			_objectDefinition2);
 		_assertFilter(
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
 			_escape(
 				String.format(
-					"%s/id le '%s'", _objectRelationship.getName(),
+					"%s/id le '%s'", _objectRelationship1.getName(),
 					_objectEntry1.getObjectEntryId())),
 			_objectDefinition2);
 		_assertFilter(
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
 			_escape(
 				String.format(
-					"%s/id lt '%s'", _objectRelationship.getName(),
+					"%s/id lt '%s'", _objectRelationship1.getName(),
 					_objectEntry1.getObjectEntryId() + 1)),
 			_objectDefinition2);
 		_assertFilter(
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
 			_escape(
 				String.format(
-					"%s/id ne '%s'", _objectRelationship.getName(),
+					"%s/id ne '%s'", _objectRelationship1.getName(),
 					_objectEntry1.getObjectEntryId() - 1)),
 			_objectDefinition2);
 
 		_objectRelationshipLocalService.deleteObjectRelationship(
-			_objectRelationship);
+			_objectRelationship1);
 
-		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+		_objectRelationship1 = _addObjectRelationshipAndRelateObjectsEntries(
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
 		// Custom field
@@ -369,42 +386,42 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
-					"%s/%s eq '%s'", _objectRelationship.getName(),
+					"%s/%s eq '%s'", _objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2)),
 			_objectDefinition1);
 		_assertFilter(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
-					"%s/%s ge '%s'", _objectRelationship.getName(),
+					"%s/%s ge '%s'", _objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2)),
 			_objectDefinition1);
 		_assertFilter(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
-					"%s/%s gt '%s'", _objectRelationship.getName(),
+					"%s/%s gt '%s'", _objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2 - 1)),
 			_objectDefinition1);
 		_assertFilter(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
-					"%s/%s le '%s'", _objectRelationship.getName(),
+					"%s/%s le '%s'", _objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2)),
 			_objectDefinition1);
 		_assertFilter(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
-					"%s/%s lt '%s'", _objectRelationship.getName(),
+					"%s/%s lt '%s'", _objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2 + 1)),
 			_objectDefinition1);
 		_assertFilter(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
-					"%s/%s ne '%s'", _objectRelationship.getName(),
+					"%s/%s ne '%s'", _objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2 - 1)),
 			_objectDefinition1);
 
@@ -414,42 +431,42 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
-					"%s/id eq '%s'", _objectRelationship.getName(),
+					"%s/id eq '%s'", _objectRelationship1.getName(),
 					_objectEntry2.getObjectEntryId())),
 			_objectDefinition1);
 		_assertFilter(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
-					"%s/id ge '%s'", _objectRelationship.getName(),
+					"%s/id ge '%s'", _objectRelationship1.getName(),
 					_objectEntry2.getObjectEntryId())),
 			_objectDefinition1);
 		_assertFilter(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
-					"%s/id gt '%s'", _objectRelationship.getName(),
+					"%s/id gt '%s'", _objectRelationship1.getName(),
 					_objectEntry2.getObjectEntryId() - 1)),
 			_objectDefinition1);
 		_assertFilter(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
-					"%s/id le '%s'", _objectRelationship.getName(),
+					"%s/id le '%s'", _objectRelationship1.getName(),
 					_objectEntry2.getObjectEntryId())),
 			_objectDefinition1);
 		_assertFilter(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
-					"%s/id lt '%s'", _objectRelationship.getName(),
+					"%s/id lt '%s'", _objectRelationship1.getName(),
 					_objectEntry2.getObjectEntryId() + 1)),
 			_objectDefinition1);
 		_assertFilter(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
-					"%s/id ne '%s'", _objectRelationship.getName(),
+					"%s/id ne '%s'", _objectRelationship1.getName(),
 					_objectEntry2.getObjectEntryId() - 1)),
 			_objectDefinition1);
 
@@ -460,42 +477,42 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
 			_escape(
 				String.format(
-					"%s/%s eq '%s'", _objectRelationship.getName(),
+					"%s/%s eq '%s'", _objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1)),
 			_objectDefinition2);
 		_assertFilter(
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
 			_escape(
 				String.format(
-					"%s/%s ge '%s'", _objectRelationship.getName(),
+					"%s/%s ge '%s'", _objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1)),
 			_objectDefinition2);
 		_assertFilter(
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
 			_escape(
 				String.format(
-					"%s/%s gt '%s'", _objectRelationship.getName(),
+					"%s/%s gt '%s'", _objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1 - 1)),
 			_objectDefinition2);
 		_assertFilter(
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
 			_escape(
 				String.format(
-					"%s/%s le '%s'", _objectRelationship.getName(),
+					"%s/%s le '%s'", _objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1)),
 			_objectDefinition2);
 		_assertFilter(
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
 			_escape(
 				String.format(
-					"%s/%s lt '%s'", _objectRelationship.getName(),
+					"%s/%s lt '%s'", _objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1 + 1)),
 			_objectDefinition2);
 		_assertFilter(
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
 			_escape(
 				String.format(
-					"%s/%s ne '%s'", _objectRelationship.getName(),
+					"%s/%s ne '%s'", _objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1 - 1)),
 			_objectDefinition2);
 
@@ -505,51 +522,487 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
 			_escape(
 				String.format(
-					"%s/id eq '%s'", _objectRelationship.getName(),
+					"%s/id eq '%s'", _objectRelationship1.getName(),
 					_objectEntry1.getObjectEntryId())),
 			_objectDefinition2);
 		_assertFilter(
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
 			_escape(
 				String.format(
-					"%s/id ge '%s'", _objectRelationship.getName(),
+					"%s/id ge '%s'", _objectRelationship1.getName(),
 					_objectEntry1.getObjectEntryId())),
 			_objectDefinition2);
 		_assertFilter(
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
 			_escape(
 				String.format(
-					"%s/id gt '%s'", _objectRelationship.getName(),
+					"%s/id gt '%s'", _objectRelationship1.getName(),
 					_objectEntry1.getObjectEntryId() - 1)),
 			_objectDefinition2);
 		_assertFilter(
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
 			_escape(
 				String.format(
-					"%s/id le '%s'", _objectRelationship.getName(),
+					"%s/id le '%s'", _objectRelationship1.getName(),
 					_objectEntry1.getObjectEntryId())),
 			_objectDefinition2);
 		_assertFilter(
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
 			_escape(
 				String.format(
-					"%s/id lt '%s'", _objectRelationship.getName(),
+					"%s/id lt '%s'", _objectRelationship1.getName(),
 					_objectEntry1.getObjectEntryId() + 1)),
 			_objectDefinition2);
 		_assertFilter(
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
 			_escape(
 				String.format(
-					"%s/id ne '%s'", _objectRelationship.getName(),
+					"%s/id ne '%s'", _objectRelationship1.getName(),
 					_objectEntry1.getObjectEntryId() - 1)),
 			_objectDefinition2);
+	}
+
+	@Test
+	public void testFilterByComparisonOperatorsObjectEntriesByRelatesObjectEntriesFieldsThroughMultipleRelationships()
+		throws Exception {
+
+		_objectRelationship1 = _addObjectRelationshipAndRelateObjectsEntries(
+			_objectDefinition1, _objectDefinition2, _objectEntry1,
+			_objectEntry2, ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		_objectRelationship2 = _addObjectRelationshipAndRelateObjectsEntries(
+			_objectDefinition2, _objectDefinition3, _objectEntry2,
+			_objectEntry3, ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		// Custom field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s/%s eq '%s'", _objectRelationship1.getName(),
+					_objectRelationship2.getName(), _OBJECT_FIELD_NAME_3,
+					_OBJECT_FIELD_VALUE_3)),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s/%s ge '%s'", _objectRelationship1.getName(),
+					_objectRelationship2.getName(), _OBJECT_FIELD_NAME_3,
+					_OBJECT_FIELD_VALUE_3)),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s/%s gt '%s'", _objectRelationship1.getName(),
+					_objectRelationship2.getName(), _OBJECT_FIELD_NAME_3,
+					_OBJECT_FIELD_VALUE_3 - 1)),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s/%s le '%s'", _objectRelationship1.getName(),
+					_objectRelationship2.getName(), _OBJECT_FIELD_NAME_3,
+					_OBJECT_FIELD_VALUE_3)),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s/%s lt '%s'", _objectRelationship1.getName(),
+					_objectRelationship2.getName(), _OBJECT_FIELD_NAME_3,
+					_OBJECT_FIELD_VALUE_3 + 1)),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s/%s ne '%s'", _objectRelationship1.getName(),
+					_objectRelationship2.getName(), _OBJECT_FIELD_NAME_3,
+					_OBJECT_FIELD_VALUE_3 - 1)),
+			_objectDefinition1);
+
+		// System fields
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s/id eq '%s'", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_objectEntry3.getObjectEntryId())),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s/id ge '%s'", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_objectEntry3.getObjectEntryId())),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s/id gt '%s'", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_objectEntry3.getObjectEntryId() - 1)),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s/id le '%s'", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_objectEntry3.getObjectEntryId())),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s/id lt '%s'", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_objectEntry3.getObjectEntryId() + 1)),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s/id ne '%s'", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_objectEntry3.getObjectEntryId() - 1)),
+			_objectDefinition1);
+
+		// Other side of the relationship
+		// Custom field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
+			_escape(
+				String.format(
+					"%s/%s/%s eq '%s'", _objectRelationship2.getName(),
+					_objectRelationship1.getName(), _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1)),
+			_objectDefinition3);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
+			_escape(
+				String.format(
+					"%s/%s/%s ge '%s'", _objectRelationship2.getName(),
+					_objectRelationship1.getName(), _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1)),
+			_objectDefinition3);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
+			_escape(
+				String.format(
+					"%s/%s/%s gt '%s'", _objectRelationship2.getName(),
+					_objectRelationship1.getName(), _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1 - 1)),
+			_objectDefinition3);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
+			_escape(
+				String.format(
+					"%s/%s/%s le '%s'", _objectRelationship2.getName(),
+					_objectRelationship1.getName(), _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1)),
+			_objectDefinition3);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
+			_escape(
+				String.format(
+					"%s/%s/%s lt '%s'", _objectRelationship2.getName(),
+					_objectRelationship1.getName(), _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1 + 1)),
+			_objectDefinition3);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
+			_escape(
+				String.format(
+					"%s/%s/%s ne '%s'", _objectRelationship2.getName(),
+					_objectRelationship1.getName(), _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1 - 1)),
+			_objectDefinition3);
+
+		// System field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
+			_escape(
+				String.format(
+					"%s/%s/id eq '%s'", _objectRelationship2.getName(),
+					_objectRelationship1.getName(),
+					_objectEntry1.getObjectEntryId())),
+			_objectDefinition3);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
+			_escape(
+				String.format(
+					"%s/%s/id ge '%s'", _objectRelationship2.getName(),
+					_objectRelationship1.getName(),
+					_objectEntry1.getObjectEntryId())),
+			_objectDefinition3);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
+			_escape(
+				String.format(
+					"%s/%s/id gt '%s'", _objectRelationship2.getName(),
+					_objectRelationship1.getName(),
+					_objectEntry1.getObjectEntryId() - 1)),
+			_objectDefinition3);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
+			_escape(
+				String.format(
+					"%s/%s/id le '%s'", _objectRelationship2.getName(),
+					_objectRelationship1.getName(),
+					_objectEntry1.getObjectEntryId())),
+			_objectDefinition3);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
+			_escape(
+				String.format(
+					"%s/%s/id lt '%s'", _objectRelationship2.getName(),
+					_objectRelationship1.getName(),
+					_objectEntry1.getObjectEntryId() + 1)),
+			_objectDefinition3);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
+			_escape(
+				String.format(
+					"%s/%s/id ne '%s'", _objectRelationship2.getName(),
+					_objectRelationship1.getName(),
+					_objectEntry1.getObjectEntryId() - 1)),
+			_objectDefinition3);
+
+		_objectRelationshipLocalService.deleteObjectRelationship(
+			_objectRelationship1);
+		_objectRelationshipLocalService.deleteObjectRelationship(
+			_objectRelationship2);
+
+		_objectRelationship1 = _addObjectRelationshipAndRelateObjectsEntries(
+			_objectDefinition1, _objectDefinition2, _objectEntry1,
+			_objectEntry2, ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		_objectRelationship2 = _addObjectRelationshipAndRelateObjectsEntries(
+			_objectDefinition2, _objectDefinition3, _objectEntry2,
+			_objectEntry3, ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		// Custom field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s/%s eq '%s'", _objectRelationship1.getName(),
+					_objectRelationship2.getName(), _OBJECT_FIELD_NAME_3,
+					_OBJECT_FIELD_VALUE_3)),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s/%s ge '%s'", _objectRelationship1.getName(),
+					_objectRelationship2.getName(), _OBJECT_FIELD_NAME_3,
+					_OBJECT_FIELD_VALUE_3)),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s/%s gt '%s'", _objectRelationship1.getName(),
+					_objectRelationship2.getName(), _OBJECT_FIELD_NAME_3,
+					_OBJECT_FIELD_VALUE_3 - 1)),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s/%s le '%s'", _objectRelationship1.getName(),
+					_objectRelationship2.getName(), _OBJECT_FIELD_NAME_3,
+					_OBJECT_FIELD_VALUE_3)),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s/%s lt '%s'", _objectRelationship1.getName(),
+					_objectRelationship2.getName(), _OBJECT_FIELD_NAME_3,
+					_OBJECT_FIELD_VALUE_3 + 1)),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s/%s ne '%s'", _objectRelationship1.getName(),
+					_objectRelationship2.getName(), _OBJECT_FIELD_NAME_3,
+					_OBJECT_FIELD_VALUE_3 - 1)),
+			_objectDefinition1);
+
+		// System fields
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s/id eq '%s'", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_objectEntry3.getObjectEntryId())),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s/id ge '%s'", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_objectEntry3.getObjectEntryId())),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s/id gt '%s'", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_objectEntry3.getObjectEntryId() - 1)),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s/id le '%s'", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_objectEntry3.getObjectEntryId())),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s/id lt '%s'", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_objectEntry3.getObjectEntryId() + 1)),
+			_objectDefinition1);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s/id ne '%s'", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_objectEntry3.getObjectEntryId() - 1)),
+			_objectDefinition1);
+
+		// Other side of the relationship
+		// Custom field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
+			_escape(
+				String.format(
+					"%s/%s/%s eq '%s'", _objectRelationship2.getName(),
+					_objectRelationship1.getName(), _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1)),
+			_objectDefinition3);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
+			_escape(
+				String.format(
+					"%s/%s/%s ge '%s'", _objectRelationship2.getName(),
+					_objectRelationship1.getName(), _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1)),
+			_objectDefinition3);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
+			_escape(
+				String.format(
+					"%s/%s/%s gt '%s'", _objectRelationship2.getName(),
+					_objectRelationship1.getName(), _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1 - 1)),
+			_objectDefinition3);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
+			_escape(
+				String.format(
+					"%s/%s/%s le '%s'", _objectRelationship2.getName(),
+					_objectRelationship1.getName(), _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1)),
+			_objectDefinition3);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
+			_escape(
+				String.format(
+					"%s/%s/%s lt '%s'", _objectRelationship2.getName(),
+					_objectRelationship1.getName(), _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1 + 1)),
+			_objectDefinition3);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
+			_escape(
+				String.format(
+					"%s/%s/%s ne '%s'", _objectRelationship2.getName(),
+					_objectRelationship1.getName(), _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1 - 1)),
+			_objectDefinition3);
+
+		// System field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
+			_escape(
+				String.format(
+					"%s/%s/id eq '%s'", _objectRelationship2.getName(),
+					_objectRelationship1.getName(),
+					_objectEntry1.getObjectEntryId())),
+			_objectDefinition3);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
+			_escape(
+				String.format(
+					"%s/%s/id ge '%s'", _objectRelationship2.getName(),
+					_objectRelationship1.getName(),
+					_objectEntry1.getObjectEntryId())),
+			_objectDefinition3);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
+			_escape(
+				String.format(
+					"%s/%s/id gt '%s'", _objectRelationship2.getName(),
+					_objectRelationship1.getName(),
+					_objectEntry1.getObjectEntryId() - 1)),
+			_objectDefinition3);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
+			_escape(
+				String.format(
+					"%s/%s/id le '%s'", _objectRelationship2.getName(),
+					_objectRelationship1.getName(),
+					_objectEntry1.getObjectEntryId())),
+			_objectDefinition3);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
+			_escape(
+				String.format(
+					"%s/%s/id lt '%s'", _objectRelationship2.getName(),
+					_objectRelationship1.getName(),
+					_objectEntry1.getObjectEntryId() + 1)),
+			_objectDefinition3);
+		_assertFilter(
+			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
+			_escape(
+				String.format(
+					"%s/%s/id ne '%s'", _objectRelationship2.getName(),
+					_objectRelationship1.getName(),
+					_objectEntry1.getObjectEntryId() - 1)),
+			_objectDefinition3);
 	}
 
 	@Test
 	public void testFilterByListOperatorsObjectEntriesByRelatesObjectEntriesFields()
 		throws Exception {
 
-		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+		_objectRelationship1 = _addObjectRelationshipAndRelateObjectsEntries(
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		// Custom field
@@ -558,7 +1011,7 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
-					"%s/%s in ('%s', '%s')", _objectRelationship.getName(),
+					"%s/%s in ('%s', '%s')", _objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
 					RandomTestUtil.randomInt())),
 			_objectDefinition1);
@@ -569,7 +1022,7 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
-					"%s/id in ('%s', '%s')", _objectRelationship.getName(),
+					"%s/id in ('%s', '%s')", _objectRelationship1.getName(),
 					_objectEntry2.getObjectEntryId(),
 					RandomTestUtil.randomInt())),
 			_objectDefinition1);
@@ -581,7 +1034,7 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
 			_escape(
 				String.format(
-					"%s/%s in ('%s', '%s')", _objectRelationship.getName(),
+					"%s/%s in ('%s', '%s')", _objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 					RandomTestUtil.randomInt())),
 			_objectDefinition2);
@@ -592,15 +1045,15 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
 			_escape(
 				String.format(
-					"%s/id in ('%s', '%s')", _objectRelationship.getName(),
+					"%s/id in ('%s', '%s')", _objectRelationship1.getName(),
 					_objectEntry1.getObjectEntryId(),
 					RandomTestUtil.randomInt())),
 			_objectDefinition2);
 
 		_objectRelationshipLocalService.deleteObjectRelationship(
-			_objectRelationship);
+			_objectRelationship1);
 
-		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+		_objectRelationship1 = _addObjectRelationshipAndRelateObjectsEntries(
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
 		// Custom field
@@ -609,7 +1062,7 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
-					"%s/%s in ('%s', '%s')", _objectRelationship.getName(),
+					"%s/%s in ('%s', '%s')", _objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
 					RandomTestUtil.randomInt())),
 			_objectDefinition1);
@@ -620,7 +1073,7 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
-					"%s/id in ('%s', '%s')", _objectRelationship.getName(),
+					"%s/id in ('%s', '%s')", _objectRelationship1.getName(),
 					_objectEntry2.getObjectEntryId(),
 					RandomTestUtil.randomInt())),
 			_objectDefinition1);
@@ -632,7 +1085,7 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
 			_escape(
 				String.format(
-					"%s/%s in ('%s', '%s')", _objectRelationship.getName(),
+					"%s/%s in ('%s', '%s')", _objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 					RandomTestUtil.randomInt())),
 			_objectDefinition2);
@@ -643,7 +1096,7 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
 			_escape(
 				String.format(
-					"%s/id in ('%s', '%s')", _objectRelationship.getName(),
+					"%s/id in ('%s', '%s')", _objectRelationship1.getName(),
 					_objectEntry1.getObjectEntryId(),
 					RandomTestUtil.randomInt())),
 			_objectDefinition2);
@@ -653,7 +1106,7 @@ public class ObjectEntryResourceTest {
 	public void testFilterByLogicalOperatorsObjectEntriesByRelatesObjectEntriesFields()
 		throws Exception {
 
-		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+		_objectRelationship1 = _addObjectRelationshipAndRelateObjectsEntries(
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		// Custom field
@@ -663,8 +1116,8 @@ public class ObjectEntryResourceTest {
 			_escape(
 				String.format(
 					"%s/%s le '%s' and %s/%s gt '%s'",
-					_objectRelationship.getName(), _OBJECT_FIELD_NAME_2,
-					_OBJECT_FIELD_VALUE_2, _objectRelationship.getName(),
+					_objectRelationship1.getName(), _OBJECT_FIELD_NAME_2,
+					_OBJECT_FIELD_VALUE_2, _objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2 - 1)),
 			_objectDefinition1);
 
@@ -673,8 +1126,8 @@ public class ObjectEntryResourceTest {
 			_escape(
 				String.format(
 					"%s/%s le '%s' or %s/%s gt '%s'",
-					_objectRelationship.getName(), _OBJECT_FIELD_NAME_2,
-					_OBJECT_FIELD_VALUE_2, _objectRelationship.getName(),
+					_objectRelationship1.getName(), _OBJECT_FIELD_NAME_2,
+					_OBJECT_FIELD_VALUE_2, _objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2 - 1)),
 			_objectDefinition1);
 
@@ -682,7 +1135,7 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
-					"not (%s/%s ge '%s')", _objectRelationship.getName(),
+					"not (%s/%s ge '%s')", _objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2 + 1)),
 			_objectDefinition1);
 
@@ -693,9 +1146,9 @@ public class ObjectEntryResourceTest {
 			_escape(
 				String.format(
 					"%s/id le '%s' and %s/id gt '%s'",
-					_objectRelationship.getName(),
+					_objectRelationship1.getName(),
 					_objectEntry2.getObjectEntryId(),
-					_objectRelationship.getName(),
+					_objectRelationship1.getName(),
 					_objectEntry2.getObjectEntryId() - 1)),
 			_objectDefinition1);
 
@@ -704,8 +1157,8 @@ public class ObjectEntryResourceTest {
 			_escape(
 				String.format(
 					"%s/id le '%s' or %s/id gt '%s'",
-					_objectRelationship.getName(), _OBJECT_FIELD_VALUE_2,
-					_objectRelationship.getName(),
+					_objectRelationship1.getName(), _OBJECT_FIELD_VALUE_2,
+					_objectRelationship1.getName(),
 					_objectEntry2.getObjectEntryId() - 1)),
 			_objectDefinition1);
 
@@ -713,7 +1166,7 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
-					"not (%s/id ge '%s')", _objectRelationship.getName(),
+					"not (%s/id ge '%s')", _objectRelationship1.getName(),
 					_objectEntry2.getObjectEntryId() + 1)),
 			_objectDefinition1);
 
@@ -725,8 +1178,8 @@ public class ObjectEntryResourceTest {
 			_escape(
 				String.format(
 					"%s/%s le '%s' and %s/%s gt '%s'",
-					_objectRelationship.getName(), _OBJECT_FIELD_NAME_1,
-					_OBJECT_FIELD_VALUE_1, _objectRelationship.getName(),
+					_objectRelationship1.getName(), _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1, _objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1 - 1)),
 			_objectDefinition2);
 
@@ -735,8 +1188,8 @@ public class ObjectEntryResourceTest {
 			_escape(
 				String.format(
 					"%s/%s le '%s' or %s/%s gt '%s'",
-					_objectRelationship.getName(), _OBJECT_FIELD_NAME_1,
-					_OBJECT_FIELD_VALUE_1, _objectRelationship.getName(),
+					_objectRelationship1.getName(), _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1, _objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1 - 1)),
 			_objectDefinition2);
 
@@ -744,7 +1197,7 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
 			_escape(
 				String.format(
-					"not (%s/%s ge '%s')", _objectRelationship.getName(),
+					"not (%s/%s ge '%s')", _objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1 + 1)),
 			_objectDefinition2);
 
@@ -755,9 +1208,9 @@ public class ObjectEntryResourceTest {
 			_escape(
 				String.format(
 					"%s/id le '%s' and %s/id gt '%s'",
-					_objectRelationship.getName(),
+					_objectRelationship1.getName(),
 					_objectEntry1.getObjectEntryId(),
-					_objectRelationship.getName(),
+					_objectRelationship1.getName(),
 					_objectEntry1.getObjectEntryId() - 1)),
 			_objectDefinition2);
 
@@ -766,8 +1219,8 @@ public class ObjectEntryResourceTest {
 			_escape(
 				String.format(
 					"%s/id le '%s' or %s/id gt '%s'",
-					_objectRelationship.getName(), _OBJECT_FIELD_VALUE_1,
-					_objectRelationship.getName(),
+					_objectRelationship1.getName(), _OBJECT_FIELD_VALUE_1,
+					_objectRelationship1.getName(),
 					_objectEntry1.getObjectEntryId() - 1)),
 			_objectDefinition2);
 
@@ -775,14 +1228,14 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
 			_escape(
 				String.format(
-					"not (%s/id ge '%s')", _objectRelationship.getName(),
+					"not (%s/id ge '%s')", _objectRelationship1.getName(),
 					_objectEntry1.getObjectEntryId() + 1)),
 			_objectDefinition2);
 
 		_objectRelationshipLocalService.deleteObjectRelationship(
-			_objectRelationship);
+			_objectRelationship1);
 
-		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+		_objectRelationship1 = _addObjectRelationshipAndRelateObjectsEntries(
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
 		// Custom field
@@ -792,8 +1245,8 @@ public class ObjectEntryResourceTest {
 			_escape(
 				String.format(
 					"%s/%s le '%s' and %s/%s gt '%s'",
-					_objectRelationship.getName(), _OBJECT_FIELD_NAME_2,
-					_OBJECT_FIELD_VALUE_2, _objectRelationship.getName(),
+					_objectRelationship1.getName(), _OBJECT_FIELD_NAME_2,
+					_OBJECT_FIELD_VALUE_2, _objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2 - 1)),
 			_objectDefinition1);
 
@@ -802,8 +1255,8 @@ public class ObjectEntryResourceTest {
 			_escape(
 				String.format(
 					"%s/%s le '%s' or %s/%s gt '%s'",
-					_objectRelationship.getName(), _OBJECT_FIELD_NAME_2,
-					_OBJECT_FIELD_VALUE_2, _objectRelationship.getName(),
+					_objectRelationship1.getName(), _OBJECT_FIELD_NAME_2,
+					_OBJECT_FIELD_VALUE_2, _objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2 - 1)),
 			_objectDefinition1);
 
@@ -811,7 +1264,7 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
-					"not (%s/%s ge '%s')", _objectRelationship.getName(),
+					"not (%s/%s ge '%s')", _objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2 + 1)),
 			_objectDefinition1);
 
@@ -822,9 +1275,9 @@ public class ObjectEntryResourceTest {
 			_escape(
 				String.format(
 					"%s/id le '%s' and %s/id gt '%s'",
-					_objectRelationship.getName(),
+					_objectRelationship1.getName(),
 					_objectEntry2.getObjectEntryId(),
-					_objectRelationship.getName(),
+					_objectRelationship1.getName(),
 					_objectEntry2.getObjectEntryId() - 1)),
 			_objectDefinition1);
 
@@ -833,8 +1286,8 @@ public class ObjectEntryResourceTest {
 			_escape(
 				String.format(
 					"%s/id le '%s' or %s/id gt '%s'",
-					_objectRelationship.getName(), _OBJECT_FIELD_VALUE_2,
-					_objectRelationship.getName(),
+					_objectRelationship1.getName(), _OBJECT_FIELD_VALUE_2,
+					_objectRelationship1.getName(),
 					_objectEntry2.getObjectEntryId() - 1)),
 			_objectDefinition1);
 
@@ -842,7 +1295,7 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
-					"not (%s/id ge '%s')", _objectRelationship.getName(),
+					"not (%s/id ge '%s')", _objectRelationship1.getName(),
 					_objectEntry2.getObjectEntryId() + 1)),
 			_objectDefinition1);
 
@@ -854,8 +1307,8 @@ public class ObjectEntryResourceTest {
 			_escape(
 				String.format(
 					"%s/%s le '%s' and %s/%s gt '%s'",
-					_objectRelationship.getName(), _OBJECT_FIELD_NAME_1,
-					_OBJECT_FIELD_VALUE_1, _objectRelationship.getName(),
+					_objectRelationship1.getName(), _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1, _objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1 - 1)),
 			_objectDefinition2);
 
@@ -864,8 +1317,8 @@ public class ObjectEntryResourceTest {
 			_escape(
 				String.format(
 					"%s/%s le '%s' or %s/%s gt '%s'",
-					_objectRelationship.getName(), _OBJECT_FIELD_NAME_1,
-					_OBJECT_FIELD_VALUE_1, _objectRelationship.getName(),
+					_objectRelationship1.getName(), _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1, _objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1 - 1)),
 			_objectDefinition2);
 
@@ -873,7 +1326,7 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
 			_escape(
 				String.format(
-					"not (%s/%s ge '%s')", _objectRelationship.getName(),
+					"not (%s/%s ge '%s')", _objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1 + 1)),
 			_objectDefinition2);
 
@@ -884,9 +1337,9 @@ public class ObjectEntryResourceTest {
 			_escape(
 				String.format(
 					"%s/id le '%s' and %s/id gt '%s'",
-					_objectRelationship.getName(),
+					_objectRelationship1.getName(),
 					_objectEntry1.getObjectEntryId(),
-					_objectRelationship.getName(),
+					_objectRelationship1.getName(),
 					_objectEntry1.getObjectEntryId() - 1)),
 			_objectDefinition2);
 
@@ -895,8 +1348,8 @@ public class ObjectEntryResourceTest {
 			_escape(
 				String.format(
 					"%s/id le '%s' or %s/id gt '%s'",
-					_objectRelationship.getName(), _OBJECT_FIELD_VALUE_1,
-					_objectRelationship.getName(),
+					_objectRelationship1.getName(), _OBJECT_FIELD_VALUE_1,
+					_objectRelationship1.getName(),
 					_objectEntry1.getObjectEntryId() - 1)),
 			_objectDefinition2);
 
@@ -904,7 +1357,7 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
 			_escape(
 				String.format(
-					"not (%s/id ge '%s')", _objectRelationship.getName(),
+					"not (%s/id ge '%s')", _objectRelationship1.getName(),
 					_objectEntry1.getObjectEntryId() + 1)),
 			_objectDefinition2);
 	}
@@ -922,7 +1375,7 @@ public class ObjectEntryResourceTest {
 		_objectEntry2 = ObjectEntryTestUtil.addObjectEntry(
 			_objectDefinition2, _OBJECT_FIELD_NAME_2, objectFieldValue2);
 
-		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+		_objectRelationship1 = _addObjectRelationshipAndRelateObjectsEntries(
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		// Custom fields
@@ -930,14 +1383,14 @@ public class ObjectEntryResourceTest {
 		_assertFilter(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			String.format(
-				"contains(%s/%s,'%s')", _objectRelationship.getName(),
+				"contains(%s/%s,'%s')", _objectRelationship1.getName(),
 				_OBJECT_FIELD_NAME_2, objectFieldValue2.substring(1)),
 			_objectDefinition1);
 
 		_assertFilter(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			String.format(
-				"startswith(%s/%s,'%s')", _objectRelationship.getName(),
+				"startswith(%s/%s,'%s')", _objectRelationship1.getName(),
 				_OBJECT_FIELD_NAME_2, objectFieldValue2.substring(0, 2)),
 			_objectDefinition1);
 
@@ -950,7 +1403,7 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			String.format(
 				"contains(%s/externalReferenceCode,'%s')",
-				_objectRelationship.getName(),
+				_objectRelationship1.getName(),
 				objectEntry2externalReferenceCode.substring(1)),
 			_objectDefinition1);
 
@@ -958,7 +1411,7 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			String.format(
 				"startswith(%s/externalReferenceCode,'%s')",
-				_objectRelationship.getName(),
+				_objectRelationship1.getName(),
 				objectEntry2externalReferenceCode.substring(0, 2)),
 			_objectDefinition1);
 
@@ -968,14 +1421,14 @@ public class ObjectEntryResourceTest {
 		_assertFilter(
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
 			String.format(
-				"contains(%s/%s,'%s')", _objectRelationship.getName(),
+				"contains(%s/%s,'%s')", _objectRelationship1.getName(),
 				_OBJECT_FIELD_NAME_1, objectFieldValue1.substring(1)),
 			_objectDefinition2);
 
 		_assertFilter(
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
 			String.format(
-				"startswith(%s/%s,'%s')", _objectRelationship.getName(),
+				"startswith(%s/%s,'%s')", _objectRelationship1.getName(),
 				_OBJECT_FIELD_NAME_1, objectFieldValue1.substring(0, 2)),
 			_objectDefinition2);
 
@@ -988,7 +1441,7 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
 			String.format(
 				"contains(%s/externalReferenceCode,'%s')",
-				_objectRelationship.getName(),
+				_objectRelationship1.getName(),
 				objectEntry1externalReferenceCode.substring(1)),
 			_objectDefinition2);
 
@@ -996,14 +1449,14 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
 			String.format(
 				"startswith(%s/externalReferenceCode,'%s')",
-				_objectRelationship.getName(),
+				_objectRelationship1.getName(),
 				objectEntry1externalReferenceCode.substring(0, 2)),
 			_objectDefinition2);
 
 		_objectRelationshipLocalService.deleteObjectRelationship(
-			_objectRelationship);
+			_objectRelationship1);
 
-		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+		_objectRelationship1 = _addObjectRelationshipAndRelateObjectsEntries(
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
 		// Custom fields
@@ -1011,14 +1464,14 @@ public class ObjectEntryResourceTest {
 		_assertFilter(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			String.format(
-				"contains(%s/%s,'%s')", _objectRelationship.getName(),
+				"contains(%s/%s,'%s')", _objectRelationship1.getName(),
 				_OBJECT_FIELD_NAME_2, objectFieldValue2.substring(1)),
 			_objectDefinition1);
 
 		_assertFilter(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			String.format(
-				"startswith(%s/%s,'%s')", _objectRelationship.getName(),
+				"startswith(%s/%s,'%s')", _objectRelationship1.getName(),
 				_OBJECT_FIELD_NAME_2, objectFieldValue2.substring(0, 2)),
 			_objectDefinition1);
 
@@ -1031,7 +1484,7 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			String.format(
 				"contains(%s/externalReferenceCode,'%s')",
-				_objectRelationship.getName(),
+				_objectRelationship1.getName(),
 				objectEntry2externalReferenceCode.substring(1)),
 			_objectDefinition1);
 
@@ -1039,7 +1492,7 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			String.format(
 				"startswith(%s/externalReferenceCode,'%s')",
-				_objectRelationship.getName(),
+				_objectRelationship1.getName(),
 				objectEntry2externalReferenceCode.substring(0, 2)),
 			_objectDefinition1);
 
@@ -1049,14 +1502,14 @@ public class ObjectEntryResourceTest {
 		_assertFilter(
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
 			String.format(
-				"contains(%s/%s,'%s')", _objectRelationship.getName(),
+				"contains(%s/%s,'%s')", _objectRelationship1.getName(),
 				_OBJECT_FIELD_NAME_1, objectFieldValue1.substring(1)),
 			_objectDefinition2);
 
 		_assertFilter(
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
 			String.format(
-				"startswith(%s/%s,'%s')", _objectRelationship.getName(),
+				"startswith(%s/%s,'%s')", _objectRelationship1.getName(),
 				_OBJECT_FIELD_NAME_1, objectFieldValue1.substring(0, 2)),
 			_objectDefinition2);
 
@@ -1069,7 +1522,7 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
 			String.format(
 				"contains(%s/externalReferenceCode,'%s')",
-				_objectRelationship.getName(),
+				_objectRelationship1.getName(),
 				objectEntry1externalReferenceCode.substring(1)),
 			_objectDefinition2);
 
@@ -1077,7 +1530,7 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
 			String.format(
 				"startswith(%s/externalReferenceCode,'%s')",
-				_objectRelationship.getName(),
+				_objectRelationship1.getName(),
 				objectEntry1externalReferenceCode.substring(0, 2)),
 			_objectDefinition2);
 	}
@@ -1086,24 +1539,24 @@ public class ObjectEntryResourceTest {
 	public void testGetNestedFieldDetailsInOneToManyRelationships()
 		throws Exception {
 
-		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+		_objectRelationship1 = _addObjectRelationshipAndRelateObjectsEntries(
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		_testGetNestedFieldDetailsInOneToManyRelationships(
 			StringBundler.concat(
 				_objectDefinition2.getRESTContextPath(), "?nestedFields=r_",
-				_objectRelationship.getName(), "_",
+				_objectRelationship1.getName(), "_",
 				_objectDefinition1.getPKObjectFieldName()),
 			StringBundler.concat(
-				"r_", _objectRelationship.getName(), "_",
+				"r_", _objectRelationship1.getName(), "_",
 				StringUtil.replaceLast(
 					_objectDefinition1.getPKObjectFieldName(), "Id", "")));
 
 		_testGetNestedFieldDetailsInOneToManyRelationships(
 			StringBundler.concat(
 				_objectDefinition2.getRESTContextPath(), "?nestedFields=",
-				_objectRelationship.getName()),
-			_objectRelationship.getName());
+				_objectRelationship1.getName()),
+			_objectRelationship1.getName());
 	}
 
 	@Test
@@ -1200,7 +1653,7 @@ public class ObjectEntryResourceTest {
 	public void testGetObjectRelationshipERCFieldNameInOneToManyRelationship()
 		throws Exception {
 
-		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+		_objectRelationship1 = _addObjectRelationshipAndRelateObjectsEntries(
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		JSONObject jsonObject = HTTPTestUtil.invoke(
@@ -1213,7 +1666,7 @@ public class ObjectEntryResourceTest {
 		JSONObject itemJSONObject = itemsJSONArray.getJSONObject(0);
 
 		Assert.assertEquals(
-			itemJSONObject.getString(_objectRelationship.getName() + "ERC"),
+			itemJSONObject.getString(_objectRelationship1.getName() + "ERC"),
 			_objectEntry1.getExternalReferenceCode());
 	}
 
@@ -1221,14 +1674,14 @@ public class ObjectEntryResourceTest {
 	public void testGetObjectRelationshipERCFieldNameInOneToManyRelationshipFromRelatedObjectEntry()
 		throws Exception {
 
-		_objectRelationship = _addObjectRelationshipAndRelateObjectsEntries(
+		_objectRelationship1 = _addObjectRelationshipAndRelateObjectsEntries(
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		JSONObject jsonObject = HTTPTestUtil.invoke(
 			null,
 			StringBundler.concat(
 				_objectDefinition1.getRESTContextPath(), "?nestedFields=",
-				_objectRelationship.getName()),
+				_objectRelationship1.getName()),
 			Http.Method.GET);
 
 		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
@@ -1238,7 +1691,7 @@ public class ObjectEntryResourceTest {
 		JSONObject itemJSONObject = itemsJSONArray.getJSONObject(0);
 
 		JSONArray relationshipJSONArray = itemJSONObject.getJSONArray(
-			_objectRelationship.getName());
+			_objectRelationship1.getName());
 
 		Assert.assertEquals(1, relationshipJSONArray.length());
 
@@ -1247,7 +1700,7 @@ public class ObjectEntryResourceTest {
 
 		Assert.assertEquals(
 			relatedObjectEntryJSONObject.getString(
-				_objectRelationship.getName() + "ERC"),
+				_objectRelationship1.getName() + "ERC"),
 			_objectEntry1.getExternalReferenceCode());
 	}
 
@@ -1343,26 +1796,26 @@ public class ObjectEntryResourceTest {
 					"WebApplicationExceptionMapper",
 				LoggerTestUtil.WARN)) {
 
-			_objectRelationship =
+			_objectRelationship1 =
 				ObjectRelationshipTestUtil.addObjectRelationship(
 					_objectDefinition1, _objectDefinition2,
 					TestPropsValues.getUserId(),
 					ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
 			_testPostCustomObjectEntryWithInvalidNestedCustomObjectEntriesInManyToManyRelationship(
-				_objectDefinition1.getRESTContextPath(), _objectRelationship);
+				_objectDefinition1.getRESTContextPath(), _objectRelationship1);
 
-			_objectRelationship =
+			_objectRelationship1 =
 				ObjectRelationshipTestUtil.addObjectRelationship(
 					_objectDefinition1, _objectDefinition2,
 					TestPropsValues.getUserId(),
 					ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 			_testPostCustomObjectEntryWithInvalidNestedCustomObjectEntriesInManyToOneRelationship(
-				_objectDefinition2.getRESTContextPath(), _objectRelationship);
+				_objectDefinition2.getRESTContextPath(), _objectRelationship1);
 
 			_testPostCustomObjectEntryWithInvalidNestedCustomObjectEntriesInOneToManyRelationship(
-				_objectDefinition1.getRESTContextPath(), _objectRelationship);
+				_objectDefinition1.getRESTContextPath(), _objectRelationship1);
 		}
 	}
 
@@ -1370,12 +1823,12 @@ public class ObjectEntryResourceTest {
 	public void testPostCustomObjectEntryWithNestedCustomObjectEntriesInManyToManyRelationship()
 		throws Exception {
 
-		_objectRelationship = ObjectRelationshipTestUtil.addObjectRelationship(
+		_objectRelationship1 = ObjectRelationshipTestUtil.addObjectRelationship(
 			_objectDefinition1, _objectDefinition2, TestPropsValues.getUserId(),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
 		JSONObject objectEntryJSONObject = JSONUtil.put(
-			_objectRelationship.getName(),
+			_objectRelationship1.getName(),
 			_createObjectEntriesJSONArray(
 				new String[] {_ERC_VALUE_1, _ERC_VALUE_2}, _OBJECT_FIELD_NAME_2,
 				new String[] {
@@ -1400,11 +1853,12 @@ public class ObjectEntryResourceTest {
 			null,
 			StringBundler.concat(
 				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
-				objectEntryId, "?nestedFields=", _objectRelationship.getName()),
+				objectEntryId, "?nestedFields=",
+				_objectRelationship1.getName()),
 			Http.Method.GET);
 
 		JSONArray nestedObjectEntriesJSONArray = jsonObject.getJSONArray(
-			_objectRelationship.getName());
+			_objectRelationship1.getName());
 
 		Assert.assertEquals(2, nestedObjectEntriesJSONArray.length());
 
@@ -1420,12 +1874,12 @@ public class ObjectEntryResourceTest {
 	public void testPostCustomObjectEntryWithNestedCustomObjectEntriesInManyToOneRelationship()
 		throws Exception {
 
-		_objectRelationship = ObjectRelationshipTestUtil.addObjectRelationship(
+		_objectRelationship1 = ObjectRelationshipTestUtil.addObjectRelationship(
 			_objectDefinition1, _objectDefinition2, TestPropsValues.getUserId(),
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		JSONObject objectEntryJSONObject = JSONUtil.put(
-			_objectRelationship.getName(),
+			_objectRelationship1.getName(),
 			JSONFactoryUtil.createJSONObject(
 				JSONUtil.put(
 					_OBJECT_FIELD_NAME_1, _NEW_OBJECT_FIELD_VALUE_1
@@ -1453,7 +1907,7 @@ public class ObjectEntryResourceTest {
 				_objectDefinition2.getRESTContextPath(), StringPool.SLASH,
 				objectEntryId, "?nestedFields=",
 				StringBundler.concat(
-					"r_", _objectRelationship.getName(), "_",
+					"r_", _objectRelationship1.getName(), "_",
 					StringUtil.replaceLast(
 						_objectDefinition1.getPKObjectFieldName(), "Id", ""))),
 			Http.Method.GET);
@@ -1461,7 +1915,7 @@ public class ObjectEntryResourceTest {
 		_assertObjectEntryField(
 			jsonObject.getJSONObject(
 				StringBundler.concat(
-					"r_", _objectRelationship.getName(), "_",
+					"r_", _objectRelationship1.getName(), "_",
 					StringUtil.replaceLast(
 						_objectDefinition1.getPKObjectFieldName(), "Id", ""))),
 			_OBJECT_FIELD_NAME_1, _NEW_OBJECT_FIELD_VALUE_1);
@@ -1471,12 +1925,12 @@ public class ObjectEntryResourceTest {
 	public void testPostCustomObjectEntryWithNestedCustomObjectEntriesInOneToManyRelationship()
 		throws Exception {
 
-		_objectRelationship = ObjectRelationshipTestUtil.addObjectRelationship(
+		_objectRelationship1 = ObjectRelationshipTestUtil.addObjectRelationship(
 			_objectDefinition1, _objectDefinition2, TestPropsValues.getUserId(),
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		JSONObject objectEntryJSONObject = JSONUtil.put(
-			_objectRelationship.getName(),
+			_objectRelationship1.getName(),
 			_createObjectEntriesJSONArray(
 				new String[] {_ERC_VALUE_1, _ERC_VALUE_2}, _OBJECT_FIELD_NAME_2,
 				new String[] {
@@ -1501,11 +1955,12 @@ public class ObjectEntryResourceTest {
 			null,
 			StringBundler.concat(
 				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
-				objectEntryId, "?nestedFields=", _objectRelationship.getName()),
+				objectEntryId, "?nestedFields=",
+				_objectRelationship1.getName()),
 			Http.Method.GET);
 
 		JSONArray nestedObjectEntriesJSONArray = jsonObject.getJSONArray(
-			_objectRelationship.getName());
+			_objectRelationship1.getName());
 
 		Assert.assertEquals(2, nestedObjectEntriesJSONArray.length());
 
@@ -1521,7 +1976,7 @@ public class ObjectEntryResourceTest {
 	public void testPutByExternalReferenceCodeManyToManyRelationship()
 		throws Exception {
 
-		_objectRelationship = ObjectRelationshipTestUtil.addObjectRelationship(
+		_objectRelationship1 = ObjectRelationshipTestUtil.addObjectRelationship(
 			_objectDefinition1, _objectDefinition2, TestPropsValues.getUserId(),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
@@ -1531,7 +1986,7 @@ public class ObjectEntryResourceTest {
 				_objectDefinition1.getRESTContextPath(),
 				"/by-external-reference-code/",
 				_objectEntry1.getExternalReferenceCode(), StringPool.SLASH,
-				_objectRelationship.getName(), StringPool.SLASH,
+				_objectRelationship1.getName(), StringPool.SLASH,
 				_objectEntry2.getExternalReferenceCode()),
 			Http.Method.PUT);
 
@@ -1547,7 +2002,7 @@ public class ObjectEntryResourceTest {
 				_objectDefinition2.getRESTContextPath(),
 				"/by-external-reference-code/",
 				_objectEntry2.getExternalReferenceCode(), StringPool.SLASH,
-				_objectRelationship.getName(), StringPool.SLASH,
+				_objectRelationship1.getName(), StringPool.SLASH,
 				_objectEntry1.getExternalReferenceCode()),
 			Http.Method.PUT);
 
@@ -1563,7 +2018,7 @@ public class ObjectEntryResourceTest {
 				_objectDefinition2.getRESTContextPath(),
 				"/by-external-reference-code/",
 				_objectEntry2.getExternalReferenceCode(), StringPool.SLASH,
-				_objectRelationship.getName(), StringPool.SLASH,
+				_objectRelationship1.getName(), StringPool.SLASH,
 				RandomTestUtil.randomString()),
 			Http.Method.PUT);
 
@@ -1576,12 +2031,12 @@ public class ObjectEntryResourceTest {
 	public void testPutCustomObjectEntryWithNestedCustomObjectEntriesInManyToManyRelationship()
 		throws Exception {
 
-		_objectRelationship = ObjectRelationshipTestUtil.addObjectRelationship(
+		_objectRelationship1 = ObjectRelationshipTestUtil.addObjectRelationship(
 			_objectDefinition1, _objectDefinition2, TestPropsValues.getUserId(),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
 		JSONObject objectEntryJSONObject = JSONUtil.put(
-			_objectRelationship.getName(),
+			_objectRelationship1.getName(),
 			_createObjectEntriesJSONArray(
 				new String[] {_ERC_VALUE_1, _ERC_VALUE_2}, _OBJECT_FIELD_NAME_2,
 				new String[] {
@@ -1593,7 +2048,7 @@ public class ObjectEntryResourceTest {
 			_objectDefinition1.getRESTContextPath(), Http.Method.POST);
 
 		JSONObject newObjectEntryJSONObject = JSONUtil.put(
-			_objectRelationship.getName(),
+			_objectRelationship1.getName(),
 			_createObjectEntriesJSONArray(
 				new String[] {_ERC_VALUE_1, _ERC_VALUE_2}, _OBJECT_FIELD_NAME_2,
 				new String[] {
@@ -1620,11 +2075,11 @@ public class ObjectEntryResourceTest {
 			StringBundler.concat(
 				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
 				_objectEntry1.getPrimaryKey(), "?nestedFields=",
-				_objectRelationship.getName()),
+				_objectRelationship1.getName()),
 			Http.Method.GET);
 
 		JSONArray nestedObjectEntriesJSONArray = jsonObject.getJSONArray(
-			_objectRelationship.getName());
+			_objectRelationship1.getName());
 
 		Assert.assertEquals(2, nestedObjectEntriesJSONArray.length());
 
@@ -1640,12 +2095,12 @@ public class ObjectEntryResourceTest {
 	public void testPutCustomObjectEntryWithNestedCustomObjectEntriesInManyToOneRelationship()
 		throws Exception {
 
-		_objectRelationship = ObjectRelationshipTestUtil.addObjectRelationship(
+		_objectRelationship1 = ObjectRelationshipTestUtil.addObjectRelationship(
 			_objectDefinition1, _objectDefinition2, TestPropsValues.getUserId(),
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		JSONObject objectEntryJSONObject = JSONUtil.put(
-			_objectRelationship.getName(),
+			_objectRelationship1.getName(),
 			JSONFactoryUtil.createJSONObject(
 				JSONUtil.put(
 					_OBJECT_FIELD_NAME_1, RandomTestUtil.randomString()
@@ -1660,7 +2115,7 @@ public class ObjectEntryResourceTest {
 		String objectEntryId = jsonObject.getString("id");
 
 		JSONObject newObjectEntryJSONObject = JSONUtil.put(
-			_objectRelationship.getName(),
+			_objectRelationship1.getName(),
 			JSONFactoryUtil.createJSONObject(
 				JSONUtil.put(
 					_OBJECT_FIELD_NAME_1, _NEW_OBJECT_FIELD_VALUE_1
@@ -1689,7 +2144,7 @@ public class ObjectEntryResourceTest {
 				_objectDefinition2.getRESTContextPath(), StringPool.SLASH,
 				objectEntryId, "?nestedFields=",
 				StringBundler.concat(
-					"r_", _objectRelationship.getName(), "_",
+					"r_", _objectRelationship1.getName(), "_",
 					StringUtil.replaceLast(
 						_objectDefinition1.getPKObjectFieldName(), "Id", ""))),
 			Http.Method.GET);
@@ -1697,7 +2152,7 @@ public class ObjectEntryResourceTest {
 		_assertObjectEntryField(
 			jsonObject.getJSONObject(
 				StringBundler.concat(
-					"r_", _objectRelationship.getName(), "_",
+					"r_", _objectRelationship1.getName(), "_",
 					StringUtil.replaceLast(
 						_objectDefinition1.getPKObjectFieldName(), "Id", ""))),
 			_OBJECT_FIELD_NAME_1, _NEW_OBJECT_FIELD_VALUE_1);
@@ -1707,12 +2162,12 @@ public class ObjectEntryResourceTest {
 	public void testPutCustomObjectEntryWithNestedCustomObjectEntriesInOneToManyRelationship()
 		throws Exception {
 
-		_objectRelationship = ObjectRelationshipTestUtil.addObjectRelationship(
+		_objectRelationship1 = ObjectRelationshipTestUtil.addObjectRelationship(
 			_objectDefinition1, _objectDefinition2, TestPropsValues.getUserId(),
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		JSONObject objectEntryJSONObject = JSONUtil.put(
-			_objectRelationship.getName(),
+			_objectRelationship1.getName(),
 			_createObjectEntriesJSONArray(
 				new String[] {_ERC_VALUE_1, _ERC_VALUE_2}, _OBJECT_FIELD_NAME_2,
 				new String[] {
@@ -1724,7 +2179,7 @@ public class ObjectEntryResourceTest {
 			_objectDefinition1.getRESTContextPath(), Http.Method.POST);
 
 		JSONObject newObjectEntryJSONObject = JSONUtil.put(
-			_objectRelationship.getName(),
+			_objectRelationship1.getName(),
 			_createObjectEntriesJSONArray(
 				new String[] {_ERC_VALUE_1, _ERC_VALUE_2}, _OBJECT_FIELD_NAME_2,
 				new String[] {
@@ -1751,11 +2206,11 @@ public class ObjectEntryResourceTest {
 			StringBundler.concat(
 				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
 				_objectEntry1.getPrimaryKey(), "?nestedFields=",
-				_objectRelationship.getName()),
+				_objectRelationship1.getName()),
 			Http.Method.GET);
 
 		JSONArray nestedObjectEntriesJSONArray = jsonObject.getJSONArray(
-			_objectRelationship.getName());
+			_objectRelationship1.getName());
 
 		Assert.assertEquals(2, nestedObjectEntriesJSONArray.length());
 
@@ -1765,6 +2220,24 @@ public class ObjectEntryResourceTest {
 		_assertObjectEntryField(
 			(JSONObject)nestedObjectEntriesJSONArray.get(1),
 			_OBJECT_FIELD_NAME_2, _NEW_OBJECT_FIELD_VALUE_2);
+	}
+
+	private ObjectRelationship _addObjectRelationshipAndRelateObjectsEntries(
+			ObjectDefinition objectDefinition1,
+			ObjectDefinition objectDefinition2, ObjectEntry objectEntry1,
+			ObjectEntry objectEntry2, String type)
+		throws Exception {
+
+		ObjectRelationship objectRelationship =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				objectDefinition1, objectDefinition2,
+				TestPropsValues.getUserId(), type);
+
+		ObjectRelationshipTestUtil.relateObjectEntries(
+			objectEntry1.getPrimaryKey(), objectEntry2.getPrimaryKey(),
+			objectRelationship, TestPropsValues.getUserId());
+
+		return objectRelationship;
 	}
 
 	private ObjectRelationship _addObjectRelationshipAndRelateObjectsEntries(
@@ -1977,23 +2450,31 @@ public class ObjectEntryResourceTest {
 	private static final String _OBJECT_FIELD_NAME_2 =
 		"x" + RandomTestUtil.randomString();
 
+	private static final String _OBJECT_FIELD_NAME_3 =
+		"x" + RandomTestUtil.randomString();
+
 	private static final int _OBJECT_FIELD_VALUE_1 = RandomTestUtil.randomInt();
 
 	private static final int _OBJECT_FIELD_VALUE_2 = RandomTestUtil.randomInt();
 
+	private static final int _OBJECT_FIELD_VALUE_3 = RandomTestUtil.randomInt();
+
 	private ObjectDefinition _objectDefinition1;
 	private ObjectDefinition _objectDefinition2;
+	private ObjectDefinition _objectDefinition3;
 
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
 
 	private ObjectEntry _objectEntry1;
 	private ObjectEntry _objectEntry2;
+	private ObjectEntry _objectEntry3;
 
 	@Inject
 	private ObjectEntryLocalService _objectEntryLocalService;
 
-	private ObjectRelationship _objectRelationship;
+	private ObjectRelationship _objectRelationship1;
+	private ObjectRelationship _objectRelationship2;
 
 	@Inject
 	private ObjectRelationshipLocalService _objectRelationshipLocalService;

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -1363,6 +1363,322 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
+	public void testFilterByLogicalOperatorsObjectEntriesByRelatesObjectEntriesFieldsThroughMultipleRelationships()
+		throws Exception {
+
+		_objectRelationship1 = _addObjectRelationshipAndRelateObjectsEntries(
+			_objectDefinition1, _objectDefinition2, _objectEntry1,
+			_objectEntry2, ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		_objectRelationship2 = _addObjectRelationshipAndRelateObjectsEntries(
+			_objectDefinition2, _objectDefinition3, _objectEntry2,
+			_objectEntry3, ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		// Custom field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s/%s le '%s' and %s/%s/%s gt '%s'",
+					_objectRelationship1.getName(),
+					_objectRelationship2.getName(), _OBJECT_FIELD_NAME_3,
+					_OBJECT_FIELD_VALUE_3, _objectRelationship1.getName(),
+					_objectRelationship2.getName(), _OBJECT_FIELD_NAME_3,
+					_OBJECT_FIELD_VALUE_3 - 1)),
+			_objectDefinition1);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s/%s le '%s' or %s/%s/%s gt '%s'",
+					_objectRelationship1.getName(),
+					_objectRelationship2.getName(), _OBJECT_FIELD_NAME_3,
+					_OBJECT_FIELD_VALUE_3, _objectRelationship1.getName(),
+					_objectRelationship2.getName(), _OBJECT_FIELD_NAME_3,
+					_OBJECT_FIELD_VALUE_3 - 1)),
+			_objectDefinition1);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"not (%s/%s/%s ge '%s')", _objectRelationship1.getName(),
+					_objectRelationship2.getName(), _OBJECT_FIELD_NAME_3,
+					_OBJECT_FIELD_VALUE_3 + 1)),
+			_objectDefinition1);
+
+		// System field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s/id le '%s' and %s/%s/id gt '%s'",
+					_objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_objectEntry3.getObjectEntryId(),
+					_objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_objectEntry3.getObjectEntryId() - 1)),
+			_objectDefinition1);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s/id le '%s' or %s/%s/id gt '%s'",
+					_objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_objectEntry3.getObjectEntryId(),
+					_objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_objectEntry3.getObjectEntryId() - 1)),
+			_objectDefinition1);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"not (%s/%s/id ge '%s')", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_objectEntry3.getObjectEntryId() + 1)),
+			_objectDefinition1);
+
+		// Other side of the relationship
+		// Custom field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
+			_escape(
+				String.format(
+					"%s/%s/%s le '%s' and %s/%s/%s gt '%s'",
+					_objectRelationship2.getName(),
+					_objectRelationship1.getName(), _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1, _objectRelationship2.getName(),
+					_objectRelationship1.getName(), _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1 - 1)),
+			_objectDefinition3);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
+			_escape(
+				String.format(
+					"%s/%s/%s le '%s' or %s/%s/%s gt '%s'",
+					_objectRelationship2.getName(),
+					_objectRelationship1.getName(), _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1, _objectRelationship2.getName(),
+					_objectRelationship1.getName(), _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1 - 1)),
+			_objectDefinition3);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
+			_escape(
+				String.format(
+					"not (%s/%s/%s ge '%s')", _objectRelationship2.getName(),
+					_objectRelationship1.getName(), _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1 + 1)),
+			_objectDefinition3);
+
+		// System field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
+			_escape(
+				String.format(
+					"%s/%s/id le '%s' and %s/%s/id gt '%s'",
+					_objectRelationship2.getName(),
+					_objectRelationship1.getName(),
+					_objectEntry1.getObjectEntryId(),
+					_objectRelationship2.getName(),
+					_objectRelationship1.getName(),
+					_objectEntry1.getObjectEntryId() - 1)),
+			_objectDefinition3);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
+			_escape(
+				String.format(
+					"%s/%s/id le '%s' or %s/%s/id gt '%s'",
+					_objectRelationship2.getName(),
+					_objectRelationship1.getName(),
+					_objectEntry1.getObjectEntryId(),
+					_objectRelationship2.getName(),
+					_objectRelationship1.getName(),
+					_objectEntry1.getObjectEntryId() - 1)),
+			_objectDefinition3);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
+			_escape(
+				String.format(
+					"not (%s/%s/id ge '%s')", _objectRelationship2.getName(),
+					_objectRelationship1.getName(),
+					_objectEntry1.getObjectEntryId() + 1)),
+			_objectDefinition3);
+
+		_objectRelationshipLocalService.deleteObjectRelationship(
+			_objectRelationship1);
+		_objectRelationshipLocalService.deleteObjectRelationship(
+			_objectRelationship2);
+
+		_objectRelationship1 = _addObjectRelationshipAndRelateObjectsEntries(
+			_objectDefinition1, _objectDefinition2, _objectEntry1,
+			_objectEntry2, ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		_objectRelationship2 = _addObjectRelationshipAndRelateObjectsEntries(
+			_objectDefinition2, _objectDefinition3, _objectEntry2,
+			_objectEntry3, ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		// Custom field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s/%s le '%s' and %s/%s/%s gt '%s'",
+					_objectRelationship1.getName(),
+					_objectRelationship2.getName(), _OBJECT_FIELD_NAME_3,
+					_OBJECT_FIELD_VALUE_3, _objectRelationship1.getName(),
+					_objectRelationship2.getName(), _OBJECT_FIELD_NAME_3,
+					_OBJECT_FIELD_VALUE_3 - 1)),
+			_objectDefinition1);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s/%s le '%s' or %s/%s/%s gt '%s'",
+					_objectRelationship1.getName(),
+					_objectRelationship2.getName(), _OBJECT_FIELD_NAME_3,
+					_OBJECT_FIELD_VALUE_3, _objectRelationship1.getName(),
+					_objectRelationship2.getName(), _OBJECT_FIELD_NAME_3,
+					_OBJECT_FIELD_VALUE_3 - 1)),
+			_objectDefinition1);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"not (%s/%s/%s ge '%s')", _objectRelationship1.getName(),
+					_objectRelationship2.getName(), _OBJECT_FIELD_NAME_3,
+					_OBJECT_FIELD_VALUE_3 + 1)),
+			_objectDefinition1);
+
+		// System field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s/id le '%s' and %s/%s/id gt '%s'",
+					_objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_objectEntry3.getObjectEntryId(),
+					_objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_objectEntry3.getObjectEntryId() - 1)),
+			_objectDefinition1);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s/id le '%s' or %s/%s/id gt '%s'",
+					_objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_objectEntry3.getObjectEntryId(),
+					_objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_objectEntry3.getObjectEntryId() - 1)),
+			_objectDefinition1);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"not (%s/%s/id ge '%s')", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_objectEntry3.getObjectEntryId() + 1)),
+			_objectDefinition1);
+
+		// Other side of the relationship
+		// Custom field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
+			_escape(
+				String.format(
+					"%s/%s/%s le '%s' and %s/%s/%s gt '%s'",
+					_objectRelationship2.getName(),
+					_objectRelationship1.getName(), _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1, _objectRelationship2.getName(),
+					_objectRelationship1.getName(), _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1 - 1)),
+			_objectDefinition3);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
+			_escape(
+				String.format(
+					"%s/%s/%s le '%s' or %s/%s/%s gt '%s'",
+					_objectRelationship2.getName(),
+					_objectRelationship1.getName(), _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1, _objectRelationship2.getName(),
+					_objectRelationship1.getName(), _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1 - 1)),
+			_objectDefinition3);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
+			_escape(
+				String.format(
+					"not (%s/%s/%s ge '%s')", _objectRelationship2.getName(),
+					_objectRelationship1.getName(), _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1 + 1)),
+			_objectDefinition3);
+
+		// System field
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
+			_escape(
+				String.format(
+					"%s/%s/id le '%s' and %s/%s/id gt '%s'",
+					_objectRelationship2.getName(),
+					_objectRelationship1.getName(),
+					_objectEntry1.getObjectEntryId(),
+					_objectRelationship2.getName(),
+					_objectRelationship1.getName(),
+					_objectEntry1.getObjectEntryId() - 1)),
+			_objectDefinition3);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
+			_escape(
+				String.format(
+					"%s/%s/id le '%s' or %s/%s/id gt '%s'",
+					_objectRelationship2.getName(),
+					_objectRelationship1.getName(),
+					_objectEntry1.getObjectEntryId(),
+					_objectRelationship2.getName(),
+					_objectRelationship1.getName(),
+					_objectEntry1.getObjectEntryId() - 1)),
+			_objectDefinition3);
+
+		_assertFilter(
+			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
+			_escape(
+				String.format(
+					"not (%s/%s/id ge '%s')", _objectRelationship2.getName(),
+					_objectRelationship1.getName(),
+					_objectEntry1.getObjectEntryId() + 1)),
+			_objectDefinition3);
+	}
+
+	@Test
 	public void testFilterByStringOperatorsObjectEntriesByRelatesObjectEntriesFields()
 		throws Exception {
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/util/ObjectEntryTestUtil.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/util/ObjectEntryTestUtil.java
@@ -32,7 +32,7 @@ public class ObjectEntryTestUtil {
 
 	public static ObjectEntry addObjectEntry(
 			ObjectDefinition objectDefinition, String objectFieldName,
-			String objectFieldValue)
+			Serializable objectFieldValue)
 		throws Exception {
 
 		long groupId = 0;


### PR DESCRIPTION
Related ticket [LPS-178464](https://issues.liferay.com/browse/LPS-178464)
___

## Purpose of the PR
Add a test to cover filtering by logical operators of the object entries related to multiple levels of relationships.

**IT GOES ON TOP OF THIS https://github.com/liferay-headless/liferay-portal/pull/1116 and https://github.com/liferay-headless/liferay-portal/pull/1117**