### PR TITLE
Lps 178636 Add tests on operate a custom object entry and its related custom objects in a single request

### DIFF
--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/CustomObjectAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/CustomObjectAPI.macro
@@ -5,12 +5,80 @@ definition {
 			-H Content-Type: application/json \
 		''';
 
-	macro _curlNObjectEntriesBody {
+	macro _curlObjectEntries {
+		Variables.assertDefined(parameterList = "${en_US_plural_label},${fieldName},${fieldValue}");
+
+		var en_US_plural_label_lowercase = StringUtil.lowerCase(${en_US_plural_label});
+
+		if (isSet(virtualHost)) {
+			if (!(isSet(port))) {
+				var port = 8080;
+			}
+
+			var portalURL = "http://${virtualHost}:${port}";
+		}
+		else {
+			var portalURL = JSONCompany.getPortalURL();
+		}
+
+		var api = "${portalURL}/o/c/${en_US_plural_label_lowercase}";
+
+		if (isSet(objectEntryId)) {
+			var api = "${api}/${objectEntryId}";
+		}
+
+		if (isSet(scopeKey)) {
+			var scopeKey = JSONGroupAPI._getGroupIdByNameNoSelenium(
+				groupName = "Guest",
+				site = "true");
+
+			var api = StringUtil.add(${api}, "/scopes/${scopeKey}", "");
+		}
+
+		var curlWithoutBody = StringUtil.add(${api}, " \ ${headers}", "");
+		var body = CustomObjectAPI._setNObjectEntriesBody(
+			externalReferenceCode = ${externalReferenceCode},
+			fieldName = ${fieldName},
+			fieldValue = ${fieldValue},
+			nestedField = ${nestedField},
+			numberOfRelatedObjectEntries = ${numberOfRelatedObjectEntries},
+			objectEntryId = ${objectEntryId},
+			relatedEntryExternalReferenceCode = ${relatedEntryExternalReferenceCode},
+			relatedEntryFieldName = ${relatedEntryFieldName},
+			secondFieldValue = ${secondFieldValue});
+
+		var curl = StringUtil.add(${curlWithoutBody}, "-d {${body}}", " ");
+
+		if (isSet(token)) {
+			var curl = StringUtil.add(${curl}, " -H 'Authorization: Bearer ${token}'", "");
+		}
+
+		return ${curl};
+	}
+
+	macro _curlObjectPermissions {
+		Variables.assertDefined(parameterList = "${en_US_plural_label},${objectEntryId}");
+
+		var en_US_plural_label_lowercase = StringUtil.lowerCase(${en_US_plural_label});
+		var portalURL = JSONCompany.getPortalURL();
+
+		var api = "${portalURL}/o/c/${en_US_plural_label_lowercase}/${objectEntryId}/permissions";
+
+		if (isSet(roleNames)) {
+			var api = StringUtil.add(${curl}, "?roleNames=${roleNames}", "");
+		}
+
+		var curl = StringUtil.add(${api}, " \ ${headers}", "");
+
+		return ${curl};
+	}
+
+	macro _setNObjectEntriesBody {
 		Variables.assertDefined(parameterList = "${fieldName},${fieldValue}");
 
 		var body = '''"${fieldName}": "${fieldValue}"''';
 
-		if (isSet(secondField)) {
+		if (isSet(secondFieldValue)) {
 			var body = StringUtil.add("${body},", "\"secondField\":\"${secondFieldValue}\"", "");
 		}
 
@@ -63,89 +131,20 @@ definition {
 		return ${body};
 	}
 
-	macro _curlObjectEntries {
-		Variables.assertDefined(parameterList = "${en_US_plural_label},${fieldName},${fieldValue}");
-
-		var en_US_plural_label_lowercase = StringUtil.lowerCase(${en_US_plural_label});
-
-		if (isSet(virtualHost)) {
-			if (!(isSet(port))) {
-				var port = 8080;
-			}
-
-			var portalURL = "http://${virtualHost}:${port}";
-		}
-		else {
-			var portalURL = JSONCompany.getPortalURL();
-		}
-
-		var api = "${portalURL}/o/c/${en_US_plural_label_lowercase}";
-
-		if (isSet(objectEntryId)) {
-			var api = "${api}/${objectEntryId}";
-		}
-
-		if (isSet(scopeKey)) {
-			var scopeKey = JSONGroupAPI._getGroupIdByNameNoSelenium(
-				groupName = "Guest",
-				site = "true");
-
-			var api = StringUtil.add(${api}, "/scopes/${scopeKey}", "");
-		}
-
-		var curlWithoutBody = StringUtil.add(${api}, " \ ${headers}", "");
-		var body = CustomObjectAPI._curlNObjectEntriesBody(
-			externalReferenceCode = ${externalReferenceCode},
-			fieldName = ${fieldName},
-			fieldValue = ${fieldValue},
-			nestedField = ${nestedField},
-			numberOfRelatedObjectEntries = ${numberOfRelatedObjectEntries},
-			objectEntryId = ${objectEntryId},
-			relatedEntryExternalReferenceCode = ${relatedEntryExternalReferenceCode},
-			relatedEntryFieldName = ${relatedEntryFieldName},
-			secondField = ${secondField},
-			secondFieldValue = ${secondFieldValue});
-
-		var curl = StringUtil.add(${curlWithoutBody}, "-d {${body}}", " ");
-
-		if (isSet(token)) {
-			var curl = StringUtil.add(${curl}, " -H 'Authorization: Bearer ${token}'", "");
-		}
-
-		return ${curl};
-	}
-
-	macro _curlObjectPermissions {
-		Variables.assertDefined(parameterList = "${en_US_plural_label},${objectEntryId}");
-
-		var en_US_plural_label_lowercase = StringUtil.lowerCase(${en_US_plural_label});
-		var portalURL = JSONCompany.getPortalURL();
-
-		var api = "${portalURL}/o/c/${en_US_plural_label_lowercase}/${objectEntryId}/permissions";
-
-		if (isSet(roleNames)) {
-			var api = StringUtil.add(${curl}, "?roleNames=${roleNames}", "");
-		}
-
-		var curl = StringUtil.add(${api}, " \ ${headers}", "");
-
-		return ${curl};
-	}
-
 	macro assertCorrectObjectEntryValuesInResponse {
-		Variables.assertDefined(parameterList = "${en_US_plural_label},${element},${expectedValues}");
+		Variables.assertDefined(parameterList = "${en_US_plural_label},${objectJsonPath},${expectedValues}");
 
 		var response = ObjectDefinitionAPI.getObjectEntries(en_US_plural_label = ${en_US_plural_label});
 
-		var actualValues = JSONUtil.getWithJSONPath(${response}, ${element});
+		var actualValues = JSONUtil.getWithJSONPath(${response}, ${objectJsonPath});
 
 		TestUtils.assertEquals(
 			actual = ${actualValues},
 			expected = ${expectedValues});
 	}
 
-	macro createObjectEntryWithField {
-		Variables.assertDefined(parameterList = "${en_US_plural_label},${fieldName},${fieldValue}");
+	macro createObjectEntryAndRelatedObjects {
+		Variables.assertDefined(parameterList = "${en_US_plural_label},${fieldName},${fieldValue},${nestedField},${numberOfRelatedObjectEntries},${relatedEntryFieldName}");
 
 		var curl = CustomObjectAPI._curlObjectEntries(
 			en_US_plural_label = ${en_US_plural_label},
@@ -155,9 +154,22 @@ definition {
 			nestedField = ${nestedField},
 			numberOfRelatedObjectEntries = ${numberOfRelatedObjectEntries},
 			relatedEntryExternalReferenceCode = ${relatedEntryExternalReferenceCode},
-			relatedEntryFieldName = ${relatedEntryFieldName},
+			relatedEntryFieldName = ${relatedEntryFieldName});
+
+		var response = JSONCurlUtil.post(${curl});
+
+		return ${response};
+	}
+
+	macro createObjectEntryWithFields {
+		Variables.assertDefined(parameterList = "${en_US_plural_label},${fieldName},${fieldValue}");
+
+		var curl = CustomObjectAPI._curlObjectEntries(
+			en_US_plural_label = ${en_US_plural_label},
+			externalReferenceCode = ${externalReferenceCode},
+			fieldName = ${fieldName},
+			fieldValue = ${fieldValue},
 			scopeKey = ${scopeKey},
-			secondField = ${secondField},
 			secondFieldValue = ${secondFieldValue},
 			token = ${token},
 			virtualHost = ${virtualHost});
@@ -195,8 +207,8 @@ definition {
 		return ${staticObjectId};
 	}
 
-	macro updateObjectEntryByPatch {
-		Variables.assertDefined(parameterList = "${en_US_plural_label},${objectEntryId},${fieldName},${fieldValue}");
+	macro updateObjectEntryAndRelatedObjectsByPatch {
+		Variables.assertDefined(parameterList = "${en_US_plural_label},${objectEntryId},${fieldName},${fieldValue},${nestedField},${numberOfRelatedObjectEntries},${objectEntryId},${relatedEntryFieldName}");
 
 		var curl = CustomObjectAPI._curlObjectEntries(
 			en_US_plural_label = ${en_US_plural_label},
@@ -213,8 +225,8 @@ definition {
 		return ${response};
 	}
 
-	macro updateObjectEntryByPut {
-		Variables.assertDefined(parameterList = "${en_US_plural_label},${objectEntryId},${fieldName},${fieldValue}");
+	macro updateObjectEntryAndRelatedObjectsByPut {
+		Variables.assertDefined(parameterList = "${en_US_plural_label},${objectEntryId},${fieldName},${fieldValue},${nestedField},${numberOfRelatedObjectEntries},${objectEntryId},${relatedEntryFieldName}");
 
 		var curl = CustomObjectAPI._curlObjectEntries(
 			en_US_plural_label = ${en_US_plural_label},

--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/CustomObjectAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/CustomObjectAPI.macro
@@ -1,14 +1,126 @@
 definition {
 
+	var headers = '''
+			-u test@liferay.com:test \
+			-H Content-Type: application/json \
+		''';
+
+	macro _curlNObjectEntriesBody {
+		Variables.assertDefined(parameterList = "${fieldName},${fieldValue}");
+
+		var body = '''"${fieldName}": "${fieldValue}"''';
+
+		if (isSet(secondField)) {
+			var body = StringUtil.add("${body},", "\"secondField\":\"${secondFieldValue}\"", "");
+		}
+
+		if (isSet(externalReferenceCode)) {
+			var body = StringUtil.add("${body},", "\"externalReferenceCode\": \"${externalReferenceCode}\"", "");
+		}
+
+		if (isSet(nestedField)) {
+			var size = ${numberOfRelatedObjectEntries};
+
+			if (!(isSet(externalReferenceCode))) {
+				var externalReferenceCode = "";
+			}
+
+			var entryBody = '''
+				"${nestedField}": [
+			''';
+			var i = 0;
+
+			while ((${i} != ${size}) && (maxIterations = "10")) {
+				var relatedEntryFieldValue = "${relatedEntryFieldName}${i}";
+
+				if (isSet(objectEntryId)) {
+					var relatedEntryFieldValue = "${relatedEntryFieldName}${i}-update";
+				}
+
+				var relatedObjectEntry = '''
+					"${relatedEntryFieldName}": "${relatedEntryFieldValue}"
+				''';
+
+				if (isSet(relatedEntryExternalReferenceCode)) {
+					var relatedObjectEntry = StringUtil.add("${relatedObjectEntry},", "\"externalReferenceCode\": \"${relatedEntryExternalReferenceCode}${i}\"", "");
+				}
+
+				var j = ${i} + 1;
+
+				if (${j} == ${size}) {
+					var entryBody = StringUtil.add(${entryBody}, "{${relatedObjectEntry}}]", "");
+				}
+				else {
+					var entryBody = StringUtil.add(${entryBody}, "{${relatedObjectEntry}},", "");
+				}
+
+				var i = ${i} + 1;
+			}
+
+			var body = StringUtil.add("${body},", ${entryBody}, "");
+		}
+
+		return ${body};
+	}
+
+	macro _curlObjectEntries {
+		Variables.assertDefined(parameterList = "${en_US_plural_label},${fieldName},${fieldValue}");
+
+		var en_US_plural_label_lowercase = StringUtil.lowerCase(${en_US_plural_label});
+
+		if (isSet(virtualHost)) {
+			if (!(isSet(port))) {
+				var port = 8080;
+			}
+
+			var portalURL = "http://${virtualHost}:${port}";
+		}
+		else {
+			var portalURL = JSONCompany.getPortalURL();
+		}
+
+		var api = "${portalURL}/o/c/${en_US_plural_label_lowercase}";
+
+		if (isSet(objectEntryId)) {
+			var api = "${api}/${objectEntryId}";
+		}
+
+		if (isSet(scopeKey)) {
+			var scopeKey = JSONGroupAPI._getGroupIdByNameNoSelenium(
+				groupName = "Guest",
+				site = "true");
+
+			var api = StringUtil.add(${api}, "/scopes/${scopeKey}", "");
+		}
+
+		var curlWithoutBody = StringUtil.add(${api}, " \ ${headers}", "");
+		var body = CustomObjectAPI._curlNObjectEntriesBody(
+			externalReferenceCode = ${externalReferenceCode},
+			fieldName = ${fieldName},
+			fieldValue = ${fieldValue},
+			nestedField = ${nestedField},
+			numberOfRelatedObjectEntries = ${numberOfRelatedObjectEntries},
+			objectEntryId = ${objectEntryId},
+			relatedEntryExternalReferenceCode = ${relatedEntryExternalReferenceCode},
+			relatedEntryFieldName = ${relatedEntryFieldName},
+			secondField = ${secondField},
+			secondFieldValue = ${secondFieldValue});
+
+		var curl = StringUtil.add(${curlWithoutBody}, "-d {${body}}", " ");
+
+		if (isSet(token)) {
+			var curl = StringUtil.add(${curl}, " -H 'Authorization: Bearer ${token}'", "");
+		}
+
+		return ${curl};
+	}
+
 	macro _curlObjectPermissions {
 		Variables.assertDefined(parameterList = "${en_US_plural_label},${objectEntryId}");
 
 		var en_US_plural_label_lowercase = StringUtil.lowerCase(${en_US_plural_label});
 		var portalURL = JSONCompany.getPortalURL();
-		var headers = '''
- 			-u test@liferay.com:test \
-			-H Content-Type: application/json \
-		''';
+
 		var api = "${portalURL}/o/c/${en_US_plural_label_lowercase}/${objectEntryId}/permissions";
 
 		if (isSet(roleNames)) {
@@ -30,6 +142,29 @@ definition {
 		TestUtils.assertEquals(
 			actual = ${objectEntryCount},
 			expected = ${expectedCount});
+	}
+
+	macro createObjectEntryWithField {
+		Variables.assertDefined(parameterList = "${en_US_plural_label},${fieldName},${fieldValue}");
+
+		var curl = CustomObjectAPI._curlObjectEntries(
+			en_US_plural_label = ${en_US_plural_label},
+			externalReferenceCode = ${externalReferenceCode},
+			fieldName = ${fieldName},
+			fieldValue = ${fieldValue},
+			nestedField = ${nestedField},
+			numberOfRelatedObjectEntries = ${numberOfRelatedObjectEntries},
+			relatedEntryExternalReferenceCode = ${relatedEntryExternalReferenceCode},
+			relatedEntryFieldName = ${relatedEntryFieldName},
+			scopeKey = ${scopeKey},
+			secondField = ${secondField},
+			secondFieldValue = ${secondFieldValue},
+			token = ${token},
+			virtualHost = ${virtualHost});
+
+		var response = JSONCurlUtil.post(${curl});
+
+		return ${response};
 	}
 
 	macro getObjectPermissions {
@@ -58,6 +193,25 @@ definition {
 		static var staticObjectId = ${objectEntryId};
 
 		return ${staticObjectId};
+	}
+
+	macro updateObjectEntry {
+		Variables.assertDefined(parameterList = "${en_US_plural_label},${objectEntryId},${fieldName},${fieldValue}");
+
+		var curl = CustomObjectAPI._curlObjectEntries(
+			en_US_plural_label = ${en_US_plural_label},
+			externalReferenceCode = ${externalReferenceCode},
+			fieldName = ${fieldName},
+			fieldValue = ${fieldValue},
+			nestedField = ${nestedField},
+			numberOfRelatedObjectEntries = ${numberOfRelatedObjectEntries},
+			objectEntryId = ${objectEntryId},
+			relatedEntryExternalReferenceCode = ${relatedEntryExternalReferenceCode},
+			relatedEntryFieldName = ${relatedEntryFieldName});
+
+		var response = JSONCurlUtil.put(${curl});
+
+		return ${response};
 	}
 
 	macro updateObjectPermissions {

--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/CustomObjectAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/CustomObjectAPI.macro
@@ -195,7 +195,25 @@ definition {
 		return ${staticObjectId};
 	}
 
-	macro updateObjectEntry {
+	macro updateObjectEntryByPatch {
+		Variables.assertDefined(parameterList = "${en_US_plural_label},${objectEntryId},${fieldName},${fieldValue}");
+
+		var curl = CustomObjectAPI._curlObjectEntries(
+			en_US_plural_label = ${en_US_plural_label},
+			fieldName = ${fieldName},
+			fieldValue = ${fieldValue},
+			nestedField = ${nestedField},
+			numberOfRelatedObjectEntries = ${numberOfRelatedObjectEntries},
+			objectEntryId = ${objectEntryId},
+			relatedEntryExternalReferenceCode = ${relatedEntryExternalReferenceCode},
+			relatedEntryFieldName = ${relatedEntryFieldName});
+
+		var response = JSONCurlUtil.patch(${curl});
+
+		return ${response};
+	}
+
+	macro updateObjectEntryByPut {
 		Variables.assertDefined(parameterList = "${en_US_plural_label},${objectEntryId},${fieldName},${fieldValue}");
 
 		var curl = CustomObjectAPI._curlObjectEntries(

--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/CustomObjectAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/CustomObjectAPI.macro
@@ -20,6 +20,18 @@ definition {
 		return ${curl};
 	}
 
+	macro assertCorrectObjectEntryCount {
+		Variables.assertDefined(parameterList = "${en_US_plural_label},${expectedCount}");
+
+		var response = ObjectDefinitionAPI.getObjectEntries(en_US_plural_label = ${en_US_plural_label});
+
+		var objectEntryCount = JSONUtil.getWithJSONPath(${response}, "$.totalCount");
+
+		TestUtils.assertEquals(
+			actual = ${objectEntryCount},
+			expected = ${expectedCount});
+	}
+
 	macro getObjectPermissions {
 		Variables.assertDefined(parameterList = "${en_US_plural_label},${objectEntryId}");
 

--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/CustomObjectAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/CustomObjectAPI.macro
@@ -132,16 +132,16 @@ definition {
 		return ${curl};
 	}
 
-	macro assertCorrectObjectEntryCount {
-		Variables.assertDefined(parameterList = "${en_US_plural_label},${expectedCount}");
+	macro assertCorrectObjectEntryValuesInResponse {
+		Variables.assertDefined(parameterList = "${en_US_plural_label},${element},${expectedValues}");
 
 		var response = ObjectDefinitionAPI.getObjectEntries(en_US_plural_label = ${en_US_plural_label});
 
-		var objectEntryCount = JSONUtil.getWithJSONPath(${response}, "$.totalCount");
+		var actualValues = JSONUtil.getWithJSONPath(${response}, ${element});
 
 		TestUtils.assertEquals(
-			actual = ${objectEntryCount},
-			expected = ${expectedCount});
+			actual = ${actualValues},
+			expected = ${expectedValues});
 	}
 
 	macro createObjectEntryWithField {

--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectDefinitionAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectDefinitionAPI.macro
@@ -119,7 +119,7 @@ definition {
 	macro _createObjectEntryWithName {
 		Variables.assertDefined(parameterList = ${name});
 
-		var response = CustomObjectAPI.createObjectEntryWithField(
+		var response = CustomObjectAPI.createObjectEntryWithFields(
 			en_US_plural_label = ${en_US_plural_label},
 			fieldName = "name",
 			fieldValue = ${name},

--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectDefinitionAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectDefinitionAPI.macro
@@ -119,7 +119,7 @@ definition {
 	macro _createObjectEntryWithName {
 		Variables.assertDefined(parameterList = ${name});
 
-		var response = ObjectDefinitionAPI.createObjectEntryWithField(
+		var response = CustomObjectAPI.createObjectEntryWithField(
 			en_US_plural_label = ${en_US_plural_label},
 			fieldName = "name",
 			fieldValue = ${name},
@@ -685,100 +685,6 @@ definition {
 			expected = ${managerFirstname});
 
 		return ${managerId};
-	}
-
-	macro createObjectEntryWithField {
-		Variables.assertDefined(parameterList = "${en_US_plural_label},${fieldName},${fieldValue}");
-
-		var en_US_plural_label_lowercase = StringUtil.lowerCase(${en_US_plural_label});
-
-		if (isSet(virtualHost)) {
-			if (!(isSet(port))) {
-				var port = 8080;
-			}
-
-			var portalURL = "http://${virtualHost}:${port}";
-		}
-		else {
-			var portalURL = JSONCompany.getPortalURL();
-		}
-
-		var body = '''"${fieldName}": "${fieldValue}"''';
-
-		if (isSet(secondField)) {
-			var body = StringUtil.add("${body},", "\"secondField\":\"${secondFieldValue}\"", "");
-		}
-
-		if (isSet(nestedField)) {
-			var size = ${numberOfRelatedObjectEntries};
-
-			if (!(isSet(externalReferenceCode))) {
-				var externalReferenceCode = "";
-			}
-
-			var data = '''
-				"externalReferenceCode": "${externalReferenceCode}",
-				"${nestedField}":
-			''';
-			var entryBody = '''[''';
-			var i = 0;
-
-			while ((${i} != ${size}) && (maxIterations = "10")) {
-				var relatedObjectEntry = '''
-					{
-						"${relatedEntryFieldName}": "${relatedEntryFieldName}${i}"
-					}
-				''';
-
-				if (isSet(relatedEntryExternalReferenceCode)) {
-					var relatedObjectEntry = '''
-					{
-						"${relatedEntryFieldName}": "${relatedEntryFieldName}${i}",
-						"externalReferenceCode": "${relatedEntryExternalReferenceCode}${i}"
-					}
-				''';
-				}
-
-				var j = ${i} + 1;
-
-				if (${j} == ${size}) {
-					var data = StringUtil.add(${data}, "${entryBody}${relatedObjectEntry}]", "");
-				}
-				else {
-					var entryBody = StringUtil.add(${entryBody}, "${relatedObjectEntry},", "");
-				}
-
-				var i = ${i} + 1;
-			}
-
-			var body = StringUtil.add("${body},", ${data}, "");
-		}
-
-		var api = ${en_US_plural_label_lowercase};
-
-		if (isSet(scopeKey)) {
-			var scopeKey = JSONGroupAPI._getGroupIdByNameNoSelenium(
-				groupName = "Guest",
-				site = "true");
-
-			var api = StringUtil.add(${api}, "/scopes/${scopeKey}", "");
-		}
-
-		var curlWithoutBody = '''
-			${portalURL}/o/c/${api} \
-				-u test@liferay.com:test \
-				-H Content-Type: application/json \
-		''';
-
-		var curl = StringUtil.add(${curlWithoutBody}, "-d {${body}}", " ");
-
-		if (isSet(token)) {
-			var curl = StringUtil.add(${curl}, " -H 'Authorization: Bearer ${token}'", "");
-		}
-
-		var response = JSONCurlUtil.post(${curl});
-
-		return ${response};
 	}
 
 	macro createObjectEntryWithName {

--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectDefinitionAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectDefinitionAPI.macro
@@ -709,6 +709,51 @@ definition {
 			var body = StringUtil.add("${body},", "\"secondField\":\"${secondFieldValue}\"", "");
 		}
 
+		if (isSet(nestedField)) {
+			var size = ${numberOfRelatedObjectEntries};
+
+			if (!(isSet(externalReferenceCode))) {
+				var externalReferenceCode = "";
+			}
+
+			var data = '''
+				"externalReferenceCode": "${externalReferenceCode}",
+				"${nestedField}":
+			''';
+			var entryBody = '''[''';
+			var i = 0;
+
+			while ((${i} != ${size}) && (maxIterations = "10")) {
+				var relatedObjectEntry = '''
+					{
+						"${relatedEntryFieldName}": "${relatedEntryFieldName}${i}"
+					}
+				''';
+
+				if (isSet(relatedEntryExternalReferenceCode)) {
+					var relatedObjectEntry = '''
+					{
+						"${relatedEntryFieldName}": "${relatedEntryFieldName}${i}",
+						"externalReferenceCode": "${relatedEntryExternalReferenceCode}${i}"
+					}
+				''';
+				}
+
+				var j = ${i} + 1;
+
+				if (${j} == ${size}) {
+					var data = StringUtil.add(${data}, "${entryBody}${relatedObjectEntry}]", "");
+				}
+				else {
+					var entryBody = StringUtil.add(${entryBody}, "${relatedObjectEntry},", "");
+				}
+
+				var i = ${i} + 1;
+			}
+
+			var body = StringUtil.add("${body},", ${data}, "");
+		}
+
 		var api = ${en_US_plural_label_lowercase};
 
 		if (isSet(scopeKey)) {

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/OperateCustomObjectAndRelatedCustomObjectsWithinSingleRequest.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/OperateCustomObjectAndRelatedCustomObjectsWithinSingleRequest.testcase
@@ -63,7 +63,7 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("And Given Student and Subject entries are created with postStudent including studentsSubjects with Subject entries information") {
-			var response = CustomObjectAPI.createObjectEntryWithField(
+			var response = CustomObjectAPI.createObjectEntryAndRelatedObjects(
 				en_US_plural_label = "students",
 				fieldName = "name",
 				fieldValue = "Able",
@@ -75,7 +75,7 @@ definition {
 		task ("When with patchStudent and studentId including studentsSubjects with new Subject entries information to update Student entry") {
 			var studentId = JSONPathUtil.getIdValue(response = ${response});
 
-			CustomObjectAPI.updateObjectEntryByPatch(
+			CustomObjectAPI.updateObjectEntryAndRelatedObjectsByPatch(
 				en_US_plural_label = "students",
 				fieldName = "name",
 				fieldValue = "Bob",
@@ -87,21 +87,21 @@ definition {
 
 		task ("Then Student entry is updated") {
 			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
-				element = "$.items[*].name",
 				en_US_plural_label = "students",
-				expectedValues = "Bob");
+				expectedValues = "Bob",
+				objectJsonPath = "$.items[*].name");
 		}
 
 		task ("And Then new Subject entries are created") {
 			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
-				element = "$.totalCount",
 				en_US_plural_label = "students",
-				expectedValues = 1);
+				expectedValues = 1,
+				objectJsonPath = "$.totalCount");
 
 			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
-				element = "$.totalCount",
 				en_US_plural_label = "subjects",
-				expectedValues = 4);
+				expectedValues = 4,
+				objectJsonPath = "$.totalCount");
 		}
 	}
 
@@ -111,7 +111,7 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("And Given Subject and Student entries are created with postSubject including studentsSubjects with Student entries information") {
-			var response = CustomObjectAPI.createObjectEntryWithField(
+			var response = CustomObjectAPI.createObjectEntryAndRelatedObjects(
 				en_US_plural_label = "subjects",
 				externalReferenceCode = "subjectErc",
 				fieldName = "name",
@@ -125,7 +125,7 @@ definition {
 		task ("When with putSubject and subjectId including studentsSubjects with new Student entries information to update Subject entry") {
 			var subjectId = JSONPathUtil.getIdValue(response = ${response});
 
-			CustomObjectAPI.updateObjectEntryByPut(
+			CustomObjectAPI.updateObjectEntryAndRelatedObjectsByPut(
 				en_US_plural_label = "subjects",
 				externalReferenceCode = "subjectErc",
 				fieldName = "name",
@@ -139,21 +139,21 @@ definition {
 
 		task ("Then Subject entry is updated") {
 			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
-				element = "$.items[*].name",
 				en_US_plural_label = "subjects",
-				expectedValues = "English");
+				expectedValues = "English",
+				objectJsonPath = "$.items[*].name");
 		}
 
 		task ("And Then new Student entries are created") {
 			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
-				element = "$.totalCount",
 				en_US_plural_label = "subjects",
-				expectedValues = 1);
+				expectedValues = 1,
+				objectJsonPath = "$.totalCount");
 
 			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
-				element = "$.totalCount",
 				en_US_plural_label = "students",
-				expectedValues = 4);
+				expectedValues = 4,
+				objectJsonPath = "$.totalCount");
 		}
 	}
 
@@ -163,7 +163,7 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("And Given two Student entries are created with postStudent including studentsStudents with another Student entry information") {
-			var response = CustomObjectAPI.createObjectEntryWithField(
+			var response = CustomObjectAPI.createObjectEntryAndRelatedObjects(
 				en_US_plural_label = "students",
 				externalReferenceCode = "ableErc",
 				fieldName = "name",
@@ -176,7 +176,7 @@ definition {
 		task ("When with putStudent and studentId including studentsStudents with new Student entry information to update Student entry") {
 			var studentId = JSONPathUtil.getIdValue(response = ${response});
 
-			CustomObjectAPI.updateObjectEntryByPut(
+			CustomObjectAPI.updateObjectEntryAndRelatedObjectsByPut(
 				en_US_plural_label = "students",
 				externalReferenceCode = "ableErc",
 				fieldName = "name",
@@ -189,16 +189,16 @@ definition {
 
 		task ("Then the original Student entry is updated") {
 			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
-				element = "$.items[*].name",
 				en_US_plural_label = "students",
-				expectedValues = "Able-update,name0,name0-update");
+				expectedValues = "Able-update,name0,name0-update",
+				objectJsonPath = "$.items[*].name");
 		}
 
 		task ("And Then one more Student entry is created") {
 			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
-				element = "$.totalCount",
 				en_US_plural_label = "students",
-				expectedValues = 3);
+				expectedValues = 3,
+				objectJsonPath = "$.totalCount");
 		}
 	}
 
@@ -208,7 +208,7 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("And Given Student and Subject entries are created with postStudent including studentsSubjects with Subject entries information") {
-			var response = CustomObjectAPI.createObjectEntryWithField(
+			var response = CustomObjectAPI.createObjectEntryAndRelatedObjects(
 				en_US_plural_label = "students",
 				externalReferenceCode = "studentErc",
 				fieldName = "name",
@@ -221,7 +221,7 @@ definition {
 		task ("When with putStudent and studentId including studentsSubjects with new Subject entries information to update Student entry") {
 			var studentId = JSONPathUtil.getIdValue(response = ${response});
 
-			CustomObjectAPI.updateObjectEntryByPut(
+			CustomObjectAPI.updateObjectEntryAndRelatedObjectsByPut(
 				en_US_plural_label = "students",
 				externalReferenceCode = "studentErc",
 				fieldName = "name",
@@ -234,21 +234,21 @@ definition {
 
 		task ("Then Student entry is updated") {
 			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
-				element = "$.items[*].name",
 				en_US_plural_label = "students",
-				expectedValues = "Bob");
+				expectedValues = "Bob",
+				objectJsonPath = "$.items[*].name");
 		}
 
 		task ("And Then new Subject entries are created") {
 			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
-				element = "$.totalCount",
 				en_US_plural_label = "students",
-				expectedValues = 1);
+				expectedValues = 1,
+				objectJsonPath = "$.totalCount");
 
 			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
-				element = "$.totalCount",
 				en_US_plural_label = "subjects",
-				expectedValues = 4);
+				expectedValues = 4,
+				objectJsonPath = "$.totalCount");
 		}
 	}
 
@@ -258,7 +258,7 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("When creating a Subject entry with postSubject including studentsSubjects with Student entries information") {
-			CustomObjectAPI.createObjectEntryWithField(
+			CustomObjectAPI.createObjectEntryAndRelatedObjects(
 				en_US_plural_label = "subjects",
 				fieldName = "name",
 				fieldValue = "Math",
@@ -269,14 +269,14 @@ definition {
 
 		task ("Then both Subject and Student entries are created") {
 			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
-				element = "$.totalCount",
 				en_US_plural_label = "students",
-				expectedValues = 2);
+				expectedValues = 2,
+				objectJsonPath = "$.totalCount");
 
 			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
-				element = "$.totalCount",
 				en_US_plural_label = "subjects",
-				expectedValues = 1);
+				expectedValues = 1,
+				objectJsonPath = "$.totalCount");
 		}
 	}
 
@@ -286,7 +286,7 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("When creating a Student entry with postStudent including studentsSubjects with Subject entries information") {
-			CustomObjectAPI.createObjectEntryWithField(
+			CustomObjectAPI.createObjectEntryAndRelatedObjects(
 				en_US_plural_label = "students",
 				fieldName = "name",
 				fieldValue = "Able",
@@ -297,14 +297,14 @@ definition {
 
 		task ("Then both Student and Subject entries are created") {
 			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
-				element = "$.totalCount",
 				en_US_plural_label = "students",
-				expectedValues = 1);
+				expectedValues = 1,
+				objectJsonPath = "$.totalCount");
 
 			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
-				element = "$.totalCount",
 				en_US_plural_label = "subjects",
-				expectedValues = 2);
+				expectedValues = 2,
+				objectJsonPath = "$.totalCount");
 		}
 	}
 
@@ -314,7 +314,7 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("When creating a Student entry with postStudent including studentsStudents with another two Student entries information") {
-			var response = CustomObjectAPI.createObjectEntryWithField(
+			var response = CustomObjectAPI.createObjectEntryAndRelatedObjects(
 				en_US_plural_label = "students",
 				externalReferenceCode = "studentErc",
 				fieldName = "name",
@@ -326,9 +326,9 @@ definition {
 
 		task ("Then three Student entries are created") {
 			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
-				element = "$.totalCount",
 				en_US_plural_label = "students",
-				expectedValues = 3);
+				expectedValues = 3,
+				objectJsonPath = "$.totalCount");
 		}
 	}
 
@@ -340,7 +340,7 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("When creating a Student entry with postStudent including studentsSubjects with nonexistent field in Subject entries") {
-			CustomObjectAPI.createObjectEntryWithField(
+			CustomObjectAPI.createObjectEntryAndRelatedObjects(
 				en_US_plural_label = "students",
 				fieldName = "name",
 				fieldValue = "Able",
@@ -351,14 +351,14 @@ definition {
 
 		task ("Then no Student and Subject entries are created") {
 			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
-				element = "$.totalCount",
 				en_US_plural_label = "students",
-				expectedValues = 0);
+				expectedValues = 0,
+				objectJsonPath = "$.totalCount");
 
 			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
-				element = "$.totalCount",
 				en_US_plural_label = "subjects",
-				expectedValues = 0);
+				expectedValues = 0,
+				objectJsonPath = "$.totalCount");
 		}
 	}
 
@@ -370,7 +370,7 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("When creating a Student entry with postStudent including nonexistent nestedField with Subject entries information") {
-			CustomObjectAPI.createObjectEntryWithField(
+			CustomObjectAPI.createObjectEntryAndRelatedObjects(
 				en_US_plural_label = "subjects",
 				fieldName = "name",
 				fieldValue = "Math",
@@ -381,14 +381,14 @@ definition {
 
 		task ("Then no Student and Subject entries are created") {
 			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
-				element = "$.totalCount",
 				en_US_plural_label = "students",
-				expectedValues = 0);
+				expectedValues = 0,
+				objectJsonPath = "$.totalCount");
 
 			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
-				element = "$.totalCount",
 				en_US_plural_label = "subjects",
-				expectedValues = 0);
+				expectedValues = 0,
+				objectJsonPath = "$.totalCount");
 		}
 	}
 
@@ -398,7 +398,7 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("And Given two Student entries with custom ERCs are created with postStudent including studentsStudents with another Student entry information") {
-			var response = CustomObjectAPI.createObjectEntryWithField(
+			var response = CustomObjectAPI.createObjectEntryAndRelatedObjects(
 				en_US_plural_label = "students",
 				fieldName = "name",
 				fieldValue = "Able",
@@ -411,7 +411,7 @@ definition {
 		task ("When with patchStudent and studentId including studentsStudents with modified Student name and its erc to update Student entry") {
 			var studentId = JSONPathUtil.getIdValue(response = ${response});
 
-			CustomObjectAPI.updateObjectEntryByPatch(
+			CustomObjectAPI.updateObjectEntryAndRelatedObjectsByPatch(
 				en_US_plural_label = "students",
 				fieldName = "name",
 				fieldValue = "Able-update",
@@ -424,9 +424,9 @@ definition {
 
 		task ("Then both Students entries are updated") {
 			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
-				element = "$.items[*].name",
 				en_US_plural_label = "students",
-				expectedValues = "Able-update,name0-update,name1-update");
+				expectedValues = "Able-update,name0-update,name1-update",
+				objectJsonPath = "$.items[*].name");
 		}
 	}
 
@@ -436,7 +436,7 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("And Given Student and Subject entries with custom ERCs are created with postStudent including studentsSubjects with Subject entries information") {
-			var response = CustomObjectAPI.createObjectEntryWithField(
+			var response = CustomObjectAPI.createObjectEntryAndRelatedObjects(
 				en_US_plural_label = "students",
 				fieldName = "name",
 				fieldValue = "Able",
@@ -449,7 +449,7 @@ definition {
 		task ("When with patchStudent and studentId including studentsSubjects with modified names of Subject entries and their ERCs to update Student entry") {
 			var studentId = JSONPathUtil.getIdValue(response = ${response});
 
-			CustomObjectAPI.updateObjectEntryByPatch(
+			CustomObjectAPI.updateObjectEntryAndRelatedObjectsByPatch(
 				en_US_plural_label = "students",
 				externalReferenceCode = "studentErc",
 				fieldName = "name",
@@ -463,14 +463,14 @@ definition {
 
 		task ("Then both Student and Subject entries are updated") {
 			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
-				element = "$.items[*].name",
 				en_US_plural_label = "students",
-				expectedValues = "Able-update");
+				expectedValues = "Able-update",
+				objectJsonPath = "$.items[*].name");
 
 			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
-				element = "$.items[*].name",
 				en_US_plural_label = "subjects",
-				expectedValues = "name0-update,name1-update");
+				expectedValues = "name0-update,name1-update",
+				objectJsonPath = "$.items[*].name");
 		}
 	}
 
@@ -480,7 +480,7 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("And Given Subject and Student entries with custom ERCs are created with postSubject including studentsSubjects with Student entries information") {
-			var response = CustomObjectAPI.createObjectEntryWithField(
+			var response = CustomObjectAPI.createObjectEntryAndRelatedObjects(
 				en_US_plural_label = "subjects",
 				externalReferenceCode = "subjectErc",
 				fieldName = "name",
@@ -494,7 +494,7 @@ definition {
 		task ("When with putSubject and subjectId including studentsSubjects with modified names of Student entries and their ERCs to update Subject entry") {
 			var subjectId = JSONPathUtil.getIdValue(response = ${response});
 
-			CustomObjectAPI.updateObjectEntryByPut(
+			CustomObjectAPI.updateObjectEntryAndRelatedObjectsByPut(
 				en_US_plural_label = "subjects",
 				externalReferenceCode = "subjectErc",
 				fieldName = "name",
@@ -508,14 +508,14 @@ definition {
 
 		task ("Then both Student and Subject entries are updated") {
 			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
-				element = "$.items[*].name",
 				en_US_plural_label = "subjects",
-				expectedValues = "English");
+				expectedValues = "English",
+				objectJsonPath = "$.items[*].name");
 
 			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
-				element = "$.items[*].name",
 				en_US_plural_label = "students",
-				expectedValues = "name0-update,name1-update");
+				expectedValues = "name0-update,name1-update",
+				objectJsonPath = "$.items[*].name");
 		}
 	}
 
@@ -525,7 +525,7 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("And Given two Student entries with custom ERCs are created with postStudent including studentsStudents with another Student entry information") {
-			var response = CustomObjectAPI.createObjectEntryWithField(
+			var response = CustomObjectAPI.createObjectEntryAndRelatedObjects(
 				en_US_plural_label = "students",
 				externalReferenceCode = "ableErc",
 				fieldName = "name",
@@ -539,7 +539,7 @@ definition {
 		task ("When with putStudent and studentId including studentsStudents with modified Student name and its erc to update Student entry") {
 			var studentId = JSONPathUtil.getIdValue(response = ${response});
 
-			CustomObjectAPI.updateObjectEntryByPut(
+			CustomObjectAPI.updateObjectEntryAndRelatedObjectsByPut(
 				en_US_plural_label = "students",
 				externalReferenceCode = "ableErc",
 				fieldName = "name",
@@ -553,9 +553,9 @@ definition {
 
 		task ("Then both Students entries are updated") {
 			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
-				element = "$.items[*].name",
 				en_US_plural_label = "students",
-				expectedValues = "Able-update,name0-update,name1-update");
+				expectedValues = "Able-update,name0-update,name1-update",
+				objectJsonPath = "$.items[*].name");
 		}
 	}
 
@@ -565,7 +565,7 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("And Given Student and Subject entries with custom ERCs are created with postStudent including studentsSubjects with Subject entries information") {
-			var response = CustomObjectAPI.createObjectEntryWithField(
+			var response = CustomObjectAPI.createObjectEntryAndRelatedObjects(
 				en_US_plural_label = "students",
 				externalReferenceCode = "studentErc",
 				fieldName = "name",
@@ -579,7 +579,7 @@ definition {
 		task ("When with putStudent and studentId including studentsSubjects with modified names of Subject entries and their ERCs to update Student entry") {
 			var studentId = JSONPathUtil.getIdValue(response = ${response});
 
-			CustomObjectAPI.updateObjectEntryByPut(
+			CustomObjectAPI.updateObjectEntryAndRelatedObjectsByPut(
 				en_US_plural_label = "students",
 				externalReferenceCode = "studentErc",
 				fieldName = "name",
@@ -593,14 +593,14 @@ definition {
 
 		task ("Then both Student and Subject entries are updated") {
 			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
-				element = "$.items[*].name",
 				en_US_plural_label = "students",
-				expectedValues = "Bob");
+				expectedValues = "Bob",
+				objectJsonPath = "$.items[*].name");
 
 			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
-				element = "$.items[*].name",
 				en_US_plural_label = "subjects",
-				expectedValues = "name0-update,name1-update");
+				expectedValues = "name0-update,name1-update",
+				objectJsonPath = "$.items[*].name");
 		}
 	}
 

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/OperateCustomObjectAndRelatedCustomObjectsWithinSingleRequest.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/OperateCustomObjectAndRelatedCustomObjectsWithinSingleRequest.testcase
@@ -27,14 +27,22 @@ definition {
 		}
 
 		task ("And Given a many-to-many studentsSubjects relationship created between Student and Subject") {
-			var objectDefinitionId1 = ObjectDefinitionAPI.getObjectDefinitionIdByName(name = "User");
-
 			ObjectDefinitionAPI.createRelationship(
 				deletionType = "cascade",
 				en_US_label = "studentsSubjects",
 				name = "studentsSubjects",
 				objectDefinitionId1 = ${studentObjectDefinitionId},
 				objectDefinitionId2 = ${subjectObjectDefinitionId},
+				type = "manyToMany");
+		}
+
+		task ("And Given a many-to-many studentsStudents relationship created between Student and itself") {
+			ObjectDefinitionAPI.createRelationship(
+				deletionType = "cascade",
+				en_US_label = "studentsStudents",
+				name = "studentsStudents",
+				objectDefinitionId1 = ${studentObjectDefinitionId},
+				objectDefinitionId2 = ${studentObjectDefinitionId},
 				type = "manyToMany");
 		}
 	}
@@ -98,6 +106,51 @@ definition {
 				element = "$.totalCount",
 				en_US_plural_label = "students",
 				expectedValues = 4);
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 4
+	test CanCreateCustomObjectEntriesWithPutChildObjectInManyToManyRelationshipWithItself {
+		property portal.acceptance = "true";
+
+		task ("And Given two Student entries are created with postStudent including studentsStudents with another Student entry information") {
+			var response = CustomObjectAPI.createObjectEntryWithField(
+				en_US_plural_label = "students",
+				externalReferenceCode = "ableErc",
+				fieldName = "name",
+				fieldValue = "Able",
+				nestedField = "studentsStudents",
+				numberOfRelatedObjectEntries = 1,
+				relatedEntryFieldName = "name");
+		}
+
+		task ("When with putStudent and studentId including studentsStudents with new Student entry information to update Student entry") {
+			var studentId = JSONPathUtil.getIdValue(response = ${response});
+
+			CustomObjectAPI.updateObjectEntry(
+				en_US_plural_label = "students",
+				externalReferenceCode = "ableErc",
+				fieldName = "name",
+				fieldValue = "Able-update",
+				nestedField = "studentsStudents",
+				numberOfRelatedObjectEntries = 1,
+				objectEntryId = ${studentId},
+				relatedEntryFieldName = "name");
+		}
+
+		task ("Then the original Student entry is updated") {
+			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
+				element = "$.items[*].name",
+				en_US_plural_label = "students",
+				expectedValues = "Able-update,name0,name0-update");
+		}
+
+		task ("And Then one more Student entry is created") {
+			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
+				element = "$.totalCount",
+				en_US_plural_label = "students",
+				expectedValues = 3);
 		}
 	}
 
@@ -207,6 +260,30 @@ definition {
 		}
 	}
 
+	@disable-webdriver = "true"
+	@priority = 4
+	test CanCreateTwoCustomObjectEntriesWithPostObjectInManyToManyRelationshipWithItself {
+		property portal.acceptance = "true";
+
+		task ("When creating a Student entry with postStudent including studentsStudents with another two Student entries information") {
+			var response = CustomObjectAPI.createObjectEntryWithField(
+				en_US_plural_label = "students",
+				externalReferenceCode = "studentErc",
+				fieldName = "name",
+				fieldValue = "Able",
+				nestedField = "studentsStudents",
+				numberOfRelatedObjectEntries = 2,
+				relatedEntryFieldName = "name");
+		}
+
+		task ("Then three Student entries are created") {
+			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
+				element = "$.totalCount",
+				en_US_plural_label = "students",
+				expectedValues = 3);
+		}
+	}
+
 	@description = "Ignore tests unitl LPS-169348 fixed"
 	@disable-webdriver = "true"
 	@ignore = "true"
@@ -309,6 +386,46 @@ definition {
 				element = "$.items[*].name",
 				en_US_plural_label = "students",
 				expectedValues = "name0-update,name1-update");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 4
+	test CanUpdateCustomObjectEntriesWithPutChildObjectInManyToManyRelationshipWithItself {
+		property portal.acceptance = "true";
+
+		task ("And Given two Student entries with custom ERCs are created with postStudent including studentsStudents with another Student entry information") {
+			var response = CustomObjectAPI.createObjectEntryWithField(
+				en_US_plural_label = "students",
+				externalReferenceCode = "ableErc",
+				fieldName = "name",
+				fieldValue = "Able",
+				nestedField = "studentsStudents",
+				numberOfRelatedObjectEntries = 2,
+				relatedEntryExternalReferenceCode = "studentErc",
+				relatedEntryFieldName = "name");
+		}
+
+		task ("When with putStudent and studentId including studentsStudents with modified Student name and its erc to update Student entry") {
+			var studentId = JSONPathUtil.getIdValue(response = ${response});
+
+			CustomObjectAPI.updateObjectEntry(
+				en_US_plural_label = "students",
+				externalReferenceCode = "ableErc",
+				fieldName = "name",
+				fieldValue = "Able-update",
+				nestedField = "studentsStudents",
+				numberOfRelatedObjectEntries = 2,
+				objectEntryId = ${studentId},
+				relatedEntryExternalReferenceCode = "studentErc",
+				relatedEntryFieldName = "name");
+		}
+
+		task ("Then both Students entries are updated") {
+			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
+				element = "$.items[*].name",
+				en_US_plural_label = "students",
+				expectedValues = "Able-update,name0-update,name1-update");
 		}
 	}
 

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/OperateCustomObjectAndRelatedCustomObjectsWithinSingleRequest.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/OperateCustomObjectAndRelatedCustomObjectsWithinSingleRequest.testcase
@@ -51,6 +51,108 @@ definition {
 
 	@disable-webdriver = "true"
 	@priority = 4
+	test CanCreateCustomObjectEntriesWithPutChildObjectInManyToManyRelationship {
+		property portal.acceptance = "true";
+
+		task ("And Given Subject and Student entries are created with postSubject including studentsSubjects with Student entries information") {
+			var response = CustomObjectAPI.createObjectEntryWithField(
+				en_US_plural_label = "subjects",
+				externalReferenceCode = "subjectErc",
+				fieldName = "name",
+				fieldValue = "Math",
+				nestedField = "studentsSubjects",
+				numberOfRelatedObjectEntries = 2,
+				relatedEntryExternalReferenceCode = "studentErc",
+				relatedEntryFieldName = "name");
+		}
+
+		task ("When with putSubject and subjectId including studentsSubjects with new Student entries information to update Subject entry") {
+			var subjectId = JSONPathUtil.getIdValue(response = ${response});
+
+			CustomObjectAPI.updateObjectEntry(
+				en_US_plural_label = "subjects",
+				externalReferenceCode = "subjectErc",
+				fieldName = "name",
+				fieldValue = "English",
+				nestedField = "studentsSubjects",
+				numberOfRelatedObjectEntries = 2,
+				objectEntryId = ${subjectId},
+				relatedEntryExternalReferenceCode = "newStudentErc",
+				relatedEntryFieldName = "name");
+		}
+
+		task ("Then Subject entry is updated") {
+			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
+				element = "$.items[*].name",
+				en_US_plural_label = "subjects",
+				expectedValues = "English");
+		}
+
+		task ("And Then new Student entries are created") {
+			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
+				element = "$.totalCount",
+				en_US_plural_label = "subjects",
+				expectedValues = 1);
+
+			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
+				element = "$.totalCount",
+				en_US_plural_label = "students",
+				expectedValues = 4);
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 3
+	test CanCreateCustomObjectEntriesWithPutParentObjectInManyToManyRelationship {
+		property portal.acceptance = "true";
+
+		task ("And Given Student and Subject entries are created with postStudent including studentsSubjects with Subject entries information") {
+			var response = CustomObjectAPI.createObjectEntryWithField(
+				en_US_plural_label = "students",
+				externalReferenceCode = "studentErc",
+				fieldName = "name",
+				fieldValue = "Able",
+				nestedField = "studentsSubjects",
+				numberOfRelatedObjectEntries = 2,
+				relatedEntryFieldName = "name");
+		}
+
+		task ("When with putStudent and studentId including studentsSubjects with new Subject entries information to update Student entry") {
+			var studentId = JSONPathUtil.getIdValue(response = ${response});
+
+			CustomObjectAPI.updateObjectEntry(
+				en_US_plural_label = "students",
+				externalReferenceCode = "studentErc",
+				fieldName = "name",
+				fieldValue = "Bob",
+				nestedField = "studentsSubjects",
+				numberOfRelatedObjectEntries = 2,
+				objectEntryId = ${studentId},
+				relatedEntryFieldName = "name");
+		}
+
+		task ("Then Student entry is updated") {
+			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
+				element = "$.items[*].name",
+				en_US_plural_label = "students",
+				expectedValues = "Bob");
+		}
+
+		task ("And Then new Subject entries are created") {
+			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
+				element = "$.totalCount",
+				en_US_plural_label = "students",
+				expectedValues = 1);
+
+			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
+				element = "$.totalCount",
+				en_US_plural_label = "subjects",
+				expectedValues = 4);
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 4
 	test CanCreateCustomObjectsEntriesWithPostChildObjectInManyToManyRelationship {
 		property portal.acceptance = "true";
 
@@ -65,11 +167,13 @@ definition {
 		}
 
 		task ("Then both Subject and Student entries are created") {
-			CustomObjectAPI.assertCorrectObjectEntryCount(
+			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
+				element = "$.totalCount",
 				en_US_plural_label = "students",
 				expectedCount = 2);
 
-			CustomObjectAPI.assertCorrectObjectEntryCount(
+			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
+				element = "$.totalCount",
 				en_US_plural_label = "subjects",
 				expectedCount = 1);
 		}
@@ -81,7 +185,7 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("When creating a Student entry with postStudent including studentsSubjects with Subject entries information") {
-			CustomObjectAPI.createObjectEntryWithField(
+			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
 				en_US_plural_label = "students",
 				fieldName = "name",
 				fieldValue = "Able",
@@ -91,11 +195,13 @@ definition {
 		}
 
 		task ("Then both Student and Subject entries are created") {
-			CustomObjectAPI.assertCorrectObjectEntryCount(
+			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
+				element = "$.totalCount",
 				en_US_plural_label = "students",
 				expectedCount = 1);
 
-			CustomObjectAPI.assertCorrectObjectEntryCount(
+			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
+				element = "$.totalCount",
 				en_US_plural_label = "subjects",
 				expectedCount = 2);
 		}
@@ -119,11 +225,13 @@ definition {
 		}
 
 		task ("Then no Student and Subject entries are created") {
-			CustomObjectAPI.assertCorrectObjectEntryCount(
+			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
+				element = "$.totalCount",
 				en_US_plural_label = "students",
 				expectedCount = 0);
 
-			CustomObjectAPI.assertCorrectObjectEntryCount(
+			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
+				element = "$.totalCount",
 				en_US_plural_label = "subjects",
 				expectedCount = 0);
 		}
@@ -147,13 +255,60 @@ definition {
 		}
 
 		task ("Then no Student and Subject entries are created") {
-			CustomObjectAPI.assertCorrectObjectEntryCount(
+			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
+				element = "$.totalCount",
 				en_US_plural_label = "students",
 				expectedCount = 0);
 
-			CustomObjectAPI.assertCorrectObjectEntryCount(
+			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
+				element = "$.totalCount",
 				en_US_plural_label = "subjects",
 				expectedCount = 0);
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 3
+	test CanUpdateCustomObjectEntriesWithPutChildObjectInManyToManyRelationship {
+		property portal.acceptance = "true";
+
+		task ("And Given Subject and Student entries with custom ERCs are created with postSubject including studentsSubjects with Student entries information") {
+			var response = CustomObjectAPI.createObjectEntryWithField(
+				en_US_plural_label = "subjects",
+				externalReferenceCode = "subjectErc",
+				fieldName = "name",
+				fieldValue = "Math",
+				nestedField = "studentsSubjects",
+				numberOfRelatedObjectEntries = 2,
+				relatedEntryExternalReferenceCode = "studentErc",
+				relatedEntryFieldName = "name");
+		}
+
+		task ("When with putSubject and subjectId including studentsSubjects with modified names of Student entries and their ERCs to update Subject entry") {
+			var subjectId = JSONPathUtil.getIdValue(response = ${response});
+
+			CustomObjectAPI.updateObjectEntry(
+				en_US_plural_label = "subjects",
+				externalReferenceCode = "subjectErc",
+				fieldName = "name",
+				fieldValue = "English",
+				nestedField = "studentsSubjects",
+				numberOfRelatedObjectEntries = 2,
+				objectEntryId = ${subjectId},
+				relatedEntryExternalReferenceCode = "studentErc",
+				relatedEntryFieldName = "name");
+		}
+
+		task ("Then both Student and Subject entries are updated") {
+			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
+				element = "$.items[*].name",
+				en_US_plural_label = "subjects",
+				expectedValues = "English");
+
+			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
+				element = "$.items[*].name",
+				en_US_plural_label = "students",
+				expectedValues = "name0-update,name1-update");
 		}
 	}
 
@@ -190,21 +345,15 @@ definition {
 		}
 
 		task ("Then both Student and Subject entries are updated") {
-			var response = ObjectDefinitionAPI.getObjectEntries(en_US_plural_label = "students");
+			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
+				element = "$.items[*].name",
+				en_US_plural_label = "students",
+				expectedValues = "Bob");
 
-			var studentName = JSONUtil.getWithJSONPath(${response}, "$.items[*].name");
-
-			TestUtils.assertEquals(
-				actual = ${studentName},
-				expected = "Bob");
-
-			var response = ObjectDefinitionAPI.getObjectEntries(en_US_plural_label = "subjects");
-
-			var subjectNames = JSONUtil.getWithJSONPath(${response}, "$.items[*].name");
-
-			TestUtils.assertEquals(
-				actual = ${subjectNames},
-				expected = "name0-update,name1-update");
+			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
+				element = "$.items[*].name",
+				en_US_plural_label = "subjects",
+				expectedValues = "name0-update,name1-update");
 		}
 	}
 

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/OperateCustomObjectAndRelatedCustomObjectsWithinSingleRequest.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/OperateCustomObjectAndRelatedCustomObjectsWithinSingleRequest.testcase
@@ -58,6 +58,54 @@ definition {
 	}
 
 	@disable-webdriver = "true"
+	@priority = 3
+	test CanCreateCustomObjectEntriesWithPatchObjectInManyToManyRelationship {
+		property portal.acceptance = "true";
+
+		task ("And Given Student and Subject entries are created with postStudent including studentsSubjects with Subject entries information") {
+			var response = CustomObjectAPI.createObjectEntryWithField(
+				en_US_plural_label = "students",
+				fieldName = "name",
+				fieldValue = "Able",
+				nestedField = "studentsSubjects",
+				numberOfRelatedObjectEntries = 2,
+				relatedEntryFieldName = "name");
+		}
+
+		task ("When with patchStudent and studentId including studentsSubjects with new Subject entries information to update Student entry") {
+			var studentId = JSONPathUtil.getIdValue(response = ${response});
+
+			CustomObjectAPI.updateObjectEntryByPatch(
+				en_US_plural_label = "students",
+				fieldName = "name",
+				fieldValue = "Bob",
+				nestedField = "studentsSubjects",
+				numberOfRelatedObjectEntries = 2,
+				objectEntryId = ${studentId},
+				relatedEntryFieldName = "name");
+		}
+
+		task ("Then Student entry is updated") {
+			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
+				element = "$.items[*].name",
+				en_US_plural_label = "students",
+				expectedValues = "Bob");
+		}
+
+		task ("And Then new Subject entries are created") {
+			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
+				element = "$.totalCount",
+				en_US_plural_label = "students",
+				expectedValues = 1);
+
+			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
+				element = "$.totalCount",
+				en_US_plural_label = "subjects",
+				expectedValues = 4);
+		}
+	}
+
+	@disable-webdriver = "true"
 	@priority = 4
 	test CanCreateCustomObjectEntriesWithPutChildObjectInManyToManyRelationship {
 		property portal.acceptance = "true";
@@ -77,7 +125,7 @@ definition {
 		task ("When with putSubject and subjectId including studentsSubjects with new Student entries information to update Subject entry") {
 			var subjectId = JSONPathUtil.getIdValue(response = ${response});
 
-			CustomObjectAPI.updateObjectEntry(
+			CustomObjectAPI.updateObjectEntryByPut(
 				en_US_plural_label = "subjects",
 				externalReferenceCode = "subjectErc",
 				fieldName = "name",
@@ -128,7 +176,7 @@ definition {
 		task ("When with putStudent and studentId including studentsStudents with new Student entry information to update Student entry") {
 			var studentId = JSONPathUtil.getIdValue(response = ${response});
 
-			CustomObjectAPI.updateObjectEntry(
+			CustomObjectAPI.updateObjectEntryByPut(
 				en_US_plural_label = "students",
 				externalReferenceCode = "ableErc",
 				fieldName = "name",
@@ -173,7 +221,7 @@ definition {
 		task ("When with putStudent and studentId including studentsSubjects with new Subject entries information to update Student entry") {
 			var studentId = JSONPathUtil.getIdValue(response = ${response});
 
-			CustomObjectAPI.updateObjectEntry(
+			CustomObjectAPI.updateObjectEntryByPut(
 				en_US_plural_label = "students",
 				externalReferenceCode = "studentErc",
 				fieldName = "name",
@@ -288,7 +336,7 @@ definition {
 	@disable-webdriver = "true"
 	@ignore = "true"
 	@priority = 4
-	test CannotCreateCustomObjectsEntriesWithInvliadObjectFieldInNestedFieldInManyToManyRelationship {
+	test CannotCreateCustomObjectsEntriesWithInvalidObjectFieldInNestedFieldInManyToManyRelationship {
 		property portal.acceptance = "true";
 
 		task ("When creating a Student entry with postStudent including studentsSubjects with nonexistent field in Subject entries") {
@@ -345,6 +393,88 @@ definition {
 	}
 
 	@disable-webdriver = "true"
+	@priority = 4
+	test CanUpdateAndCreateCustomObjectEntriesWithPatchObjectInManyToManyRelationshipWithItself {
+		property portal.acceptance = "true";
+
+		task ("And Given two Student entries with custom ERCs are created with postStudent including studentsStudents with another Student entry information") {
+			var response = CustomObjectAPI.createObjectEntryWithField(
+				en_US_plural_label = "students",
+				fieldName = "name",
+				fieldValue = "Able",
+				nestedField = "studentsStudents",
+				numberOfRelatedObjectEntries = 2,
+				relatedEntryExternalReferenceCode = "studentErc",
+				relatedEntryFieldName = "name");
+		}
+
+		task ("When with patchStudent and studentId including studentsStudents with modified Student name and its erc to update Student entry") {
+			var studentId = JSONPathUtil.getIdValue(response = ${response});
+
+			CustomObjectAPI.updateObjectEntryByPatch(
+				en_US_plural_label = "students",
+				fieldName = "name",
+				fieldValue = "Able-update",
+				nestedField = "studentsStudents",
+				numberOfRelatedObjectEntries = 2,
+				objectEntryId = ${studentId},
+				relatedEntryExternalReferenceCode = "studentErc",
+				relatedEntryFieldName = "name");
+		}
+
+		task ("Then both Students entries are updated") {
+			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
+				element = "$.items[*].name",
+				en_US_plural_label = "students",
+				expectedValues = "Able-update,name0-update,name1-update");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 4
+	test CanUpdateCustomObjectEntriesWithPatchParentObjectInManyToManyRelationship {
+		property portal.acceptance = "true";
+
+		task ("And Given Student and Subject entries with custom ERCs are created with postStudent including studentsSubjects with Subject entries information") {
+			var response = CustomObjectAPI.createObjectEntryWithField(
+				en_US_plural_label = "students",
+				fieldName = "name",
+				fieldValue = "Able",
+				nestedField = "studentsSubjects",
+				numberOfRelatedObjectEntries = 2,
+				relatedEntryExternalReferenceCode = "subjectErc",
+				relatedEntryFieldName = "name");
+		}
+
+		task ("When with patchStudent and studentId including studentsSubjects with modified names of Subject entries and their ERCs to update Student entry") {
+			var studentId = JSONPathUtil.getIdValue(response = ${response});
+
+			CustomObjectAPI.updateObjectEntryByPatch(
+				en_US_plural_label = "students",
+				externalReferenceCode = "studentErc",
+				fieldName = "name",
+				fieldValue = "Able-update",
+				nestedField = "studentsSubjects",
+				numberOfRelatedObjectEntries = 2,
+				objectEntryId = ${studentId},
+				relatedEntryExternalReferenceCode = "subjectErc",
+				relatedEntryFieldName = "name");
+		}
+
+		task ("Then both Student and Subject entries are updated") {
+			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
+				element = "$.items[*].name",
+				en_US_plural_label = "students",
+				expectedValues = "Able-update");
+
+			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
+				element = "$.items[*].name",
+				en_US_plural_label = "subjects",
+				expectedValues = "name0-update,name1-update");
+		}
+	}
+
+	@disable-webdriver = "true"
 	@priority = 3
 	test CanUpdateCustomObjectEntriesWithPutChildObjectInManyToManyRelationship {
 		property portal.acceptance = "true";
@@ -364,7 +494,7 @@ definition {
 		task ("When with putSubject and subjectId including studentsSubjects with modified names of Student entries and their ERCs to update Subject entry") {
 			var subjectId = JSONPathUtil.getIdValue(response = ${response});
 
-			CustomObjectAPI.updateObjectEntry(
+			CustomObjectAPI.updateObjectEntryByPut(
 				en_US_plural_label = "subjects",
 				externalReferenceCode = "subjectErc",
 				fieldName = "name",
@@ -409,7 +539,7 @@ definition {
 		task ("When with putStudent and studentId including studentsStudents with modified Student name and its erc to update Student entry") {
 			var studentId = JSONPathUtil.getIdValue(response = ${response});
 
-			CustomObjectAPI.updateObjectEntry(
+			CustomObjectAPI.updateObjectEntryByPut(
 				en_US_plural_label = "students",
 				externalReferenceCode = "ableErc",
 				fieldName = "name",
@@ -449,7 +579,7 @@ definition {
 		task ("When with putStudent and studentId including studentsSubjects with modified names of Subject entries and their ERCs to update Student entry") {
 			var studentId = JSONPathUtil.getIdValue(response = ${response});
 
-			CustomObjectAPI.updateObjectEntry(
+			CustomObjectAPI.updateObjectEntryByPut(
 				en_US_plural_label = "students",
 				externalReferenceCode = "studentErc",
 				fieldName = "name",

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/OperateCustomObjectAndRelatedCustomObjectsWithinSingleRequest.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/OperateCustomObjectAndRelatedCustomObjectsWithinSingleRequest.testcase
@@ -1,0 +1,164 @@
+@component-name = "portal-headless"
+definition {
+
+	property custom.properties = "feature.flag.LPS-153117=true";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Object";
+	property testray.main.component.name = "Headless";
+
+	setUp {
+		TestCase.setUpPortalInstanceNoSelenium();
+
+		task ("Given Student object with name field created and published") {
+			var studentObjectDefinitionId = ObjectDefinitionAPI.createAndPublishObjectDefinition(
+				en_US_label = "student",
+				en_US_plural_label = "students",
+				name = "Student",
+				requiredStringFieldName = "name");
+		}
+
+		task ("And Given Subject object with name field created and published") {
+			var subjectObjectDefinitionId = ObjectDefinitionAPI.createAndPublishObjectDefinition(
+				en_US_label = "subject",
+				en_US_plural_label = "subjects",
+				name = "Subject",
+				requiredStringFieldName = "name");
+		}
+
+		task ("And Given a many-to-many studentsSubjects relationship created between Student and Subject") {
+			var objectDefinitionId1 = ObjectDefinitionAPI.getObjectDefinitionIdByName(name = "User");
+
+			ObjectDefinitionAPI.createRelationship(
+				deletionType = "cascade",
+				en_US_label = "studentsSubjects",
+				name = "studentsSubjects",
+				objectDefinitionId1 = ${studentObjectDefinitionId},
+				objectDefinitionId2 = ${subjectObjectDefinitionId},
+				type = "manyToMany");
+		}
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		ObjectAdmin.deleteAllCustomObjectsViaAPI();
+
+		if (${testPortalInstance} == "true") {
+			PortalInstances.tearDownCPNoSelenium();
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 4
+	test CanCreateCustomObjectsEntriesWithPostChildObjectInManyToManyRelationship {
+		property portal.acceptance = "true";
+
+		task ("When creating a Subject entry with postSubject including studentsSubjects with Student entries information") {
+			ObjectDefinitionAPI.createObjectEntryWithField(
+				en_US_plural_label = "subjects",
+				fieldName = "name",
+				fieldValue = "Math",
+				nestedField = "studentsSubjects",
+				numberOfRelatedObjectEntries = 2,
+				relatedEntryFieldName = "name");
+		}
+
+		task ("Then both Subject and Student entries are created") {
+			CustomObjectAPI.assertCorrectObjectEntryCount(
+				en_US_plural_label = "students",
+				expectedCount = 2);
+
+			CustomObjectAPI.assertCorrectObjectEntryCount(
+				en_US_plural_label = "subjects",
+				expectedCount = 1);
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 4
+	test CanCreateCustomObjectsEntriesWithPostParentObjectInManyToManyRelationship {
+		property portal.acceptance = "true";
+
+		task ("When creating a Student entry with postStudent including studentsSubjects with Subject entries information") {
+			ObjectDefinitionAPI.createObjectEntryWithField(
+				en_US_plural_label = "students",
+				fieldName = "name",
+				fieldValue = "Able",
+				nestedField = "studentsSubjects",
+				numberOfRelatedObjectEntries = 2,
+				relatedEntryFieldName = "name");
+		}
+
+		task ("Then both Student and Subject entries are created") {
+			CustomObjectAPI.assertCorrectObjectEntryCount(
+				en_US_plural_label = "students",
+				expectedCount = 1);
+
+			CustomObjectAPI.assertCorrectObjectEntryCount(
+				en_US_plural_label = "subjects",
+				expectedCount = 2);
+		}
+	}
+
+	@description = "Ignore tests unitl LPS-169348 fixed"
+	@disable-webdriver = "true"
+	@ignore = "true"
+	@priority = 4
+	test CannotCreateCustomObjectsEntriesWithInvliadObjectFieldInNestedFieldInManyToManyRelationship {
+		property portal.acceptance = "true";
+
+		task ("When creating a Student entry with postStudent including studentsSubjects with nonexistent field in Subject entries") {
+			ObjectDefinitionAPI.createObjectEntryWithField(
+				en_US_plural_label = "students",
+				externalReferenceCode = "studentErc",
+				fieldName = "name",
+				fieldValue = "Able",
+				nestedField = "studentsSubjects",
+				numberOfRelatedObjectEntries = 1,
+				relatedEntryExternalReferenceCode = "subjectErc",
+				relatedEntryFieldName = "nonexistentField");
+		}
+
+		task ("Then no Student and Subject entries are created") {
+			CustomObjectAPI.assertCorrectObjectEntryCount(
+				en_US_plural_label = "students",
+				expectedCount = 0);
+
+			CustomObjectAPI.assertCorrectObjectEntryCount(
+				en_US_plural_label = "subjects",
+				expectedCount = 0);
+		}
+	}
+
+	@description = "Ignore tests unitl LPS-169348 fixed"
+	@disable-webdriver = "true"
+	@ignore = "true"
+	@priority = 3
+	test CannotCreateCustomObjectsEntriesWithNonexistentNestedFieldInManyToManyRelationships {
+		property portal.acceptance = "true";
+
+		task ("When creating a Student entry with postStudent including nonexistent nestedField with Subject entries information") {
+			ObjectDefinitionAPI.createObjectEntryWithField(
+				en_US_plural_label = "subjects",
+				externalReferenceCode = "subjectErc",
+				fieldName = "name",
+				fieldValue = "Math",
+				nestedField = "nonexistentNestedField",
+				numberOfRelatedObjectEntries = 1,
+				relatedEntryExternalReferenceCode = "studentErc",
+				relatedEntryFieldName = "name");
+		}
+
+		task ("Then no Student and Subject entries are created") {
+			CustomObjectAPI.assertCorrectObjectEntryCount(
+				en_US_plural_label = "students",
+				expectedCount = 0);
+
+			CustomObjectAPI.assertCorrectObjectEntryCount(
+				en_US_plural_label = "subjects",
+				expectedCount = 0);
+		}
+	}
+
+}

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/OperateCustomObjectAndRelatedCustomObjectsWithinSingleRequest.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/OperateCustomObjectAndRelatedCustomObjectsWithinSingleRequest.testcase
@@ -223,12 +223,12 @@ definition {
 			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
 				element = "$.totalCount",
 				en_US_plural_label = "students",
-				expectedCount = 2);
+				expectedValues = 2);
 
 			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
 				element = "$.totalCount",
 				en_US_plural_label = "subjects",
-				expectedCount = 1);
+				expectedValues = 1);
 		}
 	}
 
@@ -238,7 +238,7 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("When creating a Student entry with postStudent including studentsSubjects with Subject entries information") {
-			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
+			CustomObjectAPI.createObjectEntryWithField(
 				en_US_plural_label = "students",
 				fieldName = "name",
 				fieldValue = "Able",
@@ -251,12 +251,12 @@ definition {
 			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
 				element = "$.totalCount",
 				en_US_plural_label = "students",
-				expectedCount = 1);
+				expectedValues = 1);
 
 			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
 				element = "$.totalCount",
 				en_US_plural_label = "subjects",
-				expectedCount = 2);
+				expectedValues = 2);
 		}
 	}
 
@@ -305,12 +305,12 @@ definition {
 			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
 				element = "$.totalCount",
 				en_US_plural_label = "students",
-				expectedCount = 0);
+				expectedValues = 0);
 
 			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
 				element = "$.totalCount",
 				en_US_plural_label = "subjects",
-				expectedCount = 0);
+				expectedValues = 0);
 		}
 	}
 
@@ -335,12 +335,12 @@ definition {
 			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
 				element = "$.totalCount",
 				en_US_plural_label = "students",
-				expectedCount = 0);
+				expectedValues = 0);
 
 			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
 				element = "$.totalCount",
 				en_US_plural_label = "subjects",
-				expectedCount = 0);
+				expectedValues = 0);
 		}
 	}
 

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/OperateCustomObjectAndRelatedCustomObjectsWithinSingleRequest.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/OperateCustomObjectAndRelatedCustomObjectsWithinSingleRequest.testcase
@@ -55,7 +55,7 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("When creating a Subject entry with postSubject including studentsSubjects with Student entries information") {
-			ObjectDefinitionAPI.createObjectEntryWithField(
+			CustomObjectAPI.createObjectEntryWithField(
 				en_US_plural_label = "subjects",
 				fieldName = "name",
 				fieldValue = "Math",
@@ -81,7 +81,7 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("When creating a Student entry with postStudent including studentsSubjects with Subject entries information") {
-			ObjectDefinitionAPI.createObjectEntryWithField(
+			CustomObjectAPI.createObjectEntryWithField(
 				en_US_plural_label = "students",
 				fieldName = "name",
 				fieldValue = "Able",
@@ -109,14 +109,12 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("When creating a Student entry with postStudent including studentsSubjects with nonexistent field in Subject entries") {
-			ObjectDefinitionAPI.createObjectEntryWithField(
+			CustomObjectAPI.createObjectEntryWithField(
 				en_US_plural_label = "students",
-				externalReferenceCode = "studentErc",
 				fieldName = "name",
 				fieldValue = "Able",
 				nestedField = "studentsSubjects",
 				numberOfRelatedObjectEntries = 1,
-				relatedEntryExternalReferenceCode = "subjectErc",
 				relatedEntryFieldName = "nonexistentField");
 		}
 
@@ -139,14 +137,12 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("When creating a Student entry with postStudent including nonexistent nestedField with Subject entries information") {
-			ObjectDefinitionAPI.createObjectEntryWithField(
+			CustomObjectAPI.createObjectEntryWithField(
 				en_US_plural_label = "subjects",
-				externalReferenceCode = "subjectErc",
 				fieldName = "name",
 				fieldValue = "Math",
 				nestedField = "nonexistentNestedField",
 				numberOfRelatedObjectEntries = 1,
-				relatedEntryExternalReferenceCode = "studentErc",
 				relatedEntryFieldName = "name");
 		}
 
@@ -158,6 +154,57 @@ definition {
 			CustomObjectAPI.assertCorrectObjectEntryCount(
 				en_US_plural_label = "subjects",
 				expectedCount = 0);
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 4
+	test CanUpdateCustomObjectEntriesWithPutParentObjectInManyToManyRelationship {
+		property portal.acceptance = "true";
+
+		task ("And Given Student and Subject entries with custom ERCs are created with postStudent including studentsSubjects with Subject entries information") {
+			var response = CustomObjectAPI.createObjectEntryWithField(
+				en_US_plural_label = "students",
+				externalReferenceCode = "studentErc",
+				fieldName = "name",
+				fieldValue = "Able",
+				nestedField = "studentsSubjects",
+				numberOfRelatedObjectEntries = 2,
+				relatedEntryExternalReferenceCode = "subjectErc",
+				relatedEntryFieldName = "name");
+		}
+
+		task ("When with putStudent and studentId including studentsSubjects with modified names of Subject entries and their ERCs to update Student entry") {
+			var studentId = JSONPathUtil.getIdValue(response = ${response});
+
+			CustomObjectAPI.updateObjectEntry(
+				en_US_plural_label = "students",
+				externalReferenceCode = "studentErc",
+				fieldName = "name",
+				fieldValue = "Bob",
+				nestedField = "studentsSubjects",
+				numberOfRelatedObjectEntries = 2,
+				objectEntryId = ${studentId},
+				relatedEntryExternalReferenceCode = "subjectErc",
+				relatedEntryFieldName = "name");
+		}
+
+		task ("Then both Student and Subject entries are updated") {
+			var response = ObjectDefinitionAPI.getObjectEntries(en_US_plural_label = "students");
+
+			var studentName = JSONUtil.getWithJSONPath(${response}, "$.items[*].name");
+
+			TestUtils.assertEquals(
+				actual = ${studentName},
+				expected = "Bob");
+
+			var response = ObjectDefinitionAPI.getObjectEntries(en_US_plural_label = "subjects");
+
+			var subjectNames = JSONUtil.getWithJSONPath(${response}, "$.items[*].name");
+
+			TestUtils.assertEquals(
+				actual = ${subjectNames},
+				expected = "name0-update,name1-update");
 		}
 	}
 

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/ScopeObjectAPIsForDifferentInstances.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/ScopeObjectAPIsForDifferentInstances.testcase
@@ -141,7 +141,7 @@ definition {
 				resourceCheckList = "C_Test.everything",
 				resourcePanels = "C_Test");
 
-			ObjectDefinitionAPI.createObjectEntryWithField(
+			CustomObjectAPI.createObjectEntryWithField(
 				en_US_plural_label = "tests",
 				fieldName = "location",
 				fieldValue = "Object Entry in Virtual Instance",

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/ScopeObjectAPIsForDifferentInstances.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/ScopeObjectAPIsForDifferentInstances.testcase
@@ -141,7 +141,7 @@ definition {
 				resourceCheckList = "C_Test.everything",
 				resourcePanels = "C_Test");
 
-			CustomObjectAPI.createObjectEntryWithField(
+			CustomObjectAPI.createObjectEntryWithFields(
 				en_US_plural_label = "tests",
 				fieldName = "location",
 				fieldValue = "Object Entry in Virtual Instance",


### PR DESCRIPTION
Background:
- Add automation tests for story LPS-155809 As a developer I can operate a custom object entry and its related custom objects in a single request

Test Plan:
- requirements
feature.flag.[LPS-153117](https://issues.liferay.com/browse/LPS-153117)=true
Given Student object with name field created and published
And Given Subject object with name field created and published
And Given a many-to-many studentsSubjects relationship created between Student and Subject
And Given a many-to-many studentsStudents relationship created between Student and itself
- When creating a Student entry with postStudent including studentsSubjects with Subject entries information
Then both Student and Subject entries are created
- When creating a Subject entry with postSubject including studentsSubjects with Student entries information
Then both Subject and Student entries are created
- When creating a Student entry with postStudent including nonexistent nestedField with Subject entries information
Then no Student and Subject entries are created
- When creating a Student entry with postStudent including studentsSubjects with nonexistent field in Subject entries
Then no Student and Subject entries are created
- And Given Student and Subject entries with custom ERCs are created with postStudent including studentsSubjects with Subject entries information
When with putStudent and studentId including studentsSubjects with modified names of Subject entries and their ERCs to update Student entry
Then both Student and Subject entries are updated
- And Given Student and Subject entries are created with postStudent including studentsSubjects with Subject entries information
When with putStudent and studentId including studentsSubjects with new Subject entries information to update Student entry
Then Student entry is updated
And Then new Subject entries are created
- And Given Subject and Student entries with custom ERCs are created with postSubject including studentsSubjects with Student entries information
When with putSubject and subjectId including studentsSubjects with modified names of Student entries and their ERCs to update Subject entry
Then both Student and Subject entries are updated
- And Given Subject and Student entries are created with postSubject including studentsSubjects with Student entries information
When with putSubject and subjectId including studentsSubjects with new Student entries information to update Subject entry
Then Subject entry is updated
And Then new Student entries are created
- When creating a Student entry with postStudent including studentsStudents with another two Student entries information
Then three Student entries are created
- And Given two Student entries with custom ERCs are created with postStudent including studentsStudents with another Student entry information
When with putStudent and studentId including studentsStudents with modified Student name and its erc to update Student entry
Then both Students entries are updated
- And Given two Student entries are created with postStudent including studentsStudents with another Student entry information
When with putStudent and studentId including studentsStudents with new Student entry information to update Student entry
Then the original Student entry is updated
And Then one more Student entry is created

Jira Ticket:
- https://issues.liferay.com/browse/LPS-178636