### PR TITLE
LPS-180045 Avoid including the Export Batch JavaMethodSignature to the list of JavaMethodSignature

### DIFF
--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
@@ -30,6 +30,7 @@ import com.liferay.portal.tools.rest.builder.internal.freemarker.tool.java.parse
 import com.liferay.portal.tools.rest.builder.internal.freemarker.tool.java.parser.ResourceOpenAPIParser;
 import com.liferay.portal.tools.rest.builder.internal.freemarker.tool.java.parser.ResourceTestCaseOpenAPIParser;
 import com.liferay.portal.tools.rest.builder.internal.freemarker.tool.java.parser.util.OpenAPIParserUtil;
+import com.liferay.portal.tools.rest.builder.internal.freemarker.util.ConfigUtil;
 import com.liferay.portal.tools.rest.builder.internal.yaml.config.Application;
 import com.liferay.portal.tools.rest.builder.internal.yaml.config.ConfigYAML;
 import com.liferay.portal.tools.rest.builder.internal.yaml.openapi.Components;
@@ -1052,11 +1053,7 @@ public class FreeMarkerTool {
 	}
 
 	public boolean isVersionCompatible(ConfigYAML configYAML, int version) {
-		if (configYAML.getCompatibilityVersion() >= version) {
-			return true;
-		}
-
-		return false;
+		return ConfigUtil.isVersionCompatible(configYAML, version);
 	}
 
 	private static DateFormat _getDateFormat(String pattern) {

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
@@ -28,6 +28,7 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.tools.rest.builder.internal.freemarker.tool.java.JavaMethodParameter;
 import com.liferay.portal.tools.rest.builder.internal.freemarker.tool.java.JavaMethodSignature;
 import com.liferay.portal.tools.rest.builder.internal.freemarker.tool.java.parser.util.OpenAPIParserUtil;
+import com.liferay.portal.tools.rest.builder.internal.freemarker.util.ConfigUtil;
 import com.liferay.portal.tools.rest.builder.internal.freemarker.util.OpenAPIUtil;
 import com.liferay.portal.tools.rest.builder.internal.yaml.config.ConfigYAML;
 import com.liferay.portal.tools.rest.builder.internal.yaml.openapi.Content;
@@ -119,7 +120,8 @@ public class ResourceOpenAPIParser {
 
 							if (configYAML.isGenerateBatch()) {
 								_addBatchJavaMethodSignature(
-									javaMethodSignature, javaMethodSignatures);
+									configYAML, javaMethodSignature,
+									javaMethodSignatures);
 							}
 						});
 				});
@@ -366,7 +368,7 @@ public class ResourceOpenAPIParser {
 	}
 
 	private static void _addBatchJavaMethodSignature(
-		JavaMethodSignature javaMethodSignature,
+		ConfigYAML configYAML, JavaMethodSignature javaMethodSignature,
 		List<JavaMethodSignature> javaMethodSignatures) {
 
 		BatchOperationType batchOperationType = null;
@@ -376,7 +378,8 @@ public class ResourceOpenAPIParser {
 			javaMethodSignature.getParentSchemaName());
 		String schemaName = javaMethodSignature.getSchemaName();
 
-		if (methodName.equals(
+		if (ConfigUtil.isVersionCompatible(configYAML, 2) &&
+			methodName.equals(
 				StringBundler.concat(
 					"get", parentSchemaName, schemaName, "sPage"))) {
 

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/util/ConfigUtil.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/util/ConfigUtil.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.tools.rest.builder.internal.freemarker.util;
+
+import com.liferay.portal.tools.rest.builder.internal.yaml.config.ConfigYAML;
+
+/**
+ * @author Carlos Correa
+ */
+public class ConfigUtil {
+
+	public static boolean isVersionCompatible(
+		ConfigYAML configYAML, int version) {
+
+		if (configYAML.getCompatibilityVersion() >= version) {
+			return true;
+		}
+
+		return false;
+	}
+
+}

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -144,10 +144,6 @@ public abstract class Base${schemaName}ResourceImpl
 					<#assign postBatchJavaMethodSignature = javaMethodSignature />
 				</#if>
 			</#if>
-		<#elseif stringUtil.equals(javaMethodSignature.methodName, "post" + parentSchemaName + schemaName + "sPageExportBatch")>
-			<#if !freeMarkerTool.isVersionCompatible(configYAML, 2)>
-				<#continue>
-			</#if>
 		<#elseif stringUtil.equals(javaMethodSignature.methodName, "put" + schemaName)>
 			<#assign putBatchJavaMethodSignature = javaMethodSignature />
 		<#elseif stringUtil.equals(javaMethodSignature.methodName, "putByExternalReferenceCode") || stringUtil.equals(javaMethodSignature.methodName, "put" + parentSchemaName + schemaName + "ByExternalReferenceCode")>


### PR DESCRIPTION
As the list of JavaMethodSignature is being used from several .ftl templates, to avoid validating in all of them the compatibilityVersion parameter, the /export-batch java method parameter is not included anymore in the list if the compatibilityVersion is lower than 2