### PR TITLE
LPS-179275 Update the extension of the Export File Format JSONT from .jsont to .batch-engine-data.json

### DIFF
--- a/modules/apps/batch-engine/batch-engine-api/bnd.bnd
+++ b/modules/apps/batch-engine/batch-engine-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Batch Engine API
 Bundle-SymbolicName: com.liferay.batch.engine.api
-Bundle-Version: 20.0.1
+Bundle-Version: 20.1.0
 Export-Package:\
 	com.liferay.batch.engine,\
 	com.liferay.batch.engine.configuration,\

--- a/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/BatchEngineTaskContentType.java
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/BatchEngineTaskContentType.java
@@ -19,6 +19,17 @@ package com.liferay.batch.engine;
  */
 public enum BatchEngineTaskContentType {
 
-	CSV, JSON, JSONL, JSONT, XLS, XLSX
+	CSV("csv"), JSON("json"), JSONL("jsonl"), JSONT("batch-engine-data.json"),
+	XLS("xls"), XLSX("xlsx");
+
+	public String getFileExtension() {
+		return _fileExtension;
+	}
+
+	private BatchEngineTaskContentType(String fileExtension) {
+		_fileExtension = fileExtension;
+	}
+
+	private final String _fileExtension;
 
 }

--- a/modules/apps/batch-engine/batch-engine-api/src/main/resources/com/liferay/batch/engine/packageinfo
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/resources/com/liferay/batch/engine/packageinfo
@@ -1,1 +1,1 @@
-version 5.3.0
+version 5.4.0

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineExportTaskExecutorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineExportTaskExecutorImpl.java
@@ -40,7 +40,6 @@ import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
@@ -249,16 +248,6 @@ public class BatchEngineExportTaskExecutorImpl
 		return batchEngineTaskCompanyConfiguration.exportBatchSize();
 	}
 
-	private String _getExportFileExtension(
-		BatchEngineTaskContentType batchEngineTaskContentType) {
-
-		if (batchEngineTaskContentType == BatchEngineTaskContentType.JSONT) {
-			return "batch-engine-data.json";
-		}
-
-		return StringUtil.toLowerCase(batchEngineTaskContentType.name());
-	}
-
 	private ZipOutputStream _getZipOutputStream(
 			BatchEngineTaskContentType batchEngineTaskContentType,
 			UnsyncByteArrayOutputStream unsyncByteArrayOutputStream)
@@ -268,7 +257,7 @@ public class BatchEngineExportTaskExecutorImpl
 			unsyncByteArrayOutputStream);
 
 		ZipEntry zipEntry = new ZipEntry(
-			"export." + _getExportFileExtension(batchEngineTaskContentType));
+			"export." + batchEngineTaskContentType.getFileExtension());
 
 		zipOutputStream.putNextEntry(zipEntry);
 

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineExportTaskExecutorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineExportTaskExecutorImpl.java
@@ -45,9 +45,6 @@ import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 
-import java.io.IOException;
-import java.io.OutputStream;
-
 import java.util.Collection;
 import java.util.Date;
 import java.util.Map;
@@ -143,12 +140,9 @@ public class BatchEngineExportTaskExecutorImpl
 						batchEngineExportTask.getParameters(),
 						_userLocalService.getUser(
 							batchEngineExportTask.getUserId()));
-			ZipOutputStream zipOutputStream = _getZipOutputStream(
-				batchEngineExportTask.getContentType(),
-				unsyncByteArrayOutputStream);
 			BatchEngineExportTaskItemWriter batchEngineExportTaskItemWriter =
 				_getBatchEngineExportTaskItemWriter(
-					batchEngineExportTask, zipOutputStream)) {
+					batchEngineExportTask, unsyncByteArrayOutputStream)) {
 
 			int exportBatchSize = _getExportBatchSize(
 				batchEngineExportTask.getCompanyId());
@@ -199,8 +193,12 @@ public class BatchEngineExportTaskExecutorImpl
 
 	private BatchEngineExportTaskItemWriter _getBatchEngineExportTaskItemWriter(
 			BatchEngineExportTask batchEngineExportTask,
-			OutputStream outputStream)
+			UnsyncByteArrayOutputStream unsyncByteArrayOutputStream)
 		throws Exception {
+
+		BatchEngineTaskContentType batchEngineTaskContentType =
+			BatchEngineTaskContentType.valueOf(
+				batchEngineExportTask.getContentType());
 
 		BatchEngineExportTaskItemWriterBuilder
 			batchEngineExportTaskItemWriterBuilder =
@@ -208,8 +206,7 @@ public class BatchEngineExportTaskExecutorImpl
 
 		return batchEngineExportTaskItemWriterBuilder.
 			batchEngineTaskContentType(
-				BatchEngineTaskContentType.valueOf(
-					batchEngineExportTask.getContentType())
+				batchEngineTaskContentType
 			).companyId(
 				batchEngineExportTask.getCompanyId()
 			).csvFileColumnDelimiter(
@@ -223,7 +220,8 @@ public class BatchEngineExportTaskExecutorImpl
 				_batchEngineTaskMethodRegistry.getItemClass(
 					batchEngineExportTask.getClassName())
 			).outputStream(
-				outputStream
+				_getZipOutputStream(
+					batchEngineTaskContentType, unsyncByteArrayOutputStream)
 			).parameters(
 				batchEngineExportTask.getParameters()
 			).userId(
@@ -251,16 +249,26 @@ public class BatchEngineExportTaskExecutorImpl
 		return batchEngineTaskCompanyConfiguration.exportBatchSize();
 	}
 
+	private String _getExportFileExtension(
+		BatchEngineTaskContentType batchEngineTaskContentType) {
+
+		if (batchEngineTaskContentType == BatchEngineTaskContentType.JSONT) {
+			return "batch-engine-data.json";
+		}
+
+		return StringUtil.toLowerCase(batchEngineTaskContentType.name());
+	}
+
 	private ZipOutputStream _getZipOutputStream(
-			String contentType,
+			BatchEngineTaskContentType batchEngineTaskContentType,
 			UnsyncByteArrayOutputStream unsyncByteArrayOutputStream)
-		throws IOException {
+		throws Exception {
 
 		ZipOutputStream zipOutputStream = new ZipOutputStream(
 			unsyncByteArrayOutputStream);
 
 		ZipEntry zipEntry = new ZipEntry(
-			"export." + StringUtil.toLowerCase(contentType));
+			"export." + _getExportFileExtension(batchEngineTaskContentType));
 
 		zipOutputStream.putNextEntry(zipEntry);
 


### PR DESCRIPTION
Related issue: https://issues.liferay.com/browse/LPS-179275

---

This PR contains the code to update the extension of the exported file for JSONT format from `.jsont` to `.batch-engine-data.json`.

For that, the file extension has been included in the `BatchEngineTaskContentType`