### PR TITLE
LPS-179564 Pagination total count is wrong in relationship endpoints

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -598,7 +598,12 @@ public class DefaultObjectEntryManagerImpl
 					objectRelationship.getObjectRelationshipId(),
 					serviceBuilderObjectEntry.getPrimaryKey(),
 					pagination.getStartPosition(),
-					pagination.getEndPosition())));
+					pagination.getEndPosition())),
+			pagination,
+			objectRelatedModelsProvider.getRelatedModelsCount(
+				serviceBuilderObjectEntry.getGroupId(),
+				objectRelationship.getObjectRelationshipId(),
+				serviceBuilderObjectEntry.getPrimaryKey()));
 	}
 
 	@Override
@@ -637,7 +642,12 @@ public class DefaultObjectEntryManagerImpl
 					baseModel, serviceBuilderObjectEntry,
 					_systemObjectDefinitionMetadataRegistry.
 						getSystemObjectDefinitionMetadata(
-							relatedObjectDefinition.getName()))));
+							relatedObjectDefinition.getName()))),
+			pagination,
+			objectRelatedModelsProvider.getRelatedModelsCount(
+				serviceBuilderObjectEntry.getGroupId(),
+				objectRelationship.getObjectRelationshipId(),
+				serviceBuilderObjectEntry.getPrimaryKey()));
 	}
 
 	@Override
@@ -963,7 +973,11 @@ public class DefaultObjectEntryManagerImpl
 				objectRelatedModelsProvider.getRelatedModels(
 					groupId, objectRelationship.getObjectRelationshipId(),
 					objectEntryId, pagination.getStartPosition(),
-					pagination.getEndPosition())));
+					pagination.getEndPosition())),
+			pagination,
+			objectRelatedModelsProvider.getRelatedModelsCount(
+				groupId, objectRelationship.getObjectRelationshipId(),
+				objectEntryId));
 	}
 
 	private boolean _hasRelatedObjectEntries(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -397,13 +397,8 @@ public class DefaultObjectEntryManagerImpl
 
 		long groupId = getGroupId(objectDefinition, scopeKey);
 
-		int start = QueryUtil.ALL_POS;
-		int end = QueryUtil.ALL_POS;
-
-		if (pagination != null) {
-			start = pagination.getStartPosition();
-			end = pagination.getEndPosition();
-		}
+		int start = _getStartPosition(pagination);
+		int end = _getEndPosition(pagination);
 
 		List<Facet> facets = new ArrayList<>();
 
@@ -597,8 +592,8 @@ public class DefaultObjectEntryManagerImpl
 					serviceBuilderObjectEntry.getGroupId(),
 					objectRelationship.getObjectRelationshipId(),
 					serviceBuilderObjectEntry.getPrimaryKey(),
-					pagination.getStartPosition(),
-					pagination.getEndPosition())),
+					_getStartPosition(pagination),
+					_getEndPosition(pagination))),
 			pagination,
 			objectRelatedModelsProvider.getRelatedModelsCount(
 				serviceBuilderObjectEntry.getGroupId(),
@@ -636,8 +631,8 @@ public class DefaultObjectEntryManagerImpl
 						serviceBuilderObjectEntry.getGroupId(),
 						objectRelationship.getObjectRelationshipId(),
 						serviceBuilderObjectEntry.getPrimaryKey(),
-						pagination.getStartPosition(),
-						pagination.getEndPosition()),
+						_getStartPosition(pagination),
+						_getEndPosition(pagination)),
 				baseModel -> _toDTO(
 					baseModel, serviceBuilderObjectEntry,
 					_systemObjectDefinitionMetadataRegistry.
@@ -857,6 +852,14 @@ public class DefaultObjectEntryManagerImpl
 			dtoConverterContext.getUserId());
 	}
 
+	private int _getEndPosition(Pagination pagination) {
+		if (pagination != null) {
+			return pagination.getEndPosition();
+		}
+
+		return QueryUtil.ALL_POS;
+	}
+
 	private String _getObjectEntriesPermissionName(long objectDefinitionId) {
 		return ObjectConstants.RESOURCE_NAME + "#" + objectDefinitionId;
 	}
@@ -935,6 +938,14 @@ public class DefaultObjectEntryManagerImpl
 		return relatedObjectDefinition;
 	}
 
+	private int _getStartPosition(Pagination pagination) {
+		if (pagination != null) {
+			return pagination.getStartPosition();
+		}
+
+		return QueryUtil.ALL_POS;
+	}
+
 	private Page<ObjectEntry> _getSystemObjectRelatedObjectEntries(
 			DTOConverterContext dtoConverterContext,
 			ObjectDefinition objectDefinition, long objectEntryId,
@@ -972,8 +983,8 @@ public class DefaultObjectEntryManagerImpl
 				dtoConverterContext,
 				objectRelatedModelsProvider.getRelatedModels(
 					groupId, objectRelationship.getObjectRelationshipId(),
-					objectEntryId, pagination.getStartPosition(),
-					pagination.getEndPosition())),
+					objectEntryId, _getStartPosition(pagination),
+					_getEndPosition(pagination))),
 			pagination,
 			objectRelatedModelsProvider.getRelatedModelsCount(
 				groupId, objectRelationship.getObjectRelationshipId(),

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryRelatedObjectsResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryRelatedObjectsResourceImpl.java
@@ -135,7 +135,8 @@ public class ObjectEntryRelatedObjectsResourceImpl
 			transform(
 				page.getItems(),
 				objectEntry -> _getRelatedObjectEntry(
-					relatedObjectDefinition, objectEntry)));
+					relatedObjectDefinition, objectEntry)),
+			pagination, page.getTotalCount());
 	}
 
 	@Override

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
@@ -664,6 +664,16 @@ public class ObjectEntryRelatedObjectsResourceTest {
 		Assert.assertEquals(1, jsonObject.getLong("page"));
 		Assert.assertEquals(1, jsonObject.getLong("pageSize"));
 		Assert.assertEquals(2, jsonObject.getLong("totalCount"));
+
+		jsonObject = JSONFactoryUtil.createJSONObject(
+			_invoke(
+				Http.Method.GET,
+				_getLocation(objectRelationship.getName()) +
+					"?page=0&pageSize=0"));
+
+		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
+
+		Assert.assertEquals(2, itemsJSONArray.length());
 	}
 
 	private Http.Options _createOptions(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
@@ -40,6 +40,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.Http;
@@ -98,7 +99,11 @@ public class ObjectEntryRelatedObjectsResourceTest {
 		_objectEntry2 = ObjectEntryTestUtil.addObjectEntry(
 			_objectDefinition2, _OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2);
 
-		_user = TestPropsValues.getUser();
+		_objectEntry3 = ObjectEntryTestUtil.addObjectEntry(
+			_objectDefinition2, _OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2);
+
+		_user1 = TestPropsValues.getUser();
+		_user2 = UserTestUtil.addUser(TestPropsValues.getGroupId());
 
 		_userSystemObjectDefinitionMetadata =
 			_systemObjectDefinitionMetadataRegistry.
@@ -313,6 +318,47 @@ public class ObjectEntryRelatedObjectsResourceTest {
 	}
 
 	@Test
+	public void testGetRelatedCustomObjectsWithPagination() throws Exception {
+
+		// Many to many relationships
+
+		ObjectRelationship objectRelationship = _addObjectRelationship(
+			_objectDefinition1, _objectDefinition2,
+			_objectEntry1.getPrimaryKey(), _objectEntry2.getPrimaryKey(),
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		ObjectRelationshipTestUtil.relateObjectEntries(
+			_objectEntry1.getPrimaryKey(), _objectEntry3.getPrimaryKey(),
+			objectRelationship, TestPropsValues.getUserId());
+
+		_assertPagination(_objectEntry2, objectRelationship);
+
+		objectRelationship = _addObjectRelationship(
+			_objectDefinition2, _objectDefinition1,
+			_objectEntry2.getPrimaryKey(), _objectEntry1.getPrimaryKey(),
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		ObjectRelationshipTestUtil.relateObjectEntries(
+			_objectEntry3.getPrimaryKey(), _objectEntry1.getPrimaryKey(),
+			objectRelationship, TestPropsValues.getUserId());
+
+		_assertPagination(_objectEntry2, objectRelationship);
+
+		// One to many relationship
+
+		objectRelationship = _addObjectRelationship(
+			_objectDefinition1, _objectDefinition2,
+			_objectEntry1.getPrimaryKey(), _objectEntry2.getPrimaryKey(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		ObjectRelationshipTestUtil.relateObjectEntries(
+			_objectEntry1.getPrimaryKey(), _objectEntry3.getPrimaryKey(),
+			objectRelationship, TestPropsValues.getUserId());
+
+		_assertPagination(_objectEntry2, objectRelationship);
+	}
+
+	@Test
 	public void testGetRelatedObjectsWhenRelationDoesNotExist()
 		throws Exception {
 
@@ -337,17 +383,17 @@ public class ObjectEntryRelatedObjectsResourceTest {
 
 		ObjectRelationship objectRelationship = _addObjectRelationship(
 			_objectDefinition1, relatedObjectDefinition,
-			_objectEntry1.getPrimaryKey(), _user.getUserId(),
+			_objectEntry1.getPrimaryKey(), _user1.getUserId(),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
 		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
 			_invoke(
 				Http.Method.GET, _getLocation(objectRelationship.getName())));
 
-		_assertEquals(_user, jsonObject.getJSONArray("items"));
+		_assertEquals(_user1, jsonObject.getJSONArray("items"));
 
 		objectRelationship = _addObjectRelationship(
-			relatedObjectDefinition, _objectDefinition1, _user.getUserId(),
+			relatedObjectDefinition, _objectDefinition1, _user1.getUserId(),
 			_objectEntry1.getPrimaryKey(),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
@@ -355,20 +401,68 @@ public class ObjectEntryRelatedObjectsResourceTest {
 			_invoke(
 				Http.Method.GET, _getLocation(objectRelationship.getName())));
 
-		_assertEquals(_user, jsonObject.getJSONArray("items"));
+		_assertEquals(_user1, jsonObject.getJSONArray("items"));
 
 		// One to many relationship
 
 		objectRelationship = _addObjectRelationship(
 			_objectDefinition1, relatedObjectDefinition,
-			_objectEntry1.getPrimaryKey(), _user.getUserId(),
+			_objectEntry1.getPrimaryKey(), _user1.getUserId(),
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		jsonObject = JSONFactoryUtil.createJSONObject(
 			_invoke(
 				Http.Method.GET, _getLocation(objectRelationship.getName())));
 
-		_assertEquals(_user, jsonObject.getJSONArray("items"));
+		_assertEquals(_user1, jsonObject.getJSONArray("items"));
+	}
+
+	@Test
+	public void testGetRelatedSystemObjectsWithPagination() throws Exception {
+		_userSystemObjectDefinitionMetadata =
+			_systemObjectDefinitionMetadataRegistry.
+				getSystemObjectDefinitionMetadata("User");
+
+		ObjectDefinition relatedObjectDefinition =
+			_objectDefinitionLocalService.fetchSystemObjectDefinition(
+				_userSystemObjectDefinitionMetadata.getName());
+
+		// Many to many relationships
+
+		ObjectRelationship objectRelationship = _addObjectRelationship(
+			_objectDefinition1, relatedObjectDefinition,
+			_objectEntry1.getPrimaryKey(), _user1.getUserId(),
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		ObjectRelationshipTestUtil.relateObjectEntries(
+			_objectEntry1.getPrimaryKey(), _user2.getUserId(),
+			objectRelationship, TestPropsValues.getUserId());
+
+		_assertPagination(_user1, objectRelationship);
+
+		objectRelationship = _addObjectRelationship(
+			relatedObjectDefinition, _objectDefinition1, _user1.getUserId(),
+			_objectEntry1.getPrimaryKey(),
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		ObjectRelationshipTestUtil.relateObjectEntries(
+			_user2.getUserId(), _objectEntry1.getPrimaryKey(),
+			objectRelationship, TestPropsValues.getUserId());
+
+		_assertPagination(_user1, objectRelationship);
+
+		// One to many relationship
+
+		objectRelationship = _addObjectRelationship(
+			_objectDefinition1, relatedObjectDefinition,
+			_objectEntry1.getPrimaryKey(), _user1.getUserId(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		ObjectRelationshipTestUtil.relateObjectEntries(
+			_objectEntry1.getPrimaryKey(), _user2.getUserId(),
+			objectRelationship, TestPropsValues.getUserId());
+
+		_assertPagination(_user1, objectRelationship);
 	}
 
 	@Test
@@ -462,12 +556,12 @@ public class ObjectEntryRelatedObjectsResourceTest {
 		Assert.assertEquals(0, jsonArray.length());
 
 		_assertEquals(
-			_user,
+			_user1,
 			JSONFactoryUtil.createJSONObject(
 				_invoke(
 					Http.Method.PUT,
 					_getLocation(
-						objectRelationship.getName(), _user.getUserId()))));
+						objectRelationship.getName(), _user1.getUserId()))));
 
 		jsonObject = JSONFactoryUtil.createJSONObject(
 			_invoke(
@@ -475,7 +569,7 @@ public class ObjectEntryRelatedObjectsResourceTest {
 
 		jsonArray = jsonObject.getJSONArray("items");
 
-		_assertEquals(_user, jsonArray);
+		_assertEquals(_user1, jsonArray);
 
 		// One to many relationship
 
@@ -492,12 +586,12 @@ public class ObjectEntryRelatedObjectsResourceTest {
 		Assert.assertEquals(0, jsonArray.length());
 
 		_assertEquals(
-			_user,
+			_user1,
 			JSONFactoryUtil.createJSONObject(
 				_invoke(
 					Http.Method.PUT,
 					_getLocation(
-						objectRelationship.getName(), _user.getUserId()))));
+						objectRelationship.getName(), _user1.getUserId()))));
 
 		jsonObject = JSONFactoryUtil.createJSONObject(
 			_invoke(
@@ -505,7 +599,7 @@ public class ObjectEntryRelatedObjectsResourceTest {
 
 		jsonArray = jsonObject.getJSONArray("items");
 
-		_assertEquals(_user, jsonArray);
+		_assertEquals(_user1, jsonArray);
 	}
 
 	private ObjectRelationship _addObjectRelationship(
@@ -552,6 +646,24 @@ public class ObjectEntryRelatedObjectsResourceTest {
 
 		Assert.assertEquals(
 			baseModel.getPrimaryKeyObj(), jsonObject.getLong("id"));
+	}
+
+	private void _assertPagination(
+			BaseModel<?> baseModel, ObjectRelationship objectRelationship)
+		throws Exception {
+
+		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
+			_invoke(
+				Http.Method.GET,
+				_getLocation(objectRelationship.getName()) +
+					"?page=1&pageSize=1"));
+
+		_assertEquals(baseModel, jsonObject.getJSONArray("items"));
+
+		Assert.assertEquals(2, jsonObject.getLong("lastPage"));
+		Assert.assertEquals(1, jsonObject.getLong("page"));
+		Assert.assertEquals(1, jsonObject.getLong("pageSize"));
+		Assert.assertEquals(2, jsonObject.getLong("totalCount"));
 	}
 
 	private Http.Options _createOptions(
@@ -649,7 +761,7 @@ public class ObjectEntryRelatedObjectsResourceTest {
 
 		ObjectRelationship objectRelationship = _addObjectRelationship(
 			_objectDefinition1, _userSystemObjectDefinition,
-			_objectEntry1.getPrimaryKey(), _user.getUserId(), type);
+			_objectEntry1.getPrimaryKey(), _user1.getUserId(), type);
 
 		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
 			_invoke(
@@ -665,7 +777,7 @@ public class ObjectEntryRelatedObjectsResourceTest {
 				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
 				_objectEntry1.getPrimaryKey(), StringPool.SLASH,
 				objectRelationship.getName(), StringPool.SLASH,
-				_user.getUserId()),
+				_user1.getUserId()),
 			Http.Method.DELETE);
 
 		jsonObject = JSONFactoryUtil.createJSONObject(
@@ -688,7 +800,7 @@ public class ObjectEntryRelatedObjectsResourceTest {
 
 		ObjectRelationship objectRelationship = _addObjectRelationship(
 			_objectDefinition1, _userSystemObjectDefinition,
-			_objectEntry1.getPrimaryKey(), _user.getUserId(), type);
+			_objectEntry1.getPrimaryKey(), _user1.getUserId(), type);
 
 		JSONObject jsonObject = HTTPTestUtil.invoke(
 			null,
@@ -696,7 +808,7 @@ public class ObjectEntryRelatedObjectsResourceTest {
 				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
 				irrelevantPrimaryKey, StringPool.SLASH,
 				objectRelationship.getName(), StringPool.SLASH,
-				_user.getUserId()),
+				_user1.getUserId()),
 			Http.Method.DELETE);
 
 		Assert.assertEquals("NOT_FOUND", jsonObject.getString("status"));
@@ -748,6 +860,9 @@ public class ObjectEntryRelatedObjectsResourceTest {
 	@DeleteAfterTestRun
 	private ObjectEntry _objectEntry2;
 
+	@DeleteAfterTestRun
+	private ObjectEntry _objectEntry3;
+
 	private ObjectRelationship _objectRelationship;
 
 	@Inject
@@ -760,7 +875,8 @@ public class ObjectEntryRelatedObjectsResourceTest {
 	private SystemObjectDefinitionMetadataRegistry
 		_systemObjectDefinitionMetadataRegistry;
 
-	private User _user;
+	private User _user1;
+	private User _user2;
 	private ObjectDefinition _userSystemObjectDefinition;
 	private SystemObjectDefinitionMetadata _userSystemObjectDefinitionMetadata;
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/RelatedObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/RelatedObjectEntryResourceTest.java
@@ -467,6 +467,41 @@ public class RelatedObjectEntryResourceTest {
 	}
 
 	@Test
+	public void testGetSystemObjectRelatedObjectsWithPagination()
+		throws Exception {
+
+		JaxRsApplicationDescriptor jaxRsApplicationDescriptor =
+			_userSystemObjectDefinitionMetadata.getJaxRsApplicationDescriptor();
+
+		_objectRelationship = _addObjectRelationship(
+			StringUtil.randomId(), _objectDefinition.getObjectDefinitionId(),
+			_userSystemObjectDefinition.getObjectDefinitionId(),
+			_objectEntry.getPrimaryKey(), _user.getUserId(),
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
+			_objectDefinition, _OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE);
+
+		_objectRelationshipLocalService.addObjectRelationshipMappingTableValues(
+			_user.getUserId(), _objectRelationship.getObjectRelationshipId(),
+			objectEntry.getPrimaryKey(), _user.getUserId(),
+			ServiceContextTestUtil.getServiceContext());
+
+		JSONObject jsonObject = HTTPTestUtil.invoke(
+			null,
+			StringBundler.concat(
+				jaxRsApplicationDescriptor.getRESTContextPath(),
+				StringPool.SLASH, _user.getUserId(), StringPool.SLASH,
+				_objectRelationship.getName(), "?page=1&pageSize=1"),
+			Http.Method.GET);
+
+		Assert.assertEquals(2, jsonObject.getLong("lastPage"));
+		Assert.assertEquals(1, jsonObject.getLong("page"));
+		Assert.assertEquals(1, jsonObject.getLong("pageSize"));
+		Assert.assertEquals(2, jsonObject.getLong("totalCount"));
+	}
+
+	@Test
 	public void testPutSystemObjectRelatedObjectEntry() throws Exception {
 		_objectRelationship = _addObjectRelationship(
 			StringUtil.randomId(), _objectDefinition.getObjectDefinitionId(),


### PR DESCRIPTION
Fixes [LPS-179564](https://issues.liferay.com/browse/LPS-179564). We're now including the total count in the page object from the relationship endpoints.

To test it run the automated tests.