### PR TITLE
LPS-173132 

### DIFF
--- a/modules/apps/object/object-api/bnd.bnd
+++ b/modules/apps/object/object-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object API
 Bundle-SymbolicName: com.liferay.object.api
-Bundle-Version: 60.0.1
+Bundle-Version: 60.1.0
 Export-Package:\
 	com.liferay.object.action.engine,\
 	com.liferay.object.action.executor,\

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/constants/ObjectRelationshipConstants.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/constants/ObjectRelationshipConstants.java
@@ -25,6 +25,12 @@ public class ObjectRelationshipConstants {
 
 	public static final String DELETION_TYPE_PREVENT = "prevent";
 
+	public static final String PK_OBJECT_FIELD_DB_COLUMN_NAME_1 =
+		"pkObjectFieldDBColumnName1";
+
+	public static final String PK_OBJECT_FIELD_DB_COLUMN_NAME_2 =
+		"pkObjectFieldDBColumnName2";
+
 	public static final String TYPE_MANY_TO_MANY = "manyToMany";
 
 	public static final String TYPE_ONE_TO_MANY = "oneToMany";

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/relationship/util/ObjectRelationshipUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/relationship/util/ObjectRelationshipUtil.java
@@ -14,6 +14,7 @@
 
 package com.liferay.object.relationship.util;
 
+import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.exception.NoSuchObjectRelationshipException;
 import com.liferay.object.exception.ObjectRelationshipReverseException;
 import com.liferay.object.model.ObjectDefinition;
@@ -64,17 +65,19 @@ public class ObjectRelationshipUtil {
 				objectDefinition2.getObjectDefinitionId()) {
 
 			return HashMapBuilder.put(
-				"pkObjectFieldDBColumnName1", pkObjectFieldDBColumnName1
+				ObjectRelationshipConstants.PK_OBJECT_FIELD_DB_COLUMN_NAME_1,
+				pkObjectFieldDBColumnName1
 			).put(
-				"pkObjectFieldDBColumnName2", pkObjectFieldDBColumnName2
+				ObjectRelationshipConstants.PK_OBJECT_FIELD_DB_COLUMN_NAME_2,
+				pkObjectFieldDBColumnName2
 			).build();
 		}
 
 		return HashMapBuilder.put(
-			"pkObjectFieldDBColumnName1",
+			ObjectRelationshipConstants.PK_OBJECT_FIELD_DB_COLUMN_NAME_1,
 			pkObjectFieldDBColumnName1.concat(reverse ? "2" : "1")
 		).put(
-			"pkObjectFieldDBColumnName2",
+			ObjectRelationshipConstants.PK_OBJECT_FIELD_DB_COLUMN_NAME_2,
 			pkObjectFieldDBColumnName2.concat(reverse ? "1" : "2")
 		).build();
 	}

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/constants/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/constants/packageinfo
@@ -1,1 +1,1 @@
-version 7.1.0
+version 7.2.0

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/BaseObjectEntryObjectRelatedModelsPredicateProviderImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/BaseObjectEntryObjectRelatedModelsPredicateProviderImpl.java
@@ -64,10 +64,9 @@ public abstract class BaseObjectEntryObjectRelatedModelsPredicateProviderImpl
 	}
 
 	protected <T extends BaseTable<T>> Column<?, ?> getPKObjectFieldColumn(
-		BaseTable<T> baseTable, ObjectDefinition objectDefinition) {
+		BaseTable<T> baseTable, String pkObjectFieldDBColumnName) {
 
-		return baseTable.getColumn(
-			objectDefinition.getPKObjectFieldDBColumnName());
+		return baseTable.getColumn(pkObjectFieldDBColumnName);
 	}
 
 	protected final ObjectDefinition objectDefinition;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntry1toMObjectRelatedModelsPredicateProviderImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntry1toMObjectRelatedModelsPredicateProviderImpl.java
@@ -60,7 +60,7 @@ public class ObjectEntry1toMObjectRelatedModelsPredicateProviderImpl
 		Column<?, ?> objectDefinition1PKObjectFieldColumn =
 			getPKObjectFieldColumn(
 				objectDefinition1DynamicObjectDefinitionTable,
-				objectDefinition1);
+				objectDefinition1.getPKObjectFieldDBColumnName());
 
 		ObjectDefinition objectDefinition2 = _getObjectDefinition2(
 			objectRelationship);
@@ -116,7 +116,7 @@ public class ObjectEntry1toMObjectRelatedModelsPredicateProviderImpl
 		Column<?, ?> objectDefinition2PKObjectFieldColumn =
 			getPKObjectFieldColumn(
 				objectDefinition2DynamicObjectDefinitionTable,
-				objectDefinition2);
+				objectDefinition2.getPKObjectFieldDBColumnName());
 		DynamicObjectDefinitionTable objectDefinition1ExtensionTable =
 			getExtensionDynamicObjectDefinitionTable(objectDefinition1);
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntryMtoMObjectRelatedModelsPredicateProviderImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntryMtoMObjectRelatedModelsPredicateProviderImpl.java
@@ -56,7 +56,7 @@ public class ObjectEntryMtoMObjectRelatedModelsPredicateProviderImpl
 		Column<?, ?> dynamicObjectDefinitionTableColumn =
 			getPKObjectFieldColumn(
 				getDynamicObjectDefinitionTable(objectDefinition),
-				objectDefinition);
+				objectDefinition.getPKObjectFieldDBColumnName());
 
 		ObjectDefinition relatedObjectDefinition =
 			ObjectDefinitionLocalServiceUtil.getObjectDefinition(
@@ -83,7 +83,8 @@ public class ObjectEntryMtoMObjectRelatedModelsPredicateProviderImpl
 				(Column<DynamicObjectRelationshipMappingTable, ?>)
 					getPKObjectFieldColumn(
 						dynamicObjectRelationshipMappingTable,
-						relatedObjectDefinition);
+						pkObjectFieldDBColumnNames.get(
+							"pkObjectFieldDBColumnName2"));
 
 		DynamicObjectDefinitionTable relatedDynamicObjectDefinitionTable =
 			getDynamicObjectDefinitionTable(relatedObjectDefinition);
@@ -93,7 +94,9 @@ public class ObjectEntryMtoMObjectRelatedModelsPredicateProviderImpl
 		return dynamicObjectDefinitionTableColumn.in(
 			DSLQueryFactoryUtil.select(
 				getPKObjectFieldColumn(
-					dynamicObjectRelationshipMappingTable, objectDefinition)
+					dynamicObjectRelationshipMappingTable,
+					pkObjectFieldDBColumnNames.get(
+						"pkObjectFieldDBColumnName1"))
 			).from(
 				dynamicObjectRelationshipMappingTable
 			).where(
@@ -101,7 +104,8 @@ public class ObjectEntryMtoMObjectRelatedModelsPredicateProviderImpl
 					DSLQueryFactoryUtil.select(
 						getPKObjectFieldColumn(
 							relatedDynamicObjectDefinitionTable,
-							relatedObjectDefinition)
+							relatedObjectDefinition.
+								getPKObjectFieldDBColumnName())
 					).from(
 						relatedDynamicObjectDefinitionTable
 					).innerJoinON(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntryMtoMObjectRelatedModelsPredicateProviderImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntryMtoMObjectRelatedModelsPredicateProviderImpl.java
@@ -73,9 +73,11 @@ public class ObjectEntryMtoMObjectRelatedModelsPredicateProviderImpl
 			dynamicObjectRelationshipMappingTable =
 				new DynamicObjectRelationshipMappingTable(
 					pkObjectFieldDBColumnNames.get(
-						"pkObjectFieldDBColumnName1"),
+						ObjectRelationshipConstants.
+							PK_OBJECT_FIELD_DB_COLUMN_NAME_1),
 					pkObjectFieldDBColumnNames.get(
-						"pkObjectFieldDBColumnName2"),
+						ObjectRelationshipConstants.
+							PK_OBJECT_FIELD_DB_COLUMN_NAME_2),
 					objectRelationship.getDBTableName());
 
 		Column<DynamicObjectRelationshipMappingTable, ?>
@@ -84,7 +86,8 @@ public class ObjectEntryMtoMObjectRelatedModelsPredicateProviderImpl
 					getPKObjectFieldColumn(
 						dynamicObjectRelationshipMappingTable,
 						pkObjectFieldDBColumnNames.get(
-							"pkObjectFieldDBColumnName2"));
+							ObjectRelationshipConstants.
+								PK_OBJECT_FIELD_DB_COLUMN_NAME_2));
 
 		DynamicObjectDefinitionTable relatedDynamicObjectDefinitionTable =
 			getDynamicObjectDefinitionTable(relatedObjectDefinition);
@@ -96,7 +99,8 @@ public class ObjectEntryMtoMObjectRelatedModelsPredicateProviderImpl
 				getPKObjectFieldColumn(
 					dynamicObjectRelationshipMappingTable,
 					pkObjectFieldDBColumnNames.get(
-						"pkObjectFieldDBColumnName1"))
+						ObjectRelationshipConstants.
+							PK_OBJECT_FIELD_DB_COLUMN_NAME_1))
 			).from(
 				dynamicObjectRelationshipMappingTable
 			).where(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -1939,9 +1939,11 @@ public class ObjectEntryLocalServiceImpl
 			dynamicObjectRelationshipMappingTable =
 				new DynamicObjectRelationshipMappingTable(
 					pkObjectFieldDBColumnNames.get(
-						"pkObjectFieldDBColumnName1"),
+						ObjectRelationshipConstants.
+							PK_OBJECT_FIELD_DB_COLUMN_NAME_1),
 					pkObjectFieldDBColumnNames.get(
-						"pkObjectFieldDBColumnName2"),
+						ObjectRelationshipConstants.
+							PK_OBJECT_FIELD_DB_COLUMN_NAME_2),
 					objectRelationship.getDBTableName());
 
 		Column<DynamicObjectRelationshipMappingTable, Long> primaryKeyColumn1 =

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
@@ -152,10 +152,12 @@ public class ObjectRelationshipLocalServiceImpl
 				StringBundler.concat(
 					"insert into ", objectRelationship.getDBTableName(), " (",
 					pkObjectFieldDBColumnNames.get(
-						"pkObjectFieldDBColumnName1"),
+						ObjectRelationshipConstants.
+							PK_OBJECT_FIELD_DB_COLUMN_NAME_1),
 					", ",
 					pkObjectFieldDBColumnNames.get(
-						"pkObjectFieldDBColumnName2"),
+						ObjectRelationshipConstants.
+							PK_OBJECT_FIELD_DB_COLUMN_NAME_2),
 					") values (", primaryKey1, ", ", primaryKey2, ")"));
 
 			return;
@@ -232,9 +234,9 @@ public class ObjectRelationshipLocalServiceImpl
 				objectDefinition1, objectDefinition2, false);
 
 		String pkObjectFieldDBColumnName1 = pkObjectFieldDBColumnNames.get(
-			"pkObjectFieldDBColumnName1");
+			ObjectRelationshipConstants.PK_OBJECT_FIELD_DB_COLUMN_NAME_1);
 		String pkObjectFieldDBColumnName2 = pkObjectFieldDBColumnNames.get(
-			"pkObjectFieldDBColumnName2");
+			ObjectRelationshipConstants.PK_OBJECT_FIELD_DB_COLUMN_NAME_2);
 
 		runSQL(
 			StringBundler.concat(
@@ -364,7 +366,8 @@ public class ObjectRelationshipLocalServiceImpl
 					"delete from ", objectRelationship.getDBTableName(),
 					" where ",
 					pkObjectFieldDBColumnNames.get(
-						"pkObjectFieldDBColumnName1"),
+						ObjectRelationshipConstants.
+							PK_OBJECT_FIELD_DB_COLUMN_NAME_1),
 					" = ", primaryKey1));
 		}
 	}
@@ -399,10 +402,12 @@ public class ObjectRelationshipLocalServiceImpl
 					"delete from ", objectRelationship.getDBTableName(),
 					" where ",
 					pkObjectFieldDBColumnNames.get(
-						"pkObjectFieldDBColumnName1"),
+						ObjectRelationshipConstants.
+							PK_OBJECT_FIELD_DB_COLUMN_NAME_1),
 					" = ", primaryKey1, " and ",
 					pkObjectFieldDBColumnNames.get(
-						"pkObjectFieldDBColumnName2"),
+						ObjectRelationshipConstants.
+							PK_OBJECT_FIELD_DB_COLUMN_NAME_2),
 					" = ", primaryKey2));
 		}
 	}
@@ -876,9 +881,11 @@ public class ObjectRelationshipLocalServiceImpl
 			dynamicObjectRelationshipMappingTable =
 				new DynamicObjectRelationshipMappingTable(
 					pkObjectFieldDBColumnNames.get(
-						"pkObjectFieldDBColumnName1"),
+						ObjectRelationshipConstants.
+							PK_OBJECT_FIELD_DB_COLUMN_NAME_1),
 					pkObjectFieldDBColumnNames.get(
-						"pkObjectFieldDBColumnName2"),
+						ObjectRelationshipConstants.
+							PK_OBJECT_FIELD_DB_COLUMN_NAME_2),
 					objectRelationship.getDBTableName());
 
 		Column<DynamicObjectRelationshipMappingTable, Long> primaryKeyColumn1 =

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectRelationshipLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectRelationshipLocalServiceTest.java
@@ -466,11 +466,15 @@ public class ObjectRelationshipLocalServiceTest {
 		Assert.assertTrue(
 			_hasColumn(
 				objectRelationship.getDBTableName(),
-				pkObjectFieldDBColumnNames.get("pkObjectFieldDBColumnName1")));
+				pkObjectFieldDBColumnNames.get(
+					ObjectRelationshipConstants.
+						PK_OBJECT_FIELD_DB_COLUMN_NAME_1)));
 		Assert.assertTrue(
 			_hasColumn(
 				objectRelationship.getDBTableName(),
-				pkObjectFieldDBColumnNames.get("pkObjectFieldDBColumnName2")));
+				pkObjectFieldDBColumnNames.get(
+					ObjectRelationshipConstants.
+						PK_OBJECT_FIELD_DB_COLUMN_NAME_2)));
 
 		ObjectRelationship reverseObjectRelationship =
 			_objectRelationshipLocalService.fetchReverseObjectRelationship(
@@ -630,11 +634,15 @@ public class ObjectRelationshipLocalServiceTest {
 		Assert.assertTrue(
 			_hasColumn(
 				objectRelationship.getDBTableName(),
-				pkObjectFieldDBColumnNames.get("pkObjectFieldDBColumnName1")));
+				pkObjectFieldDBColumnNames.get(
+					ObjectRelationshipConstants.
+						PK_OBJECT_FIELD_DB_COLUMN_NAME_1)));
 		Assert.assertTrue(
 			_hasColumn(
 				objectRelationship.getDBTableName(),
-				pkObjectFieldDBColumnNames.get("pkObjectFieldDBColumnName2")));
+				pkObjectFieldDBColumnNames.get(
+					ObjectRelationshipConstants.
+						PK_OBJECT_FIELD_DB_COLUMN_NAME_2)));
 
 		_objectRelationshipLocalService.deleteObjectRelationship(
 			objectRelationship);


### PR DESCRIPTION
Related ticket: [LPS-173132](https://issues.liferay.com/browse/LPS-173132)
___
## Purpose of the PR
Fix the error that appears when trying to get the related elements of a relationship of an object with itself.

Let's see an example:
* Given an Object called Language with a Name field
* Given a relationship with itself called Relationship
* Given the following languages created as object entries:
  * Languages
  * Spanish -> belongs to Languages
  * English -> belongs to Languages
  * Spanish basic -> belongs to Spanish
  * Spanish intermediate -> belongs to Spanish
  * Spanish advanced -> belongs to Spanish
  * English basic -> belongs to English
  * English intermediate -> belongs to English
  * English advanced -> belongs to English

Doing the following request we will receive the immediate child
<img width="1094" alt="image" src="https://user-images.githubusercontent.com/17163902/228813225-cdb3994b-3bca-43a8-a3a9-d32a7324d3e8.png">