### PR TITLE
LPS-173132 Provide column name instead of get the PKObjectFieldDBColumnName from objectDefinition

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/BaseObjectEntryObjectRelatedModelsPredicateProviderImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/BaseObjectEntryObjectRelatedModelsPredicateProviderImpl.java
@@ -64,10 +64,9 @@ public abstract class BaseObjectEntryObjectRelatedModelsPredicateProviderImpl
 	}
 
 	protected <T extends BaseTable<T>> Column<?, ?> getPKObjectFieldColumn(
-		BaseTable<T> baseTable, ObjectDefinition objectDefinition) {
+		BaseTable<T> baseTable, String pkObjectFieldDBColumnName) {
 
-		return baseTable.getColumn(
-			objectDefinition.getPKObjectFieldDBColumnName());
+		return baseTable.getColumn(pkObjectFieldDBColumnName);
 	}
 
 	protected final ObjectDefinition objectDefinition;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntry1toMObjectRelatedModelsPredicateProviderImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntry1toMObjectRelatedModelsPredicateProviderImpl.java
@@ -60,7 +60,7 @@ public class ObjectEntry1toMObjectRelatedModelsPredicateProviderImpl
 		Column<?, ?> objectDefinition1PKObjectFieldColumn =
 			getPKObjectFieldColumn(
 				objectDefinition1DynamicObjectDefinitionTable,
-				objectDefinition1);
+				objectDefinition1.getPKObjectFieldDBColumnName());
 
 		ObjectDefinition objectDefinition2 = _getObjectDefinition2(
 			objectRelationship);
@@ -116,7 +116,7 @@ public class ObjectEntry1toMObjectRelatedModelsPredicateProviderImpl
 		Column<?, ?> objectDefinition2PKObjectFieldColumn =
 			getPKObjectFieldColumn(
 				objectDefinition2DynamicObjectDefinitionTable,
-				objectDefinition2);
+				objectDefinition2.getPKObjectFieldDBColumnName());
 		DynamicObjectDefinitionTable objectDefinition1ExtensionTable =
 			getExtensionDynamicObjectDefinitionTable(objectDefinition1);
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntryMtoMObjectRelatedModelsPredicateProviderImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntryMtoMObjectRelatedModelsPredicateProviderImpl.java
@@ -56,7 +56,7 @@ public class ObjectEntryMtoMObjectRelatedModelsPredicateProviderImpl
 		Column<?, ?> dynamicObjectDefinitionTableColumn =
 			getPKObjectFieldColumn(
 				getDynamicObjectDefinitionTable(objectDefinition),
-				objectDefinition);
+				objectDefinition.getPKObjectFieldDBColumnName());
 
 		ObjectDefinition relatedObjectDefinition =
 			ObjectDefinitionLocalServiceUtil.getObjectDefinition(
@@ -83,7 +83,8 @@ public class ObjectEntryMtoMObjectRelatedModelsPredicateProviderImpl
 				(Column<DynamicObjectRelationshipMappingTable, ?>)
 					getPKObjectFieldColumn(
 						dynamicObjectRelationshipMappingTable,
-						relatedObjectDefinition);
+						pkObjectFieldDBColumnNames.get(
+							"pkObjectFieldDBColumnName2"));
 
 		DynamicObjectDefinitionTable relatedDynamicObjectDefinitionTable =
 			getDynamicObjectDefinitionTable(relatedObjectDefinition);
@@ -93,7 +94,9 @@ public class ObjectEntryMtoMObjectRelatedModelsPredicateProviderImpl
 		return dynamicObjectDefinitionTableColumn.in(
 			DSLQueryFactoryUtil.select(
 				getPKObjectFieldColumn(
-					dynamicObjectRelationshipMappingTable, objectDefinition)
+					dynamicObjectRelationshipMappingTable,
+					pkObjectFieldDBColumnNames.get(
+						"pkObjectFieldDBColumnName1"))
 			).from(
 				dynamicObjectRelationshipMappingTable
 			).where(
@@ -101,7 +104,8 @@ public class ObjectEntryMtoMObjectRelatedModelsPredicateProviderImpl
 					DSLQueryFactoryUtil.select(
 						getPKObjectFieldColumn(
 							relatedDynamicObjectDefinitionTable,
-							relatedObjectDefinition)
+							relatedObjectDefinition.
+								getPKObjectFieldDBColumnName())
 					).from(
 						relatedDynamicObjectDefinitionTable
 					).innerJoinON(


### PR DESCRIPTION
Related ticket: [LPS-173132](https://issues.liferay.com/browse/LPS-173132)
___
## Purpose of the PR
Fix the error that appears when trying to get the related elements of a relationship of an object with itself.

Let's see an example:
* Given an Object called Language with a Name field
* Given a relationship with itself called Relationship
* Given the following languages created as object entries:
  * Languages
  * Spanish -> belongs to Languages
  * English -> belongs to Languages
  * Spanish basic -> belongs to Spanish
  * Spanish intermediate -> belongs to Spanish
  * Spanish advanced -> belongs to Spanish
  * English basic -> belongs to English
  * English intermediate -> belongs to English
  * English advanced -> belongs to English

Doing the following request we will receive the immediate child
<img width="1094" alt="image" src="https://user-images.githubusercontent.com/17163902/228813225-cdb3994b-3bca-43a8-a3a9-d32a7324d3e8.png">