### PR TITLE
LPS-180600 Disable categorization on the API when categorization is not enabled

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -462,7 +462,9 @@ public class ObjectEntryDTOConverter
 				externalReferenceCode = objectEntry.getExternalReferenceCode();
 				id = objectEntry.getObjectEntryId();
 
-				if (FeatureFlagManagerUtil.isEnabled("LPS-176651")) {
+				if (objectDefinition.isEnableCategorization() &&
+					FeatureFlagManagerUtil.isEnabled("LPS-176651")) {
+
 					keywords = ListUtil.toArray(
 						_assetTagLocalService.getTags(
 							objectDefinition.getClassName(),
@@ -487,7 +489,9 @@ public class ObjectEntryDTOConverter
 					}
 				};
 
-				if (FeatureFlagManagerUtil.isEnabled("LPS-176651")) {
+				if (objectDefinition.isEnableCategorization() &&
+					FeatureFlagManagerUtil.isEnabled("LPS-176651")) {
+
 					taxonomyCategoryBriefs = TransformUtil.transformToArray(
 						_assetCategoryLocalService.getCategories(
 							objectDefinition.getClassName(),

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/openapi/contributor/ObjectEntryOpenAPIContributor.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/openapi/contributor/ObjectEntryOpenAPIContributor.java
@@ -173,6 +173,24 @@ public class ObjectEntryOpenAPIContributor extends BaseOpenAPIContributor {
 
 			paths.remove(key);
 		}
+
+		if (!_objectDefinition.isEnableCategorization()) {
+			Components components = openAPI.getComponents();
+
+			Map<String, Schema> schemas = components.getSchemas();
+
+			schemas.remove("TaxonomyCategoryBrief");
+
+			Schema objectDefinitionSchema = schemas.get(
+				_objectDefinition.getShortName());
+
+			Map<String, Schema> properties =
+				objectDefinitionSchema.getProperties();
+
+			properties.remove("keywords");
+			properties.remove("taxonomyCategoryBriefs");
+			properties.remove("taxonomyCategoryIds");
+		}
 	}
 
 	private void _addObjectActionPathItem(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -15,7 +15,13 @@
 package com.liferay.object.rest.internal.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.asset.kernel.model.AssetTag;
 import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.kernel.service.AssetCategoryLocalServiceUtil;
+import com.liferay.asset.kernel.service.AssetEntryLocalServiceUtil;
+import com.liferay.asset.kernel.service.AssetTagLocalServiceUtil;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalServiceUtil;
 import com.liferay.headless.admin.taxonomy.client.dto.v1_0.TaxonomyCategory;
 import com.liferay.headless.admin.taxonomy.client.resource.v1_0.TaxonomyCategoryResource;
@@ -61,6 +67,7 @@ import java.io.Serializable;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 
 import org.hamcrest.CoreMatchers;
 
@@ -2771,6 +2778,59 @@ public class ObjectEntryResourceTest {
 		_assertObjectEntryField(
 			(JSONObject)nestedObjectEntriesJSONArray.get(1),
 			_OBJECT_FIELD_NAME_2, _NEW_OBJECT_FIELD_VALUE_2);
+	}
+
+	@Test
+	public void testPostObjectEntryWithKeywordsAndTaxonomyCategoryIdsWhenCategorizationDisabled()
+		throws Exception {
+
+		_objectDefinition1.setEnableCategorization(false);
+
+		_objectDefinition1 =
+			_objectDefinitionLocalService.updateObjectDefinition(
+				_objectDefinition1);
+
+		try {
+			TaxonomyCategory taxonomyCategory = _addTaxonomyCategory();
+
+			JSONObject jsonObject = HTTPTestUtil.invoke(
+				JSONUtil.put(
+					_OBJECT_FIELD_NAME_1, RandomTestUtil.randomString()
+				).put(
+					"keywords", JSONUtil.putAll("tag")
+				).put(
+					"taxonomyCategoryIds",
+					JSONUtil.putAll(taxonomyCategory.getId())
+				).toString(),
+				_objectDefinition1.getRESTContextPath(), Http.Method.POST);
+
+			Assert.assertFalse(jsonObject.has("keywords"));
+			Assert.assertFalse(jsonObject.has("taxonomyCategoryBriefs"));
+
+			AssetEntry assetEntry = AssetEntryLocalServiceUtil.getEntry(
+				_objectDefinition1.getClassName(), jsonObject.getInt("id"));
+
+			List<AssetTag> assetEntryAssetTags =
+				AssetTagLocalServiceUtil.getAssetEntryAssetTags(
+					assetEntry.getEntryId());
+
+			Assert.assertEquals(
+				assetEntryAssetTags.toString(), 0, assetEntryAssetTags.size());
+
+			List<AssetCategory> assetCategories =
+				AssetCategoryLocalServiceUtil.getCategories(
+					_objectDefinition1.getClassName(), jsonObject.getInt("id"));
+
+			Assert.assertEquals(
+				assetCategories.toString(), 0, assetCategories.size());
+		}
+		finally {
+			_objectDefinition1.setEnableCategorization(true);
+
+			_objectDefinition1 =
+				_objectDefinitionLocalService.updateObjectDefinition(
+					_objectDefinition1);
+		}
 	}
 
 	@Test

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -1159,6 +1159,11 @@ public class ObjectEntryLocalServiceImpl
 			}
 		}
 
+		if (!objectDefinition.isEnableCategorization()) {
+			assetCategoryIds = null;
+			assetTagNames = null;
+		}
+
 		AssetEntry assetEntry = _assetEntryLocalService.updateEntry(
 			userId, objectEntry.getNonzeroGroupId(),
 			objectEntry.getCreateDate(), objectEntry.getModifiedDate(),


### PR DESCRIPTION
Ticket: https://issues.liferay.com/browse/LPS-180600.

- The categorization fields and schemas will not appear in the openapi.json.
- If categories or tags are sent on a post, they will be ignored.
- No categories or keywords properties will appear in responses.