### PR TITLE
LPS-181149 Fix feature flag annotation

### DIFF
--- a/portal-test/bnd.bnd
+++ b/portal-test/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 14.5.1
+Bundle-Version: 15.0.0
 Export-Package:\
 	com.liferay.portal.kernel.dao.db.test,\
 	com.liferay.portal.kernel.test,\

--- a/portal-test/src/com/liferay/portal/test/rule/FeatureFlagTestRule.java
+++ b/portal-test/src/com/liferay/portal/test/rule/FeatureFlagTestRule.java
@@ -15,7 +15,8 @@
 package com.liferay.portal.test.rule;
 
 import com.liferay.portal.kernel.test.rule.AbstractTestRule;
-import com.liferay.portal.kernel.test.util.PropsTestUtil;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
+import com.liferay.portal.util.PropsUtil;
 
 import org.junit.runner.Description;
 
@@ -63,8 +64,10 @@ public class FeatureFlagTestRule extends AbstractTestRule<Void, Void> {
 
 		if (featureFlags != null) {
 			for (String key : featureFlags.value()) {
-				PropsTestUtil.setProps(
-					"feature.flag." + key, Boolean.toString(enabled));
+				PropsUtil.addProperties(
+					UnicodePropertiesBuilder.setProperty(
+						"feature.flag." + key, Boolean.toString(enabled)
+					).build());
 			}
 		}
 	}

--- a/portal-test/src/com/liferay/portal/test/rule/packageinfo
+++ b/portal-test/src/com/liferay/portal/test/rule/packageinfo
@@ -1,1 +1,1 @@
-version 3.5.0
+version 4.0.0


### PR DESCRIPTION
From https://github.com/liferay-headless/liferay-portal/pull/1160.

## Motivation

[Link to ticket](https://issues.liferay.com/browse/LPS-181149)

Dear Team, this PR fixes an issue introduced in https://issues.liferay.com/browse/LPS-179576. If we use PropsTestUtil, we are overriding the complete properties map, so the idea is to use PropsUtil like we traditionally do for feature flags.

Also, we leave the feature flags in the state before the tests are executed. The steps would be:

- Store the value that the FF has before the test
- Store the value that the FF has before the method (it will take the class value if set)
- Restore the value after the method (leaving it as the class value in any case if set)
- Restore the value after the class

## Test Scenario

* Run fragment-test suite twice, and no errors in "company not found" will be shown when creating an omni admin user

