### PR TITLE
LPS-178803 Add new private methods that allow parsing strings with null values

### DIFF
--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountAddressResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountAddressResourceImpl.java
@@ -780,15 +780,14 @@ public abstract class BaseAccountAddressResourceImpl
 			accountAddressUnsafeConsumer =
 				accountAddress -> patchAccountAddress(
 					accountAddress.getId() != null ? accountAddress.getId() :
-						Long.parseLong(
-							(String)parameters.get("accountAddressId")),
+						_parseLong((String)parameters.get("accountAddressId")),
 					accountAddress);
 		}
 
 		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
 			accountAddressUnsafeConsumer = accountAddress -> putAccountAddress(
 				accountAddress.getId() != null ? accountAddress.getId() :
-					Long.parseLong((String)parameters.get("accountAddressId")),
+					_parseLong((String)parameters.get("accountAddressId")),
 				accountAddress);
 		}
 
@@ -807,6 +806,14 @@ public abstract class BaseAccountAddressResourceImpl
 				accountAddressUnsafeConsumer.accept(accountAddress);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountChannelShippingOptionResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountChannelShippingOptionResourceImpl.java
@@ -547,7 +547,7 @@ public abstract class BaseAccountChannelShippingOptionResourceImpl
 					patchAccountChannelShippingOption(
 						accountChannelShippingOption.getId() != null ?
 							accountChannelShippingOption.getId() :
-								Long.parseLong(
+								_parseLong(
 									(String)parameters.get(
 										"accountChannelShippingOptionId")),
 						accountChannelShippingOption);
@@ -572,6 +572,14 @@ public abstract class BaseAccountChannelShippingOptionResourceImpl
 					accountChannelShippingOption);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountGroupResourceImpl.java
@@ -692,7 +692,7 @@ public abstract class BaseAccountGroupResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			accountGroupUnsafeConsumer = accountGroup -> patchAccountGroup(
 				accountGroup.getId() != null ? accountGroup.getId() :
-					Long.parseLong((String)parameters.get("accountGroupId")),
+					_parseLong((String)parameters.get("accountGroupId")),
 				accountGroup);
 		}
 
@@ -711,6 +711,14 @@ public abstract class BaseAccountGroupResourceImpl
 				accountGroupUnsafeConsumer.accept(accountGroup);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountResourceImpl.java
@@ -764,7 +764,7 @@ public abstract class BaseAccountResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			accountUnsafeConsumer = account -> patchAccount(
 				account.getId() != null ? account.getId() :
-					Long.parseLong((String)parameters.get("accountId")),
+					_parseLong((String)parameters.get("accountId")),
 				account);
 		}
 
@@ -782,6 +782,14 @@ public abstract class BaseAccountResourceImpl
 				accountUnsafeConsumer.accept(account);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseCatalogResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseCatalogResourceImpl.java
@@ -694,7 +694,7 @@ public abstract class BaseCatalogResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			catalogUnsafeConsumer = catalog -> patchCatalog(
 				catalog.getId() != null ? catalog.getId() :
-					Long.parseLong((String)parameters.get("catalogId")),
+					_parseLong((String)parameters.get("catalogId")),
 				catalog);
 		}
 
@@ -712,6 +712,14 @@ public abstract class BaseCatalogResourceImpl
 				catalogUnsafeConsumer.accept(catalog);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseGroupedProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseGroupedProductResourceImpl.java
@@ -440,8 +440,7 @@ public abstract class BaseGroupedProductResourceImpl
 			groupedProductUnsafeConsumer =
 				groupedProduct -> patchGroupedProduct(
 					groupedProduct.getId() != null ? groupedProduct.getId() :
-						Long.parseLong(
-							(String)parameters.get("groupedProductId")),
+						_parseLong((String)parameters.get("groupedProductId")),
 					groupedProduct);
 		}
 
@@ -460,6 +459,14 @@ public abstract class BaseGroupedProductResourceImpl
 				groupedProductUnsafeConsumer.accept(groupedProduct);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseMappedProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseMappedProductResourceImpl.java
@@ -548,7 +548,7 @@ public abstract class BaseMappedProductResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			mappedProductUnsafeConsumer = mappedProduct -> patchMappedProduct(
 				mappedProduct.getId() != null ? mappedProduct.getId() :
-					Long.parseLong((String)parameters.get("mappedProductId")),
+					_parseLong((String)parameters.get("mappedProductId")),
 				mappedProduct);
 		}
 
@@ -567,6 +567,14 @@ public abstract class BaseMappedProductResourceImpl
 				mappedProductUnsafeConsumer.accept(mappedProduct);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionCategoryResourceImpl.java
@@ -454,8 +454,7 @@ public abstract class BaseOptionCategoryResourceImpl
 			optionCategoryUnsafeConsumer =
 				optionCategory -> patchOptionCategory(
 					optionCategory.getId() != null ? optionCategory.getId() :
-						Long.parseLong(
-							(String)parameters.get("optionCategoryId")),
+						_parseLong((String)parameters.get("optionCategoryId")),
 					optionCategory);
 		}
 
@@ -474,6 +473,14 @@ public abstract class BaseOptionCategoryResourceImpl
 				optionCategoryUnsafeConsumer.accept(optionCategory);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionResourceImpl.java
@@ -615,7 +615,7 @@ public abstract class BaseOptionResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			optionUnsafeConsumer = option -> patchOption(
 				option.getId() != null ? option.getId() :
-					Long.parseLong((String)parameters.get("optionId")),
+					_parseLong((String)parameters.get("optionId")),
 				option);
 		}
 
@@ -633,6 +633,14 @@ public abstract class BaseOptionResourceImpl
 				optionUnsafeConsumer.accept(option);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionValueResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionValueResourceImpl.java
@@ -624,7 +624,7 @@ public abstract class BaseOptionValueResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			optionValueUnsafeConsumer = optionValue -> patchOptionValue(
 				optionValue.getId() != null ? optionValue.getId() :
-					Long.parseLong((String)parameters.get("optionValueId")),
+					_parseLong((String)parameters.get("optionValueId")),
 				optionValue);
 		}
 
@@ -643,6 +643,14 @@ public abstract class BaseOptionValueResourceImpl
 				optionValueUnsafeConsumer.accept(optionValue);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BasePinResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BasePinResourceImpl.java
@@ -444,7 +444,7 @@ public abstract class BasePinResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			pinUnsafeConsumer = pin -> patchPin(
 				pin.getId() != null ? pin.getId() :
-					Long.parseLong((String)parameters.get("pinId")),
+					_parseLong((String)parameters.get("pinId")),
 				pin);
 		}
 
@@ -462,6 +462,14 @@ public abstract class BasePinResourceImpl
 				pinUnsafeConsumer.accept(pin);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductGroupResourceImpl.java
@@ -617,7 +617,7 @@ public abstract class BaseProductGroupResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			productGroupUnsafeConsumer = productGroup -> patchProductGroup(
 				productGroup.getId() != null ? productGroup.getId() :
-					Long.parseLong((String)parameters.get("productGroupId")),
+					_parseLong((String)parameters.get("productGroupId")),
 				productGroup);
 		}
 
@@ -636,6 +636,14 @@ public abstract class BaseProductGroupResourceImpl
 				productGroupUnsafeConsumer.accept(productGroup);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductOptionResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductOptionResourceImpl.java
@@ -497,7 +497,7 @@ public abstract class BaseProductOptionResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			productOptionUnsafeConsumer = productOption -> patchProductOption(
 				productOption.getId() != null ? productOption.getId() :
-					Long.parseLong((String)parameters.get("productOptionId")),
+					_parseLong((String)parameters.get("productOptionId")),
 				productOption);
 		}
 
@@ -516,6 +516,14 @@ public abstract class BaseProductOptionResourceImpl
 				productOptionUnsafeConsumer.accept(productOption);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductResourceImpl.java
@@ -833,7 +833,7 @@ public abstract class BaseProductResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			productUnsafeConsumer = product -> patchProduct(
 				product.getId() != null ? product.getId() :
-					Long.parseLong((String)parameters.get("productId")),
+					_parseLong((String)parameters.get("productId")),
 				product);
 		}
 
@@ -851,6 +851,14 @@ public abstract class BaseProductResourceImpl
 				productUnsafeConsumer.accept(product);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductSpecificationResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductSpecificationResourceImpl.java
@@ -450,7 +450,7 @@ public abstract class BaseProductSpecificationResourceImpl
 				productSpecification -> patchProductSpecification(
 					productSpecification.getId() != null ?
 						productSpecification.getId() :
-							Long.parseLong(
+							_parseLong(
 								(String)parameters.get(
 									"productSpecificationId")),
 					productSpecification);
@@ -473,6 +473,14 @@ public abstract class BaseProductSpecificationResourceImpl
 				productSpecificationUnsafeConsumer.accept(productSpecification);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseSkuResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseSkuResourceImpl.java
@@ -711,7 +711,7 @@ public abstract class BaseSkuResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			skuUnsafeConsumer = sku -> patchSku(
 				sku.getId() != null ? sku.getId() :
-					Long.parseLong((String)parameters.get("skuId")),
+					_parseLong((String)parameters.get("skuId")),
 				sku);
 		}
 
@@ -729,6 +729,14 @@ public abstract class BaseSkuResourceImpl
 				skuUnsafeConsumer.accept(sku);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseSpecificationResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseSpecificationResourceImpl.java
@@ -539,7 +539,7 @@ public abstract class BaseSpecificationResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			specificationUnsafeConsumer = specification -> patchSpecification(
 				specification.getId() != null ? specification.getId() :
-					Long.parseLong((String)parameters.get("specificationId")),
+					_parseLong((String)parameters.get("specificationId")),
 				specification);
 		}
 
@@ -558,6 +558,14 @@ public abstract class BaseSpecificationResourceImpl
 				specificationUnsafeConsumer.accept(specification);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseChannelResourceImpl.java
@@ -783,14 +783,14 @@ public abstract class BaseChannelResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			channelUnsafeConsumer = channel -> patchChannel(
 				channel.getId() != null ? channel.getId() :
-					Long.parseLong((String)parameters.get("channelId")),
+					_parseLong((String)parameters.get("channelId")),
 				channel);
 		}
 
 		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
 			channelUnsafeConsumer = channel -> putChannel(
 				channel.getId() != null ? channel.getId() :
-					Long.parseLong((String)parameters.get("channelId")),
+					_parseLong((String)parameters.get("channelId")),
 				channel);
 		}
 
@@ -808,6 +808,14 @@ public abstract class BaseChannelResourceImpl
 				channelUnsafeConsumer.accept(channel);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseShippingMethodResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseShippingMethodResourceImpl.java
@@ -249,8 +249,7 @@ public abstract class BaseShippingMethodResourceImpl
 
 		if (parameters.containsKey("channelId")) {
 			return getChannelShippingMethodsPage(
-				Long.parseLong((String)parameters.get("channelId")),
-				pagination);
+				_parseLong((String)parameters.get("channelId")), pagination);
 		}
 		else {
 			throw new NotSupportedException(
@@ -288,6 +287,14 @@ public abstract class BaseShippingMethodResourceImpl
 
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseReplenishmentItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseReplenishmentItemResourceImpl.java
@@ -595,7 +595,7 @@ public abstract class BaseReplenishmentItemResourceImpl
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
 			replenishmentItemUnsafeConsumer =
 				replenishmentItem -> postReplenishmentItem(
-					Long.parseLong((String)parameters.get("warehouseId")),
+					_parseLong((String)parameters.get("warehouseId")),
 					(String)parameters.get("sku"), replenishmentItem);
 		}
 
@@ -703,7 +703,7 @@ public abstract class BaseReplenishmentItemResourceImpl
 				replenishmentItem -> patchReplenishmentItem(
 					replenishmentItem.getId() != null ?
 						replenishmentItem.getId() :
-							Long.parseLong(
+							_parseLong(
 								(String)parameters.get("replenishmentItemId")),
 					replenishmentItem);
 		}
@@ -723,6 +723,14 @@ public abstract class BaseReplenishmentItemResourceImpl
 				replenishmentItemUnsafeConsumer.accept(replenishmentItem);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseWarehouseItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseWarehouseItemResourceImpl.java
@@ -52,6 +52,7 @@ import java.io.Serializable;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -260,10 +261,10 @@ public abstract class BaseWarehouseItemResourceImpl
 	public Page<WarehouseItem> getWarehouseItemsUpdatedPage(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.ws.rs.QueryParam("end")
-			java.util.Date end,
+			Date end,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.ws.rs.QueryParam("start")
-			java.util.Date start,
+			Date start,
 			@javax.ws.rs.core.Context Pagination pagination)
 		throws Exception {
 
@@ -710,7 +711,7 @@ public abstract class BaseWarehouseItemResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			warehouseItemUnsafeConsumer = warehouseItem -> patchWarehouseItem(
 				warehouseItem.getId() != null ? warehouseItem.getId() :
-					Long.parseLong((String)parameters.get("warehouseItemId")),
+					_parseLong((String)parameters.get("warehouseItemId")),
 				warehouseItem);
 		}
 
@@ -729,6 +730,14 @@ public abstract class BaseWarehouseItemResourceImpl
 				warehouseItemUnsafeConsumer.accept(warehouseItem);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderItemResourceImpl.java
@@ -857,14 +857,14 @@ public abstract class BaseOrderItemResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			orderItemUnsafeConsumer = orderItem -> patchOrderItem(
 				orderItem.getId() != null ? orderItem.getId() :
-					Long.parseLong((String)parameters.get("orderItemId")),
+					_parseLong((String)parameters.get("orderItemId")),
 				orderItem);
 		}
 
 		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
 			orderItemUnsafeConsumer = orderItem -> putOrderItem(
 				orderItem.getId() != null ? orderItem.getId() :
-					Long.parseLong((String)parameters.get("orderItemId")),
+					_parseLong((String)parameters.get("orderItemId")),
 				orderItem);
 		}
 
@@ -883,6 +883,14 @@ public abstract class BaseOrderItemResourceImpl
 				orderItemUnsafeConsumer.accept(orderItem);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderNoteResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderNoteResourceImpl.java
@@ -600,7 +600,7 @@ public abstract class BaseOrderNoteResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			orderNoteUnsafeConsumer = orderNote -> patchOrderNote(
 				orderNote.getId() != null ? orderNote.getId() :
-					Long.parseLong((String)parameters.get("orderNoteId")),
+					_parseLong((String)parameters.get("orderNoteId")),
 				orderNote);
 		}
 
@@ -619,6 +619,14 @@ public abstract class BaseOrderNoteResourceImpl
 				orderNoteUnsafeConsumer.accept(orderNote);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderResourceImpl.java
@@ -615,7 +615,7 @@ public abstract class BaseOrderResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			orderUnsafeConsumer = order -> patchOrder(
 				order.getId() != null ? order.getId() :
-					Long.parseLong((String)parameters.get("orderId")),
+					_parseLong((String)parameters.get("orderId")),
 				order);
 		}
 
@@ -633,6 +633,14 @@ public abstract class BaseOrderResourceImpl
 				orderUnsafeConsumer.accept(order);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleResourceImpl.java
@@ -607,7 +607,7 @@ public abstract class BaseOrderRuleResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			orderRuleUnsafeConsumer = orderRule -> patchOrderRule(
 				orderRule.getId() != null ? orderRule.getId() :
-					Long.parseLong((String)parameters.get("orderRuleId")),
+					_parseLong((String)parameters.get("orderRuleId")),
 				orderRule);
 		}
 
@@ -626,6 +626,14 @@ public abstract class BaseOrderRuleResourceImpl
 				orderRuleUnsafeConsumer.accept(orderRule);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderTypeResourceImpl.java
@@ -669,7 +669,7 @@ public abstract class BaseOrderTypeResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			orderTypeUnsafeConsumer = orderType -> patchOrderType(
 				orderType.getId() != null ? orderType.getId() :
-					Long.parseLong((String)parameters.get("orderTypeId")),
+					_parseLong((String)parameters.get("orderTypeId")),
 				orderType);
 		}
 
@@ -688,6 +688,14 @@ public abstract class BaseOrderTypeResourceImpl
 				orderTypeUnsafeConsumer.accept(orderType);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseTermResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseTermResourceImpl.java
@@ -597,7 +597,7 @@ public abstract class BaseTermResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			termUnsafeConsumer = term -> patchTerm(
 				term.getId() != null ? term.getId() :
-					Long.parseLong((String)parameters.get("termId")),
+					_parseLong((String)parameters.get("termId")),
 				term);
 		}
 
@@ -615,6 +615,14 @@ public abstract class BaseTermResourceImpl
 				termUnsafeConsumer.accept(term);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountResourceImpl.java
@@ -585,7 +585,7 @@ public abstract class BaseDiscountResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			discountUnsafeConsumer = discount -> patchDiscount(
 				discount.getId() != null ? discount.getId() :
-					Long.parseLong((String)parameters.get("discountId")),
+					_parseLong((String)parameters.get("discountId")),
 				discount);
 		}
 
@@ -604,6 +604,14 @@ public abstract class BaseDiscountResourceImpl
 				discountUnsafeConsumer.accept(discount);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountRuleResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountRuleResourceImpl.java
@@ -500,7 +500,7 @@ public abstract class BaseDiscountRuleResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			discountRuleUnsafeConsumer = discountRule -> patchDiscountRule(
 				discountRule.getId() != null ? discountRule.getId() :
-					Long.parseLong((String)parameters.get("discountRuleId")),
+					_parseLong((String)parameters.get("discountRuleId")),
 				discountRule);
 		}
 
@@ -519,6 +519,14 @@ public abstract class BaseDiscountRuleResourceImpl
 				discountRuleUnsafeConsumer.accept(discountRule);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BasePriceEntryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BasePriceEntryResourceImpl.java
@@ -600,7 +600,7 @@ public abstract class BasePriceEntryResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			priceEntryUnsafeConsumer = priceEntry -> patchPriceEntry(
 				priceEntry.getId() != null ? priceEntry.getId() :
-					Long.parseLong((String)parameters.get("priceEntryId")),
+					_parseLong((String)parameters.get("priceEntryId")),
 				priceEntry);
 		}
 
@@ -619,6 +619,14 @@ public abstract class BasePriceEntryResourceImpl
 				priceEntryUnsafeConsumer.accept(priceEntry);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BasePriceListResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BasePriceListResourceImpl.java
@@ -605,7 +605,7 @@ public abstract class BasePriceListResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			priceListUnsafeConsumer = priceList -> patchPriceList(
 				priceList.getId() != null ? priceList.getId() :
-					Long.parseLong((String)parameters.get("priceListId")),
+					_parseLong((String)parameters.get("priceListId")),
 				priceList);
 		}
 
@@ -624,6 +624,14 @@ public abstract class BasePriceListResourceImpl
 				priceListUnsafeConsumer.accept(priceList);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseTierPriceResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseTierPriceResourceImpl.java
@@ -600,7 +600,7 @@ public abstract class BaseTierPriceResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			tierPriceUnsafeConsumer = tierPrice -> patchTierPrice(
 				tierPrice.getId() != null ? tierPrice.getId() :
-					Long.parseLong((String)parameters.get("tierPriceId")),
+					_parseLong((String)parameters.get("tierPriceId")),
 				tierPrice);
 		}
 
@@ -619,6 +619,14 @@ public abstract class BaseTierPriceResourceImpl
 				tierPriceUnsafeConsumer.accept(tierPrice);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountResourceImpl.java
@@ -607,7 +607,7 @@ public abstract class BaseDiscountResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			discountUnsafeConsumer = discount -> patchDiscount(
 				discount.getId() != null ? discount.getId() :
-					Long.parseLong((String)parameters.get("discountId")),
+					_parseLong((String)parameters.get("discountId")),
 				discount);
 		}
 
@@ -626,6 +626,14 @@ public abstract class BaseDiscountResourceImpl
 				discountUnsafeConsumer.accept(discount);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountRuleResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountRuleResourceImpl.java
@@ -511,7 +511,7 @@ public abstract class BaseDiscountRuleResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			discountRuleUnsafeConsumer = discountRule -> patchDiscountRule(
 				discountRule.getId() != null ? discountRule.getId() :
-					Long.parseLong((String)parameters.get("discountRuleId")),
+					_parseLong((String)parameters.get("discountRuleId")),
 				discountRule);
 		}
 
@@ -530,6 +530,14 @@ public abstract class BaseDiscountRuleResourceImpl
 				discountRuleUnsafeConsumer.accept(discountRule);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceEntryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceEntryResourceImpl.java
@@ -626,7 +626,7 @@ public abstract class BasePriceEntryResourceImpl
 			priceEntryUnsafeConsumer = priceEntry -> patchPriceEntry(
 				(priceEntry.getPriceEntryId() != null) ?
 					priceEntry.getPriceEntryId() :
-						Long.parseLong((String)parameters.get("priceEntryId")),
+						_parseLong((String)parameters.get("priceEntryId")),
 				priceEntry);
 		}
 
@@ -645,6 +645,14 @@ public abstract class BasePriceEntryResourceImpl
 				priceEntryUnsafeConsumer.accept(priceEntry);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListResourceImpl.java
@@ -607,7 +607,7 @@ public abstract class BasePriceListResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			priceListUnsafeConsumer = priceList -> patchPriceList(
 				priceList.getId() != null ? priceList.getId() :
-					Long.parseLong((String)parameters.get("priceListId")),
+					_parseLong((String)parameters.get("priceListId")),
 				priceList);
 		}
 
@@ -626,6 +626,14 @@ public abstract class BasePriceListResourceImpl
 				priceListUnsafeConsumer.accept(priceList);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierResourceImpl.java
@@ -635,7 +635,7 @@ public abstract class BasePriceModifierResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			priceModifierUnsafeConsumer = priceModifier -> patchPriceModifier(
 				priceModifier.getId() != null ? priceModifier.getId() :
-					Long.parseLong((String)parameters.get("priceModifierId")),
+					_parseLong((String)parameters.get("priceModifierId")),
 				priceModifier);
 		}
 
@@ -654,6 +654,14 @@ public abstract class BasePriceModifierResourceImpl
 				priceModifierUnsafeConsumer.accept(priceModifier);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseTierPriceResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseTierPriceResourceImpl.java
@@ -602,7 +602,7 @@ public abstract class BaseTierPriceResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			tierPriceUnsafeConsumer = tierPrice -> patchTierPrice(
 				tierPrice.getId() != null ? tierPrice.getId() :
-					Long.parseLong((String)parameters.get("tierPriceId")),
+					_parseLong((String)parameters.get("tierPriceId")),
 				tierPrice);
 		}
 
@@ -621,6 +621,14 @@ public abstract class BaseTierPriceResourceImpl
 				tierPriceUnsafeConsumer.accept(tierPrice);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/BaseShipmentItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/BaseShipmentItemResourceImpl.java
@@ -550,7 +550,7 @@ public abstract class BaseShipmentItemResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			shipmentItemUnsafeConsumer = shipmentItem -> patchShipmentItem(
 				shipmentItem.getId() != null ? shipmentItem.getId() :
-					Long.parseLong((String)parameters.get("shipmentItemId")),
+					_parseLong((String)parameters.get("shipmentItemId")),
 				shipmentItem);
 		}
 
@@ -569,6 +569,14 @@ public abstract class BaseShipmentItemResourceImpl
 				shipmentItemUnsafeConsumer.accept(shipmentItem);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/BaseShipmentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/BaseShipmentResourceImpl.java
@@ -909,7 +909,7 @@ public abstract class BaseShipmentResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			shipmentUnsafeConsumer = shipment -> patchShipment(
 				shipment.getId() != null ? shipment.getId() :
-					Long.parseLong((String)parameters.get("shipmentId")),
+					_parseLong((String)parameters.get("shipmentId")),
 				shipment);
 		}
 
@@ -928,6 +928,14 @@ public abstract class BaseShipmentResourceImpl
 				shipmentUnsafeConsumer.accept(shipment);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseAvailabilityEstimateResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseAvailabilityEstimateResourceImpl.java
@@ -464,7 +464,7 @@ public abstract class BaseAvailabilityEstimateResourceImpl
 				availabilityEstimate -> putAvailabilityEstimate(
 					availabilityEstimate.getId() != null ?
 						availabilityEstimate.getId() :
-							Long.parseLong(
+							_parseLong(
 								(String)parameters.get(
 									"availabilityEstimateId")),
 					availabilityEstimate);
@@ -487,6 +487,14 @@ public abstract class BaseAvailabilityEstimateResourceImpl
 				availabilityEstimateUnsafeConsumer.accept(availabilityEstimate);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseMeasurementUnitResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseMeasurementUnitResourceImpl.java
@@ -767,8 +767,7 @@ public abstract class BaseMeasurementUnitResourceImpl
 			measurementUnitUnsafeConsumer =
 				measurementUnit -> patchMeasurementUnit(
 					measurementUnit.getId() != null ? measurementUnit.getId() :
-						Long.parseLong(
-							(String)parameters.get("measurementUnitId")),
+						_parseLong((String)parameters.get("measurementUnitId")),
 					measurementUnit);
 		}
 
@@ -787,6 +786,14 @@ public abstract class BaseMeasurementUnitResourceImpl
 				measurementUnitUnsafeConsumer.accept(measurementUnit);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseTaxCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseTaxCategoryResourceImpl.java
@@ -425,7 +425,7 @@ public abstract class BaseTaxCategoryResourceImpl
 		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
 			taxCategoryUnsafeConsumer = taxCategory -> putTaxCategory(
 				taxCategory.getId() != null ? taxCategory.getId() :
-					Long.parseLong((String)parameters.get("taxCategoryId")),
+					_parseLong((String)parameters.get("taxCategoryId")),
 				taxCategory);
 		}
 
@@ -444,6 +444,14 @@ public abstract class BaseTaxCategoryResourceImpl
 				taxCategoryUnsafeConsumer.accept(taxCategory);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseWarehouseResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseWarehouseResourceImpl.java
@@ -432,7 +432,7 @@ public abstract class BaseWarehouseResourceImpl
 		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
 			warehouseUnsafeConsumer = warehouse -> putWarehouse(
 				warehouse.getId() != null ? warehouse.getId() :
-					Long.parseLong((String)parameters.get("warehouseId")),
+					_parseLong((String)parameters.get("warehouseId")),
 				warehouse);
 		}
 
@@ -451,6 +451,14 @@ public abstract class BaseWarehouseResourceImpl
 				warehouseUnsafeConsumer.accept(warehouse);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartCommentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartCommentResourceImpl.java
@@ -474,14 +474,14 @@ public abstract class BaseCartCommentResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			cartCommentUnsafeConsumer = cartComment -> patchCartComment(
 				cartComment.getId() != null ? cartComment.getId() :
-					Long.parseLong((String)parameters.get("cartCommentId")),
+					_parseLong((String)parameters.get("cartCommentId")),
 				cartComment);
 		}
 
 		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
 			cartCommentUnsafeConsumer = cartComment -> putCartComment(
 				cartComment.getId() != null ? cartComment.getId() :
-					Long.parseLong((String)parameters.get("cartCommentId")),
+					_parseLong((String)parameters.get("cartCommentId")),
 				cartComment);
 		}
 
@@ -500,6 +500,14 @@ public abstract class BaseCartCommentResourceImpl
 				cartCommentUnsafeConsumer.accept(cartComment);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartItemResourceImpl.java
@@ -545,14 +545,14 @@ public abstract class BaseCartItemResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			cartItemUnsafeConsumer = cartItem -> patchCartItem(
 				cartItem.getId() != null ? cartItem.getId() :
-					Long.parseLong((String)parameters.get("cartItemId")),
+					_parseLong((String)parameters.get("cartItemId")),
 				cartItem);
 		}
 
 		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
 			cartItemUnsafeConsumer = cartItem -> putCartItem(
 				cartItem.getId() != null ? cartItem.getId() :
-					Long.parseLong((String)parameters.get("cartItemId")),
+					_parseLong((String)parameters.get("cartItemId")),
 				cartItem);
 		}
 
@@ -571,6 +571,14 @@ public abstract class BaseCartItemResourceImpl
 				cartItemUnsafeConsumer.accept(cartItem);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartResourceImpl.java
@@ -693,14 +693,14 @@ public abstract class BaseCartResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			cartUnsafeConsumer = cart -> patchCart(
 				cart.getId() != null ? cart.getId() :
-					Long.parseLong((String)parameters.get("cartId")),
+					_parseLong((String)parameters.get("cartId")),
 				cart);
 		}
 
 		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
 			cartUnsafeConsumer = cart -> putCart(
 				cart.getId() != null ? cart.getId() :
-					Long.parseLong((String)parameters.get("cartId")),
+					_parseLong((String)parameters.get("cartId")),
 				cart);
 		}
 
@@ -718,6 +718,14 @@ public abstract class BaseCartResourceImpl
 				cartUnsafeConsumer.accept(cart);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BasePaymentMethodResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BasePaymentMethodResourceImpl.java
@@ -240,7 +240,7 @@ public abstract class BasePaymentMethodResourceImpl
 
 		if (parameters.containsKey("cartId")) {
 			return getCartPaymentMethodsPage(
-				Long.parseLong((String)parameters.get("cartId")));
+				_parseLong((String)parameters.get("cartId")));
 		}
 		else {
 			throw new NotSupportedException(
@@ -278,6 +278,14 @@ public abstract class BasePaymentMethodResourceImpl
 
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseShippingMethodResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseShippingMethodResourceImpl.java
@@ -240,7 +240,7 @@ public abstract class BaseShippingMethodResourceImpl
 
 		if (parameters.containsKey("cartId")) {
 			return getCartShippingMethodsPage(
-				Long.parseLong((String)parameters.get("cartId")));
+				_parseLong((String)parameters.get("cartId")));
 		}
 		else {
 			throw new NotSupportedException(
@@ -278,6 +278,14 @@ public abstract class BaseShippingMethodResourceImpl
 
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/BasePlacedOrderCommentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/BasePlacedOrderCommentResourceImpl.java
@@ -280,7 +280,7 @@ public abstract class BasePlacedOrderCommentResourceImpl
 
 		if (parameters.containsKey("placedOrderId")) {
 			return getPlacedOrderPlacedOrderCommentsPage(
-				Long.parseLong((String)parameters.get("placedOrderId")),
+				_parseLong((String)parameters.get("placedOrderId")),
 				pagination);
 		}
 		else {
@@ -319,6 +319,14 @@ public abstract class BasePlacedOrderCommentResourceImpl
 
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/BasePlacedOrderItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/BasePlacedOrderItemResourceImpl.java
@@ -300,8 +300,8 @@ public abstract class BasePlacedOrderItemResourceImpl
 
 		if (parameters.containsKey("placedOrderId")) {
 			return getPlacedOrderPlacedOrderItemsPage(
-				Long.parseLong((String)parameters.get("placedOrderId")),
-				Long.parseLong((String)parameters.get("skuId")), pagination);
+				_parseLong((String)parameters.get("placedOrderId")),
+				_parseLong((String)parameters.get("skuId")), pagination);
 		}
 		else {
 			throw new NotSupportedException(
@@ -339,6 +339,14 @@ public abstract class BasePlacedOrderItemResourceImpl
 
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/BasePlacedOrderItemShipmentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/BasePlacedOrderItemShipmentResourceImpl.java
@@ -249,7 +249,7 @@ public abstract class BasePlacedOrderItemShipmentResourceImpl
 
 		if (parameters.containsKey("placedOrderItemId")) {
 			return getPlacedOrderItemPlacedOrderItemShipmentsPage(
-				Long.parseLong((String)parameters.get("placedOrderItemId")));
+				_parseLong((String)parameters.get("placedOrderItemId")));
 		}
 		else {
 			throw new NotSupportedException(
@@ -287,6 +287,14 @@ public abstract class BasePlacedOrderItemShipmentResourceImpl
 
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionFieldLinkResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionFieldLinkResourceImpl.java
@@ -260,7 +260,7 @@ public abstract class BaseDataDefinitionFieldLinkResourceImpl
 
 		if (parameters.containsKey("dataDefinitionId")) {
 			return getDataDefinitionDataDefinitionFieldLinksPage(
-				Long.parseLong((String)parameters.get("dataDefinitionId")),
+				_parseLong((String)parameters.get("dataDefinitionId")),
 				(String)parameters.get("fieldName"));
 		}
 		else {
@@ -299,6 +299,14 @@ public abstract class BaseDataDefinitionFieldLinkResourceImpl
 
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionResourceImpl.java
@@ -888,15 +888,14 @@ public abstract class BaseDataDefinitionResourceImpl
 			dataDefinitionUnsafeConsumer =
 				dataDefinition -> patchDataDefinition(
 					dataDefinition.getId() != null ? dataDefinition.getId() :
-						Long.parseLong(
-							(String)parameters.get("dataDefinitionId")),
+						_parseLong((String)parameters.get("dataDefinitionId")),
 					dataDefinition);
 		}
 
 		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
 			dataDefinitionUnsafeConsumer = dataDefinition -> putDataDefinition(
 				dataDefinition.getId() != null ? dataDefinition.getId() :
-					Long.parseLong((String)parameters.get("dataDefinitionId")),
+					_parseLong((String)parameters.get("dataDefinitionId")),
 				dataDefinition);
 		}
 
@@ -915,6 +914,14 @@ public abstract class BaseDataDefinitionResourceImpl
 				dataDefinitionUnsafeConsumer.accept(dataDefinition);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	protected String getPermissionCheckerActionsResourceName(Object id)

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataLayoutResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataLayoutResourceImpl.java
@@ -601,8 +601,7 @@ public abstract class BaseDataLayoutResourceImpl
 			if (parameters.containsKey("dataDefinitionId")) {
 				dataLayoutUnsafeConsumer =
 					dataLayout -> postDataDefinitionDataLayout(
-						Long.parseLong(
-							(String)parameters.get("dataDefinitionId")),
+						_parseLong((String)parameters.get("dataDefinitionId")),
 						dataLayout);
 			}
 			else {
@@ -674,7 +673,7 @@ public abstract class BaseDataLayoutResourceImpl
 
 		if (parameters.containsKey("dataDefinitionId")) {
 			return getDataDefinitionDataLayoutsPage(
-				Long.parseLong((String)parameters.get("dataDefinitionId")),
+				_parseLong((String)parameters.get("dataDefinitionId")),
 				(String)parameters.get("keywords"), pagination, sorts);
 		}
 		else {
@@ -719,7 +718,7 @@ public abstract class BaseDataLayoutResourceImpl
 		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
 			dataLayoutUnsafeConsumer = dataLayout -> putDataLayout(
 				dataLayout.getId() != null ? dataLayout.getId() :
-					Long.parseLong((String)parameters.get("dataLayoutId")),
+					_parseLong((String)parameters.get("dataLayoutId")),
 				dataLayout);
 		}
 
@@ -738,6 +737,14 @@ public abstract class BaseDataLayoutResourceImpl
 				dataLayoutUnsafeConsumer.accept(dataLayout);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataListViewResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataListViewResourceImpl.java
@@ -521,8 +521,7 @@ public abstract class BaseDataListViewResourceImpl
 			if (parameters.containsKey("dataDefinitionId")) {
 				dataListViewUnsafeConsumer =
 					dataListView -> postDataDefinitionDataListView(
-						Long.parseLong(
-							(String)parameters.get("dataDefinitionId")),
+						_parseLong((String)parameters.get("dataDefinitionId")),
 						dataListView);
 			}
 			else {
@@ -594,7 +593,7 @@ public abstract class BaseDataListViewResourceImpl
 
 		if (parameters.containsKey("dataDefinitionId")) {
 			return getDataDefinitionDataListViewsPage(
-				Long.parseLong((String)parameters.get("dataDefinitionId")),
+				_parseLong((String)parameters.get("dataDefinitionId")),
 				(String)parameters.get("keywords"), pagination, sorts);
 		}
 		else {
@@ -640,7 +639,7 @@ public abstract class BaseDataListViewResourceImpl
 		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
 			dataListViewUnsafeConsumer = dataListView -> putDataListView(
 				dataListView.getId() != null ? dataListView.getId() :
-					Long.parseLong((String)parameters.get("dataListViewId")),
+					_parseLong((String)parameters.get("dataListViewId")),
 				dataListView);
 		}
 
@@ -659,6 +658,14 @@ public abstract class BaseDataListViewResourceImpl
 				dataListViewUnsafeConsumer.accept(dataListView);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordCollectionResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordCollectionResourceImpl.java
@@ -793,7 +793,7 @@ public abstract class BaseDataRecordCollectionResourceImpl
 				dataRecordCollectionUnsafeConsumer =
 					dataRecordCollection ->
 						postDataDefinitionDataRecordCollection(
-							Long.parseLong(
+							_parseLong(
 								(String)parameters.get("dataDefinitionId")),
 							dataRecordCollection);
 			}
@@ -870,7 +870,7 @@ public abstract class BaseDataRecordCollectionResourceImpl
 
 		if (parameters.containsKey("dataDefinitionId")) {
 			return getDataDefinitionDataRecordCollectionsPage(
-				Long.parseLong((String)parameters.get("dataDefinitionId")),
+				_parseLong((String)parameters.get("dataDefinitionId")),
 				(String)parameters.get("keywords"), pagination);
 		}
 		else {
@@ -918,7 +918,7 @@ public abstract class BaseDataRecordCollectionResourceImpl
 				dataRecordCollection -> putDataRecordCollection(
 					dataRecordCollection.getId() != null ?
 						dataRecordCollection.getId() :
-							Long.parseLong(
+							_parseLong(
 								(String)parameters.get(
 									"dataRecordCollectionId")),
 					dataRecordCollection);
@@ -941,6 +941,14 @@ public abstract class BaseDataRecordCollectionResourceImpl
 				dataRecordCollectionUnsafeConsumer.accept(dataRecordCollection);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	protected String getPermissionCheckerActionsResourceName(Object id)

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordResourceImpl.java
@@ -834,14 +834,13 @@ public abstract class BaseDataRecordResourceImpl
 			if (parameters.containsKey("dataDefinitionId")) {
 				dataRecordUnsafeConsumer =
 					dataRecord -> postDataDefinitionDataRecord(
-						Long.parseLong(
-							(String)parameters.get("dataDefinitionId")),
+						_parseLong((String)parameters.get("dataDefinitionId")),
 						dataRecord);
 			}
 			else if (parameters.containsKey("dataRecordCollectionId")) {
 				dataRecordUnsafeConsumer =
 					dataRecord -> postDataRecordCollectionDataRecord(
-						Long.parseLong(
+						_parseLong(
 							(String)parameters.get("dataRecordCollectionId")),
 						dataRecord);
 			}
@@ -914,15 +913,14 @@ public abstract class BaseDataRecordResourceImpl
 
 		if (parameters.containsKey("dataDefinitionId")) {
 			return getDataDefinitionDataRecordsPage(
-				Long.parseLong((String)parameters.get("dataDefinitionId")),
-				Long.parseLong((String)parameters.get("dataListViewId")),
+				_parseLong((String)parameters.get("dataDefinitionId")),
+				_parseLong((String)parameters.get("dataListViewId")),
 				(String)parameters.get("keywords"), pagination, sorts);
 		}
 		else if (parameters.containsKey("dataRecordCollectionId")) {
 			return getDataRecordCollectionDataRecordsPage(
-				Long.parseLong(
-					(String)parameters.get("dataRecordCollectionId")),
-				Long.parseLong((String)parameters.get("dataListViewId")),
+				_parseLong((String)parameters.get("dataRecordCollectionId")),
+				_parseLong((String)parameters.get("dataListViewId")),
 				(String)parameters.get("keywords"), pagination, sorts);
 		}
 		else {
@@ -967,14 +965,14 @@ public abstract class BaseDataRecordResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			dataRecordUnsafeConsumer = dataRecord -> patchDataRecord(
 				dataRecord.getId() != null ? dataRecord.getId() :
-					Long.parseLong((String)parameters.get("dataRecordId")),
+					_parseLong((String)parameters.get("dataRecordId")),
 				dataRecord);
 		}
 
 		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
 			dataRecordUnsafeConsumer = dataRecord -> putDataRecord(
 				dataRecord.getId() != null ? dataRecord.getId() :
-					Long.parseLong((String)parameters.get("dataRecordId")),
+					_parseLong((String)parameters.get("dataRecordId")),
 				dataRecord);
 		}
 
@@ -993,6 +991,14 @@ public abstract class BaseDataRecordResourceImpl
 				dataRecordUnsafeConsumer.accept(dataRecord);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/BaseCountryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/BaseCountryResourceImpl.java
@@ -686,14 +686,14 @@ public abstract class BaseCountryResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			countryUnsafeConsumer = country -> patchCountry(
 				country.getId() != null ? country.getId() :
-					Long.parseLong((String)parameters.get("countryId")),
+					_parseLong((String)parameters.get("countryId")),
 				country);
 		}
 
 		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
 			countryUnsafeConsumer = country -> putCountry(
 				country.getId() != null ? country.getId() :
-					Long.parseLong((String)parameters.get("countryId")),
+					_parseLong((String)parameters.get("countryId")),
 				country);
 		}
 
@@ -711,6 +711,14 @@ public abstract class BaseCountryResourceImpl
 				countryUnsafeConsumer.accept(country);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/BaseRegionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/BaseRegionResourceImpl.java
@@ -728,8 +728,7 @@ public abstract class BaseRegionResourceImpl
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
 			if (parameters.containsKey("countryId")) {
 				regionUnsafeConsumer = region -> postCountryRegion(
-					Long.parseLong((String)parameters.get("countryId")),
-					region);
+					_parseLong((String)parameters.get("countryId")), region);
 			}
 			else {
 				throw new NotSupportedException(
@@ -798,13 +797,13 @@ public abstract class BaseRegionResourceImpl
 
 		if (parameters.containsKey("countryId")) {
 			return getCountryRegionsPage(
-				Long.parseLong((String)parameters.get("countryId")),
-				Boolean.parseBoolean((String)parameters.get("active")), search,
+				_parseLong((String)parameters.get("countryId")),
+				_parseBoolean((String)parameters.get("active")), search,
 				pagination, sorts);
 		}
 		else {
 			return getRegionsPage(
-				Boolean.parseBoolean((String)parameters.get("active")), search,
+				_parseBoolean((String)parameters.get("active")), search,
 				pagination, sorts);
 		}
 	}
@@ -844,14 +843,14 @@ public abstract class BaseRegionResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			regionUnsafeConsumer = region -> patchRegion(
 				region.getId() != null ? region.getId() :
-					Long.parseLong((String)parameters.get("regionId")),
+					_parseLong((String)parameters.get("regionId")),
 				region);
 		}
 
 		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
 			regionUnsafeConsumer = region -> putRegion(
 				region.getId() != null ? region.getId() :
-					Long.parseLong((String)parameters.get("regionId")),
+					_parseLong((String)parameters.get("regionId")),
 				region);
 		}
 
@@ -869,6 +868,22 @@ public abstract class BaseRegionResourceImpl
 				regionUnsafeConsumer.accept(region);
 			}
 		}
+	}
+
+	private Boolean _parseBoolean(String value) {
+		if (value != null) {
+			return Boolean.parseBoolean(value);
+		}
+
+		return null;
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/BaseListTypeDefinitionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/BaseListTypeDefinitionResourceImpl.java
@@ -740,7 +740,7 @@ public abstract class BaseListTypeDefinitionResourceImpl
 				listTypeDefinition -> patchListTypeDefinition(
 					listTypeDefinition.getId() != null ?
 						listTypeDefinition.getId() :
-							Long.parseLong(
+							_parseLong(
 								(String)parameters.get("listTypeDefinitionId")),
 					listTypeDefinition);
 		}
@@ -750,7 +750,7 @@ public abstract class BaseListTypeDefinitionResourceImpl
 				listTypeDefinition -> putListTypeDefinition(
 					listTypeDefinition.getId() != null ?
 						listTypeDefinition.getId() :
-							Long.parseLong(
+							_parseLong(
 								(String)parameters.get("listTypeDefinitionId")),
 					listTypeDefinition);
 		}
@@ -770,6 +770,14 @@ public abstract class BaseListTypeDefinitionResourceImpl
 				listTypeDefinitionUnsafeConsumer.accept(listTypeDefinition);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/BaseListTypeEntryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/BaseListTypeEntryResourceImpl.java
@@ -546,7 +546,7 @@ public abstract class BaseListTypeEntryResourceImpl
 			if (parameters.containsKey("listTypeDefinitionId")) {
 				listTypeEntryUnsafeConsumer =
 					listTypeEntry -> postListTypeDefinitionListTypeEntry(
-						Long.parseLong(
+						_parseLong(
 							(String)parameters.get("listTypeDefinitionId")),
 						listTypeEntry);
 			}
@@ -658,7 +658,7 @@ public abstract class BaseListTypeEntryResourceImpl
 		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
 			listTypeEntryUnsafeConsumer = listTypeEntry -> putListTypeEntry(
 				listTypeEntry.getId() != null ? listTypeEntry.getId() :
-					Long.parseLong((String)parameters.get("listTypeEntryId")),
+					_parseLong((String)parameters.get("listTypeEntryId")),
 				listTypeEntry);
 		}
 
@@ -677,6 +677,14 @@ public abstract class BaseListTypeEntryResourceImpl
 				listTypeEntryUnsafeConsumer.accept(listTypeEntry);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseKeywordResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseKeywordResourceImpl.java
@@ -1261,7 +1261,7 @@ public abstract class BaseKeywordResourceImpl
 		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
 			keywordUnsafeConsumer = keyword -> putKeyword(
 				keyword.getId() != null ? keyword.getId() :
-					Long.parseLong((String)parameters.get("keywordId")),
+					_parseLong((String)parameters.get("keywordId")),
 				keyword);
 		}
 
@@ -1279,6 +1279,14 @@ public abstract class BaseKeywordResourceImpl
 				keywordUnsafeConsumer.accept(keyword);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	protected String getPermissionCheckerActionsResourceName(Object id)

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
@@ -1046,7 +1046,7 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 			if (parameters.containsKey("taxonomyVocabularyId")) {
 				taxonomyCategoryUnsafeConsumer =
 					taxonomyCategory -> postTaxonomyVocabularyTaxonomyCategory(
-						Long.parseLong(
+						_parseLong(
 							(String)parameters.get("taxonomyVocabularyId")),
 						taxonomyCategory);
 			}
@@ -1061,7 +1061,7 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 				putTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode(
 					taxonomyCategory.getTaxonomyVocabularyId() != null ?
 						taxonomyCategory.getTaxonomyVocabularyId() :
-							Long.parseLong(
+							_parseLong(
 								(String)parameters.get("taxonomyVocabularyId")),
 					taxonomyCategory.getExternalReferenceCode(),
 					taxonomyCategory);
@@ -1199,6 +1199,14 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 				taxonomyCategoryUnsafeConsumer.accept(taxonomyCategory);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	protected String getPermissionCheckerActionsResourceName(Object id)

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyVocabularyResourceImpl.java
@@ -1563,7 +1563,7 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 				taxonomyVocabulary -> patchTaxonomyVocabulary(
 					taxonomyVocabulary.getId() != null ?
 						taxonomyVocabulary.getId() :
-							Long.parseLong(
+							_parseLong(
 								(String)parameters.get("taxonomyVocabularyId")),
 					taxonomyVocabulary);
 		}
@@ -1573,7 +1573,7 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 				taxonomyVocabulary -> putTaxonomyVocabulary(
 					taxonomyVocabulary.getId() != null ?
 						taxonomyVocabulary.getId() :
-							Long.parseLong(
+							_parseLong(
 								(String)parameters.get("taxonomyVocabularyId")),
 					taxonomyVocabulary);
 		}
@@ -1593,6 +1593,14 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 				taxonomyVocabularyUnsafeConsumer.accept(taxonomyVocabulary);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	protected String getPermissionCheckerActionsResourceName(Object id)

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountResourceImpl.java
@@ -1193,14 +1193,14 @@ public abstract class BaseAccountResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			accountUnsafeConsumer = account -> patchAccount(
 				account.getId() != null ? account.getId() :
-					Long.parseLong((String)parameters.get("accountId")),
+					_parseLong((String)parameters.get("accountId")),
 				account);
 		}
 
 		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
 			accountUnsafeConsumer = account -> putAccount(
 				account.getId() != null ? account.getId() :
-					Long.parseLong((String)parameters.get("accountId")),
+					_parseLong((String)parameters.get("accountId")),
 				account);
 		}
 
@@ -1218,6 +1218,14 @@ public abstract class BaseAccountResourceImpl
 				accountUnsafeConsumer.accept(account);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountRoleResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountRoleResourceImpl.java
@@ -810,7 +810,7 @@ public abstract class BaseAccountRoleResourceImpl
 			if (parameters.containsKey("accountId")) {
 				accountRoleUnsafeConsumer =
 					accountRole -> postAccountAccountRole(
-						Long.parseLong((String)parameters.get("accountId")),
+						_parseLong((String)parameters.get("accountId")),
 						accountRole);
 			}
 			else {
@@ -881,7 +881,7 @@ public abstract class BaseAccountRoleResourceImpl
 
 		if (parameters.containsKey("accountId")) {
 			return getAccountAccountRolesPage(
-				Long.parseLong((String)parameters.get("accountId")),
+				_parseLong((String)parameters.get("accountId")),
 				(String)parameters.get("keywords"), filter, pagination, sorts);
 		}
 		else {
@@ -920,6 +920,14 @@ public abstract class BaseAccountRoleResourceImpl
 
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseOrganizationResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseOrganizationResourceImpl.java
@@ -1487,12 +1487,12 @@ public abstract class BaseOrganizationResourceImpl
 
 		if (parameters.containsKey("accountId")) {
 			return getAccountOrganizationsPage(
-				Long.parseLong((String)parameters.get("accountId")), search,
-				filter, pagination, sorts);
+				_parseLong((String)parameters.get("accountId")), search, filter,
+				pagination, sorts);
 		}
 		else {
 			return getOrganizationsPage(
-				Boolean.parseBoolean((String)parameters.get("flatten")), search,
+				_parseBoolean((String)parameters.get("flatten")), search,
 				filter, pagination, sorts);
 		}
 	}
@@ -1560,6 +1560,22 @@ public abstract class BaseOrganizationResourceImpl
 				organizationUnsafeConsumer.accept(organization);
 			}
 		}
+	}
+
+	private Boolean _parseBoolean(String value) {
+		if (value != null) {
+			return Boolean.parseBoolean(value);
+		}
+
+		return null;
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BasePhoneResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BasePhoneResourceImpl.java
@@ -371,7 +371,7 @@ public abstract class BasePhoneResourceImpl
 		}
 		else if (parameters.containsKey("userAccountId")) {
 			return getUserAccountPhonesPage(
-				Long.parseLong((String)parameters.get("userAccountId")));
+				_parseLong((String)parameters.get("userAccountId")));
 		}
 		else {
 			throw new NotSupportedException(
@@ -408,6 +408,14 @@ public abstract class BasePhoneResourceImpl
 
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserAccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserAccountResourceImpl.java
@@ -1775,7 +1775,7 @@ public abstract class BaseUserAccountResourceImpl
 			if (parameters.containsKey("accountId")) {
 				userAccountUnsafeConsumer =
 					userAccount -> postAccountUserAccount(
-						Long.parseLong((String)parameters.get("accountId")),
+						_parseLong((String)parameters.get("accountId")),
 						userAccount);
 			}
 		}
@@ -1854,8 +1854,8 @@ public abstract class BaseUserAccountResourceImpl
 		}
 		else if (parameters.containsKey("accountId")) {
 			return getAccountUserAccountsPage(
-				Long.parseLong((String)parameters.get("accountId")), search,
-				filter, pagination, sorts);
+				_parseLong((String)parameters.get("accountId")), search, filter,
+				pagination, sorts);
 		}
 		else if (parameters.containsKey("organizationId")) {
 			return getOrganizationUserAccountsPage(
@@ -1903,14 +1903,14 @@ public abstract class BaseUserAccountResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			userAccountUnsafeConsumer = userAccount -> patchUserAccount(
 				userAccount.getId() != null ? userAccount.getId() :
-					Long.parseLong((String)parameters.get("userAccountId")),
+					_parseLong((String)parameters.get("userAccountId")),
 				userAccount);
 		}
 
 		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
 			userAccountUnsafeConsumer = userAccount -> putUserAccount(
 				userAccount.getId() != null ? userAccount.getId() :
-					Long.parseLong((String)parameters.get("userAccountId")),
+					_parseLong((String)parameters.get("userAccountId")),
 				userAccount);
 		}
 
@@ -1929,6 +1929,14 @@ public abstract class BaseUserAccountResourceImpl
 				userAccountUnsafeConsumer.accept(userAccount);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserGroupResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserGroupResourceImpl.java
@@ -871,14 +871,14 @@ public abstract class BaseUserGroupResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			userGroupUnsafeConsumer = userGroup -> patchUserGroup(
 				userGroup.getId() != null ? userGroup.getId() :
-					Long.parseLong((String)parameters.get("userGroupId")),
+					_parseLong((String)parameters.get("userGroupId")),
 				userGroup);
 		}
 
 		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
 			userGroupUnsafeConsumer = userGroup -> putUserGroup(
 				userGroup.getId() != null ? userGroup.getId() :
-					Long.parseLong((String)parameters.get("userGroupId")),
+					_parseLong((String)parameters.get("userGroupId")),
 				userGroup);
 		}
 
@@ -897,6 +897,14 @@ public abstract class BaseUserGroupResourceImpl
 				userGroupUnsafeConsumer.accept(userGroup);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseWebUrlResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseWebUrlResourceImpl.java
@@ -371,7 +371,7 @@ public abstract class BaseWebUrlResourceImpl
 		}
 		else if (parameters.containsKey("userAccountId")) {
 			return getUserAccountWebUrlsPage(
-				Long.parseLong((String)parameters.get("userAccountId")));
+				_parseLong((String)parameters.get("userAccountId")));
 		}
 		else {
 			throw new NotSupportedException(
@@ -408,6 +408,14 @@ public abstract class BaseWebUrlResourceImpl
 
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseWorkflowDefinitionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseWorkflowDefinitionResourceImpl.java
@@ -704,8 +704,7 @@ public abstract class BaseWorkflowDefinitionResourceImpl
 		throws Exception {
 
 		return getWorkflowDefinitionsPage(
-			Boolean.parseBoolean((String)parameters.get("active")), pagination,
-			sorts);
+			_parseBoolean((String)parameters.get("active")), pagination, sorts);
 	}
 
 	@Override
@@ -747,7 +746,7 @@ public abstract class BaseWorkflowDefinitionResourceImpl
 				workflowDefinition -> putWorkflowDefinition(
 					workflowDefinition.getId() != null ?
 						workflowDefinition.getId() :
-							Long.parseLong(
+							_parseLong(
 								(String)parameters.get("workflowDefinitionId")),
 					workflowDefinition);
 		}
@@ -767,6 +766,22 @@ public abstract class BaseWorkflowDefinitionResourceImpl
 				workflowDefinitionUnsafeConsumer.accept(workflowDefinition);
 			}
 		}
+	}
+
+	private Boolean _parseBoolean(String value) {
+		if (value != null) {
+			return Boolean.parseBoolean(value);
+		}
+
+		return null;
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseWorkflowInstanceResourceImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseWorkflowInstanceResourceImpl.java
@@ -441,9 +441,8 @@ public abstract class BaseWorkflowInstanceResourceImpl
 
 		return getWorkflowInstancesPage(
 			(String)parameters.get("assetClassName"),
-			Long.parseLong((String)parameters.get("assetPrimaryKey")),
-			Boolean.parseBoolean((String)parameters.get("completed")),
-			pagination);
+			_parseLong((String)parameters.get("assetPrimaryKey")),
+			_parseBoolean((String)parameters.get("completed")), pagination);
 	}
 
 	@Override
@@ -476,6 +475,22 @@ public abstract class BaseWorkflowInstanceResourceImpl
 
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
+	}
+
+	private Boolean _parseBoolean(String value) {
+		if (value != null) {
+			return Boolean.parseBoolean(value);
+		}
+
+		return null;
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseWorkflowLogResourceImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseWorkflowLogResourceImpl.java
@@ -413,12 +413,12 @@ public abstract class BaseWorkflowLogResourceImpl
 
 		if (parameters.containsKey("workflowInstanceId")) {
 			return getWorkflowInstanceWorkflowLogsPage(
-				Long.parseLong((String)parameters.get("workflowInstanceId")),
+				_parseLong((String)parameters.get("workflowInstanceId")),
 				(String[])parameters.get("types"), pagination);
 		}
 		else if (parameters.containsKey("workflowTaskId")) {
 			return getWorkflowTaskWorkflowLogsPage(
-				Long.parseLong((String)parameters.get("workflowTaskId")),
+				_parseLong((String)parameters.get("workflowTaskId")),
 				(String[])parameters.get("types"), pagination);
 		}
 		else {
@@ -457,6 +457,14 @@ public abstract class BaseWorkflowLogResourceImpl
 
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseWorkflowTaskResourceImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseWorkflowTaskResourceImpl.java
@@ -895,9 +895,8 @@ public abstract class BaseWorkflowTaskResourceImpl
 
 		if (parameters.containsKey("workflowInstanceId")) {
 			return getWorkflowInstanceWorkflowTasksPage(
-				Long.parseLong((String)parameters.get("workflowInstanceId")),
-				Boolean.parseBoolean((String)parameters.get("completed")),
-				pagination);
+				_parseLong((String)parameters.get("workflowInstanceId")),
+				_parseBoolean((String)parameters.get("completed")), pagination);
 		}
 		else {
 			throw new NotSupportedException(
@@ -935,6 +934,22 @@ public abstract class BaseWorkflowTaskResourceImpl
 
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
+	}
+
+	private Boolean _parseBoolean(String value) {
+		if (value != null) {
+			return Boolean.parseBoolean(value);
+		}
+
+		return null;
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingResourceImpl.java
@@ -1439,14 +1439,14 @@ public abstract class BaseBlogPostingResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			blogPostingUnsafeConsumer = blogPosting -> patchBlogPosting(
 				blogPosting.getId() != null ? blogPosting.getId() :
-					Long.parseLong((String)parameters.get("blogPostingId")),
+					_parseLong((String)parameters.get("blogPostingId")),
 				blogPosting);
 		}
 
 		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
 			blogPostingUnsafeConsumer = blogPosting -> putBlogPosting(
 				blogPosting.getId() != null ? blogPosting.getId() :
-					Long.parseLong((String)parameters.get("blogPostingId")),
+					_parseLong((String)parameters.get("blogPostingId")),
 				blogPosting);
 		}
 
@@ -1465,6 +1465,14 @@ public abstract class BaseBlogPostingResourceImpl
 				blogPostingUnsafeConsumer.accept(blogPosting);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	protected String getPermissionCheckerActionsResourceName(Object id)

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseCommentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseCommentResourceImpl.java
@@ -1827,18 +1827,16 @@ public abstract class BaseCommentResourceImpl
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
 			if (parameters.containsKey("blogPostingId")) {
 				commentUnsafeConsumer = comment -> postBlogPostingComment(
-					Long.parseLong((String)parameters.get("blogPostingId")),
+					_parseLong((String)parameters.get("blogPostingId")),
 					comment);
 			}
 			else if (parameters.containsKey("documentId")) {
 				commentUnsafeConsumer = comment -> postDocumentComment(
-					Long.parseLong((String)parameters.get("documentId")),
-					comment);
+					_parseLong((String)parameters.get("documentId")), comment);
 			}
 			else if (parameters.containsKey("structuredContentId")) {
 				commentUnsafeConsumer = comment -> postStructuredContentComment(
-					Long.parseLong(
-						(String)parameters.get("structuredContentId")),
+					_parseLong((String)parameters.get("structuredContentId")),
 					comment);
 			}
 			else {
@@ -1908,17 +1906,17 @@ public abstract class BaseCommentResourceImpl
 
 		if (parameters.containsKey("blogPostingId")) {
 			return getBlogPostingCommentsPage(
-				Long.parseLong((String)parameters.get("blogPostingId")), search,
+				_parseLong((String)parameters.get("blogPostingId")), search,
 				null, filter, pagination, sorts);
 		}
 		else if (parameters.containsKey("documentId")) {
 			return getDocumentCommentsPage(
-				Long.parseLong((String)parameters.get("documentId")), search,
-				null, filter, pagination, sorts);
+				_parseLong((String)parameters.get("documentId")), search, null,
+				filter, pagination, sorts);
 		}
 		else if (parameters.containsKey("structuredContentId")) {
 			return getStructuredContentCommentsPage(
-				Long.parseLong((String)parameters.get("structuredContentId")),
+				_parseLong((String)parameters.get("structuredContentId")),
 				search, null, filter, pagination, sorts);
 		}
 		else {
@@ -1962,7 +1960,7 @@ public abstract class BaseCommentResourceImpl
 		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
 			commentUnsafeConsumer = comment -> putComment(
 				comment.getId() != null ? comment.getId() :
-					Long.parseLong((String)parameters.get("commentId")),
+					_parseLong((String)parameters.get("commentId")),
 				comment);
 		}
 
@@ -1980,6 +1978,14 @@ public abstract class BaseCommentResourceImpl
 				commentUnsafeConsumer.accept(comment);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentFolderResourceImpl.java
@@ -1989,14 +1989,14 @@ public abstract class BaseDocumentFolderResourceImpl
 		if (parameters.containsKey("assetLibraryId")) {
 			return getAssetLibraryDocumentFoldersPage(
 				(Long)parameters.get("assetLibraryId"),
-				Boolean.parseBoolean((String)parameters.get("flatten")), search,
-				null, filter, pagination, sorts);
+				_parseBoolean((String)parameters.get("flatten")), search, null,
+				filter, pagination, sorts);
 		}
 		else if (parameters.containsKey("siteId")) {
 			return getSiteDocumentFoldersPage(
 				(Long)parameters.get("siteId"),
-				Boolean.parseBoolean((String)parameters.get("flatten")), search,
-				null, filter, pagination, sorts);
+				_parseBoolean((String)parameters.get("flatten")), search, null,
+				filter, pagination, sorts);
 		}
 		else {
 			throw new NotSupportedException(
@@ -2042,15 +2042,14 @@ public abstract class BaseDocumentFolderResourceImpl
 			documentFolderUnsafeConsumer =
 				documentFolder -> patchDocumentFolder(
 					documentFolder.getId() != null ? documentFolder.getId() :
-						Long.parseLong(
-							(String)parameters.get("documentFolderId")),
+						_parseLong((String)parameters.get("documentFolderId")),
 					documentFolder);
 		}
 
 		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
 			documentFolderUnsafeConsumer = documentFolder -> putDocumentFolder(
 				documentFolder.getId() != null ? documentFolder.getId() :
-					Long.parseLong((String)parameters.get("documentFolderId")),
+					_parseLong((String)parameters.get("documentFolderId")),
 				documentFolder);
 		}
 
@@ -2069,6 +2068,22 @@ public abstract class BaseDocumentFolderResourceImpl
 				documentFolderUnsafeConsumer.accept(documentFolder);
 			}
 		}
+	}
+
+	private Boolean _parseBoolean(String value) {
+		if (value != null) {
+			return Boolean.parseBoolean(value);
+		}
+
+		return null;
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	protected String getPermissionCheckerActionsResourceName(Object id)

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentResourceImpl.java
@@ -2058,7 +2058,7 @@ public abstract class BaseDocumentResourceImpl
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
 			if (parameters.containsKey("documentFolderId")) {
 				documentUnsafeConsumer = document -> postDocumentFolderDocument(
-					Long.parseLong((String)parameters.get("documentFolderId")),
+					_parseLong((String)parameters.get("documentFolderId")),
 					(MultipartBody)parameters.get("multipartBody"));
 			}
 			else if (parameters.containsKey("assetLibraryId")) {
@@ -2149,20 +2149,20 @@ public abstract class BaseDocumentResourceImpl
 		if (parameters.containsKey("assetLibraryId")) {
 			return getAssetLibraryDocumentsPage(
 				(Long)parameters.get("assetLibraryId"),
-				Boolean.parseBoolean((String)parameters.get("flatten")), search,
-				null, filter, pagination, sorts);
+				_parseBoolean((String)parameters.get("flatten")), search, null,
+				filter, pagination, sorts);
 		}
 		else if (parameters.containsKey("siteId")) {
 			return getSiteDocumentsPage(
 				(Long)parameters.get("siteId"),
-				Boolean.parseBoolean((String)parameters.get("flatten")), search,
-				null, filter, pagination, sorts);
+				_parseBoolean((String)parameters.get("flatten")), search, null,
+				filter, pagination, sorts);
 		}
 		else if (parameters.containsKey("documentFolderId")) {
 			return getDocumentFolderDocumentsPage(
-				Long.parseLong((String)parameters.get("documentFolderId")),
-				Boolean.parseBoolean((String)parameters.get("flatten")), search,
-				null, filter, pagination, sorts);
+				_parseLong((String)parameters.get("documentFolderId")),
+				_parseBoolean((String)parameters.get("flatten")), search, null,
+				filter, pagination, sorts);
 		}
 		else {
 			throw new NotSupportedException(
@@ -2206,14 +2206,14 @@ public abstract class BaseDocumentResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			documentUnsafeConsumer = document -> patchDocument(
 				document.getId() != null ? document.getId() :
-					Long.parseLong((String)parameters.get("documentId")),
+					_parseLong((String)parameters.get("documentId")),
 				null);
 		}
 
 		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
 			documentUnsafeConsumer = document -> putDocument(
 				document.getId() != null ? document.getId() :
-					Long.parseLong((String)parameters.get("documentId")),
+					_parseLong((String)parameters.get("documentId")),
 				null);
 		}
 
@@ -2232,6 +2232,22 @@ public abstract class BaseDocumentResourceImpl
 				documentUnsafeConsumer.accept(document);
 			}
 		}
+	}
+
+	private Boolean _parseBoolean(String value) {
+		if (value != null) {
+			return Boolean.parseBoolean(value);
+		}
+
+		return null;
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	protected String getPermissionCheckerActionsResourceName(Object id)

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseArticleResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseArticleResourceImpl.java
@@ -1891,7 +1891,7 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 			if (parameters.containsKey("knowledgeBaseFolderId")) {
 				knowledgeBaseArticleUnsafeConsumer = knowledgeBaseArticle ->
 					postKnowledgeBaseFolderKnowledgeBaseArticle(
-						Long.parseLong(
+						_parseLong(
 							(String)parameters.get("knowledgeBaseFolderId")),
 						knowledgeBaseArticle);
 			}
@@ -1984,14 +1984,14 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 		if (parameters.containsKey("siteId")) {
 			return getSiteKnowledgeBaseArticlesPage(
 				(Long)parameters.get("siteId"),
-				Boolean.parseBoolean((String)parameters.get("flatten")), search,
-				null, filter, pagination, sorts);
+				_parseBoolean((String)parameters.get("flatten")), search, null,
+				filter, pagination, sorts);
 		}
 		else if (parameters.containsKey("knowledgeBaseFolderId")) {
 			return getKnowledgeBaseFolderKnowledgeBaseArticlesPage(
-				Long.parseLong((String)parameters.get("knowledgeBaseFolderId")),
-				Boolean.parseBoolean((String)parameters.get("flatten")), search,
-				null, filter, pagination, sorts);
+				_parseLong((String)parameters.get("knowledgeBaseFolderId")),
+				_parseBoolean((String)parameters.get("flatten")), search, null,
+				filter, pagination, sorts);
 		}
 		else {
 			throw new NotSupportedException(
@@ -2038,7 +2038,7 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 				knowledgeBaseArticle -> patchKnowledgeBaseArticle(
 					knowledgeBaseArticle.getId() != null ?
 						knowledgeBaseArticle.getId() :
-							Long.parseLong(
+							_parseLong(
 								(String)parameters.get(
 									"knowledgeBaseArticleId")),
 					knowledgeBaseArticle);
@@ -2049,7 +2049,7 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 				knowledgeBaseArticle -> putKnowledgeBaseArticle(
 					knowledgeBaseArticle.getId() != null ?
 						knowledgeBaseArticle.getId() :
-							Long.parseLong(
+							_parseLong(
 								(String)parameters.get(
 									"knowledgeBaseArticleId")),
 					knowledgeBaseArticle);
@@ -2072,6 +2072,22 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 				knowledgeBaseArticleUnsafeConsumer.accept(knowledgeBaseArticle);
 			}
 		}
+	}
+
+	private Boolean _parseBoolean(String value) {
+		if (value != null) {
+			return Boolean.parseBoolean(value);
+		}
+
+		return null;
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	protected String getPermissionCheckerActionsResourceName(Object id)

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseAttachmentResourceImpl.java
@@ -650,7 +650,7 @@ public abstract class BaseKnowledgeBaseAttachmentResourceImpl
 				knowledgeBaseAttachmentUnsafeConsumer =
 					knowledgeBaseAttachment ->
 						postKnowledgeBaseArticleKnowledgeBaseAttachment(
-							Long.parseLong(
+							_parseLong(
 								(String)parameters.get(
 									"knowledgeBaseArticleId")),
 							(MultipartBody)parameters.get("multipartBody"));
@@ -730,8 +730,7 @@ public abstract class BaseKnowledgeBaseAttachmentResourceImpl
 
 		if (parameters.containsKey("knowledgeBaseArticleId")) {
 			return getKnowledgeBaseArticleKnowledgeBaseAttachmentsPage(
-				Long.parseLong(
-					(String)parameters.get("knowledgeBaseArticleId")));
+				_parseLong((String)parameters.get("knowledgeBaseArticleId")));
 		}
 		else {
 			throw new NotSupportedException(
@@ -769,6 +768,14 @@ public abstract class BaseKnowledgeBaseAttachmentResourceImpl
 
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseFolderResourceImpl.java
@@ -1323,7 +1323,7 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 				knowledgeBaseFolder -> patchKnowledgeBaseFolder(
 					knowledgeBaseFolder.getId() != null ?
 						knowledgeBaseFolder.getId() :
-							Long.parseLong(
+							_parseLong(
 								(String)parameters.get(
 									"knowledgeBaseFolderId")),
 					knowledgeBaseFolder);
@@ -1334,7 +1334,7 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 				knowledgeBaseFolder -> putKnowledgeBaseFolder(
 					knowledgeBaseFolder.getId() != null ?
 						knowledgeBaseFolder.getId() :
-							Long.parseLong(
+							_parseLong(
 								(String)parameters.get(
 									"knowledgeBaseFolderId")),
 					knowledgeBaseFolder);
@@ -1357,6 +1357,14 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 				knowledgeBaseFolderUnsafeConsumer.accept(knowledgeBaseFolder);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	protected String getPermissionCheckerActionsResourceName(Object id)

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardAttachmentResourceImpl.java
@@ -809,14 +809,14 @@ public abstract class BaseMessageBoardAttachmentResourceImpl
 			if (parameters.containsKey("messageBoardMessageId")) {
 				messageBoardAttachmentUnsafeConsumer = messageBoardAttachment ->
 					postMessageBoardMessageMessageBoardAttachment(
-						Long.parseLong(
+						_parseLong(
 							(String)parameters.get("messageBoardMessageId")),
 						(MultipartBody)parameters.get("multipartBody"));
 			}
 			else if (parameters.containsKey("messageBoardThreadId")) {
 				messageBoardAttachmentUnsafeConsumer = messageBoardAttachment ->
 					postMessageBoardThreadMessageBoardAttachment(
-						Long.parseLong(
+						_parseLong(
 							(String)parameters.get("messageBoardThreadId")),
 						(MultipartBody)parameters.get("multipartBody"));
 			}
@@ -894,12 +894,11 @@ public abstract class BaseMessageBoardAttachmentResourceImpl
 
 		if (parameters.containsKey("messageBoardMessageId")) {
 			return getMessageBoardMessageMessageBoardAttachmentsPage(
-				Long.parseLong(
-					(String)parameters.get("messageBoardMessageId")));
+				_parseLong((String)parameters.get("messageBoardMessageId")));
 		}
 		else if (parameters.containsKey("messageBoardThreadId")) {
 			return getMessageBoardThreadMessageBoardAttachmentsPage(
-				Long.parseLong((String)parameters.get("messageBoardThreadId")));
+				_parseLong((String)parameters.get("messageBoardThreadId")));
 		}
 		else {
 			throw new NotSupportedException(
@@ -937,6 +936,14 @@ public abstract class BaseMessageBoardAttachmentResourceImpl
 
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardMessageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardMessageResourceImpl.java
@@ -1799,7 +1799,7 @@ public abstract class BaseMessageBoardMessageResourceImpl
 			if (parameters.containsKey("messageBoardThreadId")) {
 				messageBoardMessageUnsafeConsumer = messageBoardMessage ->
 					postMessageBoardThreadMessageBoardMessage(
-						Long.parseLong(
+						_parseLong(
 							(String)parameters.get("messageBoardThreadId")),
 						messageBoardMessage);
 			}
@@ -1885,12 +1885,12 @@ public abstract class BaseMessageBoardMessageResourceImpl
 		if (parameters.containsKey("siteId")) {
 			return getSiteMessageBoardMessagesPage(
 				(Long)parameters.get("siteId"),
-				Boolean.parseBoolean((String)parameters.get("flatten")), search,
-				null, filter, pagination, sorts);
+				_parseBoolean((String)parameters.get("flatten")), search, null,
+				filter, pagination, sorts);
 		}
 		else if (parameters.containsKey("messageBoardThreadId")) {
 			return getMessageBoardThreadMessageBoardMessagesPage(
-				Long.parseLong((String)parameters.get("messageBoardThreadId")),
+				_parseLong((String)parameters.get("messageBoardThreadId")),
 				search, null, filter, pagination, sorts);
 		}
 		else {
@@ -1938,7 +1938,7 @@ public abstract class BaseMessageBoardMessageResourceImpl
 				messageBoardMessage -> patchMessageBoardMessage(
 					messageBoardMessage.getId() != null ?
 						messageBoardMessage.getId() :
-							Long.parseLong(
+							_parseLong(
 								(String)parameters.get(
 									"messageBoardMessageId")),
 					messageBoardMessage);
@@ -1949,7 +1949,7 @@ public abstract class BaseMessageBoardMessageResourceImpl
 				messageBoardMessage -> putMessageBoardMessage(
 					messageBoardMessage.getId() != null ?
 						messageBoardMessage.getId() :
-							Long.parseLong(
+							_parseLong(
 								(String)parameters.get(
 									"messageBoardMessageId")),
 					messageBoardMessage);
@@ -1972,6 +1972,22 @@ public abstract class BaseMessageBoardMessageResourceImpl
 				messageBoardMessageUnsafeConsumer.accept(messageBoardMessage);
 			}
 		}
+	}
+
+	private Boolean _parseBoolean(String value) {
+		if (value != null) {
+			return Boolean.parseBoolean(value);
+		}
+
+		return null;
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	protected String getPermissionCheckerActionsResourceName(Object id)

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardSectionResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardSectionResourceImpl.java
@@ -1252,8 +1252,8 @@ public abstract class BaseMessageBoardSectionResourceImpl
 		if (parameters.containsKey("siteId")) {
 			return getSiteMessageBoardSectionsPage(
 				(Long)parameters.get("siteId"),
-				Boolean.parseBoolean((String)parameters.get("flatten")), search,
-				null, filter, pagination, sorts);
+				_parseBoolean((String)parameters.get("flatten")), search, null,
+				filter, pagination, sorts);
 		}
 		else {
 			throw new NotSupportedException(
@@ -1300,7 +1300,7 @@ public abstract class BaseMessageBoardSectionResourceImpl
 				messageBoardSection -> patchMessageBoardSection(
 					messageBoardSection.getId() != null ?
 						messageBoardSection.getId() :
-							Long.parseLong(
+							_parseLong(
 								(String)parameters.get(
 									"messageBoardSectionId")),
 					messageBoardSection);
@@ -1311,7 +1311,7 @@ public abstract class BaseMessageBoardSectionResourceImpl
 				messageBoardSection -> putMessageBoardSection(
 					messageBoardSection.getId() != null ?
 						messageBoardSection.getId() :
-							Long.parseLong(
+							_parseLong(
 								(String)parameters.get(
 									"messageBoardSectionId")),
 					messageBoardSection);
@@ -1334,6 +1334,22 @@ public abstract class BaseMessageBoardSectionResourceImpl
 				messageBoardSectionUnsafeConsumer.accept(messageBoardSection);
 			}
 		}
+	}
+
+	private Boolean _parseBoolean(String value) {
+		if (value != null) {
+			return Boolean.parseBoolean(value);
+		}
+
+		return null;
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	protected String getPermissionCheckerActionsResourceName(Object id)

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardThreadResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardThreadResourceImpl.java
@@ -67,6 +67,7 @@ import java.io.Serializable;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -420,10 +421,10 @@ public abstract class BaseMessageBoardThreadResourceImpl
 	public Page<MessageBoardThread> getMessageBoardThreadsRankedPage(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.ws.rs.QueryParam("dateCreated")
-			java.util.Date dateCreated,
+			Date dateCreated,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.ws.rs.QueryParam("dateModified")
-			java.util.Date dateModified,
+			Date dateModified,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.ws.rs.QueryParam("messageBoardSectionId")
 			Long messageBoardSectionId,
@@ -1627,7 +1628,7 @@ public abstract class BaseMessageBoardThreadResourceImpl
 				messageBoardThreadUnsafeConsumer =
 					messageBoardThread ->
 						postMessageBoardSectionMessageBoardThread(
-							Long.parseLong(
+							_parseLong(
 								(String)parameters.get(
 									"messageBoardSectionId")),
 							messageBoardThread);
@@ -1707,12 +1708,12 @@ public abstract class BaseMessageBoardThreadResourceImpl
 		if (parameters.containsKey("siteId")) {
 			return getSiteMessageBoardThreadsPage(
 				(Long)parameters.get("siteId"),
-				Boolean.parseBoolean((String)parameters.get("flatten")), search,
-				null, filter, pagination, sorts);
+				_parseBoolean((String)parameters.get("flatten")), search, null,
+				filter, pagination, sorts);
 		}
 		else if (parameters.containsKey("messageBoardSectionId")) {
 			return getMessageBoardSectionMessageBoardThreadsPage(
-				Long.parseLong((String)parameters.get("messageBoardSectionId")),
+				_parseLong((String)parameters.get("messageBoardSectionId")),
 				search, null, filter, pagination, sorts);
 		}
 		else {
@@ -1760,7 +1761,7 @@ public abstract class BaseMessageBoardThreadResourceImpl
 				messageBoardThread -> patchMessageBoardThread(
 					messageBoardThread.getId() != null ?
 						messageBoardThread.getId() :
-							Long.parseLong(
+							_parseLong(
 								(String)parameters.get("messageBoardThreadId")),
 					messageBoardThread);
 		}
@@ -1770,7 +1771,7 @@ public abstract class BaseMessageBoardThreadResourceImpl
 				messageBoardThread -> putMessageBoardThread(
 					messageBoardThread.getId() != null ?
 						messageBoardThread.getId() :
-							Long.parseLong(
+							_parseLong(
 								(String)parameters.get("messageBoardThreadId")),
 					messageBoardThread);
 		}
@@ -1790,6 +1791,22 @@ public abstract class BaseMessageBoardThreadResourceImpl
 				messageBoardThreadUnsafeConsumer.accept(messageBoardThread);
 			}
 		}
+	}
+
+	private Boolean _parseBoolean(String value) {
+		if (value != null) {
+			return Boolean.parseBoolean(value);
+		}
+
+		return null;
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	protected String getPermissionCheckerActionsResourceName(Object id)

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseNavigationMenuResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseNavigationMenuResourceImpl.java
@@ -909,7 +909,7 @@ public abstract class BaseNavigationMenuResourceImpl
 		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
 			navigationMenuUnsafeConsumer = navigationMenu -> putNavigationMenu(
 				navigationMenu.getId() != null ? navigationMenu.getId() :
-					Long.parseLong((String)parameters.get("navigationMenuId")),
+					_parseLong((String)parameters.get("navigationMenuId")),
 				navigationMenu);
 		}
 
@@ -928,6 +928,14 @@ public abstract class BaseNavigationMenuResourceImpl
 				navigationMenuUnsafeConsumer.accept(navigationMenu);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	protected String getPermissionCheckerActionsResourceName(Object id)

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentFolderResourceImpl.java
@@ -2014,14 +2014,14 @@ public abstract class BaseStructuredContentFolderResourceImpl
 		if (parameters.containsKey("assetLibraryId")) {
 			return getAssetLibraryStructuredContentFoldersPage(
 				(Long)parameters.get("assetLibraryId"),
-				Boolean.parseBoolean((String)parameters.get("flatten")), search,
-				null, filter, pagination, sorts);
+				_parseBoolean((String)parameters.get("flatten")), search, null,
+				filter, pagination, sorts);
 		}
 		else if (parameters.containsKey("siteId")) {
 			return getSiteStructuredContentFoldersPage(
 				(Long)parameters.get("siteId"),
-				Boolean.parseBoolean((String)parameters.get("flatten")), search,
-				null, filter, pagination, sorts);
+				_parseBoolean((String)parameters.get("flatten")), search, null,
+				filter, pagination, sorts);
 		}
 		else {
 			throw new NotSupportedException(
@@ -2068,7 +2068,7 @@ public abstract class BaseStructuredContentFolderResourceImpl
 				structuredContentFolder -> patchStructuredContentFolder(
 					structuredContentFolder.getId() != null ?
 						structuredContentFolder.getId() :
-							Long.parseLong(
+							_parseLong(
 								(String)parameters.get(
 									"structuredContentFolderId")),
 					structuredContentFolder);
@@ -2079,7 +2079,7 @@ public abstract class BaseStructuredContentFolderResourceImpl
 				structuredContentFolder -> putStructuredContentFolder(
 					structuredContentFolder.getId() != null ?
 						structuredContentFolder.getId() :
-							Long.parseLong(
+							_parseLong(
 								(String)parameters.get(
 									"structuredContentFolderId")),
 					structuredContentFolder);
@@ -2104,6 +2104,22 @@ public abstract class BaseStructuredContentFolderResourceImpl
 					structuredContentFolder);
 			}
 		}
+	}
+
+	private Boolean _parseBoolean(String value) {
+		if (value != null) {
+			return Boolean.parseBoolean(value);
+		}
+
+		return null;
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	protected String getPermissionCheckerActionsResourceName(Object id)

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
@@ -2587,7 +2587,7 @@ public abstract class BaseStructuredContentResourceImpl
 			if (parameters.containsKey("structuredContentFolderId")) {
 				structuredContentUnsafeConsumer = structuredContent ->
 					postStructuredContentFolderStructuredContent(
-						Long.parseLong(
+						_parseLong(
 							(String)parameters.get(
 								"structuredContentFolderId")),
 						structuredContent);
@@ -2683,26 +2683,25 @@ public abstract class BaseStructuredContentResourceImpl
 		if (parameters.containsKey("assetLibraryId")) {
 			return getAssetLibraryStructuredContentsPage(
 				(Long)parameters.get("assetLibraryId"),
-				Boolean.parseBoolean((String)parameters.get("flatten")), search,
-				null, filter, pagination, sorts);
+				_parseBoolean((String)parameters.get("flatten")), search, null,
+				filter, pagination, sorts);
 		}
 		else if (parameters.containsKey("siteId")) {
 			return getSiteStructuredContentsPage(
 				(Long)parameters.get("siteId"),
-				Boolean.parseBoolean((String)parameters.get("flatten")), search,
-				null, filter, pagination, sorts);
+				_parseBoolean((String)parameters.get("flatten")), search, null,
+				filter, pagination, sorts);
 		}
 		else if (parameters.containsKey("contentStructureId")) {
 			return getContentStructureStructuredContentsPage(
-				Long.parseLong((String)parameters.get("contentStructureId")),
+				_parseLong((String)parameters.get("contentStructureId")),
 				search, null, filter, pagination, sorts);
 		}
 		else if (parameters.containsKey("structuredContentFolderId")) {
 			return getStructuredContentFolderStructuredContentsPage(
-				Long.parseLong(
-					(String)parameters.get("structuredContentFolderId")),
-				Boolean.parseBoolean((String)parameters.get("flatten")), search,
-				null, filter, pagination, sorts);
+				_parseLong((String)parameters.get("structuredContentFolderId")),
+				_parseBoolean((String)parameters.get("flatten")), search, null,
+				filter, pagination, sorts);
 		}
 		else {
 			throw new NotSupportedException(
@@ -2749,7 +2748,7 @@ public abstract class BaseStructuredContentResourceImpl
 				structuredContent -> patchStructuredContent(
 					structuredContent.getId() != null ?
 						structuredContent.getId() :
-							Long.parseLong(
+							_parseLong(
 								(String)parameters.get("structuredContentId")),
 					structuredContent);
 		}
@@ -2759,7 +2758,7 @@ public abstract class BaseStructuredContentResourceImpl
 				structuredContent -> putStructuredContent(
 					structuredContent.getId() != null ?
 						structuredContent.getId() :
-							Long.parseLong(
+							_parseLong(
 								(String)parameters.get("structuredContentId")),
 					structuredContent);
 		}
@@ -2779,6 +2778,22 @@ public abstract class BaseStructuredContentResourceImpl
 				structuredContentUnsafeConsumer.accept(structuredContent);
 			}
 		}
+	}
+
+	private Boolean _parseBoolean(String value) {
+		if (value != null) {
+			return Boolean.parseBoolean(value);
+		}
+
+		return null;
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	protected String getPermissionCheckerActionsResourceName(Object id)

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiNodeResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiNodeResourceImpl.java
@@ -1129,7 +1129,7 @@ public abstract class BaseWikiNodeResourceImpl
 		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
 			wikiNodeUnsafeConsumer = wikiNode -> putWikiNode(
 				wikiNode.getId() != null ? wikiNode.getId() :
-					Long.parseLong((String)parameters.get("wikiNodeId")),
+					_parseLong((String)parameters.get("wikiNodeId")),
 				wikiNode);
 		}
 
@@ -1148,6 +1148,14 @@ public abstract class BaseWikiNodeResourceImpl
 				wikiNodeUnsafeConsumer.accept(wikiNode);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	protected String getPermissionCheckerActionsResourceName(Object id)

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageAttachmentResourceImpl.java
@@ -550,7 +550,7 @@ public abstract class BaseWikiPageAttachmentResourceImpl
 			if (parameters.containsKey("wikiPageId")) {
 				wikiPageAttachmentUnsafeConsumer =
 					wikiPageAttachment -> postWikiPageWikiPageAttachment(
-						Long.parseLong((String)parameters.get("wikiPageId")),
+						_parseLong((String)parameters.get("wikiPageId")),
 						(MultipartBody)parameters.get("multipartBody"));
 			}
 			else {
@@ -622,7 +622,7 @@ public abstract class BaseWikiPageAttachmentResourceImpl
 
 		if (parameters.containsKey("wikiPageId")) {
 			return getWikiPageWikiPageAttachmentsPage(
-				Long.parseLong((String)parameters.get("wikiPageId")));
+				_parseLong((String)parameters.get("wikiPageId")));
 		}
 		else {
 			throw new NotSupportedException(
@@ -660,6 +660,14 @@ public abstract class BaseWikiPageAttachmentResourceImpl
 
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageResourceImpl.java
@@ -961,8 +961,7 @@ public abstract class BaseWikiPageResourceImpl
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
 			if (parameters.containsKey("wikiNodeId")) {
 				wikiPageUnsafeConsumer = wikiPage -> postWikiNodeWikiPage(
-					Long.parseLong((String)parameters.get("wikiNodeId")),
-					wikiPage);
+					_parseLong((String)parameters.get("wikiNodeId")), wikiPage);
 			}
 			else {
 				throw new NotSupportedException(
@@ -1041,8 +1040,8 @@ public abstract class BaseWikiPageResourceImpl
 
 		if (parameters.containsKey("wikiNodeId")) {
 			return getWikiNodeWikiPagesPage(
-				Long.parseLong((String)parameters.get("wikiNodeId")), search,
-				null, filter, pagination, sorts);
+				_parseLong((String)parameters.get("wikiNodeId")), search, null,
+				filter, pagination, sorts);
 		}
 		else {
 			throw new NotSupportedException(
@@ -1086,7 +1085,7 @@ public abstract class BaseWikiPageResourceImpl
 		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
 			wikiPageUnsafeConsumer = wikiPage -> putWikiPage(
 				wikiPage.getId() != null ? wikiPage.getId() :
-					Long.parseLong((String)parameters.get("wikiPageId")),
+					_parseLong((String)parameters.get("wikiPageId")),
 				wikiPage);
 		}
 
@@ -1105,6 +1104,14 @@ public abstract class BaseWikiPageResourceImpl
 				wikiPageUnsafeConsumer.accept(wikiPage);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	protected String getPermissionCheckerActionsResourceName(Object id)

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormRecordResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormRecordResourceImpl.java
@@ -437,8 +437,7 @@ public abstract class BaseFormRecordResourceImpl
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
 			if (parameters.containsKey("formId")) {
 				formRecordUnsafeConsumer = formRecord -> postFormFormRecord(
-					Long.parseLong((String)parameters.get("formId")),
-					formRecord);
+					_parseLong((String)parameters.get("formId")), formRecord);
 			}
 			else {
 				throw new NotSupportedException(
@@ -508,7 +507,7 @@ public abstract class BaseFormRecordResourceImpl
 
 		if (parameters.containsKey("formId")) {
 			return getFormFormRecordsPage(
-				Long.parseLong((String)parameters.get("formId")), pagination);
+				_parseLong((String)parameters.get("formId")), pagination);
 		}
 		else {
 			throw new NotSupportedException(
@@ -552,7 +551,7 @@ public abstract class BaseFormRecordResourceImpl
 		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
 			formRecordUnsafeConsumer = formRecord -> putFormRecord(
 				formRecord.getId() != null ? formRecord.getId() :
-					Long.parseLong((String)parameters.get("formRecordId")),
+					_parseLong((String)parameters.get("formRecordId")),
 				formRecord);
 		}
 
@@ -571,6 +570,14 @@ public abstract class BaseFormRecordResourceImpl
 				formRecordUnsafeConsumer.accept(formRecord);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/notification/notification-rest-impl/src/main/java/com/liferay/notification/rest/internal/resource/v1_0/BaseNotificationTemplateResourceImpl.java
+++ b/modules/apps/notification/notification-rest-impl/src/main/java/com/liferay/notification/rest/internal/resource/v1_0/BaseNotificationTemplateResourceImpl.java
@@ -865,7 +865,7 @@ public abstract class BaseNotificationTemplateResourceImpl
 				notificationTemplate -> patchNotificationTemplate(
 					notificationTemplate.getId() != null ?
 						notificationTemplate.getId() :
-							Long.parseLong(
+							_parseLong(
 								(String)parameters.get(
 									"notificationTemplateId")),
 					notificationTemplate);
@@ -876,7 +876,7 @@ public abstract class BaseNotificationTemplateResourceImpl
 				notificationTemplate -> putNotificationTemplate(
 					notificationTemplate.getId() != null ?
 						notificationTemplate.getId() :
-							Long.parseLong(
+							_parseLong(
 								(String)parameters.get(
 									"notificationTemplateId")),
 					notificationTemplate);
@@ -899,6 +899,14 @@ public abstract class BaseNotificationTemplateResourceImpl
 				notificationTemplateUnsafeConsumer.accept(notificationTemplate);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectActionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectActionResourceImpl.java
@@ -660,7 +660,7 @@ public abstract class BaseObjectActionResourceImpl
 			if (parameters.containsKey("objectDefinitionId")) {
 				objectActionUnsafeConsumer =
 					objectAction -> postObjectDefinitionObjectAction(
-						Long.parseLong(
+						_parseLong(
 							(String)parameters.get("objectDefinitionId")),
 						objectAction);
 			}
@@ -733,7 +733,7 @@ public abstract class BaseObjectActionResourceImpl
 
 		if (parameters.containsKey("objectDefinitionId")) {
 			return getObjectDefinitionObjectActionsPage(
-				Long.parseLong((String)parameters.get("objectDefinitionId")),
+				_parseLong((String)parameters.get("objectDefinitionId")),
 				search, pagination);
 		}
 		else {
@@ -779,14 +779,14 @@ public abstract class BaseObjectActionResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			objectActionUnsafeConsumer = objectAction -> patchObjectAction(
 				objectAction.getId() != null ? objectAction.getId() :
-					Long.parseLong((String)parameters.get("objectActionId")),
+					_parseLong((String)parameters.get("objectActionId")),
 				objectAction);
 		}
 
 		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
 			objectActionUnsafeConsumer = objectAction -> putObjectAction(
 				objectAction.getId() != null ? objectAction.getId() :
-					Long.parseLong((String)parameters.get("objectActionId")),
+					_parseLong((String)parameters.get("objectActionId")),
 				objectAction);
 		}
 
@@ -805,6 +805,14 @@ public abstract class BaseObjectActionResourceImpl
 				objectActionUnsafeConsumer.accept(objectAction);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectDefinitionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectDefinitionResourceImpl.java
@@ -859,7 +859,7 @@ public abstract class BaseObjectDefinitionResourceImpl
 				objectDefinition -> patchObjectDefinition(
 					objectDefinition.getId() != null ?
 						objectDefinition.getId() :
-							Long.parseLong(
+							_parseLong(
 								(String)parameters.get("objectDefinitionId")),
 					objectDefinition);
 		}
@@ -869,7 +869,7 @@ public abstract class BaseObjectDefinitionResourceImpl
 				objectDefinition -> putObjectDefinition(
 					objectDefinition.getId() != null ?
 						objectDefinition.getId() :
-							Long.parseLong(
+							_parseLong(
 								(String)parameters.get("objectDefinitionId")),
 					objectDefinition);
 		}
@@ -889,6 +889,14 @@ public abstract class BaseObjectDefinitionResourceImpl
 				objectDefinitionUnsafeConsumer.accept(objectDefinition);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectFieldResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectFieldResourceImpl.java
@@ -709,7 +709,7 @@ public abstract class BaseObjectFieldResourceImpl
 			if (parameters.containsKey("objectDefinitionId")) {
 				objectFieldUnsafeConsumer =
 					objectField -> postObjectDefinitionObjectField(
-						Long.parseLong(
+						_parseLong(
 							(String)parameters.get("objectDefinitionId")),
 						objectField);
 			}
@@ -782,7 +782,7 @@ public abstract class BaseObjectFieldResourceImpl
 
 		if (parameters.containsKey("objectDefinitionId")) {
 			return getObjectDefinitionObjectFieldsPage(
-				Long.parseLong((String)parameters.get("objectDefinitionId")),
+				_parseLong((String)parameters.get("objectDefinitionId")),
 				search, filter, pagination, sorts);
 		}
 		else {
@@ -827,14 +827,14 @@ public abstract class BaseObjectFieldResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			objectFieldUnsafeConsumer = objectField -> patchObjectField(
 				objectField.getId() != null ? objectField.getId() :
-					Long.parseLong((String)parameters.get("objectFieldId")),
+					_parseLong((String)parameters.get("objectFieldId")),
 				objectField);
 		}
 
 		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
 			objectFieldUnsafeConsumer = objectField -> putObjectField(
 				objectField.getId() != null ? objectField.getId() :
-					Long.parseLong((String)parameters.get("objectFieldId")),
+					_parseLong((String)parameters.get("objectFieldId")),
 				objectField);
 		}
 
@@ -853,6 +853,14 @@ public abstract class BaseObjectFieldResourceImpl
 				objectFieldUnsafeConsumer.accept(objectField);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectLayoutResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectLayoutResourceImpl.java
@@ -566,7 +566,7 @@ public abstract class BaseObjectLayoutResourceImpl
 			if (parameters.containsKey("objectDefinitionId")) {
 				objectLayoutUnsafeConsumer =
 					objectLayout -> postObjectDefinitionObjectLayout(
-						Long.parseLong(
+						_parseLong(
 							(String)parameters.get("objectDefinitionId")),
 						objectLayout);
 			}
@@ -639,7 +639,7 @@ public abstract class BaseObjectLayoutResourceImpl
 
 		if (parameters.containsKey("objectDefinitionId")) {
 			return getObjectDefinitionObjectLayoutsPage(
-				Long.parseLong((String)parameters.get("objectDefinitionId")),
+				_parseLong((String)parameters.get("objectDefinitionId")),
 				search, pagination);
 		}
 		else {
@@ -685,7 +685,7 @@ public abstract class BaseObjectLayoutResourceImpl
 		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
 			objectLayoutUnsafeConsumer = objectLayout -> putObjectLayout(
 				objectLayout.getId() != null ? objectLayout.getId() :
-					Long.parseLong((String)parameters.get("objectLayoutId")),
+					_parseLong((String)parameters.get("objectLayoutId")),
 				objectLayout);
 		}
 
@@ -704,6 +704,14 @@ public abstract class BaseObjectLayoutResourceImpl
 				objectLayoutUnsafeConsumer.accept(objectLayout);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectRelationshipResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectRelationshipResourceImpl.java
@@ -609,7 +609,7 @@ public abstract class BaseObjectRelationshipResourceImpl
 				objectRelationshipUnsafeConsumer =
 					objectRelationship ->
 						postObjectDefinitionObjectRelationship(
-							Long.parseLong(
+							_parseLong(
 								(String)parameters.get("objectDefinitionId")),
 							objectRelationship);
 			}
@@ -682,7 +682,7 @@ public abstract class BaseObjectRelationshipResourceImpl
 
 		if (parameters.containsKey("objectDefinitionId")) {
 			return getObjectDefinitionObjectRelationshipsPage(
-				Long.parseLong((String)parameters.get("objectDefinitionId")),
+				_parseLong((String)parameters.get("objectDefinitionId")),
 				search, filter, pagination);
 		}
 		else {
@@ -730,7 +730,7 @@ public abstract class BaseObjectRelationshipResourceImpl
 				objectRelationship -> putObjectRelationship(
 					objectRelationship.getId() != null ?
 						objectRelationship.getId() :
-							Long.parseLong(
+							_parseLong(
 								(String)parameters.get("objectRelationshipId")),
 					objectRelationship);
 		}
@@ -750,6 +750,14 @@ public abstract class BaseObjectRelationshipResourceImpl
 				objectRelationshipUnsafeConsumer.accept(objectRelationship);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectValidationRuleResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectValidationRuleResourceImpl.java
@@ -717,7 +717,7 @@ public abstract class BaseObjectValidationRuleResourceImpl
 			if (parameters.containsKey("objectDefinitionId")) {
 				objectValidationRuleUnsafeConsumer = objectValidationRule ->
 					postObjectDefinitionObjectValidationRule(
-						Long.parseLong(
+						_parseLong(
 							(String)parameters.get("objectDefinitionId")),
 						objectValidationRule);
 			}
@@ -794,7 +794,7 @@ public abstract class BaseObjectValidationRuleResourceImpl
 
 		if (parameters.containsKey("objectDefinitionId")) {
 			return getObjectDefinitionObjectValidationRulesPage(
-				Long.parseLong((String)parameters.get("objectDefinitionId")),
+				_parseLong((String)parameters.get("objectDefinitionId")),
 				search, pagination);
 		}
 		else {
@@ -842,7 +842,7 @@ public abstract class BaseObjectValidationRuleResourceImpl
 				objectValidationRule -> patchObjectValidationRule(
 					objectValidationRule.getId() != null ?
 						objectValidationRule.getId() :
-							Long.parseLong(
+							_parseLong(
 								(String)parameters.get(
 									"objectValidationRuleId")),
 					objectValidationRule);
@@ -853,7 +853,7 @@ public abstract class BaseObjectValidationRuleResourceImpl
 				objectValidationRule -> putObjectValidationRule(
 					objectValidationRule.getId() != null ?
 						objectValidationRule.getId() :
-							Long.parseLong(
+							_parseLong(
 								(String)parameters.get(
 									"objectValidationRuleId")),
 					objectValidationRule);
@@ -876,6 +876,14 @@ public abstract class BaseObjectValidationRuleResourceImpl
 				objectValidationRuleUnsafeConsumer.accept(objectValidationRule);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectViewResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectViewResourceImpl.java
@@ -595,7 +595,7 @@ public abstract class BaseObjectViewResourceImpl
 			if (parameters.containsKey("objectDefinitionId")) {
 				objectViewUnsafeConsumer =
 					objectView -> postObjectDefinitionObjectView(
-						Long.parseLong(
+						_parseLong(
 							(String)parameters.get("objectDefinitionId")),
 						objectView);
 			}
@@ -668,7 +668,7 @@ public abstract class BaseObjectViewResourceImpl
 
 		if (parameters.containsKey("objectDefinitionId")) {
 			return getObjectDefinitionObjectViewsPage(
-				Long.parseLong((String)parameters.get("objectDefinitionId")),
+				_parseLong((String)parameters.get("objectDefinitionId")),
 				search, pagination);
 		}
 		else {
@@ -713,7 +713,7 @@ public abstract class BaseObjectViewResourceImpl
 		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
 			objectViewUnsafeConsumer = objectView -> putObjectView(
 				objectView.getId() != null ? objectView.getId() :
-					Long.parseLong((String)parameters.get("objectViewId")),
+					_parseLong((String)parameters.get("objectViewId")),
 				objectView);
 		}
 
@@ -732,6 +732,14 @@ public abstract class BaseObjectViewResourceImpl
 				objectViewUnsafeConsumer.accept(objectView);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryResourceImpl.java
@@ -1296,14 +1296,14 @@ public abstract class BaseObjectEntryResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			objectEntryUnsafeConsumer = objectEntry -> patchObjectEntry(
 				objectEntry.getId() != null ? objectEntry.getId() :
-					Long.parseLong((String)parameters.get("objectEntryId")),
+					_parseLong((String)parameters.get("objectEntryId")),
 				objectEntry);
 		}
 
 		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
 			objectEntryUnsafeConsumer = objectEntry -> putObjectEntry(
 				objectEntry.getId() != null ? objectEntry.getId() :
-					Long.parseLong((String)parameters.get("objectEntryId")),
+					_parseLong((String)parameters.get("objectEntryId")),
 				objectEntry);
 		}
 
@@ -1322,6 +1322,14 @@ public abstract class BaseObjectEntryResourceImpl
 				objectEntryUnsafeConsumer.accept(objectEntry);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	protected String getPermissionCheckerActionsResourceName(Object id)

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/BaseAccountCategoryForecastResourceImpl.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/BaseAccountCategoryForecastResourceImpl.java
@@ -52,6 +52,7 @@ import java.io.Serializable;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -140,7 +141,7 @@ public abstract class BaseAccountCategoryForecastResourceImpl
 				Integer forecastLength,
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.ws.rs.QueryParam("forecastStartDate")
-				java.util.Date forecastStartDate,
+				Date forecastStartDate,
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@javax.ws.rs.QueryParam("historyLength")
 				Integer historyLength,

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/BaseAccountForecastResourceImpl.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/BaseAccountForecastResourceImpl.java
@@ -52,6 +52,7 @@ import java.io.Serializable;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -130,7 +131,7 @@ public abstract class BaseAccountForecastResourceImpl
 			Integer forecastLength,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.ws.rs.QueryParam("forecastStartDate")
-			java.util.Date forecastStartDate,
+			Date forecastStartDate,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.ws.rs.QueryParam("historyLength")
 			Integer historyLength,

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/BaseSkuForecastResourceImpl.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/BaseSkuForecastResourceImpl.java
@@ -52,6 +52,7 @@ import java.io.Serializable;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -125,7 +126,7 @@ public abstract class BaseSkuForecastResourceImpl
 			Integer forecastLength,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.ws.rs.QueryParam("forecastStartDate")
-			java.util.Date forecastStartDate,
+			Date forecastStartDate,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.ws.rs.QueryParam("historyLength")
 			Integer historyLength,

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseHistogramMetricResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseHistogramMetricResourceImpl.java
@@ -33,6 +33,7 @@ import com.liferay.portal.workflow.metrics.rest.dto.v1_0.HistogramMetric;
 import com.liferay.portal.workflow.metrics.rest.resource.v1_0.HistogramMetricResource;
 
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -93,10 +94,10 @@ public abstract class BaseHistogramMetricResourceImpl
 			Long processId,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.ws.rs.QueryParam("dateEnd")
-			java.util.Date dateEnd,
+			Date dateEnd,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.ws.rs.QueryParam("dateStart")
-			java.util.Date dateStart,
+			Date dateStart,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.validation.constraints.NotNull
 			@javax.ws.rs.QueryParam("unit")

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseInstanceResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseInstanceResourceImpl.java
@@ -52,6 +52,7 @@ import java.io.Serializable;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -151,10 +152,10 @@ public abstract class BaseInstanceResourceImpl
 			Long[] classPKs,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.ws.rs.QueryParam("dateEnd")
-			java.util.Date dateEnd,
+			Date dateEnd,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.ws.rs.QueryParam("dateStart")
-			java.util.Date dateStart,
+			Date dateStart,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.ws.rs.QueryParam("slaStatuses")
 			String[] slaStatuses,
@@ -249,10 +250,10 @@ public abstract class BaseInstanceResourceImpl
 			Long[] classPKs,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.ws.rs.QueryParam("dateEnd")
-			java.util.Date dateEnd,
+			Date dateEnd,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.ws.rs.QueryParam("dateStart")
-			java.util.Date dateStart,
+			Date dateStart,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.ws.rs.QueryParam("slaStatuses")
 			String[] slaStatuses,
@@ -542,8 +543,7 @@ public abstract class BaseInstanceResourceImpl
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
 			if (parameters.containsKey("processId")) {
 				instanceUnsafeConsumer = instance -> postProcessInstance(
-					Long.parseLong((String)parameters.get("processId")),
-					instance);
+					_parseLong((String)parameters.get("processId")), instance);
 			}
 			else {
 				throw new NotSupportedException(
@@ -613,11 +613,11 @@ public abstract class BaseInstanceResourceImpl
 
 		if (parameters.containsKey("processId")) {
 			return getProcessInstancesPage(
-				Long.parseLong((String)parameters.get("processId")),
+				_parseLong((String)parameters.get("processId")),
 				(Long[])parameters.get("assigneeIds"),
 				(Long[])parameters.get("classPKs"),
-				new java.util.Date((String)parameters.get("dateEnd")),
-				new java.util.Date((String)parameters.get("dateStart")),
+				_parseDate((String)parameters.get("dateEnd")),
+				_parseDate((String)parameters.get("dateStart")),
 				(String[])parameters.get("slaStatuses"),
 				(String[])parameters.get("statuses"),
 				(String[])parameters.get("taskNames"), pagination, sorts);
@@ -658,6 +658,22 @@ public abstract class BaseInstanceResourceImpl
 
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
+	}
+
+	private Date _parseDate(String value) {
+		if (value != null) {
+			return new Date(value);
+		}
+
+		return null;
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseNodeMetricResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseNodeMetricResourceImpl.java
@@ -52,6 +52,7 @@ import java.io.Serializable;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -138,10 +139,10 @@ public abstract class BaseNodeMetricResourceImpl
 			Boolean completed,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.ws.rs.QueryParam("dateEnd")
-			java.util.Date dateEnd,
+			Date dateEnd,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.ws.rs.QueryParam("dateStart")
-			java.util.Date dateStart,
+			Date dateStart,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.ws.rs.QueryParam("key")
 			String key,

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseNodeResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseNodeResourceImpl.java
@@ -310,7 +310,7 @@ public abstract class BaseNodeResourceImpl
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
 			if (parameters.containsKey("processId")) {
 				nodeUnsafeConsumer = node -> postProcessNode(
-					Long.parseLong((String)parameters.get("processId")), node);
+					_parseLong((String)parameters.get("processId")), node);
 			}
 			else {
 				throw new NotSupportedException(
@@ -378,7 +378,7 @@ public abstract class BaseNodeResourceImpl
 
 		if (parameters.containsKey("processId")) {
 			return getProcessNodesPage(
-				Long.parseLong((String)parameters.get("processId")));
+				_parseLong((String)parameters.get("processId")));
 		}
 		else {
 			throw new NotSupportedException(
@@ -415,6 +415,14 @@ public abstract class BaseNodeResourceImpl
 
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessMetricResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessMetricResourceImpl.java
@@ -52,6 +52,7 @@ import java.io.Serializable;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -241,10 +242,10 @@ public abstract class BaseProcessMetricResourceImpl
 			Boolean completed,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.ws.rs.QueryParam("dateEnd")
-			java.util.Date dateEnd,
+			Date dateEnd,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.ws.rs.QueryParam("dateStart")
-			java.util.Date dateStart)
+			Date dateStart)
 		throws Exception {
 
 		return new ProcessMetric();

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessResourceImpl.java
@@ -459,7 +459,7 @@ public abstract class BaseProcessResourceImpl
 		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
 			processUnsafeConsumer = process -> putProcess(
 				process.getId() != null ? process.getId() :
-					Long.parseLong((String)parameters.get("processId")),
+					_parseLong((String)parameters.get("processId")),
 				process);
 		}
 
@@ -477,6 +477,14 @@ public abstract class BaseProcessResourceImpl
 				processUnsafeConsumer.accept(process);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessVersionResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessVersionResourceImpl.java
@@ -237,7 +237,7 @@ public abstract class BaseProcessVersionResourceImpl
 
 		if (parameters.containsKey("processId")) {
 			return getProcessProcessVersionsPage(
-				Long.parseLong((String)parameters.get("processId")));
+				_parseLong((String)parameters.get("processId")));
 		}
 		else {
 			throw new NotSupportedException(
@@ -275,6 +275,14 @@ public abstract class BaseProcessVersionResourceImpl
 
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseRoleResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseRoleResourceImpl.java
@@ -244,8 +244,8 @@ public abstract class BaseRoleResourceImpl
 
 		if (parameters.containsKey("processId")) {
 			return getProcessRolesPage(
-				Long.parseLong((String)parameters.get("processId")),
-				Boolean.parseBoolean((String)parameters.get("completed")));
+				_parseLong((String)parameters.get("processId")),
+				_parseBoolean((String)parameters.get("completed")));
 		}
 		else {
 			throw new NotSupportedException(
@@ -282,6 +282,22 @@ public abstract class BaseRoleResourceImpl
 
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
+	}
+
+	private Boolean _parseBoolean(String value) {
+		if (value != null) {
+			return Boolean.parseBoolean(value);
+		}
+
+		return null;
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseSLAResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseSLAResourceImpl.java
@@ -493,7 +493,7 @@ public abstract class BaseSLAResourceImpl
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
 			if (parameters.containsKey("processId")) {
 				slaUnsafeConsumer = sla -> postProcessSLA(
-					Long.parseLong((String)parameters.get("processId")), sla);
+					_parseLong((String)parameters.get("processId")), sla);
 			}
 			else {
 				throw new NotSupportedException(
@@ -562,8 +562,8 @@ public abstract class BaseSLAResourceImpl
 
 		if (parameters.containsKey("processId")) {
 			return getProcessSLAsPage(
-				Long.parseLong((String)parameters.get("processId")),
-				Integer.parseInt((String)parameters.get("status")), pagination);
+				_parseLong((String)parameters.get("processId")),
+				_parseInteger((String)parameters.get("status")), pagination);
 		}
 		else {
 			throw new NotSupportedException(
@@ -606,7 +606,7 @@ public abstract class BaseSLAResourceImpl
 		if ("UPDATE".equalsIgnoreCase(updateStrategy)) {
 			slaUnsafeConsumer = sla -> putSLA(
 				sla.getId() != null ? sla.getId() :
-					Long.parseLong((String)parameters.get("slaId")),
+					_parseLong((String)parameters.get("slaId")),
 				sla);
 		}
 
@@ -624,6 +624,22 @@ public abstract class BaseSLAResourceImpl
 				slaUnsafeConsumer.accept(sla);
 			}
 		}
+	}
+
+	private Integer _parseInteger(String value) {
+		if (value != null) {
+			return Integer.parseInt(value);
+		}
+
+		return null;
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseTaskResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseTaskResourceImpl.java
@@ -458,7 +458,7 @@ public abstract class BaseTaskResourceImpl
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
 			if (parameters.containsKey("processId")) {
 				taskUnsafeConsumer = task -> postProcessTask(
-					Long.parseLong((String)parameters.get("processId")), task);
+					_parseLong((String)parameters.get("processId")), task);
 			}
 			else {
 				throw new NotSupportedException(
@@ -526,7 +526,7 @@ public abstract class BaseTaskResourceImpl
 
 		if (parameters.containsKey("processId")) {
 			return getProcessTasksPage(
-				Long.parseLong((String)parameters.get("processId")));
+				_parseLong((String)parameters.get("processId")));
 		}
 		else {
 			throw new NotSupportedException(
@@ -563,6 +563,14 @@ public abstract class BaseTaskResourceImpl
 
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseFieldMappingInfoResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseFieldMappingInfoResourceImpl.java
@@ -262,7 +262,7 @@ public abstract class BaseFieldMappingInfoResourceImpl
 		throws Exception {
 
 		return getFieldMappingInfosPage(
-			Boolean.parseBoolean((String)parameters.get("external")),
+			_parseBoolean((String)parameters.get("external")),
 			(String)parameters.get("indexName"),
 			(String)parameters.get("query"));
 	}
@@ -297,6 +297,14 @@ public abstract class BaseFieldMappingInfoResourceImpl
 
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
+	}
+
+	private Boolean _parseBoolean(String value) {
+		if (value != null) {
+			return Boolean.parseBoolean(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPBlueprintResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPBlueprintResourceImpl.java
@@ -611,7 +611,7 @@ public abstract class BaseSXPBlueprintResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			sxpBlueprintUnsafeConsumer = sxpBlueprint -> patchSXPBlueprint(
 				sxpBlueprint.getId() != null ? sxpBlueprint.getId() :
-					Long.parseLong((String)parameters.get("sxpBlueprintId")),
+					_parseLong((String)parameters.get("sxpBlueprintId")),
 				sxpBlueprint);
 		}
 
@@ -630,6 +630,14 @@ public abstract class BaseSXPBlueprintResourceImpl
 				sxpBlueprintUnsafeConsumer.accept(sxpBlueprint);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPElementResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPElementResourceImpl.java
@@ -604,7 +604,7 @@ public abstract class BaseSXPElementResourceImpl
 		if ("PARTIAL_UPDATE".equalsIgnoreCase(updateStrategy)) {
 			sxpElementUnsafeConsumer = sxpElement -> patchSXPElement(
 				sxpElement.getId() != null ? sxpElement.getId() :
-					Long.parseLong((String)parameters.get("sxpElementId")),
+					_parseLong((String)parameters.get("sxpElementId")),
 				sxpElement);
 		}
 
@@ -623,6 +623,14 @@ public abstract class BaseSXPElementResourceImpl
 				sxpElementUnsafeConsumer.accept(sxpElement);
 			}
 		}
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/BaseStatusResourceImpl.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/BaseStatusResourceImpl.java
@@ -177,8 +177,7 @@ public abstract class BaseStatusResourceImpl
 		if ("INSERT".equalsIgnoreCase(createStrategy)) {
 			if (parameters.containsKey("experimentId")) {
 				statusUnsafeConsumer = status -> postExperimentStatus(
-					Long.parseLong((String)parameters.get("experimentId")),
-					status);
+					_parseLong((String)parameters.get("experimentId")), status);
 			}
 			else {
 				throw new NotSupportedException(
@@ -277,6 +276,14 @@ public abstract class BaseStatusResourceImpl
 
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
+	}
+
+	private Long _parseLong(String value) {
+		if (value != null) {
+			return Long.parseLong(value);
+		}
+
+		return null;
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
@@ -16,6 +16,7 @@ package com.liferay.portal.tools.rest.builder.internal.freemarker.tool;
 
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -103,6 +104,10 @@ public class FreeMarkerTool {
 		}
 
 		return false;
+	}
+
+	public String[] distinct(String[] array) {
+		return ArrayUtil.distinct(array);
 	}
 
 	public boolean generateBatch(

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -72,6 +72,7 @@ import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -415,6 +416,8 @@ public abstract class Base${schemaName}ResourceImpl
 
 			createStrategies = freeMarkerTool.getVulcanBatchImplementationCreateStrategies(javaMethodSignatures, properties)
 			updateStrategies = freeMarkerTool.getVulcanBatchImplementationUpdateStrategies(javaMethodSignatures)
+
+			parserMethodDataTypes = []
 		/>
 		@Override
 		@SuppressWarnings("PMD.UnusedLocalVariable")
@@ -773,6 +776,22 @@ public abstract class Base${schemaName}ResourceImpl
 				throw new UnsupportedOperationException("This method needs to be implemented");
 			</#if>
 		}
+
+		<#list freeMarkerTool.distinct(parserMethodDataTypes) as parserMethodDataType>
+			private ${parserMethodDataType} _parse${parserMethodDataType}(String value){
+				if (value != null){
+				<#if stringUtil.equals(parserMethodDataType, "Date")>
+					return new Date(value);
+				<#elseif stringUtil.equals(parserMethodDataType, "Integer")>
+					return Integer.parseInt(value);
+				<#else>
+					return ${parserMethodDataType}.parse${parserMethodDataType}(value);
+				</#if>
+				}
+
+				return null;
+			}
+		</#list>
 	</#if>
 
 	<#if generateGetPermissionCheckerMethods>
@@ -1139,15 +1158,20 @@ public abstract class Base${schemaName}ResourceImpl
 		(${type})parameters.get("${value}")
 	<#else>
 		<#if type?contains("java.lang.Boolean")>
-			Boolean.parseBoolean(
+			<#assign parserMethodDataTypes = parserMethodDataTypes + ["Boolean"] />
+				_parseBoolean(
 		<#elseif type?contains("java.util.Date")>
-			new java.util.Date(
+			<#assign parserMethodDataTypes = parserMethodDataTypes + ["Date"] />
+				_parseDate(
 		<#elseif type?contains("java.lang.Double")>
-			Double.parseDouble(
+			<#assign parserMethodDataTypes = parserMethodDataTypes + ["Double"] />
+				_parseDouble(
 		<#elseif type?contains("java.lang.Integer")>
-			Integer.parseInt(
+			<#assign parserMethodDataTypes = parserMethodDataTypes + ["Integer"] />
+				_parseInteger(
 		<#elseif type?contains("java.lang.Long")>
-			Long.parseLong(
+			<#assign parserMethodDataTypes = parserMethodDataTypes + ["Long"] />
+				_parseLong(
 		</#if>
 
 		(String)parameters.get("${value}")


### PR DESCRIPTION
**Whats New:**
- Private method named "parseLong" that recieves a String which can be null and returns a Long object that takes the value of the String in case it's not null. When null, a null Long object gets returned.
- Condition so that "parseLong" is only created when the Class needs to parse to a Long object.
**What fixes:**
- Fixes a NullPointerException that occured when an export-batch task recieved a dataDefinitionId but not a dataListView. More details can be found in the following [Jira Ticket](https://issues.liferay.com/browse/LPS-178803)
