### PR TITLE
LPS-181264 | Disable keywords and categories when categorization is not enabled

### DIFF
--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/CustomObjectAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/CustomObjectAPI.macro
@@ -40,12 +40,14 @@ definition {
 			externalReferenceCode = ${externalReferenceCode},
 			fieldName = ${fieldName},
 			fieldValue = ${fieldValue},
+			keywords = ${keywords},
 			nestedField = ${nestedField},
 			numberOfRelatedObjectEntries = ${numberOfRelatedObjectEntries},
 			objectEntryId = ${objectEntryId},
 			relatedEntryExternalReferenceCode = ${relatedEntryExternalReferenceCode},
 			relatedEntryFieldName = ${relatedEntryFieldName},
-			secondFieldValue = ${secondFieldValue});
+			secondFieldValue = ${secondFieldValue},
+			taxonomyCategoryIds = ${taxonomyCategoryIds});
 
 		var curl = StringUtil.add(${curlWithoutBody}, "-d {${body}}", " ");
 
@@ -84,6 +86,14 @@ definition {
 
 		if (isSet(externalReferenceCode)) {
 			var body = StringUtil.add("${body},", "\"externalReferenceCode\": \"${externalReferenceCode}\"", "");
+		}
+
+		if (isSet(keywords)) {
+			var body = StringUtil.add("${body},", "\"keywords\": [\"${keywords}\"]", "");
+		}
+
+		if (isSet(taxonomyCategoryIds)) {
+			var body = StringUtil.add("${body},", "\"taxonomyCategoryIds\": [${taxonomyCategoryIds}]", "");
 		}
 
 		if (isSet(nestedField)) {
@@ -169,8 +179,10 @@ definition {
 			externalReferenceCode = ${externalReferenceCode},
 			fieldName = ${fieldName},
 			fieldValue = ${fieldValue},
+			keywords = ${keywords},
 			scopeKey = ${scopeKey},
 			secondFieldValue = ${secondFieldValue},
+			taxonomyCategoryIds = ${taxonomyCategoryIds},
 			token = ${token},
 			virtualHost = ${virtualHost});
 

--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectDefinitionAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectDefinitionAPI.macro
@@ -123,6 +123,8 @@ definition {
 			en_US_plural_label = ${en_US_plural_label},
 			fieldName = "name",
 			fieldValue = ${name},
+			keywords = ${keywords},
+			taxonomyCategoryIds = ${taxonomyCategoryIds},
 			token = ${token},
 			virtualHost = ${virtualHost});
 
@@ -456,6 +458,25 @@ definition {
 		return ${response};
 	}
 
+	macro _updateObjectDefinition {
+		Variables.assertDefined(parameterList = "${objectDefinitionId},${parameter},${parameterValue}");
+
+		var portalURL = JSONCompany.getPortalURL();
+
+		var curl = '''
+			${portalURL}/o/object-admin/v1.0/object-definitions/${objectDefinitionId} \
+				-u test@liferay.com:test \
+				-H Content-Type: application/json \
+				-d {
+					"${parameter}": "${parameterValue}"
+				}
+		''';
+
+		var response = JSONCurlUtil.patch(${curl});
+
+		return ${response};
+	}
+
 	macro assertBatchActionsInResponse {
 		Variables.assertDefined(parameterList = "${responseToParse},${batchActions}");
 
@@ -690,8 +711,10 @@ definition {
 	macro createObjectEntryWithName {
 		var objectId = ObjectDefinitionAPI._createObjectEntryWithName(
 			en_US_plural_label = ${en_US_plural_label},
+			keywords = ${keywords},
 			name = ${name},
 			secondFieldValue = ${secondFieldValue},
+			taxonomyCategoryIds = ${taxonomyCategoryIds},
 			token = ${token},
 			virtualHost = ${virtualHost});
 
@@ -1017,6 +1040,13 @@ definition {
 			expected = ${employeeFirstname});
 
 		return ${employeeId};
+	}
+
+	macro updateObjectDefinitionById {
+		ObjectDefinitionAPI._updateObjectDefinition(
+			objectDefinitionId = ${objectDefinitionId},
+			parameter = ${parameter},
+			parameterValue = ${parameterValue});
 	}
 
 }

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/DisableKeywordsAndCategoriesWhenCategorizationIsNotEnabled.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/DisableKeywordsAndCategoriesWhenCategorizationIsNotEnabled.testcase
@@ -1,0 +1,229 @@
+@component-name = "portal-headless"
+definition {
+
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Object";
+	property testray.main.component.name = "Headless";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+
+		ObjectDefinitionAPI.staticUniversityObjectId();
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		ObjectAdmin.deleteAllCustomObjectsViaAPI();
+
+		TaxonomyVocabularyAPI.deleteTaxonomyVocabularyByErc(
+			externalReferenceCode = "erc",
+			groupName = "Guest");
+
+		if (${testPortalInstance} == "true") {
+			PortalInstances.tearDownCP();
+		}
+	}
+
+	@priority = 3
+	test CanGetParametersOfKeywordsAndCategoriesInEndpoint {
+		property portal.acceptance = "true";
+
+		task ("when I navigate to c/university endpoint postUniversity") {
+			APIExplorer.navigateToOpenAPI(
+				api = "c",
+				version = "universities");
+
+			Click(
+				locator1 = "OpenAPI#API_METHOD",
+				method = "postUniversity",
+				service = "University");
+		}
+
+		task ("Then I found the keywords and categories appear in the Request body") {
+			AssertTextEquals.assertPartialText(
+				locator1 = "OpenAPI#REQUEST_BODY",
+				method = "postUniversity",
+				value1 = "\"keywords\":");
+
+			AssertTextEquals.assertPartialText(
+				locator1 = "OpenAPI#REQUEST_BODY",
+				method = "postUniversity",
+				value1 = "\"taxonomyCategoryIds\":");
+		}
+	}
+
+	@priority = 4
+	test CannotAddObjectEntryWithKeywordsAndCategoriesWhenCategorizationNotEnabled {
+		property portal.acceptance = "true";
+
+		task ("And Given taxonomyVocabulary with name 'vocabulary' created") {
+			var responseFromVocabulary = TaxonomyVocabularyAPI.createTaxonomyVocabulary(
+				externalReferenceCode = "erc",
+				groupName = "Guest",
+				name = "Vocabulary");
+		}
+
+		task ("And Given category with name 'category' in 'vocabulary' created") {
+			var taxonomyVocabularyId = JSONPathUtil.getIdValue(response = ${responseFromVocabulary});
+
+			var responseFromCategory = TaxonomyCategoryAPI.createTaxonomyCategory(
+				name = "Category",
+				taxonomyVocabularyId = ${taxonomyVocabularyId});
+		}
+
+		task ("And Given I set university object with enableCategorization=false") {
+			ObjectDefinitionAPI.updateObjectDefinitionById(
+				objectDefinitionId = ${staticUniversityObjectId},
+				parameter = "enableCategorization",
+				parameterValue = "false");
+		}
+
+		task ("And Given I navigate to c/university endpoint postUniversity to create a university entry with keyword 'tag1' and taxonomyCategoryId of 'category'") {
+			var taxonomyCategoryId = JSONPathUtil.getIdValue(response = ${responseFromCategory});
+
+			var objectDefinitionEntryId = ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "universities",
+				keywords = "tag1",
+				name = "Liferay University",
+				taxonomyCategoryIds = ${taxonomyCategoryId});
+		}
+
+		task ("When I use getUniversitiesPage") {
+			var response = ObjectDefinitionAPI.getObjectEntries(en_US_plural_label = "universities");
+		}
+
+		task ("Then the response will return the details of the entries with keywords and categories that are null") {
+			var actualKeywordsValue = JSONUtil.getWithJSONPath(${response}, "$..keywords");
+
+			TestUtils.assertEquals(
+				actual = ${actualKeywordsValue},
+				expected = "");
+
+			var actualTaxonomyCategoryIdsValue = JSONUtil.getWithJSONPath(${response}, "$..taxonomyCategoryBriefs.taxonomyCategoryId");
+
+			TestUtils.assertEquals(
+				actual = ${actualTaxonomyCategoryIdsValue},
+				expected = "");
+		}
+	}
+
+	@priority = 4
+	test CannotGetKeywordsAndCategoriesValuesWhenCategorizationNotEnabled {
+		property portal.acceptance = "true";
+
+		task ("And Given taxonomyVocabulary with name 'vocabulary' created") {
+			var responseFromVocabulary = TaxonomyVocabularyAPI.createTaxonomyVocabulary(
+				externalReferenceCode = "erc",
+				groupName = "Guest",
+				name = "Vocabulary");
+		}
+
+		task ("And Given category with name 'category' in 'vocabulary' created") {
+			var taxonomyVocabularyId = JSONPathUtil.getIdValue(response = ${responseFromVocabulary});
+
+			var responseFromCategory = TaxonomyCategoryAPI.createTaxonomyCategory(
+				name = "Category",
+				taxonomyVocabularyId = ${taxonomyVocabularyId});
+		}
+
+		task ("And Given I navigate to c/university endpoint postUniversity to create a university entry with keyword 'tag1' and taxonomyCategoryId of 'category'") {
+			var taxonomyCategoryId = JSONPathUtil.getIdValue(response = ${responseFromCategory});
+
+			var objectDefinitionEntryId = ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "universities",
+				keywords = "tag1",
+				name = "Liferay University",
+				taxonomyCategoryIds = ${taxonomyCategoryId});
+		}
+
+		task ("And Given I set university object with enableCategorization=false") {
+			ObjectDefinitionAPI.updateObjectDefinitionById(
+				objectDefinitionId = ${staticUniversityObjectId},
+				parameter = "enableCategorization",
+				parameterValue = "false");
+		}
+
+		task ("When I use getUniversitiesPage") {
+			var response = ObjectDefinitionAPI.getObjectEntries(en_US_plural_label = "universities");
+		}
+
+		task ("Then the response will return the details of the entries with keywords and categories that are null") {
+			var actualKeywordsValue = JSONUtil.getWithJSONPath(${response}, "$..keywords");
+
+			TestUtils.assertEquals(
+				actual = ${actualKeywordsValue},
+				expected = "");
+
+			var actualTaxonomyCategoryIdsValue = JSONUtil.getWithJSONPath(${response}, "$..taxonomyCategoryBriefs.taxonomyCategoryId");
+
+			TestUtils.assertEquals(
+				actual = ${actualTaxonomyCategoryIdsValue},
+				expected = "");
+		}
+	}
+
+	@priority = 3
+	test CannotGetKeywordsAndCategoriesWhenCategorizationNotEnabled {
+		property portal.acceptance = "true";
+
+		task ("when I navigate to c/university endpoint postUniversity") {
+			ObjectDefinitionAPI.updateObjectDefinitionById(
+				objectDefinitionId = ${staticUniversityObjectId},
+				parameter = "enableCategorization",
+				parameterValue = "false");
+
+			APIExplorer.navigateToOpenAPI(
+				api = "c",
+				version = "universities");
+
+			Click(
+				locator1 = "OpenAPI#API_METHOD",
+				method = "postUniversity",
+				service = "University");
+		}
+
+		task ("Then the keywords and categories are not present in the Request body") {
+			AssertTextNotEquals.assertNotPartialText(
+				locator1 = "OpenAPI#REQUEST_BODY",
+				method = "postUniversity",
+				value1 = "\"keywords\":");
+
+			AssertTextNotEquals.assertNotPartialText(
+				locator1 = "OpenAPI#REQUEST_BODY",
+				method = "postUniversity",
+				value1 = "\"taxonomyCategoryIds\":");
+		}
+	}
+
+	@priority = 3
+	test CannotSeeTaxonomyCategoryBriefInSchemaWhenCategorizationNotEnabled {
+		property portal.acceptance = "true";
+
+		task ("when I navigate to c/university endpoint postUniversity") {
+			ObjectDefinitionAPI.updateObjectDefinitionById(
+				objectDefinitionId = ${staticUniversityObjectId},
+				parameter = "enableCategorization",
+				parameterValue = "false");
+
+			APIExplorer.navigateToOpenAPI(
+				api = "c",
+				version = "universities");
+
+			Click(
+				locator1 = "OpenAPI#API_METHOD",
+				method = "postUniversity",
+				service = "University");
+		}
+
+		task ("Then the Schemas doesn't contain the field Taxonomy Category Brief") {
+			AssertElementNotPresent(
+				locator1 = "OpenAPI#SCHEMA_TITLE",
+				schema = "TaxonomyCategoryBrief");
+		}
+	}
+
+}


### PR DESCRIPTION
**Background:**
Add a testcase to Disable keywords and categories when categorization is not enabled

**Test Plan**
Background
Given a university object

CanGetParametersOfKeywordsAndCategoriesInEndpoint
when I navigate to c/university endpoint postUniversity
Then I found the keywords and categories appear in the Request body

CannotSeeTaxonomyCategoryBriefInSchemaWhenCategorizationNotEnabled
Given a university object with enableCategorization=false
when I navigate to c/university
Then the Schemas doesn't contain the field Taxonomy Category Brief

CannotGetKeywordsAndCategoriesWhenCategorizationNotEnabled
Given a university object with enableCategorization=false
when I navigate to c/university endpoint postUniversity
Then the keywords and categories are not present in the Request body

CannotAddObjectEntryWithKeywordsAndCategoriesWhenCategorizationNotEnabled
Given a university object
And Given taxonomyVocabulary with name 'vocabulary' created
And Given category with name 'category' in 'vocabulary' created
And Given I set university object with enableCategorization=false
And Given I navigate to c/university endpoint postUniversity to create a university entry with keyword 'tag1' and taxonomyCategoryId of 'category'
When I use getUniversitiesPage
Then the response will return the details of the entries with keywords and categories that are null

CannotGetKeywordsAndCategoriesValuesWhenCategorizationNotEnabled
Given a university object
And Given taxonomyVocabulary with name 'vocabulary' created
And Given category with name 'category' in 'vocabulary' created
And Given I navigate to c/university endpoint postUniversity to create a university entry with keyword 'tag1' and taxonomyCategoryId of 'category'
When I set the university object with enableCategorization=false
Then the keywords and categories are not present in the response of getUniversitiesPage

**Jira ticket:**
https://issues.liferay.com/browse/LPS-181264