### PR TITLE
[TS] [Urgent] LPS-182358 PATCH requests encounter ClassCastExceptions when arrayed custom fields are involved

### DIFF
--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/util/CustomFieldsUtil.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/util/CustomFieldsUtil.java
@@ -157,12 +157,6 @@ public class CustomFieldsUtil {
 		if (ExpandoColumnConstants.DATE == attributeType) {
 			return _parseDate(String.valueOf(data));
 		}
-		else if (ExpandoColumnConstants.DOUBLE_ARRAY == attributeType) {
-			return ArrayUtil.toDoubleArray((List<Number>)data);
-		}
-		else if (ExpandoColumnConstants.FLOAT_ARRAY == attributeType) {
-			return ArrayUtil.toFloatArray((List<Number>)data);
-		}
 		else if (ExpandoColumnConstants.GEOLOCATION == attributeType) {
 			Geo geo = customValue.getGeo();
 
@@ -172,20 +166,28 @@ public class CustomFieldsUtil {
 				"longitude", geo.getLongitude()
 			).toString();
 		}
-		else if (ExpandoColumnConstants.INTEGER_ARRAY == attributeType) {
-			return ArrayUtil.toIntArray((List<Number>)data);
-		}
-		else if (ExpandoColumnConstants.LONG_ARRAY == attributeType) {
-			return ArrayUtil.toLongArray((List<Number>)data);
-		}
-		else if (ExpandoColumnConstants.STRING_ARRAY == attributeType) {
-			List<?> list = (List<?>)data;
-
-			return list.toArray(new String[0]);
-		}
 		else if (ExpandoColumnConstants.STRING_LOCALIZED == attributeType) {
 			return (Serializable)LocalizedMapUtil.getLocalizedMap(
 				locale, (String)data, customValue.getData_i18n());
+		}
+		else if (data instanceof List) {
+			if (ExpandoColumnConstants.DOUBLE_ARRAY == attributeType) {
+				return ArrayUtil.toDoubleArray((List<Number>) data);
+			}
+			else if (ExpandoColumnConstants.FLOAT_ARRAY == attributeType) {
+				return ArrayUtil.toFloatArray((List<Number>) data);
+			}
+			else if (ExpandoColumnConstants.INTEGER_ARRAY == attributeType) {
+				return ArrayUtil.toIntArray((List<Number>) data);
+			}
+			else if (ExpandoColumnConstants.LONG_ARRAY == attributeType) {
+				return ArrayUtil.toLongArray((List<Number>) data);
+			}
+			else if (ExpandoColumnConstants.STRING_ARRAY == attributeType) {
+				List<?> list = (List<?>) data;
+
+				return list.toArray(new String[0]);
+			}
 		}
 
 		return (Serializable)data;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/dto/v1_0/util/CustomFieldsUtil.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/dto/v1_0/util/CustomFieldsUtil.java
@@ -124,12 +124,6 @@ public class CustomFieldsUtil {
 		if (ExpandoColumnConstants.DATE == attributeType) {
 			return _parseDate(String.valueOf(data));
 		}
-		else if (ExpandoColumnConstants.DOUBLE_ARRAY == attributeType) {
-			return ArrayUtil.toDoubleArray((List<Number>)data);
-		}
-		else if (ExpandoColumnConstants.FLOAT_ARRAY == attributeType) {
-			return ArrayUtil.toFloatArray((List<Number>)data);
-		}
 		else if (ExpandoColumnConstants.GEOLOCATION == attributeType) {
 			Geo geo = customValue.getGeo();
 
@@ -139,20 +133,28 @@ public class CustomFieldsUtil {
 				"longitude", geo.getLongitude()
 			).toString();
 		}
-		else if (ExpandoColumnConstants.INTEGER_ARRAY == attributeType) {
-			return ArrayUtil.toIntArray((List<Number>)data);
-		}
-		else if (ExpandoColumnConstants.LONG_ARRAY == attributeType) {
-			return ArrayUtil.toLongArray((List<Number>)data);
-		}
-		else if (ExpandoColumnConstants.STRING_ARRAY == attributeType) {
-			List<?> list = (List<?>)data;
-
-			return list.toArray(new String[0]);
-		}
 		else if (ExpandoColumnConstants.STRING_LOCALIZED == attributeType) {
 			return (Serializable)LocalizedMapUtil.getLocalizedMap(
 				locale, (String)data, customValue.getData_i18n());
+		}
+		else if (data instanceof List) {
+			if (ExpandoColumnConstants.DOUBLE_ARRAY == attributeType) {
+				return ArrayUtil.toDoubleArray((List<Number>)data);
+			}
+			else if (ExpandoColumnConstants.FLOAT_ARRAY == attributeType) {
+				return ArrayUtil.toFloatArray((List<Number>)data);
+			}
+			if (ExpandoColumnConstants.INTEGER_ARRAY == attributeType) {
+				return ArrayUtil.toIntArray((List<Number>) data);
+			}
+			else if (ExpandoColumnConstants.LONG_ARRAY == attributeType) {
+				return ArrayUtil.toLongArray((List<Number>) data);
+			}
+			else if (ExpandoColumnConstants.STRING_ARRAY == attributeType) {
+				List<?> list = (List<?>) data;
+
+				return list.toArray(new String[0]);
+			}
 		}
 
 		return (Serializable)data;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/dto/v1_0/util/CustomFieldsUtil.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/dto/v1_0/util/CustomFieldsUtil.java
@@ -114,12 +114,6 @@ public class CustomFieldsUtil {
 		if (ExpandoColumnConstants.DATE == attributeType) {
 			return _parseDate(String.valueOf(data));
 		}
-		else if (ExpandoColumnConstants.DOUBLE_ARRAY == attributeType) {
-			return ArrayUtil.toDoubleArray((List<Number>)data);
-		}
-		else if (ExpandoColumnConstants.FLOAT_ARRAY == attributeType) {
-			return ArrayUtil.toFloatArray((List<Number>)data);
-		}
 		else if (ExpandoColumnConstants.GEOLOCATION == attributeType) {
 			Geo geo = customValue.getGeo();
 
@@ -129,20 +123,28 @@ public class CustomFieldsUtil {
 				"longitude", geo.getLongitude()
 			).toString();
 		}
-		else if (ExpandoColumnConstants.INTEGER_ARRAY == attributeType) {
-			return ArrayUtil.toIntArray((List<Number>)data);
-		}
-		else if (ExpandoColumnConstants.LONG_ARRAY == attributeType) {
-			return ArrayUtil.toLongArray((List<Number>)data);
-		}
-		else if (ExpandoColumnConstants.STRING_ARRAY == attributeType) {
-			List<?> list = (List<?>)data;
-
-			return list.toArray(new String[0]);
-		}
 		else if (ExpandoColumnConstants.STRING_LOCALIZED == attributeType) {
 			return (Serializable)LocalizedMapUtil.getLocalizedMap(
 				locale, (String)data, customValue.getData_i18n());
+		}
+		else if (data instanceof List<?>) {
+			if (ExpandoColumnConstants.DOUBLE_ARRAY == attributeType) {
+				return ArrayUtil.toDoubleArray((List<Number>) data);
+			}
+			else if (ExpandoColumnConstants.FLOAT_ARRAY == attributeType) {
+				return ArrayUtil.toFloatArray((List<Number>) data);
+			}
+			else if (ExpandoColumnConstants.INTEGER_ARRAY == attributeType) {
+				return ArrayUtil.toIntArray((List<Number>) data);
+			}
+			else if (ExpandoColumnConstants.LONG_ARRAY == attributeType) {
+				return ArrayUtil.toLongArray((List<Number>) data);
+			}
+			else if (ExpandoColumnConstants.STRING_ARRAY == attributeType) {
+				List<?> list = (List<?>) data;
+
+				return list.toArray(new String[0]);
+			}
 		}
 
 		return (Serializable)data;

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/util/CustomFieldsUtil.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/util/CustomFieldsUtil.java
@@ -107,18 +107,6 @@ public class CustomFieldsUtil {
 				continue;
 			}
 
-			if (ExpandoColumnConstants.DOUBLE_ARRAY == attributeType) {
-				map.put(name, ArrayUtil.toDoubleArray((List<Number>)data));
-
-				continue;
-			}
-
-			if (ExpandoColumnConstants.FLOAT_ARRAY == attributeType) {
-				map.put(name, ArrayUtil.toFloatArray((List<Number>)data));
-
-				continue;
-			}
-
 			if (ExpandoColumnConstants.GEOLOCATION == attributeType) {
 				Geo geo = customValue.getGeo();
 
@@ -133,26 +121,6 @@ public class CustomFieldsUtil {
 				continue;
 			}
 
-			if (ExpandoColumnConstants.INTEGER_ARRAY == attributeType) {
-				map.put(name, ArrayUtil.toIntArray((List<Number>)data));
-
-				continue;
-			}
-
-			if (ExpandoColumnConstants.LONG_ARRAY == attributeType) {
-				map.put(name, ArrayUtil.toLongArray((List<Number>)data));
-
-				continue;
-			}
-
-			if (ExpandoColumnConstants.STRING_ARRAY == attributeType) {
-				List<?> list = (List<?>)data;
-
-				map.put(name, list.toArray(new String[0]));
-
-				continue;
-			}
-
 			if (ExpandoColumnConstants.STRING_LOCALIZED == attributeType) {
 				map.put(
 					name,
@@ -160,6 +128,40 @@ public class CustomFieldsUtil {
 						locale, (String)data, customValue.getData_i18n()));
 
 				continue;
+			}
+
+			if (data instanceof List<?>) {
+				if (ExpandoColumnConstants.DOUBLE_ARRAY == attributeType) {
+					map.put(name, ArrayUtil.toDoubleArray((List<Number>)data));
+
+					continue;
+				}
+
+				if (ExpandoColumnConstants.FLOAT_ARRAY == attributeType) {
+					map.put(name, ArrayUtil.toFloatArray((List<Number>)data));
+
+					continue;
+				}
+
+				if (ExpandoColumnConstants.INTEGER_ARRAY == attributeType) {
+					map.put(name, ArrayUtil.toIntArray((List<Number>)data));
+
+					continue;
+				}
+
+				if (ExpandoColumnConstants.LONG_ARRAY == attributeType) {
+					map.put(name, ArrayUtil.toLongArray((List<Number>)data));
+
+					continue;
+				}
+
+				if (ExpandoColumnConstants.STRING_ARRAY == attributeType) {
+					List<?> list = (List<?>)data;
+
+					map.put(name, list.toArray(new String[0]));
+
+					continue;
+				}
 			}
 
 			map.put(name, (Serializable)data);

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/CustomFieldsUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/CustomFieldsUtil.java
@@ -103,12 +103,6 @@ public class CustomFieldsUtil {
 			if (ExpandoColumnConstants.DATE == attributeType) {
 				map.put(fieldName, _parseDate(String.valueOf(data)));
 			}
-			else if (ExpandoColumnConstants.DOUBLE_ARRAY == attributeType) {
-				map.put(fieldName, ArrayUtil.toDoubleArray((List<Number>)data));
-			}
-			else if (ExpandoColumnConstants.FLOAT_ARRAY == attributeType) {
-				map.put(fieldName, ArrayUtil.toFloatArray((List<Number>)data));
-			}
 			else if (ExpandoColumnConstants.GEOLOCATION == attributeType) {
 				Geo geo = customValue.getGeo();
 
@@ -120,22 +114,36 @@ public class CustomFieldsUtil {
 						"longitude", geo.getLongitude()
 					).toString());
 			}
-			else if (ExpandoColumnConstants.INTEGER_ARRAY == attributeType) {
-				map.put(fieldName, ArrayUtil.toIntArray((List<Number>)data));
-			}
-			else if (ExpandoColumnConstants.LONG_ARRAY == attributeType) {
-				map.put(fieldName, ArrayUtil.toLongArray((List<Number>)data));
-			}
-			else if (ExpandoColumnConstants.STRING_ARRAY == attributeType) {
-				List<?> list = (List<?>)data;
-
-				map.put(fieldName, list.toArray(new String[0]));
-			}
 			else if (ExpandoColumnConstants.STRING_LOCALIZED == attributeType) {
 				map.put(
 					fieldName,
 					(Serializable)LocalizedMapUtil.getLocalizedMap(
 						locale, (String)data, customValue.getData_i18n()));
+			}
+			else if (data instanceof List) {
+				if (ExpandoColumnConstants.DOUBLE_ARRAY == attributeType) {
+					map.put(
+						fieldName, ArrayUtil.toDoubleArray((List<Number>)data));
+				}
+				else if (ExpandoColumnConstants.FLOAT_ARRAY == attributeType) {
+					map.put(
+						fieldName, ArrayUtil.toFloatArray((List<Number>)data));
+				}
+				else if (ExpandoColumnConstants.INTEGER_ARRAY ==
+							attributeType) {
+
+					map.put(
+						fieldName, ArrayUtil.toIntArray((List<Number>)data));
+				}
+				else if (ExpandoColumnConstants.LONG_ARRAY == attributeType) {
+					map.put(
+						fieldName, ArrayUtil.toLongArray((List<Number>)data));
+				}
+				else if (ExpandoColumnConstants.STRING_ARRAY == attributeType) {
+					List<?> list = (List<?>)data;
+
+					map.put(fieldName, list.toArray(new String[0]));
+				}
 			}
 			else {
 				map.put(fieldName, (Serializable)data);


### PR DESCRIPTION
Ticket: [LPS-182358](https://issues.liferay.com/browse/LPS-182358)

Solution: Check if the data is a List first before casting it to one. If it is not a List, then that means it came from looking up the existing values via the Expando service, so it should be in the correct format that we want (i.e. an array) already, so we can just return it/put it in the Map as-is