### PR TITLE
LPS-182351 Include the methods of the GraphQL-Query classes annotated with GraphQLTypeExtension in the _resourceMethodObjectValuePairs map of ServletDataImpl

### DIFF
--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -791,6 +791,102 @@ public class ServletDataImpl implements ServletData {
 						new ObjectValuePair<>(
 							AccountOrganizationResourceImpl.class,
 							"getAccountIdAccountOrganization"));
+
+					put(
+						"query#Account.byExternalReferenceCodeAccountChannelShippingOption",
+						new ObjectValuePair<>(
+							AccountChannelShippingOptionResourceImpl.class,
+							"getAccountByExternalReferenceCodeAccountChannelShippingOptionPage"));
+					put(
+						"query#Account.byExternalReferenceCodeAccountChannelPaymentTerms",
+						new ObjectValuePair<>(
+							AccountChannelEntryResourceImpl.class,
+							"getAccountByExternalReferenceCodeAccountChannelPaymentTermsPage"));
+					put(
+						"query#Account.byExternalReferenceCodeAccountMembers",
+						new ObjectValuePair<>(
+							AccountMemberResourceImpl.class,
+							"getAccountByExternalReferenceCodeAccountMembersPage"));
+					put(
+						"query#Account.byExternalReferenceCodeAccountAddresses",
+						new ObjectValuePair<>(
+							AccountAddressResourceImpl.class,
+							"getAccountByExternalReferenceCodeAccountAddressesPage"));
+					put(
+						"query#AccountAddress.accountByExternalReferenceCode",
+						new ObjectValuePair<>(
+							AccountResourceImpl.class,
+							"getAccountByExternalReferenceCode"));
+					put(
+						"query#Account.byExternalReferenceCodeAccountChannelShippingAddresses",
+						new ObjectValuePair<>(
+							AccountChannelEntryResourceImpl.class,
+							"getAccountByExternalReferenceCodeAccountChannelShippingAddressesPage"));
+					put(
+						"query#Account.groupByExternalReferenceCode",
+						new ObjectValuePair<>(
+							AccountGroupResourceImpl.class,
+							"getAccountGroupByExternalReferenceCode"));
+					put(
+						"query#Account.byExternalReferenceCodeAccountChannelBillingAddresses",
+						new ObjectValuePair<>(
+							AccountChannelEntryResourceImpl.class,
+							"getAccountByExternalReferenceCodeAccountChannelBillingAddressesPage"));
+					put(
+						"query#Account.byExternalReferenceCodeAccountChannelUsers",
+						new ObjectValuePair<>(
+							AccountChannelEntryResourceImpl.class,
+							"getAccountByExternalReferenceCodeAccountChannelUsersPage"));
+					put(
+						"query#Account.byExternalReferenceCodeAccountMember",
+						new ObjectValuePair<>(
+							AccountMemberResourceImpl.class,
+							"getAccountByExternalReferenceCodeAccountMember"));
+					put(
+						"query#Account.byExternalReferenceCodeAccountOrganization",
+						new ObjectValuePair<>(
+							AccountOrganizationResourceImpl.class,
+							"getAccountByExternalReferenceCodeAccountOrganization"));
+					put(
+						"query#Account.byExternalReferenceCodeAccountChannelPriceLists",
+						new ObjectValuePair<>(
+							AccountChannelEntryResourceImpl.class,
+							"getAccountByExternalReferenceCodeAccountChannelPriceListsPage"));
+					put(
+						"query#Account.byExternalReferenceCodeAccountChannelCurrencies",
+						new ObjectValuePair<>(
+							AccountChannelEntryResourceImpl.class,
+							"getAccountByExternalReferenceCodeAccountChannelCurrenciesPage"));
+					put(
+						"query#Account.byExternalReferenceCodeAccountGroups",
+						new ObjectValuePair<>(
+							AccountGroupResourceImpl.class,
+							"getAccountByExternalReferenceCodeAccountGroupsPage"));
+					put(
+						"query#Account.byExternalReferenceCodeAccountChannelPaymentMethods",
+						new ObjectValuePair<>(
+							AccountChannelEntryResourceImpl.class,
+							"getAccountByExternalReferenceCodeAccountChannelPaymentMethodsPage"));
+					put(
+						"query#Account.byExternalReferenceCodeAccountOrganizations",
+						new ObjectValuePair<>(
+							AccountOrganizationResourceImpl.class,
+							"getAccountByExternalReferenceCodeAccountOrganizationsPage"));
+					put(
+						"query#Account.byExternalReferenceCodeAccountChannelDiscounts",
+						new ObjectValuePair<>(
+							AccountChannelEntryResourceImpl.class,
+							"getAccountByExternalReferenceCodeAccountChannelDiscountsPage"));
+					put(
+						"query#Account.byExternalReferenceCodeAccountChannelDeliveryTerms",
+						new ObjectValuePair<>(
+							AccountChannelEntryResourceImpl.class,
+							"getAccountByExternalReferenceCodeAccountChannelDeliveryTermsPage"));
+					put(
+						"query#Account.addressByExternalReferenceCode",
+						new ObjectValuePair<>(
+							AccountAddressResourceImpl.class,
+							"getAccountAddressByExternalReferenceCode"));
 				}
 			};
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -1244,6 +1244,176 @@ public class ServletDataImpl implements ServletData {
 						new ObjectValuePair<>(
 							SpecificationResourceImpl.class,
 							"getSpecification"));
+
+					put(
+						"query#Catalog.productByExternalReferenceCodeConfiguration",
+						new ObjectValuePair<>(
+							ProductConfigurationResourceImpl.class,
+							"getProductByExternalReferenceCodeConfiguration"));
+					put(
+						"query#Catalog.productByExternalReferenceCode",
+						new ObjectValuePair<>(
+							ProductResourceImpl.class,
+							"getProductByExternalReferenceCode"));
+					put(
+						"query#Catalog.productByExternalReferenceCodeCategories",
+						new ObjectValuePair<>(
+							CategoryResourceImpl.class,
+							"getProductByExternalReferenceCodeCategoriesPage"));
+					put(
+						"query#Catalog.productByExternalReferenceCodeGroupedProducts",
+						new ObjectValuePair<>(
+							GroupedProductResourceImpl.class,
+							"getProductByExternalReferenceCodeGroupedProductsPage"));
+					put(
+						"query#Catalog.productByExternalReferenceCodeProductChannels",
+						new ObjectValuePair<>(
+							ProductChannelResourceImpl.class,
+							"getProductByExternalReferenceCodeProductChannelsPage"));
+					put(
+						"query#Catalog.skuByExternalReferenceCodeSkuSubscriptionConfiguration",
+						new ObjectValuePair<>(
+							SkuSubscriptionConfigurationResourceImpl.class,
+							"getSkuByExternalReferenceCodeSkuSubscriptionConfiguration"));
+					put(
+						"query#Catalog.optionValueByExternalReferenceCode",
+						new ObjectValuePair<>(
+							OptionValueResourceImpl.class,
+							"getOptionValueByExternalReferenceCode"));
+					put(
+						"query#Catalog.productByExternalReferenceCodeCatalog",
+						new ObjectValuePair<>(
+							CatalogResourceImpl.class,
+							"getProductByExternalReferenceCodeCatalog"));
+					put(
+						"query#Option.catalogByExternalReferenceCode",
+						new ObjectValuePair<>(
+							CatalogResourceImpl.class,
+							"getCatalogByExternalReferenceCode"));
+					put(
+						"query#Catalog.productByExternalReferenceCodeMappedProducts",
+						new ObjectValuePair<>(
+							MappedProductResourceImpl.class,
+							"getProductByExternalReferenceCodeMappedProductsPage"));
+					put(
+						"query#Catalog.productByExternalReferenceCodeDiagram",
+						new ObjectValuePair<>(
+							DiagramResourceImpl.class,
+							"getProductByExternalReferenceCodeDiagram"));
+					put(
+						"query#Catalog.productByExternalReferenceCodeProductAccountGroups",
+						new ObjectValuePair<>(
+							ProductAccountGroupResourceImpl.class,
+							"getProductByExternalReferenceCodeProductAccountGroupsPage"));
+					put(
+						"query#Catalog.productByExternalReferenceCodeSkus",
+						new ObjectValuePair<>(
+							SkuResourceImpl.class,
+							"getProductByExternalReferenceCodeSkusPage"));
+					put(
+						"query#Catalog.productByExternalReferenceCodeShippingConfiguration",
+						new ObjectValuePair<>(
+							ProductShippingConfigurationResourceImpl.class,
+							"getProductByExternalReferenceCodeShippingConfiguration"));
+					put(
+						"query#Catalog.skuByExternalReferenceCode",
+						new ObjectValuePair<>(
+							SkuResourceImpl.class,
+							"getSkuByExternalReferenceCode"));
+					put(
+						"query#Catalog.productByExternalReferenceCodeByVersion",
+						new ObjectValuePair<>(
+							ProductResourceImpl.class,
+							"getProductByExternalReferenceCodeByVersion"));
+					put(
+						"query#Catalog.productByExternalReferenceCodeAttachments",
+						new ObjectValuePair<>(
+							AttachmentResourceImpl.class,
+							"getProductByExternalReferenceCodeAttachmentsPage"));
+					put(
+						"query#Diagram.productIdPins",
+						new ObjectValuePair<>(
+							PinResourceImpl.class, "getProductIdPinsPage"));
+					put(
+						"query#Catalog.optionByExternalReferenceCodeOptionValues",
+						new ObjectValuePair<>(
+							OptionValueResourceImpl.class,
+							"getOptionByExternalReferenceCodeOptionValuesPage"));
+					put(
+						"query#Sku.productMappedProductBySequence",
+						new ObjectValuePair<>(
+							MappedProductResourceImpl.class,
+							"getProductMappedProductBySequence"));
+					put(
+						"query#Diagram.productIdGroupedProducts",
+						new ObjectValuePair<>(
+							GroupedProductResourceImpl.class,
+							"getProductIdGroupedProductsPage"));
+					put(
+						"query#Catalog.productGroupByExternalReferenceCodeProductGroupProducts",
+						new ObjectValuePair<>(
+							ProductGroupProductResourceImpl.class,
+							"getProductGroupByExternalReferenceCodeProductGroupProductsPage"));
+					put(
+						"query#Catalog.productByExternalReferenceCodeProductOptions",
+						new ObjectValuePair<>(
+							ProductOptionResourceImpl.class,
+							"getProductByExternalReferenceCodeProductOptionsPage"));
+					put(
+						"query#Catalog.productByExternalReferenceCodeRelatedProducts",
+						new ObjectValuePair<>(
+							RelatedProductResourceImpl.class,
+							"getProductByExternalReferenceCodeRelatedProductsPage"));
+					put(
+						"query#Catalog.productByExternalReferenceCodeMappedProductBySequence",
+						new ObjectValuePair<>(
+							MappedProductResourceImpl.class,
+							"getProductByExternalReferenceCodeMappedProductBySequence"));
+					put(
+						"query#Diagram.productIdMappedProducts",
+						new ObjectValuePair<>(
+							MappedProductResourceImpl.class,
+							"getProductIdMappedProductsPage"));
+					put(
+						"query#Catalog.productByExternalReferenceCodeTaxConfiguration",
+						new ObjectValuePair<>(
+							ProductTaxConfigurationResourceImpl.class,
+							"getProductByExternalReferenceCodeTaxConfiguration"));
+					put(
+						"query#Catalog.productByExternalReferenceCodeImages",
+						new ObjectValuePair<>(
+							AttachmentResourceImpl.class,
+							"getProductByExternalReferenceCodeImagesPage"));
+					put(
+						"query#Catalog.productByExternalReferenceCodePins",
+						new ObjectValuePair<>(
+							PinResourceImpl.class,
+							"getProductByExternalReferenceCodePinsPage"));
+					put(
+						"query#Catalog.optionByExternalReferenceCode",
+						new ObjectValuePair<>(
+							OptionResourceImpl.class,
+							"getOptionByExternalReferenceCode"));
+					put(
+						"query#Catalog.productGroupByExternalReferenceCode",
+						new ObjectValuePair<>(
+							ProductGroupResourceImpl.class,
+							"getProductGroupByExternalReferenceCode"));
+					put(
+						"query#Catalog.productByExternalReferenceCodeSubscriptionConfiguration",
+						new ObjectValuePair<>(
+							ProductSubscriptionConfigurationResourceImpl.class,
+							"getProductByExternalReferenceCodeSubscriptionConfiguration"));
+					put(
+						"query#Catalog.productByExternalReferenceCodeProductVirtualSettings",
+						new ObjectValuePair<>(
+							ProductVirtualSettingsResourceImpl.class,
+							"getProductByExternalReferenceCodeProductVirtualSettings"));
+					put(
+						"query#Diagram.productIdLinkedProducts",
+						new ObjectValuePair<>(
+							LinkedProductResourceImpl.class,
+							"getProductIdLinkedProductsPage"));
 				}
 			};
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -308,6 +308,12 @@ public class ServletDataImpl implements ServletData {
 						new ObjectValuePair<>(
 							TermResourceImpl.class,
 							"getShippingFixedOptionTermTerm"));
+
+					put(
+						"query#Channel.shippingMethods",
+						new ObjectValuePair<>(
+							ShippingMethodResourceImpl.class,
+							"getChannelShippingMethodsPage"));
 				}
 			};
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -371,6 +371,37 @@ public class ServletDataImpl implements ServletData {
 						new ObjectValuePair<>(
 							WarehouseOrderTypeResourceImpl.class,
 							"getWarehouseIdWarehouseOrderTypesPage"));
+
+					put(
+						"query#ReplenishmentItem.warehouseByExternalReferenceCode",
+						new ObjectValuePair<>(
+							WarehouseResourceImpl.class,
+							"getWarehouseByExternalReferenceCode"));
+					put(
+						"query#ReplenishmentItem.warehouseItemByExternalReferenceCode",
+						new ObjectValuePair<>(
+							WarehouseItemResourceImpl.class,
+							"getWarehouseItemByExternalReferenceCode"));
+					put(
+						"query#ReplenishmentItem.warehouseByExternalReferenceCodeWarehouseOrderTypes",
+						new ObjectValuePair<>(
+							WarehouseOrderTypeResourceImpl.class,
+							"getWarehouseByExternalReferenceCodeWarehouseOrderTypesPage"));
+					put(
+						"query#ReplenishmentItem.warehouseByExternalReferenceCodeWarehouseItems",
+						new ObjectValuePair<>(
+							WarehouseItemResourceImpl.class,
+							"getWarehouseByExternalReferenceCodeWarehouseItemsPage"));
+					put(
+						"query#ReplenishmentItem.warehouseByExternalReferenceCodeWarehouseChannels",
+						new ObjectValuePair<>(
+							WarehouseChannelResourceImpl.class,
+							"getWarehouseByExternalReferenceCodeWarehouseChannelsPage"));
+					put(
+						"query#Warehouse.replenishmentItemByExternalReferenceCode",
+						new ObjectValuePair<>(
+							ReplenishmentItemResourceImpl.class,
+							"getReplenishmentItemByExternalReferenceCode"));
 				}
 			};
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -808,6 +808,97 @@ public class ServletDataImpl implements ServletData {
 						new ObjectValuePair<>(
 							TermOrderTypeResourceImpl.class,
 							"getTermIdTermOrderTypesPage"));
+
+					put(
+						"query#Order.itemByExternalReferenceCode",
+						new ObjectValuePair<>(
+							OrderItemResourceImpl.class,
+							"getOrderItemByExternalReferenceCode"));
+					put(
+						"query#Order.byExternalReferenceCodeChannel",
+						new ObjectValuePair<>(
+							ChannelResourceImpl.class,
+							"getOrderByExternalReferenceCodeChannel"));
+					put(
+						"query#Order.ruleByExternalReferenceCode",
+						new ObjectValuePair<>(
+							OrderRuleResourceImpl.class,
+							"getOrderRuleByExternalReferenceCode"));
+					put(
+						"query#Order.byExternalReferenceCodeAccount",
+						new ObjectValuePair<>(
+							AccountResourceImpl.class,
+							"getOrderByExternalReferenceCodeAccount"));
+					put(
+						"query#OrderItem.orderByExternalReferenceCode",
+						new ObjectValuePair<>(
+							OrderResourceImpl.class,
+							"getOrderByExternalReferenceCode"));
+					put(
+						"query#Order.ruleByExternalReferenceCodeOrderRuleAccountGroups",
+						new ObjectValuePair<>(
+							OrderRuleAccountGroupResourceImpl.class,
+							"getOrderRuleByExternalReferenceCodeOrderRuleAccountGroupsPage"));
+					put(
+						"query#Order.noteByExternalReferenceCode",
+						new ObjectValuePair<>(
+							OrderNoteResourceImpl.class,
+							"getOrderNoteByExternalReferenceCode"));
+					put(
+						"query#Order.byExternalReferenceCodeBillingAddress",
+						new ObjectValuePair<>(
+							BillingAddressResourceImpl.class,
+							"getOrderByExternalReferenceCodeBillingAddress"));
+					put(
+						"query#Order.typeByExternalReferenceCode",
+						new ObjectValuePair<>(
+							OrderTypeResourceImpl.class,
+							"getOrderTypeByExternalReferenceCode"));
+					put(
+						"query#Order.ruleByExternalReferenceCodeOrderRuleChannels",
+						new ObjectValuePair<>(
+							OrderRuleChannelResourceImpl.class,
+							"getOrderRuleByExternalReferenceCodeOrderRuleChannelsPage"));
+					put(
+						"query#Order.byExternalReferenceCodeOrderNotes",
+						new ObjectValuePair<>(
+							OrderNoteResourceImpl.class,
+							"getOrderByExternalReferenceCodeOrderNotesPage"));
+					put(
+						"query#Order.byExternalReferenceCodeShippingAddress",
+						new ObjectValuePair<>(
+							ShippingAddressResourceImpl.class,
+							"getOrderByExternalReferenceCodeShippingAddress"));
+					put(
+						"query#Order.ruleByExternalReferenceCodeOrderRuleAccounts",
+						new ObjectValuePair<>(
+							OrderRuleAccountResourceImpl.class,
+							"getOrderRuleByExternalReferenceCodeOrderRuleAccountsPage"));
+					put(
+						"query#Order.termByExternalReferenceCode",
+						new ObjectValuePair<>(
+							TermResourceImpl.class,
+							"getTermByExternalReferenceCode"));
+					put(
+						"query#Order.termByExternalReferenceCodeTermOrderTypes",
+						new ObjectValuePair<>(
+							TermOrderTypeResourceImpl.class,
+							"getTermByExternalReferenceCodeTermOrderTypesPage"));
+					put(
+						"query#Order.typeByExternalReferenceCodeOrderTypeChannels",
+						new ObjectValuePair<>(
+							OrderTypeChannelResourceImpl.class,
+							"getOrderTypeByExternalReferenceCodeOrderTypeChannelsPage"));
+					put(
+						"query#Order.ruleByExternalReferenceCodeOrderRuleOrderTypes",
+						new ObjectValuePair<>(
+							OrderRuleOrderTypeResourceImpl.class,
+							"getOrderRuleByExternalReferenceCodeOrderRuleOrderTypesPage"));
+					put(
+						"query#Order.byExternalReferenceCodeOrderItems",
+						new ObjectValuePair<>(
+							OrderItemResourceImpl.class,
+							"getOrderByExternalReferenceCodeOrderItemsPage"));
 				}
 			};
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -528,6 +528,62 @@ public class ServletDataImpl implements ServletData {
 						"query#tierPrice",
 						new ObjectValuePair<>(
 							TierPriceResourceImpl.class, "getTierPrice"));
+
+					put(
+						"query#Discount.byExternalReferenceCodeDiscountAccountGroups",
+						new ObjectValuePair<>(
+							DiscountAccountGroupResourceImpl.class,
+							"getDiscountByExternalReferenceCodeDiscountAccountGroupsPage"));
+					put(
+						"query#Discount.byExternalReferenceCodeDiscountCategories",
+						new ObjectValuePair<>(
+							DiscountCategoryResourceImpl.class,
+							"getDiscountByExternalReferenceCodeDiscountCategoriesPage"));
+					put(
+						"query#Discount.priceEntryByExternalReferenceCodeTierPrices",
+						new ObjectValuePair<>(
+							TierPriceResourceImpl.class,
+							"getPriceEntryByExternalReferenceCodeTierPricesPage"));
+					put(
+						"query#Discount.byExternalReferenceCodeDiscountProducts",
+						new ObjectValuePair<>(
+							DiscountProductResourceImpl.class,
+							"getDiscountByExternalReferenceCodeDiscountProductsPage"));
+					put(
+						"query#Discount.tierPriceByExternalReferenceCode",
+						new ObjectValuePair<>(
+							TierPriceResourceImpl.class,
+							"getTierPriceByExternalReferenceCode"));
+					put(
+						"query#Discount.priceListByExternalReferenceCodePriceListAccountGroup",
+						new ObjectValuePair<>(
+							PriceListAccountGroupResourceImpl.class,
+							"getPriceListByExternalReferenceCodePriceListAccountGroupPage"));
+					put(
+						"query#PriceEntry.discountByExternalReferenceCode",
+						new ObjectValuePair<>(
+							DiscountResourceImpl.class,
+							"getDiscountByExternalReferenceCode"));
+					put(
+						"query#Discount.priceEntryByExternalReferenceCode",
+						new ObjectValuePair<>(
+							PriceEntryResourceImpl.class,
+							"getPriceEntryByExternalReferenceCode"));
+					put(
+						"query#Discount.priceListByExternalReferenceCodePriceEntries",
+						new ObjectValuePair<>(
+							PriceEntryResourceImpl.class,
+							"getPriceListByExternalReferenceCodePriceEntriesPage"));
+					put(
+						"query#Discount.priceListByExternalReferenceCode",
+						new ObjectValuePair<>(
+							PriceListResourceImpl.class,
+							"getPriceListByExternalReferenceCode"));
+					put(
+						"query#Discount.byExternalReferenceCodeDiscountRules",
+						new ObjectValuePair<>(
+							DiscountRuleResourceImpl.class,
+							"getDiscountByExternalReferenceCodeDiscountRulesPage"));
 				}
 			};
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/graphql/servlet/v2_0/ServletDataImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/graphql/servlet/v2_0/ServletDataImpl.java
@@ -1201,6 +1201,150 @@ public class ServletDataImpl implements ServletData {
 						"query#tierPrice",
 						new ObjectValuePair<>(
 							TierPriceResourceImpl.class, "getTierPrice"));
+
+					put(
+						"query#PriceEntry.idProduct",
+						new ObjectValuePair<>(
+							ProductResourceImpl.class,
+							"getPriceEntryIdProduct"));
+					put(
+						"query#PriceEntry.idTierPrices",
+						new ObjectValuePair<>(
+							TierPriceResourceImpl.class,
+							"getPriceEntryIdTierPricesPage"));
+					put(
+						"query#Discount.byExternalReferenceCodeDiscountCategories",
+						new ObjectValuePair<>(
+							DiscountCategoryResourceImpl.class,
+							"getDiscountByExternalReferenceCodeDiscountCategoriesPage"));
+					put(
+						"query#Discount.byExternalReferenceCodeDiscountProductGroups",
+						new ObjectValuePair<>(
+							DiscountProductGroupResourceImpl.class,
+							"getDiscountByExternalReferenceCodeDiscountProductGroupsPage"));
+					put(
+						"query#TierPrice.priceEntry",
+						new ObjectValuePair<>(
+							PriceEntryResourceImpl.class, "getPriceEntry"));
+					put(
+						"query#Discount.byExternalReferenceCodeDiscountProducts",
+						new ObjectValuePair<>(
+							DiscountProductResourceImpl.class,
+							"getDiscountByExternalReferenceCodeDiscountProductsPage"));
+					put(
+						"query#Discount.priceListByExternalReferenceCodePriceListAccounts",
+						new ObjectValuePair<>(
+							PriceListAccountResourceImpl.class,
+							"getPriceListByExternalReferenceCodePriceListAccountsPage"));
+					put(
+						"query#PriceEntry.discountByExternalReferenceCode",
+						new ObjectValuePair<>(
+							DiscountResourceImpl.class,
+							"getDiscountByExternalReferenceCode"));
+					put(
+						"query#Discount.priceListByExternalReferenceCode",
+						new ObjectValuePair<>(
+							PriceListResourceImpl.class,
+							"getPriceListByExternalReferenceCode"));
+					put(
+						"query#Discount.priceListByExternalReferenceCodePriceListOrderTypes",
+						new ObjectValuePair<>(
+							PriceListOrderTypeResourceImpl.class,
+							"getPriceListByExternalReferenceCodePriceListOrderTypesPage"));
+					put(
+						"query#Discount.byExternalReferenceCodeDiscountOrderTypes",
+						new ObjectValuePair<>(
+							DiscountOrderTypeResourceImpl.class,
+							"getDiscountByExternalReferenceCodeDiscountOrderTypesPage"));
+					put(
+						"query#Discount.tierPriceByExternalReferenceCode",
+						new ObjectValuePair<>(
+							TierPriceResourceImpl.class,
+							"getTierPriceByExternalReferenceCode"));
+					put(
+						"query#Discount.priceModifierByExternalReferenceCodePriceModifierProducts",
+						new ObjectValuePair<>(
+							PriceModifierProductResourceImpl.class,
+							"getPriceModifierByExternalReferenceCodePriceModifierProductsPage"));
+					put(
+						"query#Discount.priceEntryByExternalReferenceCode",
+						new ObjectValuePair<>(
+							PriceEntryResourceImpl.class,
+							"getPriceEntryByExternalReferenceCode"));
+					put(
+						"query#PriceEntry.idSku",
+						new ObjectValuePair<>(
+							SkuResourceImpl.class, "getPriceEntryIdSku"));
+					put(
+						"query#Discount.priceModifierByExternalReferenceCodePriceModifierProductGroups",
+						new ObjectValuePair<>(
+							PriceModifierProductGroupResourceImpl.class,
+							"getPriceModifierByExternalReferenceCodePriceModifierProductGroupsPage"));
+					put(
+						"query#Discount.byExternalReferenceCodeDiscountAccountGroups",
+						new ObjectValuePair<>(
+							DiscountAccountGroupResourceImpl.class,
+							"getDiscountByExternalReferenceCodeDiscountAccountGroupsPage"));
+					put(
+						"query#Discount.priceListByExternalReferenceCodePriceListAccountGroups",
+						new ObjectValuePair<>(
+							PriceListAccountGroupResourceImpl.class,
+							"getPriceListByExternalReferenceCodePriceListAccountGroupsPage"));
+					put(
+						"query#Discount.priceEntryByExternalReferenceCodeTierPrices",
+						new ObjectValuePair<>(
+							TierPriceResourceImpl.class,
+							"getPriceEntryByExternalReferenceCodeTierPricesPage"));
+					put(
+						"query#Discount.priceModifierByExternalReferenceCodePriceModifierCategories",
+						new ObjectValuePair<>(
+							PriceModifierCategoryResourceImpl.class,
+							"getPriceModifierByExternalReferenceCodePriceModifierCategoriesPage"));
+					put(
+						"query#Discount.priceListByExternalReferenceCodePriceModifiers",
+						new ObjectValuePair<>(
+							PriceModifierResourceImpl.class,
+							"getPriceListByExternalReferenceCodePriceModifiersPage"));
+					put(
+						"query#Discount.byExternalReferenceCodeDiscountChannels",
+						new ObjectValuePair<>(
+							DiscountChannelResourceImpl.class,
+							"getDiscountByExternalReferenceCodeDiscountChannelsPage"));
+					put(
+						"query#Discount.priceListByExternalReferenceCodePriceListDiscounts",
+						new ObjectValuePair<>(
+							PriceListDiscountResourceImpl.class,
+							"getPriceListByExternalReferenceCodePriceListDiscountsPage"));
+					put(
+						"query#Discount.priceListByExternalReferenceCodePriceListChannels",
+						new ObjectValuePair<>(
+							PriceListChannelResourceImpl.class,
+							"getPriceListByExternalReferenceCodePriceListChannelsPage"));
+					put(
+						"query#Discount.byExternalReferenceCodeDiscountSkus",
+						new ObjectValuePair<>(
+							DiscountSkuResourceImpl.class,
+							"getDiscountByExternalReferenceCodeDiscountSkusPage"));
+					put(
+						"query#Discount.priceListByExternalReferenceCodePriceEntries",
+						new ObjectValuePair<>(
+							PriceEntryResourceImpl.class,
+							"getPriceListByExternalReferenceCodePriceEntriesPage"));
+					put(
+						"query#Discount.byExternalReferenceCodeDiscountRules",
+						new ObjectValuePair<>(
+							DiscountRuleResourceImpl.class,
+							"getDiscountByExternalReferenceCodeDiscountRulesPage"));
+					put(
+						"query#Discount.priceModifierByExternalReferenceCode",
+						new ObjectValuePair<>(
+							PriceModifierResourceImpl.class,
+							"getPriceModifierByExternalReferenceCode"));
+					put(
+						"query#Discount.byExternalReferenceCodeDiscountAccounts",
+						new ObjectValuePair<>(
+							DiscountAccountResourceImpl.class,
+							"getDiscountByExternalReferenceCodeDiscountAccountsPage"));
 				}
 			};
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -254,6 +254,36 @@ public class ServletDataImpl implements ServletData {
 						new ObjectValuePair<>(
 							ShippingAddressResourceImpl.class,
 							"getShipmentShippingAddress"));
+
+					put(
+						"query#Shipment.byExternalReferenceCodeItem",
+						new ObjectValuePair<>(
+							ShipmentItemResourceImpl.class,
+							"getShipmentByExternalReferenceCodeItem"));
+					put(
+						"query#Shipment.byExternalReferenceCodeItems",
+						new ObjectValuePair<>(
+							ShipmentItemResourceImpl.class,
+							"getShipmentByExternalReferenceCodeItemsPage"));
+					put(
+						"query#Shipment.byExternalReferenceCodeShippingAddress",
+						new ObjectValuePair<>(
+							ShippingAddressResourceImpl.class,
+							"getShipmentByExternalReferenceCodeShippingAddress"));
+					put(
+						"query#ShipmentItem.shipment",
+						new ObjectValuePair<>(
+							ShipmentResourceImpl.class, "getShipment"));
+					put(
+						"query#ShipmentItem.shipmentByExternalReferenceCode",
+						new ObjectValuePair<>(
+							ShipmentResourceImpl.class,
+							"getShipmentByExternalReferenceCode"));
+					put(
+						"query#Shipment.items",
+						new ObjectValuePair<>(
+							ShipmentItemResourceImpl.class,
+							"getShipmentItemsPage"));
 				}
 			};
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -254,6 +254,39 @@ public class ServletDataImpl implements ServletData {
 						new ObjectValuePair<>(
 							ShippingMethodResourceImpl.class,
 							"getCartShippingMethodsPage"));
+
+					put(
+						"query#Cart.paymentMethods",
+						new ObjectValuePair<>(
+							PaymentMethodResourceImpl.class,
+							"getCartPaymentMethodsPage"));
+					put(
+						"query#Cart.comments",
+						new ObjectValuePair<>(
+							CartCommentResourceImpl.class,
+							"getCartCommentsPage"));
+					put(
+						"query#Cart.shippingAddres",
+						new ObjectValuePair<>(
+							AddressResourceImpl.class,
+							"getCartShippingAddres"));
+					put(
+						"query#Cart.shippingMethods",
+						new ObjectValuePair<>(
+							ShippingMethodResourceImpl.class,
+							"getCartShippingMethodsPage"));
+					put(
+						"query#Cart.paymentURL",
+						new ObjectValuePair<>(
+							CartResourceImpl.class, "getCartPaymentURL"));
+					put(
+						"query#Cart.items",
+						new ObjectValuePair<>(
+							CartItemResourceImpl.class, "getCartItemsPage"));
+					put(
+						"query#Cart.billingAddres",
+						new ObjectValuePair<>(
+							AddressResourceImpl.class, "getCartBillingAddres"));
 				}
 			};
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -261,6 +261,12 @@ public class ServletDataImpl implements ServletData {
 						new ObjectValuePair<>(
 							WishListItemResourceImpl.class,
 							"getWishListItemsPage"));
+
+					put(
+						"query#WishList.items",
+						new ObjectValuePair<>(
+							WishListItemResourceImpl.class,
+							"getWishListItemsPage"));
 				}
 			};
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -169,6 +169,22 @@ public class ServletDataImpl implements ServletData {
 						new ObjectValuePair<>(
 							PlacedOrderItemShipmentResourceImpl.class,
 							"getPlacedOrderItemPlacedOrderItemShipmentsPage"));
+
+					put(
+						"query#PlacedOrder.paymentURL",
+						new ObjectValuePair<>(
+							PlacedOrderResourceImpl.class,
+							"getPlacedOrderPaymentURL"));
+					put(
+						"query#PlacedOrder.placedOrderBillingAddres",
+						new ObjectValuePair<>(
+							PlacedOrderAddressResourceImpl.class,
+							"getPlacedOrderPlacedOrderBillingAddres"));
+					put(
+						"query#PlacedOrder.placedOrderShippingAddres",
+						new ObjectValuePair<>(
+							PlacedOrderAddressResourceImpl.class,
+							"getPlacedOrderPlacedOrderShippingAddres"));
 				}
 			};
 

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/graphql/servlet/v2_0/ServletDataImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/graphql/servlet/v2_0/ServletDataImpl.java
@@ -446,6 +446,72 @@ public class ServletDataImpl implements ServletData {
 						new ObjectValuePair<>(
 							DataRecordCollectionResourceImpl.class,
 							"getSiteDataRecordCollectionByDataRecordCollectionKey"));
+
+					put(
+						"query#DataDefinition.dataRecordCollections",
+						new ObjectValuePair<>(
+							DataRecordCollectionResourceImpl.class,
+							"getDataDefinitionDataRecordCollectionsPage"));
+					put(
+						"query#DataDefinition.dataDefinitionFieldLinks",
+						new ObjectValuePair<>(
+							DataDefinitionFieldLinkResourceImpl.class,
+							"getDataDefinitionDataDefinitionFieldLinksPage"));
+					put(
+						"query#DataDefinition.dataRecordCollection",
+						new ObjectValuePair<>(
+							DataRecordCollectionResourceImpl.class,
+							"getDataDefinitionDataRecordCollection"));
+					put(
+						"query#DataRecord.collection",
+						new ObjectValuePair<>(
+							DataRecordCollectionResourceImpl.class,
+							"getDataRecordCollection"));
+					put(
+						"query#DataRecordCollection.dataRecordExport",
+						new ObjectValuePair<>(
+							DataRecordResourceImpl.class,
+							"getDataRecordCollectionDataRecordExport"));
+					put(
+						"query#DataRecordCollection.dataDefinition",
+						new ObjectValuePair<>(
+							DataDefinitionResourceImpl.class,
+							"getDataDefinition"));
+					put(
+						"query#DataDefinition.dataListViews",
+						new ObjectValuePair<>(
+							DataListViewResourceImpl.class,
+							"getDataDefinitionDataListViewsPage"));
+					put(
+						"query#DataDefinition.dataRecords",
+						new ObjectValuePair<>(
+							DataRecordResourceImpl.class,
+							"getDataDefinitionDataRecordsPage"));
+					put(
+						"query#DataRecordCollection.permissionByCurrentUser",
+						new ObjectValuePair<>(
+							DataRecordCollectionResourceImpl.class,
+							"getDataRecordCollectionPermissionByCurrentUser"));
+					put(
+						"query#DataDefinition.dataLayouts",
+						new ObjectValuePair<>(
+							DataLayoutResourceImpl.class,
+							"getDataDefinitionDataLayoutsPage"));
+					put(
+						"query#DataRecordCollection.dataRecords",
+						new ObjectValuePair<>(
+							DataRecordResourceImpl.class,
+							"getDataRecordCollectionDataRecordsPage"));
+					put(
+						"query#DataRecordCollection.permissions",
+						new ObjectValuePair<>(
+							DataRecordCollectionResourceImpl.class,
+							"getDataRecordCollectionPermissionsPage"));
+					put(
+						"query#DataDefinition.permissions",
+						new ObjectValuePair<>(
+							DataDefinitionResourceImpl.class,
+							"getDataDefinitionPermissionsPage"));
 				}
 			};
 

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -199,6 +199,16 @@ public class ServletDataImpl implements ServletData {
 						"query#region",
 						new ObjectValuePair<>(
 							RegionResourceImpl.class, "getRegion"));
+
+					put(
+						"query#Region.country",
+						new ObjectValuePair<>(
+							CountryResourceImpl.class, "getCountry"));
+					put(
+						"query#Country.regionByRegionCode",
+						new ObjectValuePair<>(
+							RegionResourceImpl.class,
+							"getCountryRegionByRegionCode"));
 				}
 			};
 

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -201,6 +201,12 @@ public class ServletDataImpl implements ServletData {
 						new ObjectValuePair<>(
 							ListTypeEntryResourceImpl.class,
 							"getListTypeEntry"));
+
+					put(
+						"query#ListTypeDefinition.byExternalReferenceCodeListTypeEntries",
+						new ObjectValuePair<>(
+							ListTypeEntryResourceImpl.class,
+							"getListTypeDefinitionByExternalReferenceCodeListTypeEntriesPage"));
 				}
 			};
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -393,6 +393,37 @@ public class ServletDataImpl implements ServletData {
 						new ObjectValuePair<>(
 							TaxonomyVocabularyResourceImpl.class,
 							"getTaxonomyVocabularyPermissionsPage"));
+
+					put(
+						"query#TaxonomyCategory.permissions",
+						new ObjectValuePair<>(
+							TaxonomyCategoryResourceImpl.class,
+							"getTaxonomyCategoryPermissionsPage"));
+					put(
+						"query#TaxonomyVocabulary.permissions",
+						new ObjectValuePair<>(
+							TaxonomyVocabularyResourceImpl.class,
+							"getTaxonomyVocabularyPermissionsPage"));
+					put(
+						"query#TaxonomyVocabulary.taxonomyCategories",
+						new ObjectValuePair<>(
+							TaxonomyCategoryResourceImpl.class,
+							"getTaxonomyVocabularyTaxonomyCategoriesPage"));
+					put(
+						"query#TaxonomyCategory.taxonomyCategories",
+						new ObjectValuePair<>(
+							TaxonomyCategoryResourceImpl.class,
+							"getTaxonomyCategoryTaxonomyCategoriesPage"));
+					put(
+						"query#TaxonomyCategory.taxonomyVocabulary",
+						new ObjectValuePair<>(
+							TaxonomyVocabularyResourceImpl.class,
+							"getTaxonomyVocabulary"));
+					put(
+						"query#TaxonomyVocabulary.taxonomyCategoryByExternalReferenceCode",
+						new ObjectValuePair<>(
+							TaxonomyCategoryResourceImpl.class,
+							"getTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode"));
 				}
 			};
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -891,6 +891,157 @@ public class ServletDataImpl implements ServletData {
 						"query#webUrl",
 						new ObjectValuePair<>(
 							WebUrlResourceImpl.class, "getWebUrl"));
+
+					put(
+						"query#Account.userAccounts",
+						new ObjectValuePair<>(
+							UserAccountResourceImpl.class,
+							"getAccountUserAccountsPage"));
+					put(
+						"query#UserAccount.phones",
+						new ObjectValuePair<>(
+							PhoneResourceImpl.class,
+							"getUserAccountPhonesPage"));
+					put(
+						"query#Account.accountRoles",
+						new ObjectValuePair<>(
+							AccountRoleResourceImpl.class,
+							"getAccountAccountRolesPage"));
+					put(
+						"query#Account.accountRolesByExternalReferenceCode",
+						new ObjectValuePair<>(
+							AccountRoleResourceImpl.class,
+							"getAccountAccountRolesByExternalReferenceCodePage"));
+					put(
+						"query#Organization.accountByExternalReferenceCode",
+						new ObjectValuePair<>(
+							AccountResourceImpl.class,
+							"getAccountByExternalReferenceCode"));
+					put(
+						"query#Organization.accounts",
+						new ObjectValuePair<>(
+							AccountResourceImpl.class,
+							"getOrganizationAccountsPage"));
+					put(
+						"query#Site.userAccountSegments",
+						new ObjectValuePair<>(
+							SegmentResourceImpl.class,
+							"getSiteUserAccountSegmentsPage"));
+					put(
+						"query#UserAccount.postalAddresses",
+						new ObjectValuePair<>(
+							PostalAddressResourceImpl.class,
+							"getUserAccountPostalAddressesPage"));
+					put(
+						"query#UserAccount.emailAddresses",
+						new ObjectValuePair<>(
+							EmailAddressResourceImpl.class,
+							"getUserAccountEmailAddressesPage"));
+					put(
+						"query#Account.userAccountByExternalReferenceCode",
+						new ObjectValuePair<>(
+							UserAccountResourceImpl.class,
+							"getUserAccountByExternalReferenceCode"));
+					put(
+						"query#Organization.postalAddresses",
+						new ObjectValuePair<>(
+							PostalAddressResourceImpl.class,
+							"getOrganizationPostalAddressesPage"));
+					put(
+						"query#Account.byExternalReferenceCodeOrganizations",
+						new ObjectValuePair<>(
+							OrganizationResourceImpl.class,
+							"getAccountByExternalReferenceCodeOrganizationsPage"));
+					put(
+						"query#AccountRole.account",
+						new ObjectValuePair<>(
+							AccountResourceImpl.class, "getAccount"));
+					put(
+						"query#Organization.organizations",
+						new ObjectValuePair<>(
+							OrganizationResourceImpl.class,
+							"getOrganizationOrganizationsPage"));
+					put(
+						"query#Organization.emailAddresses",
+						new ObjectValuePair<>(
+							EmailAddressResourceImpl.class,
+							"getOrganizationEmailAddressesPage"));
+					put(
+						"query#Account.userGroupByExternalReferenceCode",
+						new ObjectValuePair<>(
+							UserGroupResourceImpl.class,
+							"getUserGroupByExternalReferenceCode"));
+					put(
+						"query#Site.userAccounts",
+						new ObjectValuePair<>(
+							UserAccountResourceImpl.class,
+							"getSiteUserAccountsPage"));
+					put(
+						"query#Account.userAccountsByExternalReferenceCode",
+						new ObjectValuePair<>(
+							UserAccountResourceImpl.class,
+							"getAccountUserAccountsByExternalReferenceCodePage"));
+					put(
+						"query#AccountRole.role",
+						new ObjectValuePair<>(
+							RoleResourceImpl.class, "getRole"));
+					put(
+						"query#Account.organizations",
+						new ObjectValuePair<>(
+							OrganizationResourceImpl.class,
+							"getAccountOrganizationsPage"));
+					put(
+						"query#Account.byExternalReferenceCodeUserAccountByEmailAddressAccountRoles",
+						new ObjectValuePair<>(
+							AccountRoleResourceImpl.class,
+							"getAccountByExternalReferenceCodeUserAccountByEmailAddressAccountRolesPage"));
+					put(
+						"query#Site.segments",
+						new ObjectValuePair<>(
+							SegmentResourceImpl.class, "getSiteSegmentsPage"));
+					put(
+						"query#Organization.webUrls",
+						new ObjectValuePair<>(
+							WebUrlResourceImpl.class,
+							"getOrganizationWebUrlsPage"));
+					put(
+						"query#UserAccount.emailVerificationTicket",
+						new ObjectValuePair<>(
+							TicketResourceImpl.class,
+							"getUserAccountEmailVerificationTicket"));
+					put(
+						"query#Subscription.site",
+						new ObjectValuePair<>(
+							SiteResourceImpl.class, "getSite"));
+					put(
+						"query#UserAccount.webUrls",
+						new ObjectValuePair<>(
+							WebUrlResourceImpl.class,
+							"getUserAccountWebUrlsPage"));
+					put(
+						"query#UserAccount.passwordResetTicket",
+						new ObjectValuePair<>(
+							TicketResourceImpl.class,
+							"getUserAccountPasswordResetTicket"));
+					put(
+						"query#Account.postalAddresses",
+						new ObjectValuePair<>(
+							PostalAddressResourceImpl.class,
+							"getAccountPostalAddressesPage"));
+					put(
+						"query#Account.organizationByExternalReferenceCode",
+						new ObjectValuePair<>(
+							OrganizationResourceImpl.class,
+							"getOrganizationByExternalReferenceCode"));
+					put(
+						"query#Organization.phones",
+						new ObjectValuePair<>(
+							PhoneResourceImpl.class,
+							"getOrganizationPhonesPage"));
+					put(
+						"query#UserAccount.userUserGroups",
+						new ObjectValuePair<>(
+							UserGroupResourceImpl.class, "getUserUserGroups"));
 				}
 			};
 

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -377,6 +377,66 @@ public class ServletDataImpl implements ServletData {
 						new ObjectValuePair<>(
 							WorkflowTaskResourceImpl.class,
 							"getWorkflowTaskHasAssignableUsers"));
+
+					put(
+						"query#WorkflowInstance.workflowTasks",
+						new ObjectValuePair<>(
+							WorkflowTaskResourceImpl.class,
+							"getWorkflowInstanceWorkflowTasksPage"));
+					put(
+						"query#WorkflowInstance.workflowLogs",
+						new ObjectValuePair<>(
+							WorkflowLogResourceImpl.class,
+							"getWorkflowInstanceWorkflowLogsPage"));
+					put(
+						"query#WorkflowTask.hasAssignableUsers",
+						new ObjectValuePair<>(
+							WorkflowTaskResourceImpl.class,
+							"getWorkflowTaskHasAssignableUsers"));
+					put(
+						"query#WorkflowInstance.workflowTasksAssignedToMe",
+						new ObjectValuePair<>(
+							WorkflowTaskResourceImpl.class,
+							"getWorkflowInstanceWorkflowTasksAssignedToMePage"));
+					put(
+						"query#WorkflowTask.workflowInstance",
+						new ObjectValuePair<>(
+							WorkflowInstanceResourceImpl.class,
+							"getWorkflowInstance"));
+					put(
+						"query#WorkflowTasksBulkSelection.workflowDefinition",
+						new ObjectValuePair<>(
+							WorkflowDefinitionResourceImpl.class,
+							"getWorkflowDefinition"));
+					put(
+						"query#WorkflowTaskAssignToUser.workflowTask",
+						new ObjectValuePair<>(
+							WorkflowTaskResourceImpl.class, "getWorkflowTask"));
+					put(
+						"query#WorkflowTask.assignableUsers",
+						new ObjectValuePair<>(
+							AssigneeResourceImpl.class,
+							"getWorkflowTaskAssignableUsersPage"));
+					put(
+						"query#WorkflowTask.nextTransitions",
+						new ObjectValuePair<>(
+							TransitionResourceImpl.class,
+							"getWorkflowTaskNextTransitionsPage"));
+					put(
+						"query#WorkflowInstance.workflowTasksAssignedToUser",
+						new ObjectValuePair<>(
+							WorkflowTaskResourceImpl.class,
+							"getWorkflowInstanceWorkflowTasksAssignedToUserPage"));
+					put(
+						"query#WorkflowInstance.nextTransitions",
+						new ObjectValuePair<>(
+							TransitionResourceImpl.class,
+							"getWorkflowInstanceNextTransitionsPage"));
+					put(
+						"query#WorkflowTask.workflowLogs",
+						new ObjectValuePair<>(
+							WorkflowLogResourceImpl.class,
+							"getWorkflowTaskWorkflowLogsPage"));
 				}
 			};
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -2414,6 +2414,270 @@ public class ServletDataImpl implements ServletData {
 						new ObjectValuePair<>(
 							WikiPageAttachmentResourceImpl.class,
 							"getWikiPageWikiPageAttachmentsPage"));
+
+					put(
+						"query#Document.folder",
+						new ObjectValuePair<>(
+							DocumentFolderResourceImpl.class,
+							"getDocumentFolder"));
+					put(
+						"query#MessageBoardThread.messageBoardSection",
+						new ObjectValuePair<>(
+							MessageBoardSectionResourceImpl.class,
+							"getMessageBoardSection"));
+					put(
+						"query#Document.myRating",
+						new ObjectValuePair<>(
+							DocumentResourceImpl.class, "getDocumentMyRating"));
+					put(
+						"query#WikiPage.permissions",
+						new ObjectValuePair<>(
+							WikiPageResourceImpl.class,
+							"getWikiPagePermissionsPage"));
+					put(
+						"query#MessageBoardMessage.messageBoardAttachments",
+						new ObjectValuePair<>(
+							MessageBoardAttachmentResourceImpl.class,
+							"getMessageBoardMessageMessageBoardAttachmentsPage"));
+					put(
+						"query#DocumentFolder.documents",
+						new ObjectValuePair<>(
+							DocumentResourceImpl.class,
+							"getDocumentFolderDocumentsPage"));
+					put(
+						"query#StructuredContentFolder.permissions",
+						new ObjectValuePair<>(
+							StructuredContentFolderResourceImpl.class,
+							"getStructuredContentFolderPermissionsPage"));
+					put(
+						"query#WikiPage.wikiPageAttachments",
+						new ObjectValuePair<>(
+							WikiPageAttachmentResourceImpl.class,
+							"getWikiPageWikiPageAttachmentsPage"));
+					put(
+						"query#StructuredContent.renderedContentContentTemplate",
+						new ObjectValuePair<>(
+							StructuredContentResourceImpl.class,
+							"getStructuredContentRenderedContentContentTemplate"));
+					put(
+						"query#WikiNode.wikiPages",
+						new ObjectValuePair<>(
+							WikiPageResourceImpl.class,
+							"getWikiNodeWikiPagesPage"));
+					put(
+						"query#BlogPosting.permissions",
+						new ObjectValuePair<>(
+							BlogPostingResourceImpl.class,
+							"getBlogPostingPermissionsPage"));
+					put(
+						"query#DocumentFolder.documentFolders",
+						new ObjectValuePair<>(
+							DocumentFolderResourceImpl.class,
+							"getDocumentFolderDocumentFoldersPage"));
+					put(
+						"query#KnowledgeBaseFolder.knowledgeBaseArticles",
+						new ObjectValuePair<>(
+							KnowledgeBaseArticleResourceImpl.class,
+							"getKnowledgeBaseFolderKnowledgeBaseArticlesPage"));
+					put(
+						"query#StructuredContent.myRating",
+						new ObjectValuePair<>(
+							StructuredContentResourceImpl.class,
+							"getStructuredContentMyRating"));
+					put(
+						"query#KnowledgeBaseArticle.knowledgeBaseAttachments",
+						new ObjectValuePair<>(
+							KnowledgeBaseAttachmentResourceImpl.class,
+							"getKnowledgeBaseArticleKnowledgeBaseAttachmentsPage"));
+					put(
+						"query#StructuredContent.renderedContentByDisplayPageDisplayPageKey",
+						new ObjectValuePair<>(
+							StructuredContentResourceImpl.class,
+							"getStructuredContentRenderedContentByDisplayPageDisplayPageKey"));
+					put(
+						"query#MessageBoardMessage.myRating",
+						new ObjectValuePair<>(
+							MessageBoardMessageResourceImpl.class,
+							"getMessageBoardMessageMyRating"));
+					put(
+						"query#DocumentFolder.myRating",
+						new ObjectValuePair<>(
+							DocumentFolderResourceImpl.class,
+							"getDocumentFolderMyRating"));
+					put(
+						"query#Comment.comments",
+						new ObjectValuePair<>(
+							CommentResourceImpl.class,
+							"getCommentCommentsPage"));
+					put(
+						"query#StructuredContent.contentStructure",
+						new ObjectValuePair<>(
+							ContentStructureResourceImpl.class,
+							"getContentStructure"));
+					put(
+						"query#StructuredContent.folder",
+						new ObjectValuePair<>(
+							StructuredContentFolderResourceImpl.class,
+							"getStructuredContentFolder"));
+					put(
+						"query#MessageBoardMessage.permissions",
+						new ObjectValuePair<>(
+							MessageBoardMessageResourceImpl.class,
+							"getMessageBoardMessagePermissionsPage"));
+					put(
+						"query#StructuredContent.permissions",
+						new ObjectValuePair<>(
+							StructuredContentResourceImpl.class,
+							"getStructuredContentPermissionsPage"));
+					put(
+						"query#KnowledgeBaseArticle.permissions",
+						new ObjectValuePair<>(
+							KnowledgeBaseArticleResourceImpl.class,
+							"getKnowledgeBaseArticlePermissionsPage"));
+					put(
+						"query#DocumentFolder.permissions",
+						new ObjectValuePair<>(
+							DocumentFolderResourceImpl.class,
+							"getDocumentFolderPermissionsPage"));
+					put(
+						"query#KnowledgeBaseFolder.permissions",
+						new ObjectValuePair<>(
+							KnowledgeBaseFolderResourceImpl.class,
+							"getKnowledgeBaseFolderPermissionsPage"));
+					put(
+						"query#WikiPage.wikiNode",
+						new ObjectValuePair<>(
+							WikiNodeResourceImpl.class, "getWikiNode"));
+					put(
+						"query#KnowledgeBaseArticle.knowledgeBaseArticles",
+						new ObjectValuePair<>(
+							KnowledgeBaseArticleResourceImpl.class,
+							"getKnowledgeBaseArticleKnowledgeBaseArticlesPage"));
+					put(
+						"query#MessageBoardThread.messageBoardAttachments",
+						new ObjectValuePair<>(
+							MessageBoardAttachmentResourceImpl.class,
+							"getMessageBoardThreadMessageBoardAttachmentsPage"));
+					put(
+						"query#NavigationMenu.permissions",
+						new ObjectValuePair<>(
+							NavigationMenuResourceImpl.class,
+							"getNavigationMenuPermissionsPage"));
+					put(
+						"query#MessageBoardSection.permissions",
+						new ObjectValuePair<>(
+							MessageBoardSectionResourceImpl.class,
+							"getMessageBoardSectionPermissionsPage"));
+					put(
+						"query#ContentStructure.permissions",
+						new ObjectValuePair<>(
+							ContentStructureResourceImpl.class,
+							"getContentStructurePermissionsPage"));
+					put(
+						"query#KnowledgeBaseFolder.knowledgeBaseFolders",
+						new ObjectValuePair<>(
+							KnowledgeBaseFolderResourceImpl.class,
+							"getKnowledgeBaseFolderKnowledgeBaseFoldersPage"));
+					put(
+						"query#ContentStructure.structuredContents",
+						new ObjectValuePair<>(
+							StructuredContentResourceImpl.class,
+							"getContentStructureStructuredContentsPage"));
+					put(
+						"query#BlogPosting.comments",
+						new ObjectValuePair<>(
+							CommentResourceImpl.class,
+							"getBlogPostingCommentsPage"));
+					put(
+						"query#WikiPage.wikiPages",
+						new ObjectValuePair<>(
+							WikiPageResourceImpl.class,
+							"getWikiPageWikiPagesPage"));
+					put(
+						"query#StructuredContent.comments",
+						new ObjectValuePair<>(
+							CommentResourceImpl.class,
+							"getStructuredContentCommentsPage"));
+					put(
+						"query#KnowledgeBaseArticle.myRating",
+						new ObjectValuePair<>(
+							KnowledgeBaseArticleResourceImpl.class,
+							"getKnowledgeBaseArticleMyRating"));
+					put(
+						"query#MessageBoardMessage.messageBoardThread",
+						new ObjectValuePair<>(
+							MessageBoardThreadResourceImpl.class,
+							"getMessageBoardThread"));
+					put(
+						"query#BlogPosting.myRating",
+						new ObjectValuePair<>(
+							BlogPostingResourceImpl.class,
+							"getBlogPostingMyRating"));
+					put(
+						"query#Document.comments",
+						new ObjectValuePair<>(
+							CommentResourceImpl.class,
+							"getDocumentCommentsPage"));
+					put(
+						"query#StructuredContentFolder.structuredContents",
+						new ObjectValuePair<>(
+							StructuredContentResourceImpl.class,
+							"getStructuredContentFolderStructuredContentsPage"));
+					put(
+						"query#MessageBoardThread.permissions",
+						new ObjectValuePair<>(
+							MessageBoardThreadResourceImpl.class,
+							"getMessageBoardThreadPermissionsPage"));
+					put(
+						"query#StructuredContentFolder.structuredContentFolders",
+						new ObjectValuePair<>(
+							StructuredContentFolderResourceImpl.class,
+							"getStructuredContentFolderStructuredContentFoldersPage"));
+					put(
+						"query#MessageBoardMessage.messageBoardMessages",
+						new ObjectValuePair<>(
+							MessageBoardMessageResourceImpl.class,
+							"getMessageBoardMessageMessageBoardMessagesPage"));
+					put(
+						"query#MessageBoardSection.messageBoardSections",
+						new ObjectValuePair<>(
+							MessageBoardSectionResourceImpl.class,
+							"getMessageBoardSectionMessageBoardSectionsPage"));
+					put(
+						"query#WikiNode.permissions",
+						new ObjectValuePair<>(
+							WikiNodeResourceImpl.class,
+							"getWikiNodePermissionsPage"));
+					put(
+						"query#Document.renderedContentByDisplayPageDisplayPageKey",
+						new ObjectValuePair<>(
+							DocumentResourceImpl.class,
+							"getDocumentRenderedContentByDisplayPageDisplayPageKey"));
+					put(
+						"query#BlogPosting.renderedContentByDisplayPageDisplayPageKey",
+						new ObjectValuePair<>(
+							BlogPostingResourceImpl.class,
+							"getBlogPostingRenderedContentByDisplayPageDisplayPageKey"));
+					put(
+						"query#MessageBoardSection.messageBoardThreads",
+						new ObjectValuePair<>(
+							MessageBoardThreadResourceImpl.class,
+							"getMessageBoardSectionMessageBoardThreadsPage"));
+					put(
+						"query#MessageBoardThread.myRating",
+						new ObjectValuePair<>(
+							MessageBoardThreadResourceImpl.class,
+							"getMessageBoardThreadMyRating"));
+					put(
+						"query#Document.permissions",
+						new ObjectValuePair<>(
+							DocumentResourceImpl.class,
+							"getDocumentPermissionsPage"));
+					put(
+						"query#MessageBoardThread.messageBoardMessages",
+						new ObjectValuePair<>(
+							MessageBoardMessageResourceImpl.class,
+							"getMessageBoardThreadMessageBoardMessagesPage"));
 				}
 			};
 

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -191,6 +191,16 @@ public class ServletDataImpl implements ServletData {
 						new ObjectValuePair<>(
 							FormStructureResourceImpl.class,
 							"getSiteFormStructuresPage"));
+
+					put(
+						"query#Form.formRecordByLatestDraft",
+						new ObjectValuePair<>(
+							FormRecordResourceImpl.class,
+							"getFormFormRecordByLatestDraft"));
+					put(
+						"query#FormRecord.form",
+						new ObjectValuePair<>(
+							FormResourceImpl.class, "getForm"));
 				}
 			};
 

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -526,6 +526,51 @@ public class ServletDataImpl implements ServletData {
 						"query#objectView",
 						new ObjectValuePair<>(
 							ObjectViewResourceImpl.class, "getObjectView"));
+
+					put(
+						"query#ObjectLayoutTab.objectRelationship",
+						new ObjectValuePair<>(
+							ObjectRelationshipResourceImpl.class,
+							"getObjectRelationship"));
+					put(
+						"query#ObjectView.objectDefinition",
+						new ObjectValuePair<>(
+							ObjectDefinitionResourceImpl.class,
+							"getObjectDefinition"));
+					put(
+						"query#ObjectDefinition.byExternalReferenceCodeObjectViews",
+						new ObjectValuePair<>(
+							ObjectViewResourceImpl.class,
+							"getObjectDefinitionByExternalReferenceCodeObjectViewsPage"));
+					put(
+						"query#ObjectFieldSetting.objectField",
+						new ObjectValuePair<>(
+							ObjectFieldResourceImpl.class, "getObjectField"));
+					put(
+						"query#ObjectDefinition.byExternalReferenceCodeObjectRelationships",
+						new ObjectValuePair<>(
+							ObjectRelationshipResourceImpl.class,
+							"getObjectDefinitionByExternalReferenceCodeObjectRelationshipsPage"));
+					put(
+						"query#ObjectDefinition.byExternalReferenceCodeObjectActions",
+						new ObjectValuePair<>(
+							ObjectActionResourceImpl.class,
+							"getObjectDefinitionByExternalReferenceCodeObjectActionsPage"));
+					put(
+						"query#ObjectDefinition.byExternalReferenceCodeObjectFields",
+						new ObjectValuePair<>(
+							ObjectFieldResourceImpl.class,
+							"getObjectDefinitionByExternalReferenceCodeObjectFieldsPage"));
+					put(
+						"query#ObjectDefinition.byExternalReferenceCodeObjectLayouts",
+						new ObjectValuePair<>(
+							ObjectLayoutResourceImpl.class,
+							"getObjectDefinitionByExternalReferenceCodeObjectLayoutsPage"));
+					put(
+						"query#ObjectDefinition.byExternalReferenceCodeObjectValidationRules",
+						new ObjectValuePair<>(
+							ObjectValidationRuleResourceImpl.class,
+							"getObjectDefinitionByExternalReferenceCodeObjectValidationRulesPage"));
 				}
 			};
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/validation/ServletDataRequestContext.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/validation/ServletDataRequestContext.java
@@ -16,6 +16,7 @@ package com.liferay.portal.vulcan.internal.graphql.validation;
 
 import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLTypeExtension;
 import com.liferay.portal.vulcan.graphql.servlet.ServletData;
 import com.liferay.portal.vulcan.graphql.validation.GraphQLRequestContext;
 
@@ -70,6 +71,25 @@ public class ServletDataRequestContext implements GraphQLRequestContext {
 		return _servletData.isJaxRsResourceInvocation();
 	}
 
+	private String _getMethodName(Method method) {
+		String methodName = method.getName();
+
+		Class<?> declaringClass = method.getDeclaringClass();
+
+		if (declaringClass != null) {
+			GraphQLTypeExtension graphQLTypeExtension =
+				declaringClass.getAnnotation(GraphQLTypeExtension.class);
+
+			if (graphQLTypeExtension != null) {
+				Class<?> value = graphQLTypeExtension.value();
+
+				methodName = value.getSimpleName() + "." + methodName;
+			}
+		}
+
+		return methodName;
+	}
+
 	private String _getNamespace(ServletData servletData) {
 		if ((servletData == null) ||
 			(servletData.getGraphQLNamespace() == null)) {
@@ -90,7 +110,7 @@ public class ServletDataRequestContext implements GraphQLRequestContext {
 
 		ObjectValuePair<Class<?>, String> resourceMethodObjectValuePair =
 			servletData.getResourceMethodObjectValuePair(
-				method.getName(), mutation);
+				_getMethodName(method), mutation);
 
 		if (resourceMethodObjectValuePair == null) {
 			return null;
@@ -108,7 +128,7 @@ public class ServletDataRequestContext implements GraphQLRequestContext {
 
 		ObjectValuePair<Class<?>, String> resourceMethodObjectValuePair =
 			servletData.getResourceMethodObjectValuePair(
-				method.getName(), mutation);
+				_getMethodName(method), mutation);
 
 		if (resourceMethodObjectValuePair == null) {
 			return null;

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -427,6 +427,65 @@ public class ServletDataImpl implements ServletData {
 						"query#timeRanges",
 						new ObjectValuePair<>(
 							TimeRangeResourceImpl.class, "getTimeRangesPage"));
+
+					put(
+						"query#Process.instance",
+						new ObjectValuePair<>(
+							InstanceResourceImpl.class, "getProcessInstance"));
+					put(
+						"query#TaskBulkSelection.process",
+						new ObjectValuePair<>(
+							ProcessResourceImpl.class, "getProcess"));
+					put(
+						"query#Process.nodes",
+						new ObjectValuePair<>(
+							NodeResourceImpl.class, "getProcessNodesPage"));
+					put(
+						"query#Process.lastSLAResult",
+						new ObjectValuePair<>(
+							SLAResultResourceImpl.class,
+							"getProcessLastSLAResult"));
+					put(
+						"query#Process.histogramMetric",
+						new ObjectValuePair<>(
+							HistogramMetricResourceImpl.class,
+							"getProcessHistogramMetric"));
+					put(
+						"query#Process.tasks",
+						new ObjectValuePair<>(
+							TaskResourceImpl.class, "getProcessTasksPage"));
+					put(
+						"query#Process.sLAs",
+						new ObjectValuePair<>(
+							SLAResourceImpl.class, "getProcessSLAsPage"));
+					put(
+						"query#Process.roles",
+						new ObjectValuePair<>(
+							RoleResourceImpl.class, "getProcessRolesPage"));
+					put(
+						"query#Process.metric",
+						new ObjectValuePair<>(
+							ProcessMetricResourceImpl.class,
+							"getProcessMetric"));
+					put(
+						"query#Process.task",
+						new ObjectValuePair<>(
+							TaskResourceImpl.class, "getProcessTask"));
+					put(
+						"query#Process.processVersions",
+						new ObjectValuePair<>(
+							ProcessVersionResourceImpl.class,
+							"getProcessProcessVersionsPage"));
+					put(
+						"query#Process.nodeMetrics",
+						new ObjectValuePair<>(
+							NodeMetricResourceImpl.class,
+							"getProcessNodeMetricsPage"));
+					put(
+						"query#Process.instances",
+						new ObjectValuePair<>(
+							InstanceResourceImpl.class,
+							"getProcessInstancesPage"));
 				}
 			};
 

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -339,6 +339,21 @@ public class ServletDataImpl implements ServletData {
 						new ObjectValuePair<>(
 							SearchableAssetNameDisplayResourceImpl.class,
 							"getSearchableAssetNameLanguagePage"));
+
+					put(
+						"query#SXPElement.export",
+						new ObjectValuePair<>(
+							SXPElementResourceImpl.class,
+							"getSXPElementExport"));
+					put(
+						"query#ElementInstance.sXPElement",
+						new ObjectValuePair<>(
+							SXPElementResourceImpl.class, "getSXPElement"));
+					put(
+						"query#SXPBlueprint.export",
+						new ObjectValuePair<>(
+							SXPBlueprintResourceImpl.class,
+							"getSXPBlueprintExport"));
 				}
 			};
 

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/graphql_servlet_data.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/graphql_servlet_data.ftl
@@ -100,6 +100,10 @@ public class ServletDataImpl implements ServletData {
 			<#list queryJavaMethodSignatures as javaMethodSignature>
 				put("query#${freeMarkerTool.getGraphQLPropertyName(javaMethodSignature, queryJavaMethodSignatures)}", new ObjectValuePair<>(${javaMethodSignature.schemaName}ResourceImpl.class, "${javaMethodSignature.methodName}"));
 			</#list>
+
+			<#list freeMarkerTool.getGraphQLRelationJavaMethodSignatures(configYAML, "query", openAPIYAML) as javaMethodSignature>
+				put("query#${javaMethodSignature.parentSchemaName}.${freeMarkerTool.getGraphQLRelationName(javaMethodSignature, queryJavaMethodSignatures)}", new ObjectValuePair<>(${javaMethodSignature.schemaName}ResourceImpl.class, "${javaMethodSignature.methodName}"));
+			</#list>
 		}
 	};
 


### PR DESCRIPTION
Related issue: https://issues.liferay.com/browse/LPS-182351

---

The purpose of this PR is to fix the related issue. For that, **all** the methods of the ServletDataImpl classes have been added to the _resourceMethodObjectValuePairs map of the `ServletDataImpl` classes autogenerated by REST Builder. Before the PR, the methods whose classes were annotated with `@GraphQLTypeExtension` annotation were not being included in the map; that caused some errors when the fields were included in the GraphQL request.

For example, in the `Query` class of the `headless-delivery-impl` module, there is a class defined inside:

```
@GraphQLTypeExtension(MessageBoardThread.class)
public class GetMessageBoardThreadMyRatingTypeExtension {

	public GetMessageBoardThreadMyRatingTypeExtension(
		MessageBoardThread messageBoardThread) {

		_messageBoardThread = messageBoardThread;
	}

	@GraphQLField(
		description = "Retrieves the message board thread's rating."
	)
	public Rating myRating() throws Exception {
		return _applyComponentServiceObjects(
			_messageBoardThreadResourceComponentServiceObjects,
			Query.this::_populateResourceContext,
			messageBoardThreadResource ->
				messageBoardThreadResource.getMessageBoardThreadMyRating(
					_messageBoardThread.getId()));
	}

	private MessageBoardThread _messageBoardThread;

}
```
To provide the method that is the responsible of returning the `myRating` field of the `MessageBoardThread` (in this case the method `getMessageBoardThreadMyRating` of the `messageBoardThreadResource`), the information has been included in the `_resourceMethodObjectValuePairs` of the `ServletDataImpl` autogenerated class:

```
put(
	"query#MessageBoardMessage.myRating",
	new ObjectValuePair<>(
		MessageBoardMessageResourceImpl.class,
		"getMessageBoardMessageMyRating"));
```

With that, the resource method is properly returned when the validate method is invoked (the `graphQLRequestContext.getResourceMethod()` does not return null anymore)

```
@Component(service = GraphQLRequestContextValidator.class)
public class OAuth2GraphQLRequestContextValidator
	implements GraphQLRequestContextValidator {

	@Override
	public void validate(GraphQLRequestContext graphQLRequestContext)
		throws Exception {

		[...]

		_accessControlAdvisor.accept(
			graphQLRequestContext.getResourceMethod(), new Object[0],
			_NULL_ACCESS_CONTROLLED);
	}

```