### PR TITLE
LPS-164382 service builder erc - update service implementation signatures and implmentation

### DIFF
--- a/modules/apps/batch-planner/batch-planner-api/bnd.bnd
+++ b/modules/apps/batch-planner/batch-planner-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Batch Planner API
 Bundle-SymbolicName: com.liferay.batch.planner.api
-Bundle-Version: 12.5.1
+Bundle-Version: 13.0.0
 Export-Package:\
 	com.liferay.batch.planner.batch.engine.broker,\
 	com.liferay.batch.planner.batch.engine.task,\

--- a/modules/apps/batch-planner/batch-planner-api/src/main/java/com/liferay/batch/planner/exception/DuplicateBatchPlannerPlanExternalReferenceCodeException.java
+++ b/modules/apps/batch-planner/batch-planner-api/src/main/java/com/liferay/batch/planner/exception/DuplicateBatchPlannerPlanExternalReferenceCodeException.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+package com.liferay.batch.planner.exception;
+
+import com.liferay.portal.kernel.exception.DuplicateExternalReferenceCodeException;
+
+/**
+ * @author Igor Beslic
+ */
+public class DuplicateBatchPlannerPlanExternalReferenceCodeException extends DuplicateExternalReferenceCodeException {
+
+	public DuplicateBatchPlannerPlanExternalReferenceCodeException() {
+	}
+
+	public DuplicateBatchPlannerPlanExternalReferenceCodeException(String msg) {
+		super(msg);
+	}
+
+	public DuplicateBatchPlannerPlanExternalReferenceCodeException(String msg, Throwable throwable) {
+		super(msg, throwable);
+	}
+
+	public DuplicateBatchPlannerPlanExternalReferenceCodeException(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/modules/apps/batch-planner/batch-planner-api/src/main/java/com/liferay/batch/planner/exception/DuplicateBatchPlannerPlanExternalReferenceCodeException.java
+++ b/modules/apps/batch-planner/batch-planner-api/src/main/java/com/liferay/batch/planner/exception/DuplicateBatchPlannerPlanExternalReferenceCodeException.java
@@ -11,6 +11,7 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
+
 package com.liferay.batch.planner.exception;
 
 import com.liferay.portal.kernel.exception.DuplicateExternalReferenceCodeException;
@@ -18,7 +19,8 @@ import com.liferay.portal.kernel.exception.DuplicateExternalReferenceCodeExcepti
 /**
  * @author Igor Beslic
  */
-public class DuplicateBatchPlannerPlanExternalReferenceCodeException extends DuplicateExternalReferenceCodeException {
+public class DuplicateBatchPlannerPlanExternalReferenceCodeException
+	extends DuplicateExternalReferenceCodeException {
 
 	public DuplicateBatchPlannerPlanExternalReferenceCodeException() {
 	}
@@ -27,11 +29,15 @@ public class DuplicateBatchPlannerPlanExternalReferenceCodeException extends Dup
 		super(msg);
 	}
 
-	public DuplicateBatchPlannerPlanExternalReferenceCodeException(String msg, Throwable throwable) {
+	public DuplicateBatchPlannerPlanExternalReferenceCodeException(
+		String msg, Throwable throwable) {
+
 		super(msg, throwable);
 	}
 
-	public DuplicateBatchPlannerPlanExternalReferenceCodeException(Throwable throwable) {
+	public DuplicateBatchPlannerPlanExternalReferenceCodeException(
+		Throwable throwable) {
+
 		super(throwable);
 	}
 

--- a/modules/apps/batch-planner/batch-planner-api/src/main/java/com/liferay/batch/planner/model/BatchPlannerPlanModel.java
+++ b/modules/apps/batch-planner/batch-planner-api/src/main/java/com/liferay/batch/planner/model/BatchPlannerPlanModel.java
@@ -76,6 +76,21 @@ public interface BatchPlannerPlanModel
 	public void setMvccVersion(long mvccVersion);
 
 	/**
+	 * Returns the external reference code of this batch planner plan.
+	 *
+	 * @return the external reference code of this batch planner plan
+	 */
+	@AutoEscape
+	public String getExternalReferenceCode();
+
+	/**
+	 * Sets the external reference code of this batch planner plan.
+	 *
+	 * @param externalReferenceCode the external reference code of this batch planner plan
+	 */
+	public void setExternalReferenceCode(String externalReferenceCode);
+
+	/**
 	 * Returns the batch planner plan ID of this batch planner plan.
 	 *
 	 * @return the batch planner plan ID of this batch planner plan

--- a/modules/apps/batch-planner/batch-planner-api/src/main/java/com/liferay/batch/planner/model/BatchPlannerPlanTable.java
+++ b/modules/apps/batch-planner/batch-planner-api/src/main/java/com/liferay/batch/planner/model/BatchPlannerPlanTable.java
@@ -35,6 +35,10 @@ public class BatchPlannerPlanTable extends BaseTable<BatchPlannerPlanTable> {
 
 	public final Column<BatchPlannerPlanTable, Long> mvccVersion = createColumn(
 		"mvccVersion", Long.class, Types.BIGINT, Column.FLAG_NULLITY);
+	public final Column<BatchPlannerPlanTable, String> externalReferenceCode =
+		createColumn(
+			"externalReferenceCode", String.class, Types.VARCHAR,
+			Column.FLAG_DEFAULT);
 	public final Column<BatchPlannerPlanTable, Long> batchPlannerPlanId =
 		createColumn(
 			"batchPlannerPlanId", Long.class, Types.BIGINT,

--- a/modules/apps/batch-planner/batch-planner-api/src/main/java/com/liferay/batch/planner/model/BatchPlannerPlanWrapper.java
+++ b/modules/apps/batch-planner/batch-planner-api/src/main/java/com/liferay/batch/planner/model/BatchPlannerPlanWrapper.java
@@ -43,6 +43,7 @@ public class BatchPlannerPlanWrapper
 		Map<String, Object> attributes = new HashMap<String, Object>();
 
 		attributes.put("mvccVersion", getMvccVersion());
+		attributes.put("externalReferenceCode", getExternalReferenceCode());
 		attributes.put("batchPlannerPlanId", getBatchPlannerPlanId());
 		attributes.put("companyId", getCompanyId());
 		attributes.put("userId", getUserId());
@@ -70,6 +71,13 @@ public class BatchPlannerPlanWrapper
 
 		if (mvccVersion != null) {
 			setMvccVersion(mvccVersion);
+		}
+
+		String externalReferenceCode = (String)attributes.get(
+			"externalReferenceCode");
+
+		if (externalReferenceCode != null) {
+			setExternalReferenceCode(externalReferenceCode);
 		}
 
 		Long batchPlannerPlanId = (Long)attributes.get("batchPlannerPlanId");
@@ -251,6 +259,16 @@ public class BatchPlannerPlanWrapper
 	@Override
 	public boolean getExport() {
 		return model.getExport();
+	}
+
+	/**
+	 * Returns the external reference code of this batch planner plan.
+	 *
+	 * @return the external reference code of this batch planner plan
+	 */
+	@Override
+	public String getExternalReferenceCode() {
+		return model.getExternalReferenceCode();
 	}
 
 	/**
@@ -486,6 +504,16 @@ public class BatchPlannerPlanWrapper
 	@Override
 	public void setExport(boolean export) {
 		model.setExport(export);
+	}
+
+	/**
+	 * Sets the external reference code of this batch planner plan.
+	 *
+	 * @param externalReferenceCode the external reference code of this batch planner plan
+	 */
+	@Override
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		model.setExternalReferenceCode(externalReferenceCode);
 	}
 
 	/**

--- a/modules/apps/batch-planner/batch-planner-api/src/main/java/com/liferay/batch/planner/service/BatchPlannerPlanLocalService.java
+++ b/modules/apps/batch-planner/batch-planner-api/src/main/java/com/liferay/batch/planner/service/BatchPlannerPlanLocalService.java
@@ -77,9 +77,10 @@ public interface BatchPlannerPlanLocalService
 		BatchPlannerPlan batchPlannerPlan);
 
 	public BatchPlannerPlan addBatchPlannerPlan(
-			long userId, boolean export, String externalType,
-			String externalURL, String internalClassName, String name, int size,
-			String taskItemDelegateName, boolean template)
+			String externalReferenceCode, long userId, boolean export,
+			String externalType, String externalURL, String internalClassName,
+			String name, int size, String taskItemDelegateName,
+			boolean template)
 		throws PortalException;
 
 	/**
@@ -213,6 +214,10 @@ public interface BatchPlannerPlanLocalService
 	public BatchPlannerPlan fetchBatchPlannerPlan(long batchPlannerPlanId);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public BatchPlannerPlan fetchBatchPlannerPlanByExternalReferenceCode(
+		String externalReferenceCode, long companyId);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ActionableDynamicQuery getActionableDynamicQuery();
 
 	/**
@@ -224,6 +229,11 @@ public interface BatchPlannerPlanLocalService
 	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public BatchPlannerPlan getBatchPlannerPlan(long batchPlannerPlanId)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public BatchPlannerPlan getBatchPlannerPlanByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
 		throws PortalException;
 
 	/**

--- a/modules/apps/batch-planner/batch-planner-api/src/main/java/com/liferay/batch/planner/service/BatchPlannerPlanLocalServiceUtil.java
+++ b/modules/apps/batch-planner/batch-planner-api/src/main/java/com/liferay/batch/planner/service/BatchPlannerPlanLocalServiceUtil.java
@@ -62,14 +62,15 @@ public class BatchPlannerPlanLocalServiceUtil {
 	}
 
 	public static BatchPlannerPlan addBatchPlannerPlan(
-			long userId, boolean export, String externalType,
-			String externalURL, String internalClassName, String name, int size,
-			String taskItemDelegateName, boolean template)
+			String externalReferenceCode, long userId, boolean export,
+			String externalType, String externalURL, String internalClassName,
+			String name, int size, String taskItemDelegateName,
+			boolean template)
 		throws PortalException {
 
 		return getService().addBatchPlannerPlan(
-			userId, export, externalType, externalURL, internalClassName, name,
-			size, taskItemDelegateName, template);
+			externalReferenceCode, userId, export, externalType, externalURL,
+			internalClassName, name, size, taskItemDelegateName, template);
 	}
 
 	/**
@@ -235,6 +236,13 @@ public class BatchPlannerPlanLocalServiceUtil {
 		return getService().fetchBatchPlannerPlan(batchPlannerPlanId);
 	}
 
+	public static BatchPlannerPlan fetchBatchPlannerPlanByExternalReferenceCode(
+		String externalReferenceCode, long companyId) {
+
+		return getService().fetchBatchPlannerPlanByExternalReferenceCode(
+			externalReferenceCode, companyId);
+	}
+
 	public static com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery
 		getActionableDynamicQuery() {
 
@@ -252,6 +260,14 @@ public class BatchPlannerPlanLocalServiceUtil {
 		throws PortalException {
 
 		return getService().getBatchPlannerPlan(batchPlannerPlanId);
+	}
+
+	public static BatchPlannerPlan getBatchPlannerPlanByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
+		throws PortalException {
+
+		return getService().getBatchPlannerPlanByExternalReferenceCode(
+			externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/batch-planner/batch-planner-api/src/main/java/com/liferay/batch/planner/service/BatchPlannerPlanLocalServiceWrapper.java
+++ b/modules/apps/batch-planner/batch-planner-api/src/main/java/com/liferay/batch/planner/service/BatchPlannerPlanLocalServiceWrapper.java
@@ -57,14 +57,15 @@ public class BatchPlannerPlanLocalServiceWrapper
 
 	@Override
 	public com.liferay.batch.planner.model.BatchPlannerPlan addBatchPlannerPlan(
-			long userId, boolean export, String externalType,
-			String externalURL, String internalClassName, String name, int size,
-			String taskItemDelegateName, boolean template)
+			String externalReferenceCode, long userId, boolean export,
+			String externalType, String externalURL, String internalClassName,
+			String name, int size, String taskItemDelegateName,
+			boolean template)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _batchPlannerPlanLocalService.addBatchPlannerPlan(
-			userId, export, externalType, externalURL, internalClassName, name,
-			size, taskItemDelegateName, template);
+			externalReferenceCode, userId, export, externalType, externalURL,
+			internalClassName, name, size, taskItemDelegateName, template);
 	}
 
 	/**
@@ -265,6 +266,16 @@ public class BatchPlannerPlanLocalServiceWrapper
 	}
 
 	@Override
+	public com.liferay.batch.planner.model.BatchPlannerPlan
+		fetchBatchPlannerPlanByExternalReferenceCode(
+			String externalReferenceCode, long companyId) {
+
+		return _batchPlannerPlanLocalService.
+			fetchBatchPlannerPlanByExternalReferenceCode(
+				externalReferenceCode, companyId);
+	}
+
+	@Override
 	public com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery
 		getActionableDynamicQuery() {
 
@@ -285,6 +296,17 @@ public class BatchPlannerPlanLocalServiceWrapper
 
 		return _batchPlannerPlanLocalService.getBatchPlannerPlan(
 			batchPlannerPlanId);
+	}
+
+	@Override
+	public com.liferay.batch.planner.model.BatchPlannerPlan
+			getBatchPlannerPlanByExternalReferenceCode(
+				String externalReferenceCode, long companyId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _batchPlannerPlanLocalService.
+			getBatchPlannerPlanByExternalReferenceCode(
+				externalReferenceCode, companyId);
 	}
 
 	/**

--- a/modules/apps/batch-planner/batch-planner-api/src/main/java/com/liferay/batch/planner/service/BatchPlannerPlanService.java
+++ b/modules/apps/batch-planner/batch-planner-api/src/main/java/com/liferay/batch/planner/service/BatchPlannerPlanService.java
@@ -53,8 +53,8 @@ public interface BatchPlannerPlanService extends BaseService {
 	 * Never modify this interface directly. Add custom service methods to <code>com.liferay.batch.planner.service.impl.BatchPlannerPlanServiceImpl</code> and rerun ServiceBuilder to automatically copy the method declarations to this interface. Consume the batch planner plan remote service via injection or a <code>org.osgi.util.tracker.ServiceTracker</code>. Use {@link BatchPlannerPlanServiceUtil} if injection and service tracking are not available.
 	 */
 	public BatchPlannerPlan addBatchPlannerPlan(
-			boolean export, String externalType, String externalURL,
-			String internalClassName, String name, int size,
+			String externalReferenceCode, boolean export, String externalType,
+			String externalURL, String internalClassName, String name, int size,
 			String taskItemDelegateName, boolean template)
 		throws PortalException;
 

--- a/modules/apps/batch-planner/batch-planner-api/src/main/java/com/liferay/batch/planner/service/BatchPlannerPlanServiceUtil.java
+++ b/modules/apps/batch-planner/batch-planner-api/src/main/java/com/liferay/batch/planner/service/BatchPlannerPlanServiceUtil.java
@@ -40,14 +40,14 @@ public class BatchPlannerPlanServiceUtil {
 	 * Never modify this class directly. Add custom service methods to <code>com.liferay.batch.planner.service.impl.BatchPlannerPlanServiceImpl</code> and rerun ServiceBuilder to regenerate this class.
 	 */
 	public static BatchPlannerPlan addBatchPlannerPlan(
-			boolean export, String externalType, String externalURL,
-			String internalClassName, String name, int size,
+			String externalReferenceCode, boolean export, String externalType,
+			String externalURL, String internalClassName, String name, int size,
 			String taskItemDelegateName, boolean template)
 		throws PortalException {
 
 		return getService().addBatchPlannerPlan(
-			export, externalType, externalURL, internalClassName, name, size,
-			taskItemDelegateName, template);
+			externalReferenceCode, export, externalType, externalURL,
+			internalClassName, name, size, taskItemDelegateName, template);
 	}
 
 	public static BatchPlannerPlan deleteBatchPlannerPlan(

--- a/modules/apps/batch-planner/batch-planner-api/src/main/java/com/liferay/batch/planner/service/BatchPlannerPlanServiceWrapper.java
+++ b/modules/apps/batch-planner/batch-planner-api/src/main/java/com/liferay/batch/planner/service/BatchPlannerPlanServiceWrapper.java
@@ -39,14 +39,14 @@ public class BatchPlannerPlanServiceWrapper
 
 	@Override
 	public com.liferay.batch.planner.model.BatchPlannerPlan addBatchPlannerPlan(
-			boolean export, String externalType, String externalURL,
-			String internalClassName, String name, int size,
+			String externalReferenceCode, boolean export, String externalType,
+			String externalURL, String internalClassName, String name, int size,
 			String taskItemDelegateName, boolean template)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _batchPlannerPlanService.addBatchPlannerPlan(
-			export, externalType, externalURL, internalClassName, name, size,
-			taskItemDelegateName, template);
+			externalReferenceCode, export, externalType, externalURL,
+			internalClassName, name, size, taskItemDelegateName, template);
 	}
 
 	@Override

--- a/modules/apps/batch-planner/batch-planner-api/src/main/java/com/liferay/batch/planner/service/persistence/BatchPlannerPlanPersistence.java
+++ b/modules/apps/batch-planner/batch-planner-api/src/main/java/com/liferay/batch/planner/service/persistence/BatchPlannerPlanPersistence.java
@@ -1394,6 +1394,59 @@ public interface BatchPlannerPlanPersistence
 		long companyId, boolean export, boolean template);
 
 	/**
+	 * Returns the batch planner plan where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchPlanException</code> if it could not be found.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
+	 * @return the matching batch planner plan
+	 * @throws NoSuchPlanException if a matching batch planner plan could not be found
+	 */
+	public BatchPlannerPlan findByERC_C(
+			String externalReferenceCode, long companyId)
+		throws NoSuchPlanException;
+
+	/**
+	 * Returns the batch planner plan where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
+	 * @return the matching batch planner plan, or <code>null</code> if a matching batch planner plan could not be found
+	 */
+	public BatchPlannerPlan fetchByERC_C(
+		String externalReferenceCode, long companyId);
+
+	/**
+	 * Returns the batch planner plan where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching batch planner plan, or <code>null</code> if a matching batch planner plan could not be found
+	 */
+	public BatchPlannerPlan fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache);
+
+	/**
+	 * Removes the batch planner plan where externalReferenceCode = &#63; and companyId = &#63; from the database.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
+	 * @return the batch planner plan that was removed
+	 */
+	public BatchPlannerPlan removeByERC_C(
+			String externalReferenceCode, long companyId)
+		throws NoSuchPlanException;
+
+	/**
+	 * Returns the number of batch planner plans where externalReferenceCode = &#63; and companyId = &#63;.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
+	 * @return the number of matching batch planner plans
+	 */
+	public int countByERC_C(String externalReferenceCode, long companyId);
+
+	/**
 	 * Caches the batch planner plan in the entity cache if it is enabled.
 	 *
 	 * @param batchPlannerPlan the batch planner plan

--- a/modules/apps/batch-planner/batch-planner-api/src/main/java/com/liferay/batch/planner/service/persistence/BatchPlannerPlanUtil.java
+++ b/modules/apps/batch-planner/batch-planner-api/src/main/java/com/liferay/batch/planner/service/persistence/BatchPlannerPlanUtil.java
@@ -1746,6 +1746,76 @@ public class BatchPlannerPlanUtil {
 	}
 
 	/**
+	 * Returns the batch planner plan where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchPlanException</code> if it could not be found.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
+	 * @return the matching batch planner plan
+	 * @throws NoSuchPlanException if a matching batch planner plan could not be found
+	 */
+	public static BatchPlannerPlan findByERC_C(
+			String externalReferenceCode, long companyId)
+		throws com.liferay.batch.planner.exception.NoSuchPlanException {
+
+		return getPersistence().findByERC_C(externalReferenceCode, companyId);
+	}
+
+	/**
+	 * Returns the batch planner plan where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
+	 * @return the matching batch planner plan, or <code>null</code> if a matching batch planner plan could not be found
+	 */
+	public static BatchPlannerPlan fetchByERC_C(
+		String externalReferenceCode, long companyId) {
+
+		return getPersistence().fetchByERC_C(externalReferenceCode, companyId);
+	}
+
+	/**
+	 * Returns the batch planner plan where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching batch planner plan, or <code>null</code> if a matching batch planner plan could not be found
+	 */
+	public static BatchPlannerPlan fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
+
+		return getPersistence().fetchByERC_C(
+			externalReferenceCode, companyId, useFinderCache);
+	}
+
+	/**
+	 * Removes the batch planner plan where externalReferenceCode = &#63; and companyId = &#63; from the database.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
+	 * @return the batch planner plan that was removed
+	 */
+	public static BatchPlannerPlan removeByERC_C(
+			String externalReferenceCode, long companyId)
+		throws com.liferay.batch.planner.exception.NoSuchPlanException {
+
+		return getPersistence().removeByERC_C(externalReferenceCode, companyId);
+	}
+
+	/**
+	 * Returns the number of batch planner plans where externalReferenceCode = &#63; and companyId = &#63;.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
+	 * @return the number of matching batch planner plans
+	 */
+	public static int countByERC_C(
+		String externalReferenceCode, long companyId) {
+
+		return getPersistence().countByERC_C(externalReferenceCode, companyId);
+	}
+
+	/**
 	 * Caches the batch planner plan in the entity cache if it is enabled.
 	 *
 	 * @param batchPlannerPlan the batch planner plan

--- a/modules/apps/batch-planner/batch-planner-api/src/main/resources/com/liferay/batch/planner/exception/packageinfo
+++ b/modules/apps/batch-planner/batch-planner-api/src/main/resources/com/liferay/batch/planner/exception/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/apps/batch-planner/batch-planner-api/src/main/resources/com/liferay/batch/planner/model/packageinfo
+++ b/modules/apps/batch-planner/batch-planner-api/src/main/resources/com/liferay/batch/planner/model/packageinfo
@@ -1,1 +1,1 @@
-version 3.1.0
+version 3.2.0

--- a/modules/apps/batch-planner/batch-planner-api/src/main/resources/com/liferay/batch/planner/service/packageinfo
+++ b/modules/apps/batch-planner/batch-planner-api/src/main/resources/com/liferay/batch/planner/service/packageinfo
@@ -1,1 +1,1 @@
-version 10.0.0
+version 11.0.0

--- a/modules/apps/batch-planner/batch-planner-api/src/main/resources/com/liferay/batch/planner/service/persistence/packageinfo
+++ b/modules/apps/batch-planner/batch-planner-api/src/main/resources/com/liferay/batch/planner/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 5.0.0
+version 5.1.0

--- a/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/PlanResourceImpl.java
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/PlanResourceImpl.java
@@ -114,9 +114,10 @@ public class PlanResourceImpl extends BasePlanResourceImpl {
 	public Plan postPlan(Plan plan) throws Exception {
 		BatchPlannerPlan batchPlannerPlan =
 			_batchPlannerPlanService.addBatchPlannerPlan(
-				plan.getExport(), plan.getExternalType(), plan.getExternalURL(),
-				plan.getInternalClassName(), plan.getName(), 0,
-				plan.getTaskItemDelegateName(), plan.getTemplate());
+				null, plan.getExport(), plan.getExternalType(),
+				plan.getExternalURL(), plan.getInternalClassName(),
+				plan.getName(), 0, plan.getTaskItemDelegateName(),
+				plan.getTemplate());
 
 		Mapping[] mappings = plan.getMappings();
 

--- a/modules/apps/batch-planner/batch-planner-service/service.xml
+++ b/modules/apps/batch-planner/batch-planner-service/service.xml
@@ -44,7 +44,7 @@
 			<finder-column name="internalFieldName" />
 		</finder>
 	</entity>
-	<entity local-service="true" name="BatchPlannerPlan" remote-service="true">
+	<entity external-reference-code="company" local-service="true" name="BatchPlannerPlan" remote-service="true">
 
 		<!-- PK fields -->
 

--- a/modules/apps/batch-planner/batch-planner-service/src/main/java/com/liferay/batch/planner/model/impl/BatchPlannerPlanCacheModel.java
+++ b/modules/apps/batch-planner/batch-planner-service/src/main/java/com/liferay/batch/planner/model/impl/BatchPlannerPlanCacheModel.java
@@ -78,10 +78,12 @@ public class BatchPlannerPlanCacheModel
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(37);
+		StringBundler sb = new StringBundler(39);
 
 		sb.append("{mvccVersion=");
 		sb.append(mvccVersion);
+		sb.append(", externalReferenceCode=");
+		sb.append(externalReferenceCode);
 		sb.append(", batchPlannerPlanId=");
 		sb.append(batchPlannerPlanId);
 		sb.append(", companyId=");
@@ -126,6 +128,15 @@ public class BatchPlannerPlanCacheModel
 		BatchPlannerPlanImpl batchPlannerPlanImpl = new BatchPlannerPlanImpl();
 
 		batchPlannerPlanImpl.setMvccVersion(mvccVersion);
+
+		if (externalReferenceCode == null) {
+			batchPlannerPlanImpl.setExternalReferenceCode("");
+		}
+		else {
+			batchPlannerPlanImpl.setExternalReferenceCode(
+				externalReferenceCode);
+		}
+
 		batchPlannerPlanImpl.setBatchPlannerPlanId(batchPlannerPlanId);
 		batchPlannerPlanImpl.setCompanyId(companyId);
 		batchPlannerPlanImpl.setUserId(userId);
@@ -203,6 +214,7 @@ public class BatchPlannerPlanCacheModel
 	@Override
 	public void readExternal(ObjectInput objectInput) throws IOException {
 		mvccVersion = objectInput.readLong();
+		externalReferenceCode = objectInput.readUTF();
 
 		batchPlannerPlanId = objectInput.readLong();
 
@@ -234,6 +246,13 @@ public class BatchPlannerPlanCacheModel
 	@Override
 	public void writeExternal(ObjectOutput objectOutput) throws IOException {
 		objectOutput.writeLong(mvccVersion);
+
+		if (externalReferenceCode == null) {
+			objectOutput.writeUTF("");
+		}
+		else {
+			objectOutput.writeUTF(externalReferenceCode);
+		}
 
 		objectOutput.writeLong(batchPlannerPlanId);
 
@@ -300,6 +319,7 @@ public class BatchPlannerPlanCacheModel
 	}
 
 	public long mvccVersion;
+	public String externalReferenceCode;
 	public long batchPlannerPlanId;
 	public long companyId;
 	public long userId;

--- a/modules/apps/batch-planner/batch-planner-service/src/main/java/com/liferay/batch/planner/model/impl/BatchPlannerPlanModelImpl.java
+++ b/modules/apps/batch-planner/batch-planner-service/src/main/java/com/liferay/batch/planner/model/impl/BatchPlannerPlanModelImpl.java
@@ -72,15 +72,16 @@ public class BatchPlannerPlanModelImpl
 	public static final String TABLE_NAME = "BatchPlannerPlan";
 
 	public static final Object[][] TABLE_COLUMNS = {
-		{"mvccVersion", Types.BIGINT}, {"batchPlannerPlanId", Types.BIGINT},
-		{"companyId", Types.BIGINT}, {"userId", Types.BIGINT},
-		{"userName", Types.VARCHAR}, {"createDate", Types.TIMESTAMP},
-		{"modifiedDate", Types.TIMESTAMP}, {"active_", Types.BOOLEAN},
-		{"export", Types.BOOLEAN}, {"externalType", Types.VARCHAR},
-		{"externalURL", Types.VARCHAR}, {"internalClassName", Types.VARCHAR},
-		{"name", Types.VARCHAR}, {"size_", Types.INTEGER},
-		{"taskItemDelegateName", Types.VARCHAR}, {"total", Types.INTEGER},
-		{"template", Types.BOOLEAN}, {"status", Types.INTEGER}
+		{"mvccVersion", Types.BIGINT}, {"externalReferenceCode", Types.VARCHAR},
+		{"batchPlannerPlanId", Types.BIGINT}, {"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT}, {"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP}, {"modifiedDate", Types.TIMESTAMP},
+		{"active_", Types.BOOLEAN}, {"export", Types.BOOLEAN},
+		{"externalType", Types.VARCHAR}, {"externalURL", Types.VARCHAR},
+		{"internalClassName", Types.VARCHAR}, {"name", Types.VARCHAR},
+		{"size_", Types.INTEGER}, {"taskItemDelegateName", Types.VARCHAR},
+		{"total", Types.INTEGER}, {"template", Types.BOOLEAN},
+		{"status", Types.INTEGER}
 	};
 
 	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
@@ -88,6 +89,7 @@ public class BatchPlannerPlanModelImpl
 
 	static {
 		TABLE_COLUMNS_MAP.put("mvccVersion", Types.BIGINT);
+		TABLE_COLUMNS_MAP.put("externalReferenceCode", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("batchPlannerPlanId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
@@ -108,7 +110,7 @@ public class BatchPlannerPlanModelImpl
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table BatchPlannerPlan (mvccVersion LONG default 0 not null,batchPlannerPlanId LONG not null primary key,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,active_ BOOLEAN,export BOOLEAN,externalType VARCHAR(75) null,externalURL STRING null,internalClassName VARCHAR(75) null,name VARCHAR(75) null,size_ INTEGER,taskItemDelegateName VARCHAR(75) null,total INTEGER,template BOOLEAN,status INTEGER)";
+		"create table BatchPlannerPlan (mvccVersion LONG default 0 not null,externalReferenceCode VARCHAR(75) null,batchPlannerPlanId LONG not null primary key,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,active_ BOOLEAN,export BOOLEAN,externalType VARCHAR(75) null,externalURL STRING null,internalClassName VARCHAR(75) null,name VARCHAR(75) null,size_ INTEGER,taskItemDelegateName VARCHAR(75) null,total INTEGER,template BOOLEAN,status INTEGER)";
 
 	public static final String TABLE_SQL_DROP = "drop table BatchPlannerPlan";
 
@@ -140,26 +142,32 @@ public class BatchPlannerPlanModelImpl
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long NAME_COLUMN_BITMASK = 4L;
+	public static final long EXTERNALREFERENCECODE_COLUMN_BITMASK = 4L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long TEMPLATE_COLUMN_BITMASK = 8L;
+	public static final long NAME_COLUMN_BITMASK = 8L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long USERID_COLUMN_BITMASK = 16L;
+	public static final long TEMPLATE_COLUMN_BITMASK = 16L;
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
+	 */
+	@Deprecated
+	public static final long USERID_COLUMN_BITMASK = 32L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
 	 *		#getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long MODIFIEDDATE_COLUMN_BITMASK = 32L;
+	public static final long MODIFIEDDATE_COLUMN_BITMASK = 64L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
@@ -274,6 +282,9 @@ public class BatchPlannerPlanModelImpl
 			attributeGetterFunctions.put(
 				"mvccVersion", BatchPlannerPlan::getMvccVersion);
 			attributeGetterFunctions.put(
+				"externalReferenceCode",
+				BatchPlannerPlan::getExternalReferenceCode);
+			attributeGetterFunctions.put(
 				"batchPlannerPlanId", BatchPlannerPlan::getBatchPlannerPlanId);
 			attributeGetterFunctions.put(
 				"companyId", BatchPlannerPlan::getCompanyId);
@@ -323,6 +334,10 @@ public class BatchPlannerPlanModelImpl
 				"mvccVersion",
 				(BiConsumer<BatchPlannerPlan, Long>)
 					BatchPlannerPlan::setMvccVersion);
+			attributeSetterBiConsumers.put(
+				"externalReferenceCode",
+				(BiConsumer<BatchPlannerPlan, String>)
+					BatchPlannerPlan::setExternalReferenceCode);
 			attributeSetterBiConsumers.put(
 				"batchPlannerPlanId",
 				(BiConsumer<BatchPlannerPlan, Long>)
@@ -411,6 +426,35 @@ public class BatchPlannerPlanModelImpl
 		}
 
 		_mvccVersion = mvccVersion;
+	}
+
+	@JSON
+	@Override
+	public String getExternalReferenceCode() {
+		if (_externalReferenceCode == null) {
+			return "";
+		}
+		else {
+			return _externalReferenceCode;
+		}
+	}
+
+	@Override
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_externalReferenceCode = externalReferenceCode;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getColumnOriginalValue(String)}
+	 */
+	@Deprecated
+	public String getOriginalExternalReferenceCode() {
+		return getColumnOriginalValue("externalReferenceCode");
 	}
 
 	@JSON
@@ -843,6 +887,8 @@ public class BatchPlannerPlanModelImpl
 		BatchPlannerPlanImpl batchPlannerPlanImpl = new BatchPlannerPlanImpl();
 
 		batchPlannerPlanImpl.setMvccVersion(getMvccVersion());
+		batchPlannerPlanImpl.setExternalReferenceCode(
+			getExternalReferenceCode());
 		batchPlannerPlanImpl.setBatchPlannerPlanId(getBatchPlannerPlanId());
 		batchPlannerPlanImpl.setCompanyId(getCompanyId());
 		batchPlannerPlanImpl.setUserId(getUserId());
@@ -872,6 +918,8 @@ public class BatchPlannerPlanModelImpl
 
 		batchPlannerPlanImpl.setMvccVersion(
 			this.<Long>getColumnOriginalValue("mvccVersion"));
+		batchPlannerPlanImpl.setExternalReferenceCode(
+			this.<String>getColumnOriginalValue("externalReferenceCode"));
 		batchPlannerPlanImpl.setBatchPlannerPlanId(
 			this.<Long>getColumnOriginalValue("batchPlannerPlanId"));
 		batchPlannerPlanImpl.setCompanyId(
@@ -986,6 +1034,18 @@ public class BatchPlannerPlanModelImpl
 			new BatchPlannerPlanCacheModel();
 
 		batchPlannerPlanCacheModel.mvccVersion = getMvccVersion();
+
+		batchPlannerPlanCacheModel.externalReferenceCode =
+			getExternalReferenceCode();
+
+		String externalReferenceCode =
+			batchPlannerPlanCacheModel.externalReferenceCode;
+
+		if ((externalReferenceCode != null) &&
+			(externalReferenceCode.length() == 0)) {
+
+			batchPlannerPlanCacheModel.externalReferenceCode = null;
+		}
 
 		batchPlannerPlanCacheModel.batchPlannerPlanId = getBatchPlannerPlanId();
 
@@ -1138,6 +1198,7 @@ public class BatchPlannerPlanModelImpl
 	}
 
 	private long _mvccVersion;
+	private String _externalReferenceCode;
 	private long _batchPlannerPlanId;
 	private long _companyId;
 	private long _userId;
@@ -1188,6 +1249,8 @@ public class BatchPlannerPlanModelImpl
 		_columnOriginalValues = new HashMap<String, Object>();
 
 		_columnOriginalValues.put("mvccVersion", _mvccVersion);
+		_columnOriginalValues.put(
+			"externalReferenceCode", _externalReferenceCode);
 		_columnOriginalValues.put("batchPlannerPlanId", _batchPlannerPlanId);
 		_columnOriginalValues.put("companyId", _companyId);
 		_columnOriginalValues.put("userId", _userId);
@@ -1232,39 +1295,41 @@ public class BatchPlannerPlanModelImpl
 
 		columnBitmasks.put("mvccVersion", 1L);
 
-		columnBitmasks.put("batchPlannerPlanId", 2L);
+		columnBitmasks.put("externalReferenceCode", 2L);
 
-		columnBitmasks.put("companyId", 4L);
+		columnBitmasks.put("batchPlannerPlanId", 4L);
 
-		columnBitmasks.put("userId", 8L);
+		columnBitmasks.put("companyId", 8L);
 
-		columnBitmasks.put("userName", 16L);
+		columnBitmasks.put("userId", 16L);
 
-		columnBitmasks.put("createDate", 32L);
+		columnBitmasks.put("userName", 32L);
 
-		columnBitmasks.put("modifiedDate", 64L);
+		columnBitmasks.put("createDate", 64L);
 
-		columnBitmasks.put("active_", 128L);
+		columnBitmasks.put("modifiedDate", 128L);
 
-		columnBitmasks.put("export", 256L);
+		columnBitmasks.put("active_", 256L);
 
-		columnBitmasks.put("externalType", 512L);
+		columnBitmasks.put("export", 512L);
 
-		columnBitmasks.put("externalURL", 1024L);
+		columnBitmasks.put("externalType", 1024L);
 
-		columnBitmasks.put("internalClassName", 2048L);
+		columnBitmasks.put("externalURL", 2048L);
 
-		columnBitmasks.put("name", 4096L);
+		columnBitmasks.put("internalClassName", 4096L);
 
-		columnBitmasks.put("size_", 8192L);
+		columnBitmasks.put("name", 8192L);
 
-		columnBitmasks.put("taskItemDelegateName", 16384L);
+		columnBitmasks.put("size_", 16384L);
 
-		columnBitmasks.put("total", 32768L);
+		columnBitmasks.put("taskItemDelegateName", 32768L);
 
-		columnBitmasks.put("template", 65536L);
+		columnBitmasks.put("total", 65536L);
 
-		columnBitmasks.put("status", 131072L);
+		columnBitmasks.put("template", 131072L);
+
+		columnBitmasks.put("status", 262144L);
 
 		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
 	}

--- a/modules/apps/batch-planner/batch-planner-service/src/main/java/com/liferay/batch/planner/service/base/BatchPlannerPlanLocalServiceBaseImpl.java
+++ b/modules/apps/batch-planner/batch-planner-service/src/main/java/com/liferay/batch/planner/service/base/BatchPlannerPlanLocalServiceBaseImpl.java
@@ -254,6 +254,23 @@ public abstract class BatchPlannerPlanLocalServiceBaseImpl
 			batchPlannerPlanId);
 	}
 
+	@Override
+	public BatchPlannerPlan fetchBatchPlannerPlanByExternalReferenceCode(
+		String externalReferenceCode, long companyId) {
+
+		return batchPlannerPlanPersistence.fetchByERC_C(
+			externalReferenceCode, companyId);
+	}
+
+	@Override
+	public BatchPlannerPlan getBatchPlannerPlanByExternalReferenceCode(
+			String externalReferenceCode, long companyId)
+		throws PortalException {
+
+		return batchPlannerPlanPersistence.findByERC_C(
+			externalReferenceCode, companyId);
+	}
+
 	/**
 	 * Returns the batch planner plan with the primary key.
 	 *

--- a/modules/apps/batch-planner/batch-planner-service/src/main/java/com/liferay/batch/planner/service/http/BatchPlannerPlanServiceHttp.java
+++ b/modules/apps/batch-planner/batch-planner-service/src/main/java/com/liferay/batch/planner/service/http/BatchPlannerPlanServiceHttp.java
@@ -52,8 +52,8 @@ public class BatchPlannerPlanServiceHttp {
 
 	public static com.liferay.batch.planner.model.BatchPlannerPlan
 			addBatchPlannerPlan(
-				HttpPrincipal httpPrincipal, boolean export,
-				String externalType, String externalURL,
+				HttpPrincipal httpPrincipal, String externalReferenceCode,
+				boolean export, String externalType, String externalURL,
 				String internalClassName, String name, int size,
 				String taskItemDelegateName, boolean template)
 		throws com.liferay.portal.kernel.exception.PortalException {
@@ -64,8 +64,9 @@ public class BatchPlannerPlanServiceHttp {
 				_addBatchPlannerPlanParameterTypes0);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, export, externalType, externalURL, internalClassName,
-				name, size, taskItemDelegateName, template);
+				methodKey, externalReferenceCode, export, externalType,
+				externalURL, internalClassName, name, size,
+				taskItemDelegateName, template);
 
 			Object returnObj = null;
 
@@ -687,8 +688,8 @@ public class BatchPlannerPlanServiceHttp {
 
 	private static final Class<?>[] _addBatchPlannerPlanParameterTypes0 =
 		new Class[] {
-			boolean.class, String.class, String.class, String.class,
-			String.class, int.class, String.class, boolean.class
+			String.class, boolean.class, String.class, String.class,
+			String.class, String.class, int.class, String.class, boolean.class
 		};
 	private static final Class<?>[] _deleteBatchPlannerPlanParameterTypes1 =
 		new Class[] {long.class};

--- a/modules/apps/batch-planner/batch-planner-service/src/main/java/com/liferay/batch/planner/service/impl/BatchPlannerPlanLocalServiceImpl.java
+++ b/modules/apps/batch-planner/batch-planner-service/src/main/java/com/liferay/batch/planner/service/impl/BatchPlannerPlanLocalServiceImpl.java
@@ -58,10 +58,11 @@ public class BatchPlannerPlanLocalServiceImpl
 	extends BatchPlannerPlanLocalServiceBaseImpl {
 
 	@Override
-	public BatchPlannerPlan addBatchPlannerPlan(String externalReferenceCode, 
-			long userId, boolean export, String externalType,
-			String externalURL, String internalClassName, String name, int size,
-			String taskItemDelegateName, boolean template)
+	public BatchPlannerPlan addBatchPlannerPlan(
+			String externalReferenceCode, long userId, boolean export,
+			String externalType, String externalURL, String internalClassName,
+			String name, int size, String taskItemDelegateName,
+			boolean template)
 		throws PortalException {
 
 		_validateExternalType(externalType);

--- a/modules/apps/batch-planner/batch-planner-service/src/main/java/com/liferay/batch/planner/service/impl/BatchPlannerPlanLocalServiceImpl.java
+++ b/modules/apps/batch-planner/batch-planner-service/src/main/java/com/liferay/batch/planner/service/impl/BatchPlannerPlanLocalServiceImpl.java
@@ -58,7 +58,7 @@ public class BatchPlannerPlanLocalServiceImpl
 	extends BatchPlannerPlanLocalServiceBaseImpl {
 
 	@Override
-	public BatchPlannerPlan addBatchPlannerPlan(
+	public BatchPlannerPlan addBatchPlannerPlan(String externalReferenceCode, 
 			long userId, boolean export, String externalType,
 			String externalURL, String internalClassName, String name, int size,
 			String taskItemDelegateName, boolean template)
@@ -78,6 +78,7 @@ public class BatchPlannerPlanLocalServiceImpl
 		BatchPlannerPlan batchPlannerPlan = batchPlannerPlanPersistence.create(
 			counterLocalService.increment());
 
+		batchPlannerPlan.setExternalReferenceCode(externalReferenceCode);
 		batchPlannerPlan.setCompanyId(user.getCompanyId());
 		batchPlannerPlan.setUserId(userId);
 		batchPlannerPlan.setUserName(user.getFullName());

--- a/modules/apps/batch-planner/batch-planner-service/src/main/java/com/liferay/batch/planner/service/impl/BatchPlannerPlanServiceImpl.java
+++ b/modules/apps/batch-planner/batch-planner-service/src/main/java/com/liferay/batch/planner/service/impl/BatchPlannerPlanServiceImpl.java
@@ -54,9 +54,9 @@ public class BatchPlannerPlanServiceImpl
 	extends BatchPlannerPlanServiceBaseImpl {
 
 	@Override
-	public BatchPlannerPlan addBatchPlannerPlan(String externalReferenceCode, 
-			boolean export, String externalType, String externalURL,
-			String internalClassName, String name, int size,
+	public BatchPlannerPlan addBatchPlannerPlan(
+			String externalReferenceCode, boolean export, String externalType,
+			String externalURL, String internalClassName, String name, int size,
 			String taskItemDelegateName, boolean template)
 		throws PortalException {
 
@@ -67,9 +67,9 @@ public class BatchPlannerPlanServiceImpl
 			BatchPlannerActionKeys.ADD_BATCH_PLANNER_PLAN);
 
 		return batchPlannerPlanLocalService.addBatchPlannerPlan(
-
-			externalReferenceCode,			permissionChecker.getUserId(), export, externalType, externalURL,
-			internalClassName, name, size, taskItemDelegateName, template);
+			externalReferenceCode, permissionChecker.getUserId(), export,
+			externalType, externalURL, internalClassName, name, size,
+			taskItemDelegateName, template);
 	}
 
 	@Override

--- a/modules/apps/batch-planner/batch-planner-service/src/main/java/com/liferay/batch/planner/service/impl/BatchPlannerPlanServiceImpl.java
+++ b/modules/apps/batch-planner/batch-planner-service/src/main/java/com/liferay/batch/planner/service/impl/BatchPlannerPlanServiceImpl.java
@@ -54,7 +54,7 @@ public class BatchPlannerPlanServiceImpl
 	extends BatchPlannerPlanServiceBaseImpl {
 
 	@Override
-	public BatchPlannerPlan addBatchPlannerPlan(
+	public BatchPlannerPlan addBatchPlannerPlan(String externalReferenceCode, 
 			boolean export, String externalType, String externalURL,
 			String internalClassName, String name, int size,
 			String taskItemDelegateName, boolean template)
@@ -67,7 +67,8 @@ public class BatchPlannerPlanServiceImpl
 			BatchPlannerActionKeys.ADD_BATCH_PLANNER_PLAN);
 
 		return batchPlannerPlanLocalService.addBatchPlannerPlan(
-			permissionChecker.getUserId(), export, externalType, externalURL,
+
+			externalReferenceCode,			permissionChecker.getUserId(), export, externalType, externalURL,
 			internalClassName, name, size, taskItemDelegateName, template);
 	}
 

--- a/modules/apps/batch-planner/batch-planner-service/src/main/java/com/liferay/batch/planner/service/persistence/impl/BatchPlannerPlanPersistenceImpl.java
+++ b/modules/apps/batch-planner/batch-planner-service/src/main/java/com/liferay/batch/planner/service/persistence/impl/BatchPlannerPlanPersistenceImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.batch.planner.service.persistence.impl;
 
+import com.liferay.batch.planner.exception.DuplicateBatchPlannerPlanExternalReferenceCodeException;
 import com.liferay.batch.planner.exception.NoSuchPlanException;
 import com.liferay.batch.planner.model.BatchPlannerPlan;
 import com.liferay.batch.planner.model.BatchPlannerPlanTable;
@@ -46,6 +47,7 @@ import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.kernel.util.Validator;
 
 import java.io.Serializable;
 
@@ -5848,6 +5850,262 @@ public class BatchPlannerPlanPersistenceImpl
 	private static final String _FINDER_COLUMN_C_E_T_TEMPLATE_2 =
 		"batchPlannerPlan.template = ?";
 
+	private FinderPath _finderPathFetchByERC_C;
+	private FinderPath _finderPathCountByERC_C;
+
+	/**
+	 * Returns the batch planner plan where externalReferenceCode = &#63; and companyId = &#63; or throws a <code>NoSuchPlanException</code> if it could not be found.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
+	 * @return the matching batch planner plan
+	 * @throws NoSuchPlanException if a matching batch planner plan could not be found
+	 */
+	@Override
+	public BatchPlannerPlan findByERC_C(
+			String externalReferenceCode, long companyId)
+		throws NoSuchPlanException {
+
+		BatchPlannerPlan batchPlannerPlan = fetchByERC_C(
+			externalReferenceCode, companyId);
+
+		if (batchPlannerPlan == null) {
+			StringBundler sb = new StringBundler(6);
+
+			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+			sb.append("externalReferenceCode=");
+			sb.append(externalReferenceCode);
+
+			sb.append(", companyId=");
+			sb.append(companyId);
+
+			sb.append("}");
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(sb.toString());
+			}
+
+			throw new NoSuchPlanException(sb.toString());
+		}
+
+		return batchPlannerPlan;
+	}
+
+	/**
+	 * Returns the batch planner plan where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
+	 * @return the matching batch planner plan, or <code>null</code> if a matching batch planner plan could not be found
+	 */
+	@Override
+	public BatchPlannerPlan fetchByERC_C(
+		String externalReferenceCode, long companyId) {
+
+		return fetchByERC_C(externalReferenceCode, companyId, true);
+	}
+
+	/**
+	 * Returns the batch planner plan where externalReferenceCode = &#63; and companyId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching batch planner plan, or <code>null</code> if a matching batch planner plan could not be found
+	 */
+	@Override
+	public BatchPlannerPlan fetchByERC_C(
+		String externalReferenceCode, long companyId, boolean useFinderCache) {
+
+		externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+		Object[] finderArgs = null;
+
+		if (useFinderCache) {
+			finderArgs = new Object[] {externalReferenceCode, companyId};
+		}
+
+		Object result = null;
+
+		if (useFinderCache) {
+			result = finderCache.getResult(
+				_finderPathFetchByERC_C, finderArgs, this);
+		}
+
+		if (result instanceof BatchPlannerPlan) {
+			BatchPlannerPlan batchPlannerPlan = (BatchPlannerPlan)result;
+
+			if (!Objects.equals(
+					externalReferenceCode,
+					batchPlannerPlan.getExternalReferenceCode()) ||
+				(companyId != batchPlannerPlan.getCompanyId())) {
+
+				result = null;
+			}
+		}
+
+		if (result == null) {
+			StringBundler sb = new StringBundler(4);
+
+			sb.append(_SQL_SELECT_BATCHPLANNERPLAN_WHERE);
+
+			boolean bindExternalReferenceCode = false;
+
+			if (externalReferenceCode.isEmpty()) {
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
+			}
+			else {
+				bindExternalReferenceCode = true;
+
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
+			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				if (bindExternalReferenceCode) {
+					queryPos.add(externalReferenceCode);
+				}
+
+				queryPos.add(companyId);
+
+				List<BatchPlannerPlan> list = query.list();
+
+				if (list.isEmpty()) {
+					if (useFinderCache) {
+						finderCache.putResult(
+							_finderPathFetchByERC_C, finderArgs, list);
+					}
+				}
+				else {
+					BatchPlannerPlan batchPlannerPlan = list.get(0);
+
+					result = batchPlannerPlan;
+
+					cacheResult(batchPlannerPlan);
+				}
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		if (result instanceof List<?>) {
+			return null;
+		}
+		else {
+			return (BatchPlannerPlan)result;
+		}
+	}
+
+	/**
+	 * Removes the batch planner plan where externalReferenceCode = &#63; and companyId = &#63; from the database.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
+	 * @return the batch planner plan that was removed
+	 */
+	@Override
+	public BatchPlannerPlan removeByERC_C(
+			String externalReferenceCode, long companyId)
+		throws NoSuchPlanException {
+
+		BatchPlannerPlan batchPlannerPlan = findByERC_C(
+			externalReferenceCode, companyId);
+
+		return remove(batchPlannerPlan);
+	}
+
+	/**
+	 * Returns the number of batch planner plans where externalReferenceCode = &#63; and companyId = &#63;.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param companyId the company ID
+	 * @return the number of matching batch planner plans
+	 */
+	@Override
+	public int countByERC_C(String externalReferenceCode, long companyId) {
+		externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+		FinderPath finderPath = _finderPathCountByERC_C;
+
+		Object[] finderArgs = new Object[] {externalReferenceCode, companyId};
+
+		Long count = (Long)finderCache.getResult(finderPath, finderArgs, this);
+
+		if (count == null) {
+			StringBundler sb = new StringBundler(3);
+
+			sb.append(_SQL_COUNT_BATCHPLANNERPLAN_WHERE);
+
+			boolean bindExternalReferenceCode = false;
+
+			if (externalReferenceCode.isEmpty()) {
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3);
+			}
+			else {
+				bindExternalReferenceCode = true;
+
+				sb.append(_FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2);
+			}
+
+			sb.append(_FINDER_COLUMN_ERC_C_COMPANYID_2);
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				if (bindExternalReferenceCode) {
+					queryPos.add(externalReferenceCode);
+				}
+
+				queryPos.add(companyId);
+
+				count = (Long)query.uniqueResult();
+
+				finderCache.putResult(finderPath, finderArgs, count);
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return count.intValue();
+	}
+
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_2 =
+		"batchPlannerPlan.externalReferenceCode = ? AND ";
+
+	private static final String _FINDER_COLUMN_ERC_C_EXTERNALREFERENCECODE_3 =
+		"(batchPlannerPlan.externalReferenceCode IS NULL OR batchPlannerPlan.externalReferenceCode = '') AND ";
+
+	private static final String _FINDER_COLUMN_ERC_C_COMPANYID_2 =
+		"batchPlannerPlan.companyId = ?";
+
 	public BatchPlannerPlanPersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
 
@@ -5873,6 +6131,14 @@ public class BatchPlannerPlanPersistenceImpl
 	public void cacheResult(BatchPlannerPlan batchPlannerPlan) {
 		entityCache.putResult(
 			BatchPlannerPlanImpl.class, batchPlannerPlan.getPrimaryKey(),
+			batchPlannerPlan);
+
+		finderCache.putResult(
+			_finderPathFetchByERC_C,
+			new Object[] {
+				batchPlannerPlan.getExternalReferenceCode(),
+				batchPlannerPlan.getCompanyId()
+			},
 			batchPlannerPlan);
 	}
 
@@ -5944,6 +6210,19 @@ public class BatchPlannerPlanPersistenceImpl
 		for (Serializable primaryKey : primaryKeys) {
 			entityCache.removeResult(BatchPlannerPlanImpl.class, primaryKey);
 		}
+	}
+
+	protected void cacheUniqueFindersCache(
+		BatchPlannerPlanModelImpl batchPlannerPlanModelImpl) {
+
+		Object[] args = new Object[] {
+			batchPlannerPlanModelImpl.getExternalReferenceCode(),
+			batchPlannerPlanModelImpl.getCompanyId()
+		};
+
+		finderCache.putResult(_finderPathCountByERC_C, args, Long.valueOf(1));
+		finderCache.putResult(
+			_finderPathFetchByERC_C, args, batchPlannerPlanModelImpl);
 	}
 
 	/**
@@ -6074,6 +6353,38 @@ public class BatchPlannerPlanPersistenceImpl
 		BatchPlannerPlanModelImpl batchPlannerPlanModelImpl =
 			(BatchPlannerPlanModelImpl)batchPlannerPlan;
 
+		if (Validator.isNull(batchPlannerPlan.getExternalReferenceCode())) {
+			batchPlannerPlan.setExternalReferenceCode(
+				String.valueOf(batchPlannerPlan.getPrimaryKey()));
+		}
+		else {
+			BatchPlannerPlan ercBatchPlannerPlan = fetchByERC_C(
+				batchPlannerPlan.getExternalReferenceCode(),
+				batchPlannerPlan.getCompanyId());
+
+			if (isNew) {
+				if (ercBatchPlannerPlan != null) {
+					throw new DuplicateBatchPlannerPlanExternalReferenceCodeException(
+						"Duplicate batch planner plan with external reference code " +
+							batchPlannerPlan.getExternalReferenceCode() +
+								" and company " +
+									batchPlannerPlan.getCompanyId());
+				}
+			}
+			else {
+				if ((ercBatchPlannerPlan != null) &&
+					(batchPlannerPlan.getBatchPlannerPlanId() !=
+						ercBatchPlannerPlan.getBatchPlannerPlanId())) {
+
+					throw new DuplicateBatchPlannerPlanExternalReferenceCodeException(
+						"Duplicate batch planner plan with external reference code " +
+							batchPlannerPlan.getExternalReferenceCode() +
+								" and company " +
+									batchPlannerPlan.getCompanyId());
+				}
+			}
+		}
+
 		ServiceContext serviceContext =
 			ServiceContextThreadLocal.getServiceContext();
 
@@ -6121,6 +6432,8 @@ public class BatchPlannerPlanPersistenceImpl
 
 		entityCache.putResult(
 			BatchPlannerPlanImpl.class, batchPlannerPlanModelImpl, false, true);
+
+		cacheUniqueFindersCache(batchPlannerPlanModelImpl);
 
 		if (isNew) {
 			batchPlannerPlan.setNew(false);
@@ -6525,6 +6838,16 @@ public class BatchPlannerPlanPersistenceImpl
 				Boolean.class.getName()
 			},
 			new String[] {"companyId", "export", "template"}, false);
+
+		_finderPathFetchByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, true);
+
+		_finderPathCountByERC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByERC_C",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "companyId"}, false);
 
 		_setBatchPlannerPlanUtilPersistence(this);
 	}

--- a/modules/apps/batch-planner/batch-planner-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/apps/batch-planner/batch-planner-service/src/main/resources/META-INF/module-hbm.xml
@@ -27,6 +27,7 @@
 			<generator class="assigned" />
 		</id>
 		<version access="com.liferay.portal.dao.orm.hibernate.PrivateFieldPropertyAccessor" name="mvccVersion" type="long" />
+		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="externalReferenceCode" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="companyId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="userId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="userName" type="com.liferay.portal.dao.orm.hibernate.StringType" />

--- a/modules/apps/batch-planner/batch-planner-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/batch-planner/batch-planner-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -28,6 +28,7 @@
 	</model>
 	<model name="com.liferay.batch.planner.model.BatchPlannerPlan">
 		<field name="mvccVersion" type="long" />
+		<field name="externalReferenceCode" type="String" />
 		<field name="batchPlannerPlanId" type="long" />
 		<field name="companyId" type="long" />
 		<field name="userId" type="long" />

--- a/modules/apps/batch-planner/batch-planner-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/batch-planner/batch-planner-service/src/main/resources/META-INF/sql/indexes.sql
@@ -4,5 +4,6 @@ create index IX_18CD7477 on BatchPlannerPlan (companyId, export, template);
 create index IX_221A54A0 on BatchPlannerPlan (companyId, name[$COLUMN_LENGTH:75$]);
 create index IX_F2F05D4F on BatchPlannerPlan (companyId, template);
 create index IX_874FA8DB on BatchPlannerPlan (companyId, userId);
+create unique index IX_EF6CC932 on BatchPlannerPlan (externalReferenceCode[$COLUMN_LENGTH:75$], companyId);
 
 create unique index IX_A8E0209F on BatchPlannerPolicy (batchPlannerPlanId, name[$COLUMN_LENGTH:75$]);

--- a/modules/apps/batch-planner/batch-planner-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/batch-planner/batch-planner-service/src/main/resources/META-INF/sql/tables.sql
@@ -16,6 +16,7 @@ create table BatchPlannerMapping (
 
 create table BatchPlannerPlan (
 	mvccVersion LONG default 0 not null,
+	externalReferenceCode VARCHAR(75) null,
 	batchPlannerPlanId LONG not null primary key,
 	companyId LONG,
 	userId LONG,

--- a/modules/apps/batch-planner/batch-planner-test/src/testIntegration/java/com/liferay/batch/planner/service/persistence/test/BatchPlannerPlanPersistenceTest.java
+++ b/modules/apps/batch-planner/batch-planner-test/src/testIntegration/java/com/liferay/batch/planner/service/persistence/test/BatchPlannerPlanPersistenceTest.java
@@ -15,6 +15,7 @@
 package com.liferay.batch.planner.service.persistence.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.batch.planner.exception.DuplicateBatchPlannerPlanExternalReferenceCodeException;
 import com.liferay.batch.planner.exception.NoSuchPlanException;
 import com.liferay.batch.planner.model.BatchPlannerPlan;
 import com.liferay.batch.planner.service.BatchPlannerPlanLocalServiceUtil;
@@ -26,6 +27,8 @@ import com.liferay.portal.kernel.dao.orm.DynamicQueryFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.ProjectionFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
+import com.liferay.portal.kernel.dao.orm.Session;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.transaction.Propagation;
@@ -124,6 +127,9 @@ public class BatchPlannerPlanPersistenceTest {
 
 		newBatchPlannerPlan.setMvccVersion(RandomTestUtil.nextLong());
 
+		newBatchPlannerPlan.setExternalReferenceCode(
+			RandomTestUtil.randomString());
+
 		newBatchPlannerPlan.setCompanyId(RandomTestUtil.nextLong());
 
 		newBatchPlannerPlan.setUserId(RandomTestUtil.nextLong());
@@ -165,6 +171,9 @@ public class BatchPlannerPlanPersistenceTest {
 		Assert.assertEquals(
 			existingBatchPlannerPlan.getMvccVersion(),
 			newBatchPlannerPlan.getMvccVersion());
+		Assert.assertEquals(
+			existingBatchPlannerPlan.getExternalReferenceCode(),
+			newBatchPlannerPlan.getExternalReferenceCode());
 		Assert.assertEquals(
 			existingBatchPlannerPlan.getBatchPlannerPlanId(),
 			newBatchPlannerPlan.getBatchPlannerPlanId());
@@ -214,6 +223,28 @@ public class BatchPlannerPlanPersistenceTest {
 		Assert.assertEquals(
 			existingBatchPlannerPlan.getStatus(),
 			newBatchPlannerPlan.getStatus());
+	}
+
+	@Test(
+		expected = DuplicateBatchPlannerPlanExternalReferenceCodeException.class
+	)
+	public void testUpdateWithExistingExternalReferenceCode() throws Exception {
+		BatchPlannerPlan batchPlannerPlan = addBatchPlannerPlan();
+
+		BatchPlannerPlan newBatchPlannerPlan = addBatchPlannerPlan();
+
+		newBatchPlannerPlan.setCompanyId(batchPlannerPlan.getCompanyId());
+
+		newBatchPlannerPlan = _persistence.update(newBatchPlannerPlan);
+
+		Session session = _persistence.getCurrentSession();
+
+		session.evict(newBatchPlannerPlan);
+
+		newBatchPlannerPlan.setExternalReferenceCode(
+			batchPlannerPlan.getExternalReferenceCode());
+
+		_persistence.update(newBatchPlannerPlan);
 	}
 
 	@Test
@@ -267,6 +298,15 @@ public class BatchPlannerPlanPersistenceTest {
 	}
 
 	@Test
+	public void testCountByERC_C() throws Exception {
+		_persistence.countByERC_C("", RandomTestUtil.nextLong());
+
+		_persistence.countByERC_C("null", 0L);
+
+		_persistence.countByERC_C((String)null, 0L);
+	}
+
+	@Test
 	public void testFindByPrimaryKeyExisting() throws Exception {
 		BatchPlannerPlan newBatchPlannerPlan = addBatchPlannerPlan();
 
@@ -291,12 +331,13 @@ public class BatchPlannerPlanPersistenceTest {
 
 	protected OrderByComparator<BatchPlannerPlan> getOrderByComparator() {
 		return OrderByComparatorFactoryUtil.create(
-			"BatchPlannerPlan", "mvccVersion", true, "batchPlannerPlanId", true,
-			"companyId", true, "userId", true, "userName", true, "createDate",
-			true, "modifiedDate", true, "active", true, "export", true,
-			"externalType", true, "externalURL", true, "internalClassName",
-			true, "name", true, "size", true, "taskItemDelegateName", true,
-			"total", true, "template", true, "status", true);
+			"BatchPlannerPlan", "mvccVersion", true, "externalReferenceCode",
+			true, "batchPlannerPlanId", true, "companyId", true, "userId", true,
+			"userName", true, "createDate", true, "modifiedDate", true,
+			"active", true, "export", true, "externalType", true, "externalURL",
+			true, "internalClassName", true, "name", true, "size", true,
+			"taskItemDelegateName", true, "total", true, "template", true,
+			"status", true);
 	}
 
 	@Test
@@ -516,12 +557,79 @@ public class BatchPlannerPlanPersistenceTest {
 		Assert.assertEquals(0, result.size());
 	}
 
+	@Test
+	public void testResetOriginalValues() throws Exception {
+		BatchPlannerPlan newBatchPlannerPlan = addBatchPlannerPlan();
+
+		_persistence.clearCache();
+
+		_assertOriginalValues(
+			_persistence.findByPrimaryKey(newBatchPlannerPlan.getPrimaryKey()));
+	}
+
+	@Test
+	public void testResetOriginalValuesWithDynamicQueryLoadFromDatabase()
+		throws Exception {
+
+		_testResetOriginalValuesWithDynamicQuery(true);
+	}
+
+	@Test
+	public void testResetOriginalValuesWithDynamicQueryLoadFromSession()
+		throws Exception {
+
+		_testResetOriginalValuesWithDynamicQuery(false);
+	}
+
+	private void _testResetOriginalValuesWithDynamicQuery(boolean clearSession)
+		throws Exception {
+
+		BatchPlannerPlan newBatchPlannerPlan = addBatchPlannerPlan();
+
+		if (clearSession) {
+			Session session = _persistence.openSession();
+
+			session.flush();
+
+			session.clear();
+		}
+
+		DynamicQuery dynamicQuery = DynamicQueryFactoryUtil.forClass(
+			BatchPlannerPlan.class, _dynamicQueryClassLoader);
+
+		dynamicQuery.add(
+			RestrictionsFactoryUtil.eq(
+				"batchPlannerPlanId",
+				newBatchPlannerPlan.getBatchPlannerPlanId()));
+
+		List<BatchPlannerPlan> result = _persistence.findWithDynamicQuery(
+			dynamicQuery);
+
+		_assertOriginalValues(result.get(0));
+	}
+
+	private void _assertOriginalValues(BatchPlannerPlan batchPlannerPlan) {
+		Assert.assertEquals(
+			batchPlannerPlan.getExternalReferenceCode(),
+			ReflectionTestUtil.invoke(
+				batchPlannerPlan, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "externalReferenceCode"));
+		Assert.assertEquals(
+			Long.valueOf(batchPlannerPlan.getCompanyId()),
+			ReflectionTestUtil.<Long>invoke(
+				batchPlannerPlan, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "companyId"));
+	}
+
 	protected BatchPlannerPlan addBatchPlannerPlan() throws Exception {
 		long pk = RandomTestUtil.nextLong();
 
 		BatchPlannerPlan batchPlannerPlan = _persistence.create(pk);
 
 		batchPlannerPlan.setMvccVersion(RandomTestUtil.nextLong());
+
+		batchPlannerPlan.setExternalReferenceCode(
+			RandomTestUtil.randomString());
 
 		batchPlannerPlan.setCompanyId(RandomTestUtil.nextLong());
 

--- a/modules/apps/batch-planner/batch-planner-test/src/testIntegration/java/com/liferay/batch/planner/service/test/BatchPlannerPlanServiceTest.java
+++ b/modules/apps/batch-planner/batch-planner-test/src/testIntegration/java/com/liferay/batch/planner/service/test/BatchPlannerPlanServiceTest.java
@@ -63,7 +63,7 @@ public class BatchPlannerPlanServiceTest {
 
 		BatchPlannerPlan batchPlannerPlan =
 			_batchPlannerPlanService.addBatchPlannerPlan(
-				true, BatchPlannerPlanConstants.EXTERNAL_TYPE_CSV,
+				null, true, BatchPlannerPlanConstants.EXTERNAL_TYPE_CSV,
 				"/" + RandomTestUtil.randomString(),
 				RandomTestUtil.randomString(), name, 0, null, false);
 
@@ -74,7 +74,7 @@ public class BatchPlannerPlanServiceTest {
 
 		try {
 			_batchPlannerPlanService.addBatchPlannerPlan(
-				true, "", "/" + RandomTestUtil.randomString(),
+				null, true, "", "/" + RandomTestUtil.randomString(),
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(), 0,
 				null, false);
 
@@ -94,7 +94,7 @@ public class BatchPlannerPlanServiceTest {
 
 		try {
 			_batchPlannerPlanService.addBatchPlannerPlan(
-				true, BatchPlannerPlanConstants.EXTERNAL_TYPE_CSV,
+				null, true, BatchPlannerPlanConstants.EXTERNAL_TYPE_CSV,
 				"/" + RandomTestUtil.randomString(), null, name, 0, null,
 				false);
 
@@ -108,7 +108,7 @@ public class BatchPlannerPlanServiceTest {
 
 		try {
 			_batchPlannerPlanService.addBatchPlannerPlan(
-				true, BatchPlannerPlanConstants.EXTERNAL_TYPE_CSV,
+				null, true, BatchPlannerPlanConstants.EXTERNAL_TYPE_CSV,
 				"/" + RandomTestUtil.randomString(),
 				RandomTestUtil.randomString(), "", 0, null, true);
 
@@ -124,7 +124,7 @@ public class BatchPlannerPlanServiceTest {
 
 		try {
 			_batchPlannerPlanService.addBatchPlannerPlan(
-				true, BatchPlannerPlanConstants.EXTERNAL_TYPE_CSV,
+				null, true, BatchPlannerPlanConstants.EXTERNAL_TYPE_CSV,
 				"/" + RandomTestUtil.randomString(),
 				RandomTestUtil.randomString(),
 				RandomTestUtil.randomString(maxLength + 1), 0, null, false);
@@ -139,12 +139,12 @@ public class BatchPlannerPlanServiceTest {
 
 		try {
 			_batchPlannerPlanService.addBatchPlannerPlan(
-				true, BatchPlannerPlanConstants.EXTERNAL_TYPE_CSV,
+				null, true, BatchPlannerPlanConstants.EXTERNAL_TYPE_CSV,
 				"/" + RandomTestUtil.randomString(),
 				RandomTestUtil.randomString(), name, 0, null, true);
 
 			_batchPlannerPlanService.addBatchPlannerPlan(
-				true, BatchPlannerPlanConstants.EXTERNAL_TYPE_CSV,
+				null, true, BatchPlannerPlanConstants.EXTERNAL_TYPE_CSV,
 				"/" + RandomTestUtil.randomString(),
 				RandomTestUtil.randomString(), name, 0, null, true);
 
@@ -166,13 +166,13 @@ public class BatchPlannerPlanServiceTest {
 
 		_testUpdateBatchPlannerPlanStatusFailed(
 			_batchPlannerPlanService.addBatchPlannerPlan(
-				true, BatchPlannerPlanConstants.EXTERNAL_TYPE_CSV,
+				null, true, BatchPlannerPlanConstants.EXTERNAL_TYPE_CSV,
 				"/" + RandomTestUtil.randomString(),
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(), 0,
 				null, false));
 		_testUpdateBatchPlannerPlanStatusFailed(
 			_batchPlannerPlanService.addBatchPlannerPlan(
-				true, BatchPlannerPlanConstants.EXTERNAL_TYPE_CSV,
+				null, true, BatchPlannerPlanConstants.EXTERNAL_TYPE_CSV,
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 				RandomTestUtil.randomString(), 0, null, false));
 	}
@@ -208,7 +208,7 @@ public class BatchPlannerPlanServiceTest {
 	public void testUpdateBatchPlannerPlan() throws Exception {
 		BatchPlannerPlan batchPlannerPlan =
 			_batchPlannerPlanService.addBatchPlannerPlan(
-				true, BatchPlannerPlanConstants.EXTERNAL_TYPE_CSV,
+				null, true, BatchPlannerPlanConstants.EXTERNAL_TYPE_CSV,
 				"/" + RandomTestUtil.randomString(),
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(), 0,
 				null, false);
@@ -237,7 +237,7 @@ public class BatchPlannerPlanServiceTest {
 
 		BatchPlannerPlan batchPlannerPlan =
 			_batchPlannerPlanService.addBatchPlannerPlan(
-				export, BatchPlannerPlanConstants.EXTERNAL_TYPE_CSV,
+				null, export, BatchPlannerPlanConstants.EXTERNAL_TYPE_CSV,
 				"/" + RandomTestUtil.randomString(), internalClassName, name, 0,
 				null, false);
 

--- a/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/helper/BatchPlannerPlanHelper.java
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/helper/BatchPlannerPlanHelper.java
@@ -71,8 +71,8 @@ public class BatchPlannerPlanHelper {
 
 		BatchPlannerPlan batchPlannerPlan =
 			_batchPlannerPlanService.addBatchPlannerPlan(
-				true, externalType, StringPool.SLASH, internalClassName, name,
-				0, taskItemDelegateName, template);
+				null, true, externalType, StringPool.SLASH, internalClassName,
+				name, 0, taskItemDelegateName, template);
 
 		_addBatchPlannerPolicies(
 			batchPlannerPlan.getBatchPlannerPlanId(), portletRequest);
@@ -113,8 +113,8 @@ public class BatchPlannerPlanHelper {
 
 		BatchPlannerPlan batchPlannerPlan =
 			_batchPlannerPlanService.addBatchPlannerPlan(
-				false, externalType, importFileURI, internalClassName, name,
-				size, taskItemDelegateName, template);
+				null, false, externalType, importFileURI, internalClassName,
+				name, size, taskItemDelegateName, template);
 
 		_addBatchPlannerPolicies(
 			batchPlannerPlan.getBatchPlannerPlanId(), portletRequest);
@@ -217,7 +217,7 @@ public class BatchPlannerPlanHelper {
 
 		BatchPlannerPlan batchPlannerPlan =
 			_batchPlannerPlanService.addBatchPlannerPlan(
-				templateBatchPlannerPlan.isExport(),
+				null, templateBatchPlannerPlan.isExport(),
 				templateBatchPlannerPlan.getExternalType(), externalURL,
 				templateBatchPlannerPlan.getInternalClassName(), name,
 				(int)file.length(),

--- a/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/ServiceBuilder.java
+++ b/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/ServiceBuilder.java
@@ -76,9 +76,11 @@ import freemarker.template.TemplateHashModel;
 
 import java.beans.Introspector;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -113,6 +115,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.Scanner;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -221,6 +224,8 @@ public class ServiceBuilder {
 		String targetEntityName = arguments.get("service.target.entity.name");
 		String testDirName = arguments.get("service.test.dir");
 		String uadDirName = arguments.get("service.uad.dir");
+		boolean updateServiceMethodSignatureWithErc = GetterUtil.getBoolean(
+			arguments.get("service.impl.update.signature.erc"));
 
 		Set<String> resourceActionModels = readResourceActionModels(
 			implDirName, resourcesDirName, resourceActionsConfigs);
@@ -245,7 +250,7 @@ public class ServiceBuilder {
 				resourceActionModels, resourcesDirName, springFileName,
 				springNamespaces, sqlDirName, sqlFileName, sqlIndexesFileName,
 				sqlSequencesFileName, targetEntityName, testDirName, uadDirName,
-				true);
+				true, updateServiceMethodSignatureWithErc);
 
 			String modifiedFileNames = StringUtil.merge(
 				serviceBuilder.getModifiedFileNames());
@@ -497,7 +502,7 @@ public class ServiceBuilder {
 			pluginName, propsUtil, readOnlyPrefixes, resourceActionModels,
 			resourcesDirName, springFileName, springNamespaces, sqlDirName,
 			sqlFileName, sqlIndexesFileName, sqlSequencesFileName,
-			targetEntityName, testDirName, uadDirName, true);
+			targetEntityName, testDirName, uadDirName, true, false);
 	}
 
 	public ServiceBuilder(
@@ -512,7 +517,8 @@ public class ServiceBuilder {
 			String springFileName, String[] springNamespaces, String sqlDirName,
 			String sqlFileName, String sqlIndexesFileName,
 			String sqlSequencesFileName, String targetEntityName,
-			String testDirName, String uadDirName, boolean build)
+			String testDirName, String uadDirName, boolean build,
+			boolean updateServiceImplMethodSignatureWithERC)
 		throws Exception {
 
 		_tplBadAliasNames = _getTplProperty(
@@ -601,6 +607,8 @@ public class ServiceBuilder {
 			_testDirName = _normalize(testDirName);
 			_uadDirName = _normalize(uadDirName);
 			_build = build;
+			_updateServiceImplMethodSignatureWithERC =
+				updateServiceImplMethodSignatureWithERC;
 
 			_badAliasNames = _readLines(_tplBadAliasNames);
 			_badColumnNames = _readLines(_tplBadColumnNames);
@@ -1265,7 +1273,7 @@ public class ServiceBuilder {
 			_resourceActionModels, _resourcesDirName, _springFileName,
 			_springNamespaces, _sqlDirName, _sqlFileName, _sqlIndexesFileName,
 			_sqlSequencesFileName, _targetEntityName, _testDirName, _uadDirName,
-			false);
+			false, false);
 
 		entity = serviceBuilder.getEntity(refEntity);
 
@@ -3774,6 +3782,12 @@ public class ServiceBuilder {
 				_getSessionTypeName(sessionType), "ServiceImpl.java"));
 
 		if (file.exists()) {
+			if (entity.hasExternalReferenceCode() &&
+				_updateServiceImplMethodSignatureWithERC) {
+
+				_updateServiceImplMethodSignatureWithERC(entity, file);
+			}
+
 			return;
 		}
 
@@ -5870,6 +5884,14 @@ public class ServiceBuilder {
 		version = version.substring(1);
 
 		return Version.getInstance(version);
+	}
+
+	private boolean _hasAnyOf(String string, String[] expressions) {
+		if (StringUtil.indexOfAny(string, expressions) > 0) {
+			return true;
+		}
+
+		return false;
 	}
 
 	private boolean _hasFinderThatIsNotUniqueByCompany(
@@ -7990,6 +8012,76 @@ public class ServiceBuilder {
 		Files.createFile(file.toPath());
 	}
 
+	private void _updateServiceImplMethodSignatureWithERC(
+			Entity entity, File file)
+		throws Exception {
+
+		ByteArrayOutputStream byteArrayOutputStream =
+			new ByteArrayOutputStream();
+
+		Scanner scanner = new Scanner(new FileInputStream(file));
+
+		while (scanner.hasNextLine()) {
+			String line = scanner.nextLine();
+
+			if (_hasAnyOf(
+					line,
+					new String[] {
+						"add(",
+						"add" + entity.getName() + StringPool.OPEN_PARENTHESIS
+					})) {
+
+				line = _updateSignature(line, scanner);
+			}
+
+			byteArrayOutputStream.write(line.getBytes());
+
+			if (scanner.hasNextLine()) {
+				byteArrayOutputStream.write(CharPool.NEW_LINE);
+			}
+		}
+
+		try (FileOutputStream fileOutputStream = new FileOutputStream(file)) {
+			fileOutputStream.write(byteArrayOutputStream.toByteArray());
+		}
+	}
+
+	private String _updateSignature(String line, Scanner scanner) {
+		StringBuilder stringBuilder = new StringBuilder(line);
+
+		while (!line.contains(StringPool.OPEN_CURLY_BRACE)) {
+			line = scanner.nextLine();
+
+			stringBuilder.append(line);
+
+			if (!line.contains(StringPool.OPEN_CURLY_BRACE)) {
+				stringBuilder.append(StringPool.NEW_LINE);
+			}
+		}
+
+		if (stringBuilder.indexOf("externalReferenceCode") > 0) {
+			return stringBuilder.toString();
+		}
+
+		String externalReferenceCodeArgumentExpression =
+			"String externalReferenceCode, ";
+
+		if ((stringBuilder.indexOf(StringPool.PERIOD) > 0) &&
+			(stringBuilder.indexOf(StringPool.PERIOD) < stringBuilder.indexOf(
+				StringPool.OPEN_PARENTHESIS))) {
+
+			externalReferenceCodeArgumentExpression = "externalReferenceCode, ";
+		}
+
+		stringBuilder.replace(
+			stringBuilder.indexOf(StringPool.OPEN_PARENTHESIS),
+			stringBuilder.indexOf(StringPool.OPEN_PARENTHESIS) + 1,
+			StringPool.OPEN_PARENTHESIS +
+				externalReferenceCodeArgumentExpression);
+
+		return stringBuilder.toString();
+	}
+
 	private void _write(File file, String s) throws IOException {
 		Path path = file.toPath();
 
@@ -8185,5 +8277,6 @@ public class ServiceBuilder {
 	private final Map<String, List<Entity>> _uadApplicationEntities =
 		new HashMap<>();
 	private String _uadDirName;
+	private boolean _updateServiceImplMethodSignatureWithERC;
 
 }

--- a/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/ServiceBuilder.java
+++ b/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/ServiceBuilder.java
@@ -2185,41 +2185,6 @@ public class ServiceBuilder {
 		return sb.toString();
 	}
 
-	public static class CharacterCounter {
-
-		public CharacterCounter(char character) {
-			_character = character;
-		}
-
-		public void count(String line) {
-			for (int i = 0; i < line.length(); i++) {
-				if (line.charAt(i) == _character) {
-					_count++;
-				}
-
-				for (CharacterCounter characterCounter : _characterCounters) {
-					if (line.charAt(i) == characterCounter._character) {
-						characterCounter._count++;
-					}
-				}
-			}
-		}
-
-		public CharacterCounter getLinkedCharacterCounter(char character) {
-			CharacterCounter characterCounter = new CharacterCounter(character);
-
-			_characterCounters.add(characterCounter);
-
-			return characterCounter;
-		}
-
-		private final char _character;
-		private final List<CharacterCounter> _characterCounters =
-			new ArrayList<>();
-		private int _count;
-
-	}
-
 	private static SAXReader _getSAXReader() {
 		return SAXReaderFactory.getSAXReader(null, false, false);
 	}
@@ -8061,14 +8026,10 @@ public class ServiceBuilder {
 	private String _updateBody(
 		String line, Entity entity, Scanner scanner, int sessionType) {
 
-		CharacterCounter openCurlyBraceCharacterCounter = new CharacterCounter(
-			CharPool.OPEN_CURLY_BRACE);
-
-		CharacterCounter closeCurlyBraceCharacterCounter =
-			openCurlyBraceCharacterCounter.getLinkedCharacterCounter(
-				CharPool.CLOSE_CURLY_BRACE);
-
-		openCurlyBraceCharacterCounter.count(line);
+		int closeCurlyBraceCount = StringUtil.count(
+			line, CharPool.CLOSE_CURLY_BRACE);
+		int openCurlyBraceCount = StringUtil.count(
+			line, CharPool.OPEN_CURLY_BRACE);
 
 		String targetExpression = _getExternalReferenceCodeExpression(
 			entity, sessionType);
@@ -8079,9 +8040,7 @@ public class ServiceBuilder {
 
 		stringBuilder.append(StringPool.NEW_LINE);
 
-		while (closeCurlyBraceCharacterCounter._count <=
-					openCurlyBraceCharacterCounter._count) {
-
+		while (closeCurlyBraceCount <= openCurlyBraceCount) {
 			if (line.contains(targetExpression)) {
 				targetExpressionPresent = true;
 
@@ -8108,11 +8067,12 @@ public class ServiceBuilder {
 
 			stringBuilder.append(line);
 
-			openCurlyBraceCharacterCounter.count(line);
+			closeCurlyBraceCount += StringUtil.count(
+				line, CharPool.CLOSE_CURLY_BRACE);
+			openCurlyBraceCount += StringUtil.count(
+				line, CharPool.OPEN_CURLY_BRACE);
 
-			if (closeCurlyBraceCharacterCounter._count <=
-					openCurlyBraceCharacterCounter._count) {
-
+			if (closeCurlyBraceCount <= openCurlyBraceCount) {
 				stringBuilder.append(StringPool.NEW_LINE);
 			}
 		}

--- a/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/ServiceBuilder.java
+++ b/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/ServiceBuilder.java
@@ -3820,7 +3820,8 @@ public class ServiceBuilder {
 			if (entity.hasExternalReferenceCode() &&
 				_updateServiceImplMethodSignatureWithERC) {
 
-				_updateServiceImplMethodSignatureWithERC(entity, file);
+				_updateServiceImplMethodSignatureWithERC(
+					entity, file, sessionType);
 			}
 
 			return;
@@ -5552,6 +5553,16 @@ public class ServiceBuilder {
 		}
 
 		return mappingPKEntityColumnDBNames;
+	}
+
+	private String _getExternalReferenceCodeExpression(
+		Entity entity, int sessionType) {
+
+		if (sessionType == _SESSION_TYPE_LOCAL) {
+			return ".setExternalReferenceCode(";
+		}
+
+		return "LocalService.add" + entity.getName() + "(";
 	}
 
 	private JavaClass _getJavaClass(String fileName) throws Exception {
@@ -8047,16 +8058,8 @@ public class ServiceBuilder {
 		Files.createFile(file.toPath());
 	}
 
-	private String _updateBody(String line, Entity entity, Scanner scanner)
-		throws Exception {
-
-		StringBuilder stringBuilder = new StringBuilder(line);
-
-		String setExternalReferenceCode = ".setExternalReferenceCode(";
-		String entityVariableName = StringUtil.lowerCaseFirstLetter(
-			entity.getName());
-		boolean setExternalReferenceCodePresent = false;
-		int pos = -1;
+	private String _updateBody(
+		String line, Entity entity, Scanner scanner, int sessionType) {
 
 		CharacterCounter openCurlyBraceCharacterCounter = new CharacterCounter(
 			CharPool.OPEN_CURLY_BRACE);
@@ -8067,41 +8070,58 @@ public class ServiceBuilder {
 
 		openCurlyBraceCharacterCounter.count(line);
 
+		String targetExpression = _getExternalReferenceCodeExpression(
+			entity, sessionType);
+
+		boolean targetExpressionPresent = false;
+
+		StringBuilder stringBuilder = new StringBuilder(line);
+
+		stringBuilder.append(StringPool.NEW_LINE);
+
 		while (closeCurlyBraceCharacterCounter._count <=
 					openCurlyBraceCharacterCounter._count) {
 
-			if (line.contains(setExternalReferenceCode)) {
-				setExternalReferenceCodePresent = true;
+			if (line.contains(targetExpression)) {
+				targetExpressionPresent = true;
+
+				if (sessionType == _SESSION_TYPE_REMOTE) {
+					stringBuilder.append(StringPool.NEW_LINE);
+					stringBuilder.append("\t\t\texternalReferenceCode,");
+				}
 			}
 
-			if ((pos < 0) && line.contains(entityVariableName + ".set")) {
-				pos = stringBuilder.length() - (line.length() + 1);
+			if (!targetExpressionPresent &&
+				line.contains(entity.getVariableName() + ".set")) {
+
+				stringBuilder.insert(
+					stringBuilder.length() - (line.length() + 1),
+					StringBundler.concat(
+						StringPool.TAB, StringPool.TAB,
+						entity.getVariableName(), targetExpression,
+						"externalReferenceCode);\n"));
+
+				targetExpressionPresent = true;
 			}
 
 			line = scanner.nextLine();
 
 			stringBuilder.append(line);
 
-			stringBuilder.append(StringPool.NEW_LINE);
-
 			openCurlyBraceCharacterCounter.count(line);
-		}
 
-		if (setExternalReferenceCodePresent || (pos < 0)) {
-			return stringBuilder.toString();
-		}
+			if (closeCurlyBraceCharacterCounter._count <=
+					openCurlyBraceCharacterCounter._count) {
 
-		stringBuilder.insert(
-			pos,
-			StringBundler.concat(
-				StringPool.TAB, StringPool.TAB, entityVariableName,
-				setExternalReferenceCode, "externalReferenceCode);\n"));
+				stringBuilder.append(StringPool.NEW_LINE);
+			}
+		}
 
 		return stringBuilder.toString();
 	}
 
 	private void _updateServiceImplMethodSignatureWithERC(
-			Entity entity, File file)
+			Entity entity, File file, int sessionType)
 		throws Exception {
 
 		ByteArrayOutputStream byteArrayOutputStream =
@@ -8123,7 +8143,8 @@ public class ServiceBuilder {
 
 				byteArrayOutputStream.write(line.getBytes());
 
-				line = _updateBody(scanner.nextLine(), entity, scanner);
+				line = _updateBody(
+					scanner.nextLine(), entity, scanner, sessionType);
 			}
 
 			byteArrayOutputStream.write(line.getBytes());
@@ -8140,6 +8161,8 @@ public class ServiceBuilder {
 
 	private String _updateSignature(String line, Scanner scanner) {
 		StringBuilder stringBuilder = new StringBuilder(line);
+
+		stringBuilder.append(StringPool.NEW_LINE);
 
 		while (!line.contains(StringPool.OPEN_CURLY_BRACE)) {
 			line = scanner.nextLine();
@@ -8170,6 +8193,8 @@ public class ServiceBuilder {
 			stringBuilder.indexOf(StringPool.OPEN_PARENTHESIS) + 1,
 			StringPool.OPEN_PARENTHESIS +
 				externalReferenceCodeArgumentExpression);
+
+		stringBuilder.append(StringPool.NEW_LINE);
 
 		return stringBuilder.toString();
 	}

--- a/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/ServiceBuilder.java
+++ b/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/ServiceBuilder.java
@@ -2185,6 +2185,41 @@ public class ServiceBuilder {
 		return sb.toString();
 	}
 
+	public static class CharacterCounter {
+
+		public CharacterCounter(char character) {
+			_character = character;
+		}
+
+		public void count(String line) {
+			for (int i = 0; i < line.length(); i++) {
+				if (line.charAt(i) == _character) {
+					_count++;
+				}
+
+				for (CharacterCounter characterCounter : _characterCounters) {
+					if (line.charAt(i) == characterCounter._character) {
+						characterCounter._count++;
+					}
+				}
+			}
+		}
+
+		public CharacterCounter getLinkedCharacterCounter(char character) {
+			CharacterCounter characterCounter = new CharacterCounter(character);
+
+			_characterCounters.add(characterCounter);
+
+			return characterCounter;
+		}
+
+		private final char _character;
+		private final List<CharacterCounter> _characterCounters =
+			new ArrayList<>();
+		private int _count;
+
+	}
+
 	private static SAXReader _getSAXReader() {
 		return SAXReaderFactory.getSAXReader(null, false, false);
 	}
@@ -8012,6 +8047,59 @@ public class ServiceBuilder {
 		Files.createFile(file.toPath());
 	}
 
+	private String _updateBody(String line, Entity entity, Scanner scanner)
+		throws Exception {
+
+		StringBuilder stringBuilder = new StringBuilder(line);
+
+		String setExternalReferenceCode = ".setExternalReferenceCode(";
+		String entityVariableName = StringUtil.lowerCaseFirstLetter(
+			entity.getName());
+		boolean setExternalReferenceCodePresent = false;
+		int pos = -1;
+
+		CharacterCounter openCurlyBraceCharacterCounter = new CharacterCounter(
+			CharPool.OPEN_CURLY_BRACE);
+
+		CharacterCounter closeCurlyBraceCharacterCounter =
+			openCurlyBraceCharacterCounter.getLinkedCharacterCounter(
+				CharPool.CLOSE_CURLY_BRACE);
+
+		openCurlyBraceCharacterCounter.count(line);
+
+		while (closeCurlyBraceCharacterCounter._count <=
+					openCurlyBraceCharacterCounter._count) {
+
+			if (line.contains(setExternalReferenceCode)) {
+				setExternalReferenceCodePresent = true;
+			}
+
+			if ((pos < 0) && line.contains(entityVariableName + ".set")) {
+				pos = stringBuilder.length() - (line.length() + 1);
+			}
+
+			line = scanner.nextLine();
+
+			stringBuilder.append(line);
+
+			stringBuilder.append(StringPool.NEW_LINE);
+
+			openCurlyBraceCharacterCounter.count(line);
+		}
+
+		if (setExternalReferenceCodePresent || (pos < 0)) {
+			return stringBuilder.toString();
+		}
+
+		stringBuilder.insert(
+			pos,
+			StringBundler.concat(
+				StringPool.TAB, StringPool.TAB, entityVariableName,
+				setExternalReferenceCode, "externalReferenceCode);\n"));
+
+		return stringBuilder.toString();
+	}
+
 	private void _updateServiceImplMethodSignatureWithERC(
 			Entity entity, File file)
 		throws Exception {
@@ -8032,6 +8120,10 @@ public class ServiceBuilder {
 					})) {
 
 				line = _updateSignature(line, scanner);
+
+				byteArrayOutputStream.write(line.getBytes());
+
+				line = _updateBody(scanner.nextLine(), entity, scanner);
 			}
 
 			byteArrayOutputStream.write(line.getBytes());

--- a/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/ServiceBuilderInvoker.java
+++ b/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/ServiceBuilderInvoker.java
@@ -76,8 +76,8 @@ public class ServiceBuilderInvoker {
 			serviceBuilderArgs.getSqlSequencesFileName(),
 			serviceBuilderArgs.getTargetEntityName(),
 			_getAbsolutePath(baseDir, serviceBuilderArgs.getTestDirName()),
-			_getAbsolutePath(baseDir, serviceBuilderArgs.getUADDirName()),
-			true);
+			_getAbsolutePath(baseDir, serviceBuilderArgs.getUADDirName()), true,
+			false);
 	}
 
 	private static String _getAbsolutePath(File baseDir, String fileName) {


### PR DESCRIPTION
After this change it would be possible to run service builder with parameter `service.impl.update.signature.erc=true`

Complete gradle task execution command would be:
`gradlew buildService --args="service.impl.update.signature.erc=true"`

Local service would be updated with:
- additional argument in add method
- body of add method would be updated with setExernalReferenceCode
Remote service would be updated with:
- additional argument in add method
- FORWARDING call to WRAPPED local service would be updated with setExernalReferenceCode
