### PR TITLE
LPS-157518 Allow developers to update ERC after creation

### DIFF
--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountAddressResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountAddressResourceImpl.java
@@ -21,6 +21,7 @@ import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.search.Sort;
@@ -402,7 +403,13 @@ public abstract class BaseAccountAddressResourceImpl
 
 		preparePatch(accountAddress, existingAccountAddress);
 
-		return putAccountAddress(id, existingAccountAddress);
+		AccountAddress putAccountAddress = putAccountAddress(
+			id, existingAccountAddress);
+
+		updateExternalReferenceCode(
+			accountAddress.getExternalReferenceCode(), accountAddress.getId());
+
+		return putAccountAddress;
 	}
 
 	/**
@@ -1086,6 +1093,14 @@ public abstract class BaseAccountAddressResourceImpl
 	protected UnsafeBiConsumer
 		<Collection<AccountAddress>, UnsafeConsumer<AccountAddress, Exception>,
 		 Exception> contextBatchUnsafeConsumer;
+
+	protected AccountAddress updateExternalReferenceCode(
+			String externalReferenceCode, Long accountAddressId)
+		throws PortalException {
+
+		return null;
+	}
+
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseChannelResourceImpl.java
@@ -20,6 +20,7 @@ import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.search.Sort;
@@ -389,8 +390,13 @@ public abstract class BaseChannelResourceImpl
 
 		preparePatch(channel, existingChannel);
 
-		return putChannelByExternalReferenceCode(
+		Channel putChannel = putChannelByExternalReferenceCode(
 			externalReferenceCode, existingChannel);
+
+		updateExternalReferenceCode(
+			channel.getExternalReferenceCode(), channel.getId());
+
+		return putChannel;
 	}
 
 	/**
@@ -586,7 +592,12 @@ public abstract class BaseChannelResourceImpl
 
 		preparePatch(channel, existingChannel);
 
-		return putChannel(channelId, existingChannel);
+		Channel putChannel = putChannel(channelId, existingChannel);
+
+		updateExternalReferenceCode(
+			channel.getExternalReferenceCode(), channel.getId());
+
+		return putChannel;
 	}
 
 	/**
@@ -1086,6 +1097,14 @@ public abstract class BaseChannelResourceImpl
 	protected UnsafeBiConsumer
 		<Collection<Channel>, UnsafeConsumer<Channel, Exception>, Exception>
 			contextBatchUnsafeConsumer;
+
+	protected Channel updateExternalReferenceCode(
+			String externalReferenceCode, Long channelId)
+		throws PortalException {
+
+		return null;
+	}
+
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/BaseShipmentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/BaseShipmentResourceImpl.java
@@ -20,6 +20,7 @@ import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.search.Sort;
@@ -404,8 +405,13 @@ public abstract class BaseShipmentResourceImpl
 
 		preparePatch(shipment, existingShipment);
 
-		return putShipmentByExternalReferenceCode(
+		Shipment putShipment = putShipmentByExternalReferenceCode(
 			externalReferenceCode, existingShipment);
+
+		updateExternalReferenceCode(
+			shipment.getExternalReferenceCode(), shipment.getId());
+
+		return putShipment;
 	}
 
 	/**
@@ -1181,6 +1187,14 @@ public abstract class BaseShipmentResourceImpl
 	protected UnsafeBiConsumer
 		<Collection<Shipment>, UnsafeConsumer<Shipment, Exception>, Exception>
 			contextBatchUnsafeConsumer;
+
+	protected Shipment updateExternalReferenceCode(
+			String externalReferenceCode, Long shipmentId)
+		throws PortalException {
+
+		return null;
+	}
+
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartCommentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartCommentResourceImpl.java
@@ -221,7 +221,10 @@ public abstract class BaseCartCommentResourceImpl
 
 		preparePatch(cartComment, existingCartComment);
 
-		return putCartComment(cartCommentId, existingCartComment);
+		CartComment putCartComment = putCartComment(
+			cartCommentId, existingCartComment);
+
+		return putCartComment;
 	}
 
 	/**

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartItemResourceImpl.java
@@ -250,7 +250,9 @@ public abstract class BaseCartItemResourceImpl
 
 		preparePatch(cartItem, existingCartItem);
 
-		return putCartItem(cartItemId, existingCartItem);
+		CartItem putCartItem = putCartItem(cartItemId, existingCartItem);
+
+		return putCartItem;
 	}
 
 	/**

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartResourceImpl.java
@@ -283,7 +283,9 @@ public abstract class BaseCartResourceImpl
 
 		preparePatch(cart, existingCart);
 
-		return putCart(cartId, existingCart);
+		Cart putCart = putCart(cartId, existingCart);
+
+		return putCart;
 	}
 
 	/**

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionResourceImpl.java
@@ -397,7 +397,10 @@ public abstract class BaseDataDefinitionResourceImpl
 
 		preparePatch(dataDefinition, existingDataDefinition);
 
-		return putDataDefinition(dataDefinitionId, existingDataDefinition);
+		DataDefinition putDataDefinition = putDataDefinition(
+			dataDefinitionId, existingDataDefinition);
+
+		return putDataDefinition;
 	}
 
 	/**

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordResourceImpl.java
@@ -735,7 +735,10 @@ public abstract class BaseDataRecordResourceImpl
 
 		preparePatch(dataRecord, existingDataRecord);
 
-		return putDataRecord(dataRecordId, existingDataRecord);
+		DataRecord putDataRecord = putDataRecord(
+			dataRecordId, existingDataRecord);
+
+		return putDataRecord;
 	}
 
 	/**

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/BaseCountryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/BaseCountryResourceImpl.java
@@ -494,7 +494,9 @@ public abstract class BaseCountryResourceImpl
 
 		preparePatch(country, existingCountry);
 
-		return putCountry(countryId, existingCountry);
+		Country putCountry = putCountry(countryId, existingCountry);
+
+		return putCountry;
 	}
 
 	/**

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/BaseRegionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/BaseRegionResourceImpl.java
@@ -631,7 +631,9 @@ public abstract class BaseRegionResourceImpl
 
 		preparePatch(region, existingRegion);
 
-		return putRegion(regionId, existingRegion);
+		Region putRegion = putRegion(regionId, existingRegion);
+
+		return putRegion;
 	}
 
 	/**

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/BaseListTypeDefinitionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/BaseListTypeDefinitionResourceImpl.java
@@ -20,6 +20,7 @@ import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.search.Sort;
@@ -510,8 +511,14 @@ public abstract class BaseListTypeDefinitionResourceImpl
 
 		preparePatch(listTypeDefinition, existingListTypeDefinition);
 
-		return putListTypeDefinition(
+		ListTypeDefinition putListTypeDefinition = putListTypeDefinition(
 			listTypeDefinitionId, existingListTypeDefinition);
+
+		updateExternalReferenceCode(
+			listTypeDefinition.getExternalReferenceCode(),
+			listTypeDefinition.getId());
+
+		return putListTypeDefinition;
 	}
 
 	/**
@@ -1037,6 +1044,14 @@ public abstract class BaseListTypeDefinitionResourceImpl
 		<Collection<ListTypeDefinition>,
 		 UnsafeConsumer<ListTypeDefinition, Exception>, Exception>
 			contextBatchUnsafeConsumer;
+
+	protected ListTypeDefinition updateExternalReferenceCode(
+			String externalReferenceCode, Long listTypeDefinitionId)
+		throws PortalException {
+
+		return null;
+	}
+
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
@@ -20,6 +20,7 @@ import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.Resource;
@@ -452,8 +453,14 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 
 		preparePatch(taxonomyCategory, existingTaxonomyCategory);
 
-		return putTaxonomyCategory(
+		TaxonomyCategory putTaxonomyCategory = putTaxonomyCategory(
 			taxonomyCategoryId, existingTaxonomyCategory);
+
+		updateExternalReferenceCode(
+			taxonomyCategory.getExternalReferenceCode(),
+			taxonomyCategory.getId());
+
+		return putTaxonomyCategory;
 	}
 
 	/**
@@ -1611,6 +1618,14 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 		<Collection<TaxonomyCategory>,
 		 UnsafeConsumer<TaxonomyCategory, Exception>, Exception>
 			contextBatchUnsafeConsumer;
+
+	protected TaxonomyCategory updateExternalReferenceCode(
+			String externalReferenceCode, String taxonomyCategoryId)
+		throws PortalException {
+
+		return null;
+	}
+
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyVocabularyResourceImpl.java
@@ -20,6 +20,7 @@ import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.Resource;
@@ -1159,8 +1160,14 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 
 		preparePatch(taxonomyVocabulary, existingTaxonomyVocabulary);
 
-		return putTaxonomyVocabulary(
+		TaxonomyVocabulary putTaxonomyVocabulary = putTaxonomyVocabulary(
 			taxonomyVocabularyId, existingTaxonomyVocabulary);
+
+		updateExternalReferenceCode(
+			taxonomyVocabulary.getExternalReferenceCode(),
+			taxonomyVocabulary.getId());
+
+		return putTaxonomyVocabulary;
 	}
 
 	/**
@@ -2003,6 +2010,14 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 		<Collection<TaxonomyVocabulary>,
 		 UnsafeConsumer<TaxonomyVocabulary, Exception>, Exception>
 			contextBatchUnsafeConsumer;
+
+	protected TaxonomyVocabulary updateExternalReferenceCode(
+			String externalReferenceCode, Long taxonomyVocabularyId)
+		throws PortalException {
+
+		return null;
+	}
+
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountResourceImpl.java
@@ -20,6 +20,7 @@ import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.search.Sort;
@@ -407,8 +408,13 @@ public abstract class BaseAccountResourceImpl
 
 		preparePatch(account, existingAccount);
 
-		return putAccountByExternalReferenceCode(
+		Account putAccount = putAccountByExternalReferenceCode(
 			externalReferenceCode, existingAccount);
+
+		updateExternalReferenceCode(
+			account.getExternalReferenceCode(), account.getId());
+
+		return putAccount;
 	}
 
 	/**
@@ -622,7 +628,12 @@ public abstract class BaseAccountResourceImpl
 
 		preparePatch(account, existingAccount);
 
-		return putAccount(accountId, existingAccount);
+		Account putAccount = putAccount(accountId, existingAccount);
+
+		updateExternalReferenceCode(
+			account.getExternalReferenceCode(), account.getId());
+
+		return putAccount;
 	}
 
 	/**
@@ -1480,6 +1491,14 @@ public abstract class BaseAccountResourceImpl
 	protected UnsafeBiConsumer
 		<Collection<Account>, UnsafeConsumer<Account, Exception>, Exception>
 			contextBatchUnsafeConsumer;
+
+	protected Account updateExternalReferenceCode(
+			String externalReferenceCode, Long accountId)
+		throws PortalException {
+
+		return null;
+	}
+
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseOrganizationResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseOrganizationResourceImpl.java
@@ -21,6 +21,7 @@ import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.search.Sort;
@@ -753,8 +754,13 @@ public abstract class BaseOrganizationResourceImpl
 
 		preparePatch(organization, existingOrganization);
 
-		return putOrganizationByExternalReferenceCode(
+		Organization putOrganization = putOrganizationByExternalReferenceCode(
 			externalReferenceCode, existingOrganization);
+
+		updateExternalReferenceCode(
+			organization.getExternalReferenceCode(), organization.getId());
+
+		return putOrganization;
 	}
 
 	/**
@@ -951,7 +957,13 @@ public abstract class BaseOrganizationResourceImpl
 
 		preparePatch(organization, existingOrganization);
 
-		return putOrganization(organizationId, existingOrganization);
+		Organization putOrganization = putOrganization(
+			organizationId, existingOrganization);
+
+		updateExternalReferenceCode(
+			organization.getExternalReferenceCode(), organization.getId());
+
+		return putOrganization;
 	}
 
 	/**
@@ -1775,6 +1787,14 @@ public abstract class BaseOrganizationResourceImpl
 	protected UnsafeBiConsumer
 		<Collection<Organization>, UnsafeConsumer<Organization, Exception>,
 		 Exception> contextBatchUnsafeConsumer;
+
+	protected Organization updateExternalReferenceCode(
+			String externalReferenceCode, String organizationId)
+		throws PortalException {
+
+		return null;
+	}
+
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserAccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserAccountResourceImpl.java
@@ -20,6 +20,7 @@ import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.search.Sort;
@@ -1599,7 +1600,13 @@ public abstract class BaseUserAccountResourceImpl
 
 		preparePatch(userAccount, existingUserAccount);
 
-		return putUserAccount(userAccountId, existingUserAccount);
+		UserAccount putUserAccount = putUserAccount(
+			userAccountId, existingUserAccount);
+
+		updateExternalReferenceCode(
+			userAccount.getExternalReferenceCode(), userAccount.getId());
+
+		return putUserAccount;
 	}
 
 	/**
@@ -2166,6 +2173,14 @@ public abstract class BaseUserAccountResourceImpl
 	protected UnsafeBiConsumer
 		<Collection<UserAccount>, UnsafeConsumer<UserAccount, Exception>,
 		 Exception> contextBatchUnsafeConsumer;
+
+	protected UserAccount updateExternalReferenceCode(
+			String externalReferenceCode, Long userAccountId)
+		throws PortalException {
+
+		return null;
+	}
+
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserGroupResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserGroupResourceImpl.java
@@ -20,6 +20,7 @@ import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.search.Sort;
@@ -408,8 +409,13 @@ public abstract class BaseUserGroupResourceImpl
 
 		preparePatch(userGroup, existingUserGroup);
 
-		return putUserGroupByExternalReferenceCode(
+		UserGroup putUserGroup = putUserGroupByExternalReferenceCode(
 			externalReferenceCode, existingUserGroup);
+
+		updateExternalReferenceCode(
+			userGroup.getExternalReferenceCode(), userGroup.getId());
+
+		return putUserGroup;
 	}
 
 	/**
@@ -594,7 +600,12 @@ public abstract class BaseUserGroupResourceImpl
 
 		preparePatch(userGroup, existingUserGroup);
 
-		return putUserGroup(userGroupId, existingUserGroup);
+		UserGroup putUserGroup = putUserGroup(userGroupId, existingUserGroup);
+
+		updateExternalReferenceCode(
+			userGroup.getExternalReferenceCode(), userGroup.getId());
+
+		return putUserGroup;
 	}
 
 	/**
@@ -1160,6 +1171,14 @@ public abstract class BaseUserGroupResourceImpl
 	protected UnsafeBiConsumer
 		<Collection<UserGroup>, UnsafeConsumer<UserGroup, Exception>, Exception>
 			contextBatchUnsafeConsumer;
+
+	protected UserGroup updateExternalReferenceCode(
+			String externalReferenceCode, Long userGroupId)
+		throws PortalException {
+
+		return null;
+	}
+
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingResourceImpl.java
@@ -23,6 +23,7 @@ import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.Resource;
@@ -297,7 +298,13 @@ public abstract class BaseBlogPostingResourceImpl
 
 		preparePatch(blogPosting, existingBlogPosting);
 
-		return putBlogPosting(blogPostingId, existingBlogPosting);
+		BlogPosting putBlogPosting = putBlogPosting(
+			blogPostingId, existingBlogPosting);
+
+		updateExternalReferenceCode(
+			blogPosting.getExternalReferenceCode(), blogPosting.getId());
+
+		return putBlogPosting;
 	}
 
 	/**
@@ -1881,6 +1888,14 @@ public abstract class BaseBlogPostingResourceImpl
 	protected UnsafeBiConsumer
 		<Collection<BlogPosting>, UnsafeConsumer<BlogPosting, Exception>,
 		 Exception> contextBatchUnsafeConsumer;
+
+	protected BlogPosting updateExternalReferenceCode(
+			String externalReferenceCode, Long blogPostingId)
+		throws PortalException {
+
+		return null;
+	}
+
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentFolderResourceImpl.java
@@ -22,6 +22,7 @@ import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.Resource;
@@ -729,7 +730,13 @@ public abstract class BaseDocumentFolderResourceImpl
 
 		preparePatch(documentFolder, existingDocumentFolder);
 
-		return putDocumentFolder(documentFolderId, existingDocumentFolder);
+		DocumentFolder putDocumentFolder = putDocumentFolder(
+			documentFolderId, existingDocumentFolder);
+
+		updateExternalReferenceCode(
+			documentFolder.getExternalReferenceCode(), documentFolder.getId());
+
+		return putDocumentFolder;
 	}
 
 	/**
@@ -2481,6 +2488,14 @@ public abstract class BaseDocumentFolderResourceImpl
 	protected UnsafeBiConsumer
 		<Collection<DocumentFolder>, UnsafeConsumer<DocumentFolder, Exception>,
 		 Exception> contextBatchUnsafeConsumer;
+
+	protected DocumentFolder updateExternalReferenceCode(
+			String externalReferenceCode, Long documentFolderId)
+		throws PortalException {
+
+		return null;
+	}
+
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseArticleResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseArticleResourceImpl.java
@@ -22,6 +22,7 @@ import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.Resource;
@@ -318,8 +319,14 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 
 		preparePatch(knowledgeBaseArticle, existingKnowledgeBaseArticle);
 
-		return putKnowledgeBaseArticle(
+		KnowledgeBaseArticle putKnowledgeBaseArticle = putKnowledgeBaseArticle(
 			knowledgeBaseArticleId, existingKnowledgeBaseArticle);
+
+		updateExternalReferenceCode(
+			knowledgeBaseArticle.getExternalReferenceCode(),
+			knowledgeBaseArticle.getId());
+
+		return putKnowledgeBaseArticle;
 	}
 
 	/**
@@ -2485,6 +2492,14 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 		<Collection<KnowledgeBaseArticle>,
 		 UnsafeConsumer<KnowledgeBaseArticle, Exception>, Exception>
 			contextBatchUnsafeConsumer;
+
+	protected KnowledgeBaseArticle updateExternalReferenceCode(
+			String externalReferenceCode, Long knowledgeBaseArticleId)
+		throws PortalException {
+
+		return null;
+	}
+
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseFolderResourceImpl.java
@@ -21,6 +21,7 @@ import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.Resource;
@@ -291,8 +292,14 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 
 		preparePatch(knowledgeBaseFolder, existingKnowledgeBaseFolder);
 
-		return putKnowledgeBaseFolder(
+		KnowledgeBaseFolder putKnowledgeBaseFolder = putKnowledgeBaseFolder(
 			knowledgeBaseFolderId, existingKnowledgeBaseFolder);
+
+		updateExternalReferenceCode(
+			knowledgeBaseFolder.getExternalReferenceCode(),
+			knowledgeBaseFolder.getId());
+
+		return putKnowledgeBaseFolder;
 	}
 
 	/**
@@ -1772,6 +1779,14 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 		<Collection<KnowledgeBaseFolder>,
 		 UnsafeConsumer<KnowledgeBaseFolder, Exception>, Exception>
 			contextBatchUnsafeConsumer;
+
+	protected KnowledgeBaseFolder updateExternalReferenceCode(
+			String externalReferenceCode, Long knowledgeBaseFolderId)
+		throws PortalException {
+
+		return null;
+	}
+
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardMessageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardMessageResourceImpl.java
@@ -22,6 +22,7 @@ import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.Resource;
@@ -333,8 +334,14 @@ public abstract class BaseMessageBoardMessageResourceImpl
 
 		preparePatch(messageBoardMessage, existingMessageBoardMessage);
 
-		return putMessageBoardMessage(
+		MessageBoardMessage putMessageBoardMessage = putMessageBoardMessage(
 			messageBoardMessageId, existingMessageBoardMessage);
+
+		updateExternalReferenceCode(
+			messageBoardMessage.getExternalReferenceCode(),
+			messageBoardMessage.getId());
+
+		return putMessageBoardMessage;
 	}
 
 	/**
@@ -2380,6 +2387,14 @@ public abstract class BaseMessageBoardMessageResourceImpl
 		<Collection<MessageBoardMessage>,
 		 UnsafeConsumer<MessageBoardMessage, Exception>, Exception>
 			contextBatchUnsafeConsumer;
+
+	protected MessageBoardMessage updateExternalReferenceCode(
+			String externalReferenceCode, Long messageBoardMessageId)
+		throws PortalException {
+
+		return null;
+	}
+
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardSectionResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardSectionResourceImpl.java
@@ -287,8 +287,10 @@ public abstract class BaseMessageBoardSectionResourceImpl
 
 		preparePatch(messageBoardSection, existingMessageBoardSection);
 
-		return putMessageBoardSection(
+		MessageBoardSection putMessageBoardSection = putMessageBoardSection(
 			messageBoardSectionId, existingMessageBoardSection);
+
+		return putMessageBoardSection;
 	}
 
 	/**

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardThreadResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardThreadResourceImpl.java
@@ -664,8 +664,10 @@ public abstract class BaseMessageBoardThreadResourceImpl
 
 		preparePatch(messageBoardThread, existingMessageBoardThread);
 
-		return putMessageBoardThread(
+		MessageBoardThread putMessageBoardThread = putMessageBoardThread(
 			messageBoardThreadId, existingMessageBoardThread);
+
+		return putMessageBoardThread;
 	}
 
 	/**

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentFolderResourceImpl.java
@@ -21,6 +21,7 @@ import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.Resource;
@@ -1700,8 +1701,15 @@ public abstract class BaseStructuredContentFolderResourceImpl
 
 		preparePatch(structuredContentFolder, existingStructuredContentFolder);
 
-		return putStructuredContentFolder(
-			structuredContentFolderId, existingStructuredContentFolder);
+		StructuredContentFolder putStructuredContentFolder =
+			putStructuredContentFolder(
+				structuredContentFolderId, existingStructuredContentFolder);
+
+		updateExternalReferenceCode(
+			structuredContentFolder.getExternalReferenceCode(),
+			structuredContentFolder.getId());
+
+		return putStructuredContentFolder;
 	}
 
 	/**
@@ -2515,6 +2523,14 @@ public abstract class BaseStructuredContentFolderResourceImpl
 		<Collection<StructuredContentFolder>,
 		 UnsafeConsumer<StructuredContentFolder, Exception>, Exception>
 			contextBatchUnsafeConsumer;
+
+	protected StructuredContentFolder updateExternalReferenceCode(
+			String externalReferenceCode, Long structuredContentFolderId)
+		throws PortalException {
+
+		return null;
+	}
+
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
@@ -23,6 +23,7 @@ import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.Resource;
@@ -1969,8 +1970,14 @@ public abstract class BaseStructuredContentResourceImpl
 
 		preparePatch(structuredContent, existingStructuredContent);
 
-		return putStructuredContent(
+		StructuredContent putStructuredContent = putStructuredContent(
 			structuredContentId, existingStructuredContent);
+
+		updateExternalReferenceCode(
+			structuredContent.getExternalReferenceCode(),
+			structuredContent.getId());
+
+		return putStructuredContent;
 	}
 
 	/**
@@ -3179,6 +3186,14 @@ public abstract class BaseStructuredContentResourceImpl
 		<Collection<StructuredContent>,
 		 UnsafeConsumer<StructuredContent, Exception>, Exception>
 			contextBatchUnsafeConsumer;
+
+	protected StructuredContent updateExternalReferenceCode(
+			String externalReferenceCode, Long structuredContentId)
+		throws PortalException {
+
+		return null;
+	}
+
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;

--- a/modules/apps/notification/notification-rest-impl/src/main/java/com/liferay/notification/rest/internal/resource/v1_0/BaseNotificationTemplateResourceImpl.java
+++ b/modules/apps/notification/notification-rest-impl/src/main/java/com/liferay/notification/rest/internal/resource/v1_0/BaseNotificationTemplateResourceImpl.java
@@ -20,6 +20,7 @@ import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.search.Sort;
@@ -594,8 +595,14 @@ public abstract class BaseNotificationTemplateResourceImpl
 
 		preparePatch(notificationTemplate, existingNotificationTemplate);
 
-		return putNotificationTemplate(
+		NotificationTemplate putNotificationTemplate = putNotificationTemplate(
 			notificationTemplateId, existingNotificationTemplate);
+
+		updateExternalReferenceCode(
+			notificationTemplate.getExternalReferenceCode(),
+			notificationTemplate.getId());
+
+		return putNotificationTemplate;
 	}
 
 	/**
@@ -1166,6 +1173,14 @@ public abstract class BaseNotificationTemplateResourceImpl
 		<Collection<NotificationTemplate>,
 		 UnsafeConsumer<NotificationTemplate, Exception>, Exception>
 			contextBatchUnsafeConsumer;
+
+	protected NotificationTemplate updateExternalReferenceCode(
+			String externalReferenceCode, Long notificationTemplateId)
+		throws PortalException {
+
+		return null;
+	}
+
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectActionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectActionResourceImpl.java
@@ -20,6 +20,7 @@ import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.search.Sort;
@@ -258,7 +259,13 @@ public abstract class BaseObjectActionResourceImpl
 
 		preparePatch(objectAction, existingObjectAction);
 
-		return putObjectAction(objectActionId, existingObjectAction);
+		ObjectAction putObjectAction = putObjectAction(
+			objectActionId, existingObjectAction);
+
+		updateExternalReferenceCode(
+			objectAction.getExternalReferenceCode(), objectAction.getId());
+
+		return putObjectAction;
 	}
 
 	/**
@@ -1071,6 +1078,14 @@ public abstract class BaseObjectActionResourceImpl
 	protected UnsafeBiConsumer
 		<Collection<ObjectAction>, UnsafeConsumer<ObjectAction, Exception>,
 		 Exception> contextBatchUnsafeConsumer;
+
+	protected ObjectAction updateExternalReferenceCode(
+			String externalReferenceCode, Long objectActionId)
+		throws PortalException {
+
+		return null;
+	}
+
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectDefinitionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectDefinitionResourceImpl.java
@@ -20,6 +20,7 @@ import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.search.Sort;
@@ -592,8 +593,14 @@ public abstract class BaseObjectDefinitionResourceImpl
 
 		preparePatch(objectDefinition, existingObjectDefinition);
 
-		return putObjectDefinition(
+		ObjectDefinition putObjectDefinition = putObjectDefinition(
 			objectDefinitionId, existingObjectDefinition);
+
+		updateExternalReferenceCode(
+			objectDefinition.getExternalReferenceCode(),
+			objectDefinition.getId());
+
+		return putObjectDefinition;
 	}
 
 	/**
@@ -1147,6 +1154,14 @@ public abstract class BaseObjectDefinitionResourceImpl
 		<Collection<ObjectDefinition>,
 		 UnsafeConsumer<ObjectDefinition, Exception>, Exception>
 			contextBatchUnsafeConsumer;
+
+	protected ObjectDefinition updateExternalReferenceCode(
+			String externalReferenceCode, Long objectDefinitionId)
+		throws PortalException {
+
+		return null;
+	}
+
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectFieldResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectFieldResourceImpl.java
@@ -20,6 +20,7 @@ import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.search.Sort;
@@ -605,7 +606,13 @@ public abstract class BaseObjectFieldResourceImpl
 
 		preparePatch(objectField, existingObjectField);
 
-		return putObjectField(objectFieldId, existingObjectField);
+		ObjectField putObjectField = putObjectField(
+			objectFieldId, existingObjectField);
+
+		updateExternalReferenceCode(
+			objectField.getExternalReferenceCode(), objectField.getId());
+
+		return putObjectField;
 	}
 
 	/**
@@ -1123,6 +1130,14 @@ public abstract class BaseObjectFieldResourceImpl
 	protected UnsafeBiConsumer
 		<Collection<ObjectField>, UnsafeConsumer<ObjectField, Exception>,
 		 Exception> contextBatchUnsafeConsumer;
+
+	protected ObjectField updateExternalReferenceCode(
+			String externalReferenceCode, Long objectFieldId)
+		throws PortalException {
+
+		return null;
+	}
+
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectValidationRuleResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectValidationRuleResourceImpl.java
@@ -592,8 +592,10 @@ public abstract class BaseObjectValidationRuleResourceImpl
 
 		preparePatch(objectValidationRule, existingObjectValidationRule);
 
-		return putObjectValidationRule(
+		ObjectValidationRule putObjectValidationRule = putObjectValidationRule(
 			objectValidationRuleId, existingObjectValidationRule);
+
+		return putObjectValidationRule;
 	}
 
 	/**

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryResourceImpl.java
@@ -20,6 +20,7 @@ import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.model.Resource;
@@ -372,8 +373,13 @@ public abstract class BaseObjectEntryResourceImpl
 
 		preparePatch(objectEntry, existingObjectEntry);
 
-		return putByExternalReferenceCode(
+		ObjectEntry putObjectEntry = putByExternalReferenceCode(
 			externalReferenceCode, existingObjectEntry);
+
+		updateExternalReferenceCode(
+			objectEntry.getExternalReferenceCode(), objectEntry.getId());
+
+		return putObjectEntry;
 	}
 
 	@io.swagger.v3.oas.annotations.Parameters(
@@ -583,8 +589,13 @@ public abstract class BaseObjectEntryResourceImpl
 
 		preparePatch(objectEntry, existingObjectEntry);
 
-		return putScopeScopeKeyByExternalReferenceCode(
+		ObjectEntry putObjectEntry = putScopeScopeKeyByExternalReferenceCode(
 			scopeKey, externalReferenceCode, existingObjectEntry);
+
+		updateExternalReferenceCode(
+			objectEntry.getExternalReferenceCode(), objectEntry.getId());
+
+		return putObjectEntry;
 	}
 
 	@io.swagger.v3.oas.annotations.Parameters(
@@ -818,7 +829,13 @@ public abstract class BaseObjectEntryResourceImpl
 
 		preparePatch(objectEntry, existingObjectEntry);
 
-		return putObjectEntry(objectEntryId, existingObjectEntry);
+		ObjectEntry putObjectEntry = putObjectEntry(
+			objectEntryId, existingObjectEntry);
+
+		updateExternalReferenceCode(
+			objectEntry.getExternalReferenceCode(), objectEntry.getId());
+
+		return putObjectEntry;
 	}
 
 	@io.swagger.v3.oas.annotations.Parameters(
@@ -1728,6 +1745,14 @@ public abstract class BaseObjectEntryResourceImpl
 	protected UnsafeBiConsumer
 		<Collection<ObjectEntry>, UnsafeConsumer<ObjectEntry, Exception>,
 		 Exception> contextBatchUnsafeConsumer;
+
+	protected ObjectEntry updateExternalReferenceCode(
+			String externalReferenceCode, Long objectEntryId)
+		throws PortalException {
+
+		return null;
+	}
+
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -106,6 +106,7 @@ public abstract class Base${schemaName}ResourceImpl
 		javaDataType = freeMarkerTool.getJavaDataType(configYAML, openAPIYAML, schemaName)!""
 		javaMethodSignatures = freeMarkerTool.getResourceJavaMethodSignatures(configYAML, openAPIYAML, schemaName)
 		generateBatch = freeMarkerTool.generateBatch(configYAML, javaDataType, javaMethodSignatures, schemaName)
+		properties = freeMarkerTool.getDTOProperties(configYAML, openAPIYAML, schema)
 	/>
 
 	<#if generateBatch>
@@ -412,8 +413,6 @@ public abstract class Base${schemaName}ResourceImpl
 
 	<#if generateBatch>
 		<#assign
-			properties = freeMarkerTool.getDTOProperties(configYAML, openAPIYAML, schema)
-
 			createStrategies = freeMarkerTool.getVulcanBatchImplementationCreateStrategies(javaMethodSignatures, properties)
 			updateStrategies = freeMarkerTool.getVulcanBatchImplementationUpdateStrategies(javaMethodSignatures)
 

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -118,6 +118,7 @@ public abstract class Base${schemaName}ResourceImpl
 	<#assign
 		generateGetPermissionCheckerMethods = false
 		generatePatchMethods = false
+		generateUpdateExternalReferenceCodeMethod = false
 		getParentBatchJavaMethodSignatures = []
 		postParentBatchJavaMethodSignatures = []
 	/>
@@ -396,15 +397,22 @@ public abstract class Base${schemaName}ResourceImpl
 					<#assign javaMethodParameterName = "put" + schemaName />
 				</#if>
 
-				return ${javaMethodParameterName}(
-					<#list javaMethodParameters as javaMethodParameter>
-						${javaMethodParameter.parameterName}
+				${javaDataType} put${schemaName} = ${javaMethodParameterName}(
+				   <#list javaMethodParameters as javaMethodParameter>
+					  ${javaMethodParameter.parameterName}
 
-						<#sep>, </#sep>
-					</#list>
+					  <#sep>, </#sep>
+				   </#list>
 
-					, existing${schemaName}
+				   , existing${schemaName}
 				);
+
+				<#if properties?keys?seq_contains("externalReferenceCode")>
+					<#assign generateUpdateExternalReferenceCodeMethod = true />
+					updateExternalReferenceCode(${schemaVarName}.getExternalReferenceCode(), ${schemaVarName}.getId());
+				</#if>
+
+				return put${schemaName};
 			<#else>
 				return new ${javaMethodSignature.returnType}();
 			</#if>
@@ -1087,6 +1095,21 @@ public abstract class Base${schemaName}ResourceImpl
 
 	<#if generateBatch>
 		protected UnsafeBiConsumer<Collection<${javaDataType}>, UnsafeConsumer<${javaDataType}, Exception>, Exception> contextBatchUnsafeConsumer;
+	</#if>
+
+	<#if generateUpdateExternalReferenceCodeMethod>
+		protected ${schemaName} updateExternalReferenceCode(
+			String externalReferenceCode,
+			<#if properties?keys?seq_contains("id")>
+				${properties["id"]}
+			<#elseif properties?keys?seq_contains(schemaVarName + "Id")>
+				${properties[ schemaVarName + "id"]}
+			</#if>
+			 ${schemaVarName}Id)
+			throws PortalException {
+
+			return null;
+		}
 	</#if>
 
 	protected com.liferay.portal.kernel.model.Company contextCompany;

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -367,15 +367,15 @@ public abstract class Base${schemaName}ResourceImpl
 					</#list>
 				);
 
-				<#assign properties = freeMarkerTool.getWritableDTOProperties(configYAML, openAPIYAML, schema) />
+				<#assign writableProperties = freeMarkerTool.getWritableDTOProperties(configYAML, openAPIYAML, schema) />
 
-				<#list properties?keys as propertyName>
+				<#list writableProperties?keys as propertyName>
 					<#if !freeMarkerTool.isDTOSchemaProperty(openAPIYAML, propertyName, schema) && !stringUtil.equals(propertyName, "id")>
 						if (${schemaVarName}.get${propertyName?cap_first}() != null) {
 							<#assign dtoPropertySchema = freeMarkerTool.getDTOPropertySchema(propertyName, schema) />
 
 							<#if dtoPropertySchema.isJsonMap()>
-								${properties[propertyName]} ${propertyName} = existing${schemaName}.get${propertyName?cap_first}();
+								${writableProperties[propertyName]} ${propertyName} = existing${schemaName}.get${propertyName?cap_first}();
 
 								${propertyName}.putAll(${schemaVarName}.get${propertyName?cap_first}());
 


### PR DESCRIPTION
**What's new:**
- Added generated method updateExternalReferenceCode in the interfaces of entities that have an ExternalReferenceCode and don't have specific implementations becouse of how are them designed.
- Added call to previously mentioned method inside the PATCH definition of previously said entities

**NOTE:** The added method returns a NULL value becouse depending of the Entity access to a specific service

Here you can find the [Jira Ticket](https://issues.liferay.com/browse/LPS-157518) that defines the Story.