### PR TITLE
LPS-182365 PATCH requests can cause localized Custom Field data to be deleted if not provided in the request body

### DIFF
--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/BaseShipmentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/BaseShipmentResourceImpl.java
@@ -367,6 +367,8 @@ public abstract class BaseShipmentResourceImpl
 			existingShipment.setCarrier(shipment.getCarrier());
 		}
 
+		existingShipment.setCustomFields(shipment.getCustomFields());
+
 		if (shipment.getExpectedDate() != null) {
 			existingShipment.setExpectedDate(shipment.getExpectedDate());
 		}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/AccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/AccountResourceImpl.java
@@ -306,15 +306,6 @@ public class AccountResourceImpl
 				_getServiceContext(account)));
 	}
 
-	@Override
-	protected void preparePatch(Account account, Account existingAccount) {
-		super.preparePatch(account, existingAccount);
-
-		if (account.getCustomFields() != null) {
-			existingAccount.setCustomFields(account.getCustomFields());
-		}
-	}
-
 	private String[] _getDomains(Account account) {
 		String[] domains = account.getDomains();
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountResourceImpl.java
@@ -372,6 +372,8 @@ public abstract class BaseAccountResourceImpl
 		Account existingAccount = getAccountByExternalReferenceCode(
 			externalReferenceCode);
 
+		existingAccount.setCustomFields(account.getCustomFields());
+
 		if (account.getDescription() != null) {
 			existingAccount.setDescription(account.getDescription());
 		}
@@ -586,6 +588,8 @@ public abstract class BaseAccountResourceImpl
 		throws Exception {
 
 		Account existingAccount = getAccount(accountId);
+
+		existingAccount.setCustomFields(account.getCustomFields());
 
 		if (account.getDescription() != null) {
 			existingAccount.setDescription(account.getDescription());

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseOrganizationResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseOrganizationResourceImpl.java
@@ -742,6 +742,8 @@ public abstract class BaseOrganizationResourceImpl
 			existingOrganization.setComment(organization.getComment());
 		}
 
+		existingOrganization.setCustomFields(organization.getCustomFields());
+
 		if (organization.getExternalReferenceCode() != null) {
 			existingOrganization.setExternalReferenceCode(
 				organization.getExternalReferenceCode());
@@ -939,6 +941,8 @@ public abstract class BaseOrganizationResourceImpl
 		if (organization.getComment() != null) {
 			existingOrganization.setComment(organization.getComment());
 		}
+
+		existingOrganization.setCustomFields(organization.getCustomFields());
 
 		if (organization.getExternalReferenceCode() != null) {
 			existingOrganization.setExternalReferenceCode(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserAccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserAccountResourceImpl.java
@@ -1567,6 +1567,8 @@ public abstract class BaseUserAccountResourceImpl
 				userAccount.getCurrentPassword());
 		}
 
+		existingUserAccount.setCustomFields(userAccount.getCustomFields());
+
 		if (userAccount.getEmailAddress() != null) {
 			existingUserAccount.setEmailAddress(userAccount.getEmailAddress());
 		}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/UserAccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/UserAccountResourceImpl.java
@@ -22,7 +22,6 @@ import com.liferay.announcements.kernel.service.AnnouncementsDeliveryLocalServic
 import com.liferay.captcha.util.CaptchaUtil;
 import com.liferay.headless.admin.user.dto.v1_0.Account;
 import com.liferay.headless.admin.user.dto.v1_0.AccountBrief;
-import com.liferay.headless.admin.user.dto.v1_0.CustomField;
 import com.liferay.headless.admin.user.dto.v1_0.EmailAddress;
 import com.liferay.headless.admin.user.dto.v1_0.OrganizationBrief;
 import com.liferay.headless.admin.user.dto.v1_0.Phone;
@@ -822,12 +821,6 @@ public class UserAccountResourceImpl
 
 		if (accountBriefs != null) {
 			existingUserAccount.setAccountBriefs(accountBriefs);
-		}
-
-		CustomField[] customFields = userAccount.getCustomFields();
-
-		if (customFields != null) {
-			existingUserAccount.setCustomFields(customFields);
 		}
 
 		OrganizationBrief[] organizationBriefs =

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingResourceImpl.java
@@ -259,6 +259,8 @@ public abstract class BaseBlogPostingResourceImpl
 			existingBlogPosting.setArticleBody(blogPosting.getArticleBody());
 		}
 
+		existingBlogPosting.setCustomFields(blogPosting.getCustomFields());
+
 		if (blogPosting.getDatePublished() != null) {
 			existingBlogPosting.setDatePublished(
 				blogPosting.getDatePublished());

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentFolderResourceImpl.java
@@ -703,6 +703,9 @@ public abstract class BaseDocumentFolderResourceImpl
 		DocumentFolder existingDocumentFolder = getDocumentFolder(
 			documentFolderId);
 
+		existingDocumentFolder.setCustomFields(
+			documentFolder.getCustomFields());
+
 		if (documentFolder.getDescription() != null) {
 			existingDocumentFolder.setDescription(
 				documentFolder.getDescription());

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseArticleResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseArticleResourceImpl.java
@@ -271,6 +271,9 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 				knowledgeBaseArticle.getArticleBody());
 		}
 
+		existingKnowledgeBaseArticle.setCustomFields(
+			knowledgeBaseArticle.getCustomFields());
+
 		if (knowledgeBaseArticle.getDescription() != null) {
 			existingKnowledgeBaseArticle.setDescription(
 				knowledgeBaseArticle.getDescription());

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseFolderResourceImpl.java
@@ -265,6 +265,9 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 		KnowledgeBaseFolder existingKnowledgeBaseFolder =
 			getKnowledgeBaseFolder(knowledgeBaseFolderId);
 
+		existingKnowledgeBaseFolder.setCustomFields(
+			knowledgeBaseFolder.getCustomFields());
+
 		if (knowledgeBaseFolder.getDescription() != null) {
 			existingKnowledgeBaseFolder.setDescription(
 				knowledgeBaseFolder.getDescription());

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardMessageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardMessageResourceImpl.java
@@ -276,6 +276,9 @@ public abstract class BaseMessageBoardMessageResourceImpl
 				messageBoardMessage.getArticleBody());
 		}
 
+		existingMessageBoardMessage.setCustomFields(
+			messageBoardMessage.getCustomFields());
+
 		if (messageBoardMessage.getEncodingFormat() != null) {
 			existingMessageBoardMessage.setEncodingFormat(
 				messageBoardMessage.getEncodingFormat());

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardSectionResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardSectionResourceImpl.java
@@ -265,6 +265,9 @@ public abstract class BaseMessageBoardSectionResourceImpl
 		MessageBoardSection existingMessageBoardSection =
 			getMessageBoardSection(messageBoardSectionId);
 
+		existingMessageBoardSection.setCustomFields(
+			messageBoardSection.getCustomFields());
+
 		if (messageBoardSection.getDescription() != null) {
 			existingMessageBoardSection.setDescription(
 				messageBoardSection.getDescription());

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardThreadResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardThreadResourceImpl.java
@@ -602,6 +602,9 @@ public abstract class BaseMessageBoardThreadResourceImpl
 				messageBoardThread.getArticleBody());
 		}
 
+		existingMessageBoardThread.setCustomFields(
+			messageBoardThread.getCustomFields());
+
 		if (messageBoardThread.getEncodingFormat() != null) {
 			existingMessageBoardThread.setEncodingFormat(
 				messageBoardThread.getEncodingFormat());

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentFolderResourceImpl.java
@@ -1671,6 +1671,9 @@ public abstract class BaseStructuredContentFolderResourceImpl
 		StructuredContentFolder existingStructuredContentFolder =
 			getStructuredContentFolder(structuredContentFolderId);
 
+		existingStructuredContentFolder.setCustomFields(
+			structuredContentFolder.getCustomFields());
+
 		if (structuredContentFolder.getDescription() != null) {
 			existingStructuredContentFolder.setDescription(
 				structuredContentFolder.getDescription());

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
@@ -1908,6 +1908,9 @@ public abstract class BaseStructuredContentResourceImpl
 				structuredContent.getContentStructureId());
 		}
 
+		existingStructuredContent.setCustomFields(
+			structuredContent.getCustomFields());
+
 		if (structuredContent.getDatePublished() != null) {
 			existingStructuredContent.setDatePublished(
 				structuredContent.getDatePublished());

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -383,6 +383,8 @@ public abstract class Base${schemaName}ResourceImpl
 								existing${schemaName}.set${propertyName?cap_first}(${schemaVarName}.get${propertyName?cap_first}());
 							</#if>
 						}
+					<#elseif stringUtil.equals(properties[propertyName], "CustomField[]")>
+						existing${schemaName}.set${propertyName?cap_first}(${schemaVarName}.get${propertyName?cap_first}());
 					</#if>
 				</#list>
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-182365

When customFields are not passed in PATCH, they are being populated in the existing entity with [acceptAllLanguages = false](https://github.com/liferay/liferay-portal/blob/aae616071f686e01dcc6c8960ae8c2a61947e976/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/UserResourceDTOConverter.java#L135).  This means [the data_i18n map is not being populated](https://github.com/liferay/liferay-portal/blob/22927a43cf8fe787f4c3f61c0ab1d68f96af093c/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/util/CustomFieldsUtil.java#L292-L294) with the existing translations and therefore only the default one ends up being set.

With this fix we ensure `customFields` are set to null if not present in the payload, which makes them being untouched at the end of the operation.