### PR TITLE
LPS-180229 | Manage categories for object entries

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testFunctional/macros/TaxonomyCategoryAPI.macro
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testFunctional/macros/TaxonomyCategoryAPI.macro
@@ -3,8 +3,15 @@ definition {
 	macro _createTaxonomyCategory {
 		var portalURL = JSONCompany.getPortalURL();
 
+		if (isSet(parentTaxonomyCategoryId)) {
+			var api = "taxonomy-categories/${parentTaxonomyCategoryId}/taxonomy-categories";
+		}
+		else {
+			var api = "taxonomy-vocabularies/${taxonomyVocabularyId}/taxonomy-categories";
+		}
+
 		var curl = '''
-			${portalURL}/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/${taxonomyVocabularyId}/taxonomy-categories \
+			${portalURL}/o/headless-admin-taxonomy/v1.0/${api} \
 				-u test@liferay.com:test \
 				-H Content-Type: application/json \
 				-d {
@@ -50,7 +57,7 @@ definition {
 	}
 
 	macro createTaxonomyCategory {
-		Variables.assertDefined(parameterList = "${taxonomyVocabularyId},${name}");
+		Variables.assertDefined(parameterList = ${name});
 
 		if (!(isSet(externalReferenceCode))) {
 			var externalReferenceCode = "";
@@ -59,6 +66,7 @@ definition {
 		var response = TaxonomyCategoryAPI._createTaxonomyCategory(
 			externalReferenceCode = ${externalReferenceCode},
 			name = ${name},
+			parentTaxonomyCategoryId = ${parentTaxonomyCategoryId},
 			taxonomyVocabularyId = ${taxonomyVocabularyId});
 
 		return ${response};
@@ -101,6 +109,29 @@ definition {
 		static var responseOfCreated = ${response};
 
 		return ${responseOfCreated};
+	}
+
+	macro staticTaxonomyCategoryId {
+		Variables.assertDefined(parameterList = ${name});
+
+		var response = TaxonomyCategoryAPI.createTaxonomyCategory(
+			externalReferenceCode = ${externalReferenceCode},
+			name = ${name},
+			parentTaxonomyCategoryId = ${parentTaxonomyCategoryId},
+			taxonomyVocabularyId = ${taxonomyVocabularyId});
+
+		var taxonomyCategoryId = JSONPathUtil.getIdValue(response = ${response});
+
+		if (isSet(parentTaxonomyCategoryId)) {
+			static var staticChildTaxonomyCategoryId = ${taxonomyCategoryId};
+
+			return ${staticChildTaxonomyCategoryId};
+		}
+		else {
+			static var staticTaxonomyCategoryId = ${taxonomyCategoryId};
+
+			return ${staticTaxonomyCategoryId};
+		}
 	}
 
 	macro updateTaxonomyCategoryByErc {

--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/CustomObjectAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/CustomObjectAPI.macro
@@ -296,7 +296,8 @@ definition {
 			fieldName = "name",
 			fieldValue = ${fieldValue},
 			keywords = ${keywords},
-			objectEntryId = ${objectEntryId});
+			objectEntryId = ${objectEntryId},
+			taxonomyCategoryIds = ${taxonomyCategoryIds});
 
 		var response = JSONCurlUtil.put(${curl});
 

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/ManageCategoriesForObjectEntries.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/ManageCategoriesForObjectEntries.testcase
@@ -1,0 +1,195 @@
+@component-name = "portal-headless"
+definition {
+
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Object";
+	property testray.main.component.name = "Headless";
+
+	setUp {
+		TestCase.setUpPortalInstanceNoSelenium();
+
+		task ("Given taxonomyVocabulary with name 'vocabulary' created") {
+			var responseFromVocabulary = TaxonomyVocabularyAPI.createTaxonomyVocabulary(
+				externalReferenceCode = "erc",
+				groupName = "Guest",
+				name = "vocabulary");
+		}
+
+		task ("And Given category with name 'category_parent' in 'vocabulary' created") {
+			var taxonomyVocabularyId = JSONPathUtil.getIdValue(response = ${responseFromVocabulary});
+
+			TaxonomyCategoryAPI.staticTaxonomyCategoryId(
+				name = "category_parent",
+				taxonomyVocabularyId = ${taxonomyVocabularyId});
+		}
+
+		task ("And Given category with name 'category_child' in 'category_parent' created") {
+			TaxonomyCategoryAPI.staticTaxonomyCategoryId(
+				name = "category_child",
+				parentTaxonomyCategoryId = ${staticTaxonomyCategoryId});
+		}
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		ObjectAdmin.deleteAllCustomObjectsViaAPI();
+
+		TaxonomyVocabularyAPI.deleteTaxonomyVocabularyByErc(
+			externalReferenceCode = "erc",
+			groupName = "Guest");
+
+		if (${testPortalInstance} == "true") {
+			PortalInstances.tearDownCP();
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 4
+	test CanEmptyTaxonomyCategoryBriefsOfObjectEntry {
+		property portal.acceptance = "true";
+
+		task ("And Given object definition 'Student' with name field created") {
+			ObjectDefinitionAPI.createAndPublishObjectDefinition(
+				en_US_label = "student",
+				en_US_plural_label = "students",
+				name = "Student",
+				requiredStringFieldName = "name");
+		}
+
+		task ("And Given Student entry created with taxonomyCategoryId of 'category_parent'") {
+			var studentEntryId = ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "students",
+				name = "Tom",
+				taxonomyCategoryIds = ${staticTaxonomyCategoryId});
+		}
+
+		task ("When requesting putStudent with {studentId} and empty "taxonomyCategoryIds": []") {
+			CustomObjectAPI.putObjectEntryById(
+				en_US_plural_label = "students",
+				fieldValue = "Tom",
+				objectEntryId = ${studentEntryId},
+				taxonomyCategoryIds = "");
+		}
+
+		task ("Then 'category_parent' is not visible in the taxonomyCategoryBriefs of the entry") {
+			var response = ObjectDefinitionAPI.getObjectEntries(en_US_plural_label = "students");
+
+			var actualValue = JSONUtil.getWithJSONPath(${response}, "$..items[?(@.id==${studentEntryId})].taxonomyCategoryBriefs");
+
+			TestUtils.assertEquals(
+				actual = ${actualValue},
+				expected = "[]");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 4
+	test CanGetTaxonomyCategoryBriefsOfEntriesCollection {
+		property portal.acceptance = "true";
+
+		task ("And Given object definition 'Student' with name field created") {
+			ObjectDefinitionAPI.createAndPublishObjectDefinition(
+				en_US_label = "student",
+				en_US_plural_label = "students",
+				name = "Student",
+				requiredStringFieldName = "name");
+		}
+
+		task ("And Given Student entry created with taxonomyCategoryId of 'category_parent'") {
+			var studentEntryId = ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "students",
+				name = "Tom",
+				taxonomyCategoryIds = ${staticTaxonomyCategoryId});
+		}
+
+		task ("When requesting getStudentsPage") {
+			var response = ObjectDefinitionAPI.getObjectEntries(en_US_plural_label = "students");
+		}
+
+		task ("Then I can see 'category_parent' details in the taxonomyCategoryBriefs of the entry with {studentId}") {
+			var actualValue = JSONUtil.getWithJSONPath(${response}, "$..items[?(@.id==${studentEntryId})].taxonomyCategoryBriefs..taxonomyCategoryName");
+
+			TestUtils.assertEquals(
+				actual = ${actualValue},
+				expected = "category_parent");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 4
+	test CanUpdateEntryWithExistingTaxonomyCategory {
+		property portal.acceptance = "true";
+
+		task ("And Given object definition 'Student' with name field created") {
+			ObjectDefinitionAPI.createAndPublishObjectDefinition(
+				en_US_label = "student",
+				en_US_plural_label = "students",
+				name = "Student",
+				requiredStringFieldName = "name");
+		}
+
+		task ("When requesting putStudent with {studentId} to associate 'category_child'") {
+			var studentEntryId = ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "students",
+				name = "Tom");
+
+			CustomObjectAPI.putObjectEntryById(
+				en_US_plural_label = "students",
+				fieldValue = "Tom",
+				objectEntryId = ${studentEntryId},
+				taxonomyCategoryIds = ${staticChildTaxonomyCategoryId});
+		}
+
+		task ("Then 'category_child' is visible in the taxonomyCategoryBriefs of the entry") {
+			var response = ObjectDefinitionAPI.getObjectEntries(en_US_plural_label = "students");
+
+			var actualValue = JSONUtil.getWithJSONPath(${response}, "$..items[?(@.id==${studentEntryId})].taxonomyCategoryBriefs..taxonomyCategoryName");
+
+			TestUtils.assertEquals(
+				actual = ${actualValue},
+				expected = "category_child");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 4
+	test CanUpdateSiteScopedObjectEntryWithTaxonomyCategoryWithinSameScope {
+		property portal.acceptance = "true";
+
+		task ("And Given object definition 'Student' with name field and Scope: Site created") {
+			ObjectDefinitionAPI.createAndPublishObjectDefinition(
+				en_US_label = "student",
+				en_US_plural_label = "students",
+				name = "Student",
+				requiredStringFieldName = "name",
+				scope = "site");
+		}
+
+		task ("And Given Student entry created") {
+			var studentEntryId = ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "students",
+				name = "Tom");
+		}
+
+		task ("When requesting putStudent with {studentId} to associate {category_parentId}") {
+			CustomObjectAPI.putObjectEntryById(
+				en_US_plural_label = "students",
+				fieldValue = "Tom",
+				objectEntryId = ${studentEntryId},
+				taxonomyCategoryIds = ${staticTaxonomyCategoryId});
+		}
+
+		task ("Then I can see 'category_parent' details in the taxonomyCategoryBriefs of the entry with {studentId}") {
+			var response = ObjectDefinitionAPI.getObjectEntries(en_US_plural_label = "students");
+
+			var actualValue = JSONUtil.getWithJSONPath(${response}, "$..items[?(@.id==${studentEntryId})].taxonomyCategoryBriefs..taxonomyCategoryName");
+
+			TestUtils.assertEquals(
+				actual = ${actualValue},
+				expected = "category_parent");
+		}
+	}
+
+}


### PR DESCRIPTION
**Background:**
Add a testcase to manage keywords associated to object entries

**Test Plan**
Background
Given taxonomyVocabulary with name 'vocabulary' created
And Given category with name 'category_parent' in 'vocabulary' created
And Given category with name 'category_child' in 'category_parent' created

CanGetTaxonomyCategoryBriefsOfEntriesCollection
And Given Student entry created with taxonomyCategoryId of 'category_parent'
When requesting getStudentsPage
Then I can see 'category_parent' details in the taxonomyCategoryBriefs of the entry with {studentId}

CanEmptyTaxonomyCategoryBriefsOfObjectEntry
And Given Student entry created with taxonomyCategoryId of 'category_parent'
When requesting putStudent with {studentId} and empty  "taxonomyCategoryIds": []
Then 'category_parent' is not visible in the taxonomyCategoryBriefs of the entry

CanUpdateEntryWithExistingTaxonomyCategory
When requesting putStudent with {studentId} to associate 'category_child'
Then 'category_child' is visible in the taxonomyCategoryBriefs of the entry

CanUpdateSiteScopedObjectEntryWithTaxonomyCategoryWithinSameScope
And Given object definition 'Student' with name field and Scope: Site created
And Given Student entry created
When requesting putStudent with {studentId} to associate {category_parentId}
Then I can see 'category_parent' details in the taxonomyCategoryBriefs of the entry with {studentId}

**Jira ticket:**
https://issues.liferay.com/browse/LPS-182485