### PR TITLE
LPS-183109 Return the proper Resource class for the GET_RELATIONSHIP operation in GraphQLDTOContributor

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/graphql/dto/v1_0/ObjectDefinitionGraphQLDTOContributor.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/graphql/dto/v1_0/ObjectDefinitionGraphQLDTOContributor.java
@@ -23,6 +23,7 @@ import com.liferay.object.rest.dto.v1_0.FileEntry;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
 import com.liferay.object.rest.dto.v1_0.Status;
 import com.liferay.object.rest.internal.odata.entity.v1_0.ObjectEntryEntityModel;
+import com.liferay.object.rest.internal.resource.v1_0.ObjectEntryRelatedObjectsResourceImpl;
 import com.liferay.object.rest.internal.resource.v1_0.ObjectEntryResourceImpl;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.object.rest.petra.sql.dsl.expression.FilterPredicateFactory;
@@ -35,6 +36,7 @@ import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.vulcan.aggregation.Aggregation;
@@ -280,16 +282,32 @@ public class ObjectDefinitionGraphQLDTOContributor
 	}
 
 	@Override
-	public Class<?> getResourceClass() {
-		return ObjectEntryResourceImpl.class;
+	public Class<?> getResourceClass(Operation operation) {
+		ObjectValuePair<Class<?>, String> objectValuePair =
+			_resourceMethods.get(operation);
+
+		if (objectValuePair == null) {
+			return null;
+		}
+
+		return objectValuePair.getKey();
 	}
 
 	@Override
 	public Method getResourceMethod(Operation operation) {
-		for (Method method : ObjectEntryResourceImpl.class.getMethods()) {
-			if (Objects.equals(
-					method.getName(), _resourceMethods.get(operation))) {
+		ObjectValuePair<Class<?>, String> objectValuePair =
+			_resourceMethods.get(operation);
 
+		if (objectValuePair == null) {
+			return null;
+		}
+
+		Class<?> clazz = objectValuePair.getKey();
+
+		String methodName = objectValuePair.getValue();
+
+		for (Method method : clazz.getMethods()) {
+			if (Objects.equals(method.getName(), methodName)) {
 				return method;
 			}
 		}
@@ -413,21 +431,34 @@ public class ObjectDefinitionGraphQLDTOContributor
 
 	private static final Pattern _relationshipIdNamePattern = Pattern.compile(
 		"r_.+_c_.+Id");
-	private static final Map<Operation, String> _resourceMethods =
-		HashMapBuilder.<Operation, String>put(
-			Operation.CREATE, "postObjectEntry"
-		).put(
-			Operation.DELETE, "deleteObjectEntry"
-		).put(
-			Operation.GET, "getObjectEntry"
-		).put(
-			Operation.GET_RELATIONSHIP,
-			"getCurrentObjectEntriesObjectRelationshipNamePage"
-		).put(
-			Operation.LIST, "getObjectEntriesPage"
-		).put(
-			Operation.UPDATE, "putObjectEntry"
-		).build();
+	private static final Map<Operation, ObjectValuePair<Class<?>, String>>
+		_resourceMethods =
+			HashMapBuilder.<Operation, ObjectValuePair<Class<?>, String>>put(
+				Operation.CREATE,
+				new ObjectValuePair<>(
+					ObjectEntryResourceImpl.class, "postObjectEntry")
+			).put(
+				Operation.DELETE,
+				new ObjectValuePair<>(
+					ObjectEntryResourceImpl.class, "deleteObjectEntry")
+			).put(
+				Operation.GET,
+				new ObjectValuePair<>(
+					ObjectEntryResourceImpl.class, "getObjectEntry")
+			).put(
+				Operation.GET_RELATIONSHIP,
+				new ObjectValuePair<>(
+					ObjectEntryRelatedObjectsResourceImpl.class,
+					"getCurrentObjectEntriesObjectRelationshipNamePage")
+			).put(
+				Operation.LIST,
+				new ObjectValuePair<>(
+					ObjectEntryResourceImpl.class, "getObjectEntriesPage")
+			).put(
+				Operation.UPDATE,
+				new ObjectValuePair<>(
+					ObjectEntryResourceImpl.class, "putObjectEntry")
+			).build();
 	private static final Map<String, Class<?>> _typedClasses =
 		HashMapBuilder.<String, Class<?>>put(
 			"BigDecimal", BigDecimal.class

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/graphql/v1_0/test/ObjectDefinitionGraphQLTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/graphql/v1_0/test/ObjectDefinitionGraphQLTest.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.object.graphql.test;
+package com.liferay.object.rest.internal.graphql.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.list.type.model.ListTypeDefinition;

--- a/modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Vulcan API
 Bundle-SymbolicName: com.liferay.portal.vulcan.api
-Bundle-Version: 33.1.0
+Bundle-Version: 34.0.0
 Export-Package:\
 	com.liferay.portal.vulcan.accept.language,\
 	com.liferay.portal.vulcan.aggregation,\

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/graphql/dto/GraphQLDTOContributor.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/graphql/dto/GraphQLDTOContributor.java
@@ -72,7 +72,7 @@ public interface GraphQLDTOContributor<D, R> {
 		return null;
 	}
 
-	public Class<?> getResourceClass();
+	public Class<?> getResourceClass(Operation operation);
 
 	public Method getResourceMethod(Operation operation);
 

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/graphql/dto/packageinfo
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/graphql/dto/packageinfo
@@ -1,1 +1,1 @@
-version 1.4.0
+version 2.0.0

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/validation/GraphQLDTOContributorRequestContext.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/validation/GraphQLDTOContributorRequestContext.java
@@ -51,7 +51,7 @@ public class GraphQLDTOContributorRequestContext
 
 	@Override
 	public Class<?> getResourceClass() {
-		return _graphQLDTOContributor.getResourceClass();
+		return _graphQLDTOContributor.getResourceClass(_operation);
 	}
 
 	@Override


### PR DESCRIPTION
Related issue: https://issues.liferay.com/browse/LPS-183109

---

This PR contains the code to return the custom objects related to custom objects in GraphQL when the relationship name is included in the GraphQL request. For that, the JAX-RS Resource implementation class that is in charge of returning the related custom objects to a custom object entry must be returned when the operation is GET_RELATIONSHIP.

cc/ @LuismiBarcos 