### PR TITLE
LPS-183204 Fix the nested field validation in a many to one relationship to allow the nested fields that contains the related object definition name

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -55,6 +55,7 @@ import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.system.SystemObjectDefinitionManager;
 import com.liferay.object.system.SystemObjectDefinitionManagerRegistry;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
@@ -62,6 +63,8 @@ import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -156,6 +159,9 @@ public class ObjectEntryDTOConverter
 				objectFieldName.lastIndexOf(StringPool.UNDERLINE) + 1),
 			"Id", "");
 
+		String manyToOneRelationshipName = StringUtil.removeLast(
+			objectFieldName, "Id");
+
 		AtomicReference<Serializable> relatedObjectEntryAtomicReference =
 			new AtomicReference<>();
 
@@ -168,6 +174,21 @@ public class ObjectEntryDTOConverter
 							nestedFieldName, objectRelationship.getName())) {
 
 						return null;
+					}
+
+					if (!StringUtil.equals(
+							nestedFieldName, manyToOneRelationshipName) &&
+						!StringUtil.equals(
+							nestedFieldName, objectRelationship.getName()) &&
+						!StringUtil.equals(
+							nestedFieldName, relatedObjectDefinitionName) &&
+						_log.isWarnEnabled()) {
+
+						_log.warn(
+							StringBundler.concat(
+								"Using deprecated nested field '",
+								nestedFieldName, "'. Please, replace with '",
+								objectRelationship.getName(), "'"));
 					}
 
 					if (relatedObjectEntryAtomicReference.get() != null) {
@@ -222,9 +243,6 @@ public class ObjectEntryDTOConverter
 		if (nestedFieldValues == null) {
 			return;
 		}
-
-		String manyToOneRelationshipName = StringUtil.removeLast(
-			objectFieldName, "Id");
 
 		for (Map.Entry<String, Serializable> entry :
 				nestedFieldValues.entrySet()) {
@@ -704,6 +722,9 @@ public class ObjectEntryDTOConverter
 
 		return map;
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		ObjectEntryDTOConverter.class);
 
 	@Reference
 	private AssetCategoryLocalService _assetCategoryLocalService;

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -156,22 +156,16 @@ public class ObjectEntryDTOConverter
 				objectFieldName.lastIndexOf(StringPool.UNDERLINE) + 1),
 			"Id", "");
 
-		String manyToOneRelationshipName = StringUtil.removeLast(
-			objectFieldName, "Id");
-
 		AtomicReference<Serializable> relatedObjectEntryAtomicReference =
 			new AtomicReference<>();
 
 		Map<String, Serializable> nestedFieldValues =
 			NestedFieldsSupplier.supply(
 				nestedFieldName -> {
-					if (!StringUtil.equals(
-							nestedFieldName, manyToOneRelationshipName) &&
-						!StringUtil.equals(nestedFieldName, objectFieldName) &&
+					if (!nestedFieldName.contains(
+							relatedObjectDefinitionName) &&
 						!StringUtil.equals(
-							nestedFieldName, objectRelationship.getName()) &&
-						!StringUtil.equals(
-							nestedFieldName, relatedObjectDefinitionName)) {
+							nestedFieldName, objectRelationship.getName())) {
 
 						return null;
 					}
@@ -229,6 +223,9 @@ public class ObjectEntryDTOConverter
 			return;
 		}
 
+		String manyToOneRelationshipName = StringUtil.removeLast(
+			objectFieldName, "Id");
+
 		for (Map.Entry<String, Serializable> entry :
 				nestedFieldValues.entrySet()) {
 
@@ -237,15 +234,12 @@ public class ObjectEntryDTOConverter
 			if (StringUtil.equals(
 					nestedFieldName, objectRelationship.getName())) {
 
-				map.put(nestedFieldName, entry.getValue());
+				map.put(objectRelationship.getName(), entry.getValue());
 			}
 
-			if (StringUtil.equals(nestedFieldName, manyToOneRelationshipName) ||
-				StringUtil.equals(nestedFieldName, objectFieldName) ||
+			if (nestedFieldName.contains(relatedObjectDefinitionName) ||
 				StringUtil.equals(
-					nestedFieldName, objectRelationship.getName()) ||
-				StringUtil.equals(
-					nestedFieldName, relatedObjectDefinitionName)) {
+					nestedFieldName, objectRelationship.getName())) {
 
 				map.put(manyToOneRelationshipName, entry.getValue());
 			}

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -3081,6 +3081,19 @@ public class ObjectEntryResourceTest {
 				_objectDefinition2.getRESTContextPath(), "?nestedFields=",
 				_objectRelationship1.getName()),
 			_objectRelationship1.getName());
+
+		_testGetNestedFieldDetailsInOneToManyRelationships(
+			StringBundler.concat(
+				_objectDefinition2.getRESTContextPath(), "?nestedFields=",
+				RandomTestUtil.randomString(),
+				StringUtil.removeFirst(
+					StringUtil.removeLast(
+						_objectDefinition1.getPKObjectFieldName(), "Id"),
+					"c_")),
+			StringBundler.concat(
+				"r_", _objectRelationship1.getName(), "_",
+				StringUtil.replaceLast(
+					_objectDefinition1.getPKObjectFieldName(), "Id", "")));
 	}
 
 	@Test


### PR DESCRIPTION
Related issue: https://issues.liferay.com/browse/LPS-183204

---

The purpose of this PR is to rollback the nested field validation in many to one relationship (one to many from the many side) to return, as before, the related object entries if the `nestedFields` query parameter contains a value that contains the related object definition name.

**NOTE:** The change is performed to keep returning certain nested field with the information of the related object entries if if matches a `contains` condition, just to avoid including breaking changes in the API

---

**How to test:**

- Deploy `modules/apps/object/object-rest-impl` module
- Create an Object Definition, for example Student
- Create an Object Definition, for example University
- Create a one to many relationship called universityStudents between University and Student
- Create a University, a Student and relate both of them
- Perform the following request:

`curl -X GET http://localhost:8080/o/c/students?nestedFields=textuniversity`

**Result:**

The university is returned in the field r_universityStudents_c_university