### PR TITLE
LPS-183309 Add missing method to the Service Access Policy

### DIFF
--- a/modules/apps/questions/questions-web/src/main/java/com/liferay/questions/web/internal/configuration/persistence/listener/QuestionsConfigurationModelListener.java
+++ b/modules/apps/questions/questions-web/src/main/java/com/liferay/questions/web/internal/configuration/persistence/listener/QuestionsConfigurationModelListener.java
@@ -167,6 +167,8 @@ public class QuestionsConfigurationModelListener
 					"getMessageBoardSection\n", headlessDeliveryPackage,
 					"MessageBoardSectionResourceImpl#",
 					"getSiteMessageBoardSectionsPage\n",
+					headlessDeliveryPackage, "MessageBoardSectionResourceImpl#",
+					"getMessageBoardSectionMessageBoardSectionsPage\n",
 					headlessDeliveryPackage, "MessageBoardThreadResourceImpl#",
 					"getMessageBoardSectionMessageBoardThreadsPage\n",
 					headlessDeliveryPackage, "MessageBoardThreadResourceImpl#",


### PR DESCRIPTION
Related ticket -> [LPS-183309](https://issues.liferay.com/browse/LPS-183309)
____
## Context of the PR
The questions app has a configuration that allows it to show the question to a not logged users (knowns as anonymous).

Internally, what the configuration does is create a [Service Access Policy](https://learn.liferay.com/w/dxp/installation-and-upgrades/securing-liferay/securing-web-services/setting-service-access-policies) to allow anonymous users to consume some specific functionalities of the services.

The PR just adds a missing method to consume by the Anonymous user (in this case, to see the sections of the message boards)