### PR TITLE
LPS-183853 Return related elements in POST / PUT for custom objects

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -156,13 +156,10 @@ public class DefaultObjectEntryManagerImpl
 					objectEntry, dtoConverterContext.getUserId()));
 
 		if (FeatureFlagManagerUtil.isEnabled("LPS-153117")) {
-			_addOrUpdateNestedObjectEntries(
+			serviceBuilderObjectEntry = _addOrUpdateNestedObjectEntries(
 				dtoConverterContext, objectDefinition, objectEntry,
 				_getObjectRelationships(objectDefinition, objectEntry),
 				serviceBuilderObjectEntry.getPrimaryKey());
-
-			serviceBuilderObjectEntry = _objectEntryLocalService.getObjectEntry(
-				serviceBuilderObjectEntry.getObjectEntryId());
 		}
 
 		return _toObjectEntry(
@@ -674,7 +671,7 @@ public class DefaultObjectEntryManagerImpl
 				objectEntry, dtoConverterContext.getUserId()));
 
 		if (FeatureFlagManagerUtil.isEnabled("LPS-153117")) {
-			_addOrUpdateNestedObjectEntries(
+			serviceBuilderObjectEntry = _addOrUpdateNestedObjectEntries(
 				dtoConverterContext, objectDefinition, objectEntry,
 				_getObjectRelationships(objectDefinition, objectEntry),
 				serviceBuilderObjectEntry.getPrimaryKey());
@@ -710,11 +707,12 @@ public class DefaultObjectEntryManagerImpl
 			uriInfo);
 	}
 
-	private void _addOrUpdateNestedObjectEntries(
-			DTOConverterContext dtoConverterContext,
-			ObjectDefinition objectDefinition, ObjectEntry objectEntry,
-			Map<String, ObjectRelationship> objectRelationships,
-			long primaryKey)
+	private com.liferay.object.model.ObjectEntry
+			_addOrUpdateNestedObjectEntries(
+				DTOConverterContext dtoConverterContext,
+				ObjectDefinition objectDefinition, ObjectEntry objectEntry,
+				Map<String, ObjectRelationship> objectRelationships,
+				long primaryKey)
 		throws Exception {
 
 		Map<String, Object> properties = objectEntry.getProperties();
@@ -786,6 +784,8 @@ public class DefaultObjectEntryManagerImpl
 				}
 			}
 		}
+
+		return _objectEntryLocalService.getObjectEntry(primaryKey);
 	}
 
 	private void _checkObjectEntryObjectDefinitionId(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -160,6 +160,9 @@ public class DefaultObjectEntryManagerImpl
 				dtoConverterContext, objectDefinition, objectEntry,
 				_getObjectRelationships(objectDefinition, objectEntry),
 				serviceBuilderObjectEntry.getPrimaryKey());
+
+			serviceBuilderObjectEntry = _objectEntryLocalService.getObjectEntry(
+				serviceBuilderObjectEntry.getObjectEntryId());
 		}
 
 		return _toObjectEntry(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -101,6 +101,7 @@ import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
+import com.liferay.portal.vulcan.fields.NestedFieldsSupplier;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.util.ActionUtil;
@@ -775,6 +776,10 @@ public class DefaultObjectEntryManagerImpl
 					_relateNestedObjectEntry(
 						objectDefinition, objectRelationship, primaryKey,
 						nestedObjectEntry.getId());
+				}
+
+				if (!nestedObjectEntries.isEmpty()) {
+					NestedFieldsSupplier.addFieldName(entry.getKey());
 				}
 			}
 		}

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -755,6 +755,10 @@ public class DefaultObjectEntryManagerImpl
 							relatedObjectDefinition.getCompanyId(),
 							dtoConverterContext.getUser(), nestedObjectEntry));
 				}
+
+				if (!nestedObjectEntries.isEmpty()) {
+					NestedFieldsSupplier.addFieldName(entry.getKey());
+				}
 			}
 			else {
 				ObjectEntryManager objectEntryManager =

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -755,10 +755,6 @@ public class DefaultObjectEntryManagerImpl
 							relatedObjectDefinition.getCompanyId(),
 							dtoConverterContext.getUser(), nestedObjectEntry));
 				}
-
-				if (!nestedObjectEntries.isEmpty()) {
-					NestedFieldsSupplier.addFieldName(entry.getKey());
-				}
 			}
 			else {
 				ObjectEntryManager objectEntryManager =
@@ -782,10 +778,10 @@ public class DefaultObjectEntryManagerImpl
 						objectDefinition, objectRelationship, primaryKey,
 						nestedObjectEntry.getId());
 				}
+			}
 
-				if (!nestedObjectEntries.isEmpty()) {
-					NestedFieldsSupplier.addFieldName(entry.getKey());
-				}
+			if (properties.containsKey(entry.getKey())) {
+				NestedFieldsSupplier.addFieldName(entry.getKey());
 			}
 		}
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
@@ -515,6 +515,7 @@ public class ObjectEntryRelatedObjectsResourceTest {
 		}
 	}
 
+	@FeatureFlags("LPS-165819")
 	@Test
 	public void testPostCustomObjectEntryWithNestedSystemObjectEntry()
 		throws Exception {
@@ -550,6 +551,7 @@ public class ObjectEntryRelatedObjectsResourceTest {
 				ObjectRelationshipConstants.TYPE_ONE_TO_MANY));
 	}
 
+	@FeatureFlags("LPS-165819")
 	@Test
 	public void testPutCustomObjectEntryWithNestedSystemObjectEntry()
 		throws Exception {
@@ -1140,6 +1142,22 @@ public class ObjectEntryRelatedObjectsResourceTest {
 				"code"
 			));
 
+		if (manyToOne) {
+			_assertSystemObjectEntry(
+				jsonObject.getJSONObject(objectRelationship.getName()),
+				_SYSTEM_OBJECT_FIELD_NAME_1, _SYSTEM_OBJECT_FIELD_VALUE,
+				userAccount);
+		}
+		else {
+			JSONArray relatedSystemObjectEntriesJSONArray =
+				jsonObject.getJSONArray(objectRelationship.getName());
+
+			_assertSystemObjectEntry(
+				relatedSystemObjectEntriesJSONArray.getJSONObject(0),
+				_SYSTEM_OBJECT_FIELD_NAME_1, _SYSTEM_OBJECT_FIELD_VALUE,
+				userAccount);
+		}
+
 		JaxRsApplicationDescriptor jaxRsApplicationDescriptor =
 			_userSystemObjectDefinitionManager.getJaxRsApplicationDescriptor();
 
@@ -1209,7 +1227,7 @@ public class ObjectEntryRelatedObjectsResourceTest {
 
 		String systemObjectFieldValue = RandomTestUtil.randomString();
 
-		HTTPTestUtil.invoke(
+		JSONObject jsonObject = HTTPTestUtil.invoke(
 			_toBody(
 				manyToOne, objectRelationship,
 				_createSystemObjectEntryJSONObject(
@@ -1219,6 +1237,22 @@ public class ObjectEntryRelatedObjectsResourceTest {
 				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
 				customObjectEntryId),
 			Http.Method.PUT);
+
+		if (manyToOne) {
+			_assertSystemObjectEntry(
+				jsonObject.getJSONObject(objectRelationship.getName()),
+				_SYSTEM_OBJECT_FIELD_NAME_2, systemObjectFieldValue,
+				putUserAccount);
+		}
+		else {
+			JSONArray relatedSystemObjectEntriesJSONArray =
+				jsonObject.getJSONArray(objectRelationship.getName());
+
+			_assertSystemObjectEntry(
+				relatedSystemObjectEntriesJSONArray.getJSONObject(0),
+				_SYSTEM_OBJECT_FIELD_NAME_2, systemObjectFieldValue,
+				putUserAccount);
+		}
 
 		JaxRsApplicationDescriptor jaxRsApplicationDescriptor =
 			_userSystemObjectDefinitionManager.getJaxRsApplicationDescriptor();

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -3983,6 +3983,28 @@ public class ObjectEntryResourceTest {
 		_assertObjectEntryField(
 			(JSONObject)nestedObjectEntriesJSONArray.get(1),
 			_OBJECT_FIELD_NAME_2, _NEW_OBJECT_FIELD_VALUE_2);
+
+		String objectEntryId = jsonObject.getString("id");
+
+		jsonObject = HTTPTestUtil.invoke(
+			null,
+			StringBundler.concat(
+				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
+				objectEntryId, "?nestedFields=",
+				_objectRelationship1.getName()),
+			Http.Method.GET);
+
+		nestedObjectEntriesJSONArray = jsonObject.getJSONArray(
+			_objectRelationship1.getName());
+
+		Assert.assertEquals(2, nestedObjectEntriesJSONArray.length());
+
+		_assertObjectEntryField(
+			(JSONObject)nestedObjectEntriesJSONArray.get(0),
+			_OBJECT_FIELD_NAME_2, _NEW_OBJECT_FIELD_VALUE_1);
+		_assertObjectEntryField(
+			(JSONObject)nestedObjectEntriesJSONArray.get(1),
+			_OBJECT_FIELD_NAME_2, _NEW_OBJECT_FIELD_VALUE_2);
 	}
 
 	@Test
@@ -4013,6 +4035,27 @@ public class ObjectEntryResourceTest {
 			).get(
 				"code"
 			));
+
+		_assertObjectEntryField(
+			jsonObject.getJSONObject(
+				StringBundler.concat(
+					"r_", _objectRelationship1.getName(), "_",
+					StringUtil.replaceLast(
+						_objectDefinition1.getPKObjectFieldName(), "Id", ""))),
+			_OBJECT_FIELD_NAME_1, _NEW_OBJECT_FIELD_VALUE_1);
+
+		String objectEntryId = jsonObject.getString("id");
+
+		jsonObject = HTTPTestUtil.invoke(
+			null,
+			StringBundler.concat(
+				_objectDefinition2.getRESTContextPath(), StringPool.SLASH,
+				objectEntryId, "?nestedFields=",
+				StringBundler.concat(
+					"r_", _objectRelationship1.getName(), "_",
+					StringUtil.replaceLast(
+						_objectDefinition1.getPKObjectFieldName(), "Id", ""))),
+			Http.Method.GET);
 
 		_assertObjectEntryField(
 			jsonObject.getJSONObject(
@@ -4052,6 +4095,28 @@ public class ObjectEntryResourceTest {
 			));
 
 		JSONArray nestedObjectEntriesJSONArray = jsonObject.getJSONArray(
+			_objectRelationship1.getName());
+
+		Assert.assertEquals(2, nestedObjectEntriesJSONArray.length());
+
+		_assertObjectEntryField(
+			(JSONObject)nestedObjectEntriesJSONArray.get(0),
+			_OBJECT_FIELD_NAME_2, _NEW_OBJECT_FIELD_VALUE_1);
+		_assertObjectEntryField(
+			(JSONObject)nestedObjectEntriesJSONArray.get(1),
+			_OBJECT_FIELD_NAME_2, _NEW_OBJECT_FIELD_VALUE_2);
+
+		String objectEntryId = jsonObject.getString("id");
+
+		jsonObject = HTTPTestUtil.invoke(
+			null,
+			StringBundler.concat(
+				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
+				objectEntryId, "?nestedFields=",
+				_objectRelationship1.getName()),
+			Http.Method.GET);
+
+		nestedObjectEntriesJSONArray = jsonObject.getJSONArray(
 			_objectRelationship1.getName());
 
 		Assert.assertEquals(2, nestedObjectEntriesJSONArray.length());
@@ -4228,6 +4293,26 @@ public class ObjectEntryResourceTest {
 		_assertObjectEntryField(
 			(JSONObject)nestedObjectEntriesJSONArray.get(1),
 			_OBJECT_FIELD_NAME_2, _NEW_OBJECT_FIELD_VALUE_2);
+
+		jsonObject = HTTPTestUtil.invoke(
+			null,
+			StringBundler.concat(
+				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
+				_objectEntry1.getPrimaryKey(), "?nestedFields=",
+				_objectRelationship1.getName()),
+			Http.Method.GET);
+
+		nestedObjectEntriesJSONArray = jsonObject.getJSONArray(
+			_objectRelationship1.getName());
+
+		Assert.assertEquals(2, nestedObjectEntriesJSONArray.length());
+
+		_assertObjectEntryField(
+			(JSONObject)nestedObjectEntriesJSONArray.get(0),
+			_OBJECT_FIELD_NAME_2, _NEW_OBJECT_FIELD_VALUE_1);
+		_assertObjectEntryField(
+			(JSONObject)nestedObjectEntriesJSONArray.get(1),
+			_OBJECT_FIELD_NAME_2, _NEW_OBJECT_FIELD_VALUE_2);
 	}
 
 	@Test
@@ -4284,6 +4369,25 @@ public class ObjectEntryResourceTest {
 					StringUtil.replaceLast(
 						_objectDefinition1.getPKObjectFieldName(), "Id", ""))),
 			_OBJECT_FIELD_NAME_1, _NEW_OBJECT_FIELD_VALUE_1);
+
+		jsonObject = HTTPTestUtil.invoke(
+			null,
+			StringBundler.concat(
+				_objectDefinition2.getRESTContextPath(), StringPool.SLASH,
+				objectEntryId, "?nestedFields=",
+				StringBundler.concat(
+					"r_", _objectRelationship1.getName(), "_",
+					StringUtil.replaceLast(
+						_objectDefinition1.getPKObjectFieldName(), "Id", ""))),
+			Http.Method.GET);
+
+		_assertObjectEntryField(
+			jsonObject.getJSONObject(
+				StringBundler.concat(
+					"r_", _objectRelationship1.getName(), "_",
+					StringUtil.replaceLast(
+						_objectDefinition1.getPKObjectFieldName(), "Id", ""))),
+			_OBJECT_FIELD_NAME_1, _NEW_OBJECT_FIELD_VALUE_1);
 	}
 
 	@Test
@@ -4330,6 +4434,26 @@ public class ObjectEntryResourceTest {
 			));
 
 		JSONArray nestedObjectEntriesJSONArray = jsonObject.getJSONArray(
+			_objectRelationship1.getName());
+
+		Assert.assertEquals(2, nestedObjectEntriesJSONArray.length());
+
+		_assertObjectEntryField(
+			(JSONObject)nestedObjectEntriesJSONArray.get(0),
+			_OBJECT_FIELD_NAME_2, _NEW_OBJECT_FIELD_VALUE_1);
+		_assertObjectEntryField(
+			(JSONObject)nestedObjectEntriesJSONArray.get(1),
+			_OBJECT_FIELD_NAME_2, _NEW_OBJECT_FIELD_VALUE_2);
+
+		jsonObject = HTTPTestUtil.invoke(
+			null,
+			StringBundler.concat(
+				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
+				_objectEntry1.getPrimaryKey(), "?nestedFields=",
+				_objectRelationship1.getName()),
+			Http.Method.GET);
+
+		nestedObjectEntriesJSONArray = jsonObject.getJSONArray(
 			_objectRelationship1.getName());
 
 		Assert.assertEquals(2, nestedObjectEntriesJSONArray.length());

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -4217,14 +4217,6 @@ public class ObjectEntryResourceTest {
 				"code"
 			));
 
-		jsonObject = HTTPTestUtil.invoke(
-			null,
-			StringBundler.concat(
-				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
-				_objectEntry1.getPrimaryKey(), "?nestedFields=",
-				_objectRelationship1.getName()),
-			Http.Method.GET);
-
 		JSONArray nestedObjectEntriesJSONArray = jsonObject.getJSONArray(
 			_objectRelationship1.getName());
 
@@ -4285,17 +4277,6 @@ public class ObjectEntryResourceTest {
 				"code"
 			));
 
-		jsonObject = HTTPTestUtil.invoke(
-			null,
-			StringBundler.concat(
-				_objectDefinition2.getRESTContextPath(), StringPool.SLASH,
-				objectEntryId, "?nestedFields=",
-				StringBundler.concat(
-					"r_", _objectRelationship1.getName(), "_",
-					StringUtil.replaceLast(
-						_objectDefinition1.getPKObjectFieldName(), "Id", ""))),
-			Http.Method.GET);
-
 		_assertObjectEntryField(
 			jsonObject.getJSONObject(
 				StringBundler.concat(
@@ -4347,14 +4328,6 @@ public class ObjectEntryResourceTest {
 			).get(
 				"code"
 			));
-
-		jsonObject = HTTPTestUtil.invoke(
-			null,
-			StringBundler.concat(
-				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
-				_objectEntry1.getPrimaryKey(), "?nestedFields=",
-				_objectRelationship1.getName()),
-			Http.Method.GET);
 
 		JSONArray nestedObjectEntriesJSONArray = jsonObject.getJSONArray(
 			_objectRelationship1.getName());

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -3972,6 +3972,18 @@ public class ObjectEntryResourceTest {
 				"code"
 			));
 
+		JSONArray nestedObjectEntriesJSONArray = jsonObject.getJSONArray(
+			_objectRelationship1.getName());
+
+		Assert.assertEquals(2, nestedObjectEntriesJSONArray.length());
+
+		_assertObjectEntryField(
+			(JSONObject)nestedObjectEntriesJSONArray.get(0),
+			_OBJECT_FIELD_NAME_2, _NEW_OBJECT_FIELD_VALUE_1);
+		_assertObjectEntryField(
+			(JSONObject)nestedObjectEntriesJSONArray.get(1),
+			_OBJECT_FIELD_NAME_2, _NEW_OBJECT_FIELD_VALUE_2);
+
 		String objectEntryId = jsonObject.getString("id");
 
 		jsonObject = HTTPTestUtil.invoke(
@@ -3982,7 +3994,7 @@ public class ObjectEntryResourceTest {
 				_objectRelationship1.getName()),
 			Http.Method.GET);
 
-		JSONArray nestedObjectEntriesJSONArray = jsonObject.getJSONArray(
+		nestedObjectEntriesJSONArray = jsonObject.getJSONArray(
 			_objectRelationship1.getName());
 
 		Assert.assertEquals(2, nestedObjectEntriesJSONArray.length());
@@ -4074,6 +4086,18 @@ public class ObjectEntryResourceTest {
 				"code"
 			));
 
+		JSONArray nestedObjectEntriesJSONArray = jsonObject.getJSONArray(
+			_objectRelationship1.getName());
+
+		Assert.assertEquals(2, nestedObjectEntriesJSONArray.length());
+
+		_assertObjectEntryField(
+			(JSONObject)nestedObjectEntriesJSONArray.get(0),
+			_OBJECT_FIELD_NAME_2, _NEW_OBJECT_FIELD_VALUE_1);
+		_assertObjectEntryField(
+			(JSONObject)nestedObjectEntriesJSONArray.get(1),
+			_OBJECT_FIELD_NAME_2, _NEW_OBJECT_FIELD_VALUE_2);
+
 		String objectEntryId = jsonObject.getString("id");
 
 		jsonObject = HTTPTestUtil.invoke(
@@ -4084,7 +4108,7 @@ public class ObjectEntryResourceTest {
 				_objectRelationship1.getName()),
 			Http.Method.GET);
 
-		JSONArray nestedObjectEntriesJSONArray = jsonObject.getJSONArray(
+		nestedObjectEntriesJSONArray = jsonObject.getJSONArray(
 			_objectRelationship1.getName());
 
 		Assert.assertEquals(2, nestedObjectEntriesJSONArray.length());

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -4036,26 +4036,27 @@ public class ObjectEntryResourceTest {
 				"code"
 			));
 
+		String nestedFieldName = StringBundler.concat(
+			"r_", _objectRelationship1.getName(), "_",
+			StringUtil.replaceLast(
+				_objectDefinition1.getPKObjectFieldName(), "Id", ""));
+
+		_assertObjectEntryField(
+			jsonObject.getJSONObject(nestedFieldName), _OBJECT_FIELD_NAME_1,
+			_NEW_OBJECT_FIELD_VALUE_1);
+
 		String objectEntryId = jsonObject.getString("id");
 
 		jsonObject = HTTPTestUtil.invoke(
 			null,
 			StringBundler.concat(
 				_objectDefinition2.getRESTContextPath(), StringPool.SLASH,
-				objectEntryId, "?nestedFields=",
-				StringBundler.concat(
-					"r_", _objectRelationship1.getName(), "_",
-					StringUtil.replaceLast(
-						_objectDefinition1.getPKObjectFieldName(), "Id", ""))),
+				objectEntryId, "?nestedFields=", nestedFieldName),
 			Http.Method.GET);
 
 		_assertObjectEntryField(
-			jsonObject.getJSONObject(
-				StringBundler.concat(
-					"r_", _objectRelationship1.getName(), "_",
-					StringUtil.replaceLast(
-						_objectDefinition1.getPKObjectFieldName(), "Id", ""))),
-			_OBJECT_FIELD_NAME_1, _NEW_OBJECT_FIELD_VALUE_1);
+			jsonObject.getJSONObject(nestedFieldName), _OBJECT_FIELD_NAME_1,
+			_NEW_OBJECT_FIELD_VALUE_1);
 	}
 
 	@Test

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -3983,28 +3983,6 @@ public class ObjectEntryResourceTest {
 		_assertObjectEntryField(
 			(JSONObject)nestedObjectEntriesJSONArray.get(1),
 			_OBJECT_FIELD_NAME_2, _NEW_OBJECT_FIELD_VALUE_2);
-
-		String objectEntryId = jsonObject.getString("id");
-
-		jsonObject = HTTPTestUtil.invoke(
-			null,
-			StringBundler.concat(
-				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
-				objectEntryId, "?nestedFields=",
-				_objectRelationship1.getName()),
-			Http.Method.GET);
-
-		nestedObjectEntriesJSONArray = jsonObject.getJSONArray(
-			_objectRelationship1.getName());
-
-		Assert.assertEquals(2, nestedObjectEntriesJSONArray.length());
-
-		_assertObjectEntryField(
-			(JSONObject)nestedObjectEntriesJSONArray.get(0),
-			_OBJECT_FIELD_NAME_2, _NEW_OBJECT_FIELD_VALUE_1);
-		_assertObjectEntryField(
-			(JSONObject)nestedObjectEntriesJSONArray.get(1),
-			_OBJECT_FIELD_NAME_2, _NEW_OBJECT_FIELD_VALUE_2);
 	}
 
 	@Test
@@ -4036,27 +4014,13 @@ public class ObjectEntryResourceTest {
 				"code"
 			));
 
-		String nestedFieldName = StringBundler.concat(
-			"r_", _objectRelationship1.getName(), "_",
-			StringUtil.replaceLast(
-				_objectDefinition1.getPKObjectFieldName(), "Id", ""));
-
 		_assertObjectEntryField(
-			jsonObject.getJSONObject(nestedFieldName), _OBJECT_FIELD_NAME_1,
-			_NEW_OBJECT_FIELD_VALUE_1);
-
-		String objectEntryId = jsonObject.getString("id");
-
-		jsonObject = HTTPTestUtil.invoke(
-			null,
-			StringBundler.concat(
-				_objectDefinition2.getRESTContextPath(), StringPool.SLASH,
-				objectEntryId, "?nestedFields=", nestedFieldName),
-			Http.Method.GET);
-
-		_assertObjectEntryField(
-			jsonObject.getJSONObject(nestedFieldName), _OBJECT_FIELD_NAME_1,
-			_NEW_OBJECT_FIELD_VALUE_1);
+			jsonObject.getJSONObject(
+				StringBundler.concat(
+					"r_", _objectRelationship1.getName(), "_",
+					StringUtil.replaceLast(
+						_objectDefinition1.getPKObjectFieldName(), "Id", ""))),
+			_OBJECT_FIELD_NAME_1, _NEW_OBJECT_FIELD_VALUE_1);
 	}
 
 	@Test
@@ -4088,28 +4052,6 @@ public class ObjectEntryResourceTest {
 			));
 
 		JSONArray nestedObjectEntriesJSONArray = jsonObject.getJSONArray(
-			_objectRelationship1.getName());
-
-		Assert.assertEquals(2, nestedObjectEntriesJSONArray.length());
-
-		_assertObjectEntryField(
-			(JSONObject)nestedObjectEntriesJSONArray.get(0),
-			_OBJECT_FIELD_NAME_2, _NEW_OBJECT_FIELD_VALUE_1);
-		_assertObjectEntryField(
-			(JSONObject)nestedObjectEntriesJSONArray.get(1),
-			_OBJECT_FIELD_NAME_2, _NEW_OBJECT_FIELD_VALUE_2);
-
-		String objectEntryId = jsonObject.getString("id");
-
-		jsonObject = HTTPTestUtil.invoke(
-			null,
-			StringBundler.concat(
-				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
-				objectEntryId, "?nestedFields=",
-				_objectRelationship1.getName()),
-			Http.Method.GET);
-
-		nestedObjectEntriesJSONArray = jsonObject.getJSONArray(
 			_objectRelationship1.getName());
 
 		Assert.assertEquals(2, nestedObjectEntriesJSONArray.length());

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -3913,6 +3913,35 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
+	public void testPostCustomObjectEntryWithEmptyNestedCustomObjectEntriesInOneToManyRelationship()
+		throws Exception {
+
+		_objectRelationship1 = ObjectRelationshipTestUtil.addObjectRelationship(
+			_objectDefinition1, _objectDefinition2, TestPropsValues.getUserId(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		JSONObject objectEntryJSONObject = JSONUtil.put(
+			_objectRelationship1.getName(), JSONFactoryUtil.createJSONArray());
+
+		JSONObject jsonObject = HTTPTestUtil.invoke(
+			objectEntryJSONObject.toString(),
+			_objectDefinition1.getRESTContextPath(), Http.Method.POST);
+
+		Assert.assertEquals(
+			0,
+			jsonObject.getJSONObject(
+				"status"
+			).get(
+				"code"
+			));
+
+		JSONArray jsonArray = jsonObject.getJSONArray(
+			_objectRelationship1.getName());
+
+		Assert.assertEquals(0, jsonArray.length());
+	}
+
+	@Test
 	public void testPostCustomObjectEntryWithInvalidNestedCustomObjectEntries()
 		throws Exception {
 

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/fields/NestedFieldsContext.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/fields/NestedFieldsContext.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.vulcan.fields;
 
+import com.liferay.portal.kernel.util.ListUtil;
+
 import java.util.List;
 
 import javax.ws.rs.core.MultivaluedMap;
@@ -31,11 +33,15 @@ public class NestedFieldsContext {
 		MultivaluedMap<String, String> queryParameters) {
 
 		_depth = depth;
-		_fieldNames = fieldNames;
+		_fieldNames = ListUtil.copy(fieldNames);
 		_message = message;
 		_pathParameters = pathParameters;
 		_resourceVersion = resourceVersion;
 		_queryParameters = queryParameters;
+	}
+
+	public void addFieldName(String fieldName) {
+		_fieldNames.add(fieldName);
 	}
 
 	public void decrementCurrentDepth() {

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/fields/NestedFieldsSupplier.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/fields/NestedFieldsSupplier.java
@@ -26,6 +26,15 @@ import java.util.Map;
  */
 public class NestedFieldsSupplier<T> {
 
+	public static void addFieldName(String fieldName) {
+		NestedFieldsContext nestedFieldsContext =
+			NestedFieldsContextThreadLocal.getNestedFieldsContext();
+
+		if (nestedFieldsContext != null) {
+			nestedFieldsContext.addFieldName(fieldName);
+		}
+	}
+
 	public static <T> T supply(
 			String fieldName,
 			UnsafeFunction<String, T, Exception> unsafeFunction)

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/writer/interceptor/NestedFieldsWriterInterceptor.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/writer/interceptor/NestedFieldsWriterInterceptor.java
@@ -20,6 +20,7 @@ import com.liferay.petra.lang.HashUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.vulcan.fields.NestedField;
 import com.liferay.portal.vulcan.fields.NestedFieldId;
 import com.liferay.portal.vulcan.fields.NestedFieldSupport;
@@ -89,7 +90,9 @@ public class NestedFieldsWriterInterceptor implements WriterInterceptor {
 		NestedFieldsContext nestedFieldsContext =
 			NestedFieldsContextThreadLocal.getNestedFieldsContext();
 
-		if (nestedFieldsContext == null) {
+		if ((nestedFieldsContext == null) ||
+			ListUtil.isEmpty(nestedFieldsContext.getFieldNames())) {
+
 			writerInterceptorContext.proceed();
 
 			return;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-183853

This PR will force the nestedField associated to the newly related elements to be added to the response. It will be equivalent to sending `nestedFields=xxxx` in a GET request.

These are the combinations supported after this PR:

| | Custom | System |
|--------|--------|--------|
| Custom | ✅ | ✅ |
| System | ⌛️ | ❌ |
