### PR TITLE
LPS-184145 Review and fix usages of ObjectDefinition#isSystem

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -344,7 +344,7 @@ public class ObjectEntryDTOConverter
 						groupId, objectRelationship.getObjectRelationshipId(),
 						primaryKey, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
-				if (relatedObjectDefinition.isSystem()) {
+				if (relatedObjectDefinition.isUnmodifiableSystemObject()) {
 					if (!FeatureFlagManagerUtil.isEnabled("LPS-165819")) {
 						return null;
 					}

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -734,7 +734,7 @@ public class DefaultObjectEntryManagerImpl
 						relatedObjectDefinition.getCompanyId(),
 						objectRelationship.getType());
 
-			if (relatedObjectDefinition.isSystem()) {
+			if (relatedObjectDefinition.isUnmodifiableSystemObject()) {
 				SystemObjectDefinitionManager systemObjectDefinitionManager =
 					_systemObjectDefinitionManagerRegistry.
 						getSystemObjectDefinitionManager(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/openapi/contributor/BaseOpenAPIContributor.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/openapi/contributor/BaseOpenAPIContributor.java
@@ -49,7 +49,7 @@ public abstract class BaseOpenAPIContributor implements OpenAPIContributor {
 	}
 
 	protected String getSchemaName(ObjectDefinition objectDefinition) {
-		if (objectDefinition.isSystem()) {
+		if (objectDefinition.isUnmodifiableSystemObject()) {
 			return StringUtil.extractLast(
 				getExternalDTOClassName(objectDefinition), StringPool.PERIOD);
 		}


### PR DESCRIPTION
`isSystem` now includes the special custom objects that are provided out of the box. To check for servicebuilder system objects we must check for `isUnmodifiableSystem`. Some places in headless code had not been properly migrated.