### PR TITLE
LPS-184183 Allow string fields to be passed as json

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/resolver/ObjectMapperContextResolver.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/resolver/ObjectMapperContextResolver.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.vulcan.internal.jaxrs.deserializer.JSONStringStdDeserializer;
 import com.liferay.portal.vulcan.internal.jaxrs.serializer.JSONArrayStdSerializer;
 import com.liferay.portal.vulcan.internal.jaxrs.serializer.JSONObjectStdSerializer;
 
@@ -50,6 +51,9 @@ public class ObjectMapperContextResolver
 			registerModule(
 				new SimpleModule() {
 					{
+						addDeserializer(
+							String.class,
+							new JSONStringStdDeserializer(String.class));
 						addSerializer(
 							JSONArray.class,
 							new JSONArrayStdSerializer(JSONArray.class));

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/deserializer/JSONStringStdDeserializer.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/deserializer/JSONStringStdDeserializer.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.internal.jaxrs.deserializer;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.TreeNode;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.io.IOException;
+
+/**
+ * @author Alejandro Tardín
+ */
+public class JSONStringStdDeserializer extends StdDeserializer<String> {
+
+	public JSONStringStdDeserializer(Class<String> clazz) {
+		super(clazz);
+	}
+
+	@Override
+	public String deserialize(
+			JsonParser jsonParser,
+			DeserializationContext deserializationContext)
+		throws IOException {
+
+		if (jsonParser.hasToken(JsonToken.VALUE_STRING)) {
+			return jsonParser.getText();
+		}
+
+		if (StringUtil.endsWith(
+				StringUtil.toLowerCase(jsonParser.getCurrentName()), "json")) {
+
+			TreeNode treeNode = jsonParser.readValueAsTree();
+
+			return treeNode.toString();
+		}
+
+		return (String)deserializationContext.handleUnexpectedToken(
+			String.class, jsonParser);
+	}
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/test/JSONMessageBodyReaderTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/test/JSONMessageBodyReaderTest.java
@@ -1,0 +1,195 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.internal.jaxrs.context.provider.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.servlet.HttpHeaders;
+import com.liferay.portal.kernel.util.Base64;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.nio.charset.StandardCharsets;
+
+import java.util.Collections;
+import java.util.Set;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Application;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceRegistration;
+
+/**
+ * @author Alejandro Tardín
+ */
+@RunWith(Arquillian.class)
+public class JSONMessageBodyReaderTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() {
+		Bundle bundle = FrameworkUtil.getBundle(
+			JSONMessageBodyReaderTest.class);
+
+		BundleContext bundleContext = bundle.getBundleContext();
+
+		_serviceRegistration = bundleContext.registerService(
+			Application.class, new TestApplication(),
+			HashMapDictionaryBuilder.<String, Object>put(
+				"liferay.auth.verifier", true
+			).put(
+				"liferay.jackson", false
+			).put(
+				"liferay.oauth2", false
+			).put(
+				"osgi.jaxrs.application.base", "/test-vulcan"
+			).put(
+				"osgi.jaxrs.extension.select",
+				"(osgi.jaxrs.name=Liferay.Vulcan)"
+			).build());
+	}
+
+	@After
+	public void tearDown() {
+		_serviceRegistration.unregister();
+	}
+
+	@Test
+	public void testCanNotDeserializeObjectToTextString() throws Exception {
+		Assert.assertEquals(
+			JSONUtil.put(
+				"status", "BAD_REQUEST"
+			).put(
+				"title", "Unable to map JSON path: text"
+			).toString(),
+			_getJSONObject(
+				JSONUtil.put("text", JSONUtil.put("key", "value")),
+				"test-vulcan/test", Http.Method.POST
+			).toString());
+	}
+
+	@Test
+	public void testDeserializeArrayToJSONString() throws Exception {
+		Assert.assertEquals(
+			JSONUtil.put(
+				"json",
+				JSONUtil.putAll(
+					"item1", "item2"
+				).toString()
+			).toString(),
+			_getJSONObject(
+				JSONUtil.put("json", JSONUtil.putAll("item1", "item2")),
+				"test-vulcan/test", Http.Method.POST
+			).toString());
+	}
+
+	@Test
+	public void testDeserializeObjectToJSONString() throws Exception {
+		Assert.assertEquals(
+			JSONUtil.put(
+				"json",
+				JSONUtil.put(
+					"key", "value"
+				).toString()
+			).toString(),
+			_getJSONObject(
+				JSONUtil.put("json", JSONUtil.put("key", "value")),
+				"test-vulcan/test", Http.Method.POST
+			).toString());
+	}
+
+	@Test
+	public void testDeserializeStringToString() throws Exception {
+		Assert.assertEquals(
+			JSONUtil.put(
+				"json", "content"
+			).toString(),
+			_getJSONObject(
+				JSONUtil.put("json", "content"), "test-vulcan/test",
+				Http.Method.POST
+			).toString());
+	}
+
+	public static class TestApplication extends Application {
+
+		@Override
+		public Set<Object> getSingletons() {
+			return Collections.singleton(this);
+		}
+
+		@Consumes("application/json")
+		@Path("/test")
+		@POST
+		@Produces("application/json")
+		public TestDTO testClass(TestDTO testDTO) {
+			return testDTO;
+		}
+
+	}
+
+	public static class TestDTO {
+
+		public String json;
+		public String text;
+
+	}
+
+	private JSONObject _getJSONObject(
+			JSONObject bodyJSONObject, String endpoint, Http.Method httpMethod)
+		throws Exception {
+
+		Http.Options options = new Http.Options();
+
+		options.addHeader(
+			HttpHeaders.CONTENT_TYPE, ContentTypes.APPLICATION_JSON);
+		options.addHeader(
+			"Authorization",
+			"Basic " + Base64.encode("test@liferay.com:test".getBytes()));
+		options.setLocation("http://localhost:8080/o/" + endpoint);
+		options.setMethod(httpMethod);
+
+		options.setBody(
+			bodyJSONObject.toString(), ContentTypes.APPLICATION_JSON,
+			StandardCharsets.UTF_8.name());
+
+		return JSONFactoryUtil.createJSONObject(HttpUtil.URLtoString(options));
+	}
+
+	private ServiceRegistration<Application> _serviceRegistration;
+
+}

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/src/main/resources/site-initializer/object-entries/1_application.json
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/src/main/resources/site-initializer/object-entries/1_application.json
@@ -6,7 +6,60 @@
 			"applicationCreateDate": "2021-11-17T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "Los Angeles",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":19,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Osgood\",\"gender\":\"Male\",\"lastName\":\"Dummer\",\"maritalStatus\":\"Widowed\",\"millitaryAffiliation\":null,\"occupation\":\"Government\",\"governmentAffliation\":\"ABC Sherriff Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"Masters\",\"creditRating\":\"Very Good\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":70785,\"year\":2017,\"make\":\"Ford\",\"model\":\"F-150 Super 250 XL\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring\",\"ownership\":\"loan\",\"primaryusage\":\"business\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$30,000 / $60,000\",\"medical\":\"$10,000\",\"propertyDamage\":\"$25,000\",\"uninsuredOrUnderinsuredMBI\":\"$300,000\",\"uninsuredOrUnderinsuredMPD\":\"$500,000 / $ 500,000\"},\"vehicles\":[{\"collision\":\"$1,000\",\"comprehensive\":\"$1,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$30,000 / $60,000",
+						"medical": "$10,000",
+						"propertyDamage": "$25,000",
+						"uninsuredOrUnderinsuredMBI": "$300,000",
+						"uninsuredOrUnderinsuredMPD": "$500,000 / $ 500,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$1,000",
+							"comprehensive": "$1,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 19,
+							"creditRating": "Very Good",
+							"firstName": "Osgood",
+							"gender": "Male",
+							"governmentAffliation": "ABC Sherriff Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "Masters",
+							"lastName": "Dummer",
+							"maritalStatus": "Widowed",
+							"millitaryAffiliation": null,
+							"occupation": "Government",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 70785,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring",
+							"make": "Ford",
+							"model": "F-150 Super 250 XL",
+							"ownership": "loan",
+							"primaryusage": "business",
+							"year": 2017
+						}
+					]
+				}
+			},
 			"email": "odummer1a@wikia.com",
 			"externalReferenceCode": "AP-58-839-1582",
 			"firstName": "Osgood",
@@ -26,7 +79,60 @@
 			"applicationCreateDate": "2022-01-01T00:00:00.000+00:00",
 			"applicationStatus": "incomplete",
 			"city": "New York City",
-			"dataJSON": "{\"contactInfo\":{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"dateOfBirth\":\"04/06/2023\",\"ownership\":\"own\"}},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":18,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Pincus\",\"gender\":\"Male\",\"lastName\":\"Middup\",\"maritalStatus\":\"Separated\",\"millitaryAffiliation\":null,\"occupation\":\"Government\",\"governmentAffliation\":\"State Firefighters Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Average\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":20276,\"year\":2016,\"make\":\"Volvo\",\"model\":\"S90 R-Design\",\"features\":\"Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"lease\",\"primaryusage\":\"pleasure\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $100,000\",\"medical\":\"$1,000\",\"propertyDamage\":\"$300,000\",\"uninsuredOrUnderinsuredMBI\":\"$150,000\",\"uninsuredOrUnderinsuredMPD\":\"$25,000 / $50,000\"},\"vehicles\":[{\"collision\":\"$5,000\",\"comprehensive\":\"$5,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2023",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $100,000",
+						"medical": "$1,000",
+						"propertyDamage": "$300,000",
+						"uninsuredOrUnderinsuredMBI": "$150,000",
+						"uninsuredOrUnderinsuredMPD": "$25,000 / $50,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$5,000",
+							"comprehensive": "$5,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 18,
+							"creditRating": "Average",
+							"firstName": "Pincus",
+							"gender": "Male",
+							"governmentAffliation": "State Firefighters Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "College",
+							"lastName": "Middup",
+							"maritalStatus": "Separated",
+							"millitaryAffiliation": null,
+							"occupation": "Government",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 20276,
+							"features": "Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Volvo",
+							"model": "S90 R-Design",
+							"ownership": "lease",
+							"primaryusage": "pleasure",
+							"year": 2016
+						}
+					]
+				}
+			},
 			"email": "pmiddup2@ted.com",
 			"externalReferenceCode": "AP-18-059-1877",
 			"firstName": "Pincus",
@@ -45,7 +151,60 @@
 			"applicationCreateDate": "2023-04-05T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "Los Angeles",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":19,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Osgood\",\"gender\":\"Male\",\"lastName\":\"Dummer\",\"maritalStatus\":\"Widowed\",\"millitaryAffiliation\":null,\"occupation\":\"Government\",\"governmentAffliation\":\"ABC Sherriff Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"Masters\",\"creditRating\":\"Very Good\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":70785,\"year\":2017,\"make\":\"Ford\",\"model\":\"F-150 Super 250 XL\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring\",\"ownership\":\"loan\",\"primaryusage\":\"business\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$30,000 / $60,000\",\"medical\":\"$10,000\",\"propertyDamage\":\"$25,000\",\"uninsuredOrUnderinsuredMBI\":\"$300,000\",\"uninsuredOrUnderinsuredMPD\":\"$500,000 / $ 500,000\"},\"vehicles\":[{\"collision\":\"$1,000\",\"comprehensive\":\"$1,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$30,000 / $60,000",
+						"medical": "$10,000",
+						"propertyDamage": "$25,000",
+						"uninsuredOrUnderinsuredMBI": "$300,000",
+						"uninsuredOrUnderinsuredMPD": "$500,000 / $ 500,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$1,000",
+							"comprehensive": "$1,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 19,
+							"creditRating": "Very Good",
+							"firstName": "Osgood",
+							"gender": "Male",
+							"governmentAffliation": "ABC Sherriff Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "Masters",
+							"lastName": "Dummer",
+							"maritalStatus": "Widowed",
+							"millitaryAffiliation": null,
+							"occupation": "Government",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 70785,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring",
+							"make": "Ford",
+							"model": "F-150 Super 250 XL",
+							"ownership": "loan",
+							"primaryusage": "business",
+							"year": 2017
+						}
+					]
+				}
+			},
 			"email": "odummer1a@wikia.com",
 			"externalReferenceCode": "AP-60-859-1682",
 			"firstName": "Osgood",
@@ -65,7 +224,60 @@
 			"applicationCreateDate": "2023-03-31T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "New York City",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":18,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Pincus\",\"gender\":\"Male\",\"lastName\":\"Middup\",\"maritalStatus\":\"Separated\",\"millitaryAffiliation\":null,\"occupation\":\"Government\",\"governmentAffliation\":\"State Firefighters Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Average\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":20276,\"year\":2016,\"make\":\"Volvo\",\"model\":\"S90 R-Design\",\"features\":\"Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"lease\",\"primaryusage\":\"pleasure\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $100,000\",\"medical\":\"$1,000\",\"propertyDamage\":\"$300,000\",\"uninsuredOrUnderinsuredMBI\":\"$150,000\",\"uninsuredOrUnderinsuredMPD\":\"$25,000 / $50,000\"},\"vehicles\":[{\"collision\":\"$5,000\",\"comprehensive\":\"$5,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $100,000",
+						"medical": "$1,000",
+						"propertyDamage": "$300,000",
+						"uninsuredOrUnderinsuredMBI": "$150,000",
+						"uninsuredOrUnderinsuredMPD": "$25,000 / $50,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$5,000",
+							"comprehensive": "$5,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 18,
+							"creditRating": "Average",
+							"firstName": "Pincus",
+							"gender": "Male",
+							"governmentAffliation": "State Firefighters Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "College",
+							"lastName": "Middup",
+							"maritalStatus": "Separated",
+							"millitaryAffiliation": null,
+							"occupation": "Government",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 20276,
+							"features": "Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Volvo",
+							"model": "S90 R-Design",
+							"ownership": "lease",
+							"primaryusage": "pleasure",
+							"year": 2016
+						}
+					]
+				}
+			},
 			"email": "pmiddup2@ted.com",
 			"externalReferenceCode": "AP-60-859-1683",
 			"firstName": "Pincus",
@@ -85,7 +297,60 @@
 			"applicationCreateDate": "2021-10-07T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "Buffalo",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":19,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Jessa\",\"gender\":\"Female\",\"lastName\":\"Capron\",\"maritalStatus\":\"Separated\",\"millitaryAffiliation\":null,\"occupation\":\"Dentist\",\"governmentAffliation\":\"ABC Sherriff Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Poor\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":25174,\"year\":2016,\"make\":\"Ford\",\"model\":\"Mustang GT Fastback\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring\",\"ownership\":\"lease\",\"primaryusage\":\"commuting\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$500,000 / $ 500,000\",\"medical\":\"$5,000\",\"propertyDamage\":\"$25,000\",\"uninsuredOrUnderinsuredMBI\":\"$25,000\",\"uninsuredOrUnderinsuredMPD\":\"$300,000 / $ 300,000\"},\"vehicles\":[{\"collision\":\"$5,000\",\"comprehensive\":\"$750\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$500,000 / $ 500,000",
+						"medical": "$5,000",
+						"propertyDamage": "$25,000",
+						"uninsuredOrUnderinsuredMBI": "$25,000",
+						"uninsuredOrUnderinsuredMPD": "$300,000 / $ 300,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$5,000",
+							"comprehensive": "$750"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 19,
+							"creditRating": "Poor",
+							"firstName": "Jessa",
+							"gender": "Female",
+							"governmentAffliation": "ABC Sherriff Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "College",
+							"lastName": "Capron",
+							"maritalStatus": "Separated",
+							"millitaryAffiliation": null,
+							"occupation": "Dentist",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 25174,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring",
+							"make": "Ford",
+							"model": "Mustang GT Fastback",
+							"ownership": "lease",
+							"primaryusage": "commuting",
+							"year": 2016
+						}
+					]
+				}
+			},
 			"email": "jcapronb@cisco.com",
 			"externalReferenceCode": "AP-62-174-3884",
 			"firstName": "Jessa",
@@ -105,7 +370,60 @@
 			"applicationCreateDate": "2022-01-19T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "Rochester",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":20,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Shurlocke\",\"gender\":\"Male\",\"lastName\":\"Letessier\",\"maritalStatus\":\"Separated\",\"millitaryAffiliation\":null,\"occupation\":\"Dentist\",\"governmentAffliation\":\"ABC Sherriff Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"Phd\",\"creditRating\":\"Very Good\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":24871,\"year\":2013,\"make\":\"Toyota\",\"model\":\"Tundra SR6\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"lease\",\"primaryusage\":\"business\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $100,000\",\"medical\":\"$2,000\",\"propertyDamage\":\"$150,000\",\"uninsuredOrUnderinsuredMBI\":\"$25,000\",\"uninsuredOrUnderinsuredMPD\":\"$30,000 / $60,000\"},\"vehicles\":[{\"collision\":\"$5,000\",\"comprehensive\":\"$5,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $100,000",
+						"medical": "$2,000",
+						"propertyDamage": "$150,000",
+						"uninsuredOrUnderinsuredMBI": "$25,000",
+						"uninsuredOrUnderinsuredMPD": "$30,000 / $60,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$5,000",
+							"comprehensive": "$5,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 20,
+							"creditRating": "Very Good",
+							"firstName": "Shurlocke",
+							"gender": "Male",
+							"governmentAffliation": "ABC Sherriff Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "Phd",
+							"lastName": "Letessier",
+							"maritalStatus": "Separated",
+							"millitaryAffiliation": null,
+							"occupation": "Dentist",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 24871,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Toyota",
+							"model": "Tundra SR6",
+							"ownership": "lease",
+							"primaryusage": "business",
+							"year": 2013
+						}
+					]
+				}
+			},
 			"email": "sletessiern@google.ru",
 			"externalReferenceCode": "AP-95-825-9374",
 			"firstName": "Shurlocke",
@@ -125,7 +443,60 @@
 			"applicationCreateDate": "2021-12-31T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "Jamaica",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":19,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Jameson\",\"gender\":\"Male\",\"lastName\":\"Norcliff\",\"maritalStatus\":\"Single\",\"millitaryAffiliation\":null,\"occupation\":\"Dentist\",\"governmentAffliation\":\"State Firefighters Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Very Good\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":27768,\"year\":2018,\"make\":\"Volvo\",\"model\":\"S90 R-Design\",\"features\":\"Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"own\",\"primaryusage\":\"commuting\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$30,000 / $60,000\",\"medical\":\"$1,000\",\"propertyDamage\":\"$150,000\",\"uninsuredOrUnderinsuredMBI\":\"$25,000\",\"uninsuredOrUnderinsuredMPD\":\"$100,000 / $ 300,000\"},\"vehicles\":[{\"collision\":\"$2,000\",\"comprehensive\":\"$5,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$30,000 / $60,000",
+						"medical": "$1,000",
+						"propertyDamage": "$150,000",
+						"uninsuredOrUnderinsuredMBI": "$25,000",
+						"uninsuredOrUnderinsuredMPD": "$100,000 / $ 300,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$2,000",
+							"comprehensive": "$5,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 19,
+							"creditRating": "Very Good",
+							"firstName": "Jameson",
+							"gender": "Male",
+							"governmentAffliation": "State Firefighters Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "College",
+							"lastName": "Norcliff",
+							"maritalStatus": "Single",
+							"millitaryAffiliation": null,
+							"occupation": "Dentist",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 27768,
+							"features": "Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Volvo",
+							"model": "S90 R-Design",
+							"ownership": "own",
+							"primaryusage": "commuting",
+							"year": 2018
+						}
+					]
+				}
+			},
 			"email": "jnorcliff3@bandcamp.com",
 			"externalReferenceCode": "AP-84-436-9853",
 			"firstName": "Jameson",
@@ -145,7 +516,60 @@
 			"applicationCreateDate": "2022-05-09T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "South Lake Tahoe",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":18,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Keelby\",\"gender\":\"Male\",\"lastName\":\"Vaen\",\"maritalStatus\":\"Married\",\"millitaryAffiliation\":null,\"occupation\":\"Engineer\",\"governmentAffliation\":\"FBI Academy Associates\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"Masters\",\"creditRating\":\"Poor\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":75619,\"year\":2016,\"make\":\"Ford\",\"model\":\"F-150 Super 250 XL\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"own\",\"primaryusage\":\"commuting\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $ 300,000\",\"medical\":\"$5,000\",\"propertyDamage\":\"$100,000\",\"uninsuredOrUnderinsuredMBI\":\"$300,000\",\"uninsuredOrUnderinsuredMPD\":\"$30,000 / $60,000\"},\"vehicles\":[{\"collision\":\"$250\",\"comprehensive\":\"$500\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $ 300,000",
+						"medical": "$5,000",
+						"propertyDamage": "$100,000",
+						"uninsuredOrUnderinsuredMBI": "$300,000",
+						"uninsuredOrUnderinsuredMPD": "$30,000 / $60,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$250",
+							"comprehensive": "$500"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 18,
+							"creditRating": "Poor",
+							"firstName": "Keelby",
+							"gender": "Male",
+							"governmentAffliation": "FBI Academy Associates",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "Masters",
+							"lastName": "Vaen",
+							"maritalStatus": "Married",
+							"millitaryAffiliation": null,
+							"occupation": "Engineer",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 75619,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Ford",
+							"model": "F-150 Super 250 XL",
+							"ownership": "own",
+							"primaryusage": "commuting",
+							"year": 2016
+						}
+					]
+				}
+			},
 			"email": "kvaens@devhub.com",
 			"externalReferenceCode": "AP-57-081-0414",
 			"firstName": "Keelby",
@@ -165,7 +589,60 @@
 			"applicationCreateDate": "2022-01-03T00:00:00.000+00:00",
 			"applicationStatus": "rejected",
 			"city": "Bakersfield",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":18,\"hasAccidentOrCitations\":\"yes\",\"accidentCitation\":\"Citation - Driving under the influence\",\"firstName\":\"Dynah\",\"gender\":\"Female\",\"lastName\":\"Jordeson\",\"maritalStatus\":\"Married\",\"millitaryAffiliation\":null,\"occupation\":\"Dentist\",\"governmentAffliation\":\"FBI Academy Associates\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"Masters\",\"creditRating\":\"Average\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":73994,\"year\":2019,\"make\":\"Toyota\",\"model\":\"Camry Hybrid XLE\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring\",\"ownership\":\"own\",\"primaryusage\":\"commuting\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$30,000 / $60,000\",\"medical\":\"$5,000\",\"propertyDamage\":\"$25,000\",\"uninsuredOrUnderinsuredMBI\":\"$25,000\",\"uninsuredOrUnderinsuredMPD\":\"$300,000 / $ 300,000\"},\"vehicles\":[{\"collision\":\"$250\",\"comprehensive\":\"$1,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$30,000 / $60,000",
+						"medical": "$5,000",
+						"propertyDamage": "$25,000",
+						"uninsuredOrUnderinsuredMBI": "$25,000",
+						"uninsuredOrUnderinsuredMPD": "$300,000 / $ 300,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$250",
+							"comprehensive": "$1,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": "Citation - Driving under the influence",
+							"ageFirstLicensed": 18,
+							"creditRating": "Average",
+							"firstName": "Dynah",
+							"gender": "Female",
+							"governmentAffliation": "FBI Academy Associates",
+							"hasAccidentOrCitations": "yes",
+							"highestEducation": "Masters",
+							"lastName": "Jordeson",
+							"maritalStatus": "Married",
+							"millitaryAffiliation": null,
+							"occupation": "Dentist",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 73994,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring",
+							"make": "Toyota",
+							"model": "Camry Hybrid XLE",
+							"ownership": "own",
+							"primaryusage": "commuting",
+							"year": 2019
+						}
+					]
+				}
+			},
 			"email": "djordeson17@alibaba.com",
 			"externalReferenceCode": "AP-95-804-2114",
 			"firstName": "Dynah",
@@ -184,7 +661,60 @@
 			"applicationCreateDate": "2021-11-10T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "Long Beach",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":16,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Evvy\",\"gender\":\"Female\",\"lastName\":\"Woodley\",\"maritalStatus\":\"Married\",\"millitaryAffiliation\":null,\"occupation\":\"Dentist\",\"governmentAffliation\":\"FBI Academy Associates\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"High School\",\"creditRating\":\"Good\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":5490,\"year\":2018,\"make\":\"Volvo\",\"model\":\"XC90 Inscription\",\"features\":\"Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"own\",\"primaryusage\":\"pleasure\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $100,000\",\"medical\":\"$10,000\",\"propertyDamage\":\"$300,000\",\"uninsuredOrUnderinsuredMBI\":\"$100,000\",\"uninsuredOrUnderinsuredMPD\":\"$50,000 / $100,000\"},\"vehicles\":[{\"collision\":\"$1,000\",\"comprehensive\":\"$1,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $100,000",
+						"medical": "$10,000",
+						"propertyDamage": "$300,000",
+						"uninsuredOrUnderinsuredMBI": "$100,000",
+						"uninsuredOrUnderinsuredMPD": "$50,000 / $100,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$1,000",
+							"comprehensive": "$1,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 16,
+							"creditRating": "Good",
+							"firstName": "Evvy",
+							"gender": "Female",
+							"governmentAffliation": "FBI Academy Associates",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "High School",
+							"lastName": "Woodley",
+							"maritalStatus": "Married",
+							"millitaryAffiliation": null,
+							"occupation": "Dentist",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 5490,
+							"features": "Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Volvo",
+							"model": "XC90 Inscription",
+							"ownership": "own",
+							"primaryusage": "pleasure",
+							"year": 2018
+						}
+					]
+				}
+			},
 			"email": "ewoodleyl@gov.uk",
 			"externalReferenceCode": "AP-96-710-6810",
 			"firstName": "Evvy",
@@ -204,7 +734,60 @@
 			"applicationCreateDate": "2022-12-06T00:00:00.000+00:00",
 			"applicationStatus": "rejected",
 			"city": "Lancaster",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":17,\"hasAccidentOrCitations\":\"yes\",\"accidentCitation\":\"Citation - Driving under the influence\",\"firstName\":\"Shane\",\"gender\":\"Female\",\"lastName\":\"Orgen\",\"maritalStatus\":\"Married\",\"millitaryAffiliation\":null,\"occupation\":\"Other\",\"governmentAffliation\":\"FBI Academy Associates\",\"otherOccupation\":\"Graphic Designer\",\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Average\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":61715,\"year\":2017,\"make\":\"Toyota\",\"model\":\"Tundra SR6\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring\",\"ownership\":\"loan\",\"primaryusage\":\"commuting\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$15,000 / $30,000\",\"medical\":\"$10,000\",\"propertyDamage\":\"$25,000\",\"uninsuredOrUnderinsuredMBI\":\"$25,000\",\"uninsuredOrUnderinsuredMPD\":\"$500,000 / $ 500,000\"},\"vehicles\":[{\"collision\":\"$1,000\",\"comprehensive\":\"$1,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$15,000 / $30,000",
+						"medical": "$10,000",
+						"propertyDamage": "$25,000",
+						"uninsuredOrUnderinsuredMBI": "$25,000",
+						"uninsuredOrUnderinsuredMPD": "$500,000 / $ 500,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$1,000",
+							"comprehensive": "$1,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": "Citation - Driving under the influence",
+							"ageFirstLicensed": 17,
+							"creditRating": "Average",
+							"firstName": "Shane",
+							"gender": "Female",
+							"governmentAffliation": "FBI Academy Associates",
+							"hasAccidentOrCitations": "yes",
+							"highestEducation": "College",
+							"lastName": "Orgen",
+							"maritalStatus": "Married",
+							"millitaryAffiliation": null,
+							"occupation": "Other",
+							"otherOccupation": "Graphic Designer",
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 61715,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring",
+							"make": "Toyota",
+							"model": "Tundra SR6",
+							"ownership": "loan",
+							"primaryusage": "commuting",
+							"year": 2017
+						}
+					]
+				}
+			},
 			"email": "sorgenf@economist.com",
 			"externalReferenceCode": "AP-60-406-4890",
 			"firstName": "Shane",
@@ -223,7 +806,60 @@
 			"applicationCreateDate": "2022-01-27T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "Jamaica",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":19,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Jameson\",\"gender\":\"Male\",\"lastName\":\"Norcliff\",\"maritalStatus\":\"Single\",\"millitaryAffiliation\":null,\"occupation\":\"Engineer\",\"governmentAffliation\":\"ABC Sherriff Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"High School\",\"creditRating\":\"Poor\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":66695,\"year\":2013,\"make\":\"Ford\",\"model\":\"Focus S Sedan\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring\",\"ownership\":\"own\",\"primaryusage\":\"pleasure\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$500,000 / $ 500,000\",\"medical\":\"$1,000\",\"propertyDamage\":\"$300,000\",\"uninsuredOrUnderinsuredMBI\":\"$25,000\",\"uninsuredOrUnderinsuredMPD\":\"$25,000 / $50,000\"},\"vehicles\":[{\"collision\":\"$2,000\",\"comprehensive\":\"$2,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$500,000 / $ 500,000",
+						"medical": "$1,000",
+						"propertyDamage": "$300,000",
+						"uninsuredOrUnderinsuredMBI": "$25,000",
+						"uninsuredOrUnderinsuredMPD": "$25,000 / $50,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$2,000",
+							"comprehensive": "$2,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 19,
+							"creditRating": "Poor",
+							"firstName": "Jameson",
+							"gender": "Male",
+							"governmentAffliation": "ABC Sherriff Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "High School",
+							"lastName": "Norcliff",
+							"maritalStatus": "Single",
+							"millitaryAffiliation": null,
+							"occupation": "Engineer",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 66695,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring",
+							"make": "Ford",
+							"model": "Focus S Sedan",
+							"ownership": "own",
+							"primaryusage": "pleasure",
+							"year": 2013
+						}
+					]
+				}
+			},
 			"email": "jnorcliff3@bandcamp.com",
 			"externalReferenceCode": "AP-71-316-5330",
 			"firstName": "Jameson",
@@ -243,7 +879,60 @@
 			"applicationCreateDate": "2022-01-21T00:00:00.000+00:00",
 			"applicationStatus": "rejected",
 			"city": "Fullerton",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":21,\"hasAccidentOrCitations\":\"yes\",\"accidentCitation\":\"Citation - Driving under the influence\",\"firstName\":\"Monah\",\"gender\":\"Female\",\"lastName\":\"Woolens\",\"maritalStatus\":\"Single\",\"millitaryAffiliation\":null,\"occupation\":\"Other\",\"governmentAffliation\":\"FBI Academy Associates\",\"otherOccupation\":\"Health Coach I\",\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Good\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":68979,\"year\":2013,\"make\":\"Toyota\",\"model\":\"Camry Hybrid XLE\",\"features\":\"Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"loan\",\"primaryusage\":\"pleasure\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $100,000\",\"medical\":\"$5,000\",\"propertyDamage\":\"$25,000\",\"uninsuredOrUnderinsuredMBI\":\"$25,000\",\"uninsuredOrUnderinsuredMPD\":\"$50,000 / $100,000\"},\"vehicles\":[{\"collision\":\"$1,000\",\"comprehensive\":\"$500\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $100,000",
+						"medical": "$5,000",
+						"propertyDamage": "$25,000",
+						"uninsuredOrUnderinsuredMBI": "$25,000",
+						"uninsuredOrUnderinsuredMPD": "$50,000 / $100,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$1,000",
+							"comprehensive": "$500"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": "Citation - Driving under the influence",
+							"ageFirstLicensed": 21,
+							"creditRating": "Good",
+							"firstName": "Monah",
+							"gender": "Female",
+							"governmentAffliation": "FBI Academy Associates",
+							"hasAccidentOrCitations": "yes",
+							"highestEducation": "College",
+							"lastName": "Woolens",
+							"maritalStatus": "Single",
+							"millitaryAffiliation": null,
+							"occupation": "Other",
+							"otherOccupation": "Health Coach I",
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 68979,
+							"features": "Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Toyota",
+							"model": "Camry Hybrid XLE",
+							"ownership": "loan",
+							"primaryusage": "pleasure",
+							"year": 2013
+						}
+					]
+				}
+			},
 			"email": "mwoolens8@samsung.com",
 			"externalReferenceCode": "AP-95-484-1180",
 			"firstName": "Monah",
@@ -262,7 +951,60 @@
 			"applicationCreateDate": "2021-11-22T00:00:00.000+00:00",
 			"applicationStatus": "underwriting",
 			"city": "Oakland",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":15,\"hasAccidentOrCitations\":\"yes\",\"accidentCitation\":\"US Citation - Speeding\",\"firstName\":\"Rycca\",\"gender\":\"Female\",\"lastName\":\"Fortescue\",\"maritalStatus\":\"Widowed\",\"millitaryAffiliation\":null,\"occupation\":\"Accountant\",\"governmentAffliation\":\"ABC Sherriff Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"Phd\",\"creditRating\":\"Excellent\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":73581,\"year\":2017,\"make\":\"Toyota\",\"model\":\"Camry Hybrid XLE\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"own\",\"primaryusage\":\"business\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$30,000 / $60,000\",\"medical\":\"$1,000\",\"propertyDamage\":\"$25,000\",\"uninsuredOrUnderinsuredMBI\":\"$300,000\",\"uninsuredOrUnderinsuredMPD\":\"$500,000 / $ 500,000\"},\"vehicles\":[{\"collision\":\"$1,000\",\"comprehensive\":\"$1,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$30,000 / $60,000",
+						"medical": "$1,000",
+						"propertyDamage": "$25,000",
+						"uninsuredOrUnderinsuredMBI": "$300,000",
+						"uninsuredOrUnderinsuredMPD": "$500,000 / $ 500,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$1,000",
+							"comprehensive": "$1,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": "US Citation - Speeding",
+							"ageFirstLicensed": 15,
+							"creditRating": "Excellent",
+							"firstName": "Rycca",
+							"gender": "Female",
+							"governmentAffliation": "ABC Sherriff Association",
+							"hasAccidentOrCitations": "yes",
+							"highestEducation": "Phd",
+							"lastName": "Fortescue",
+							"maritalStatus": "Widowed",
+							"millitaryAffiliation": null,
+							"occupation": "Accountant",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 73581,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Toyota",
+							"model": "Camry Hybrid XLE",
+							"ownership": "own",
+							"primaryusage": "business",
+							"year": 2017
+						}
+					]
+				}
+			},
 			"email": "rfortescuez@usa.gov",
 			"externalReferenceCode": "AP-25-788-4691",
 			"firstName": "Rycca",
@@ -281,7 +1023,60 @@
 			"applicationCreateDate": "2022-05-29T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "San Bernardino",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":19,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Bonnie\",\"gender\":\"Female\",\"lastName\":\"Nevett\",\"maritalStatus\":\"Single\",\"millitaryAffiliation\":null,\"occupation\":\"Dentist\",\"governmentAffliation\":\"State Firefighters Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Poor\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":50715,\"year\":2015,\"make\":\"Ford\",\"model\":\"F-150 Super 250 XL\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"loan\",\"primaryusage\":\"pleasure\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $ 300,000\",\"medical\":\"$10,000\",\"propertyDamage\":\"$300,000\",\"uninsuredOrUnderinsuredMBI\":\"$25,000\",\"uninsuredOrUnderinsuredMPD\":\"$300,000 / $ 300,000\"},\"vehicles\":[{\"collision\":\"$500\",\"comprehensive\":\"$1,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $ 300,000",
+						"medical": "$10,000",
+						"propertyDamage": "$300,000",
+						"uninsuredOrUnderinsuredMBI": "$25,000",
+						"uninsuredOrUnderinsuredMPD": "$300,000 / $ 300,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$500",
+							"comprehensive": "$1,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 19,
+							"creditRating": "Poor",
+							"firstName": "Bonnie",
+							"gender": "Female",
+							"governmentAffliation": "State Firefighters Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "College",
+							"lastName": "Nevett",
+							"maritalStatus": "Single",
+							"millitaryAffiliation": null,
+							"occupation": "Dentist",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 50715,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Ford",
+							"model": "F-150 Super 250 XL",
+							"ownership": "loan",
+							"primaryusage": "pleasure",
+							"year": 2015
+						}
+					]
+				}
+			},
 			"email": "bnevetta@dedecms.com",
 			"externalReferenceCode": "AP-14-768-3243",
 			"firstName": "Bonnie",
@@ -301,7 +1096,60 @@
 			"applicationCreateDate": "2022-02-14T00:00:00.000+00:00",
 			"applicationStatus": "rejected",
 			"city": "Bakersfield",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":21,\"hasAccidentOrCitations\":\"yes\",\"accidentCitation\":\"Citation - Driving under the influence\",\"firstName\":\"Dynah\",\"gender\":\"Female\",\"lastName\":\"Jordeson\",\"maritalStatus\":\"Single\",\"millitaryAffiliation\":null,\"occupation\":\"Accountant\",\"governmentAffliation\":\"ABC Sherriff Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Poor\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":68016,\"year\":2015,\"make\":\"Toyota\",\"model\":\"Camry Hybrid XLE\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"own\",\"primaryusage\":\"business\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$30,000 / $60,000\",\"medical\":\"$1,000\",\"propertyDamage\":\"$25,000\",\"uninsuredOrUnderinsuredMBI\":\"$100,000\",\"uninsuredOrUnderinsuredMPD\":\"$25,000 / $50,000\"},\"vehicles\":[{\"collision\":\"$1,000\",\"comprehensive\":\"$500\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$30,000 / $60,000",
+						"medical": "$1,000",
+						"propertyDamage": "$25,000",
+						"uninsuredOrUnderinsuredMBI": "$100,000",
+						"uninsuredOrUnderinsuredMPD": "$25,000 / $50,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$1,000",
+							"comprehensive": "$500"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": "Citation - Driving under the influence",
+							"ageFirstLicensed": 21,
+							"creditRating": "Poor",
+							"firstName": "Dynah",
+							"gender": "Female",
+							"governmentAffliation": "ABC Sherriff Association",
+							"hasAccidentOrCitations": "yes",
+							"highestEducation": "College",
+							"lastName": "Jordeson",
+							"maritalStatus": "Single",
+							"millitaryAffiliation": null,
+							"occupation": "Accountant",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 68016,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Toyota",
+							"model": "Camry Hybrid XLE",
+							"ownership": "own",
+							"primaryusage": "business",
+							"year": 2015
+						}
+					]
+				}
+			},
 			"email": "djordeson17@alibaba.com",
 			"externalReferenceCode": "AP-75-348-3128",
 			"firstName": "Dynah",
@@ -320,7 +1168,60 @@
 			"applicationCreateDate": "2022-02-21T00:00:00.000+00:00",
 			"applicationStatus": "rejected",
 			"city": "San Francisco",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":15,\"hasAccidentOrCitations\":\"yes\",\"accidentCitation\":\"Citation - Driving under the influence\",\"firstName\":\"Humfrey\",\"gender\":\"Male\",\"lastName\":\"Hymor\",\"maritalStatus\":\"Separated\",\"millitaryAffiliation\":null,\"occupation\":\"Government\",\"governmentAffliation\":\"State Firefighters Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Excellent\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":35189,\"year\":2017,\"make\":\"Volvo\",\"model\":\"XC90 Inscription\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"loan\",\"primaryusage\":\"commuting\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$15,000 / $30,000\",\"medical\":\"$1,000\",\"propertyDamage\":\"$25,000\",\"uninsuredOrUnderinsuredMBI\":\"$100,000\",\"uninsuredOrUnderinsuredMPD\":\"$15,000 / $30,000\"},\"vehicles\":[{\"collision\":\"$250\",\"comprehensive\":\"$1,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$15,000 / $30,000",
+						"medical": "$1,000",
+						"propertyDamage": "$25,000",
+						"uninsuredOrUnderinsuredMBI": "$100,000",
+						"uninsuredOrUnderinsuredMPD": "$15,000 / $30,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$250",
+							"comprehensive": "$1,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": "Citation - Driving under the influence",
+							"ageFirstLicensed": 15,
+							"creditRating": "Excellent",
+							"firstName": "Humfrey",
+							"gender": "Male",
+							"governmentAffliation": "State Firefighters Association",
+							"hasAccidentOrCitations": "yes",
+							"highestEducation": "College",
+							"lastName": "Hymor",
+							"maritalStatus": "Separated",
+							"millitaryAffiliation": null,
+							"occupation": "Government",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 35189,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Volvo",
+							"model": "XC90 Inscription",
+							"ownership": "loan",
+							"primaryusage": "commuting",
+							"year": 2017
+						}
+					]
+				}
+			},
 			"email": "hhymorr@i2i.jp",
 			"externalReferenceCode": "AP-87-601-0961",
 			"firstName": "Humfrey",
@@ -339,7 +1240,60 @@
 			"applicationCreateDate": "2022-03-05T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "Fullerton",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":18,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Monah\",\"gender\":\"Female\",\"lastName\":\"Woolens\",\"maritalStatus\":\"Married\",\"millitaryAffiliation\":null,\"occupation\":\"Dentist\",\"governmentAffliation\":\"State Firefighters Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"Phd\",\"creditRating\":\"Very Good\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":53280,\"year\":2018,\"make\":\"Ford\",\"model\":\"F-150 Super 250 XL\",\"features\":\"Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"own\",\"primaryusage\":\"pleasure\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$30,000 / $60,000\",\"medical\":\"$1,000\",\"propertyDamage\":\"$100,000\",\"uninsuredOrUnderinsuredMBI\":\"$100,000\",\"uninsuredOrUnderinsuredMPD\":\"$30,000 / $60,000\"},\"vehicles\":[{\"collision\":\"$500\",\"comprehensive\":\"$500\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$30,000 / $60,000",
+						"medical": "$1,000",
+						"propertyDamage": "$100,000",
+						"uninsuredOrUnderinsuredMBI": "$100,000",
+						"uninsuredOrUnderinsuredMPD": "$30,000 / $60,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$500",
+							"comprehensive": "$500"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 18,
+							"creditRating": "Very Good",
+							"firstName": "Monah",
+							"gender": "Female",
+							"governmentAffliation": "State Firefighters Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "Phd",
+							"lastName": "Woolens",
+							"maritalStatus": "Married",
+							"millitaryAffiliation": null,
+							"occupation": "Dentist",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 53280,
+							"features": "Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Ford",
+							"model": "F-150 Super 250 XL",
+							"ownership": "own",
+							"primaryusage": "pleasure",
+							"year": 2018
+						}
+					]
+				}
+			},
 			"email": "mwoolens8@samsung.com",
 			"externalReferenceCode": "AP-57-402-8342",
 			"firstName": "Monah",
@@ -359,7 +1313,60 @@
 			"applicationCreateDate": "2022-03-10T00:00:00.000+00:00",
 			"applicationStatus": "underwriting",
 			"city": "Fullerton",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":20,\"hasAccidentOrCitations\":\"yes\",\"accidentCitation\":\"Accident - At fault\",\"firstName\":\"Monah\",\"gender\":\"Female\",\"lastName\":\"Woolens\",\"maritalStatus\":\"Widowed\",\"millitaryAffiliation\":null,\"occupation\":\"Other\",\"governmentAffliation\":\"FBI Academy Associates\",\"otherOccupation\":\"Occupational Therapist\",\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Very Good\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":30555,\"year\":2019,\"make\":\"Ford\",\"model\":\"Focus S Sedan\",\"features\":\"Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"own\",\"primaryusage\":\"pleasure\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$15,000 / $30,000\",\"medical\":\"$5,000\",\"propertyDamage\":\"$25,000\",\"uninsuredOrUnderinsuredMBI\":\"$25,000\",\"uninsuredOrUnderinsuredMPD\":\"$15,000 / $30,000\"},\"vehicles\":[{\"collision\":\"$250\",\"comprehensive\":\"$1,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$15,000 / $30,000",
+						"medical": "$5,000",
+						"propertyDamage": "$25,000",
+						"uninsuredOrUnderinsuredMBI": "$25,000",
+						"uninsuredOrUnderinsuredMPD": "$15,000 / $30,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$250",
+							"comprehensive": "$1,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": "Accident - At fault",
+							"ageFirstLicensed": 20,
+							"creditRating": "Very Good",
+							"firstName": "Monah",
+							"gender": "Female",
+							"governmentAffliation": "FBI Academy Associates",
+							"hasAccidentOrCitations": "yes",
+							"highestEducation": "College",
+							"lastName": "Woolens",
+							"maritalStatus": "Widowed",
+							"millitaryAffiliation": null,
+							"occupation": "Other",
+							"otherOccupation": "Occupational Therapist",
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 30555,
+							"features": "Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Ford",
+							"model": "Focus S Sedan",
+							"ownership": "own",
+							"primaryusage": "pleasure",
+							"year": 2019
+						}
+					]
+				}
+			},
 			"email": "mwoolens8@samsung.com",
 			"externalReferenceCode": "AP-54-184-8770",
 			"firstName": "Monah",
@@ -378,7 +1385,60 @@
 			"applicationCreateDate": "2022-09-11T00:00:00.000+00:00",
 			"applicationStatus": "incomplete",
 			"city": "Fullerton",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":15,\"hasAccidentOrCitations\":\"yes\",\"accidentCitation\":\"Citation - Driving under the influence\",\"firstName\":\"Bogart\",\"gender\":\"Male\",\"lastName\":\"Becaris\",\"maritalStatus\":\"Widowed\",\"millitaryAffiliation\":null,\"occupation\":\"Other\",\"governmentAffliation\":\"FBI Academy Associates\",\"otherOccupation\":\"VP Sales\",\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Very Good\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":66167,\"year\":2019,\"make\":\"Ford\",\"model\":\"Edge SE\",\"features\":\"Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"loan\",\"primaryusage\":\"commuting\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $100,000\",\"medical\":\"$5,000\",\"propertyDamage\":\"$300,000\",\"uninsuredOrUnderinsuredMBI\":\"$300,000\",\"uninsuredOrUnderinsuredMPD\":\"$500,000 / $ 500,000\"},\"vehicles\":[{\"collision\":\"$500\",\"comprehensive\":\"$250\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $100,000",
+						"medical": "$5,000",
+						"propertyDamage": "$300,000",
+						"uninsuredOrUnderinsuredMBI": "$300,000",
+						"uninsuredOrUnderinsuredMPD": "$500,000 / $ 500,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$500",
+							"comprehensive": "$250"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": "Citation - Driving under the influence",
+							"ageFirstLicensed": 15,
+							"creditRating": "Very Good",
+							"firstName": "Bogart",
+							"gender": "Male",
+							"governmentAffliation": "FBI Academy Associates",
+							"hasAccidentOrCitations": "yes",
+							"highestEducation": "College",
+							"lastName": "Becaris",
+							"maritalStatus": "Widowed",
+							"millitaryAffiliation": null,
+							"occupation": "Other",
+							"otherOccupation": "VP Sales",
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 66167,
+							"features": "Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Ford",
+							"model": "Edge SE",
+							"ownership": "loan",
+							"primaryusage": "commuting",
+							"year": 2019
+						}
+					]
+				}
+			},
 			"email": "bbecarisw@symantec.com",
 			"externalReferenceCode": "AP-36-146-7949",
 			"firstName": "Bogart",
@@ -397,7 +1457,60 @@
 			"applicationCreateDate": "2022-11-08T00:00:00.000+00:00",
 			"applicationStatus": "underwriting",
 			"city": "Rochester",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":21,\"hasAccidentOrCitations\":\"yes\",\"accidentCitation\":\"Accident - Not at fault\",\"firstName\":\"Shurlocke\",\"gender\":\"Male\",\"lastName\":\"Letessier\",\"maritalStatus\":\"Widowed\",\"millitaryAffiliation\":null,\"occupation\":\"Dentist\",\"governmentAffliation\":\"State Firefighters Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"Phd\",\"creditRating\":\"Poor\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":58654,\"year\":2017,\"make\":\"Ford\",\"model\":\"Mustang GT Fastback\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring\",\"ownership\":\"lease\",\"primaryusage\":\"business\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $100,000\",\"medical\":\"$2,000\",\"propertyDamage\":\"$150,000\",\"uninsuredOrUnderinsuredMBI\":\"$25,000\",\"uninsuredOrUnderinsuredMPD\":\"$100,000 / $ 300,000\"},\"vehicles\":[{\"collision\":\"$2,000\",\"comprehensive\":\"$5,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $100,000",
+						"medical": "$2,000",
+						"propertyDamage": "$150,000",
+						"uninsuredOrUnderinsuredMBI": "$25,000",
+						"uninsuredOrUnderinsuredMPD": "$100,000 / $ 300,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$2,000",
+							"comprehensive": "$5,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": "Accident - Not at fault",
+							"ageFirstLicensed": 21,
+							"creditRating": "Poor",
+							"firstName": "Shurlocke",
+							"gender": "Male",
+							"governmentAffliation": "State Firefighters Association",
+							"hasAccidentOrCitations": "yes",
+							"highestEducation": "Phd",
+							"lastName": "Letessier",
+							"maritalStatus": "Widowed",
+							"millitaryAffiliation": null,
+							"occupation": "Dentist",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 58654,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring",
+							"make": "Ford",
+							"model": "Mustang GT Fastback",
+							"ownership": "lease",
+							"primaryusage": "business",
+							"year": 2017
+						}
+					]
+				}
+			},
 			"email": "sletessiern@google.ru",
 			"externalReferenceCode": "AP-48-399-9258",
 			"firstName": "Shurlocke",
@@ -416,7 +1529,60 @@
 			"applicationCreateDate": "2023-02-21T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "Jamaica",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":17,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Jameson\",\"gender\":\"Male\",\"lastName\":\"Norcliff\",\"maritalStatus\":\"Married\",\"millitaryAffiliation\":null,\"occupation\":\"Engineer\",\"governmentAffliation\":\"ABC Sherriff Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"Phd\",\"creditRating\":\"Excellent\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":31264,\"year\":2016,\"make\":\"Volvo\",\"model\":\"V90 Cross Country\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring\",\"ownership\":\"loan\",\"primaryusage\":\"business\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$500,000 / $ 500,000\",\"medical\":\"$5,000\",\"propertyDamage\":\"$25,000\",\"uninsuredOrUnderinsuredMBI\":\"$25,000\",\"uninsuredOrUnderinsuredMPD\":\"$50,000 / $100,000\"},\"vehicles\":[{\"collision\":\"$5,000\",\"comprehensive\":\"$2,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$500,000 / $ 500,000",
+						"medical": "$5,000",
+						"propertyDamage": "$25,000",
+						"uninsuredOrUnderinsuredMBI": "$25,000",
+						"uninsuredOrUnderinsuredMPD": "$50,000 / $100,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$5,000",
+							"comprehensive": "$2,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 17,
+							"creditRating": "Excellent",
+							"firstName": "Jameson",
+							"gender": "Male",
+							"governmentAffliation": "ABC Sherriff Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "Phd",
+							"lastName": "Norcliff",
+							"maritalStatus": "Married",
+							"millitaryAffiliation": null,
+							"occupation": "Engineer",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 31264,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring",
+							"make": "Volvo",
+							"model": "V90 Cross Country",
+							"ownership": "loan",
+							"primaryusage": "business",
+							"year": 2016
+						}
+					]
+				}
+			},
 			"email": "jnorcliff3@bandcamp.com",
 			"externalReferenceCode": "AP-81-788-4032",
 			"firstName": "Jameson",
@@ -436,7 +1602,60 @@
 			"applicationCreateDate": "2022-02-06T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "San Bernardino",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":19,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Mitzi\",\"gender\":\"Female\",\"lastName\":\"Barnwall\",\"maritalStatus\":\"Married\",\"millitaryAffiliation\":\"None\",\"occupation\":\"Dentist\",\"governmentAffliation\":\"ABC Sherriff Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"High School\",\"creditRating\":\"Average\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":63285,\"year\":2016,\"make\":\"Volvo\",\"model\":\"V90 Cross Country\",\"features\":\"Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"loan\",\"primaryusage\":\"pleasure\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$15,000 / $30,000\",\"medical\":\"$1,000\",\"propertyDamage\":\"$25,000\",\"uninsuredOrUnderinsuredMBI\":\"$300,000\",\"uninsuredOrUnderinsuredMPD\":\"$500,000 / $ 500,000\"},\"vehicles\":[{\"collision\":\"$500\",\"comprehensive\":\"$250\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$15,000 / $30,000",
+						"medical": "$1,000",
+						"propertyDamage": "$25,000",
+						"uninsuredOrUnderinsuredMBI": "$300,000",
+						"uninsuredOrUnderinsuredMPD": "$500,000 / $ 500,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$500",
+							"comprehensive": "$250"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 19,
+							"creditRating": "Average",
+							"firstName": "Mitzi",
+							"gender": "Female",
+							"governmentAffliation": "ABC Sherriff Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "High School",
+							"lastName": "Barnwall",
+							"maritalStatus": "Married",
+							"millitaryAffiliation": "None",
+							"occupation": "Dentist",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 63285,
+							"features": "Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Volvo",
+							"model": "V90 Cross Country",
+							"ownership": "loan",
+							"primaryusage": "pleasure",
+							"year": 2016
+						}
+					]
+				}
+			},
 			"email": "mbarnwall4@drupal.org",
 			"externalReferenceCode": "AP-97-931-1823",
 			"firstName": "Mitzi",
@@ -456,7 +1675,60 @@
 			"applicationCreateDate": "2022-04-03T00:00:00.000+00:00",
 			"applicationStatus": "rejected",
 			"city": "Brooklyn",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":21,\"hasAccidentOrCitations\":\"yes\",\"accidentCitation\":\"Citation - Driving under the influence\",\"firstName\":\"Yehudi\",\"gender\":\"Male\",\"lastName\":\"Mancell\",\"maritalStatus\":\"Widowed\",\"millitaryAffiliation\":null,\"occupation\":\"Government\",\"governmentAffliation\":\"State Firefighters Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"High School\",\"creditRating\":\"Excellent\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":57343,\"year\":2018,\"make\":\"Volvo\",\"model\":\"XC90 Inscription\",\"features\":\"Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"lease\",\"primaryusage\":\"pleasure\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$30,000 / $60,000\",\"medical\":\"$1,000\",\"propertyDamage\":\"$300,000\",\"uninsuredOrUnderinsuredMBI\":\"$25,000\",\"uninsuredOrUnderinsuredMPD\":\"$25,000 / $50,000\"},\"vehicles\":[{\"collision\":\"$750\",\"comprehensive\":\"$2,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$30,000 / $60,000",
+						"medical": "$1,000",
+						"propertyDamage": "$300,000",
+						"uninsuredOrUnderinsuredMBI": "$25,000",
+						"uninsuredOrUnderinsuredMPD": "$25,000 / $50,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$750",
+							"comprehensive": "$2,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": "Citation - Driving under the influence",
+							"ageFirstLicensed": 21,
+							"creditRating": "Excellent",
+							"firstName": "Yehudi",
+							"gender": "Male",
+							"governmentAffliation": "State Firefighters Association",
+							"hasAccidentOrCitations": "yes",
+							"highestEducation": "High School",
+							"lastName": "Mancell",
+							"maritalStatus": "Widowed",
+							"millitaryAffiliation": null,
+							"occupation": "Government",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 57343,
+							"features": "Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Volvo",
+							"model": "XC90 Inscription",
+							"ownership": "lease",
+							"primaryusage": "pleasure",
+							"year": 2018
+						}
+					]
+				}
+			},
 			"email": "ymancellc@163.com",
 			"externalReferenceCode": "AP-43-289-3257",
 			"firstName": "Yehudi",
@@ -475,7 +1747,60 @@
 			"applicationCreateDate": "2021-11-11T00:00:00.000+00:00",
 			"applicationStatus": "incomplete",
 			"city": "Fresno",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":20,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Jolie\",\"gender\":\"Female\",\"lastName\":\"Zecchi\",\"maritalStatus\":\"Separated\",\"millitaryAffiliation\":null,\"occupation\":\"Other\",\"governmentAffliation\":\"FBI Academy Associates\",\"otherOccupation\":\"Safety Technician II\",\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Poor\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":70195,\"year\":2015,\"make\":\"Volvo\",\"model\":\"S90 R-Design\",\"features\":\"Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"lease\",\"primaryusage\":\"commuting\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$15,000 / $30,000\",\"medical\":\"$10,000\",\"propertyDamage\":\"$25,000\",\"uninsuredOrUnderinsuredMBI\":\"$25,000\",\"uninsuredOrUnderinsuredMPD\":\"$50,000 / $100,000\"},\"vehicles\":[{\"collision\":\"$250\",\"comprehensive\":\"$1,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$15,000 / $30,000",
+						"medical": "$10,000",
+						"propertyDamage": "$25,000",
+						"uninsuredOrUnderinsuredMBI": "$25,000",
+						"uninsuredOrUnderinsuredMPD": "$50,000 / $100,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$250",
+							"comprehensive": "$1,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 20,
+							"creditRating": "Poor",
+							"firstName": "Jolie",
+							"gender": "Female",
+							"governmentAffliation": "FBI Academy Associates",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "College",
+							"lastName": "Zecchi",
+							"maritalStatus": "Separated",
+							"millitaryAffiliation": null,
+							"occupation": "Other",
+							"otherOccupation": "Safety Technician II",
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 70195,
+							"features": "Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Volvo",
+							"model": "S90 R-Design",
+							"ownership": "lease",
+							"primaryusage": "commuting",
+							"year": 2015
+						}
+					]
+				}
+			},
 			"email": "jzecchi7@google.cn",
 			"externalReferenceCode": "AP-46-634-7310",
 			"firstName": "Jolie",
@@ -494,7 +1819,60 @@
 			"applicationCreateDate": "2023-02-07T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "Anaheim",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":15,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Gerri\",\"gender\":\"Male\",\"lastName\":\"Goodlett\",\"maritalStatus\":\"Married\",\"millitaryAffiliation\":null,\"occupation\":\"Dentist\",\"governmentAffliation\":\"State Firefighters Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Average\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":65992,\"year\":2016,\"make\":\"Toyota\",\"model\":\"Tundra SR6\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring\",\"ownership\":\"loan\",\"primaryusage\":\"commuting\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $ 300,000\",\"medical\":\"$10,000\",\"propertyDamage\":\"$100,000\",\"uninsuredOrUnderinsuredMBI\":\"$100,000\",\"uninsuredOrUnderinsuredMPD\":\"$30,000 / $60,000\"},\"vehicles\":[{\"collision\":\"$250\",\"comprehensive\":\"$250\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $ 300,000",
+						"medical": "$10,000",
+						"propertyDamage": "$100,000",
+						"uninsuredOrUnderinsuredMBI": "$100,000",
+						"uninsuredOrUnderinsuredMPD": "$30,000 / $60,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$250",
+							"comprehensive": "$250"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 15,
+							"creditRating": "Average",
+							"firstName": "Gerri",
+							"gender": "Male",
+							"governmentAffliation": "State Firefighters Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "College",
+							"lastName": "Goodlett",
+							"maritalStatus": "Married",
+							"millitaryAffiliation": null,
+							"occupation": "Dentist",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 65992,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring",
+							"make": "Toyota",
+							"model": "Tundra SR6",
+							"ownership": "loan",
+							"primaryusage": "commuting",
+							"year": 2016
+						}
+					]
+				}
+			},
 			"email": "ggoodlett9@tiny.cc",
 			"externalReferenceCode": "AP-95-575-8266",
 			"firstName": "Gerri",
@@ -514,7 +1892,60 @@
 			"applicationCreateDate": "2023-01-13T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "Lancaster",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":17,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Ferrel\",\"gender\":\"Male\",\"lastName\":\"Sames\",\"maritalStatus\":\"Single\",\"millitaryAffiliation\":null,\"occupation\":\"Accountant\",\"governmentAffliation\":\"State Firefighters Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Excellent\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":66055,\"year\":2016,\"make\":\"Ford\",\"model\":\"F-150 Super 250 XL\",\"features\":\"Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"loan\",\"primaryusage\":\"business\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $ 300,000\",\"medical\":\"$10,000\",\"propertyDamage\":\"$25,000\",\"uninsuredOrUnderinsuredMBI\":\"$300,000\",\"uninsuredOrUnderinsuredMPD\":\"$25,000 / $50,000\"},\"vehicles\":[{\"collision\":\"$1,000\",\"comprehensive\":\"$500\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $ 300,000",
+						"medical": "$10,000",
+						"propertyDamage": "$25,000",
+						"uninsuredOrUnderinsuredMBI": "$300,000",
+						"uninsuredOrUnderinsuredMPD": "$25,000 / $50,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$1,000",
+							"comprehensive": "$500"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 17,
+							"creditRating": "Excellent",
+							"firstName": "Ferrel",
+							"gender": "Male",
+							"governmentAffliation": "State Firefighters Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "College",
+							"lastName": "Sames",
+							"maritalStatus": "Single",
+							"millitaryAffiliation": null,
+							"occupation": "Accountant",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 66055,
+							"features": "Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Ford",
+							"model": "F-150 Super 250 XL",
+							"ownership": "loan",
+							"primaryusage": "business",
+							"year": 2016
+						}
+					]
+				}
+			},
 			"email": "fsames11@ucoz.com",
 			"externalReferenceCode": "AP-96-765-6341",
 			"firstName": "Ferrel",
@@ -534,7 +1965,60 @@
 			"applicationCreateDate": "2022-01-21T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "San Bernardino",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":15,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Bonnie\",\"gender\":\"Female\",\"lastName\":\"Nevett\",\"maritalStatus\":\"Married\",\"millitaryAffiliation\":null,\"occupation\":\"Other\",\"governmentAffliation\":\"ABC Sherriff Association\",\"otherOccupation\":\"Quality Control Specialist\",\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Poor\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":59943,\"year\":2016,\"make\":\"Ford\",\"model\":\"F-150 Super 250 XL\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"lease\",\"primaryusage\":\"pleasure\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $100,000\",\"medical\":\"$5,000\",\"propertyDamage\":\"$100,000\",\"uninsuredOrUnderinsuredMBI\":\"$300,000\",\"uninsuredOrUnderinsuredMPD\":\"$50,000 / $100,000\"},\"vehicles\":[{\"collision\":\"$1,000\",\"comprehensive\":\"$250\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $100,000",
+						"medical": "$5,000",
+						"propertyDamage": "$100,000",
+						"uninsuredOrUnderinsuredMBI": "$300,000",
+						"uninsuredOrUnderinsuredMPD": "$50,000 / $100,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$1,000",
+							"comprehensive": "$250"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 15,
+							"creditRating": "Poor",
+							"firstName": "Bonnie",
+							"gender": "Female",
+							"governmentAffliation": "ABC Sherriff Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "College",
+							"lastName": "Nevett",
+							"maritalStatus": "Married",
+							"millitaryAffiliation": null,
+							"occupation": "Other",
+							"otherOccupation": "Quality Control Specialist",
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 59943,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Ford",
+							"model": "F-150 Super 250 XL",
+							"ownership": "lease",
+							"primaryusage": "pleasure",
+							"year": 2016
+						}
+					]
+				}
+			},
 			"email": "bnevetta@dedecms.com",
 			"externalReferenceCode": "AP-38-562-7204",
 			"firstName": "Bonnie",
@@ -554,7 +2038,60 @@
 			"applicationCreateDate": "2022-10-30T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "Pomona",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":18,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Hew\",\"gender\":\"Male\",\"lastName\":\"Island\",\"maritalStatus\":\"Widowed\",\"millitaryAffiliation\":\"None\",\"occupation\":\"Government\",\"governmentAffliation\":\"FBI Academy Associates\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"Masters\",\"creditRating\":\"Good\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":19236,\"year\":2016,\"make\":\"Volvo\",\"model\":\"S90 R-Design\",\"features\":\"Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"loan\",\"primaryusage\":\"commuting\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$15,000 / $30,000\",\"medical\":\"$5,000\",\"propertyDamage\":\"$100,000\",\"uninsuredOrUnderinsuredMBI\":\"$25,000\",\"uninsuredOrUnderinsuredMPD\":\"$25,000 / $50,000\"},\"vehicles\":[{\"collision\":\"$250\",\"comprehensive\":\"$250\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$15,000 / $30,000",
+						"medical": "$5,000",
+						"propertyDamage": "$100,000",
+						"uninsuredOrUnderinsuredMBI": "$25,000",
+						"uninsuredOrUnderinsuredMPD": "$25,000 / $50,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$250",
+							"comprehensive": "$250"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 18,
+							"creditRating": "Good",
+							"firstName": "Hew",
+							"gender": "Male",
+							"governmentAffliation": "FBI Academy Associates",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "Masters",
+							"lastName": "Island",
+							"maritalStatus": "Widowed",
+							"millitaryAffiliation": "None",
+							"occupation": "Government",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 19236,
+							"features": "Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Volvo",
+							"model": "S90 R-Design",
+							"ownership": "loan",
+							"primaryusage": "commuting",
+							"year": 2016
+						}
+					]
+				}
+			},
 			"email": "hisland12@simplemachines.org",
 			"externalReferenceCode": "AP-61-589-8738",
 			"firstName": "Hew",
@@ -574,7 +2111,60 @@
 			"applicationCreateDate": "2023-02-03T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "Bakersfield",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":16,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Leelah\",\"gender\":\"Female\",\"lastName\":\"Hicklingbottom\",\"maritalStatus\":\"Married\",\"millitaryAffiliation\":null,\"occupation\":\"Government\",\"governmentAffliation\":\"ABC Sherriff Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Excellent\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":61748,\"year\":2014,\"make\":\"Volvo\",\"model\":\"V90 Cross Country\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"loan\",\"primaryusage\":\"commuting\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $100,000\",\"medical\":\"$1,000\",\"propertyDamage\":\"$100,000\",\"uninsuredOrUnderinsuredMBI\":\"$300,000\",\"uninsuredOrUnderinsuredMPD\":\"$500,000 / $ 500,000\"},\"vehicles\":[{\"collision\":\"$250\",\"comprehensive\":\"$1,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $100,000",
+						"medical": "$1,000",
+						"propertyDamage": "$100,000",
+						"uninsuredOrUnderinsuredMBI": "$300,000",
+						"uninsuredOrUnderinsuredMPD": "$500,000 / $ 500,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$250",
+							"comprehensive": "$1,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 16,
+							"creditRating": "Excellent",
+							"firstName": "Leelah",
+							"gender": "Female",
+							"governmentAffliation": "ABC Sherriff Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "College",
+							"lastName": "Hicklingbottom",
+							"maritalStatus": "Married",
+							"millitaryAffiliation": null,
+							"occupation": "Government",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 61748,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Volvo",
+							"model": "V90 Cross Country",
+							"ownership": "loan",
+							"primaryusage": "commuting",
+							"year": 2014
+						}
+					]
+				}
+			},
 			"email": "lhicklingbottomm@sohu.com",
 			"externalReferenceCode": "AP-24-969-1132",
 			"firstName": "Leelah",
@@ -594,7 +2184,60 @@
 			"applicationCreateDate": "2021-12-23T00:00:00.000+00:00",
 			"applicationStatus": "incomplete",
 			"city": "Lancaster",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":18,\"hasAccidentOrCitations\":\"yes\",\"accidentCitation\":\"Citation - Failing to Yield\",\"firstName\":\"Ferrel\",\"gender\":\"Male\",\"lastName\":\"Sames\",\"maritalStatus\":\"Single\",\"millitaryAffiliation\":\"US Coast Guard\",\"occupation\":\"Government\",\"governmentAffliation\":\"FBI Academy Associates\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Poor\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":25195,\"year\":2014,\"make\":\"Ford\",\"model\":\"Focus S Sedan\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring\",\"ownership\":\"own\",\"primaryusage\":\"commuting\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $100,000\",\"medical\":\"$5,000\",\"propertyDamage\":\"$300,000\",\"uninsuredOrUnderinsuredMBI\":\"$100,000\",\"uninsuredOrUnderinsuredMPD\":\"$15,000 / $30,000\"},\"vehicles\":[{\"collision\":\"$1,000\",\"comprehensive\":\"$250\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $100,000",
+						"medical": "$5,000",
+						"propertyDamage": "$300,000",
+						"uninsuredOrUnderinsuredMBI": "$100,000",
+						"uninsuredOrUnderinsuredMPD": "$15,000 / $30,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$1,000",
+							"comprehensive": "$250"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": "Citation - Failing to Yield",
+							"ageFirstLicensed": 18,
+							"creditRating": "Poor",
+							"firstName": "Ferrel",
+							"gender": "Male",
+							"governmentAffliation": "FBI Academy Associates",
+							"hasAccidentOrCitations": "yes",
+							"highestEducation": "College",
+							"lastName": "Sames",
+							"maritalStatus": "Single",
+							"millitaryAffiliation": "US Coast Guard",
+							"occupation": "Government",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 25195,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring",
+							"make": "Ford",
+							"model": "Focus S Sedan",
+							"ownership": "own",
+							"primaryusage": "commuting",
+							"year": 2014
+						}
+					]
+				}
+			},
 			"email": "fsames11@ucoz.com",
 			"externalReferenceCode": "AP-30-773-1991",
 			"firstName": "Ferrel",
@@ -613,7 +2256,60 @@
 			"applicationCreateDate": "2022-05-13T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "San Bernardino",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":17,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Bonnie\",\"gender\":\"Female\",\"lastName\":\"Nevett\",\"maritalStatus\":\"Widowed\",\"millitaryAffiliation\":null,\"occupation\":\"Engineer\",\"governmentAffliation\":\"FBI Academy Associates\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Poor\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":76763,\"year\":2014,\"make\":\"Toyota\",\"model\":\"Corolla LE\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"loan\",\"primaryusage\":\"commuting\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $100,000\",\"medical\":\"$5,000\",\"propertyDamage\":\"$300,000\",\"uninsuredOrUnderinsuredMBI\":\"$100,000\",\"uninsuredOrUnderinsuredMPD\":\"$300,000 / $ 300,000\"},\"vehicles\":[{\"collision\":\"$250\",\"comprehensive\":\"$250\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $100,000",
+						"medical": "$5,000",
+						"propertyDamage": "$300,000",
+						"uninsuredOrUnderinsuredMBI": "$100,000",
+						"uninsuredOrUnderinsuredMPD": "$300,000 / $ 300,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$250",
+							"comprehensive": "$250"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 17,
+							"creditRating": "Poor",
+							"firstName": "Bonnie",
+							"gender": "Female",
+							"governmentAffliation": "FBI Academy Associates",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "College",
+							"lastName": "Nevett",
+							"maritalStatus": "Widowed",
+							"millitaryAffiliation": null,
+							"occupation": "Engineer",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 76763,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Toyota",
+							"model": "Corolla LE",
+							"ownership": "loan",
+							"primaryusage": "commuting",
+							"year": 2014
+						}
+					]
+				}
+			},
 			"email": "bnevetta@dedecms.com",
 			"externalReferenceCode": "AP-22-792-2963",
 			"firstName": "Bonnie",
@@ -633,7 +2329,60 @@
 			"applicationCreateDate": "2022-01-24T00:00:00.000+00:00",
 			"applicationStatus": "rejected",
 			"city": "Los Angeles",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":17,\"hasAccidentOrCitations\":\"yes\",\"accidentCitation\":\"Citation - Driving under the influence\",\"firstName\":\"Janeen\",\"gender\":\"Female\",\"lastName\":\"Orrill\",\"maritalStatus\":\"Single\",\"millitaryAffiliation\":null,\"occupation\":\"Accountant\",\"governmentAffliation\":\"State Firefighters Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"High School\",\"creditRating\":\"Average\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":68970,\"year\":2019,\"make\":\"Volvo\",\"model\":\"V90 Cross Country\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring\",\"ownership\":\"loan\",\"primaryusage\":\"pleasure\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $100,000\",\"medical\":\"$5,000\",\"propertyDamage\":\"$25,000\",\"uninsuredOrUnderinsuredMBI\":\"$100,000\",\"uninsuredOrUnderinsuredMPD\":\"$15,000 / $30,000\"},\"vehicles\":[{\"collision\":\"$250\",\"comprehensive\":\"$250\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $100,000",
+						"medical": "$5,000",
+						"propertyDamage": "$25,000",
+						"uninsuredOrUnderinsuredMBI": "$100,000",
+						"uninsuredOrUnderinsuredMPD": "$15,000 / $30,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$250",
+							"comprehensive": "$250"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": "Citation - Driving under the influence",
+							"ageFirstLicensed": 17,
+							"creditRating": "Average",
+							"firstName": "Janeen",
+							"gender": "Female",
+							"governmentAffliation": "State Firefighters Association",
+							"hasAccidentOrCitations": "yes",
+							"highestEducation": "High School",
+							"lastName": "Orrill",
+							"maritalStatus": "Single",
+							"millitaryAffiliation": null,
+							"occupation": "Accountant",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 68970,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring",
+							"make": "Volvo",
+							"model": "V90 Cross Country",
+							"ownership": "loan",
+							"primaryusage": "pleasure",
+							"year": 2019
+						}
+					]
+				}
+			},
 			"email": "jorrilli@amazon.co.jp",
 			"externalReferenceCode": "AP-02-102-4224",
 			"firstName": "Janeen",
@@ -652,7 +2401,60 @@
 			"applicationCreateDate": "2022-08-27T00:00:00.000+00:00",
 			"applicationStatus": "underwriting",
 			"city": "Los Angeles",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":18,\"hasAccidentOrCitations\":\"yes\",\"accidentCitation\":\"Accident - Not at fault\",\"firstName\":\"Janeen\",\"gender\":\"Female\",\"lastName\":\"Orrill\",\"maritalStatus\":\"Widowed\",\"millitaryAffiliation\":null,\"occupation\":\"Accountant\",\"governmentAffliation\":\"ABC Sherriff Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"High School\",\"creditRating\":\"Average\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":57495,\"year\":2016,\"make\":\"Ford\",\"model\":\"F-150 Super 250 XL\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"lease\",\"primaryusage\":\"pleasure\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $100,000\",\"medical\":\"$10,000\",\"propertyDamage\":\"$300,000\",\"uninsuredOrUnderinsuredMBI\":\"$25,000\",\"uninsuredOrUnderinsuredMPD\":\"$50,000 / $100,000\"},\"vehicles\":[{\"collision\":\"$500\",\"comprehensive\":\"$1,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $100,000",
+						"medical": "$10,000",
+						"propertyDamage": "$300,000",
+						"uninsuredOrUnderinsuredMBI": "$25,000",
+						"uninsuredOrUnderinsuredMPD": "$50,000 / $100,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$500",
+							"comprehensive": "$1,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": "Accident - Not at fault",
+							"ageFirstLicensed": 18,
+							"creditRating": "Average",
+							"firstName": "Janeen",
+							"gender": "Female",
+							"governmentAffliation": "ABC Sherriff Association",
+							"hasAccidentOrCitations": "yes",
+							"highestEducation": "High School",
+							"lastName": "Orrill",
+							"maritalStatus": "Widowed",
+							"millitaryAffiliation": null,
+							"occupation": "Accountant",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 57495,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Ford",
+							"model": "F-150 Super 250 XL",
+							"ownership": "lease",
+							"primaryusage": "pleasure",
+							"year": 2016
+						}
+					]
+				}
+			},
 			"email": "jorrilli@amazon.co.jp",
 			"externalReferenceCode": "AP-31-043-3107",
 			"firstName": "Janeen",
@@ -671,7 +2473,60 @@
 			"applicationCreateDate": "2022-04-29T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "San Francisco",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":19,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Felice\",\"gender\":\"Male\",\"lastName\":\"Lippett\",\"maritalStatus\":\"Married\",\"millitaryAffiliation\":null,\"occupation\":\"Government\",\"governmentAffliation\":\"State Firefighters Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"High School\",\"creditRating\":\"Excellent\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":50125,\"year\":2015,\"make\":\"Volvo\",\"model\":\"S90 R-Design\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"lease\",\"primaryusage\":\"pleasure\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $ 300,000\",\"medical\":\"$1,000\",\"propertyDamage\":\"$25,000\",\"uninsuredOrUnderinsuredMBI\":\"$300,000\",\"uninsuredOrUnderinsuredMPD\":\"$100,000 / $ 300,000\"},\"vehicles\":[{\"collision\":\"$500\",\"comprehensive\":\"$500\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $ 300,000",
+						"medical": "$1,000",
+						"propertyDamage": "$25,000",
+						"uninsuredOrUnderinsuredMBI": "$300,000",
+						"uninsuredOrUnderinsuredMPD": "$100,000 / $ 300,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$500",
+							"comprehensive": "$500"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 19,
+							"creditRating": "Excellent",
+							"firstName": "Felice",
+							"gender": "Male",
+							"governmentAffliation": "State Firefighters Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "High School",
+							"lastName": "Lippett",
+							"maritalStatus": "Married",
+							"millitaryAffiliation": null,
+							"occupation": "Government",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 50125,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Volvo",
+							"model": "S90 R-Design",
+							"ownership": "lease",
+							"primaryusage": "pleasure",
+							"year": 2015
+						}
+					]
+				}
+			},
 			"email": "flippett14@newyorker.com",
 			"externalReferenceCode": "AP-49-835-7668",
 			"firstName": "Felice",
@@ -691,7 +2546,60 @@
 			"applicationCreateDate": "2022-01-17T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "Fullerton",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":15,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Bogart\",\"gender\":\"Male\",\"lastName\":\"Becaris\",\"maritalStatus\":\"Widowed\",\"millitaryAffiliation\":null,\"occupation\":\"Government\",\"governmentAffliation\":\"ABC Sherriff Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Very Good\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":37292,\"year\":2013,\"make\":\"Ford\",\"model\":\"Mustang GT Fastback\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring\",\"ownership\":\"lease\",\"primaryusage\":\"pleasure\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$30,000 / $60,000\",\"medical\":\"$10,000\",\"propertyDamage\":\"$100,000\",\"uninsuredOrUnderinsuredMBI\":\"$300,000\",\"uninsuredOrUnderinsuredMPD\":\"$15,000 / $30,000\"},\"vehicles\":[{\"collision\":\"$500\",\"comprehensive\":\"$500\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$30,000 / $60,000",
+						"medical": "$10,000",
+						"propertyDamage": "$100,000",
+						"uninsuredOrUnderinsuredMBI": "$300,000",
+						"uninsuredOrUnderinsuredMPD": "$15,000 / $30,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$500",
+							"comprehensive": "$500"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 15,
+							"creditRating": "Very Good",
+							"firstName": "Bogart",
+							"gender": "Male",
+							"governmentAffliation": "ABC Sherriff Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "College",
+							"lastName": "Becaris",
+							"maritalStatus": "Widowed",
+							"millitaryAffiliation": null,
+							"occupation": "Government",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 37292,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring",
+							"make": "Ford",
+							"model": "Mustang GT Fastback",
+							"ownership": "lease",
+							"primaryusage": "pleasure",
+							"year": 2013
+						}
+					]
+				}
+			},
 			"email": "bbecarisw@symantec.com",
 			"externalReferenceCode": "AP-76-150-9970",
 			"firstName": "Bogart",
@@ -711,7 +2619,60 @@
 			"applicationCreateDate": "2022-11-04T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "Buffalo",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":19,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Jada\",\"gender\":\"Female\",\"lastName\":\"Lewin\",\"maritalStatus\":\"Single\",\"millitaryAffiliation\":null,\"occupation\":\"Government\",\"governmentAffliation\":\"State Firefighters Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"Phd\",\"creditRating\":\"Good\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":74485,\"year\":2016,\"make\":\"Volvo\",\"model\":\"XC90 Inscription\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"loan\",\"primaryusage\":\"pleasure\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $100,000\",\"medical\":\"$1,000\",\"propertyDamage\":\"$150,000\",\"uninsuredOrUnderinsuredMBI\":\"$300,000\",\"uninsuredOrUnderinsuredMPD\":\"$15,000 / $30,000\"},\"vehicles\":[{\"collision\":\"$2,000\",\"comprehensive\":\"$5,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $100,000",
+						"medical": "$1,000",
+						"propertyDamage": "$150,000",
+						"uninsuredOrUnderinsuredMBI": "$300,000",
+						"uninsuredOrUnderinsuredMPD": "$15,000 / $30,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$2,000",
+							"comprehensive": "$5,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 19,
+							"creditRating": "Good",
+							"firstName": "Jada",
+							"gender": "Female",
+							"governmentAffliation": "State Firefighters Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "Phd",
+							"lastName": "Lewin",
+							"maritalStatus": "Single",
+							"millitaryAffiliation": null,
+							"occupation": "Government",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 74485,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Volvo",
+							"model": "XC90 Inscription",
+							"ownership": "loan",
+							"primaryusage": "pleasure",
+							"year": 2016
+						}
+					]
+				}
+			},
 			"email": "jlewint@intel.com",
 			"externalReferenceCode": "AP-95-533-1890",
 			"firstName": "Jada",
@@ -731,7 +2692,60 @@
 			"applicationCreateDate": "2021-12-22T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "San Francisco",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":20,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Felice\",\"gender\":\"Male\",\"lastName\":\"Lippett\",\"maritalStatus\":\"Separated\",\"millitaryAffiliation\":null,\"occupation\":\"Government\",\"governmentAffliation\":\"FBI Academy Associates\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Good\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":9732,\"year\":2016,\"make\":\"Volvo\",\"model\":\"V90 Cross Country\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"loan\",\"primaryusage\":\"business\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$30,000 / $60,000\",\"medical\":\"$10,000\",\"propertyDamage\":\"$25,000\",\"uninsuredOrUnderinsuredMBI\":\"$100,000\",\"uninsuredOrUnderinsuredMPD\":\"$30,000 / $60,000\"},\"vehicles\":[{\"collision\":\"$1,000\",\"comprehensive\":\"$500\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$30,000 / $60,000",
+						"medical": "$10,000",
+						"propertyDamage": "$25,000",
+						"uninsuredOrUnderinsuredMBI": "$100,000",
+						"uninsuredOrUnderinsuredMPD": "$30,000 / $60,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$1,000",
+							"comprehensive": "$500"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 20,
+							"creditRating": "Good",
+							"firstName": "Felice",
+							"gender": "Male",
+							"governmentAffliation": "FBI Academy Associates",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "College",
+							"lastName": "Lippett",
+							"maritalStatus": "Separated",
+							"millitaryAffiliation": null,
+							"occupation": "Government",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 9732,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Volvo",
+							"model": "V90 Cross Country",
+							"ownership": "loan",
+							"primaryusage": "business",
+							"year": 2016
+						}
+					]
+				}
+			},
 			"email": "flippett14@newyorker.com",
 			"externalReferenceCode": "AP-14-445-2863",
 			"firstName": "Felice",
@@ -751,7 +2765,60 @@
 			"applicationCreateDate": "2022-07-24T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "San Jose",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":18,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Hall\",\"gender\":\"Male\",\"lastName\":\"Allicock\",\"maritalStatus\":\"Married\",\"millitaryAffiliation\":null,\"occupation\":\"Other\",\"governmentAffliation\":\"State Firefighters Association\",\"otherOccupation\":\"Senior Cost Accountant\",\"relationToContact\":\"Self\",\"highestEducation\":\"Phd\",\"creditRating\":\"Average\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":47362,\"year\":2014,\"make\":\"Toyota\",\"model\":\"Tundra SR6\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring\",\"ownership\":\"own\",\"primaryusage\":\"pleasure\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$30,000 / $60,000\",\"medical\":\"$1,000\",\"propertyDamage\":\"$100,000\",\"uninsuredOrUnderinsuredMBI\":\"$300,000\",\"uninsuredOrUnderinsuredMPD\":\"$15,000 / $30,000\"},\"vehicles\":[{\"collision\":\"$250\",\"comprehensive\":\"$1,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$30,000 / $60,000",
+						"medical": "$1,000",
+						"propertyDamage": "$100,000",
+						"uninsuredOrUnderinsuredMBI": "$300,000",
+						"uninsuredOrUnderinsuredMPD": "$15,000 / $30,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$250",
+							"comprehensive": "$1,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 18,
+							"creditRating": "Average",
+							"firstName": "Hall",
+							"gender": "Male",
+							"governmentAffliation": "State Firefighters Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "Phd",
+							"lastName": "Allicock",
+							"maritalStatus": "Married",
+							"millitaryAffiliation": null,
+							"occupation": "Other",
+							"otherOccupation": "Senior Cost Accountant",
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 47362,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring",
+							"make": "Toyota",
+							"model": "Tundra SR6",
+							"ownership": "own",
+							"primaryusage": "pleasure",
+							"year": 2014
+						}
+					]
+				}
+			},
 			"email": "hallicockq@livejournal.com",
 			"externalReferenceCode": "AP-26-210-0080",
 			"firstName": "Hall",
@@ -771,7 +2838,60 @@
 			"applicationCreateDate": "2021-09-17T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "Buffalo",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":15,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Jada\",\"gender\":\"Female\",\"lastName\":\"Lewin\",\"maritalStatus\":\"Separated\",\"millitaryAffiliation\":\"US Coast Guard\",\"occupation\":\"Other\",\"governmentAffliation\":\"ABC Sherriff Association\",\"otherOccupation\":\"Computer Systems Analyst IV\",\"relationToContact\":\"Self\",\"highestEducation\":\"Phd\",\"creditRating\":\"Poor\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":61286,\"year\":2013,\"make\":\"Volvo\",\"model\":\"XC90 Inscription\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"loan\",\"primaryusage\":\"commuting\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $100,000\",\"medical\":\"$5,000\",\"propertyDamage\":\"$150,000\",\"uninsuredOrUnderinsuredMBI\":\"$300,000\",\"uninsuredOrUnderinsuredMPD\":\"$30,000 / $60,000\"},\"vehicles\":[{\"collision\":\"$2,000\",\"comprehensive\":\"$5,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $100,000",
+						"medical": "$5,000",
+						"propertyDamage": "$150,000",
+						"uninsuredOrUnderinsuredMBI": "$300,000",
+						"uninsuredOrUnderinsuredMPD": "$30,000 / $60,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$2,000",
+							"comprehensive": "$5,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 15,
+							"creditRating": "Poor",
+							"firstName": "Jada",
+							"gender": "Female",
+							"governmentAffliation": "ABC Sherriff Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "Phd",
+							"lastName": "Lewin",
+							"maritalStatus": "Separated",
+							"millitaryAffiliation": "US Coast Guard",
+							"occupation": "Other",
+							"otherOccupation": "Computer Systems Analyst IV",
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 61286,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Volvo",
+							"model": "XC90 Inscription",
+							"ownership": "loan",
+							"primaryusage": "commuting",
+							"year": 2013
+						}
+					]
+				}
+			},
 			"email": "jlewint@intel.com",
 			"externalReferenceCode": "AP-35-340-7974",
 			"firstName": "Jada",
@@ -791,7 +2911,60 @@
 			"applicationCreateDate": "2022-07-01T00:00:00.000+00:00",
 			"applicationStatus": "rejected",
 			"city": "Modesto",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":20,\"hasAccidentOrCitations\":\"yes\",\"accidentCitation\":\"Citation - Driving under the influence\",\"firstName\":\"Cthrine\",\"gender\":\"Female\",\"lastName\":\"Kirkby\",\"maritalStatus\":\"Married\",\"millitaryAffiliation\":null,\"occupation\":\"Dentist\",\"governmentAffliation\":\"ABC Sherriff Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Poor\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":50387,\"year\":2019,\"make\":\"Toyota\",\"model\":\"Corolla LE\",\"features\":\"Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"own\",\"primaryusage\":\"business\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$30,000 / $60,000\",\"medical\":\"$10,000\",\"propertyDamage\":\"$100,000\",\"uninsuredOrUnderinsuredMBI\":\"$300,000\",\"uninsuredOrUnderinsuredMPD\":\"$500,000 / $ 500,000\"},\"vehicles\":[{\"collision\":\"$250\",\"comprehensive\":\"$500\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$30,000 / $60,000",
+						"medical": "$10,000",
+						"propertyDamage": "$100,000",
+						"uninsuredOrUnderinsuredMBI": "$300,000",
+						"uninsuredOrUnderinsuredMPD": "$500,000 / $ 500,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$250",
+							"comprehensive": "$500"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": "Citation - Driving under the influence",
+							"ageFirstLicensed": 20,
+							"creditRating": "Poor",
+							"firstName": "Cthrine",
+							"gender": "Female",
+							"governmentAffliation": "ABC Sherriff Association",
+							"hasAccidentOrCitations": "yes",
+							"highestEducation": "College",
+							"lastName": "Kirkby",
+							"maritalStatus": "Married",
+							"millitaryAffiliation": null,
+							"occupation": "Dentist",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 50387,
+							"features": "Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Toyota",
+							"model": "Corolla LE",
+							"ownership": "own",
+							"primaryusage": "business",
+							"year": 2019
+						}
+					]
+				}
+			},
 			"email": "ckirkbyj@blogger.com",
 			"externalReferenceCode": "AP-70-696-0206",
 			"firstName": "Cthrine",
@@ -810,7 +2983,60 @@
 			"applicationCreateDate": "2021-09-22T00:00:00.000+00:00",
 			"applicationStatus": "incomplete",
 			"city": "Modesto",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":18,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Cthrine\",\"gender\":\"Female\",\"lastName\":\"Kirkby\",\"maritalStatus\":\"Married\",\"millitaryAffiliation\":null,\"occupation\":\"Government\",\"governmentAffliation\":\"FBI Academy Associates\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"High School\",\"creditRating\":\"Very Good\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":57504,\"year\":2015,\"make\":\"Volvo\",\"model\":\"V90 Cross Country\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"lease\",\"primaryusage\":\"commuting\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$30,000 / $60,000\",\"medical\":\"$1,000\",\"propertyDamage\":\"$25,000\",\"uninsuredOrUnderinsuredMBI\":\"$25,000\",\"uninsuredOrUnderinsuredMPD\":\"$100,000 / $100000\"},\"vehicles\":[{\"collision\":\"$500\",\"comprehensive\":\"$500\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$30,000 / $60,000",
+						"medical": "$1,000",
+						"propertyDamage": "$25,000",
+						"uninsuredOrUnderinsuredMBI": "$25,000",
+						"uninsuredOrUnderinsuredMPD": "$100,000 / $100000"
+					},
+					"vehicles": [
+						{
+							"collision": "$500",
+							"comprehensive": "$500"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 18,
+							"creditRating": "Very Good",
+							"firstName": "Cthrine",
+							"gender": "Female",
+							"governmentAffliation": "FBI Academy Associates",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "High School",
+							"lastName": "Kirkby",
+							"maritalStatus": "Married",
+							"millitaryAffiliation": null,
+							"occupation": "Government",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 57504,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Volvo",
+							"model": "V90 Cross Country",
+							"ownership": "lease",
+							"primaryusage": "commuting",
+							"year": 2015
+						}
+					]
+				}
+			},
 			"email": "ckirkbyj@blogger.com",
 			"externalReferenceCode": "AP-72-958-1782",
 			"firstName": "Cthrine",
@@ -829,7 +3055,60 @@
 			"applicationCreateDate": "2022-03-07T00:00:00.000+00:00",
 			"applicationStatus": "incomplete",
 			"city": "Fresno",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":20,\"hasAccidentOrCitations\":\"yes\",\"accidentCitation\":\"Accident - Not at fault\",\"firstName\":\"Thane\",\"gender\":\"Male\",\"lastName\":\"Fones\",\"maritalStatus\":\"Married\",\"millitaryAffiliation\":null,\"occupation\":\"Accountant\",\"governmentAffliation\":\"FBI Academy Associates\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"Phd\",\"creditRating\":\"Good\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":79673,\"year\":2018,\"make\":\"Ford\",\"model\":\"Edge SE\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring\",\"ownership\":\"own\",\"primaryusage\":\"pleasure\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$30,000 / $60,000\",\"medical\":\"$5,000\",\"propertyDamage\":\"$300,000\",\"uninsuredOrUnderinsuredMBI\":\"$100,000\",\"uninsuredOrUnderinsuredMPD\":\"$25,000 / $50,000\"},\"vehicles\":[{\"collision\":\"$250\",\"comprehensive\":\"$1,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$30,000 / $60,000",
+						"medical": "$5,000",
+						"propertyDamage": "$300,000",
+						"uninsuredOrUnderinsuredMBI": "$100,000",
+						"uninsuredOrUnderinsuredMPD": "$25,000 / $50,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$250",
+							"comprehensive": "$1,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": "Accident - Not at fault",
+							"ageFirstLicensed": 20,
+							"creditRating": "Good",
+							"firstName": "Thane",
+							"gender": "Male",
+							"governmentAffliation": "FBI Academy Associates",
+							"hasAccidentOrCitations": "yes",
+							"highestEducation": "Phd",
+							"lastName": "Fones",
+							"maritalStatus": "Married",
+							"millitaryAffiliation": null,
+							"occupation": "Accountant",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 79673,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring",
+							"make": "Ford",
+							"model": "Edge SE",
+							"ownership": "own",
+							"primaryusage": "pleasure",
+							"year": 2018
+						}
+					]
+				}
+			},
 			"email": "ckirkbyj@blogger.com",
 			"externalReferenceCode": "AP-17-200-4752",
 			"firstName": "Thane",
@@ -848,7 +3127,60 @@
 			"applicationCreateDate": "2022-06-22T00:00:00.000+00:00",
 			"applicationStatus": "underwriting",
 			"city": "Los Angeles",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":17,\"hasAccidentOrCitations\":\"yes\",\"accidentCitation\":\"Accident - Not at fault\",\"firstName\":\"Janeen\",\"gender\":\"Female\",\"lastName\":\"Orrill\",\"maritalStatus\":\"Married\",\"millitaryAffiliation\":null,\"occupation\":\"Government\",\"governmentAffliation\":\"State Firefighters Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"High School\",\"creditRating\":\"Poor\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":58628,\"year\":2013,\"make\":\"Volvo\",\"model\":\"V90 Cross Country\",\"features\":\"Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"own\",\"primaryusage\":\"pleasure\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $100,000\",\"medical\":\"$5,000\",\"propertyDamage\":\"$25,000\",\"uninsuredOrUnderinsuredMBI\":\"$100,000\",\"uninsuredOrUnderinsuredMPD\":\"$30,000 / $60,000\"},\"vehicles\":[{\"collision\":\"$500\",\"comprehensive\":\"$1,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $100,000",
+						"medical": "$5,000",
+						"propertyDamage": "$25,000",
+						"uninsuredOrUnderinsuredMBI": "$100,000",
+						"uninsuredOrUnderinsuredMPD": "$30,000 / $60,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$500",
+							"comprehensive": "$1,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": "Accident - Not at fault",
+							"ageFirstLicensed": 17,
+							"creditRating": "Poor",
+							"firstName": "Janeen",
+							"gender": "Female",
+							"governmentAffliation": "State Firefighters Association",
+							"hasAccidentOrCitations": "yes",
+							"highestEducation": "High School",
+							"lastName": "Orrill",
+							"maritalStatus": "Married",
+							"millitaryAffiliation": null,
+							"occupation": "Government",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 58628,
+							"features": "Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Volvo",
+							"model": "V90 Cross Country",
+							"ownership": "own",
+							"primaryusage": "pleasure",
+							"year": 2013
+						}
+					]
+				}
+			},
 			"email": "jorrilli@amazon.co.jp",
 			"externalReferenceCode": "AP-58-999-0992",
 			"firstName": "Janeen",
@@ -867,7 +3199,60 @@
 			"applicationCreateDate": "2022-04-25T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "San Bernardino",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":21,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Bonnie\",\"gender\":\"Female\",\"lastName\":\"Nevett\",\"maritalStatus\":\"Married\",\"millitaryAffiliation\":null,\"occupation\":\"Dentist\",\"governmentAffliation\":\"ABC Sherriff Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Excellent\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":17959,\"year\":2016,\"make\":\"Toyota\",\"model\":\"Camry Hybrid XLE\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring\",\"ownership\":\"lease\",\"primaryusage\":\"pleasure\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$15,000 / $30,000\",\"medical\":\"$1,000\",\"propertyDamage\":\"$25,000\",\"uninsuredOrUnderinsuredMBI\":\"$25,000\",\"uninsuredOrUnderinsuredMPD\":\"$30,000 / $60,000\"},\"vehicles\":[{\"collision\":\"$1,000\",\"comprehensive\":\"$500\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$15,000 / $30,000",
+						"medical": "$1,000",
+						"propertyDamage": "$25,000",
+						"uninsuredOrUnderinsuredMBI": "$25,000",
+						"uninsuredOrUnderinsuredMPD": "$30,000 / $60,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$1,000",
+							"comprehensive": "$500"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 21,
+							"creditRating": "Excellent",
+							"firstName": "Bonnie",
+							"gender": "Female",
+							"governmentAffliation": "ABC Sherriff Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "College",
+							"lastName": "Nevett",
+							"maritalStatus": "Married",
+							"millitaryAffiliation": null,
+							"occupation": "Dentist",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 17959,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring",
+							"make": "Toyota",
+							"model": "Camry Hybrid XLE",
+							"ownership": "lease",
+							"primaryusage": "pleasure",
+							"year": 2016
+						}
+					]
+				}
+			},
 			"email": "bnevetta@dedecms.com",
 			"externalReferenceCode": "AP-75-970-0972",
 			"firstName": "Bonnie",
@@ -887,7 +3272,60 @@
 			"applicationCreateDate": "2022-10-04T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "Oakland",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":16,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Rycca\",\"gender\":\"Female\",\"lastName\":\"Fortescue\",\"maritalStatus\":\"Single\",\"millitaryAffiliation\":null,\"occupation\":\"Other\",\"governmentAffliation\":\"FBI Academy Associates\",\"otherOccupation\":\"Data Coordiator\",\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Excellent\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":25770,\"year\":2019,\"make\":\"Ford\",\"model\":\"Focus S Sedan\",\"features\":\"Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"loan\",\"primaryusage\":\"commuting\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $ 300,000\",\"medical\":\"$5,000\",\"propertyDamage\":\"$300,000\",\"uninsuredOrUnderinsuredMBI\":\"$25,000\",\"uninsuredOrUnderinsuredMPD\":\"$100,000 / $ 300,000\"},\"vehicles\":[{\"collision\":\"$250\",\"comprehensive\":\"$1,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $ 300,000",
+						"medical": "$5,000",
+						"propertyDamage": "$300,000",
+						"uninsuredOrUnderinsuredMBI": "$25,000",
+						"uninsuredOrUnderinsuredMPD": "$100,000 / $ 300,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$250",
+							"comprehensive": "$1,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 16,
+							"creditRating": "Excellent",
+							"firstName": "Rycca",
+							"gender": "Female",
+							"governmentAffliation": "FBI Academy Associates",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "College",
+							"lastName": "Fortescue",
+							"maritalStatus": "Single",
+							"millitaryAffiliation": null,
+							"occupation": "Other",
+							"otherOccupation": "Data Coordiator",
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 25770,
+							"features": "Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Ford",
+							"model": "Focus S Sedan",
+							"ownership": "loan",
+							"primaryusage": "commuting",
+							"year": 2019
+						}
+					]
+				}
+			},
 			"email": "rfortescuez@usa.gov",
 			"externalReferenceCode": "AP-45-524-6958",
 			"firstName": "Rycca",
@@ -907,7 +3345,60 @@
 			"applicationCreateDate": "2023-02-05T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "San Bernardino",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":18,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Mitzi\",\"gender\":\"Female\",\"lastName\":\"Barnwall\",\"maritalStatus\":\"Widowed\",\"millitaryAffiliation\":null,\"occupation\":\"Government\",\"governmentAffliation\":\"State Firefighters Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"High School\",\"creditRating\":\"Very Good\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":52828,\"year\":2015,\"make\":\"Ford\",\"model\":\"Edge SE\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring\",\"ownership\":\"own\",\"primaryusage\":\"business\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $ 300,000\",\"medical\":\"$1,000\",\"propertyDamage\":\"$300,000\",\"uninsuredOrUnderinsuredMBI\":\"$300,000\",\"uninsuredOrUnderinsuredMPD\":\"$100,000 / $ 300,000\"},\"vehicles\":[{\"collision\":\"$500\",\"comprehensive\":\"$1,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $ 300,000",
+						"medical": "$1,000",
+						"propertyDamage": "$300,000",
+						"uninsuredOrUnderinsuredMBI": "$300,000",
+						"uninsuredOrUnderinsuredMPD": "$100,000 / $ 300,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$500",
+							"comprehensive": "$1,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 18,
+							"creditRating": "Very Good",
+							"firstName": "Mitzi",
+							"gender": "Female",
+							"governmentAffliation": "State Firefighters Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "High School",
+							"lastName": "Barnwall",
+							"maritalStatus": "Widowed",
+							"millitaryAffiliation": null,
+							"occupation": "Government",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 52828,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring",
+							"make": "Ford",
+							"model": "Edge SE",
+							"ownership": "own",
+							"primaryusage": "business",
+							"year": 2015
+						}
+					]
+				}
+			},
 			"email": "mbarnwall4@drupal.org",
 			"externalReferenceCode": "AP-01-048-4146",
 			"firstName": "Mitzi",
@@ -927,7 +3418,60 @@
 			"applicationCreateDate": "2022-08-03T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "Los Angeles",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":20,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Osgood\",\"gender\":\"Male\",\"lastName\":\"Dummer\",\"maritalStatus\":\"Single\",\"millitaryAffiliation\":null,\"occupation\":\"Engineer\",\"governmentAffliation\":\"FBI Academy Associates\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Excellent\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":3369,\"year\":2014,\"make\":\"Volvo\",\"model\":\"V90 Cross Country\",\"features\":\"Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"lease\",\"primaryusage\":\"business\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$15,000 / $30,000\",\"medical\":\"$10,000\",\"propertyDamage\":\"$100,000\",\"uninsuredOrUnderinsuredMBI\":\"$100,000\",\"uninsuredOrUnderinsuredMPD\":\"$500,000 / $ 500,000\"},\"vehicles\":[{\"collision\":\"$500\",\"comprehensive\":\"$250\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$15,000 / $30,000",
+						"medical": "$10,000",
+						"propertyDamage": "$100,000",
+						"uninsuredOrUnderinsuredMBI": "$100,000",
+						"uninsuredOrUnderinsuredMPD": "$500,000 / $ 500,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$500",
+							"comprehensive": "$250"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 20,
+							"creditRating": "Excellent",
+							"firstName": "Osgood",
+							"gender": "Male",
+							"governmentAffliation": "FBI Academy Associates",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "College",
+							"lastName": "Dummer",
+							"maritalStatus": "Single",
+							"millitaryAffiliation": null,
+							"occupation": "Engineer",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 3369,
+							"features": "Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Volvo",
+							"model": "V90 Cross Country",
+							"ownership": "lease",
+							"primaryusage": "business",
+							"year": 2014
+						}
+					]
+				}
+			},
 			"email": "odummer1a@wikia.com",
 			"externalReferenceCode": "AP-54-652-1207",
 			"firstName": "Osgood",
@@ -947,7 +3491,60 @@
 			"applicationCreateDate": "2022-11-16T00:00:00.000+00:00",
 			"applicationStatus": "underwriting",
 			"city": "San Francisco",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":15,\"hasAccidentOrCitations\":\"yes\",\"accidentCitation\":\"Accident - Car rolled over\",\"firstName\":\"Brendis\",\"gender\":\"Male\",\"lastName\":\"McVee\",\"maritalStatus\":\"Married\",\"millitaryAffiliation\":null,\"occupation\":\"Engineer\",\"governmentAffliation\":\"ABC Sherriff Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"Masters\",\"creditRating\":\"Good\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":9940,\"year\":2016,\"make\":\"Volvo\",\"model\":\"V90 Cross Country\",\"features\":\"Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"lease\",\"primaryusage\":\"commuting\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$15,000 / $30,000\",\"medical\":\"$10,000\",\"propertyDamage\":\"$300,000\",\"uninsuredOrUnderinsuredMBI\":\"$25,000\",\"uninsuredOrUnderinsuredMPD\":\"$30,000 / $60,000\"},\"vehicles\":[{\"collision\":\"$1,000\",\"comprehensive\":\"$250\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$15,000 / $30,000",
+						"medical": "$10,000",
+						"propertyDamage": "$300,000",
+						"uninsuredOrUnderinsuredMBI": "$25,000",
+						"uninsuredOrUnderinsuredMPD": "$30,000 / $60,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$1,000",
+							"comprehensive": "$250"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": "Accident - Car rolled over",
+							"ageFirstLicensed": 15,
+							"creditRating": "Good",
+							"firstName": "Brendis",
+							"gender": "Male",
+							"governmentAffliation": "ABC Sherriff Association",
+							"hasAccidentOrCitations": "yes",
+							"highestEducation": "Masters",
+							"lastName": "McVee",
+							"maritalStatus": "Married",
+							"millitaryAffiliation": null,
+							"occupation": "Engineer",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 9940,
+							"features": "Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Volvo",
+							"model": "V90 Cross Country",
+							"ownership": "lease",
+							"primaryusage": "commuting",
+							"year": 2016
+						}
+					]
+				}
+			},
 			"email": "bmcveep@apache.org",
 			"externalReferenceCode": "AP-76-965-4276",
 			"firstName": "Brendis",
@@ -966,7 +3563,60 @@
 			"applicationCreateDate": "2022-10-06T00:00:00.000+00:00",
 			"applicationStatus": "underwriting",
 			"city": "Bronx",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":17,\"hasAccidentOrCitations\":\"yes\",\"accidentCitation\":\"Citation - Failing to Yield\",\"firstName\":\"Pembroke\",\"gender\":\"Male\",\"lastName\":\"Hutable\",\"maritalStatus\":\"Single\",\"millitaryAffiliation\":null,\"occupation\":\"Dentist\",\"governmentAffliation\":\"State Firefighters Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Very Good\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":30644,\"year\":2014,\"make\":\"Ford\",\"model\":\"Edge SE\",\"features\":\"Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"lease\",\"primaryusage\":\"business\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $100,000\",\"medical\":\"$5,000\",\"propertyDamage\":\"$150,000\",\"uninsuredOrUnderinsuredMBI\":\"$300,000\",\"uninsuredOrUnderinsuredMPD\":\"$500,000 / $ 500,000\"},\"vehicles\":[{\"collision\":\"$750\",\"comprehensive\":\"$2,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $100,000",
+						"medical": "$5,000",
+						"propertyDamage": "$150,000",
+						"uninsuredOrUnderinsuredMBI": "$300,000",
+						"uninsuredOrUnderinsuredMPD": "$500,000 / $ 500,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$750",
+							"comprehensive": "$2,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": "Citation - Failing to Yield",
+							"ageFirstLicensed": 17,
+							"creditRating": "Very Good",
+							"firstName": "Pembroke",
+							"gender": "Male",
+							"governmentAffliation": "State Firefighters Association",
+							"hasAccidentOrCitations": "yes",
+							"highestEducation": "College",
+							"lastName": "Hutable",
+							"maritalStatus": "Single",
+							"millitaryAffiliation": null,
+							"occupation": "Dentist",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 30644,
+							"features": "Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Ford",
+							"model": "Edge SE",
+							"ownership": "lease",
+							"primaryusage": "business",
+							"year": 2014
+						}
+					]
+				}
+			},
 			"email": "phutablee@amazon.co.uk",
 			"externalReferenceCode": "AP-32-942-6477",
 			"firstName": "Pembroke",
@@ -985,7 +3635,60 @@
 			"applicationCreateDate": "2022-12-24T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "Bronx",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":17,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Pembroke\",\"gender\":\"Male\",\"lastName\":\"Hutable\",\"maritalStatus\":\"Single\",\"millitaryAffiliation\":null,\"occupation\":\"Government\",\"governmentAffliation\":\"ABC Sherriff Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"High School\",\"creditRating\":\"Average\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":54874,\"year\":2013,\"make\":\"Ford\",\"model\":\"Edge SE\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"own\",\"primaryusage\":\"business\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $100,000\",\"medical\":\"$5,000\",\"propertyDamage\":\"$300,000\",\"uninsuredOrUnderinsuredMBI\":\"$25,000\",\"uninsuredOrUnderinsuredMPD\":\"$50,000 / $100,000\"},\"vehicles\":[{\"collision\":\"$2,000\",\"comprehensive\":\"$5,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $100,000",
+						"medical": "$5,000",
+						"propertyDamage": "$300,000",
+						"uninsuredOrUnderinsuredMBI": "$25,000",
+						"uninsuredOrUnderinsuredMPD": "$50,000 / $100,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$2,000",
+							"comprehensive": "$5,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 17,
+							"creditRating": "Average",
+							"firstName": "Pembroke",
+							"gender": "Male",
+							"governmentAffliation": "ABC Sherriff Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "High School",
+							"lastName": "Hutable",
+							"maritalStatus": "Single",
+							"millitaryAffiliation": null,
+							"occupation": "Government",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 54874,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Ford",
+							"model": "Edge SE",
+							"ownership": "own",
+							"primaryusage": "business",
+							"year": 2013
+						}
+					]
+				}
+			},
 			"email": "phutablee@amazon.co.uk",
 			"externalReferenceCode": "AP-81-289-9483",
 			"firstName": "Pembroke",
@@ -1005,7 +3708,60 @@
 			"applicationCreateDate": "2022-09-04T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "Bronx",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":20,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Pembroke\",\"gender\":\"Male\",\"lastName\":\"Hutable\",\"maritalStatus\":\"Separated\",\"millitaryAffiliation\":null,\"occupation\":\"Dentist\",\"governmentAffliation\":\"FBI Academy Associates\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Poor\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":25258,\"year\":2013,\"make\":\"Toyota\",\"model\":\"Camry Hybrid XLE\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"own\",\"primaryusage\":\"commuting\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$30,000 / $60,000\",\"medical\":\"$1,000\",\"propertyDamage\":\"$300,000\",\"uninsuredOrUnderinsuredMBI\":\"$150,000\",\"uninsuredOrUnderinsuredMPD\":\"$15,000 / $30,000\"},\"vehicles\":[{\"collision\":\"$5,000\",\"comprehensive\":\"$2,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$30,000 / $60,000",
+						"medical": "$1,000",
+						"propertyDamage": "$300,000",
+						"uninsuredOrUnderinsuredMBI": "$150,000",
+						"uninsuredOrUnderinsuredMPD": "$15,000 / $30,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$5,000",
+							"comprehensive": "$2,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 20,
+							"creditRating": "Poor",
+							"firstName": "Pembroke",
+							"gender": "Male",
+							"governmentAffliation": "FBI Academy Associates",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "College",
+							"lastName": "Hutable",
+							"maritalStatus": "Separated",
+							"millitaryAffiliation": null,
+							"occupation": "Dentist",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 25258,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Toyota",
+							"model": "Camry Hybrid XLE",
+							"ownership": "own",
+							"primaryusage": "commuting",
+							"year": 2013
+						}
+					]
+				}
+			},
 			"dateCreated": "2023-03-21T17:26:13.679+00:00",
 			"dateModified": "2023-03-21T19:14:18.999+00:00",
 			"email": "phutablee@amazon.co.uk",
@@ -1027,7 +3783,60 @@
 			"applicationCreateDate": "2021-09-22T00:00:00.000+00:00",
 			"applicationStatus": "rejected",
 			"city": "San Diego",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":15,\"hasAccidentOrCitations\":\"yes\",\"accidentCitation\":\"Citation - Driving under the influence\",\"firstName\":\"Ariel\",\"gender\":\"Female\",\"lastName\":\"Wight\",\"maritalStatus\":\"Single\",\"millitaryAffiliation\":null,\"occupation\":\"Other\",\"governmentAffliation\":\"FBI Academy Associates\",\"otherOccupation\":\"Librarian\",\"relationToContact\":\"Self\",\"highestEducation\":\"Phd\",\"creditRating\":\"Poor\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":40302,\"year\":2017,\"make\":\"Toyota\",\"model\":\"Tundra SR6\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring\",\"ownership\":\"own\",\"primaryusage\":\"pleasure\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$30,000 / $60,000\",\"medical\":\"$5,000\",\"propertyDamage\":\"$300,000\",\"uninsuredOrUnderinsuredMBI\":\"$25,000\",\"uninsuredOrUnderinsuredMPD\":\"$25,000 / $50,000\"},\"vehicles\":[{\"collision\":\"$250\",\"comprehensive\":\"$500\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$30,000 / $60,000",
+						"medical": "$5,000",
+						"propertyDamage": "$300,000",
+						"uninsuredOrUnderinsuredMBI": "$25,000",
+						"uninsuredOrUnderinsuredMPD": "$25,000 / $50,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$250",
+							"comprehensive": "$500"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": "Citation - Driving under the influence",
+							"ageFirstLicensed": 15,
+							"creditRating": "Poor",
+							"firstName": "Ariel",
+							"gender": "Female",
+							"governmentAffliation": "FBI Academy Associates",
+							"hasAccidentOrCitations": "yes",
+							"highestEducation": "Phd",
+							"lastName": "Wight",
+							"maritalStatus": "Single",
+							"millitaryAffiliation": null,
+							"occupation": "Other",
+							"otherOccupation": "Librarian",
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 40302,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring",
+							"make": "Toyota",
+							"model": "Tundra SR6",
+							"ownership": "own",
+							"primaryusage": "pleasure",
+							"year": 2017
+						}
+					]
+				}
+			},
 			"email": "awightv@intel.com",
 			"externalReferenceCode": "AP-74-058-1499",
 			"firstName": "Ariel",
@@ -1046,7 +3855,60 @@
 			"applicationCreateDate": "2023-02-14T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "San Bernardino",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":19,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Mitzi\",\"gender\":\"Female\",\"lastName\":\"Barnwall\",\"maritalStatus\":\"Single\",\"millitaryAffiliation\":null,\"occupation\":\"Accountant\",\"governmentAffliation\":\"ABC Sherriff Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Excellent\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":23299,\"year\":2017,\"make\":\"Toyota\",\"model\":\"Corolla LE\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring\",\"ownership\":\"lease\",\"primaryusage\":\"pleasure\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$15,000 / $30,000\",\"medical\":\"$1,000\",\"propertyDamage\":\"$100,000\",\"uninsuredOrUnderinsuredMBI\":\"$100,000\",\"uninsuredOrUnderinsuredMPD\":\"$30,000 / $60,000\"},\"vehicles\":[{\"collision\":\"$250\",\"comprehensive\":\"$1,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$15,000 / $30,000",
+						"medical": "$1,000",
+						"propertyDamage": "$100,000",
+						"uninsuredOrUnderinsuredMBI": "$100,000",
+						"uninsuredOrUnderinsuredMPD": "$30,000 / $60,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$250",
+							"comprehensive": "$1,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 19,
+							"creditRating": "Excellent",
+							"firstName": "Mitzi",
+							"gender": "Female",
+							"governmentAffliation": "ABC Sherriff Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "College",
+							"lastName": "Barnwall",
+							"maritalStatus": "Single",
+							"millitaryAffiliation": null,
+							"occupation": "Accountant",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 23299,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring",
+							"make": "Toyota",
+							"model": "Corolla LE",
+							"ownership": "lease",
+							"primaryusage": "pleasure",
+							"year": 2017
+						}
+					]
+				}
+			},
 			"email": "mbarnwall4@drupal.org",
 			"externalReferenceCode": "AP-63-953-3761",
 			"firstName": "Mitzi",
@@ -1066,7 +3928,60 @@
 			"applicationCreateDate": "2023-03-03T00:00:00.000+00:00",
 			"applicationStatus": "rejected",
 			"city": "New York City",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":16,\"hasAccidentOrCitations\":\"yes\",\"accidentCitation\":\"Citation - Driving under the influence\",\"firstName\":\"Aloysius\",\"gender\":\"Male\",\"lastName\":\"Ridsdale\",\"maritalStatus\":\"Married\",\"millitaryAffiliation\":null,\"occupation\":\"Engineer\",\"governmentAffliation\":\"FBI Academy Associates\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Very Good\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":43273,\"year\":2016,\"make\":\"Volvo\",\"model\":\"V90 Cross Country\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring\",\"ownership\":\"loan\",\"primaryusage\":\"business\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$500,000 / $ 500,000\",\"medical\":\"$1,000\",\"propertyDamage\":\"$25,000\",\"uninsuredOrUnderinsuredMBI\":\"$150,000\",\"uninsuredOrUnderinsuredMPD\":\"$100,000 / $ 300,000\"},\"vehicles\":[{\"collision\":\"$5,000\",\"comprehensive\":\"$2,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$500,000 / $ 500,000",
+						"medical": "$1,000",
+						"propertyDamage": "$25,000",
+						"uninsuredOrUnderinsuredMBI": "$150,000",
+						"uninsuredOrUnderinsuredMPD": "$100,000 / $ 300,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$5,000",
+							"comprehensive": "$2,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": "Citation - Driving under the influence",
+							"ageFirstLicensed": 16,
+							"creditRating": "Very Good",
+							"firstName": "Aloysius",
+							"gender": "Male",
+							"governmentAffliation": "FBI Academy Associates",
+							"hasAccidentOrCitations": "yes",
+							"highestEducation": "College",
+							"lastName": "Ridsdale",
+							"maritalStatus": "Married",
+							"millitaryAffiliation": null,
+							"occupation": "Engineer",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 43273,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring",
+							"make": "Volvo",
+							"model": "V90 Cross Country",
+							"ownership": "loan",
+							"primaryusage": "business",
+							"year": 2016
+						}
+					]
+				}
+			},
 			"email": "aridsdale10@nymag.com",
 			"externalReferenceCode": "AP-05-150-7621",
 			"firstName": "Aloysius",
@@ -1085,7 +4000,60 @@
 			"applicationCreateDate": "2022-06-28T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "Buffalo",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":21,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Jessa\",\"gender\":\"Female\",\"lastName\":\"Capron\",\"maritalStatus\":\"Separated\",\"millitaryAffiliation\":null,\"occupation\":\"Government\",\"governmentAffliation\":\"State Firefighters Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Poor\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":10030,\"year\":2013,\"make\":\"Toyota\",\"model\":\"Corolla LE\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring\",\"ownership\":\"own\",\"primaryusage\":\"business\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$30,000 / $60,000\",\"medical\":\"$1,000\",\"propertyDamage\":\"$25,000\",\"uninsuredOrUnderinsuredMBI\":\"$150,000\",\"uninsuredOrUnderinsuredMPD\":\"$15,000 / $30,000\"},\"vehicles\":[{\"collision\":\"$750\",\"comprehensive\":\"$750\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$30,000 / $60,000",
+						"medical": "$1,000",
+						"propertyDamage": "$25,000",
+						"uninsuredOrUnderinsuredMBI": "$150,000",
+						"uninsuredOrUnderinsuredMPD": "$15,000 / $30,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$750",
+							"comprehensive": "$750"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 21,
+							"creditRating": "Poor",
+							"firstName": "Jessa",
+							"gender": "Female",
+							"governmentAffliation": "State Firefighters Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "College",
+							"lastName": "Capron",
+							"maritalStatus": "Separated",
+							"millitaryAffiliation": null,
+							"occupation": "Government",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 10030,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring",
+							"make": "Toyota",
+							"model": "Corolla LE",
+							"ownership": "own",
+							"primaryusage": "business",
+							"year": 2013
+						}
+					]
+				}
+			},
 			"email": "jcapronb@cisco.com",
 			"externalReferenceCode": "AP-47-952-6071",
 			"firstName": "Jessa",
@@ -1105,7 +4073,60 @@
 			"applicationCreateDate": "2022-11-30T00:00:00.000+00:00",
 			"applicationStatus": "underwriting",
 			"city": "Bakersfield",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":17,\"hasAccidentOrCitations\":\"yes\",\"accidentCitation\":\"Accident - At fault\",\"firstName\":\"Leelah\",\"gender\":\"Female\",\"lastName\":\"Hicklingbottom\",\"maritalStatus\":\"Single\",\"millitaryAffiliation\":\"US Air Force\",\"occupation\":\"Government\",\"governmentAffliation\":\"FBI Academy Associates\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"High School\",\"creditRating\":\"Excellent\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":42581,\"year\":2014,\"make\":\"Volvo\",\"model\":\"S90 R-Design\",\"features\":\"Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"loan\",\"primaryusage\":\"business\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $100,000\",\"medical\":\"$1,000\",\"propertyDamage\":\"$25,000\",\"uninsuredOrUnderinsuredMBI\":\"$25,000\",\"uninsuredOrUnderinsuredMPD\":\"$300,000 / $ 300,000\"},\"vehicles\":[{\"collision\":\"$250\",\"comprehensive\":\"$500\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $100,000",
+						"medical": "$1,000",
+						"propertyDamage": "$25,000",
+						"uninsuredOrUnderinsuredMBI": "$25,000",
+						"uninsuredOrUnderinsuredMPD": "$300,000 / $ 300,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$250",
+							"comprehensive": "$500"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": "Accident - At fault",
+							"ageFirstLicensed": 17,
+							"creditRating": "Excellent",
+							"firstName": "Leelah",
+							"gender": "Female",
+							"governmentAffliation": "FBI Academy Associates",
+							"hasAccidentOrCitations": "yes",
+							"highestEducation": "High School",
+							"lastName": "Hicklingbottom",
+							"maritalStatus": "Single",
+							"millitaryAffiliation": "US Air Force",
+							"occupation": "Government",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 42581,
+							"features": "Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Volvo",
+							"model": "S90 R-Design",
+							"ownership": "loan",
+							"primaryusage": "business",
+							"year": 2014
+						}
+					]
+				}
+			},
 			"email": "lhicklingbottomm@sohu.com",
 			"externalReferenceCode": "AP-29-671-2837",
 			"firstName": "Leelah",
@@ -1124,7 +4145,60 @@
 			"applicationCreateDate": "2022-01-28T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "Brooklyn",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":17,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Yehudi\",\"gender\":\"Male\",\"lastName\":\"Mancell\",\"maritalStatus\":\"Single\",\"millitaryAffiliation\":null,\"occupation\":\"Other\",\"governmentAffliation\":\"FBI Academy Associates\",\"otherOccupation\":\"Structural Analysis Engineer\",\"relationToContact\":\"Self\",\"highestEducation\":\"High School\",\"creditRating\":\"Good\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":39713,\"year\":2014,\"make\":\"Ford\",\"model\":\"Mustang GT Fastback\",\"features\":\"Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"lease\",\"primaryusage\":\"commuting\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$500,000 / $ 500,000\",\"medical\":\"$5,000\",\"propertyDamage\":\"$25,000\",\"uninsuredOrUnderinsuredMBI\":\"$150,000\",\"uninsuredOrUnderinsuredMPD\":\"$500,000 / $ 500,000\"},\"vehicles\":[{\"collision\":\"$2,000\",\"comprehensive\":\"$750\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$500,000 / $ 500,000",
+						"medical": "$5,000",
+						"propertyDamage": "$25,000",
+						"uninsuredOrUnderinsuredMBI": "$150,000",
+						"uninsuredOrUnderinsuredMPD": "$500,000 / $ 500,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$2,000",
+							"comprehensive": "$750"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 17,
+							"creditRating": "Good",
+							"firstName": "Yehudi",
+							"gender": "Male",
+							"governmentAffliation": "FBI Academy Associates",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "High School",
+							"lastName": "Mancell",
+							"maritalStatus": "Single",
+							"millitaryAffiliation": null,
+							"occupation": "Other",
+							"otherOccupation": "Structural Analysis Engineer",
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 39713,
+							"features": "Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Ford",
+							"model": "Mustang GT Fastback",
+							"ownership": "lease",
+							"primaryusage": "commuting",
+							"year": 2014
+						}
+					]
+				}
+			},
 			"email": "ymancellc@163.com",
 			"externalReferenceCode": "AP-54-848-2327",
 			"firstName": "Yehudi",
@@ -1144,7 +4218,60 @@
 			"applicationCreateDate": "2022-01-14T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "Buffalo",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":18,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Jessa\",\"gender\":\"Female\",\"lastName\":\"Capron\",\"maritalStatus\":\"Single\",\"millitaryAffiliation\":null,\"occupation\":\"Other\",\"governmentAffliation\":\"State Firefighters Association\",\"otherOccupation\":\"Human Resources Assistant III\",\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Good\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":15501,\"year\":2013,\"make\":\"Ford\",\"model\":\"Edge SE\",\"features\":\"Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"own\",\"primaryusage\":\"commuting\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$30,000 / $60,000\",\"medical\":\"$5,000\",\"propertyDamage\":\"$25,000\",\"uninsuredOrUnderinsuredMBI\":\"$25,000\",\"uninsuredOrUnderinsuredMPD\":\"$50,000 / $100,000\"},\"vehicles\":[{\"collision\":\"$750\",\"comprehensive\":\"$750\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$30,000 / $60,000",
+						"medical": "$5,000",
+						"propertyDamage": "$25,000",
+						"uninsuredOrUnderinsuredMBI": "$25,000",
+						"uninsuredOrUnderinsuredMPD": "$50,000 / $100,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$750",
+							"comprehensive": "$750"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 18,
+							"creditRating": "Good",
+							"firstName": "Jessa",
+							"gender": "Female",
+							"governmentAffliation": "State Firefighters Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "College",
+							"lastName": "Capron",
+							"maritalStatus": "Single",
+							"millitaryAffiliation": null,
+							"occupation": "Other",
+							"otherOccupation": "Human Resources Assistant III",
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 15501,
+							"features": "Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Ford",
+							"model": "Edge SE",
+							"ownership": "own",
+							"primaryusage": "commuting",
+							"year": 2013
+						}
+					]
+				}
+			},
 			"email": "jcapronb@cisco.com",
 			"externalReferenceCode": "AP-60-350-1793",
 			"firstName": "Jessa",
@@ -1164,7 +4291,60 @@
 			"applicationCreateDate": "2022-01-21T00:00:00.000+00:00",
 			"applicationStatus": "underwriting",
 			"city": "New York City",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":17,\"hasAccidentOrCitations\":\"yes\",\"accidentCitation\":\"Accident - Not at fault\",\"firstName\":\"Gregor\",\"gender\":\"Male\",\"lastName\":\"Ferreo\",\"maritalStatus\":\"Married\",\"millitaryAffiliation\":null,\"occupation\":\"Government\",\"governmentAffliation\":\"State Firefighters Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"High School\",\"creditRating\":\"Poor\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":30524,\"year\":2017,\"make\":\"Ford\",\"model\":\"Edge SE\",\"features\":\"Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"loan\",\"primaryusage\":\"pleasure\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$500,000 / $ 500,000\",\"medical\":\"$1,000\",\"propertyDamage\":\"$25,000\",\"uninsuredOrUnderinsuredMBI\":\"$150,000\",\"uninsuredOrUnderinsuredMPD\":\"$500,000 / $ 500,000\"},\"vehicles\":[{\"collision\":\"$5,000\",\"comprehensive\":\"$2,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$500,000 / $ 500,000",
+						"medical": "$1,000",
+						"propertyDamage": "$25,000",
+						"uninsuredOrUnderinsuredMBI": "$150,000",
+						"uninsuredOrUnderinsuredMPD": "$500,000 / $ 500,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$5,000",
+							"comprehensive": "$2,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": "Accident - Not at fault",
+							"ageFirstLicensed": 17,
+							"creditRating": "Poor",
+							"firstName": "Gregor",
+							"gender": "Male",
+							"governmentAffliation": "State Firefighters Association",
+							"hasAccidentOrCitations": "yes",
+							"highestEducation": "High School",
+							"lastName": "Ferreo",
+							"maritalStatus": "Married",
+							"millitaryAffiliation": null,
+							"occupation": "Government",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 30524,
+							"features": "Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Ford",
+							"model": "Edge SE",
+							"ownership": "loan",
+							"primaryusage": "pleasure",
+							"year": 2017
+						}
+					]
+				}
+			},
 			"email": "gferreod@reference.com",
 			"externalReferenceCode": "AP-51-165-3210",
 			"firstName": "Gregor",
@@ -1183,7 +4363,60 @@
 			"applicationCreateDate": "2022-04-16T00:00:00.000+00:00",
 			"applicationStatus": "rejected",
 			"city": "New York City",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":20,\"hasAccidentOrCitations\":\"yes\",\"accidentCitation\":\"Citation - Driving under the influence\",\"firstName\":\"Stevana\",\"gender\":\"Female\",\"lastName\":\"Casiero\",\"maritalStatus\":\"Widowed\",\"millitaryAffiliation\":null,\"occupation\":\"Government\",\"governmentAffliation\":\"ABC Sherriff Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"High School\",\"creditRating\":\"Poor\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":50146,\"year\":2015,\"make\":\"Toyota\",\"model\":\"Tundra SR6\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring\",\"ownership\":\"own\",\"primaryusage\":\"pleasure\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $100,000\",\"medical\":\"$5,000\",\"propertyDamage\":\"$150,000\",\"uninsuredOrUnderinsuredMBI\":\"$300,000\",\"uninsuredOrUnderinsuredMPD\":\"$300,000 / $ 300,000\"},\"vehicles\":[{\"collision\":\"$750\",\"comprehensive\":\"$2,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $100,000",
+						"medical": "$5,000",
+						"propertyDamage": "$150,000",
+						"uninsuredOrUnderinsuredMBI": "$300,000",
+						"uninsuredOrUnderinsuredMPD": "$300,000 / $ 300,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$750",
+							"comprehensive": "$2,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": "Citation - Driving under the influence",
+							"ageFirstLicensed": 20,
+							"creditRating": "Poor",
+							"firstName": "Stevana",
+							"gender": "Female",
+							"governmentAffliation": "ABC Sherriff Association",
+							"hasAccidentOrCitations": "yes",
+							"highestEducation": "High School",
+							"lastName": "Casiero",
+							"maritalStatus": "Widowed",
+							"millitaryAffiliation": null,
+							"occupation": "Government",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 50146,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring",
+							"make": "Toyota",
+							"model": "Tundra SR6",
+							"ownership": "own",
+							"primaryusage": "pleasure",
+							"year": 2015
+						}
+					]
+				}
+			},
 			"email": "scasiero19@alibaba.com",
 			"externalReferenceCode": "AP-07-586-9724",
 			"firstName": "Stevana",
@@ -1202,7 +4435,64 @@
 			"applicationCreateDate": "2022-06-20T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "Los Angeles",
-			"dataJSON": "{\"contactInfo\":{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"dateOfBirth\":\"04/06/2023\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":19,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Osgood\",\"gender\":\"Male\",\"lastName\":\"Dummer\",\"maritalStatus\":\"Single\",\"millitaryAffiliation\":null,\"occupation\":\"Engineer\",\"governmentAffliation\":\"State Firefighters Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Excellent\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":29172,\"year\":2014,\"make\":\"Volvo\",\"model\":\"XC90 Inscription\",\"features\":\"Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"lease\",\"primaryusage\":\"pleasure\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$15,000 / $30,000\",\"medical\":\"$1,000\",\"propertyDamage\":\"$25,000\",\"uninsuredOrUnderinsuredMBI\":\"$100,000\",\"uninsuredOrUnderinsuredMPD\":\"$300,000 / $ 300,000\"},\"vehicles\":[{\"collision\":\"$1,000\",\"comprehensive\":\"$250\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"contactInfo": {
+						"dateOfBirth": "04/06/2000",
+						"ownership": "own"
+					},
+					"dateOfBirth": "04/06/2023",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$15,000 / $30,000",
+						"medical": "$1,000",
+						"propertyDamage": "$25,000",
+						"uninsuredOrUnderinsuredMBI": "$100,000",
+						"uninsuredOrUnderinsuredMPD": "$300,000 / $ 300,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$1,000",
+							"comprehensive": "$250"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 19,
+							"creditRating": "Excellent",
+							"firstName": "Osgood",
+							"gender": "Male",
+							"governmentAffliation": "State Firefighters Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "College",
+							"lastName": "Dummer",
+							"maritalStatus": "Single",
+							"millitaryAffiliation": null,
+							"occupation": "Engineer",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 29172,
+							"features": "Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Volvo",
+							"model": "XC90 Inscription",
+							"ownership": "lease",
+							"primaryusage": "pleasure",
+							"year": 2014
+						}
+					]
+				}
+			},
 			"email": "odummer1a@wikia.com",
 			"externalReferenceCode": "AP-27-283-4989",
 			"firstName": "Osgood",
@@ -1222,7 +4512,60 @@
 			"applicationCreateDate": "2022-01-13T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "Fresno",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":20,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Jolie\",\"gender\":\"Female\",\"lastName\":\"Zecchi\",\"maritalStatus\":\"Married\",\"millitaryAffiliation\":null,\"occupation\":\"Government\",\"governmentAffliation\":\"ABC Sherriff Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Poor\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":35072,\"year\":2019,\"make\":\"Volvo\",\"model\":\"V90 Cross Country\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"lease\",\"primaryusage\":\"business\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$30,000 / $60,000\",\"medical\":\"$10,000\",\"propertyDamage\":\"$300,000\",\"uninsuredOrUnderinsuredMBI\":\"$25,000\",\"uninsuredOrUnderinsuredMPD\":\"$500,000 / $ 500,000\"},\"vehicles\":[{\"collision\":\"$1,000\",\"comprehensive\":\"$250\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$30,000 / $60,000",
+						"medical": "$10,000",
+						"propertyDamage": "$300,000",
+						"uninsuredOrUnderinsuredMBI": "$25,000",
+						"uninsuredOrUnderinsuredMPD": "$500,000 / $ 500,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$1,000",
+							"comprehensive": "$250"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 20,
+							"creditRating": "Poor",
+							"firstName": "Jolie",
+							"gender": "Female",
+							"governmentAffliation": "ABC Sherriff Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "College",
+							"lastName": "Zecchi",
+							"maritalStatus": "Married",
+							"millitaryAffiliation": null,
+							"occupation": "Government",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 35072,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Volvo",
+							"model": "V90 Cross Country",
+							"ownership": "lease",
+							"primaryusage": "business",
+							"year": 2019
+						}
+					]
+				}
+			},
 			"email": "jzecchi7@google.cn",
 			"externalReferenceCode": "AP-29-447-1413",
 			"firstName": "Jolie",
@@ -1242,7 +4585,60 @@
 			"applicationCreateDate": "2022-09-10T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "New York City",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":16,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Gregor\",\"gender\":\"Male\",\"lastName\":\"Ferreo\",\"maritalStatus\":\"Single\",\"millitaryAffiliation\":null,\"occupation\":\"Other\",\"governmentAffliation\":\"State Firefighters Association\",\"otherOccupation\":\"VP Sales\",\"relationToContact\":\"Self\",\"highestEducation\":\"High School\",\"creditRating\":\"Poor\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":48422,\"year\":2019,\"make\":\"Ford\",\"model\":\"F-150 Super 250 XL\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring\",\"ownership\":\"lease\",\"primaryusage\":\"pleasure\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$30,000 / $60,000\",\"medical\":\"$2,000\",\"propertyDamage\":\"$150,000\",\"uninsuredOrUnderinsuredMBI\":\"$300,000\",\"uninsuredOrUnderinsuredMPD\":\"$15,000 / $30,000\"},\"vehicles\":[{\"collision\":\"$750\",\"comprehensive\":\"$750\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$30,000 / $60,000",
+						"medical": "$2,000",
+						"propertyDamage": "$150,000",
+						"uninsuredOrUnderinsuredMBI": "$300,000",
+						"uninsuredOrUnderinsuredMPD": "$15,000 / $30,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$750",
+							"comprehensive": "$750"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 16,
+							"creditRating": "Poor",
+							"firstName": "Gregor",
+							"gender": "Male",
+							"governmentAffliation": "State Firefighters Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "High School",
+							"lastName": "Ferreo",
+							"maritalStatus": "Single",
+							"millitaryAffiliation": null,
+							"occupation": "Other",
+							"otherOccupation": "VP Sales",
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 48422,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring",
+							"make": "Ford",
+							"model": "F-150 Super 250 XL",
+							"ownership": "lease",
+							"primaryusage": "pleasure",
+							"year": 2019
+						}
+					]
+				}
+			},
 			"email": "gferreod@reference.com",
 			"externalReferenceCode": "AP-15-542-8250",
 			"firstName": "Gregor",
@@ -1262,7 +4658,60 @@
 			"applicationCreateDate": "2023-01-04T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "Oceanside",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":19,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Merrily\",\"gender\":\"Female\",\"lastName\":\"Phibb\",\"maritalStatus\":\"Single\",\"millitaryAffiliation\":null,\"occupation\":\"Other\",\"governmentAffliation\":\"ABC Sherriff Association\",\"otherOccupation\":\"Speech Pathologist\",\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Average\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":44418,\"year\":2013,\"make\":\"Ford\",\"model\":\"Mustang GT Fastback\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring\",\"ownership\":\"loan\",\"primaryusage\":\"business\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $100,000\",\"medical\":\"$10,000\",\"propertyDamage\":\"$300,000\",\"uninsuredOrUnderinsuredMBI\":\"$100,000\",\"uninsuredOrUnderinsuredMPD\":\"$100,000 / $100000\"},\"vehicles\":[{\"collision\":\"$1,000\",\"comprehensive\":\"$250\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $100,000",
+						"medical": "$10,000",
+						"propertyDamage": "$300,000",
+						"uninsuredOrUnderinsuredMBI": "$100,000",
+						"uninsuredOrUnderinsuredMPD": "$100,000 / $100000"
+					},
+					"vehicles": [
+						{
+							"collision": "$1,000",
+							"comprehensive": "$250"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 19,
+							"creditRating": "Average",
+							"firstName": "Merrily",
+							"gender": "Female",
+							"governmentAffliation": "ABC Sherriff Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "College",
+							"lastName": "Phibb",
+							"maritalStatus": "Single",
+							"millitaryAffiliation": null,
+							"occupation": "Other",
+							"otherOccupation": "Speech Pathologist",
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 44418,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring",
+							"make": "Ford",
+							"model": "Mustang GT Fastback",
+							"ownership": "loan",
+							"primaryusage": "business",
+							"year": 2013
+						}
+					]
+				}
+			},
 			"email": "mphibb16@scribd.com",
 			"externalReferenceCode": "AP-60-665-7410",
 			"firstName": "Merrily",
@@ -1282,7 +4731,60 @@
 			"applicationCreateDate": "2022-12-08T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "Redwood City",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":19,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Cleon\",\"gender\":\"Male\",\"lastName\":\"Hambribe\",\"maritalStatus\":\"Single\",\"millitaryAffiliation\":null,\"occupation\":\"Other\",\"governmentAffliation\":\"State Firefighters Association\",\"otherOccupation\":\"Developer IV\",\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Good\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":52967,\"year\":2017,\"make\":\"Toyota\",\"model\":\"Tundra SR6\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring\",\"ownership\":\"own\",\"primaryusage\":\"business\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $100,000\",\"medical\":\"$10,000\",\"propertyDamage\":\"$25,000\",\"uninsuredOrUnderinsuredMBI\":\"$25,000\",\"uninsuredOrUnderinsuredMPD\":\"$100,000 / $ 300,000\"},\"vehicles\":[{\"collision\":\"$500\",\"comprehensive\":\"$250\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $100,000",
+						"medical": "$10,000",
+						"propertyDamage": "$25,000",
+						"uninsuredOrUnderinsuredMBI": "$25,000",
+						"uninsuredOrUnderinsuredMPD": "$100,000 / $ 300,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$500",
+							"comprehensive": "$250"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 19,
+							"creditRating": "Good",
+							"firstName": "Cleon",
+							"gender": "Male",
+							"governmentAffliation": "State Firefighters Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "College",
+							"lastName": "Hambribe",
+							"maritalStatus": "Single",
+							"millitaryAffiliation": null,
+							"occupation": "Other",
+							"otherOccupation": "Developer IV",
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 52967,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring",
+							"make": "Toyota",
+							"model": "Tundra SR6",
+							"ownership": "own",
+							"primaryusage": "business",
+							"year": 2017
+						}
+					]
+				}
+			},
 			"email": "chambribe1c@macromedia.com",
 			"externalReferenceCode": "AP-41-006-2886",
 			"firstName": "Cleon",
@@ -1302,7 +4804,60 @@
 			"applicationCreateDate": "2021-11-15T00:00:00.000+00:00",
 			"applicationStatus": "underwriting",
 			"city": "Jamaica",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":18,\"hasAccidentOrCitations\":\"yes\",\"accidentCitation\":\"Accident - Car rolled over\",\"firstName\":\"Addy\",\"gender\":\"Female\",\"lastName\":\"Smalles\",\"maritalStatus\":\"Single\",\"millitaryAffiliation\":null,\"occupation\":\"Dentist\",\"governmentAffliation\":\"State Firefighters Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"Phd\",\"creditRating\":\"Very Good\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":60069,\"year\":2016,\"make\":\"Volvo\",\"model\":\"S90 R-Design\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"own\",\"primaryusage\":\"commuting\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$500,000 / $ 500,000\",\"medical\":\"$2,000\",\"propertyDamage\":\"$25,000\",\"uninsuredOrUnderinsuredMBI\":\"$300,000\",\"uninsuredOrUnderinsuredMPD\":\"$300,000 / $ 300,000\"},\"vehicles\":[{\"collision\":\"$2,000\",\"comprehensive\":\"$750\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$500,000 / $ 500,000",
+						"medical": "$2,000",
+						"propertyDamage": "$25,000",
+						"uninsuredOrUnderinsuredMBI": "$300,000",
+						"uninsuredOrUnderinsuredMPD": "$300,000 / $ 300,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$2,000",
+							"comprehensive": "$750"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": "Accident - Car rolled over",
+							"ageFirstLicensed": 18,
+							"creditRating": "Very Good",
+							"firstName": "Addy",
+							"gender": "Female",
+							"governmentAffliation": "State Firefighters Association",
+							"hasAccidentOrCitations": "yes",
+							"highestEducation": "Phd",
+							"lastName": "Smalles",
+							"maritalStatus": "Single",
+							"millitaryAffiliation": null,
+							"occupation": "Dentist",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 60069,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Volvo",
+							"model": "S90 R-Design",
+							"ownership": "own",
+							"primaryusage": "commuting",
+							"year": 2016
+						}
+					]
+				}
+			},
 			"email": "asmalles13@blogspot.com",
 			"externalReferenceCode": "AP-86-951-7231",
 			"firstName": "Addy",
@@ -1321,7 +4876,60 @@
 			"applicationCreateDate": "2022-01-03T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "Redwood City",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":20,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Cleon\",\"gender\":\"Male\",\"lastName\":\"Hambribe\",\"maritalStatus\":\"Widowed\",\"millitaryAffiliation\":null,\"occupation\":\"Engineer\",\"governmentAffliation\":\"ABC Sherriff Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Very Good\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":22434,\"year\":2014,\"make\":\"Ford\",\"model\":\"Mustang GT Fastback\",\"features\":\"Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"lease\",\"primaryusage\":\"business\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $ 300,000\",\"medical\":\"$1,000\",\"propertyDamage\":\"$25,000\",\"uninsuredOrUnderinsuredMBI\":\"$100,000\",\"uninsuredOrUnderinsuredMPD\":\"$15,000 / $30,000\"},\"vehicles\":[{\"collision\":\"$500\",\"comprehensive\":\"$250\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $ 300,000",
+						"medical": "$1,000",
+						"propertyDamage": "$25,000",
+						"uninsuredOrUnderinsuredMBI": "$100,000",
+						"uninsuredOrUnderinsuredMPD": "$15,000 / $30,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$500",
+							"comprehensive": "$250"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 20,
+							"creditRating": "Very Good",
+							"firstName": "Cleon",
+							"gender": "Male",
+							"governmentAffliation": "ABC Sherriff Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "College",
+							"lastName": "Hambribe",
+							"maritalStatus": "Widowed",
+							"millitaryAffiliation": null,
+							"occupation": "Engineer",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 22434,
+							"features": "Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Ford",
+							"model": "Mustang GT Fastback",
+							"ownership": "lease",
+							"primaryusage": "business",
+							"year": 2014
+						}
+					]
+				}
+			},
 			"email": "chambribe1c@macromedia.com",
 			"externalReferenceCode": "AP-06-747-0313",
 			"firstName": "Cleon",
@@ -1341,7 +4949,60 @@
 			"applicationCreateDate": "2022-08-04T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "South Lake Tahoe",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":20,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Keelby\",\"gender\":\"Male\",\"lastName\":\"Vaen\",\"maritalStatus\":\"Married\",\"millitaryAffiliation\":null,\"occupation\":\"Other\",\"governmentAffliation\":\"ABC Sherriff Association\",\"otherOccupation\":\"Account Executive\",\"relationToContact\":\"Self\",\"highestEducation\":\"Phd\",\"creditRating\":\"Very Good\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":20446,\"year\":2015,\"make\":\"Toyota\",\"model\":\"Camry Hybrid XLE\",\"features\":\"Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"own\",\"primaryusage\":\"business\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $ 300,000\",\"medical\":\"$5,000\",\"propertyDamage\":\"$25,000\",\"uninsuredOrUnderinsuredMBI\":\"$100,000\",\"uninsuredOrUnderinsuredMPD\":\"$15,000 / $30,000\"},\"vehicles\":[{\"collision\":\"$500\",\"comprehensive\":\"$1,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $ 300,000",
+						"medical": "$5,000",
+						"propertyDamage": "$25,000",
+						"uninsuredOrUnderinsuredMBI": "$100,000",
+						"uninsuredOrUnderinsuredMPD": "$15,000 / $30,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$500",
+							"comprehensive": "$1,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 20,
+							"creditRating": "Very Good",
+							"firstName": "Keelby",
+							"gender": "Male",
+							"governmentAffliation": "ABC Sherriff Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "Phd",
+							"lastName": "Vaen",
+							"maritalStatus": "Married",
+							"millitaryAffiliation": null,
+							"occupation": "Other",
+							"otherOccupation": "Account Executive",
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 20446,
+							"features": "Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Toyota",
+							"model": "Camry Hybrid XLE",
+							"ownership": "own",
+							"primaryusage": "business",
+							"year": 2015
+						}
+					]
+				}
+			},
 			"email": "kvaens@devhub.com",
 			"externalReferenceCode": "AP-76-477-2427",
 			"firstName": "Keelby",
@@ -1361,7 +5022,60 @@
 			"applicationCreateDate": "2022-07-22T00:00:00.000+00:00",
 			"applicationStatus": "underwriting",
 			"city": "Anaheim",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":17,\"hasAccidentOrCitations\":\"yes\",\"accidentCitation\":\"Citation - Failing to Yield\",\"firstName\":\"Gerri\",\"gender\":\"Male\",\"lastName\":\"Goodlett\",\"maritalStatus\":\"Married\",\"millitaryAffiliation\":\"US Air Force\",\"occupation\":\"Government\",\"governmentAffliation\":\"ABC Sherriff Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"High School\",\"creditRating\":\"Poor\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":25015,\"year\":2018,\"make\":\"Ford\",\"model\":\"Edge SE\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring\",\"ownership\":\"own\",\"primaryusage\":\"business\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$15,000 / $30,000\",\"medical\":\"$1,000\",\"propertyDamage\":\"$300,000\",\"uninsuredOrUnderinsuredMBI\":\"$100,000\",\"uninsuredOrUnderinsuredMPD\":\"$25,000 / $50,000\"},\"vehicles\":[{\"collision\":\"$500\",\"comprehensive\":\"$1,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$15,000 / $30,000",
+						"medical": "$1,000",
+						"propertyDamage": "$300,000",
+						"uninsuredOrUnderinsuredMBI": "$100,000",
+						"uninsuredOrUnderinsuredMPD": "$25,000 / $50,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$500",
+							"comprehensive": "$1,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": "Citation - Failing to Yield",
+							"ageFirstLicensed": 17,
+							"creditRating": "Poor",
+							"firstName": "Gerri",
+							"gender": "Male",
+							"governmentAffliation": "ABC Sherriff Association",
+							"hasAccidentOrCitations": "yes",
+							"highestEducation": "High School",
+							"lastName": "Goodlett",
+							"maritalStatus": "Married",
+							"millitaryAffiliation": "US Air Force",
+							"occupation": "Government",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 25015,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring",
+							"make": "Ford",
+							"model": "Edge SE",
+							"ownership": "own",
+							"primaryusage": "business",
+							"year": 2018
+						}
+					]
+				}
+			},
 			"email": "ggoodlett9@tiny.cc",
 			"externalReferenceCode": "AP-21-241-1817",
 			"firstName": "Gerri",
@@ -1380,7 +5094,60 @@
 			"applicationCreateDate": "2022-10-18T00:00:00.000+00:00",
 			"applicationStatus": "underwriting",
 			"city": "Carson City",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":16,\"hasAccidentOrCitations\":\"yes\",\"accidentCitation\":\"Accident - Not at fault\",\"firstName\":\"Anallese\",\"gender\":\"Female\",\"lastName\":\"Gillson\",\"maritalStatus\":\"Married\",\"millitaryAffiliation\":null,\"occupation\":\"Engineer\",\"governmentAffliation\":\"State Firefighters Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Poor\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":10157,\"year\":2019,\"make\":\"Volvo\",\"model\":\"XC90 Inscription\",\"features\":\"Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"loan\",\"primaryusage\":\"pleasure\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $100,000\",\"medical\":\"$1,000\",\"propertyDamage\":\"$50,000\",\"uninsuredOrUnderinsuredMBI\":\"$250,000\",\"uninsuredOrUnderinsuredMPD\":\"$30,000 / $60,000\"},\"vehicles\":[{\"collision\":\"$1,000\",\"comprehensive\":\"$5,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $100,000",
+						"medical": "$1,000",
+						"propertyDamage": "$50,000",
+						"uninsuredOrUnderinsuredMBI": "$250,000",
+						"uninsuredOrUnderinsuredMPD": "$30,000 / $60,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$1,000",
+							"comprehensive": "$5,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": "Accident - Not at fault",
+							"ageFirstLicensed": 16,
+							"creditRating": "Poor",
+							"firstName": "Anallese",
+							"gender": "Female",
+							"governmentAffliation": "State Firefighters Association",
+							"hasAccidentOrCitations": "yes",
+							"highestEducation": "College",
+							"lastName": "Gillson",
+							"maritalStatus": "Married",
+							"millitaryAffiliation": null,
+							"occupation": "Engineer",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 10157,
+							"features": "Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Volvo",
+							"model": "XC90 Inscription",
+							"ownership": "loan",
+							"primaryusage": "pleasure",
+							"year": 2019
+						}
+					]
+				}
+			},
 			"email": "agillson1@wunderground.com",
 			"externalReferenceCode": "AP-20-728-3833",
 			"firstName": "Anallese",
@@ -1399,7 +5166,60 @@
 			"applicationCreateDate": "2021-11-20T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "North Las Vegas",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":21,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Heidi\",\"gender\":\"Female\",\"lastName\":\"Bulmer\",\"maritalStatus\":\"Married\",\"millitaryAffiliation\":null,\"occupation\":\"Dentist\",\"governmentAffliation\":\"State Firefighters Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"Masters\",\"creditRating\":\"Poor\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":26161,\"year\":2017,\"make\":\"Volvo\",\"model\":\"V90 Cross Country\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"lease\",\"primaryusage\":\"commuting\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$50,000 / $100,000\",\"medical\":\"$1,000\",\"propertyDamage\":\"$50,000\",\"uninsuredOrUnderinsuredMBI\":\"$500,000\",\"uninsuredOrUnderinsuredMPD\":\"$30,000 / $60,000\"},\"vehicles\":[{\"collision\":\"$1,000\",\"comprehensive\":\"$1,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$50,000 / $100,000",
+						"medical": "$1,000",
+						"propertyDamage": "$50,000",
+						"uninsuredOrUnderinsuredMBI": "$500,000",
+						"uninsuredOrUnderinsuredMPD": "$30,000 / $60,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$1,000",
+							"comprehensive": "$1,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 21,
+							"creditRating": "Poor",
+							"firstName": "Heidi",
+							"gender": "Female",
+							"governmentAffliation": "State Firefighters Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "Masters",
+							"lastName": "Bulmer",
+							"maritalStatus": "Married",
+							"millitaryAffiliation": null,
+							"occupation": "Dentist",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 26161,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Volvo",
+							"model": "V90 Cross Country",
+							"ownership": "lease",
+							"primaryusage": "commuting",
+							"year": 2017
+						}
+					]
+				}
+			},
 			"email": "hbulmer1b@bandcamp.com",
 			"externalReferenceCode": "AP-26-196-7958",
 			"firstName": "Heidi",
@@ -1419,7 +5239,60 @@
 			"applicationCreateDate": "2021-12-22T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "Oceanside",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":16,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Merrily\",\"gender\":\"Female\",\"lastName\":\"Phibb\",\"maritalStatus\":\"Widowed\",\"millitaryAffiliation\":null,\"occupation\":\"Engineer\",\"governmentAffliation\":\"State Firefighters Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"Phd\",\"creditRating\":\"Excellent\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":71809,\"year\":2018,\"make\":\"Ford\",\"model\":\"F-150 Super 250 XL\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring\",\"ownership\":\"own\",\"primaryusage\":\"business\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $ 300,000\",\"medical\":\"$10,000\",\"propertyDamage\":\"$100,000\",\"uninsuredOrUnderinsuredMBI\":\"$100,000\",\"uninsuredOrUnderinsuredMPD\":\"$30,000 / $60,000\"},\"vehicles\":[{\"collision\":\"$500\",\"comprehensive\":\"$250\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $ 300,000",
+						"medical": "$10,000",
+						"propertyDamage": "$100,000",
+						"uninsuredOrUnderinsuredMBI": "$100,000",
+						"uninsuredOrUnderinsuredMPD": "$30,000 / $60,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$500",
+							"comprehensive": "$250"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 16,
+							"creditRating": "Excellent",
+							"firstName": "Merrily",
+							"gender": "Female",
+							"governmentAffliation": "State Firefighters Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "Phd",
+							"lastName": "Phibb",
+							"maritalStatus": "Widowed",
+							"millitaryAffiliation": null,
+							"occupation": "Engineer",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 71809,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring",
+							"make": "Ford",
+							"model": "F-150 Super 250 XL",
+							"ownership": "own",
+							"primaryusage": "business",
+							"year": 2018
+						}
+					]
+				}
+			},
 			"email": "mphibb16@scribd.com",
 			"externalReferenceCode": "AP-36-827-1445",
 			"firstName": "Merrily",
@@ -1439,7 +5312,60 @@
 			"applicationCreateDate": "2022-07-31T00:00:00.000+00:00",
 			"applicationStatus": "underwriting",
 			"city": "North Las Vegas",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":20,\"hasAccidentOrCitations\":\"yes\",\"accidentCitation\":\"Accident - Car rolled over\",\"firstName\":\"Heidi\",\"gender\":\"Female\",\"lastName\":\"Bulmer\",\"maritalStatus\":\"Single\",\"millitaryAffiliation\":null,\"occupation\":\"Accountant\",\"governmentAffliation\":\"State Firefighters Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"High School\",\"creditRating\":\"Excellent\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":67863,\"year\":2017,\"make\":\"Toyota\",\"model\":\"Tundra SR6\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"own\",\"primaryusage\":\"commuting\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$30,000 / $60,000\",\"medical\":\"$500\",\"propertyDamage\":\"$50,000\",\"uninsuredOrUnderinsuredMBI\":\"$50,000\",\"uninsuredOrUnderinsuredMPD\":\"$100,000 / $ 300,000\"},\"vehicles\":[{\"collision\":\"$500\",\"comprehensive\":\"$1,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$30,000 / $60,000",
+						"medical": "$500",
+						"propertyDamage": "$50,000",
+						"uninsuredOrUnderinsuredMBI": "$50,000",
+						"uninsuredOrUnderinsuredMPD": "$100,000 / $ 300,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$500",
+							"comprehensive": "$1,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": "Accident - Car rolled over",
+							"ageFirstLicensed": 20,
+							"creditRating": "Excellent",
+							"firstName": "Heidi",
+							"gender": "Female",
+							"governmentAffliation": "State Firefighters Association",
+							"hasAccidentOrCitations": "yes",
+							"highestEducation": "High School",
+							"lastName": "Bulmer",
+							"maritalStatus": "Single",
+							"millitaryAffiliation": null,
+							"occupation": "Accountant",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 67863,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Toyota",
+							"model": "Tundra SR6",
+							"ownership": "own",
+							"primaryusage": "commuting",
+							"year": 2017
+						}
+					]
+				}
+			},
 			"email": "hbulmer1b@bandcamp.com",
 			"externalReferenceCode": "AP-71-931-0702",
 			"firstName": "Heidi",
@@ -1458,7 +5384,60 @@
 			"applicationCreateDate": "2021-10-13T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "Fullerton",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":21,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Monah\",\"gender\":\"Female\",\"lastName\":\"Woolens\",\"maritalStatus\":\"Single\",\"millitaryAffiliation\":null,\"occupation\":\"Engineer\",\"governmentAffliation\":\"ABC Sherriff Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"Masters\",\"creditRating\":\"Good\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":10420,\"year\":2016,\"make\":\"Ford\",\"model\":\"F-150 Super 250 XL\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"own\",\"primaryusage\":\"commuting\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$15,000 / $30,000\",\"medical\":\"$5,000\",\"propertyDamage\":\"$100,000\",\"uninsuredOrUnderinsuredMBI\":\"$25,000\",\"uninsuredOrUnderinsuredMPD\":\"$300,000 / $ 300,000\"},\"vehicles\":[{\"collision\":\"$500\",\"comprehensive\":\"$500\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$15,000 / $30,000",
+						"medical": "$5,000",
+						"propertyDamage": "$100,000",
+						"uninsuredOrUnderinsuredMBI": "$25,000",
+						"uninsuredOrUnderinsuredMPD": "$300,000 / $ 300,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$500",
+							"comprehensive": "$500"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 21,
+							"creditRating": "Good",
+							"firstName": "Monah",
+							"gender": "Female",
+							"governmentAffliation": "ABC Sherriff Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "Masters",
+							"lastName": "Woolens",
+							"maritalStatus": "Single",
+							"millitaryAffiliation": null,
+							"occupation": "Engineer",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 10420,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Ford",
+							"model": "F-150 Super 250 XL",
+							"ownership": "own",
+							"primaryusage": "commuting",
+							"year": 2016
+						}
+					]
+				}
+			},
 			"email": "mwoolens8@samsung.com",
 			"externalReferenceCode": "AP-27-857-7605",
 			"firstName": "Monah",
@@ -1478,7 +5457,60 @@
 			"applicationCreateDate": "2021-09-20T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "New York City",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":20,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Stevana\",\"gender\":\"Female\",\"lastName\":\"Casiero\",\"maritalStatus\":\"Married\",\"millitaryAffiliation\":null,\"occupation\":\"Accountant\",\"governmentAffliation\":\"State Firefighters Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"High School\",\"creditRating\":\"Average\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":27969,\"year\":2019,\"make\":\"Ford\",\"model\":\"F-150 Super 250 XL\",\"features\":\"Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"loan\",\"primaryusage\":\"business\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$30,000 / $60,000\",\"medical\":\"$1,000\",\"propertyDamage\":\"$25,000\",\"uninsuredOrUnderinsuredMBI\":\"$25,000\",\"uninsuredOrUnderinsuredMPD\":\"$30,000 / $60,000\"},\"vehicles\":[{\"collision\":\"$2,000\",\"comprehensive\":\"$2,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$30,000 / $60,000",
+						"medical": "$1,000",
+						"propertyDamage": "$25,000",
+						"uninsuredOrUnderinsuredMBI": "$25,000",
+						"uninsuredOrUnderinsuredMPD": "$30,000 / $60,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$2,000",
+							"comprehensive": "$2,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 20,
+							"creditRating": "Average",
+							"firstName": "Stevana",
+							"gender": "Female",
+							"governmentAffliation": "State Firefighters Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "High School",
+							"lastName": "Casiero",
+							"maritalStatus": "Married",
+							"millitaryAffiliation": null,
+							"occupation": "Accountant",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 27969,
+							"features": "Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Ford",
+							"model": "F-150 Super 250 XL",
+							"ownership": "loan",
+							"primaryusage": "business",
+							"year": 2019
+						}
+					]
+				}
+			},
 			"email": "scasiero19@alibaba.com",
 			"externalReferenceCode": "AP-50-665-3617",
 			"firstName": "Stevana",
@@ -1498,7 +5530,60 @@
 			"applicationCreateDate": "2022-02-09T00:00:00.000+00:00",
 			"applicationStatus": "rejected",
 			"city": "Lancaster",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":18,\"hasAccidentOrCitations\":\"yes\",\"accidentCitation\":\"Citation - Driving under the influence\",\"firstName\":\"Ferrel\",\"gender\":\"Male\",\"lastName\":\"Sames\",\"maritalStatus\":\"Separated\",\"millitaryAffiliation\":\"US Air Force\",\"occupation\":\"Other\",\"governmentAffliation\":\"ABC Sherriff Association\",\"otherOccupation\":\"Programmer III\",\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Poor\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":41257,\"year\":2018,\"make\":\"Volvo\",\"model\":\"S90 R-Design\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring\",\"ownership\":\"lease\",\"primaryusage\":\"commuting\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$15,000 / $30,000\",\"medical\":\"$10,000\",\"propertyDamage\":\"$100,000\",\"uninsuredOrUnderinsuredMBI\":\"$300,000\",\"uninsuredOrUnderinsuredMPD\":\"$50,000 / $100,000\"},\"vehicles\":[{\"collision\":\"$250\",\"comprehensive\":\"$500\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$15,000 / $30,000",
+						"medical": "$10,000",
+						"propertyDamage": "$100,000",
+						"uninsuredOrUnderinsuredMBI": "$300,000",
+						"uninsuredOrUnderinsuredMPD": "$50,000 / $100,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$250",
+							"comprehensive": "$500"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": "Citation - Driving under the influence",
+							"ageFirstLicensed": 18,
+							"creditRating": "Poor",
+							"firstName": "Ferrel",
+							"gender": "Male",
+							"governmentAffliation": "ABC Sherriff Association",
+							"hasAccidentOrCitations": "yes",
+							"highestEducation": "College",
+							"lastName": "Sames",
+							"maritalStatus": "Separated",
+							"millitaryAffiliation": "US Air Force",
+							"occupation": "Other",
+							"otherOccupation": "Programmer III",
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 41257,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring",
+							"make": "Volvo",
+							"model": "S90 R-Design",
+							"ownership": "lease",
+							"primaryusage": "commuting",
+							"year": 2018
+						}
+					]
+				}
+			},
 			"email": "fsames11@ucoz.com",
 			"externalReferenceCode": "AP-58-186-3941",
 			"firstName": "Ferrel",
@@ -1517,7 +5602,60 @@
 			"applicationCreateDate": "2021-09-18T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "Bronx",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":18,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Pembroke\",\"gender\":\"Male\",\"lastName\":\"Hutable\",\"maritalStatus\":\"Single\",\"millitaryAffiliation\":null,\"occupation\":\"Other\",\"governmentAffliation\":\"FBI Academy Associates\",\"otherOccupation\":\"Account Executive\",\"relationToContact\":\"Self\",\"highestEducation\":\"High School\",\"creditRating\":\"Very Good\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":17766,\"year\":2013,\"make\":\"Volvo\",\"model\":\"S90 R-Design\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring\",\"ownership\":\"loan\",\"primaryusage\":\"commuting\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$30,000 / $60,000\",\"medical\":\"$2,000\",\"propertyDamage\":\"$300,000\",\"uninsuredOrUnderinsuredMBI\":\"$150,000\",\"uninsuredOrUnderinsuredMPD\":\"$15,000 / $30,000\"},\"vehicles\":[{\"collision\":\"$2,000\",\"comprehensive\":\"$5,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$30,000 / $60,000",
+						"medical": "$2,000",
+						"propertyDamage": "$300,000",
+						"uninsuredOrUnderinsuredMBI": "$150,000",
+						"uninsuredOrUnderinsuredMPD": "$15,000 / $30,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$2,000",
+							"comprehensive": "$5,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 18,
+							"creditRating": "Very Good",
+							"firstName": "Pembroke",
+							"gender": "Male",
+							"governmentAffliation": "FBI Academy Associates",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "High School",
+							"lastName": "Hutable",
+							"maritalStatus": "Single",
+							"millitaryAffiliation": null,
+							"occupation": "Other",
+							"otherOccupation": "Account Executive",
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 17766,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring",
+							"make": "Volvo",
+							"model": "S90 R-Design",
+							"ownership": "loan",
+							"primaryusage": "commuting",
+							"year": 2013
+						}
+					]
+				}
+			},
 			"email": "phutablee@amazon.co.uk",
 			"externalReferenceCode": "AP-02-464-7849",
 			"firstName": "Pembroke",
@@ -1537,7 +5675,60 @@
 			"applicationCreateDate": "2022-01-28T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "Brooklyn",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":15,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Yehudi\",\"gender\":\"Male\",\"lastName\":\"Mancell\",\"maritalStatus\":\"Separated\",\"millitaryAffiliation\":null,\"occupation\":\"Accountant\",\"governmentAffliation\":\"State Firefighters Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"Masters\",\"creditRating\":\"Excellent\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":66528,\"year\":2015,\"make\":\"Volvo\",\"model\":\"S90 R-Design\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"lease\",\"primaryusage\":\"commuting\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$30,000 / $60,000\",\"medical\":\"$2,000\",\"propertyDamage\":\"$300,000\",\"uninsuredOrUnderinsuredMBI\":\"$300,000\",\"uninsuredOrUnderinsuredMPD\":\"$15,000 / $30,000\"},\"vehicles\":[{\"collision\":\"$2,000\",\"comprehensive\":\"$5,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$30,000 / $60,000",
+						"medical": "$2,000",
+						"propertyDamage": "$300,000",
+						"uninsuredOrUnderinsuredMBI": "$300,000",
+						"uninsuredOrUnderinsuredMPD": "$15,000 / $30,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$2,000",
+							"comprehensive": "$5,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 15,
+							"creditRating": "Excellent",
+							"firstName": "Yehudi",
+							"gender": "Male",
+							"governmentAffliation": "State Firefighters Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "Masters",
+							"lastName": "Mancell",
+							"maritalStatus": "Separated",
+							"millitaryAffiliation": null,
+							"occupation": "Accountant",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 66528,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Volvo",
+							"model": "S90 R-Design",
+							"ownership": "lease",
+							"primaryusage": "commuting",
+							"year": 2015
+						}
+					]
+				}
+			},
 			"email": "ymancellc@163.com",
 			"externalReferenceCode": "AP-61-121-5224",
 			"firstName": "Yehudi",
@@ -1557,7 +5748,60 @@
 			"applicationCreateDate": "2022-08-13T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "San Bernardino",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":15,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Bonnie\",\"gender\":\"Female\",\"lastName\":\"Nevett\",\"maritalStatus\":\"Single\",\"millitaryAffiliation\":null,\"occupation\":\"Dentist\",\"governmentAffliation\":\"ABC Sherriff Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"High School\",\"creditRating\":\"Very Good\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":46081,\"year\":2015,\"make\":\"Volvo\",\"model\":\"V90 Cross Country\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring\",\"ownership\":\"loan\",\"primaryusage\":\"pleasure\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $ 300,000\",\"medical\":\"$5,000\",\"propertyDamage\":\"$300,000\",\"uninsuredOrUnderinsuredMBI\":\"$100,000\",\"uninsuredOrUnderinsuredMPD\":\"$25,000 / $50,000\"},\"vehicles\":[{\"collision\":\"$1,000\",\"comprehensive\":\"$500\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $ 300,000",
+						"medical": "$5,000",
+						"propertyDamage": "$300,000",
+						"uninsuredOrUnderinsuredMBI": "$100,000",
+						"uninsuredOrUnderinsuredMPD": "$25,000 / $50,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$1,000",
+							"comprehensive": "$500"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 15,
+							"creditRating": "Very Good",
+							"firstName": "Bonnie",
+							"gender": "Female",
+							"governmentAffliation": "ABC Sherriff Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "High School",
+							"lastName": "Nevett",
+							"maritalStatus": "Single",
+							"millitaryAffiliation": null,
+							"occupation": "Dentist",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 46081,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring",
+							"make": "Volvo",
+							"model": "V90 Cross Country",
+							"ownership": "loan",
+							"primaryusage": "pleasure",
+							"year": 2015
+						}
+					]
+				}
+			},
 			"email": "bnevetta@dedecms.com",
 			"externalReferenceCode": "AP-68-705-6331",
 			"firstName": "Bonnie",
@@ -1577,7 +5821,60 @@
 			"applicationCreateDate": "2022-04-03T00:00:00.000+00:00",
 			"applicationStatus": "incomplete",
 			"city": "San Francisco",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":16,\"hasAccidentOrCitations\":\"yes\",\"accidentCitation\":\"Citation - Failing to Yield\",\"firstName\":\"Humfrey\",\"gender\":\"Male\",\"lastName\":\"Hymor\",\"maritalStatus\":\"Single\",\"millitaryAffiliation\":null,\"occupation\":\"Engineer\",\"governmentAffliation\":\"FBI Academy Associates\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Very Good\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":11802,\"year\":2019,\"make\":\"Volvo\",\"model\":\"S90 R-Design\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"lease\",\"primaryusage\":\"business\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $100,000\",\"medical\":\"$10,000\",\"propertyDamage\":\"$25,000\",\"uninsuredOrUnderinsuredMBI\":\"$300,000\",\"uninsuredOrUnderinsuredMPD\":\"$100,000 / $100000\"},\"vehicles\":[{\"collision\":\"$250\",\"comprehensive\":\"$250\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $100,000",
+						"medical": "$10,000",
+						"propertyDamage": "$25,000",
+						"uninsuredOrUnderinsuredMBI": "$300,000",
+						"uninsuredOrUnderinsuredMPD": "$100,000 / $100000"
+					},
+					"vehicles": [
+						{
+							"collision": "$250",
+							"comprehensive": "$250"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": "Citation - Failing to Yield",
+							"ageFirstLicensed": 16,
+							"creditRating": "Very Good",
+							"firstName": "Humfrey",
+							"gender": "Male",
+							"governmentAffliation": "FBI Academy Associates",
+							"hasAccidentOrCitations": "yes",
+							"highestEducation": "College",
+							"lastName": "Hymor",
+							"maritalStatus": "Single",
+							"millitaryAffiliation": null,
+							"occupation": "Engineer",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 11802,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Volvo",
+							"model": "S90 R-Design",
+							"ownership": "lease",
+							"primaryusage": "business",
+							"year": 2019
+						}
+					]
+				}
+			},
 			"email": "hhymorr@i2i.jp",
 			"externalReferenceCode": "AP-17-516-1088",
 			"firstName": "Humfrey",
@@ -1596,7 +5893,60 @@
 			"applicationCreateDate": "2021-11-12T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "Rochester",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":19,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Shurlocke\",\"gender\":\"Male\",\"lastName\":\"Letessier\",\"maritalStatus\":\"Married\",\"millitaryAffiliation\":null,\"occupation\":\"Government\",\"governmentAffliation\":\"State Firefighters Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Average\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":49919,\"year\":2019,\"make\":\"Toyota\",\"model\":\"Camry Hybrid XLE\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring\",\"ownership\":\"lease\",\"primaryusage\":\"commuting\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$30,000 / $60,000\",\"medical\":\"$5,000\",\"propertyDamage\":\"$25,000\",\"uninsuredOrUnderinsuredMBI\":\"$300,000\",\"uninsuredOrUnderinsuredMPD\":\"$30,000 / $60,000\"},\"vehicles\":[{\"collision\":\"$750\",\"comprehensive\":\"$2,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$30,000 / $60,000",
+						"medical": "$5,000",
+						"propertyDamage": "$25,000",
+						"uninsuredOrUnderinsuredMBI": "$300,000",
+						"uninsuredOrUnderinsuredMPD": "$30,000 / $60,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$750",
+							"comprehensive": "$2,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 19,
+							"creditRating": "Average",
+							"firstName": "Shurlocke",
+							"gender": "Male",
+							"governmentAffliation": "State Firefighters Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "College",
+							"lastName": "Letessier",
+							"maritalStatus": "Married",
+							"millitaryAffiliation": null,
+							"occupation": "Government",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 49919,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring",
+							"make": "Toyota",
+							"model": "Camry Hybrid XLE",
+							"ownership": "lease",
+							"primaryusage": "commuting",
+							"year": 2019
+						}
+					]
+				}
+			},
 			"email": "sletessiern@google.ru",
 			"externalReferenceCode": "AP-82-419-3469",
 			"firstName": "Shurlocke",
@@ -1616,7 +5966,60 @@
 			"applicationCreateDate": "2023-01-26T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "Santa Rosa",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":19,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Vale\",\"gender\":\"Male\",\"lastName\":\"Vynall\",\"maritalStatus\":\"Separated\",\"millitaryAffiliation\":null,\"occupation\":\"Government\",\"governmentAffliation\":\"ABC Sherriff Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Good\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":31645,\"year\":2013,\"make\":\"Toyota\",\"model\":\"Camry Hybrid XLE\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring\",\"ownership\":\"loan\",\"primaryusage\":\"business\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$30,000 / $60,000\",\"medical\":\"$10,000\",\"propertyDamage\":\"$25,000\",\"uninsuredOrUnderinsuredMBI\":\"$100,000\",\"uninsuredOrUnderinsuredMPD\":\"$15,000 / $30,000\"},\"vehicles\":[{\"collision\":\"$500\",\"comprehensive\":\"$500\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$30,000 / $60,000",
+						"medical": "$10,000",
+						"propertyDamage": "$25,000",
+						"uninsuredOrUnderinsuredMBI": "$100,000",
+						"uninsuredOrUnderinsuredMPD": "$15,000 / $30,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$500",
+							"comprehensive": "$500"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 19,
+							"creditRating": "Good",
+							"firstName": "Vale",
+							"gender": "Male",
+							"governmentAffliation": "ABC Sherriff Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "College",
+							"lastName": "Vynall",
+							"maritalStatus": "Separated",
+							"millitaryAffiliation": null,
+							"occupation": "Government",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 31645,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring",
+							"make": "Toyota",
+							"model": "Camry Hybrid XLE",
+							"ownership": "loan",
+							"primaryusage": "business",
+							"year": 2013
+						}
+					]
+				}
+			},
 			"email": "vvynall15@zdnet.com",
 			"externalReferenceCode": "AP-39-022-9968",
 			"firstName": "Vale",
@@ -1636,7 +6039,60 @@
 			"applicationCreateDate": "2022-05-25T00:00:00.000+00:00",
 			"applicationStatus": "underwriting",
 			"city": "Bronx",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":17,\"hasAccidentOrCitations\":\"yes\",\"accidentCitation\":\"Accident - Car rolled over\",\"firstName\":\"Pembroke\",\"gender\":\"Male\",\"lastName\":\"Hutable\",\"maritalStatus\":\"Married\",\"millitaryAffiliation\":null,\"occupation\":\"Dentist\",\"governmentAffliation\":\"FBI Academy Associates\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"High School\",\"creditRating\":\"Average\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":44049,\"year\":2019,\"make\":\"Ford\",\"model\":\"Edge SE\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring\",\"ownership\":\"loan\",\"primaryusage\":\"business\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$30,000 / $60,000\",\"medical\":\"$5,000\",\"propertyDamage\":\"$25,000\",\"uninsuredOrUnderinsuredMBI\":\"$150,000\",\"uninsuredOrUnderinsuredMPD\":\"$300,000 / $ 300,000\"},\"vehicles\":[{\"collision\":\"$750\",\"comprehensive\":\"$750\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$30,000 / $60,000",
+						"medical": "$5,000",
+						"propertyDamage": "$25,000",
+						"uninsuredOrUnderinsuredMBI": "$150,000",
+						"uninsuredOrUnderinsuredMPD": "$300,000 / $ 300,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$750",
+							"comprehensive": "$750"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": "Accident - Car rolled over",
+							"ageFirstLicensed": 17,
+							"creditRating": "Average",
+							"firstName": "Pembroke",
+							"gender": "Male",
+							"governmentAffliation": "FBI Academy Associates",
+							"hasAccidentOrCitations": "yes",
+							"highestEducation": "High School",
+							"lastName": "Hutable",
+							"maritalStatus": "Married",
+							"millitaryAffiliation": null,
+							"occupation": "Dentist",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 44049,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring",
+							"make": "Ford",
+							"model": "Edge SE",
+							"ownership": "loan",
+							"primaryusage": "business",
+							"year": 2019
+						}
+					]
+				}
+			},
 			"email": "phutablee@amazon.co.uk",
 			"externalReferenceCode": "AP-08-574-1048",
 			"firstName": "Pembroke",
@@ -1655,7 +6111,60 @@
 			"applicationCreateDate": "2022-06-25T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "Lancaster",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":19,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Shane\",\"gender\":\"Female\",\"lastName\":\"Orgen\",\"maritalStatus\":\"Single\",\"millitaryAffiliation\":\"None\",\"occupation\":\"Accountant\",\"governmentAffliation\":\"ABC Sherriff Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"High School\",\"creditRating\":\"Good\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":46303,\"year\":2017,\"make\":\"Volvo\",\"model\":\"S90 R-Design\",\"features\":\"Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"own\",\"primaryusage\":\"pleasure\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$30,000 / $60,000\",\"medical\":\"$10,000\",\"propertyDamage\":\"$100,000\",\"uninsuredOrUnderinsuredMBI\":\"$100,000\",\"uninsuredOrUnderinsuredMPD\":\"$50,000 / $100,000\"},\"vehicles\":[{\"collision\":\"$250\",\"comprehensive\":\"$500\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$30,000 / $60,000",
+						"medical": "$10,000",
+						"propertyDamage": "$100,000",
+						"uninsuredOrUnderinsuredMBI": "$100,000",
+						"uninsuredOrUnderinsuredMPD": "$50,000 / $100,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$250",
+							"comprehensive": "$500"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 19,
+							"creditRating": "Good",
+							"firstName": "Shane",
+							"gender": "Female",
+							"governmentAffliation": "ABC Sherriff Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "High School",
+							"lastName": "Orgen",
+							"maritalStatus": "Single",
+							"millitaryAffiliation": "None",
+							"occupation": "Accountant",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 46303,
+							"features": "Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Volvo",
+							"model": "S90 R-Design",
+							"ownership": "own",
+							"primaryusage": "pleasure",
+							"year": 2017
+						}
+					]
+				}
+			},
 			"email": "sorgenf@economist.com",
 			"externalReferenceCode": "AP-66-128-8419",
 			"firstName": "Shane",
@@ -1675,7 +6184,60 @@
 			"applicationCreateDate": "2021-11-11T00:00:00.000+00:00",
 			"applicationStatus": "underwriting",
 			"city": "New York City",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":20,\"hasAccidentOrCitations\":\"yes\",\"accidentCitation\":\"US Citation - Speeding\",\"firstName\":\"Gregor\",\"gender\":\"Male\",\"lastName\":\"Ferreo\",\"maritalStatus\":\"Separated\",\"millitaryAffiliation\":\"None\",\"occupation\":\"Government\",\"governmentAffliation\":\"ABC Sherriff Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Excellent\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":74868,\"year\":2017,\"make\":\"Volvo\",\"model\":\"XC90 Inscription\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring\",\"ownership\":\"loan\",\"primaryusage\":\"business\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$500,000 / $ 500,000\",\"medical\":\"$1,000\",\"propertyDamage\":\"$25,000\",\"uninsuredOrUnderinsuredMBI\":\"$150,000\",\"uninsuredOrUnderinsuredMPD\":\"$500,000 / $ 500,000\"},\"vehicles\":[{\"collision\":\"$750\",\"comprehensive\":\"$2,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$500,000 / $ 500,000",
+						"medical": "$1,000",
+						"propertyDamage": "$25,000",
+						"uninsuredOrUnderinsuredMBI": "$150,000",
+						"uninsuredOrUnderinsuredMPD": "$500,000 / $ 500,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$750",
+							"comprehensive": "$2,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": "US Citation - Speeding",
+							"ageFirstLicensed": 20,
+							"creditRating": "Excellent",
+							"firstName": "Gregor",
+							"gender": "Male",
+							"governmentAffliation": "ABC Sherriff Association",
+							"hasAccidentOrCitations": "yes",
+							"highestEducation": "College",
+							"lastName": "Ferreo",
+							"maritalStatus": "Separated",
+							"millitaryAffiliation": "None",
+							"occupation": "Government",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 74868,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring",
+							"make": "Volvo",
+							"model": "XC90 Inscription",
+							"ownership": "loan",
+							"primaryusage": "business",
+							"year": 2017
+						}
+					]
+				}
+			},
 			"email": "gferreod@reference.com",
 			"externalReferenceCode": "AP-51-464-5168",
 			"firstName": "Gregor",
@@ -1694,7 +6256,60 @@
 			"applicationCreateDate": "2022-03-09T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "Buffalo",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":16,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Jada\",\"gender\":\"Female\",\"lastName\":\"Lewin\",\"maritalStatus\":\"Single\",\"millitaryAffiliation\":null,\"occupation\":\"Government\",\"governmentAffliation\":\"State Firefighters Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Good\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":10999,\"year\":2018,\"make\":\"Toyota\",\"model\":\"Camry Hybrid XLE\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring\",\"ownership\":\"own\",\"primaryusage\":\"commuting\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$30,000 / $60,000\",\"medical\":\"$5,000\",\"propertyDamage\":\"$25,000\",\"uninsuredOrUnderinsuredMBI\":\"$25,000\",\"uninsuredOrUnderinsuredMPD\":\"$30,000 / $60,000\"},\"vehicles\":[{\"collision\":\"$750\",\"comprehensive\":\"$5,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$30,000 / $60,000",
+						"medical": "$5,000",
+						"propertyDamage": "$25,000",
+						"uninsuredOrUnderinsuredMBI": "$25,000",
+						"uninsuredOrUnderinsuredMPD": "$30,000 / $60,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$750",
+							"comprehensive": "$5,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 16,
+							"creditRating": "Good",
+							"firstName": "Jada",
+							"gender": "Female",
+							"governmentAffliation": "State Firefighters Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "College",
+							"lastName": "Lewin",
+							"maritalStatus": "Single",
+							"millitaryAffiliation": null,
+							"occupation": "Government",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 10999,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring",
+							"make": "Toyota",
+							"model": "Camry Hybrid XLE",
+							"ownership": "own",
+							"primaryusage": "commuting",
+							"year": 2018
+						}
+					]
+				}
+			},
 			"email": "jlewint@intel.com",
 			"externalReferenceCode": "AP-50-527-9425",
 			"firstName": "Jada",
@@ -1714,7 +6329,60 @@
 			"applicationCreateDate": "2022-10-31T00:00:00.000+00:00",
 			"applicationStatus": "incomplete",
 			"city": "Buffalo",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":19,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Jessa\",\"gender\":\"Female\",\"lastName\":\"Capron\",\"maritalStatus\":\"Married\",\"millitaryAffiliation\":null,\"occupation\":\"Government\",\"governmentAffliation\":\"ABC Sherriff Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"Masters\",\"creditRating\":\"Excellent\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":38449,\"year\":2014,\"make\":\"Volvo\",\"model\":\"XC90 Inscription\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"lease\",\"primaryusage\":\"commuting\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$500,000 / $ 500,000\",\"medical\":\"$2,000\",\"propertyDamage\":\"$300,000\",\"uninsuredOrUnderinsuredMBI\":\"$25,000\",\"uninsuredOrUnderinsuredMPD\":\"$100,000 / $100000\"},\"vehicles\":[{\"collision\":\"$5,000\",\"comprehensive\":\"$750\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$500,000 / $ 500,000",
+						"medical": "$2,000",
+						"propertyDamage": "$300,000",
+						"uninsuredOrUnderinsuredMBI": "$25,000",
+						"uninsuredOrUnderinsuredMPD": "$100,000 / $100000"
+					},
+					"vehicles": [
+						{
+							"collision": "$5,000",
+							"comprehensive": "$750"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 19,
+							"creditRating": "Excellent",
+							"firstName": "Jessa",
+							"gender": "Female",
+							"governmentAffliation": "ABC Sherriff Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "Masters",
+							"lastName": "Capron",
+							"maritalStatus": "Married",
+							"millitaryAffiliation": null,
+							"occupation": "Government",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 38449,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Volvo",
+							"model": "XC90 Inscription",
+							"ownership": "lease",
+							"primaryusage": "commuting",
+							"year": 2014
+						}
+					]
+				}
+			},
 			"email": "jcapronb@cisco.com",
 			"externalReferenceCode": "AP-44-769-5685",
 			"firstName": "Jessa",
@@ -1733,7 +6401,60 @@
 			"applicationCreateDate": "2023-02-03T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "San Diego",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":16,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Ariel\",\"gender\":\"Female\",\"lastName\":\"Wight\",\"maritalStatus\":\"Single\",\"millitaryAffiliation\":null,\"occupation\":\"Other\",\"governmentAffliation\":\"State Firefighters Association\",\"otherOccupation\":\"Editor\",\"relationToContact\":\"Self\",\"highestEducation\":\"High School\",\"creditRating\":\"Good\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":16021,\"year\":2018,\"make\":\"Ford\",\"model\":\"F-150 Super 250 XL\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"loan\",\"primaryusage\":\"pleasure\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$30,000 / $60,000\",\"medical\":\"$1,000\",\"propertyDamage\":\"$100,000\",\"uninsuredOrUnderinsuredMBI\":\"$25,000\",\"uninsuredOrUnderinsuredMPD\":\"$300,000 / $ 300,000\"},\"vehicles\":[{\"collision\":\"$1,000\",\"comprehensive\":\"$500\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$30,000 / $60,000",
+						"medical": "$1,000",
+						"propertyDamage": "$100,000",
+						"uninsuredOrUnderinsuredMBI": "$25,000",
+						"uninsuredOrUnderinsuredMPD": "$300,000 / $ 300,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$1,000",
+							"comprehensive": "$500"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 16,
+							"creditRating": "Good",
+							"firstName": "Ariel",
+							"gender": "Female",
+							"governmentAffliation": "State Firefighters Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "High School",
+							"lastName": "Wight",
+							"maritalStatus": "Single",
+							"millitaryAffiliation": null,
+							"occupation": "Other",
+							"otherOccupation": "Editor",
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 16021,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Ford",
+							"model": "F-150 Super 250 XL",
+							"ownership": "loan",
+							"primaryusage": "pleasure",
+							"year": 2018
+						}
+					]
+				}
+			},
 			"email": "awightv@intel.com",
 			"externalReferenceCode": "AP-84-871-1015",
 			"firstName": "Ariel",
@@ -1753,7 +6474,60 @@
 			"applicationCreateDate": "2022-10-31T00:00:00.000+00:00",
 			"applicationStatus": "incomplete",
 			"city": "New York City",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":17,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Bethanne\",\"gender\":\"Female\",\"lastName\":\"Ritchings\",\"maritalStatus\":\"Single\",\"millitaryAffiliation\":null,\"occupation\":\"Government\",\"governmentAffliation\":\"FBI Academy Associates\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Good\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":51059,\"year\":2015,\"make\":\"Toyota\",\"model\":\"Corolla LE\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"own\",\"primaryusage\":\"commuting\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $100,000\",\"medical\":\"$5,000\",\"propertyDamage\":\"$150,000\",\"uninsuredOrUnderinsuredMBI\":\"$25,000\",\"uninsuredOrUnderinsuredMPD\":\"$100,000 / $ 300,000\"},\"vehicles\":[{\"collision\":\"$750\",\"comprehensive\":\"$750\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $100,000",
+						"medical": "$5,000",
+						"propertyDamage": "$150,000",
+						"uninsuredOrUnderinsuredMBI": "$25,000",
+						"uninsuredOrUnderinsuredMPD": "$100,000 / $ 300,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$750",
+							"comprehensive": "$750"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 17,
+							"creditRating": "Good",
+							"firstName": "Bethanne",
+							"gender": "Female",
+							"governmentAffliation": "FBI Academy Associates",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "College",
+							"lastName": "Ritchings",
+							"maritalStatus": "Single",
+							"millitaryAffiliation": null,
+							"occupation": "Government",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 51059,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Toyota",
+							"model": "Corolla LE",
+							"ownership": "own",
+							"primaryusage": "commuting",
+							"year": 2015
+						}
+					]
+				}
+			},
 			"email": "britchingsy@deliciousdays.com",
 			"externalReferenceCode": "AP-68-336-5689",
 			"firstName": "Bethanne",
@@ -1772,7 +6546,60 @@
 			"applicationCreateDate": "2023-02-13T00:00:00.000+00:00",
 			"applicationStatus": "underwriting",
 			"city": "Long Beach",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":15,\"hasAccidentOrCitations\":\"yes\",\"accidentCitation\":\"Accident - Not at fault\",\"firstName\":\"Evvy\",\"gender\":\"Female\",\"lastName\":\"Woodley\",\"maritalStatus\":\"Separated\",\"millitaryAffiliation\":null,\"occupation\":\"Dentist\",\"governmentAffliation\":\"State Firefighters Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"Phd\",\"creditRating\":\"Average\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":74415,\"year\":2017,\"make\":\"Volvo\",\"model\":\"XC90 Inscription\",\"features\":\"Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"lease\",\"primaryusage\":\"business\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$15,000 / $30,000\",\"medical\":\"$10,000\",\"propertyDamage\":\"$300,000\",\"uninsuredOrUnderinsuredMBI\":\"$100,000\",\"uninsuredOrUnderinsuredMPD\":\"$15,000 / $30,000\"},\"vehicles\":[{\"collision\":\"$250\",\"comprehensive\":\"$500\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$15,000 / $30,000",
+						"medical": "$10,000",
+						"propertyDamage": "$300,000",
+						"uninsuredOrUnderinsuredMBI": "$100,000",
+						"uninsuredOrUnderinsuredMPD": "$15,000 / $30,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$250",
+							"comprehensive": "$500"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": "Accident - Not at fault",
+							"ageFirstLicensed": 15,
+							"creditRating": "Average",
+							"firstName": "Evvy",
+							"gender": "Female",
+							"governmentAffliation": "State Firefighters Association",
+							"hasAccidentOrCitations": "yes",
+							"highestEducation": "Phd",
+							"lastName": "Woodley",
+							"maritalStatus": "Separated",
+							"millitaryAffiliation": null,
+							"occupation": "Dentist",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 74415,
+							"features": "Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Volvo",
+							"model": "XC90 Inscription",
+							"ownership": "lease",
+							"primaryusage": "business",
+							"year": 2017
+						}
+					]
+				}
+			},
 			"email": "ewoodleyl@gov.uk",
 			"externalReferenceCode": "AP-22-412-0077",
 			"firstName": "Evvy",
@@ -1791,7 +6618,60 @@
 			"applicationCreateDate": "2022-04-03T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "Buffalo",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":15,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Jada\",\"gender\":\"Female\",\"lastName\":\"Lewin\",\"maritalStatus\":\"Single\",\"millitaryAffiliation\":null,\"occupation\":\"Dentist\",\"governmentAffliation\":\"State Firefighters Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"High School\",\"creditRating\":\"Good\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":52149,\"year\":2019,\"make\":\"Toyota\",\"model\":\"Corolla LE\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"loan\",\"primaryusage\":\"business\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$500,000 / $ 500,000\",\"medical\":\"$2,000\",\"propertyDamage\":\"$300,000\",\"uninsuredOrUnderinsuredMBI\":\"$300,000\",\"uninsuredOrUnderinsuredMPD\":\"$30,000 / $60,000\"},\"vehicles\":[{\"collision\":\"$5,000\",\"comprehensive\":\"$750\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$500,000 / $ 500,000",
+						"medical": "$2,000",
+						"propertyDamage": "$300,000",
+						"uninsuredOrUnderinsuredMBI": "$300,000",
+						"uninsuredOrUnderinsuredMPD": "$30,000 / $60,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$5,000",
+							"comprehensive": "$750"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 15,
+							"creditRating": "Good",
+							"firstName": "Jada",
+							"gender": "Female",
+							"governmentAffliation": "State Firefighters Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "High School",
+							"lastName": "Lewin",
+							"maritalStatus": "Single",
+							"millitaryAffiliation": null,
+							"occupation": "Dentist",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 52149,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Toyota",
+							"model": "Corolla LE",
+							"ownership": "loan",
+							"primaryusage": "business",
+							"year": 2019
+						}
+					]
+				}
+			},
 			"email": "jlewint@intel.com",
 			"externalReferenceCode": "AP-29-197-4437",
 			"firstName": "Jada",
@@ -1811,7 +6691,60 @@
 			"applicationCreateDate": "2022-02-07T00:00:00.000+00:00",
 			"applicationStatus": "underwriting",
 			"city": "New York City",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":16,\"hasAccidentOrCitations\":\"yes\",\"accidentCitation\":\"Citation - Failing to Yield\",\"firstName\":\"Aloysius\",\"gender\":\"Male\",\"lastName\":\"Ridsdale\",\"maritalStatus\":\"Widowed\",\"millitaryAffiliation\":null,\"occupation\":\"Other\",\"governmentAffliation\":\"State Firefighters Association\",\"otherOccupation\":\"Quality Control Specialist\",\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Good\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":46746,\"year\":2016,\"make\":\"Volvo\",\"model\":\"S90 R-Design\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring\",\"ownership\":\"own\",\"primaryusage\":\"pleasure\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $100,000\",\"medical\":\"$1,000\",\"propertyDamage\":\"$150,000\",\"uninsuredOrUnderinsuredMBI\":\"$300,000\",\"uninsuredOrUnderinsuredMPD\":\"$25,000 / $50,000\"},\"vehicles\":[{\"collision\":\"$750\",\"comprehensive\":\"$5,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $100,000",
+						"medical": "$1,000",
+						"propertyDamage": "$150,000",
+						"uninsuredOrUnderinsuredMBI": "$300,000",
+						"uninsuredOrUnderinsuredMPD": "$25,000 / $50,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$750",
+							"comprehensive": "$5,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": "Citation - Failing to Yield",
+							"ageFirstLicensed": 16,
+							"creditRating": "Good",
+							"firstName": "Aloysius",
+							"gender": "Male",
+							"governmentAffliation": "State Firefighters Association",
+							"hasAccidentOrCitations": "yes",
+							"highestEducation": "College",
+							"lastName": "Ridsdale",
+							"maritalStatus": "Widowed",
+							"millitaryAffiliation": null,
+							"occupation": "Other",
+							"otherOccupation": "Quality Control Specialist",
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 46746,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring",
+							"make": "Volvo",
+							"model": "S90 R-Design",
+							"ownership": "own",
+							"primaryusage": "pleasure",
+							"year": 2016
+						}
+					]
+				}
+			},
 			"email": "aridsdale10@nymag.com",
 			"externalReferenceCode": "AP-13-646-2674",
 			"firstName": "Aloysius",
@@ -1830,7 +6763,60 @@
 			"applicationCreateDate": "2021-11-11T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "New York City",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":18,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Stevana\",\"gender\":\"Female\",\"lastName\":\"Casiero\",\"maritalStatus\":\"Single\",\"millitaryAffiliation\":null,\"occupation\":\"Accountant\",\"governmentAffliation\":\"ABC Sherriff Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Good\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":25328,\"year\":2018,\"make\":\"Volvo\",\"model\":\"V90 Cross Country\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring\",\"ownership\":\"own\",\"primaryusage\":\"commuting\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $100,000\",\"medical\":\"$5,000\",\"propertyDamage\":\"$300,000\",\"uninsuredOrUnderinsuredMBI\":\"$150,000\",\"uninsuredOrUnderinsuredMPD\":\"$25,000 / $50,000\"},\"vehicles\":[{\"collision\":\"$750\",\"comprehensive\":\"$750\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $100,000",
+						"medical": "$5,000",
+						"propertyDamage": "$300,000",
+						"uninsuredOrUnderinsuredMBI": "$150,000",
+						"uninsuredOrUnderinsuredMPD": "$25,000 / $50,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$750",
+							"comprehensive": "$750"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 18,
+							"creditRating": "Good",
+							"firstName": "Stevana",
+							"gender": "Female",
+							"governmentAffliation": "ABC Sherriff Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "College",
+							"lastName": "Casiero",
+							"maritalStatus": "Single",
+							"millitaryAffiliation": null,
+							"occupation": "Accountant",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 25328,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring",
+							"make": "Volvo",
+							"model": "V90 Cross Country",
+							"ownership": "own",
+							"primaryusage": "commuting",
+							"year": 2018
+						}
+					]
+				}
+			},
 			"email": "scasiero19@alibaba.com",
 			"externalReferenceCode": "AP-71-999-0946",
 			"firstName": "Stevana",
@@ -1850,7 +6836,60 @@
 			"applicationCreateDate": "2022-11-25T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "Lancaster",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":15,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Ferrel\",\"gender\":\"Male\",\"lastName\":\"Sames\",\"maritalStatus\":\"Married\",\"millitaryAffiliation\":null,\"occupation\":\"Other\",\"governmentAffliation\":\"ABC Sherriff Association\",\"otherOccupation\":\"Analyst Programmer\",\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Average\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":14903,\"year\":2013,\"make\":\"Toyota\",\"model\":\"Camry Hybrid XLE\",\"features\":\"Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"loan\",\"primaryusage\":\"pleasure\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $ 300,000\",\"medical\":\"$10,000\",\"propertyDamage\":\"$300,000\",\"uninsuredOrUnderinsuredMBI\":\"$300,000\",\"uninsuredOrUnderinsuredMPD\":\"$50,000 / $100,000\"},\"vehicles\":[{\"collision\":\"$1,000\",\"comprehensive\":\"$250\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $ 300,000",
+						"medical": "$10,000",
+						"propertyDamage": "$300,000",
+						"uninsuredOrUnderinsuredMBI": "$300,000",
+						"uninsuredOrUnderinsuredMPD": "$50,000 / $100,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$1,000",
+							"comprehensive": "$250"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 15,
+							"creditRating": "Average",
+							"firstName": "Ferrel",
+							"gender": "Male",
+							"governmentAffliation": "ABC Sherriff Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "College",
+							"lastName": "Sames",
+							"maritalStatus": "Married",
+							"millitaryAffiliation": null,
+							"occupation": "Other",
+							"otherOccupation": "Analyst Programmer",
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 14903,
+							"features": "Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Toyota",
+							"model": "Camry Hybrid XLE",
+							"ownership": "loan",
+							"primaryusage": "pleasure",
+							"year": 2013
+						}
+					]
+				}
+			},
 			"email": "fsames11@ucoz.com",
 			"externalReferenceCode": "AP-65-321-8913",
 			"firstName": "Ferrel",
@@ -1870,7 +6909,60 @@
 			"applicationCreateDate": "2022-05-21T00:00:00.000+00:00",
 			"applicationStatus": "incomplete",
 			"city": "San Francisco",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":16,\"hasAccidentOrCitations\":\"yes\",\"accidentCitation\":\"Citation - Failing to Yield\",\"firstName\":\"Brendis\",\"gender\":\"Male\",\"lastName\":\"McVee\",\"maritalStatus\":\"Single\",\"millitaryAffiliation\":null,\"occupation\":\"Engineer\",\"governmentAffliation\":\"ABC Sherriff Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Good\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":51049,\"year\":2013,\"make\":\"Volvo\",\"model\":\"XC90 Inscription\",\"features\":\"Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"loan\",\"primaryusage\":\"business\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $ 300,000\",\"medical\":\"$1,000\",\"propertyDamage\":\"$25,000\",\"uninsuredOrUnderinsuredMBI\":\"$100,000\",\"uninsuredOrUnderinsuredMPD\":\"$30,000 / $60,000\"},\"vehicles\":[{\"collision\":\"$1,000\",\"comprehensive\":\"$250\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $ 300,000",
+						"medical": "$1,000",
+						"propertyDamage": "$25,000",
+						"uninsuredOrUnderinsuredMBI": "$100,000",
+						"uninsuredOrUnderinsuredMPD": "$30,000 / $60,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$1,000",
+							"comprehensive": "$250"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": "Citation - Failing to Yield",
+							"ageFirstLicensed": 16,
+							"creditRating": "Good",
+							"firstName": "Brendis",
+							"gender": "Male",
+							"governmentAffliation": "ABC Sherriff Association",
+							"hasAccidentOrCitations": "yes",
+							"highestEducation": "College",
+							"lastName": "McVee",
+							"maritalStatus": "Single",
+							"millitaryAffiliation": null,
+							"occupation": "Engineer",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 51049,
+							"features": "Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Volvo",
+							"model": "XC90 Inscription",
+							"ownership": "loan",
+							"primaryusage": "business",
+							"year": 2013
+						}
+					]
+				}
+			},
 			"email": "bmcveep@apache.org",
 			"externalReferenceCode": "AP-34-250-2380",
 			"firstName": "Brendis",
@@ -1889,7 +6981,60 @@
 			"applicationCreateDate": "2022-11-06T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "Oceanside",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":15,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Merrily\",\"gender\":\"Female\",\"lastName\":\"Phibb\",\"maritalStatus\":\"Married\",\"millitaryAffiliation\":null,\"occupation\":\"Government\",\"governmentAffliation\":\"FBI Academy Associates\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Good\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":17934,\"year\":2019,\"make\":\"Ford\",\"model\":\"Focus S Sedan\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"own\",\"primaryusage\":\"business\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $100,000\",\"medical\":\"$5,000\",\"propertyDamage\":\"$300,000\",\"uninsuredOrUnderinsuredMBI\":\"$25,000\",\"uninsuredOrUnderinsuredMPD\":\"$100,000 / $100000\"},\"vehicles\":[{\"collision\":\"$500\",\"comprehensive\":\"$1,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $100,000",
+						"medical": "$5,000",
+						"propertyDamage": "$300,000",
+						"uninsuredOrUnderinsuredMBI": "$25,000",
+						"uninsuredOrUnderinsuredMPD": "$100,000 / $100000"
+					},
+					"vehicles": [
+						{
+							"collision": "$500",
+							"comprehensive": "$1,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 15,
+							"creditRating": "Good",
+							"firstName": "Merrily",
+							"gender": "Female",
+							"governmentAffliation": "FBI Academy Associates",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "College",
+							"lastName": "Phibb",
+							"maritalStatus": "Married",
+							"millitaryAffiliation": null,
+							"occupation": "Government",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 17934,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Ford",
+							"model": "Focus S Sedan",
+							"ownership": "own",
+							"primaryusage": "business",
+							"year": 2019
+						}
+					]
+				}
+			},
 			"email": "mphibb16@scribd.com",
 			"externalReferenceCode": "AP-03-257-1188",
 			"firstName": "Merrily",
@@ -1909,7 +7054,60 @@
 			"applicationCreateDate": "2022-07-08T00:00:00.000+00:00",
 			"applicationStatus": "underwriting",
 			"city": "Orange",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":15,\"hasAccidentOrCitations\":\"yes\",\"accidentCitation\":\"Accident - At fault\",\"firstName\":\"Lothario\",\"gender\":\"Male\",\"lastName\":\"Fantonetti\",\"maritalStatus\":\"Separated\",\"millitaryAffiliation\":\"None\",\"occupation\":\"Government\",\"governmentAffliation\":\"FBI Academy Associates\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"High School\",\"creditRating\":\"Average\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":24539,\"year\":2015,\"make\":\"Volvo\",\"model\":\"S90 R-Design\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"own\",\"primaryusage\":\"commuting\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $ 300,000\",\"medical\":\"$10,000\",\"propertyDamage\":\"$25,000\",\"uninsuredOrUnderinsuredMBI\":\"$25,000\",\"uninsuredOrUnderinsuredMPD\":\"$25,000 / $50,000\"},\"vehicles\":[{\"collision\":\"$250\",\"comprehensive\":\"$250\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $ 300,000",
+						"medical": "$10,000",
+						"propertyDamage": "$25,000",
+						"uninsuredOrUnderinsuredMBI": "$25,000",
+						"uninsuredOrUnderinsuredMPD": "$25,000 / $50,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$250",
+							"comprehensive": "$250"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": "Accident - At fault",
+							"ageFirstLicensed": 15,
+							"creditRating": "Average",
+							"firstName": "Lothario",
+							"gender": "Male",
+							"governmentAffliation": "FBI Academy Associates",
+							"hasAccidentOrCitations": "yes",
+							"highestEducation": "High School",
+							"lastName": "Fantonetti",
+							"maritalStatus": "Separated",
+							"millitaryAffiliation": "None",
+							"occupation": "Government",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 24539,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Volvo",
+							"model": "S90 R-Design",
+							"ownership": "own",
+							"primaryusage": "commuting",
+							"year": 2015
+						}
+					]
+				}
+			},
 			"email": "lfantonettix@arstechnica.com",
 			"externalReferenceCode": "AP-49-947-8897",
 			"firstName": "Lothario",
@@ -1928,7 +7126,60 @@
 			"applicationCreateDate": "2022-12-06T00:00:00.000+00:00",
 			"applicationStatus": "rejected",
 			"city": "New York City",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":20,\"hasAccidentOrCitations\":\"yes\",\"accidentCitation\":\"Citation - Driving under the influence\",\"firstName\":\"Aloysius\",\"gender\":\"Male\",\"lastName\":\"Ridsdale\",\"maritalStatus\":\"Single\",\"millitaryAffiliation\":null,\"occupation\":\"Government\",\"governmentAffliation\":\"ABC Sherriff Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"Phd\",\"creditRating\":\"Good\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":65552,\"year\":2018,\"make\":\"Toyota\",\"model\":\"Camry Hybrid XLE\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"loan\",\"primaryusage\":\"pleasure\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $100,000\",\"medical\":\"$2,000\",\"propertyDamage\":\"$150,000\",\"uninsuredOrUnderinsuredMBI\":\"$150,000\",\"uninsuredOrUnderinsuredMPD\":\"$100,000 / $100000\"},\"vehicles\":[{\"collision\":\"$5,000\",\"comprehensive\":\"$2,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $100,000",
+						"medical": "$2,000",
+						"propertyDamage": "$150,000",
+						"uninsuredOrUnderinsuredMBI": "$150,000",
+						"uninsuredOrUnderinsuredMPD": "$100,000 / $100000"
+					},
+					"vehicles": [
+						{
+							"collision": "$5,000",
+							"comprehensive": "$2,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": "Citation - Driving under the influence",
+							"ageFirstLicensed": 20,
+							"creditRating": "Good",
+							"firstName": "Aloysius",
+							"gender": "Male",
+							"governmentAffliation": "ABC Sherriff Association",
+							"hasAccidentOrCitations": "yes",
+							"highestEducation": "Phd",
+							"lastName": "Ridsdale",
+							"maritalStatus": "Single",
+							"millitaryAffiliation": null,
+							"occupation": "Government",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 65552,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Toyota",
+							"model": "Camry Hybrid XLE",
+							"ownership": "loan",
+							"primaryusage": "pleasure",
+							"year": 2018
+						}
+					]
+				}
+			},
 			"email": "aridsdale10@nymag.com",
 			"externalReferenceCode": "AP-75-649-0042",
 			"firstName": "Aloysius",
@@ -1947,7 +7198,60 @@
 			"applicationCreateDate": "2022-08-20T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "Bakersfield",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":19,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Dynah\",\"gender\":\"Female\",\"lastName\":\"Jordeson\",\"maritalStatus\":\"Single\",\"millitaryAffiliation\":\"US Air Force\",\"occupation\":\"Other\",\"governmentAffliation\":\"ABC Sherriff Association\",\"otherOccupation\":\"Legal Assistant\",\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Very Good\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":49394,\"year\":2016,\"make\":\"Toyota\",\"model\":\"Tundra SR6\",\"features\":\"Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring\",\"ownership\":\"lease\",\"primaryusage\":\"commuting\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $100,000\",\"medical\":\"$5,000\",\"propertyDamage\":\"$300,000\",\"uninsuredOrUnderinsuredMBI\":\"$100,000\",\"uninsuredOrUnderinsuredMPD\":\"$25,000 / $50,000\"},\"vehicles\":[{\"collision\":\"$1,000\",\"comprehensive\":\"$500\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $100,000",
+						"medical": "$5,000",
+						"propertyDamage": "$300,000",
+						"uninsuredOrUnderinsuredMBI": "$100,000",
+						"uninsuredOrUnderinsuredMPD": "$25,000 / $50,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$1,000",
+							"comprehensive": "$500"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 19,
+							"creditRating": "Very Good",
+							"firstName": "Dynah",
+							"gender": "Female",
+							"governmentAffliation": "ABC Sherriff Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "College",
+							"lastName": "Jordeson",
+							"maritalStatus": "Single",
+							"millitaryAffiliation": "US Air Force",
+							"occupation": "Other",
+							"otherOccupation": "Legal Assistant",
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 49394,
+							"features": "Anti-lock braking system that is factory-installed,Lane-Departure Warning,Blind-Spot Monitoring",
+							"make": "Toyota",
+							"model": "Tundra SR6",
+							"ownership": "lease",
+							"primaryusage": "commuting",
+							"year": 2016
+						}
+					]
+				}
+			},
 			"email": "djordeson17@alibaba.com",
 			"externalReferenceCode": "AP-98-127-2687",
 			"firstName": "Dynah",
@@ -1967,7 +7271,60 @@
 			"applicationCreateDate": "2021-09-23T00:00:00.000+00:00",
 			"applicationStatus": "bound",
 			"city": "Los Angeles",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":20,\"hasAccidentOrCitations\":\"no\",\"accidentCitation\":null,\"firstName\":\"Janeen\",\"gender\":\"Female\",\"lastName\":\"Orrill\",\"maritalStatus\":\"Single\",\"millitaryAffiliation\":null,\"occupation\":\"Engineer\",\"governmentAffliation\":\"ABC Sherriff Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Average\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":13062,\"year\":2017,\"make\":\"Ford\",\"model\":\"Mustang GT Fastback\",\"features\":\"Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"loan\",\"primaryusage\":\"pleasure\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$100,000 / $100,000\",\"medical\":\"$10,000\",\"propertyDamage\":\"$100,000\",\"uninsuredOrUnderinsuredMBI\":\"$100,000\",\"uninsuredOrUnderinsuredMPD\":\"$30,000 / $60,000\"},\"vehicles\":[{\"collision\":\"$250\",\"comprehensive\":\"$1,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$100,000 / $100,000",
+						"medical": "$10,000",
+						"propertyDamage": "$100,000",
+						"uninsuredOrUnderinsuredMBI": "$100,000",
+						"uninsuredOrUnderinsuredMPD": "$30,000 / $60,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$250",
+							"comprehensive": "$1,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": null,
+							"ageFirstLicensed": 20,
+							"creditRating": "Average",
+							"firstName": "Janeen",
+							"gender": "Female",
+							"governmentAffliation": "ABC Sherriff Association",
+							"hasAccidentOrCitations": "no",
+							"highestEducation": "College",
+							"lastName": "Orrill",
+							"maritalStatus": "Single",
+							"millitaryAffiliation": null,
+							"occupation": "Engineer",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 13062,
+							"features": "Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Ford",
+							"model": "Mustang GT Fastback",
+							"ownership": "loan",
+							"primaryusage": "pleasure",
+							"year": 2017
+						}
+					]
+				}
+			},
 			"email": "jorrilli@amazon.co.jp",
 			"externalReferenceCode": "AP-56-014-6401",
 			"firstName": "Janeen",
@@ -1987,7 +7344,60 @@
 			"applicationCreateDate": "2022-04-20T00:00:00.000+00:00",
 			"applicationStatus": "underwriting",
 			"city": "New York City",
-			"dataJSON": "{\"contactInfo\":{\"dateOfBirth\":\"04/06/2000\",\"ownership\":\"own\"},\"driverInfo\":{\"form\":[{\"ageFirstLicensed\":16,\"hasAccidentOrCitations\":\"yes\",\"accidentCitation\":\"Accident - Not at fault\",\"firstName\":\"Gregor\",\"gender\":\"Male\",\"lastName\":\"Ferreo\",\"maritalStatus\":\"Married\",\"millitaryAffiliation\":null,\"occupation\":\"Engineer\",\"governmentAffliation\":\"ABC Sherriff Association\",\"otherOccupation\":null,\"relationToContact\":\"Self\",\"highestEducation\":\"College\",\"creditRating\":\"Excellent\"}]},\"vehicleInfo\":{\"form\":[{\"annualMileage\":23350,\"year\":2013,\"make\":\"Volvo\",\"model\":\"S90 R-Design\",\"features\":\"Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring\",\"ownership\":\"lease\",\"primaryusage\":\"business\"}]},\"coverage\":{\"form\":{\"bodilyInjury\":\"$30,000 / $60,000\",\"medical\":\"$2,000\",\"propertyDamage\":\"$300,000\",\"uninsuredOrUnderinsuredMBI\":\"$300,000\",\"uninsuredOrUnderinsuredMPD\":\"$15,000 / $30,000\"},\"vehicles\":[{\"collision\":\"$2,000\",\"comprehensive\":\"$2,000\"}]}}",
+			"dataJSON": {
+				"contactInfo": {
+					"dateOfBirth": "04/06/2000",
+					"ownership": "own"
+				},
+				"coverage": {
+					"form": {
+						"bodilyInjury": "$30,000 / $60,000",
+						"medical": "$2,000",
+						"propertyDamage": "$300,000",
+						"uninsuredOrUnderinsuredMBI": "$300,000",
+						"uninsuredOrUnderinsuredMPD": "$15,000 / $30,000"
+					},
+					"vehicles": [
+						{
+							"collision": "$2,000",
+							"comprehensive": "$2,000"
+						}
+					]
+				},
+				"driverInfo": {
+					"form": [
+						{
+							"accidentCitation": "Accident - Not at fault",
+							"ageFirstLicensed": 16,
+							"creditRating": "Excellent",
+							"firstName": "Gregor",
+							"gender": "Male",
+							"governmentAffliation": "ABC Sherriff Association",
+							"hasAccidentOrCitations": "yes",
+							"highestEducation": "College",
+							"lastName": "Ferreo",
+							"maritalStatus": "Married",
+							"millitaryAffiliation": null,
+							"occupation": "Engineer",
+							"otherOccupation": null,
+							"relationToContact": "Self"
+						}
+					]
+				},
+				"vehicleInfo": {
+					"form": [
+						{
+							"annualMileage": 23350,
+							"features": "Anti-lock braking system that is factory-installed,Alarm that can be heard from at least 300 feet away for three or more minutes,Lane-Departure Warning & Lane-Keeping Assist,Forward-Collision Warning,Blind-Spot Monitoring",
+							"make": "Volvo",
+							"model": "S90 R-Design",
+							"ownership": "lease",
+							"primaryusage": "business",
+							"year": 2013
+						}
+					]
+				}
+			},
 			"email": "158 Hoepker Way",
 			"externalReferenceCode": "AP-99-786-3286",
 			"firstName": "Gregor",

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/src/main/resources/site-initializer/object-entries/3_policy.json
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/src/main/resources/site-initializer/object-entries/3_policy.json
@@ -4,7 +4,24 @@
 			"boundDate": "2021-12-03T22:18:47Z",
 			"commission": 497,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2021-12-03T22:18:47Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2021-12-06T22:18:47Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2021-12-15T22:18:47Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Scott Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Scott Producer (Producer)",
+						"Date1": "2021-12-03T22:18:47Z",
+						"Date2": "2021-12-06T22:18:47Z",
+						"Date3": "2021-12-15T22:18:47Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2022-12-03T22:18:47Z",
 			"externalReferenceCode": "PO-58-839-1582",
 			"lastPaymentDate": "2022-11-03T22:18:47Z",
@@ -24,7 +41,24 @@
 			"boundDate": "2021-10-24T12:43:32Z",
 			"commission": 269,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2021-10-24T12:43:32Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2021-10-27T12:43:32Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2021-11-05T12:43:32Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Scott Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Scott Producer (Producer)",
+						"Date1": "2021-10-24T12:43:32Z",
+						"Date2": "2021-10-27T12:43:32Z",
+						"Date3": "2021-11-05T12:43:32Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2022-10-24T12:43:32Z",
 			"externalReferenceCode": "PO-62-174-3884",
 			"lastPaymentDate": "2022-09-24T12:43:32Z",
@@ -44,7 +78,24 @@
 			"boundDate": "2022-01-27T01:20:26Z",
 			"commission": 353,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2022-01-27T01:20:26Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Marie Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2022-01-28T01:20:26Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2022-02-06T01:20:26Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Marie Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Marie Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Marie Producer (Producer)",
+						"Date1": "2022-01-27T01:20:26Z",
+						"Date2": "2022-01-28T01:20:26Z",
+						"Date3": "2022-02-06T01:20:26Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2023-01-27T01:20:26Z",
 			"externalReferenceCode": "PO-95-825-9374",
 			"lastPaymentDate": "2022-12-27T01:20:26Z",
@@ -64,7 +115,24 @@
 			"boundDate": "2022-01-01T19:21:02Z",
 			"commission": 340,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2022-01-01T19:21:02Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2022-01-03T19:21:02Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2022-01-11T19:21:02Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Scott Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Scott Producer (Producer)",
+						"Date1": "2022-01-01T19:21:02Z",
+						"Date2": "2022-01-03T19:21:02Z",
+						"Date3": "2022-01-11T19:21:02Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2023-01-01T19:21:02Z",
 			"externalReferenceCode": "PO-84-436-9853",
 			"lastPaymentDate": "2022-12-01T19:21:02Z",
@@ -84,7 +152,24 @@
 			"boundDate": "2022-05-28T17:41:37Z",
 			"commission": 152,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2022-05-28T17:41:37Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2022-05-30T17:41:37Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2022-06-07T17:41:37Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Scott Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Scott Producer (Producer)",
+						"Date1": "2022-05-28T17:41:37Z",
+						"Date2": "2022-05-30T17:41:37Z",
+						"Date3": "2022-06-07T17:41:37Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2023-05-28T17:41:37Z",
 			"externalReferenceCode": "PO-57-081-0414",
 			"lastPaymentDate": "2023-04-28T17:41:37Z",
@@ -104,7 +189,24 @@
 			"boundDate": "2021-11-18T15:52:38Z",
 			"commission": 193,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2021-11-18T15:52:38Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2021-11-22T15:52:38Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2021-11-28T15:52:38Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Scott Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Scott Producer (Producer)",
+						"Date1": "2021-11-18T15:52:38Z",
+						"Date2": "2021-11-22T15:52:38Z",
+						"Date3": "2021-11-28T15:52:38Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2022-11-18T15:52:38Z",
 			"externalReferenceCode": "PO-96-710-6810",
 			"lastPaymentDate": "2022-10-18T15:52:38Z",
@@ -124,7 +226,24 @@
 			"boundDate": "2022-02-15T16:25:11Z",
 			"commission": 189,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2022-02-15T16:25:11Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Marie Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2022-02-16T16:25:11Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2022-02-25T16:25:11Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Marie Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Marie Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Marie Producer (Producer)",
+						"Date1": "2022-02-15T16:25:11Z",
+						"Date2": "2022-02-16T16:25:11Z",
+						"Date3": "2022-02-25T16:25:11Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2023-02-15T16:25:11Z",
 			"externalReferenceCode": "PO-71-316-5330",
 			"lastPaymentDate": "2023-01-15T16:25:11Z",
@@ -144,7 +263,24 @@
 			"boundDate": "2022-06-25T14:59:31",
 			"commission": 554,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2022-06-25T14:59:31Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Marie Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2022-06-26T14:59:31Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2022-07-06T14:59:31Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Marie Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Marie Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Marie Producer (Producer)",
+						"Date1": "2022-06-25T14:59:31Z",
+						"Date2": "2022-06-26T14:59:31Z",
+						"Date3": "2022-07-06T14:59:31Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2023-06-25T14:59:31Z",
 			"externalReferenceCode": "PO-14-768-3243",
 			"lastPaymentDate": "2023-05-25T14:59:31Z",
@@ -164,7 +300,24 @@
 			"boundDate": "2022-03-06T14:32:47Z",
 			"commission": 561,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2022-03-06T14:32:47Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2022-03-08T14:32:47Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2022-03-18T14:32:47Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Scott Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Scott Producer (Producer)",
+						"Date1": "2022-03-06T14:32:47Z",
+						"Date2": "2022-03-08T14:32:47Z",
+						"Date3": "2022-03-18T14:32:47Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2023-03-06T14:32:47Z",
 			"externalReferenceCode": "PO-57-402-8342",
 			"lastPaymentDate": "2023-02-06T14:32:47Z",
@@ -184,7 +337,24 @@
 			"boundDate": "2023-03-30T14:32:47Z",
 			"commission": 561,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2022-03-06T14:32:47Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2022-03-08T14:32:47Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2022-03-18T14:32:47Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Scott Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Scott Producer (Producer)",
+						"Date1": "2022-03-06T14:32:47Z",
+						"Date2": "2022-03-08T14:32:47Z",
+						"Date3": "2022-03-18T14:32:47Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2024-03-06T14:32:47Z",
 			"externalReferenceCode": "PO-57-402-8342",
 			"lastPaymentDate": "2023-03-30T14:32:47Z",
@@ -204,7 +374,24 @@
 			"boundDate": "2023-04-01T14:32:47Z",
 			"commission": 561,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2022-03-06T14:32:47Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2022-03-08T14:32:47Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2022-03-18T14:32:47Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Scott Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Scott Producer (Producer)",
+						"Date1": "2022-03-06T14:32:47Z",
+						"Date2": "2022-03-08T14:32:47Z",
+						"Date3": "2022-03-18T14:32:47Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2024-03-06T14:32:47Z",
 			"externalReferenceCode": "PO-57-402-8342",
 			"lastPaymentDate": "2023-04-01T14:32:47Z",
@@ -224,7 +411,24 @@
 			"boundDate": "2023-03-01T13:04:21Z",
 			"commission": 548,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2023-03-01T13:04:21Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Marie Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2023-03-04T13:04:21Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2023-03-11T13:04:21Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Marie Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Marie Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Marie Producer (Producer)",
+						"Date1": "2023-03-01T13:04:21Z",
+						"Date2": "2023-03-04T13:04:21Z",
+						"Date3": "2023-03-11T13:04:21Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2024-03-01T13:04:21Z",
 			"externalReferenceCode": "PO-81-788-4032",
 			"lastPaymentDate": "2024-02-01T13:04:21Z",
@@ -244,7 +448,24 @@
 			"boundDate": "2022-02-21T04:20:43Z",
 			"commission": 412,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2022-02-21T04:20:43Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2022-02-22T04:20:43Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2022-03-04T04:20:43Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Scott Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Scott Producer (Producer)",
+						"Date1": "2022-02-21T04:20:43Z",
+						"Date2": "2022-02-22T04:20:43Z",
+						"Date3": "2022-03-04T04:20:43Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2023-02-21T04:20:43Z",
 			"externalReferenceCode": "PO-97-931-1823",
 			"lastPaymentDate": "2023-01-21T04:20:43Z",
@@ -264,7 +485,24 @@
 			"boundDate": "2023-03-08T19:40:53Z",
 			"commission": 218,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2023-03-08T19:40:53Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Marie Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2023-03-11T19:40:53Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2023-03-18T19:40:53Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Marie Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Marie Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Marie Producer (Producer)",
+						"Date1": "2023-03-08T19:40:53Z",
+						"Date2": "2023-03-11T19:40:53Z",
+						"Date3": "2023-03-18T19:40:53Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2024-03-08T19:40:53Z",
 			"externalReferenceCode": "PO-95-575-8266",
 			"lastPaymentDate": "2024-02-08T19:40:53Z",
@@ -284,7 +522,24 @@
 			"boundDate": "2023-01-22T04:05:51Z",
 			"commission": 512,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2023-01-22T04:05:51Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Marie Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2023-01-25T04:05:51Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2023-02-03T04:05:51Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Marie Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Marie Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Marie Producer (Producer)",
+						"Date1": "2023-01-22T04:05:51Z",
+						"Date2": "2023-01-25T04:05:51Z",
+						"Date3": "2023-02-03T04:05:51Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2024-01-22T04:05:51Z",
 			"externalReferenceCode": "PO-96-765-6341",
 			"lastPaymentDate": "2023-12-22T04:05:51Z",
@@ -304,7 +559,24 @@
 			"boundDate": "2022-02-11T16:13:36Z",
 			"commission": 385,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2022-02-11T16:13:36Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2022-02-14T16:13:36Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2022-02-21T16:13:36Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Scott Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Scott Producer (Producer)",
+						"Date1": "2022-02-11T16:13:36Z",
+						"Date2": "2022-02-14T16:13:36Z",
+						"Date3": "2022-02-21T16:13:36Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2023-02-11T16:13:36Z",
 			"externalReferenceCode": "PO-38-562-7204",
 			"lastPaymentDate": "2023-01-11T16:13:36Z",
@@ -324,7 +596,24 @@
 			"boundDate": "2022-11-25T23:31:13Z",
 			"commission": 123,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2022-11-25T23:31:13Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2022-11-26T23:31:13Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2022-12-06T23:31:13Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Scott Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Scott Producer (Producer)",
+						"Date1": "2022-11-25T23:31:13Z",
+						"Date2": "2022-11-26T23:31:13Z",
+						"Date3": "2022-12-06T23:31:13Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2023-11-25T23:31:13Z",
 			"externalReferenceCode": "PO-61-589-8738",
 			"lastPaymentDate": "2023-10-25T23:31:13Z",
@@ -344,7 +633,24 @@
 			"boundDate": "2023-02-05T09:24:22Z",
 			"commission": 415,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2023-02-05T09:24:22Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2023-02-06T09:24:22Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2023-02-15T09:24:22Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Scott Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Scott Producer (Producer)",
+						"Date1": "2023-02-05T09:24:22Z",
+						"Date2": "2023-02-06T09:24:22Z",
+						"Date3": "2023-02-15T09:24:22Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2024-02-05T09:24:22Z",
 			"externalReferenceCode": "PO-24-969-1132",
 			"lastPaymentDate": "2024-01-05T09:24:22Z",
@@ -364,7 +670,24 @@
 			"boundDate": "2022-05-17T15:13:55Z",
 			"commission": 257,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2022-05-17T15:13:55Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2022-05-19T15:13:55Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2022-05-29T15:13:55Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Scott Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Scott Producer (Producer)",
+						"Date1": "2022-05-17T15:13:55Z",
+						"Date2": "2022-05-19T15:13:55Z",
+						"Date3": "2022-05-29T15:13:55Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2023-05-17T15:13:55Z",
 			"externalReferenceCode": "PO-22-792-2963",
 			"lastPaymentDate": "2023-04-17T15:13:55Z",
@@ -384,7 +707,24 @@
 			"boundDate": "2022-05-29T11:27:46Z",
 			"commission": 137,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2022-05-29T11:27:46Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Marie Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2022-05-31T11:27:46Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2022-06-09T11:27:46Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Marie Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Marie Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Marie Producer (Producer)",
+						"Date1": "2022-05-29T11:27:46Z",
+						"Date2": "2022-05-31T11:27:46Z",
+						"Date3": "2022-06-09T11:27:46Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2023-05-29T11:27:46Z",
 			"externalReferenceCode": "PO-49-835-7668",
 			"lastPaymentDate": "2023-04-29T11:27:46Z",
@@ -404,7 +744,24 @@
 			"boundDate": "2022-02-07T04:37:23Z",
 			"commission": 416,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2022-02-07T04:37:23Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2022-02-09T04:37:23Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2022-02-17T04:37:23Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Scott Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Scott Producer (Producer)",
+						"Date1": "2022-02-07T04:37:23Z",
+						"Date2": "2022-02-09T04:37:23Z",
+						"Date3": "2022-02-17T04:37:23Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2023-02-07T04:37:23Z",
 			"externalReferenceCode": "PO-76-150-9970",
 			"lastPaymentDate": "2023-01-07T04:37:23Z",
@@ -424,7 +781,24 @@
 			"boundDate": "2022-11-28T14:17:51Z",
 			"commission": 229,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2022-11-28T14:17:51Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2022-11-30T14:17:51Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2022-12-09T14:17:51Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Scott Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Scott Producer (Producer)",
+						"Date1": "2022-11-28T14:17:51Z",
+						"Date2": "2022-11-30T14:17:51Z",
+						"Date3": "2022-12-09T14:17:51Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2023-11-28T14:17:51Z",
 			"externalReferenceCode": "PO-95-533-1890",
 			"lastPaymentDate": "2023-10-28T14:17:51Z",
@@ -444,7 +818,24 @@
 			"boundDate": "2021-12-26T21:10:09Z",
 			"commission": 208,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2021-12-26T21:10:09Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2021-12-27T21:10:09Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2022-01-06T21:10:09Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Scott Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Scott Producer (Producer)",
+						"Date1": "2021-12-26T21:10:09Z",
+						"Date2": "2021-12-27T21:10:09Z",
+						"Date3": "2022-01-06T21:10:09Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2022-12-26T21:10:09Z",
 			"externalReferenceCode": "PO-14-445-2863",
 			"lastPaymentDate": "2022-11-26T21:10:09Z",
@@ -464,7 +855,24 @@
 			"boundDate": "2022-08-23T05:22:50Z",
 			"commission": 274,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2022-08-23T05:22:50Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Marie Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2022-08-27T05:22:50Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2022-09-02T05:22:50Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Marie Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Marie Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Marie Producer (Producer)",
+						"Date1": "2022-08-23T05:22:50Z",
+						"Date2": "2022-08-27T05:22:50Z",
+						"Date3": "2022-09-02T05:22:50Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2023-08-23T05:22:50Z",
 			"externalReferenceCode": "PO-26-210-0080",
 			"lastPaymentDate": "2023-07-23T05:22:50Z",
@@ -484,7 +892,24 @@
 			"boundDate": "2021-09-18T02:08:08Z",
 			"commission": 560,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2021-09-18T02:08:08Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2021-09-19T02:08:08Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2021-09-28T02:08:08Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Scott Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Scott Producer (Producer)",
+						"Date1": "2021-09-18T02:08:08Z",
+						"Date2": "2021-09-19T02:08:08Z",
+						"Date3": "2021-09-28T02:08:08Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2022-09-18T02:08:08Z",
 			"externalReferenceCode": "PO-35-340-7974",
 			"lastPaymentDate": "2022-08-18T02:08:08Z",
@@ -504,7 +929,24 @@
 			"boundDate": "2022-04-27T21:30:18Z",
 			"commission": 104,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2022-04-27T21:30:18Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Marie Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2022-04-28T21:30:18Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2022-05-09T21:30:18Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Marie Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Marie Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Marie Producer (Producer)",
+						"Date1": "2022-04-27T21:30:18Z",
+						"Date2": "2022-04-28T21:30:18Z",
+						"Date3": "2022-05-09T21:30:18Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2023-04-27T21:30:18Z",
 			"externalReferenceCode": "PO-75-970-0972",
 			"lastPaymentDate": "2023-03-27T21:30:18Z",
@@ -524,7 +966,24 @@
 			"boundDate": "2022-10-14T08:16:59Z",
 			"commission": 381,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2022-10-14T08:16:59Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Marie Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2022-10-17T08:16:59Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2022-10-26T08:16:59Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Marie Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Marie Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Marie Producer (Producer)",
+						"Date1": "2022-10-14T08:16:59Z",
+						"Date2": "2022-10-17T08:16:59Z",
+						"Date3": "2022-10-26T08:16:59Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2023-10-14T08:16:59Z",
 			"externalReferenceCode": "PO-45-524-6958",
 			"lastPaymentDate": "2023-09-14T08:16:59Z",
@@ -544,7 +1003,24 @@
 			"boundDate": "2023-02-15T15:34:02Z",
 			"commission": 98,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2023-02-15T15:34:02Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Marie Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2023-02-17T15:34:02Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2023-02-26T15:34:02Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Marie Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Marie Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Marie Producer (Producer)",
+						"Date1": "2023-02-15T15:34:02Z",
+						"Date2": "2023-02-17T15:34:02Z",
+						"Date3": "2023-02-26T15:34:02Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2024-02-15T15:34:02Z",
 			"externalReferenceCode": "PO-01-048-4146",
 			"lastPaymentDate": "2024-01-15T15:34:02Z",
@@ -564,7 +1040,24 @@
 			"boundDate": "2022-09-02T08:05:50Z",
 			"commission": 286,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2022-09-02T08:05:50Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Marie Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2022-09-05T08:05:50Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2022-09-13T08:05:50Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Marie Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Marie Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Marie Producer (Producer)",
+						"Date1": "2022-09-02T08:05:50Z",
+						"Date2": "2022-09-05T08:05:50Z",
+						"Date3": "2022-09-13T08:05:50Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2023-09-02T08:05:50Z",
 			"externalReferenceCode": "PO-54-652-1207",
 			"lastPaymentDate": "2023-08-02T08:05:50Z",
@@ -584,7 +1077,24 @@
 			"boundDate": "2022-12-26T02:40:07Z",
 			"commission": 400,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2022-12-26T02:40:07Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2022-12-30T02:40:07Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2023-01-05T02:40:07Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Scott Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Scott Producer (Producer)",
+						"Date1": "2022-12-26T02:40:07Z",
+						"Date2": "2022-12-30T02:40:07Z",
+						"Date3": "2023-01-05T02:40:07Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2023-12-26T02:40:07Z",
 			"externalReferenceCode": "PO-81-289-9483",
 			"lastPaymentDate": "2023-11-26T02:40:07Z",
@@ -604,7 +1114,24 @@
 			"boundDate": "2022-10-02T02:07:57Z",
 			"commission": 1133,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2022-10-02T02:07:57Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2022-10-03T02:07:57Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2022-10-14T02:07:57Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Scott Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Scott Producer (Producer)",
+						"Date1": "2022-10-02T02:07:57Z",
+						"Date2": "2022-10-03T02:07:57Z",
+						"Date3": "2022-10-14T02:07:57Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2023-10-02T02:07:57Z",
 			"externalReferenceCode": "PO-07-512-8878",
 			"lastPaymentDate": "2023-09-02T02:07:57Z",
@@ -624,7 +1151,24 @@
 			"boundDate": "2023-03-01T00:50:37Z",
 			"commission": 575,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2023-03-01T00:50:37Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2023-03-04T00:50:37Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2023-03-13T00:50:37Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Scott Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Scott Producer (Producer)",
+						"Date1": "2023-03-01T00:50:37Z",
+						"Date2": "2023-03-04T00:50:37Z",
+						"Date3": "2023-03-13T00:50:37Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2024-03-01T00:50:37Z",
 			"externalReferenceCode": "PO-63-953-3761",
 			"lastPaymentDate": "2024-08-01T02:07:57Z",
@@ -644,7 +1188,24 @@
 			"boundDate": "2022-07-14T20:11:37Z",
 			"commission": 132,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2022-07-14T20:11:37Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2022-07-16T20:11:37Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2022-07-26T20:11:37Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Scott Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Scott Producer (Producer)",
+						"Date1": "2022-07-14T20:11:37Z",
+						"Date2": "2022-07-16T20:11:37Z",
+						"Date3": "2022-07-26T20:11:37Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2023-07-14T20:11:37Z",
 			"externalReferenceCode": "PO-47-952-6071",
 			"lastPaymentDate": "2023-06-14T20:11:37Z",
@@ -664,7 +1225,24 @@
 			"boundDate": "2022-02-19T02:24:11Z",
 			"commission": 443,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2022-02-19T02:24:11Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2022-02-20T02:24:11Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2022-03-02T02:24:11Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Scott Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Scott Producer (Producer)",
+						"Date1": "2022-02-19T02:24:11Z",
+						"Date2": "2022-02-20T02:24:11Z",
+						"Date3": "2022-03-02T02:24:11Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2023-02-19T02:24:11Z",
 			"externalReferenceCode": "PO-54-848-2327",
 			"lastPaymentDate": "2023-01-19T02:24:11Z",
@@ -684,7 +1262,24 @@
 			"boundDate": "2022-01-25T18:39:46Z",
 			"commission": 279,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2022-01-25T18:39:46Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2022-01-28T18:39:46Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2022-02-06T18:39:46Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Scott Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Scott Producer (Producer)",
+						"Date1": "2022-01-25T18:39:46Z",
+						"Date2": "2022-01-28T18:39:46Z",
+						"Date3": "2022-02-06T18:39:46Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2023-01-25T18:39:46Z",
 			"externalReferenceCode": "PO-60-350-1793",
 			"lastPaymentDate": "2022-12-25T18:39:46Z",
@@ -704,7 +1299,24 @@
 			"boundDate": "2022-07-07T06:58:31Z",
 			"commission": 511,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2022-07-07T06:58:31Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2022-07-11T06:58:31Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2022-07-18T06:58:31Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Scott Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Scott Producer (Producer)",
+						"Date1": "2022-07-07T06:58:31Z",
+						"Date2": "2022-07-11T06:58:31Z",
+						"Date3": "2022-07-18T06:58:31Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2023-07-07T06:58:31Z",
 			"externalReferenceCode": "PO-27-283-4989",
 			"lastPaymentDate": "2023-06-07T06:58:31Z",
@@ -724,7 +1336,24 @@
 			"boundDate": "2022-01-16T02:34:18Z",
 			"commission": 509,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2022-01-16T02:34:18Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Marie Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2022-01-20T02:34:18Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2022-01-26T02:34:18Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Marie Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Marie Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Marie Producer (Producer)",
+						"Date1": "2022-01-16T02:34:18Z",
+						"Date2": "2022-01-20T02:34:18Z",
+						"Date3": "2022-01-26T02:34:18Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2023-01-16T02:34:18Z",
 			"externalReferenceCode": "PO-29-447-1413",
 			"lastPaymentDate": "2022-12-16T02:34:18Z",
@@ -744,7 +1373,24 @@
 			"boundDate": "2022-09-21T04:27:38Z",
 			"commission": 1057,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2022-09-21T04:27:38Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2022-09-24T04:27:38Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2022-10-03T04:27:38Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Scott Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Scott Producer (Producer)",
+						"Date1": "2022-09-21T04:27:38Z",
+						"Date2": "2022-09-24T04:27:38Z",
+						"Date3": "2022-10-03T04:27:38Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2023-09-21T04:27:38Z",
 			"externalReferenceCode": "PO-15-542-8250",
 			"lastPaymentDate": "2023-08-21T04:27:38Z",
@@ -764,7 +1410,24 @@
 			"boundDate": "2023-01-09T11:17:54Z",
 			"commission": 341,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2023-01-09T11:17:54Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2023-01-10T11:17:54Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2023-01-19T11:17:54Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Scott Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Scott Producer (Producer)",
+						"Date1": "2023-01-09T11:17:54Z",
+						"Date2": "2023-01-10T11:17:54Z",
+						"Date3": "2023-01-19T11:17:54Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2024-01-09T11:17:54Z",
 			"externalReferenceCode": "PO-60-665-7410",
 			"lastPaymentDate": "2023-12-09T11:17:54Z",
@@ -784,7 +1447,24 @@
 			"boundDate": "2022-12-18T12:03:51Z",
 			"commission": 547,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2022-12-18T12:03:51Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2022-12-20T12:03:51Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2022-12-28T12:03:51Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Scott Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Scott Producer (Producer)",
+						"Date1": "2022-12-18T12:03:51Z",
+						"Date2": "2022-12-20T12:03:51Z",
+						"Date3": "2022-12-28T12:03:51Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2023-12-18T12:03:51Z",
 			"externalReferenceCode": "PO-41-006-2886",
 			"lastPaymentDate": "2023-11-18T12:03:51Z",
@@ -804,7 +1484,24 @@
 			"boundDate": "2022-01-31T22:29:52Z",
 			"commission": 182,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2022-01-31T22:29:52Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2022-02-03T22:29:52Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2022-02-10T22:29:52Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Scott Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Scott Producer (Producer)",
+						"Date1": "2022-01-31T22:29:52Z",
+						"Date2": "2022-02-03T22:29:52Z",
+						"Date3": "2022-02-10T22:29:52Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2023-01-31T22:29:52Z",
 			"externalReferenceCode": "PO-06-747-0313",
 			"lastPaymentDate": "2022-12-31T22:29:52Z",
@@ -824,7 +1521,24 @@
 			"boundDate": "2022-08-16T11:08:09Z",
 			"commission": 277,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2022-08-16T11:08:09Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Marie Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2022-08-18T11:08:09Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2022-08-28T11:08:09Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Marie Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Marie Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Marie Producer (Producer)",
+						"Date1": "2022-08-16T11:08:09Z",
+						"Date2": "2022-08-18T11:08:09Z",
+						"Date3": "2022-08-28T11:08:09Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2023-08-16T11:08:09Z",
 			"externalReferenceCode": "PO-76-477-2427",
 			"lastPaymentDate": "2023-07-16T11:08:09Z",
@@ -844,7 +1558,24 @@
 			"boundDate": "2021-12-08T21:03:02Z",
 			"commission": 549,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2021-12-08T21:03:02Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2021-12-12T21:03:02Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2021-12-19T21:03:02Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Scott Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Scott Producer (Producer)",
+						"Date1": "2021-12-08T21:03:02Z",
+						"Date2": "2021-12-12T21:03:02Z",
+						"Date3": "2021-12-19T21:03:02Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2022-12-08T21:03:02Z",
 			"externalReferenceCode": "PO-26-196-7958",
 			"lastPaymentDate": "2022-11-08T21:03:02Z",
@@ -864,7 +1595,24 @@
 			"boundDate": "2022-01-13T06:40:02Z",
 			"commission": 0,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2022-01-13T06:40:02Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Marie Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2022-01-16T06:40:02Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2022-01-24T06:40:02Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Marie Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Marie Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Marie Producer (Producer)",
+						"Date1": "2022-01-13T06:40:02Z",
+						"Date2": "2022-01-16T06:40:02Z",
+						"Date3": "2022-01-24T06:40:02Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2023-01-13T06:40:02Z",
 			"externalReferenceCode": "PO-36-827-1445",
 			"lastPaymentDate": "2022-12-13T06:40:02Z",
@@ -884,7 +1632,24 @@
 			"boundDate": "2021-10-15T17:51:18Z",
 			"commission": 288,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2021-10-15T17:51:18Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2021-10-16T17:51:18Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2021-10-26T17:51:18Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Scott Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Scott Producer (Producer)",
+						"Date1": "2021-10-15T17:51:18Z",
+						"Date2": "2021-10-16T17:51:18Z",
+						"Date3": "2021-10-26T17:51:18Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2022-10-15T17:51:18Z",
 			"externalReferenceCode": "PO-27-857-7605",
 			"lastPaymentDate": "2022-09-15T17:51:18Z",
@@ -904,7 +1669,24 @@
 			"boundDate": "2021-09-30T13:09:39Z",
 			"commission": 4560,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2021-09-30T13:09:39Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Marie Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2021-10-02T13:09:39Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2021-10-12T13:09:39Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Marie Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Marie Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Marie Producer (Producer)",
+						"Date1": "2021-09-30T13:09:39Z",
+						"Date2": "2021-10-02T13:09:39Z",
+						"Date3": "2021-10-12T13:09:39Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2022-09-30T13:09:39Z",
 			"externalReferenceCode": "PO-50-665-3617",
 			"lastPaymentDate": "2022-08-30T13:09:39Z",
@@ -924,7 +1706,24 @@
 			"boundDate": "2021-10-05T08:43:57Z",
 			"commission": 205,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2021-10-05T08:43:57Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2021-10-09T08:43:57Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2021-10-17T08:43:57Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Scott Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Scott Producer (Producer)",
+						"Date1": "2021-10-05T08:43:57Z",
+						"Date2": "2021-10-09T08:43:57Z",
+						"Date3": "2021-10-17T08:43:57Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2022-10-05T08:43:57Z",
 			"externalReferenceCode": "PO-02-464-7849",
 			"lastPaymentDate": "2022-09-05T08:43:57Z",
@@ -944,7 +1743,24 @@
 			"boundDate": "2022-02-16T09:07:57Z",
 			"commission": 239,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2022-02-16T09:07:57Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2022-02-19T09:07:57Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2022-02-27T09:07:57Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Scott Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Scott Producer (Producer)",
+						"Date1": "2022-02-16T09:07:57Z",
+						"Date2": "2022-02-19T09:07:57Z",
+						"Date3": "2022-02-27T09:07:57Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2023-02-16T09:07:57Z",
 			"externalReferenceCode": "PO-61-121-5224",
 			"lastPaymentDate": "2023-01-16T09:07:57Z",
@@ -964,7 +1780,24 @@
 			"boundDate": "2022-08-18T07:53:17Z",
 			"commission": 391,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2022-08-18T07:53:17Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2022-08-21T07:53:17Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2022-08-28T07:53:17Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Scott Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Scott Producer (Producer)",
+						"Date1": "2022-08-18T07:53:17Z",
+						"Date2": "2022-08-21T07:53:17Z",
+						"Date3": "2022-08-28T07:53:17Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2023-08-18T07:53:17Z",
 			"externalReferenceCode": "PO-68-705-6331",
 			"lastPaymentDate": "2023-07-18T07:53:17Z",
@@ -984,7 +1817,24 @@
 			"boundDate": "2021-12-07T20:59:18Z",
 			"commission": 229,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2021-12-07T20:59:18Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2021-12-10T20:59:18Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2021-12-19T20:59:18Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Scott Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Scott Producer (Producer)",
+						"Date1": "2021-12-07T20:59:18Z",
+						"Date2": "2021-12-10T20:59:18Z",
+						"Date3": "2021-12-19T20:59:18Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2022-12-07T20:59:18Z",
 			"externalReferenceCode": "PO-82-419-3469",
 			"lastPaymentDate": "2022-11-07T20:59:18Z",
@@ -1004,7 +1854,24 @@
 			"boundDate": "2023-02-04T22:41:21Z",
 			"commission": 566,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2023-02-04T22:41:21Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Marie Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2023-02-05T22:41:21Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2023-02-15T22:41:21Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Marie Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Marie Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Marie Producer (Producer)",
+						"Date1": "2023-02-04T22:41:21Z",
+						"Date2": "2023-02-05T22:41:21Z",
+						"Date3": "2023-02-15T22:41:21Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2024-02-04T22:41:21Z",
 			"externalReferenceCode": "PO-39-022-9968",
 			"lastPaymentDate": "2024-01-04T22:41:21Z",
@@ -1024,7 +1891,24 @@
 			"boundDate": "2022-07-24T04:02:03Z",
 			"commission": 522,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2022-07-24T04:02:03Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2022-07-28T04:02:03Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2022-08-05T04:02:03Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Scott Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Scott Producer (Producer)",
+						"Date1": "2022-07-24T04:02:03Z",
+						"Date2": "2022-07-28T04:02:03Z",
+						"Date3": "2022-08-05T04:02:03Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2023-07-24T04:02:03Z",
 			"externalReferenceCode": "PO-66-128-8419",
 			"lastPaymentDate": "2023-06-24T04:02:03Z",
@@ -1044,7 +1928,24 @@
 			"boundDate": "2022-03-31T08:44:10Z",
 			"commission": 425,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2022-03-31T08:44:10Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Marie Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2022-04-02T08:44:10Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2022-04-10T08:44:10Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Marie Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Marie Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Marie Producer (Producer)",
+						"Date1": "2022-03-31T08:44:10Z",
+						"Date2": "2022-04-02T08:44:10Z",
+						"Date3": "2022-04-10T08:44:10Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2023-03-31T08:44:10Z",
 			"externalReferenceCode": "PO-50-527-9425",
 			"lastPaymentDate": "2023-02-28T08:44:10Z",
@@ -1064,7 +1965,24 @@
 			"boundDate": "2023-03-02T04:12:30Z",
 			"commission": 84,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2023-03-02T04:12:30Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2023-03-04T04:12:30Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2023-03-14T04:12:30Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Scott Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Scott Producer (Producer)",
+						"Date1": "2023-03-02T04:12:30Z",
+						"Date2": "2023-03-04T04:12:30Z",
+						"Date3": "2023-03-14T04:12:30Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2024-03-02T04:12:30Z",
 			"externalReferenceCode": "PO-84-871-1015",
 			"lastPaymentDate": "2024-02-02T04:12:30Z",
@@ -1084,7 +2002,24 @@
 			"boundDate": "2022-05-03T07:45:52Z",
 			"commission": 582,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2022-05-03T07:45:52Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2022-05-07T07:45:52Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2022-05-13T07:45:52Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Scott Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Scott Producer (Producer)",
+						"Date1": "2022-05-03T07:45:52Z",
+						"Date2": "2022-05-07T07:45:52Z",
+						"Date3": "2022-05-13T07:45:52Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2023-05-03T07:45:52Z",
 			"externalReferenceCode": "PO-29-197-4437",
 			"lastPaymentDate": "2023-04-03T07:45:52Z",
@@ -1104,7 +2039,24 @@
 			"boundDate": "2021-12-05T08:30:36Z",
 			"commission": 434,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2021-12-05T08:30:36Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2021-12-07T08:30:36Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2021-12-17T08:30:36Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Scott Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Scott Producer (Producer)",
+						"Date1": "2021-12-05T08:30:36Z",
+						"Date2": "2021-12-07T08:30:36Z",
+						"Date3": "2021-12-17T08:30:36Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2022-12-05T08:30:36Z",
 			"externalReferenceCode": "PO-71-999-0946",
 			"lastPaymentDate": "2022-11-05T08:30:36Z",
@@ -1124,7 +2076,24 @@
 			"boundDate": "2022-11-26T02:37:07Z",
 			"commission": 405,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2022-11-26T02:37:07Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Marie Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2022-11-30T02:37:07Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2022-12-06T02:37:07Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Marie Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Marie Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Marie Producer (Producer)",
+						"Date1": "2022-11-26T02:37:07Z",
+						"Date2": "2022-11-30T02:37:07Z",
+						"Date3": "2022-12-06T02:37:07Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2023-11-26T02:37:07Z",
 			"externalReferenceCode": "PO-65-321-8913",
 			"lastPaymentDate": "2023-10-26T02:37:07Z",
@@ -1144,7 +2113,24 @@
 			"boundDate": "2022-11-10T14:17:28Z",
 			"commission": 566,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2022-11-10T14:17:28Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Marie Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2022-11-11T14:17:28Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2022-11-21T14:17:28Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Marie Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Marie Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Marie Producer (Producer)",
+						"Date1": "2022-11-10T14:17:28Z",
+						"Date2": "2022-11-11T14:17:28Z",
+						"Date3": "2022-11-21T14:17:28Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2023-11-10T14:17:28Z",
 			"externalReferenceCode": "PO-03-257-1188",
 			"lastPaymentDate": "2023-10-10T14:17:28Z",
@@ -1164,7 +2150,24 @@
 			"boundDate": "2022-09-18T04:43:09Z",
 			"commission": 425,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2022-09-18T04:43:09Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2022-09-21T04:43:09Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2022-09-29T04:43:09Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Scott Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Scott Producer (Producer)",
+						"Date1": "2022-09-18T04:43:09Z",
+						"Date2": "2022-09-21T04:43:09Z",
+						"Date3": "2022-09-29T04:43:09Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2023-09-18T04:43:09Z",
 			"externalReferenceCode": "PO-98-127-2687",
 			"lastPaymentDate": "2023-08-18T04:43:09Z",
@@ -1184,7 +2187,24 @@
 			"boundDate": "2021-10-06T18:29:05Z",
 			"commission": 276,
 			"currencyType": "USD",
-			"dataJSON": "{\"Detail\":{\"Activity\":{\"Date1\":\"2021-10-06T18:29:05Z\",\"Desc1\":\"Application Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Detail1\":\"The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.\",\"Date2\":\"2021-10-07T18:29:05Z\",\"Desc2\":\"Inquiry for documents\",\"By2\":\"Carl Alexander (Underwriter)\",\"Detail2\":\"For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.\",\"Date3\":\"2021-10-16T18:29:05Z\",\"Desc3\":\"Requested driving History\",\"By3\":\"Scott Producer (Producer)\",\"Detail3\":\"I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply.\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Carl Alexander (Underwriter)",
+						"By3": "Scott Producer (Producer)",
+						"Date1": "2021-10-06T18:29:05Z",
+						"Date2": "2021-10-07T18:29:05Z",
+						"Date3": "2021-10-16T18:29:05Z",
+						"Desc1": "Application Submitted",
+						"Desc2": "Inquiry for documents",
+						"Desc3": "Requested driving History",
+						"Detail1": "The insured called me this morning at 10am requesting a multi-line application for both auto and home. I submitted the application on behalf of the insured, and the application is currently waiting for underwriting process to begin.",
+						"Detail2": "For further risk assessment, we need more information regarding the insured's driving history. Please contact the insured and request complete driving history including any driver's education classes.",
+						"Detail3": "I contacted the insured with the request from the underwriter for a full driving history. Waiting for reply."
+					}
+				}
+			},
 			"endDate": "2022-10-06T18:29:05Z",
 			"externalReferenceCode": "PO-56-014-6401",
 			"lastPaymentDate": "2022-09-06T18:29:05Z",

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/src/main/resources/site-initializer/object-entries/4_claim.json
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/src/main/resources/site-initializer/object-entries/4_claim.json
@@ -4,7 +4,60 @@
 			"claimAmount": 2634,
 			"claimCreateDate": "2022-06-21T22:18:47Z",
 			"claimStatus": "claimSubmitted",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Osgood Dummer\",\"InsuredSSN\":\"270-21-8085\",\"InsuredVehicle\":\"2017 Ford F-150 Super 250 XL\",\"InsuredVIN\":\"1C6RD7NT6CS560502\"},\"IncidentDetail\":{\"Location\":\"5 Muir Hill\",\"LocationCity\":\"Sacramento\",\"LocationState\":\"CA\",\"LocationZIP\":\"94230\",\"Type\":\"Vehicle incident while filling fuel\",\"Detail\":\"Incident with more than one passenger\",\"OtherVehicleMake\":\"Toyota\",\"OtherVehicleModel\":\"Land Cruiser\",\"OtherVehicleVIN\":\"JM3TB2CA1F0994620\",\"OtherVehicleOccupant\":\"Faina Chater\",\"OtherVehicleOccupant2\":\"Barbaraanne Moine\",\"OtherVehicleOccupant3\":\"Judd Borthram\",\"OtherVehicleInsurance\":\"Liberty Mutual\",\"Damage\":{\"Condition\":\"Good to drive\",\"Interior\":\"Seats\",\"Exterior\":\"Passenger Side\"}},\"VehicleRepair\":{\"Status\":\"Not Started\",\"Description\":\"Insured has not started repair\",\"MechanicName\":\"Hyperion Automotive Center\",\"MechanicPhone\":\"(323) 665-7864\",\"MechanicAddress\":\"2938 Hyperion Ave Los Angeles, CA 90027\",\"MechanicOrderNum\":\"vur2tz\",\"MechanicCompleteDate\":\"2022-07-10T22:18:47Z\",\"MechanicCost\":2239},\"Activity\":{\"Date1\":\"2022-06-21T22:18:47Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Date2\":\"2022-06-22T22:18:47Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2022-06-28T22:18:47Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2022-07-10T22:18:47Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Scott Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Scott Producer (Producer)",
+						"Date1": "2022-06-21T22:18:47Z",
+						"Date2": "2022-06-22T22:18:47Z",
+						"Date3": "2022-06-28T22:18:47Z",
+						"Date4": "2022-07-10T22:18:47Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Good to drive",
+							"Exterior": "Passenger Side",
+							"Interior": "Seats"
+						},
+						"Detail": "Incident with more than one passenger",
+						"Location": "5 Muir Hill",
+						"LocationCity": "Sacramento",
+						"LocationState": "CA",
+						"LocationZIP": "94230",
+						"OtherVehicleInsurance": "Liberty Mutual",
+						"OtherVehicleMake": "Toyota",
+						"OtherVehicleModel": "Land Cruiser",
+						"OtherVehicleOccupant": "Faina Chater",
+						"OtherVehicleOccupant2": "Barbaraanne Moine",
+						"OtherVehicleOccupant3": "Judd Borthram",
+						"OtherVehicleVIN": "JM3TB2CA1F0994620",
+						"Type": "Vehicle incident while filling fuel"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Osgood Dummer",
+						"InsuredSSN": "270-21-8085",
+						"InsuredVIN": "1C6RD7NT6CS560502",
+						"InsuredVehicle": "2017 Ford F-150 Super 250 XL"
+					},
+					"VehicleRepair": {
+						"Description": "Insured has not started repair",
+						"MechanicAddress": "2938 Hyperion Ave Los Angeles, CA 90027",
+						"MechanicCompleteDate": "2022-07-10T22:18:47Z",
+						"MechanicCost": 2239,
+						"MechanicName": "Hyperion Automotive Center",
+						"MechanicOrderNum": "vur2tz",
+						"MechanicPhone": "(323) 665-7864",
+						"Status": "Not Started"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-58-839-1582",
 			"incidentDate": "2022-06-20T22:18:47Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-58-839-1582",
@@ -14,7 +67,60 @@
 			"claimAmount": 3441,
 			"claimCreateDate": "2022-01-07T12:43:32Z",
 			"claimStatus": "repair",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Jessa Capron\",\"InsuredSSN\":\"483-23-9736\",\"InsuredVehicle\":\"2016 Ford Mustang GT Fastback\",\"InsuredVIN\":\"WAUHE98P69A080483\"},\"IncidentDetail\":{\"Location\":\"89 Stone Corner Street\",\"LocationCity\":\"Pasadena\",\"LocationState\":\"CA\",\"LocationZIP\":\"91117\",\"Type\":\"Vehicle incident while parking\",\"Detail\":\"Incident with single passenger\",\"OtherVehicleMake\":\"Lincoln\",\"OtherVehicleModel\":\"Town Car\",\"OtherVehicleVIN\":\"JTDZN3EU1EJ184131\",\"OtherVehicleOccupant\":\"Moises Yablsley\",\"OtherVehicleOccupant2\":\"Merna Toombes\",\"OtherVehicleOccupant3\":null,\"OtherVehicleInsurance\":\"Travelers\",\"Damage\":{\"Condition\":\"Major damage and not safe to drive\",\"Interior\":\"Seats\",\"Exterior\":\"Passenger Side\"}},\"VehicleRepair\":{\"Status\":\"Pending\",\"Description\":\"Vehicle pending repair\",\"MechanicName\":\"Hyperion Automotive Center\",\"MechanicPhone\":\"(323) 665-7864\",\"MechanicAddress\":\"2938 Hyperion Ave Los Angeles, CA 90027\",\"MechanicOrderNum\":\"zqo0my\",\"MechanicCompleteDate\":\"2022-01-25T12:43:32Z\",\"MechanicCost\":2925},\"Activity\":{\"Date1\":\"2022-01-07T12:43:32Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Date2\":\"2022-01-08T12:43:32Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2022-01-11T12:43:32Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2022-01-25T12:43:32Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Scott Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Scott Producer (Producer)",
+						"Date1": "2022-01-07T12:43:32Z",
+						"Date2": "2022-01-08T12:43:32Z",
+						"Date3": "2022-01-11T12:43:32Z",
+						"Date4": "2022-01-25T12:43:32Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Major damage and not safe to drive",
+							"Exterior": "Passenger Side",
+							"Interior": "Seats"
+						},
+						"Detail": "Incident with single passenger",
+						"Location": "89 Stone Corner Street",
+						"LocationCity": "Pasadena",
+						"LocationState": "CA",
+						"LocationZIP": "91117",
+						"OtherVehicleInsurance": "Travelers",
+						"OtherVehicleMake": "Lincoln",
+						"OtherVehicleModel": "Town Car",
+						"OtherVehicleOccupant": "Moises Yablsley",
+						"OtherVehicleOccupant2": "Merna Toombes",
+						"OtherVehicleOccupant3": null,
+						"OtherVehicleVIN": "JTDZN3EU1EJ184131",
+						"Type": "Vehicle incident while parking"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Jessa Capron",
+						"InsuredSSN": "483-23-9736",
+						"InsuredVIN": "WAUHE98P69A080483",
+						"InsuredVehicle": "2016 Ford Mustang GT Fastback"
+					},
+					"VehicleRepair": {
+						"Description": "Vehicle pending repair",
+						"MechanicAddress": "2938 Hyperion Ave Los Angeles, CA 90027",
+						"MechanicCompleteDate": "2022-01-25T12:43:32Z",
+						"MechanicCost": 2925,
+						"MechanicName": "Hyperion Automotive Center",
+						"MechanicOrderNum": "zqo0my",
+						"MechanicPhone": "(323) 665-7864",
+						"Status": "Pending"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-62-174-3884",
 			"incidentDate": "2022-01-05T12:43:32Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-62-174-3884",
@@ -24,7 +130,60 @@
 			"claimAmount": 4082,
 			"claimCreateDate": "2022-03-12T01:20:26Z",
 			"claimStatus": "pendingSettlement",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Shurlocke Letessier\",\"InsuredSSN\":\"672-50-5288\",\"InsuredVehicle\":\"2013 Toyota Tundra SR6\",\"InsuredVIN\":\"5GAKRBED0CJ888688\"},\"IncidentDetail\":{\"Location\":\"33591 Lighthouse Bay Place\",\"LocationCity\":\"Las Vegas\",\"LocationState\":\"NV\",\"LocationZIP\":\"89105\",\"Type\":\"Vehicle incident while filling fuel\",\"Detail\":\"Incident alone\",\"OtherVehicleMake\":\"Saturn\",\"OtherVehicleModel\":\"S-Series\",\"OtherVehicleVIN\":\"1G6DF8EG1A0700568\",\"OtherVehicleOccupant\":\"Seth Crame\",\"OtherVehicleOccupant2\":null,\"OtherVehicleOccupant3\":null,\"OtherVehicleInsurance\":\"USAA\",\"Damage\":{\"Condition\":\"Major damage and not safe to drive\",\"Interior\":\"Wheels & Dashboard\",\"Exterior\":\"Passenger Rear,Rear\"}},\"VehicleRepair\":{\"Status\":\"Not Started\",\"Description\":\"Insured has not started repair\",\"MechanicName\":\"Diamond Auto Repair\",\"MechanicPhone\":\"(310) 458-3492\",\"MechanicAddress\":\"1432 Wilshire Blvd. Los Angeles, CA 90010\",\"MechanicOrderNum\":\"xgb7ky\",\"MechanicCompleteDate\":\"2022-03-28T01:20:26Z\",\"MechanicCost\":3470},\"Activity\":{\"Date1\":\"2022-03-12T01:20:26Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Marie Producer (Producer)\",\"Date2\":\"2022-03-14T01:20:26Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2022-03-21T01:20:26Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2022-03-28T01:20:26Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Marie Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Marie Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Marie Producer (Producer)",
+						"Date1": "2022-03-12T01:20:26Z",
+						"Date2": "2022-03-14T01:20:26Z",
+						"Date3": "2022-03-21T01:20:26Z",
+						"Date4": "2022-03-28T01:20:26Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Major damage and not safe to drive",
+							"Exterior": "Passenger Rear,Rear",
+							"Interior": "Wheels & Dashboard"
+						},
+						"Detail": "Incident alone",
+						"Location": "33591 Lighthouse Bay Place",
+						"LocationCity": "Las Vegas",
+						"LocationState": "NV",
+						"LocationZIP": "89105",
+						"OtherVehicleInsurance": "USAA",
+						"OtherVehicleMake": "Saturn",
+						"OtherVehicleModel": "S-Series",
+						"OtherVehicleOccupant": "Seth Crame",
+						"OtherVehicleOccupant2": null,
+						"OtherVehicleOccupant3": null,
+						"OtherVehicleVIN": "1G6DF8EG1A0700568",
+						"Type": "Vehicle incident while filling fuel"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Shurlocke Letessier",
+						"InsuredSSN": "672-50-5288",
+						"InsuredVIN": "5GAKRBED0CJ888688",
+						"InsuredVehicle": "2013 Toyota Tundra SR6"
+					},
+					"VehicleRepair": {
+						"Description": "Insured has not started repair",
+						"MechanicAddress": "1432 Wilshire Blvd. Los Angeles, CA 90010",
+						"MechanicCompleteDate": "2022-03-28T01:20:26Z",
+						"MechanicCost": 3470,
+						"MechanicName": "Diamond Auto Repair",
+						"MechanicOrderNum": "xgb7ky",
+						"MechanicPhone": "(310) 458-3492",
+						"Status": "Not Started"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-95-825-9374",
 			"incidentDate": "2022-03-11T01:20:26Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-95-825-9374",
@@ -34,7 +193,60 @@
 			"claimAmount": 4002,
 			"claimCreateDate": "2022-09-17T19:21:02Z",
 			"claimStatus": "pendingSettlement",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Jameson Norcliff\",\"InsuredSSN\":\"870-25-4892\",\"InsuredVehicle\":\"2018 Volvo S90 R-Design\",\"InsuredVIN\":\"WAUKFBFL1BN395801\"},\"IncidentDetail\":{\"Location\":\"47294 Mifflin Street\",\"LocationCity\":\"New York City\",\"LocationState\":\"NY\",\"LocationZIP\":\"10275\",\"Type\":\"Vehicle incident while parking\",\"Detail\":\"Incident with single passenger\",\"OtherVehicleMake\":\"McLaren\",\"OtherVehicleModel\":\"MP4-12C\",\"OtherVehicleVIN\":\"5N1AR1NB3CC018923\",\"OtherVehicleOccupant\":\"Jacintha Berth\",\"OtherVehicleOccupant2\":\"Mac Maidlow\",\"OtherVehicleOccupant3\":null,\"OtherVehicleInsurance\":\"Mercury\",\"Damage\":{\"Condition\":\"Minor damage and safe to drive\",\"Interior\":\"Interior Trim\",\"Exterior\":\"Driver Side, Driver Rear\"}},\"VehicleRepair\":{\"Status\":\"Not Started\",\"Description\":\"Insured has not started repair\",\"MechanicName\":\"Hyperion Automotive Center\",\"MechanicPhone\":\"(323) 665-7864\",\"MechanicAddress\":\"2938 Hyperion Ave Los Angeles, CA 90027\",\"MechanicOrderNum\":\"tbd2ss\",\"MechanicCompleteDate\":\"2022-10-02T19:21:02Z\",\"MechanicCost\":3402},\"Activity\":{\"Date1\":\"2022-09-17T19:21:02Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Date2\":\"2022-09-18T19:21:02Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2022-09-21T19:21:02Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2022-10-02T19:21:02Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Scott Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Scott Producer (Producer)",
+						"Date1": "2022-09-17T19:21:02Z",
+						"Date2": "2022-09-18T19:21:02Z",
+						"Date3": "2022-09-21T19:21:02Z",
+						"Date4": "2022-10-02T19:21:02Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Minor damage and safe to drive",
+							"Exterior": "Driver Side, Driver Rear",
+							"Interior": "Interior Trim"
+						},
+						"Detail": "Incident with single passenger",
+						"Location": "47294 Mifflin Street",
+						"LocationCity": "New York City",
+						"LocationState": "NY",
+						"LocationZIP": "10275",
+						"OtherVehicleInsurance": "Mercury",
+						"OtherVehicleMake": "McLaren",
+						"OtherVehicleModel": "MP4-12C",
+						"OtherVehicleOccupant": "Jacintha Berth",
+						"OtherVehicleOccupant2": "Mac Maidlow",
+						"OtherVehicleOccupant3": null,
+						"OtherVehicleVIN": "5N1AR1NB3CC018923",
+						"Type": "Vehicle incident while parking"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Jameson Norcliff",
+						"InsuredSSN": "870-25-4892",
+						"InsuredVIN": "WAUKFBFL1BN395801",
+						"InsuredVehicle": "2018 Volvo S90 R-Design"
+					},
+					"VehicleRepair": {
+						"Description": "Insured has not started repair",
+						"MechanicAddress": "2938 Hyperion Ave Los Angeles, CA 90027",
+						"MechanicCompleteDate": "2022-10-02T19:21:02Z",
+						"MechanicCost": 3402,
+						"MechanicName": "Hyperion Automotive Center",
+						"MechanicOrderNum": "tbd2ss",
+						"MechanicPhone": "(323) 665-7864",
+						"Status": "Not Started"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-84-436-9853",
 			"incidentDate": "2022-09-10T19:21:02Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-84-436-9853",
@@ -44,7 +256,60 @@
 			"claimAmount": 3662,
 			"claimCreateDate": "2022-09-04T17:41:37Z",
 			"claimStatus": "claimSubmitted",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Keelby Vaen\",\"InsuredSSN\":\"206-56-2008\",\"InsuredVehicle\":\"2016 Ford F-150 Super 250 XL\",\"InsuredVIN\":\"WAUDH94F76N249515\"},\"IncidentDetail\":{\"Location\":\"895 Monterey Parkway\",\"LocationCity\":\"New York City\",\"LocationState\":\"NY\",\"LocationZIP\":\"10024\",\"Type\":\"Vehicle incident while parked\",\"Detail\":\"Incident with more than one passenger\",\"OtherVehicleMake\":\"Ford\",\"OtherVehicleModel\":\"Crown Victoria\",\"OtherVehicleVIN\":\"3N1CN7APXEK062981\",\"OtherVehicleOccupant\":\"Rochell Yukhnini\",\"OtherVehicleOccupant2\":\"Elisabetta Keig\",\"OtherVehicleOccupant3\":\"Rosanne Weal\",\"OtherVehicleInsurance\":\"Mercury\",\"Damage\":{\"Condition\":\"Major damage and not safe to drive\",\"Interior\":\"Wheels & Dashboard\",\"Exterior\":\"Passenger Side\"}},\"VehicleRepair\":{\"Status\":\"Not Started\",\"Description\":\"Insured has not started repair\",\"MechanicName\":\"Diamond Auto Repair\",\"MechanicPhone\":\"(310) 458-3492\",\"MechanicAddress\":\"1432 Wilshire Blvd. Los Angeles, CA 90010\",\"MechanicOrderNum\":\"lqu8ix\",\"MechanicCompleteDate\":\"2022-09-23T17:41:37Z\",\"MechanicCost\":3113},\"Activity\":{\"Date1\":\"2022-09-04T17:41:37Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Date2\":\"2022-09-05T17:41:37Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2022-09-09T17:41:37Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2022-09-23T17:41:37Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Scott Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Scott Producer (Producer)",
+						"Date1": "2022-09-04T17:41:37Z",
+						"Date2": "2022-09-05T17:41:37Z",
+						"Date3": "2022-09-09T17:41:37Z",
+						"Date4": "2022-09-23T17:41:37Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Major damage and not safe to drive",
+							"Exterior": "Passenger Side",
+							"Interior": "Wheels & Dashboard"
+						},
+						"Detail": "Incident with more than one passenger",
+						"Location": "895 Monterey Parkway",
+						"LocationCity": "New York City",
+						"LocationState": "NY",
+						"LocationZIP": "10024",
+						"OtherVehicleInsurance": "Mercury",
+						"OtherVehicleMake": "Ford",
+						"OtherVehicleModel": "Crown Victoria",
+						"OtherVehicleOccupant": "Rochell Yukhnini",
+						"OtherVehicleOccupant2": "Elisabetta Keig",
+						"OtherVehicleOccupant3": "Rosanne Weal",
+						"OtherVehicleVIN": "3N1CN7APXEK062981",
+						"Type": "Vehicle incident while parked"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Keelby Vaen",
+						"InsuredSSN": "206-56-2008",
+						"InsuredVIN": "WAUDH94F76N249515",
+						"InsuredVehicle": "2016 Ford F-150 Super 250 XL"
+					},
+					"VehicleRepair": {
+						"Description": "Insured has not started repair",
+						"MechanicAddress": "1432 Wilshire Blvd. Los Angeles, CA 90010",
+						"MechanicCompleteDate": "2022-09-23T17:41:37Z",
+						"MechanicCost": 3113,
+						"MechanicName": "Diamond Auto Repair",
+						"MechanicOrderNum": "lqu8ix",
+						"MechanicPhone": "(310) 458-3492",
+						"Status": "Not Started"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-57-081-0414",
 			"incidentDate": "2022-09-02T17:41:37Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-57-081-0414",
@@ -54,7 +319,60 @@
 			"claimAmount": 932,
 			"claimCreateDate": "2022-05-02T15:52:38Z",
 			"claimStatus": "approved",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Evvy Woodley\",\"InsuredSSN\":\"429-04-6980\",\"InsuredVehicle\":\"2018 Volvo XC90 Inscription\",\"InsuredVIN\":\"WAUKGAFB2BN608267\"},\"IncidentDetail\":{\"Location\":\"882 Butternut Road\",\"LocationCity\":\"San Francisco\",\"LocationState\":\"CA\",\"LocationZIP\":\"94142\",\"Type\":\"Vehicle incident while parking\",\"Detail\":\"Incident alone\",\"OtherVehicleMake\":\"Mercury\",\"OtherVehicleModel\":\"Cougar\",\"OtherVehicleVIN\":\"WBA3A9C5XFK626154\",\"OtherVehicleOccupant\":\"Heath Briggdale\",\"OtherVehicleOccupant2\":null,\"OtherVehicleOccupant3\":null,\"OtherVehicleInsurance\":\"USAA\",\"Damage\":{\"Condition\":\"Good to drive\",\"Interior\":\"Seats\",\"Exterior\":\"Front,Driver Side\"}},\"VehicleRepair\":{\"Status\":\"Pending\",\"Description\":\"Vehicle pending repair\",\"MechanicName\":\"Diamond Auto Repair\",\"MechanicPhone\":\"(310) 458-3492\",\"MechanicAddress\":\"1432 Wilshire Blvd. Los Angeles, CA 90010\",\"MechanicOrderNum\":\"ozk6bo\",\"MechanicCompleteDate\":\"2022-05-18T15:52:38Z\",\"MechanicCost\":792},\"Activity\":{\"Date1\":\"2022-05-02T15:52:38Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Date2\":\"2022-05-03T15:52:38Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2022-05-12T15:52:38Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2022-05-18T15:52:38Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Scott Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Scott Producer (Producer)",
+						"Date1": "2022-05-02T15:52:38Z",
+						"Date2": "2022-05-03T15:52:38Z",
+						"Date3": "2022-05-12T15:52:38Z",
+						"Date4": "2022-05-18T15:52:38Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Good to drive",
+							"Exterior": "Front,Driver Side",
+							"Interior": "Seats"
+						},
+						"Detail": "Incident alone",
+						"Location": "882 Butternut Road",
+						"LocationCity": "San Francisco",
+						"LocationState": "CA",
+						"LocationZIP": "94142",
+						"OtherVehicleInsurance": "USAA",
+						"OtherVehicleMake": "Mercury",
+						"OtherVehicleModel": "Cougar",
+						"OtherVehicleOccupant": "Heath Briggdale",
+						"OtherVehicleOccupant2": null,
+						"OtherVehicleOccupant3": null,
+						"OtherVehicleVIN": "WBA3A9C5XFK626154",
+						"Type": "Vehicle incident while parking"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Evvy Woodley",
+						"InsuredSSN": "429-04-6980",
+						"InsuredVIN": "WAUKGAFB2BN608267",
+						"InsuredVehicle": "2018 Volvo XC90 Inscription"
+					},
+					"VehicleRepair": {
+						"Description": "Vehicle pending repair",
+						"MechanicAddress": "1432 Wilshire Blvd. Los Angeles, CA 90010",
+						"MechanicCompleteDate": "2022-05-18T15:52:38Z",
+						"MechanicCost": 792,
+						"MechanicName": "Diamond Auto Repair",
+						"MechanicOrderNum": "ozk6bo",
+						"MechanicPhone": "(310) 458-3492",
+						"Status": "Pending"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-96-710-6810",
 			"incidentDate": "2022-04-29T15:52:38Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-96-710-6810",
@@ -64,7 +382,60 @@
 			"claimAmount": 2961,
 			"claimCreateDate": "2022-07-20T16:25:11Z",
 			"claimStatus": "inInvestigation",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Jameson Norcliff\",\"InsuredSSN\":\"611-95-0919\",\"InsuredVehicle\":\"2013 Ford Focus S Sedan\",\"InsuredVIN\":\"SCFFDCCD6CG141652\"},\"IncidentDetail\":{\"Location\":\"66 Killdeer Trail\",\"LocationCity\":\"Fresno\",\"LocationState\":\"CA\",\"LocationZIP\":\"93709\",\"Type\":\"Vehicle incident while parking\",\"Detail\":\"Incident alone\",\"OtherVehicleMake\":\"GMC\",\"OtherVehicleModel\":\"2500 Club Coupe\",\"OtherVehicleVIN\":\"1G6AB5RX2D0356535\",\"OtherVehicleOccupant\":\"Grethel MacTague\",\"OtherVehicleOccupant2\":null,\"OtherVehicleOccupant3\":null,\"OtherVehicleInsurance\":\"Travelers\",\"Damage\":{\"Condition\":\"Major damage and not safe to drive\",\"Interior\":\"Interior Trim\",\"Exterior\":\"Passenger Side\"}},\"VehicleRepair\":{\"Status\":\"Not Started\",\"Description\":\"Insured has not started repair\",\"MechanicName\":\"Hyperion Automotive Center\",\"MechanicPhone\":\"(323) 665-7864\",\"MechanicAddress\":\"2938 Hyperion Ave Los Angeles, CA 90027\",\"MechanicOrderNum\":\"qpo5ev\",\"MechanicCompleteDate\":\"2022-08-08T16:25:11Z\",\"MechanicCost\":2517},\"Activity\":{\"Date1\":\"2022-07-20T16:25:11Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Marie Producer (Producer)\",\"Date2\":\"2022-07-21T16:25:11Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2022-07-30T16:25:11Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2022-08-08T16:25:11Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Marie Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Marie Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Marie Producer (Producer)",
+						"Date1": "2022-07-20T16:25:11Z",
+						"Date2": "2022-07-21T16:25:11Z",
+						"Date3": "2022-07-30T16:25:11Z",
+						"Date4": "2022-08-08T16:25:11Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Major damage and not safe to drive",
+							"Exterior": "Passenger Side",
+							"Interior": "Interior Trim"
+						},
+						"Detail": "Incident alone",
+						"Location": "66 Killdeer Trail",
+						"LocationCity": "Fresno",
+						"LocationState": "CA",
+						"LocationZIP": "93709",
+						"OtherVehicleInsurance": "Travelers",
+						"OtherVehicleMake": "GMC",
+						"OtherVehicleModel": "2500 Club Coupe",
+						"OtherVehicleOccupant": "Grethel MacTague",
+						"OtherVehicleOccupant2": null,
+						"OtherVehicleOccupant3": null,
+						"OtherVehicleVIN": "1G6AB5RX2D0356535",
+						"Type": "Vehicle incident while parking"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Jameson Norcliff",
+						"InsuredSSN": "611-95-0919",
+						"InsuredVIN": "SCFFDCCD6CG141652",
+						"InsuredVehicle": "2013 Ford Focus S Sedan"
+					},
+					"VehicleRepair": {
+						"Description": "Insured has not started repair",
+						"MechanicAddress": "2938 Hyperion Ave Los Angeles, CA 90027",
+						"MechanicCompleteDate": "2022-08-08T16:25:11Z",
+						"MechanicCost": 2517,
+						"MechanicName": "Hyperion Automotive Center",
+						"MechanicOrderNum": "qpo5ev",
+						"MechanicPhone": "(323) 665-7864",
+						"Status": "Not Started"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-71-316-5330",
 			"incidentDate": "2022-07-16T16:25:11Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-71-316-5330",
@@ -74,7 +445,60 @@
 			"claimAmount": 815,
 			"claimCreateDate": "2023-04-12T14:59:31Z",
 			"claimStatus": "inEstimation",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Bonnie Nevett\",\"InsuredSSN\":\"646-96-0088\",\"InsuredVehicle\":\"2015 Ford F-150 Super 250 XL\",\"InsuredVIN\":\"SALVP2BG6EH547489\"},\"IncidentDetail\":{\"Location\":\"92 Sunnyside Parkway\",\"LocationCity\":\"Fresno\",\"LocationState\":\"CA\",\"LocationZIP\":\"93740\",\"Type\":\"Vehicle incident while filling fuel\",\"Detail\":\"Incident alone\",\"OtherVehicleMake\":\"Ford\",\"OtherVehicleModel\":\"Taurus\",\"OtherVehicleVIN\":\"1LNHL9DK8FG338851\",\"OtherVehicleOccupant\":\"Klement Vick\",\"OtherVehicleOccupant2\":null,\"OtherVehicleOccupant3\":null,\"OtherVehicleInsurance\":\"Travelers\",\"Damage\":{\"Condition\":\"Minor damage and safe to drive\",\"Interior\":\"Upholstery\",\"Exterior\":\"Front,Driver Side\"}},\"VehicleRepair\":{\"Status\":\"Not Started\",\"Description\":\"Insured has not started repair\",\"MechanicName\":\"Hyperion Automotive Center\",\"MechanicPhone\":\"(323) 665-7864\",\"MechanicAddress\":\"2938 Hyperion Ave Los Angeles, CA 90027\",\"MechanicOrderNum\":\"qru7vs\",\"MechanicCompleteDate\":\"2023-04-30T14:59:31Z\",\"MechanicCost\":693},\"Activity\":{\"Date1\":\"2023-04-12T14:59:31Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Marie Producer (Producer)\",\"Date2\":\"2023-04-14T14:59:31Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2023-04-17T14:59:31Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2023-04-30T14:59:31Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Marie Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Marie Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Marie Producer (Producer)",
+						"Date1": "2023-04-12T14:59:31Z",
+						"Date2": "2023-04-14T14:59:31Z",
+						"Date3": "2023-04-17T14:59:31Z",
+						"Date4": "2023-04-30T14:59:31Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Minor damage and safe to drive",
+							"Exterior": "Front,Driver Side",
+							"Interior": "Upholstery"
+						},
+						"Detail": "Incident alone",
+						"Location": "92 Sunnyside Parkway",
+						"LocationCity": "Fresno",
+						"LocationState": "CA",
+						"LocationZIP": "93740",
+						"OtherVehicleInsurance": "Travelers",
+						"OtherVehicleMake": "Ford",
+						"OtherVehicleModel": "Taurus",
+						"OtherVehicleOccupant": "Klement Vick",
+						"OtherVehicleOccupant2": null,
+						"OtherVehicleOccupant3": null,
+						"OtherVehicleVIN": "1LNHL9DK8FG338851",
+						"Type": "Vehicle incident while filling fuel"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Bonnie Nevett",
+						"InsuredSSN": "646-96-0088",
+						"InsuredVIN": "SALVP2BG6EH547489",
+						"InsuredVehicle": "2015 Ford F-150 Super 250 XL"
+					},
+					"VehicleRepair": {
+						"Description": "Insured has not started repair",
+						"MechanicAddress": "2938 Hyperion Ave Los Angeles, CA 90027",
+						"MechanicCompleteDate": "2023-04-30T14:59:31Z",
+						"MechanicCost": 693,
+						"MechanicName": "Hyperion Automotive Center",
+						"MechanicOrderNum": "qru7vs",
+						"MechanicPhone": "(323) 665-7864",
+						"Status": "Not Started"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-14-768-3243",
 			"incidentDate": "2023-04-11T14:59:31Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-14-768-3243",
@@ -84,7 +508,60 @@
 			"claimAmount": 4185,
 			"claimCreateDate": "2022-12-05T14:32:47Z",
 			"claimStatus": "repair",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Monah Woolens\",\"InsuredSSN\":\"371-98-1643\",\"InsuredVehicle\":\"2018 Ford F-150 Super 250 XL\",\"InsuredVIN\":\"WAUGGAFR2DA698890\"},\"IncidentDetail\":{\"Location\":\"708 Shelley Circle\",\"LocationCity\":\"Concord\",\"LocationState\":\"CA\",\"LocationZIP\":\"94522\",\"Type\":\"Vehicle incident while filling fuel\",\"Detail\":\"Incident with single passenger\",\"OtherVehicleMake\":\"Citroën\",\"OtherVehicleModel\":\"CX\",\"OtherVehicleVIN\":\"1B3CC5FB1AN309749\",\"OtherVehicleOccupant\":\"Wesley Cicco\",\"OtherVehicleOccupant2\":\"Brina Youthead\",\"OtherVehicleOccupant3\":null,\"OtherVehicleInsurance\":\"Travelers\",\"Damage\":{\"Condition\":\"Good to drive\",\"Interior\":\"Wheels & Dashboard\",\"Exterior\":\"Driver Side, Driver Rear\"}},\"VehicleRepair\":{\"Status\":\"Pending\",\"Description\":\"Vehicle pending repair\",\"MechanicName\":\"Hyperion Automotive Center\",\"MechanicPhone\":\"(323) 665-7864\",\"MechanicAddress\":\"2938 Hyperion Ave Los Angeles, CA 90027\",\"MechanicOrderNum\":\"mja5na\",\"MechanicCompleteDate\":\"2022-12-23T14:32:47Z\",\"MechanicCost\":3557},\"Activity\":{\"Date1\":\"2022-12-05T14:32:47Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Date2\":\"2022-12-08T14:32:47Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2022-12-14T14:32:47Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2022-12-23T14:32:47Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Scott Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Scott Producer (Producer)",
+						"Date1": "2022-12-05T14:32:47Z",
+						"Date2": "2022-12-08T14:32:47Z",
+						"Date3": "2022-12-14T14:32:47Z",
+						"Date4": "2022-12-23T14:32:47Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Good to drive",
+							"Exterior": "Driver Side, Driver Rear",
+							"Interior": "Wheels & Dashboard"
+						},
+						"Detail": "Incident with single passenger",
+						"Location": "708 Shelley Circle",
+						"LocationCity": "Concord",
+						"LocationState": "CA",
+						"LocationZIP": "94522",
+						"OtherVehicleInsurance": "Travelers",
+						"OtherVehicleMake": "Citroën",
+						"OtherVehicleModel": "CX",
+						"OtherVehicleOccupant": "Wesley Cicco",
+						"OtherVehicleOccupant2": "Brina Youthead",
+						"OtherVehicleOccupant3": null,
+						"OtherVehicleVIN": "1B3CC5FB1AN309749",
+						"Type": "Vehicle incident while filling fuel"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Monah Woolens",
+						"InsuredSSN": "371-98-1643",
+						"InsuredVIN": "WAUGGAFR2DA698890",
+						"InsuredVehicle": "2018 Ford F-150 Super 250 XL"
+					},
+					"VehicleRepair": {
+						"Description": "Vehicle pending repair",
+						"MechanicAddress": "2938 Hyperion Ave Los Angeles, CA 90027",
+						"MechanicCompleteDate": "2022-12-23T14:32:47Z",
+						"MechanicCost": 3557,
+						"MechanicName": "Hyperion Automotive Center",
+						"MechanicOrderNum": "mja5na",
+						"MechanicPhone": "(323) 665-7864",
+						"Status": "Pending"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-57-402-8342",
 			"incidentDate": "2022-11-29T14:32:47Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-57-402-8342",
@@ -94,7 +571,60 @@
 			"claimAmount": 0,
 			"claimCreateDate": "2023-07-08T13:04:21Z",
 			"claimStatus": "approved",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Jameson Norcliff\",\"InsuredSSN\":\"844-83-9574\",\"InsuredVehicle\":\"2016 Volvo V90 Cross Country\",\"InsuredVIN\":\"WAUCFAFH5FN050075\"},\"IncidentDetail\":{\"Location\":\"0250 Raven Parkway\",\"LocationCity\":\"San Jose\",\"LocationState\":\"CA\",\"LocationZIP\":\"95150\",\"Type\":\"Vehicle incident while parking\",\"Detail\":\"Incident with more than one passenger\",\"OtherVehicleMake\":\"Lotus\",\"OtherVehicleModel\":\"Exige\",\"OtherVehicleVIN\":\"WDDPK4HA0EF863954\",\"OtherVehicleOccupant\":\"Cynthea Brushfield\",\"OtherVehicleOccupant2\":\"Rebeca Muino\",\"OtherVehicleOccupant3\":\"Bordy Droogan\",\"OtherVehicleInsurance\":\"Mercury\",\"Damage\":{\"Condition\":\"Major damage and not safe to drive\",\"Interior\":\"Wheels & Dashboard\",\"Exterior\":\"Passenger Rear,Rear\"}},\"VehicleRepair\":{\"Status\":\"Pending\",\"Description\":\"Vehicle pending repair\",\"MechanicName\":\"Hyperion Automotive Center\",\"MechanicPhone\":\"(323) 665-7864\",\"MechanicAddress\":\"2938 Hyperion Ave Los Angeles, CA 90027\",\"MechanicOrderNum\":\"gss3wx\",\"MechanicCompleteDate\":\"2023-07-28T13:04:21Z\",\"MechanicCost\":751},\"Activity\":{\"Date1\":\"2023-07-08T13:04:21Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Marie Producer (Producer)\",\"Date2\":\"2023-07-11T13:04:21Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2023-07-18T13:04:21Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2023-07-28T13:04:21Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Marie Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Marie Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Marie Producer (Producer)",
+						"Date1": "2023-07-08T13:04:21Z",
+						"Date2": "2023-07-11T13:04:21Z",
+						"Date3": "2023-07-18T13:04:21Z",
+						"Date4": "2023-07-28T13:04:21Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Major damage and not safe to drive",
+							"Exterior": "Passenger Rear,Rear",
+							"Interior": "Wheels & Dashboard"
+						},
+						"Detail": "Incident with more than one passenger",
+						"Location": "0250 Raven Parkway",
+						"LocationCity": "San Jose",
+						"LocationState": "CA",
+						"LocationZIP": "95150",
+						"OtherVehicleInsurance": "Mercury",
+						"OtherVehicleMake": "Lotus",
+						"OtherVehicleModel": "Exige",
+						"OtherVehicleOccupant": "Cynthea Brushfield",
+						"OtherVehicleOccupant2": "Rebeca Muino",
+						"OtherVehicleOccupant3": "Bordy Droogan",
+						"OtherVehicleVIN": "WDDPK4HA0EF863954",
+						"Type": "Vehicle incident while parking"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Jameson Norcliff",
+						"InsuredSSN": "844-83-9574",
+						"InsuredVIN": "WAUCFAFH5FN050075",
+						"InsuredVehicle": "2016 Volvo V90 Cross Country"
+					},
+					"VehicleRepair": {
+						"Description": "Vehicle pending repair",
+						"MechanicAddress": "2938 Hyperion Ave Los Angeles, CA 90027",
+						"MechanicCompleteDate": "2023-07-28T13:04:21Z",
+						"MechanicCost": 751,
+						"MechanicName": "Hyperion Automotive Center",
+						"MechanicOrderNum": "gss3wx",
+						"MechanicPhone": "(323) 665-7864",
+						"Status": "Pending"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-81-788-4032",
 			"incidentDate": "2023-07-07T13:04:21Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-81-788-4032",
@@ -104,7 +634,60 @@
 			"claimAmount": 4409,
 			"claimCreateDate": "2022-10-09T04:20:43Z",
 			"claimStatus": "approved",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Mitzi Barnwall\",\"InsuredSSN\":\"305-67-2083\",\"InsuredVehicle\":\"2016 Volvo V90 Cross Country\",\"InsuredVIN\":\"WAUGL58E55A251131\"},\"IncidentDetail\":{\"Location\":\"411 Erie Street\",\"LocationCity\":\"San Diego\",\"LocationState\":\"CA\",\"LocationZIP\":\"92121\",\"Type\":\"Vehicle incident while parked\",\"Detail\":\"Incident with single passenger\",\"OtherVehicleMake\":\"Toyota\",\"OtherVehicleModel\":\"Land Cruiser\",\"OtherVehicleVIN\":\"1GTN1TEX4DZ686166\",\"OtherVehicleOccupant\":\"Ximenes Rief\",\"OtherVehicleOccupant2\":\"Udell Provost\",\"OtherVehicleOccupant3\":null,\"OtherVehicleInsurance\":\"USAA\",\"Damage\":{\"Condition\":\"Major damage and not safe to drive\",\"Interior\":\"Seats\",\"Exterior\":\"Passenger Rear,Rear\"}},\"VehicleRepair\":{\"Status\":\"Pending\",\"Description\":\"Vehicle pending repair\",\"MechanicName\":\"Hyperion Automotive Center\",\"MechanicPhone\":\"(323) 665-7864\",\"MechanicAddress\":\"2938 Hyperion Ave Los Angeles, CA 90027\",\"MechanicOrderNum\":\"zvt1tg\",\"MechanicCompleteDate\":\"2022-10-22T04:20:43Z\",\"MechanicCost\":3748},\"Activity\":{\"Date1\":\"2022-10-09T04:20:43Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Date2\":\"2022-10-10T04:20:43Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2022-10-19T04:20:43Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2022-10-22T04:20:43Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Scott Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Scott Producer (Producer)",
+						"Date1": "2022-10-09T04:20:43Z",
+						"Date2": "2022-10-10T04:20:43Z",
+						"Date3": "2022-10-19T04:20:43Z",
+						"Date4": "2022-10-22T04:20:43Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Major damage and not safe to drive",
+							"Exterior": "Passenger Rear,Rear",
+							"Interior": "Seats"
+						},
+						"Detail": "Incident with single passenger",
+						"Location": "411 Erie Street",
+						"LocationCity": "San Diego",
+						"LocationState": "CA",
+						"LocationZIP": "92121",
+						"OtherVehicleInsurance": "USAA",
+						"OtherVehicleMake": "Toyota",
+						"OtherVehicleModel": "Land Cruiser",
+						"OtherVehicleOccupant": "Ximenes Rief",
+						"OtherVehicleOccupant2": "Udell Provost",
+						"OtherVehicleOccupant3": null,
+						"OtherVehicleVIN": "1GTN1TEX4DZ686166",
+						"Type": "Vehicle incident while parked"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Mitzi Barnwall",
+						"InsuredSSN": "305-67-2083",
+						"InsuredVIN": "WAUGL58E55A251131",
+						"InsuredVehicle": "2016 Volvo V90 Cross Country"
+					},
+					"VehicleRepair": {
+						"Description": "Vehicle pending repair",
+						"MechanicAddress": "2938 Hyperion Ave Los Angeles, CA 90027",
+						"MechanicCompleteDate": "2022-10-22T04:20:43Z",
+						"MechanicCost": 3748,
+						"MechanicName": "Hyperion Automotive Center",
+						"MechanicOrderNum": "zvt1tg",
+						"MechanicPhone": "(323) 665-7864",
+						"Status": "Pending"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-97-931-1823",
 			"incidentDate": "2022-10-05T04:20:43Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-97-931-1823",
@@ -114,7 +697,60 @@
 			"claimAmount": 2270,
 			"claimCreateDate": "2023-12-10T19:40:53Z",
 			"claimStatus": "settled",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Gerri Goodlett\",\"InsuredSSN\":\"310-86-9661\",\"InsuredVehicle\":\"2016 Toyota Tundra SR6\",\"InsuredVIN\":\"1G6AW5SX9F0792025\"},\"IncidentDetail\":{\"Location\":\"714 Roth Pass\",\"LocationCity\":\"Carson City\",\"LocationState\":\"NV\",\"LocationZIP\":\"89706\",\"Type\":\"Vehicle incident while filling fuel\",\"Detail\":\"Incident with single passenger\",\"OtherVehicleMake\":\"Subaru\",\"OtherVehicleModel\":\"XT\",\"OtherVehicleVIN\":\"WAUPL68EX5A643740\",\"OtherVehicleOccupant\":\"Ainslie Casina\",\"OtherVehicleOccupant2\":\"Jarred Rowell\",\"OtherVehicleOccupant3\":null,\"OtherVehicleInsurance\":\"Travelers\",\"Damage\":{\"Condition\":\"Good to drive\",\"Interior\":\"Interior Trim\",\"Exterior\":\"Front,Driver Side\"}},\"VehicleRepair\":{\"Status\":\"Complete\",\"Description\":\"Insured contacted mechanic and completed repair\",\"MechanicName\":\"Lyons Auto Pro Plus\",\"MechanicPhone\":\"(310) 987-4567\",\"MechanicAddress\":\"675 Main Street Los Angeles, CA 90005\",\"MechanicOrderNum\":\"loi7gh\",\"MechanicCompleteDate\":\"2023-12-21T19:40:53Z\",\"MechanicCost\":1930},\"Activity\":{\"Date1\":\"2023-12-10T19:40:53Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Marie Producer (Producer)\",\"Date2\":\"2023-12-12T19:40:53Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2023-12-20T19:40:53Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2023-12-21T19:40:53Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Marie Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Marie Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Marie Producer (Producer)",
+						"Date1": "2023-12-10T19:40:53Z",
+						"Date2": "2023-12-12T19:40:53Z",
+						"Date3": "2023-12-20T19:40:53Z",
+						"Date4": "2023-12-21T19:40:53Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Good to drive",
+							"Exterior": "Front,Driver Side",
+							"Interior": "Interior Trim"
+						},
+						"Detail": "Incident with single passenger",
+						"Location": "714 Roth Pass",
+						"LocationCity": "Carson City",
+						"LocationState": "NV",
+						"LocationZIP": "89706",
+						"OtherVehicleInsurance": "Travelers",
+						"OtherVehicleMake": "Subaru",
+						"OtherVehicleModel": "XT",
+						"OtherVehicleOccupant": "Ainslie Casina",
+						"OtherVehicleOccupant2": "Jarred Rowell",
+						"OtherVehicleOccupant3": null,
+						"OtherVehicleVIN": "WAUPL68EX5A643740",
+						"Type": "Vehicle incident while filling fuel"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Gerri Goodlett",
+						"InsuredSSN": "310-86-9661",
+						"InsuredVIN": "1G6AW5SX9F0792025",
+						"InsuredVehicle": "2016 Toyota Tundra SR6"
+					},
+					"VehicleRepair": {
+						"Description": "Insured contacted mechanic and completed repair",
+						"MechanicAddress": "675 Main Street Los Angeles, CA 90005",
+						"MechanicCompleteDate": "2023-12-21T19:40:53Z",
+						"MechanicCost": 1930,
+						"MechanicName": "Lyons Auto Pro Plus",
+						"MechanicOrderNum": "loi7gh",
+						"MechanicPhone": "(310) 987-4567",
+						"Status": "Complete"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-95-575-8266",
 			"incidentDate": "2023-12-04T19:40:53Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-95-575-8266",
@@ -124,7 +760,60 @@
 			"claimAmount": 3259,
 			"claimCreateDate": "2023-03-16T04:05:51Z",
 			"claimStatus": "settled",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Ferrel Sames\",\"InsuredSSN\":\"317-37-7379\",\"InsuredVehicle\":\"2016 Ford F-150 Super 250 XL\",\"InsuredVIN\":\"1FTEW1E88AF197214\"},\"IncidentDetail\":{\"Location\":\"9219 Dorton Park\",\"LocationCity\":\"New York City\",\"LocationState\":\"NY\",\"LocationZIP\":\"10099\",\"Type\":\"Vehicle incident while parking\",\"Detail\":\"Incident with more than one passenger\",\"OtherVehicleMake\":\"Smart\",\"OtherVehicleModel\":\"Fortwo\",\"OtherVehicleVIN\":\"WBALX3C59CD671792\",\"OtherVehicleOccupant\":\"Glen Seyler\",\"OtherVehicleOccupant2\":\"Burg O'Daly\",\"OtherVehicleOccupant3\":\"Kippie Willisch\",\"OtherVehicleInsurance\":\"Geico\",\"Damage\":{\"Condition\":\"Major damage and not safe to drive\",\"Interior\":\"Wheels & Dashboard\",\"Exterior\":\"Front,Driver Side\"}},\"VehicleRepair\":{\"Status\":\"Complete\",\"Description\":\"Insured contacted mechanic and completed repair\",\"MechanicName\":\"Lyons Auto Pro Plus\",\"MechanicPhone\":\"(310) 987-4567\",\"MechanicAddress\":\"675 Main Street Los Angeles, CA 90005\",\"MechanicOrderNum\":\"oyo1lk\",\"MechanicCompleteDate\":\"2023-03-31T04:05:51Z\",\"MechanicCost\":2770},\"Activity\":{\"Date1\":\"2023-03-16T04:05:51Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Marie Producer (Producer)\",\"Date2\":\"2023-03-18T04:05:51Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2023-03-24T04:05:51Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2023-03-31T04:05:51Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Marie Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Marie Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Marie Producer (Producer)",
+						"Date1": "2023-03-16T04:05:51Z",
+						"Date2": "2023-03-18T04:05:51Z",
+						"Date3": "2023-03-24T04:05:51Z",
+						"Date4": "2023-03-31T04:05:51Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Major damage and not safe to drive",
+							"Exterior": "Front,Driver Side",
+							"Interior": "Wheels & Dashboard"
+						},
+						"Detail": "Incident with more than one passenger",
+						"Location": "9219 Dorton Park",
+						"LocationCity": "New York City",
+						"LocationState": "NY",
+						"LocationZIP": "10099",
+						"OtherVehicleInsurance": "Geico",
+						"OtherVehicleMake": "Smart",
+						"OtherVehicleModel": "Fortwo",
+						"OtherVehicleOccupant": "Glen Seyler",
+						"OtherVehicleOccupant2": "Burg O'Daly",
+						"OtherVehicleOccupant3": "Kippie Willisch",
+						"OtherVehicleVIN": "WBALX3C59CD671792",
+						"Type": "Vehicle incident while parking"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Ferrel Sames",
+						"InsuredSSN": "317-37-7379",
+						"InsuredVIN": "1FTEW1E88AF197214",
+						"InsuredVehicle": "2016 Ford F-150 Super 250 XL"
+					},
+					"VehicleRepair": {
+						"Description": "Insured contacted mechanic and completed repair",
+						"MechanicAddress": "675 Main Street Los Angeles, CA 90005",
+						"MechanicCompleteDate": "2023-03-31T04:05:51Z",
+						"MechanicCost": 2770,
+						"MechanicName": "Lyons Auto Pro Plus",
+						"MechanicOrderNum": "oyo1lk",
+						"MechanicPhone": "(310) 987-4567",
+						"Status": "Complete"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-96-765-6341",
 			"incidentDate": "2023-03-12T04:05:51Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-96-765-6341",
@@ -134,7 +823,60 @@
 			"claimAmount": 446,
 			"claimCreateDate": "2022-11-05T16:13:36Z",
 			"claimStatus": "approved",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Bonnie Nevett\",\"InsuredSSN\":\"260-94-7054\",\"InsuredVehicle\":\"2016 Ford F-150 Super 250 XL\",\"InsuredVIN\":\"SAJWA4GC7EM809592\"},\"IncidentDetail\":{\"Location\":\"6 Blue Bill Park Parkway\",\"LocationCity\":\"Reno\",\"LocationState\":\"NV\",\"LocationZIP\":\"89519\",\"Type\":\"Vehicle incident while driving\",\"Detail\":\"Incident alone\",\"OtherVehicleMake\":\"Chevrolet\",\"OtherVehicleModel\":\"Avalanche 1500\",\"OtherVehicleVIN\":\"WBSBL93481J788517\",\"OtherVehicleOccupant\":\"Alic Mulcock\",\"OtherVehicleOccupant2\":null,\"OtherVehicleOccupant3\":null,\"OtherVehicleInsurance\":\"Mercury\",\"Damage\":{\"Condition\":\"Good to drive\",\"Interior\":\"Seats\",\"Exterior\":\"Passenger Side\"}},\"VehicleRepair\":{\"Status\":\"Pending\",\"Description\":\"Vehicle pending repair\",\"MechanicName\":\"Lyons Auto Pro Plus\",\"MechanicPhone\":\"(310) 987-4567\",\"MechanicAddress\":\"675 Main Street Los Angeles, CA 90005\",\"MechanicOrderNum\":\"hze4vc\",\"MechanicCompleteDate\":\"2022-11-16T16:13:36Z\",\"MechanicCost\":379},\"Activity\":{\"Date1\":\"2022-11-05T16:13:36Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Date2\":\"2022-11-08T16:13:36Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2022-11-11T16:13:36Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2022-11-16T16:13:36Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Scott Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Scott Producer (Producer)",
+						"Date1": "2022-11-05T16:13:36Z",
+						"Date2": "2022-11-08T16:13:36Z",
+						"Date3": "2022-11-11T16:13:36Z",
+						"Date4": "2022-11-16T16:13:36Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Good to drive",
+							"Exterior": "Passenger Side",
+							"Interior": "Seats"
+						},
+						"Detail": "Incident alone",
+						"Location": "6 Blue Bill Park Parkway",
+						"LocationCity": "Reno",
+						"LocationState": "NV",
+						"LocationZIP": "89519",
+						"OtherVehicleInsurance": "Mercury",
+						"OtherVehicleMake": "Chevrolet",
+						"OtherVehicleModel": "Avalanche 1500",
+						"OtherVehicleOccupant": "Alic Mulcock",
+						"OtherVehicleOccupant2": null,
+						"OtherVehicleOccupant3": null,
+						"OtherVehicleVIN": "WBSBL93481J788517",
+						"Type": "Vehicle incident while driving"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Bonnie Nevett",
+						"InsuredSSN": "260-94-7054",
+						"InsuredVIN": "SAJWA4GC7EM809592",
+						"InsuredVehicle": "2016 Ford F-150 Super 250 XL"
+					},
+					"VehicleRepair": {
+						"Description": "Vehicle pending repair",
+						"MechanicAddress": "675 Main Street Los Angeles, CA 90005",
+						"MechanicCompleteDate": "2022-11-16T16:13:36Z",
+						"MechanicCost": 379,
+						"MechanicName": "Lyons Auto Pro Plus",
+						"MechanicOrderNum": "hze4vc",
+						"MechanicPhone": "(310) 987-4567",
+						"Status": "Pending"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-38-562-7204",
 			"incidentDate": "2022-10-30T16:13:36Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-38-562-7204",
@@ -144,7 +886,60 @@
 			"claimAmount": 3491,
 			"claimCreateDate": "2023-07-11T23:31:13Z",
 			"claimStatus": "declined",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Hew Island\",\"InsuredSSN\":\"104-88-7597\",\"InsuredVehicle\":\"2016 Volvo S90 R-Design\",\"InsuredVIN\":\"ZFBCFADH5FZ508182\"},\"IncidentDetail\":{\"Location\":\"61550 Mosinee Street\",\"LocationCity\":\"Jamaica\",\"LocationState\":\"NY\",\"LocationZIP\":\"11499\",\"Type\":\"Vehicle incident while filling fuel\",\"Detail\":\"Incident with more than one passenger\",\"OtherVehicleMake\":\"Maserati\",\"OtherVehicleModel\":\"228\",\"OtherVehicleVIN\":\"SCFAD01A75G842107\",\"OtherVehicleOccupant\":\"Rock O' Mullane\",\"OtherVehicleOccupant2\":\"Ethelyn Creavin\",\"OtherVehicleOccupant3\":\"Kerstin Lyddon\",\"OtherVehicleInsurance\":\"State Farm\",\"Damage\":{\"Condition\":\"Major damage and not safe to drive\",\"Interior\":\"Seats\",\"Exterior\":\"Driver Side, Driver Rear\"}},\"VehicleRepair\":{\"Status\":\"Not Started\",\"Description\":\"Insured has not started repair\",\"MechanicName\":\"Hyperion Automotive Center\",\"MechanicPhone\":\"(323) 665-7864\",\"MechanicAddress\":\"2938 Hyperion Ave Los Angeles, CA 90027\",\"MechanicOrderNum\":\"qmd4ya\",\"MechanicCompleteDate\":\"2023-07-26T23:31:13Z\",\"MechanicCost\":2967},\"Activity\":{\"Date1\":\"2023-07-11T23:31:13Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Date2\":\"2023-07-13T23:31:13Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2023-07-20T23:31:13Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2023-07-26T23:31:13Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Scott Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Scott Producer (Producer)",
+						"Date1": "2023-07-11T23:31:13Z",
+						"Date2": "2023-07-13T23:31:13Z",
+						"Date3": "2023-07-20T23:31:13Z",
+						"Date4": "2023-07-26T23:31:13Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Major damage and not safe to drive",
+							"Exterior": "Driver Side, Driver Rear",
+							"Interior": "Seats"
+						},
+						"Detail": "Incident with more than one passenger",
+						"Location": "61550 Mosinee Street",
+						"LocationCity": "Jamaica",
+						"LocationState": "NY",
+						"LocationZIP": "11499",
+						"OtherVehicleInsurance": "State Farm",
+						"OtherVehicleMake": "Maserati",
+						"OtherVehicleModel": "228",
+						"OtherVehicleOccupant": "Rock O' Mullane",
+						"OtherVehicleOccupant2": "Ethelyn Creavin",
+						"OtherVehicleOccupant3": "Kerstin Lyddon",
+						"OtherVehicleVIN": "SCFAD01A75G842107",
+						"Type": "Vehicle incident while filling fuel"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Hew Island",
+						"InsuredSSN": "104-88-7597",
+						"InsuredVIN": "ZFBCFADH5FZ508182",
+						"InsuredVehicle": "2016 Volvo S90 R-Design"
+					},
+					"VehicleRepair": {
+						"Description": "Insured has not started repair",
+						"MechanicAddress": "2938 Hyperion Ave Los Angeles, CA 90027",
+						"MechanicCompleteDate": "2023-07-26T23:31:13Z",
+						"MechanicCost": 2967,
+						"MechanicName": "Hyperion Automotive Center",
+						"MechanicOrderNum": "qmd4ya",
+						"MechanicPhone": "(323) 665-7864",
+						"Status": "Not Started"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-61-589-8738",
 			"incidentDate": "2023-07-08T23:31:13Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-61-589-8738",
@@ -154,7 +949,60 @@
 			"claimAmount": 1317,
 			"claimCreateDate": "2023-05-25T09:24:22Z",
 			"claimStatus": "approved",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Leelah Hicklingbottom\",\"InsuredSSN\":\"305-30-0789\",\"InsuredVehicle\":\"2014 Volvo V90 Cross Country\",\"InsuredVIN\":\"WAUJC68E53A548604\"},\"IncidentDetail\":{\"Location\":\"96228 Burrows Alley\",\"LocationCity\":\"Orange\",\"LocationState\":\"CA\",\"LocationZIP\":\"92867\",\"Type\":\"Vehicle incident while driving\",\"Detail\":\"Incident alone\",\"OtherVehicleMake\":\"Mazda\",\"OtherVehicleModel\":\"MX-6\",\"OtherVehicleVIN\":\"WDDHH8HB8BA179018\",\"OtherVehicleOccupant\":\"Dalton Clendennen\",\"OtherVehicleOccupant2\":null,\"OtherVehicleOccupant3\":null,\"OtherVehicleInsurance\":\"Geico\",\"Damage\":{\"Condition\":\"Good to drive\",\"Interior\":\"Upholstery\",\"Exterior\":\"Front,Driver Side\"}},\"VehicleRepair\":{\"Status\":\"Pending\",\"Description\":\"Vehicle pending repair\",\"MechanicName\":\"Diamond Auto Repair\",\"MechanicPhone\":\"(310) 458-3492\",\"MechanicAddress\":\"1432 Wilshire Blvd. Los Angeles, CA 90010\",\"MechanicOrderNum\":\"raq4bh\",\"MechanicCompleteDate\":\"2023-06-08T09:24:22Z\",\"MechanicCost\":1119},\"Activity\":{\"Date1\":\"2023-05-25T09:24:22Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Date2\":\"2023-05-28T09:24:22Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2023-05-29T09:24:22Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2023-06-08T09:24:22Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Scott Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Scott Producer (Producer)",
+						"Date1": "2023-05-25T09:24:22Z",
+						"Date2": "2023-05-28T09:24:22Z",
+						"Date3": "2023-05-29T09:24:22Z",
+						"Date4": "2023-06-08T09:24:22Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Good to drive",
+							"Exterior": "Front,Driver Side",
+							"Interior": "Upholstery"
+						},
+						"Detail": "Incident alone",
+						"Location": "96228 Burrows Alley",
+						"LocationCity": "Orange",
+						"LocationState": "CA",
+						"LocationZIP": "92867",
+						"OtherVehicleInsurance": "Geico",
+						"OtherVehicleMake": "Mazda",
+						"OtherVehicleModel": "MX-6",
+						"OtherVehicleOccupant": "Dalton Clendennen",
+						"OtherVehicleOccupant2": null,
+						"OtherVehicleOccupant3": null,
+						"OtherVehicleVIN": "WDDHH8HB8BA179018",
+						"Type": "Vehicle incident while driving"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Leelah Hicklingbottom",
+						"InsuredSSN": "305-30-0789",
+						"InsuredVIN": "WAUJC68E53A548604",
+						"InsuredVehicle": "2014 Volvo V90 Cross Country"
+					},
+					"VehicleRepair": {
+						"Description": "Vehicle pending repair",
+						"MechanicAddress": "1432 Wilshire Blvd. Los Angeles, CA 90010",
+						"MechanicCompleteDate": "2023-06-08T09:24:22Z",
+						"MechanicCost": 1119,
+						"MechanicName": "Diamond Auto Repair",
+						"MechanicOrderNum": "raq4bh",
+						"MechanicPhone": "(310) 458-3492",
+						"Status": "Pending"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-24-969-1132",
 			"incidentDate": "2023-05-24T09:24:22Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-24-969-1132",
@@ -164,7 +1012,60 @@
 			"claimAmount": 2786,
 			"claimCreateDate": "2023-02-14T15:13:55Z",
 			"claimStatus": "settled",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Bonnie Nevett\",\"InsuredSSN\":\"538-80-6468\",\"InsuredVehicle\":\"2014 Toyota Corolla LE\",\"InsuredVIN\":\"WDDEJ7EB9DA948473\"},\"IncidentDetail\":{\"Location\":\"3 Esch Circle\",\"LocationCity\":\"Whittier\",\"LocationState\":\"CA\",\"LocationZIP\":\"90610\",\"Type\":\"Vehicle incident while filling fuel\",\"Detail\":\"Incident with more than one passenger\",\"OtherVehicleMake\":\"Infiniti\",\"OtherVehicleModel\":\"QX\",\"OtherVehicleVIN\":\"WA1VMBFE4DD103956\",\"OtherVehicleOccupant\":\"Noland Annear\",\"OtherVehicleOccupant2\":\"Marmaduke Libreros\",\"OtherVehicleOccupant3\":\"Gwen Southon\",\"OtherVehicleInsurance\":\"Mercury\",\"Damage\":{\"Condition\":\"Major damage and not safe to drive\",\"Interior\":\"Wheels & Dashboard\",\"Exterior\":\"Front,Driver Side\"}},\"VehicleRepair\":{\"Status\":\"Complete\",\"Description\":\"Insured contacted mechanic and completed repair\",\"MechanicName\":\"Hyperion Automotive Center\",\"MechanicPhone\":\"(323) 665-7864\",\"MechanicAddress\":\"2938 Hyperion Ave Los Angeles, CA 90027\",\"MechanicOrderNum\":\"xde8hv\",\"MechanicCompleteDate\":\"2023-03-03T15:13:55Z\",\"MechanicCost\":2368},\"Activity\":{\"Date1\":\"2023-02-14T15:13:55Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Date2\":\"2023-02-16T15:13:55Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2023-02-18T15:13:55Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2023-03-03T15:13:55Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Scott Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Scott Producer (Producer)",
+						"Date1": "2023-02-14T15:13:55Z",
+						"Date2": "2023-02-16T15:13:55Z",
+						"Date3": "2023-02-18T15:13:55Z",
+						"Date4": "2023-03-03T15:13:55Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Major damage and not safe to drive",
+							"Exterior": "Front,Driver Side",
+							"Interior": "Wheels & Dashboard"
+						},
+						"Detail": "Incident with more than one passenger",
+						"Location": "3 Esch Circle",
+						"LocationCity": "Whittier",
+						"LocationState": "CA",
+						"LocationZIP": "90610",
+						"OtherVehicleInsurance": "Mercury",
+						"OtherVehicleMake": "Infiniti",
+						"OtherVehicleModel": "QX",
+						"OtherVehicleOccupant": "Noland Annear",
+						"OtherVehicleOccupant2": "Marmaduke Libreros",
+						"OtherVehicleOccupant3": "Gwen Southon",
+						"OtherVehicleVIN": "WA1VMBFE4DD103956",
+						"Type": "Vehicle incident while filling fuel"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Bonnie Nevett",
+						"InsuredSSN": "538-80-6468",
+						"InsuredVIN": "WDDEJ7EB9DA948473",
+						"InsuredVehicle": "2014 Toyota Corolla LE"
+					},
+					"VehicleRepair": {
+						"Description": "Insured contacted mechanic and completed repair",
+						"MechanicAddress": "2938 Hyperion Ave Los Angeles, CA 90027",
+						"MechanicCompleteDate": "2023-03-03T15:13:55Z",
+						"MechanicCost": 2368,
+						"MechanicName": "Hyperion Automotive Center",
+						"MechanicOrderNum": "xde8hv",
+						"MechanicPhone": "(323) 665-7864",
+						"Status": "Complete"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-22-792-2963",
 			"incidentDate": "2023-02-13T15:13:55Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-22-792-2963",
@@ -174,7 +1075,60 @@
 			"claimAmount": 0,
 			"claimCreateDate": "2022-11-16T11:27:46Z",
 			"claimStatus": "repair",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Felice Lippett\",\"InsuredSSN\":\"139-71-9330\",\"InsuredVehicle\":\"2015 Volvo S90 R-Design\",\"InsuredVIN\":\"1GD01ZCG7BF879924\"},\"IncidentDetail\":{\"Location\":\"49722 Dakota Plaza\",\"LocationCity\":\"Fullerton\",\"LocationState\":\"CA\",\"LocationZIP\":\"92835\",\"Type\":\"Vehicle incident while driving\",\"Detail\":\"Incident alone\",\"OtherVehicleMake\":\"Ford\",\"OtherVehicleModel\":\"Mustang\",\"OtherVehicleVIN\":\"3LNDL2L33BR393078\",\"OtherVehicleOccupant\":\"Fabien Gravie\",\"OtherVehicleOccupant2\":null,\"OtherVehicleOccupant3\":null,\"OtherVehicleInsurance\":\"Liberty Mutual\",\"Damage\":{\"Condition\":\"Minor damage and safe to drive\",\"Interior\":\"Upholstery\",\"Exterior\":\"Passenger Rear,Rear\"}},\"VehicleRepair\":{\"Status\":\"Pending\",\"Description\":\"Vehicle pending repair\",\"MechanicName\":\"Diamond Auto Repair\",\"MechanicPhone\":\"(310) 458-3492\",\"MechanicAddress\":\"1432 Wilshire Blvd. Los Angeles, CA 90010\",\"MechanicOrderNum\":\"ioc1lb\",\"MechanicCompleteDate\":\"2022-12-06T11:27:46Z\",\"MechanicCost\":1397},\"Activity\":{\"Date1\":\"2022-11-16T11:27:46Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Marie Producer (Producer)\",\"Date2\":\"2022-11-19T11:27:46Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2022-11-24T11:27:46Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2022-12-06T11:27:46Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Marie Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Marie Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Marie Producer (Producer)",
+						"Date1": "2022-11-16T11:27:46Z",
+						"Date2": "2022-11-19T11:27:46Z",
+						"Date3": "2022-11-24T11:27:46Z",
+						"Date4": "2022-12-06T11:27:46Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Minor damage and safe to drive",
+							"Exterior": "Passenger Rear,Rear",
+							"Interior": "Upholstery"
+						},
+						"Detail": "Incident alone",
+						"Location": "49722 Dakota Plaza",
+						"LocationCity": "Fullerton",
+						"LocationState": "CA",
+						"LocationZIP": "92835",
+						"OtherVehicleInsurance": "Liberty Mutual",
+						"OtherVehicleMake": "Ford",
+						"OtherVehicleModel": "Mustang",
+						"OtherVehicleOccupant": "Fabien Gravie",
+						"OtherVehicleOccupant2": null,
+						"OtherVehicleOccupant3": null,
+						"OtherVehicleVIN": "3LNDL2L33BR393078",
+						"Type": "Vehicle incident while driving"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Felice Lippett",
+						"InsuredSSN": "139-71-9330",
+						"InsuredVIN": "1GD01ZCG7BF879924",
+						"InsuredVehicle": "2015 Volvo S90 R-Design"
+					},
+					"VehicleRepair": {
+						"Description": "Vehicle pending repair",
+						"MechanicAddress": "1432 Wilshire Blvd. Los Angeles, CA 90010",
+						"MechanicCompleteDate": "2022-12-06T11:27:46Z",
+						"MechanicCost": 1397,
+						"MechanicName": "Diamond Auto Repair",
+						"MechanicOrderNum": "ioc1lb",
+						"MechanicPhone": "(310) 458-3492",
+						"Status": "Pending"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-49-835-7668",
 			"incidentDate": "2022-11-11T11:27:46Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-49-835-7668",
@@ -184,7 +1138,60 @@
 			"claimAmount": 350,
 			"claimCreateDate": "2022-10-17T04:37:23Z",
 			"claimStatus": "settled",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Bogart Becaris\",\"InsuredSSN\":\"232-41-6839\",\"InsuredVehicle\":\"2013 Ford Mustang GT Fastback\",\"InsuredVIN\":\"WUATNAFG3BN875686\"},\"IncidentDetail\":{\"Location\":\"1063 Northwestern Crossing\",\"LocationCity\":\"Berkeley\",\"LocationState\":\"CA\",\"LocationZIP\":\"94712\",\"Type\":\"Vehicle incident while parking\",\"Detail\":\"Incident alone\",\"OtherVehicleMake\":\"Land Rover\",\"OtherVehicleModel\":\"Range Rover\",\"OtherVehicleVIN\":\"2V4RW3DG1BR770012\",\"OtherVehicleOccupant\":\"Timmi Heffron\",\"OtherVehicleOccupant2\":null,\"OtherVehicleOccupant3\":null,\"OtherVehicleInsurance\":\"Travelers\",\"Damage\":{\"Condition\":\"Minor damage and safe to drive\",\"Interior\":\"Seats\",\"Exterior\":\"Front,Driver Side\"}},\"VehicleRepair\":{\"Status\":\"Complete\",\"Description\":\"Insured contacted mechanic and completed repair\",\"MechanicName\":\"Lyons Auto Pro Plus\",\"MechanicPhone\":\"(310) 987-4567\",\"MechanicAddress\":\"675 Main Street Los Angeles, CA 90005\",\"MechanicOrderNum\":\"xuo0xu\",\"MechanicCompleteDate\":\"2022-11-01T04:37:23Z\",\"MechanicCost\":298},\"Activity\":{\"Date1\":\"2022-10-17T04:37:23Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Date2\":\"2022-10-18T04:37:23Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2022-10-23T04:37:23Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2022-11-01T04:37:23Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Scott Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Scott Producer (Producer)",
+						"Date1": "2022-10-17T04:37:23Z",
+						"Date2": "2022-10-18T04:37:23Z",
+						"Date3": "2022-10-23T04:37:23Z",
+						"Date4": "2022-11-01T04:37:23Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Minor damage and safe to drive",
+							"Exterior": "Front,Driver Side",
+							"Interior": "Seats"
+						},
+						"Detail": "Incident alone",
+						"Location": "1063 Northwestern Crossing",
+						"LocationCity": "Berkeley",
+						"LocationState": "CA",
+						"LocationZIP": "94712",
+						"OtherVehicleInsurance": "Travelers",
+						"OtherVehicleMake": "Land Rover",
+						"OtherVehicleModel": "Range Rover",
+						"OtherVehicleOccupant": "Timmi Heffron",
+						"OtherVehicleOccupant2": null,
+						"OtherVehicleOccupant3": null,
+						"OtherVehicleVIN": "2V4RW3DG1BR770012",
+						"Type": "Vehicle incident while parking"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Bogart Becaris",
+						"InsuredSSN": "232-41-6839",
+						"InsuredVIN": "WUATNAFG3BN875686",
+						"InsuredVehicle": "2013 Ford Mustang GT Fastback"
+					},
+					"VehicleRepair": {
+						"Description": "Insured contacted mechanic and completed repair",
+						"MechanicAddress": "675 Main Street Los Angeles, CA 90005",
+						"MechanicCompleteDate": "2022-11-01T04:37:23Z",
+						"MechanicCost": 298,
+						"MechanicName": "Lyons Auto Pro Plus",
+						"MechanicOrderNum": "xuo0xu",
+						"MechanicPhone": "(310) 987-4567",
+						"Status": "Complete"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-76-150-9970",
 			"incidentDate": "2022-10-11T04:37:23Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-76-150-9970",
@@ -194,7 +1201,60 @@
 			"claimAmount": 2764,
 			"claimCreateDate": "2022-08-23T21:10:09Z",
 			"claimStatus": "settled",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Felice Lippett\",\"InsuredSSN\":\"288-72-3739\",\"InsuredVehicle\":\"2016 Volvo V90 Cross Country\",\"InsuredVIN\":\"WBABS33402P198315\"},\"IncidentDetail\":{\"Location\":\"5 American Court\",\"LocationCity\":\"Yonkers\",\"LocationState\":\"NY\",\"LocationZIP\":\"10705\",\"Type\":\"Vehicle incident while parked\",\"Detail\":\"Incident with more than one passenger\",\"OtherVehicleMake\":\"Toyota\",\"OtherVehicleModel\":\"Land Cruiser\",\"OtherVehicleVIN\":\"1GYS3CEF4BR894172\",\"OtherVehicleOccupant\":\"Dulcia Kohen\",\"OtherVehicleOccupant2\":\"Kele Karlowicz\",\"OtherVehicleOccupant3\":\"Andie Mawman\",\"OtherVehicleInsurance\":\"State Farm\",\"Damage\":{\"Condition\":\"Good to drive\",\"Interior\":\"Interior Trim\",\"Exterior\":\"Front,Driver Side\"}},\"VehicleRepair\":{\"Status\":\"Complete\",\"Description\":\"Insured contacted mechanic and completed repair\",\"MechanicName\":\"Hyperion Automotive Center\",\"MechanicPhone\":\"(323) 665-7864\",\"MechanicAddress\":\"2938 Hyperion Ave Los Angeles, CA 90027\",\"MechanicOrderNum\":\"hcl2dy\",\"MechanicCompleteDate\":\"2022-09-03T21:10:09Z\",\"MechanicCost\":2349},\"Activity\":{\"Date1\":\"2022-08-23T21:10:09Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Date2\":\"2022-08-25T21:10:09Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2022-08-30T21:10:09Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2022-09-03T21:10:09Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Scott Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Scott Producer (Producer)",
+						"Date1": "2022-08-23T21:10:09Z",
+						"Date2": "2022-08-25T21:10:09Z",
+						"Date3": "2022-08-30T21:10:09Z",
+						"Date4": "2022-09-03T21:10:09Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Good to drive",
+							"Exterior": "Front,Driver Side",
+							"Interior": "Interior Trim"
+						},
+						"Detail": "Incident with more than one passenger",
+						"Location": "5 American Court",
+						"LocationCity": "Yonkers",
+						"LocationState": "NY",
+						"LocationZIP": "10705",
+						"OtherVehicleInsurance": "State Farm",
+						"OtherVehicleMake": "Toyota",
+						"OtherVehicleModel": "Land Cruiser",
+						"OtherVehicleOccupant": "Dulcia Kohen",
+						"OtherVehicleOccupant2": "Kele Karlowicz",
+						"OtherVehicleOccupant3": "Andie Mawman",
+						"OtherVehicleVIN": "1GYS3CEF4BR894172",
+						"Type": "Vehicle incident while parked"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Felice Lippett",
+						"InsuredSSN": "288-72-3739",
+						"InsuredVIN": "WBABS33402P198315",
+						"InsuredVehicle": "2016 Volvo V90 Cross Country"
+					},
+					"VehicleRepair": {
+						"Description": "Insured contacted mechanic and completed repair",
+						"MechanicAddress": "2938 Hyperion Ave Los Angeles, CA 90027",
+						"MechanicCompleteDate": "2022-09-03T21:10:09Z",
+						"MechanicCost": 2349,
+						"MechanicName": "Hyperion Automotive Center",
+						"MechanicOrderNum": "hcl2dy",
+						"MechanicPhone": "(323) 665-7864",
+						"Status": "Complete"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-14-445-2863",
 			"incidentDate": "2022-08-16T21:10:09Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-14-445-2863",
@@ -204,7 +1264,60 @@
 			"claimAmount": 4691,
 			"claimCreateDate": "2023-05-19T05:22:50Z",
 			"claimStatus": "claimSubmitted",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Hall Allicock\",\"InsuredSSN\":\"848-46-6572\",\"InsuredVehicle\":\"2014 Toyota Tundra SR6\",\"InsuredVIN\":\"1N6AA0ED8FN715095\"},\"IncidentDetail\":{\"Location\":\"32213 Northridge Lane\",\"LocationCity\":\"Oakland\",\"LocationState\":\"CA\",\"LocationZIP\":\"94622\",\"Type\":\"Vehicle incident while parking\",\"Detail\":\"Incident with more than one passenger\",\"OtherVehicleMake\":\"Plymouth\",\"OtherVehicleModel\":\"Grand Voyager\",\"OtherVehicleVIN\":\"WAUSH78EX7A359643\",\"OtherVehicleOccupant\":\"Ida Pratley\",\"OtherVehicleOccupant2\":\"Eldredge Gantley\",\"OtherVehicleOccupant3\":\"Cherri Laven\",\"OtherVehicleInsurance\":\"USAA\",\"Damage\":{\"Condition\":\"Good to drive\",\"Interior\":\"Upholstery\",\"Exterior\":\"Front,Driver Side\"}},\"VehicleRepair\":{\"Status\":\"Not Started\",\"Description\":\"Insured has not started repair\",\"MechanicName\":\"Lyons Auto Pro Plus\",\"MechanicPhone\":\"(310) 987-4567\",\"MechanicAddress\":\"675 Main Street Los Angeles, CA 90005\",\"MechanicOrderNum\":\"prf6go\",\"MechanicCompleteDate\":\"2023-06-07T05:22:50Z\",\"MechanicCost\":3987},\"Activity\":{\"Date1\":\"2023-05-19T05:22:50Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Marie Producer (Producer)\",\"Date2\":\"2023-05-22T05:22:50Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2023-05-26T05:22:50Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2023-06-07T05:22:50Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Marie Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Marie Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Marie Producer (Producer)",
+						"Date1": "2023-05-19T05:22:50Z",
+						"Date2": "2023-05-22T05:22:50Z",
+						"Date3": "2023-05-26T05:22:50Z",
+						"Date4": "2023-06-07T05:22:50Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Good to drive",
+							"Exterior": "Front,Driver Side",
+							"Interior": "Upholstery"
+						},
+						"Detail": "Incident with more than one passenger",
+						"Location": "32213 Northridge Lane",
+						"LocationCity": "Oakland",
+						"LocationState": "CA",
+						"LocationZIP": "94622",
+						"OtherVehicleInsurance": "USAA",
+						"OtherVehicleMake": "Plymouth",
+						"OtherVehicleModel": "Grand Voyager",
+						"OtherVehicleOccupant": "Ida Pratley",
+						"OtherVehicleOccupant2": "Eldredge Gantley",
+						"OtherVehicleOccupant3": "Cherri Laven",
+						"OtherVehicleVIN": "WAUSH78EX7A359643",
+						"Type": "Vehicle incident while parking"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Hall Allicock",
+						"InsuredSSN": "848-46-6572",
+						"InsuredVIN": "1N6AA0ED8FN715095",
+						"InsuredVehicle": "2014 Toyota Tundra SR6"
+					},
+					"VehicleRepair": {
+						"Description": "Insured has not started repair",
+						"MechanicAddress": "675 Main Street Los Angeles, CA 90005",
+						"MechanicCompleteDate": "2023-06-07T05:22:50Z",
+						"MechanicCost": 3987,
+						"MechanicName": "Lyons Auto Pro Plus",
+						"MechanicOrderNum": "prf6go",
+						"MechanicPhone": "(310) 987-4567",
+						"Status": "Not Started"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-26-210-0080",
 			"incidentDate": "2023-05-15T05:22:50Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-26-210-0080",
@@ -214,7 +1327,60 @@
 			"claimAmount": 346,
 			"claimCreateDate": "2022-05-22T02:08:08Z",
 			"claimStatus": "settled",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Jada Lewin\",\"InsuredSSN\":\"493-70-4420\",\"InsuredVehicle\":\"2013 Volvo XC90 Inscription\",\"InsuredVIN\":\"2G4WC552671522280\"},\"IncidentDetail\":{\"Location\":\"4162 Hintze Park\",\"LocationCity\":\"Las Vegas\",\"LocationState\":\"NV\",\"LocationZIP\":\"89155\",\"Type\":\"Vehicle incident while parking\",\"Detail\":\"Incident with single passenger\",\"OtherVehicleMake\":\"Toyota\",\"OtherVehicleModel\":\"T100\",\"OtherVehicleVIN\":\"3D7LP2ET4BG431985\",\"OtherVehicleOccupant\":\"Anallise Kivlehan\",\"OtherVehicleOccupant2\":\"Maritsa Waldie\",\"OtherVehicleOccupant3\":null,\"OtherVehicleInsurance\":\"Liberty Mutual\",\"Damage\":{\"Condition\":\"Major damage and not safe to drive\",\"Interior\":\"Wheels & Dashboard\",\"Exterior\":\"Passenger Side\"}},\"VehicleRepair\":{\"Status\":\"Complete\",\"Description\":\"Insured contacted mechanic and completed repair\",\"MechanicName\":\"Hyperion Automotive Center\",\"MechanicPhone\":\"(323) 665-7864\",\"MechanicAddress\":\"2938 Hyperion Ave Los Angeles, CA 90027\",\"MechanicOrderNum\":\"kkd2ot\",\"MechanicCompleteDate\":\"2022-06-03T02:08:08Z\",\"MechanicCost\":294},\"Activity\":{\"Date1\":\"2022-05-22T02:08:08Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Date2\":\"2022-05-23T02:08:08Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2022-05-28T02:08:08Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2022-06-03T02:08:08Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Scott Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Scott Producer (Producer)",
+						"Date1": "2022-05-22T02:08:08Z",
+						"Date2": "2022-05-23T02:08:08Z",
+						"Date3": "2022-05-28T02:08:08Z",
+						"Date4": "2022-06-03T02:08:08Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Major damage and not safe to drive",
+							"Exterior": "Passenger Side",
+							"Interior": "Wheels & Dashboard"
+						},
+						"Detail": "Incident with single passenger",
+						"Location": "4162 Hintze Park",
+						"LocationCity": "Las Vegas",
+						"LocationState": "NV",
+						"LocationZIP": "89155",
+						"OtherVehicleInsurance": "Liberty Mutual",
+						"OtherVehicleMake": "Toyota",
+						"OtherVehicleModel": "T100",
+						"OtherVehicleOccupant": "Anallise Kivlehan",
+						"OtherVehicleOccupant2": "Maritsa Waldie",
+						"OtherVehicleOccupant3": null,
+						"OtherVehicleVIN": "3D7LP2ET4BG431985",
+						"Type": "Vehicle incident while parking"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Jada Lewin",
+						"InsuredSSN": "493-70-4420",
+						"InsuredVIN": "2G4WC552671522280",
+						"InsuredVehicle": "2013 Volvo XC90 Inscription"
+					},
+					"VehicleRepair": {
+						"Description": "Insured contacted mechanic and completed repair",
+						"MechanicAddress": "2938 Hyperion Ave Los Angeles, CA 90027",
+						"MechanicCompleteDate": "2022-06-03T02:08:08Z",
+						"MechanicCost": 294,
+						"MechanicName": "Hyperion Automotive Center",
+						"MechanicOrderNum": "kkd2ot",
+						"MechanicPhone": "(323) 665-7864",
+						"Status": "Complete"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-35-340-7974",
 			"incidentDate": "2022-05-21T02:08:08Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-35-340-7974",
@@ -224,7 +1390,60 @@
 			"claimAmount": 3076,
 			"claimCreateDate": "2022-07-25T21:30:18Z",
 			"claimStatus": "settled",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Bonnie Nevett\",\"InsuredSSN\":\"560-23-9000\",\"InsuredVehicle\":\"2016 Toyota Camry Hybrid XLE\",\"InsuredVIN\":\"1FTMF1EW9AK655926\"},\"IncidentDetail\":{\"Location\":\"2 Bunting Trail\",\"LocationCity\":\"New York City\",\"LocationState\":\"NY\",\"LocationZIP\":\"10034\",\"Type\":\"Vehicle incident while parked\",\"Detail\":\"Incident alone\",\"OtherVehicleMake\":\"Acura\",\"OtherVehicleModel\":\"MDX\",\"OtherVehicleVIN\":\"3FADP4AJ4FM229580\",\"OtherVehicleOccupant\":\"Norri Essberger\",\"OtherVehicleOccupant2\":null,\"OtherVehicleOccupant3\":null,\"OtherVehicleInsurance\":\"Mercury\",\"Damage\":{\"Condition\":\"Major damage and not safe to drive\",\"Interior\":\"Interior Trim\",\"Exterior\":\"Passenger Side\"}},\"VehicleRepair\":{\"Status\":\"Complete\",\"Description\":\"Insured contacted mechanic and completed repair\",\"MechanicName\":\"Lyons Auto Pro Plus\",\"MechanicPhone\":\"(310) 987-4567\",\"MechanicAddress\":\"675 Main Street Los Angeles, CA 90005\",\"MechanicOrderNum\":\"zfi3rf\",\"MechanicCompleteDate\":\"2022-08-13T21:30:18Z\",\"MechanicCost\":2615},\"Activity\":{\"Date1\":\"2022-07-25T21:30:18Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Marie Producer (Producer)\",\"Date2\":\"2022-07-28T21:30:18Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2022-08-01T21:30:18Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2022-08-13T21:30:18Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Marie Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Marie Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Marie Producer (Producer)",
+						"Date1": "2022-07-25T21:30:18Z",
+						"Date2": "2022-07-28T21:30:18Z",
+						"Date3": "2022-08-01T21:30:18Z",
+						"Date4": "2022-08-13T21:30:18Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Major damage and not safe to drive",
+							"Exterior": "Passenger Side",
+							"Interior": "Interior Trim"
+						},
+						"Detail": "Incident alone",
+						"Location": "2 Bunting Trail",
+						"LocationCity": "New York City",
+						"LocationState": "NY",
+						"LocationZIP": "10034",
+						"OtherVehicleInsurance": "Mercury",
+						"OtherVehicleMake": "Acura",
+						"OtherVehicleModel": "MDX",
+						"OtherVehicleOccupant": "Norri Essberger",
+						"OtherVehicleOccupant2": null,
+						"OtherVehicleOccupant3": null,
+						"OtherVehicleVIN": "3FADP4AJ4FM229580",
+						"Type": "Vehicle incident while parked"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Bonnie Nevett",
+						"InsuredSSN": "560-23-9000",
+						"InsuredVIN": "1FTMF1EW9AK655926",
+						"InsuredVehicle": "2016 Toyota Camry Hybrid XLE"
+					},
+					"VehicleRepair": {
+						"Description": "Insured contacted mechanic and completed repair",
+						"MechanicAddress": "675 Main Street Los Angeles, CA 90005",
+						"MechanicCompleteDate": "2022-08-13T21:30:18Z",
+						"MechanicCost": 2615,
+						"MechanicName": "Lyons Auto Pro Plus",
+						"MechanicOrderNum": "zfi3rf",
+						"MechanicPhone": "(310) 987-4567",
+						"Status": "Complete"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-75-970-0972",
 			"incidentDate": "2022-07-19T21:30:18Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-75-970-0972",
@@ -234,7 +1453,60 @@
 			"claimAmount": 4289,
 			"claimCreateDate": "2023-07-09T08:16:59Z",
 			"claimStatus": "declined",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Rycca Fortescue\",\"InsuredSSN\":\"632-41-1779\",\"InsuredVehicle\":\"2019 Ford Focus S Sedan\",\"InsuredVIN\":\"19UUA8F57EA351037\"},\"IncidentDetail\":{\"Location\":\"71819 Bultman Crossing\",\"LocationCity\":\"Chico\",\"LocationState\":\"CA\",\"LocationZIP\":\"95973\",\"Type\":\"Vehicle incident while filling fuel\",\"Detail\":\"Incident with single passenger\",\"OtherVehicleMake\":\"Chrysler\",\"OtherVehicleModel\":\"Sebring\",\"OtherVehicleVIN\":\"JH4DC53844S631544\",\"OtherVehicleOccupant\":\"Madelon Speers\",\"OtherVehicleOccupant2\":\"Allis Scally\",\"OtherVehicleOccupant3\":null,\"OtherVehicleInsurance\":\"Mercury\",\"Damage\":{\"Condition\":\"Good to drive\",\"Interior\":\"Interior Trim\",\"Exterior\":\"Front,Driver Side\"}},\"VehicleRepair\":{\"Status\":\"Not Started\",\"Description\":\"Insured has not started repair\",\"MechanicName\":\"Lyons Auto Pro Plus\",\"MechanicPhone\":\"(310) 987-4567\",\"MechanicAddress\":\"675 Main Street Los Angeles, CA 90005\",\"MechanicOrderNum\":\"ahk2jv\",\"MechanicCompleteDate\":\"2023-07-21T08:16:59Z\",\"MechanicCost\":3646},\"Activity\":{\"Date1\":\"2023-07-09T08:16:59Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Marie Producer (Producer)\",\"Date2\":\"2023-07-12T08:16:59Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2023-07-13T08:16:59Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2023-07-21T08:16:59Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Marie Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Marie Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Marie Producer (Producer)",
+						"Date1": "2023-07-09T08:16:59Z",
+						"Date2": "2023-07-12T08:16:59Z",
+						"Date3": "2023-07-13T08:16:59Z",
+						"Date4": "2023-07-21T08:16:59Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Good to drive",
+							"Exterior": "Front,Driver Side",
+							"Interior": "Interior Trim"
+						},
+						"Detail": "Incident with single passenger",
+						"Location": "71819 Bultman Crossing",
+						"LocationCity": "Chico",
+						"LocationState": "CA",
+						"LocationZIP": "95973",
+						"OtherVehicleInsurance": "Mercury",
+						"OtherVehicleMake": "Chrysler",
+						"OtherVehicleModel": "Sebring",
+						"OtherVehicleOccupant": "Madelon Speers",
+						"OtherVehicleOccupant2": "Allis Scally",
+						"OtherVehicleOccupant3": null,
+						"OtherVehicleVIN": "JH4DC53844S631544",
+						"Type": "Vehicle incident while filling fuel"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Rycca Fortescue",
+						"InsuredSSN": "632-41-1779",
+						"InsuredVIN": "19UUA8F57EA351037",
+						"InsuredVehicle": "2019 Ford Focus S Sedan"
+					},
+					"VehicleRepair": {
+						"Description": "Insured has not started repair",
+						"MechanicAddress": "675 Main Street Los Angeles, CA 90005",
+						"MechanicCompleteDate": "2023-07-21T08:16:59Z",
+						"MechanicCost": 3646,
+						"MechanicName": "Lyons Auto Pro Plus",
+						"MechanicOrderNum": "ahk2jv",
+						"MechanicPhone": "(310) 987-4567",
+						"Status": "Not Started"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-45-524-6958",
 			"incidentDate": "2023-07-08T08:16:59Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-45-524-6958",
@@ -244,7 +1516,60 @@
 			"claimAmount": 4814,
 			"claimCreateDate": "2023-10-01T15:34:02Z",
 			"claimStatus": "inEstimation",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Mitzi Barnwall\",\"InsuredSSN\":\"622-71-1197\",\"InsuredVehicle\":\"2015 Ford Edge SE\",\"InsuredVIN\":\"1G6AE5S3XF0277891\"},\"IncidentDetail\":{\"Location\":\"0 Comanche Way\",\"LocationCity\":\"Sacramento\",\"LocationState\":\"CA\",\"LocationZIP\":\"95818\",\"Type\":\"Vehicle incident while parked\",\"Detail\":\"Incident with single passenger\",\"OtherVehicleMake\":\"Lotus\",\"OtherVehicleModel\":\"Esprit\",\"OtherVehicleVIN\":\"1G6DC8EY7B0965465\",\"OtherVehicleOccupant\":\"Hart Braunstein\",\"OtherVehicleOccupant2\":\"Paulette Hosier\",\"OtherVehicleOccupant3\":null,\"OtherVehicleInsurance\":\"Liberty Mutual\",\"Damage\":{\"Condition\":\"Major damage and not safe to drive\",\"Interior\":\"Seats\",\"Exterior\":\"Driver Side, Driver Rear\"}},\"VehicleRepair\":{\"Status\":\"Not Started\",\"Description\":\"Insured has not started repair\",\"MechanicName\":\"Lyons Auto Pro Plus\",\"MechanicPhone\":\"(310) 987-4567\",\"MechanicAddress\":\"675 Main Street Los Angeles, CA 90005\",\"MechanicOrderNum\":\"uyp1fq\",\"MechanicCompleteDate\":\"2023-10-14T15:34:02Z\",\"MechanicCost\":4092},\"Activity\":{\"Date1\":\"2023-10-01T15:34:02Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Marie Producer (Producer)\",\"Date2\":\"2023-10-03T15:34:02Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2023-10-07T15:34:02Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2023-10-14T15:34:02Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Marie Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Marie Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Marie Producer (Producer)",
+						"Date1": "2023-10-01T15:34:02Z",
+						"Date2": "2023-10-03T15:34:02Z",
+						"Date3": "2023-10-07T15:34:02Z",
+						"Date4": "2023-10-14T15:34:02Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Major damage and not safe to drive",
+							"Exterior": "Driver Side, Driver Rear",
+							"Interior": "Seats"
+						},
+						"Detail": "Incident with single passenger",
+						"Location": "0 Comanche Way",
+						"LocationCity": "Sacramento",
+						"LocationState": "CA",
+						"LocationZIP": "95818",
+						"OtherVehicleInsurance": "Liberty Mutual",
+						"OtherVehicleMake": "Lotus",
+						"OtherVehicleModel": "Esprit",
+						"OtherVehicleOccupant": "Hart Braunstein",
+						"OtherVehicleOccupant2": "Paulette Hosier",
+						"OtherVehicleOccupant3": null,
+						"OtherVehicleVIN": "1G6DC8EY7B0965465",
+						"Type": "Vehicle incident while parked"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Mitzi Barnwall",
+						"InsuredSSN": "622-71-1197",
+						"InsuredVIN": "1G6AE5S3XF0277891",
+						"InsuredVehicle": "2015 Ford Edge SE"
+					},
+					"VehicleRepair": {
+						"Description": "Insured has not started repair",
+						"MechanicAddress": "675 Main Street Los Angeles, CA 90005",
+						"MechanicCompleteDate": "2023-10-14T15:34:02Z",
+						"MechanicCost": 4092,
+						"MechanicName": "Lyons Auto Pro Plus",
+						"MechanicOrderNum": "uyp1fq",
+						"MechanicPhone": "(310) 987-4567",
+						"Status": "Not Started"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-01-048-4146",
 			"incidentDate": "2023-09-24T15:34:02Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-01-048-4146",
@@ -254,7 +1579,60 @@
 			"claimAmount": 3390,
 			"claimCreateDate": "2023-03-11T08:05:50Z",
 			"claimStatus": "inInvestigation",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Osgood Dummer\",\"InsuredSSN\":\"672-77-7564\",\"InsuredVehicle\":\"2014 Volvo V90 Cross Country\",\"InsuredVIN\":\"NM0KS6BN4AT244729\"},\"IncidentDetail\":{\"Location\":\"033 Farmco Road\",\"LocationCity\":\"Garden Grove\",\"LocationState\":\"CA\",\"LocationZIP\":\"92645\",\"Type\":\"Vehicle incident while driving\",\"Detail\":\"Incident alone\",\"OtherVehicleMake\":\"Bentley\",\"OtherVehicleModel\":\"Continental Flying Spur\",\"OtherVehicleVIN\":\"3D73M3CL9BG782036\",\"OtherVehicleOccupant\":\"Lindsey Havock\",\"OtherVehicleOccupant2\":null,\"OtherVehicleOccupant3\":null,\"OtherVehicleInsurance\":\"Liberty Mutual\",\"Damage\":{\"Condition\":\"Major damage and not safe to drive\",\"Interior\":\"Interior Trim\",\"Exterior\":\"Passenger Rear,Rear\"}},\"VehicleRepair\":{\"Status\":\"Not Started\",\"Description\":\"Insured has not started repair\",\"MechanicName\":\"Lyons Auto Pro Plus\",\"MechanicPhone\":\"(310) 987-4567\",\"MechanicAddress\":\"675 Main Street Los Angeles, CA 90005\",\"MechanicOrderNum\":\"gpz0ei\",\"MechanicCompleteDate\":\"2023-03-22T08:05:50Z\",\"MechanicCost\":2882},\"Activity\":{\"Date1\":\"2023-03-11T08:05:50Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Marie Producer (Producer)\",\"Date2\":\"2023-03-13T08:05:50Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2023-03-20T08:05:50Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2023-03-22T08:05:50Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Marie Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Marie Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Marie Producer (Producer)",
+						"Date1": "2023-03-11T08:05:50Z",
+						"Date2": "2023-03-13T08:05:50Z",
+						"Date3": "2023-03-20T08:05:50Z",
+						"Date4": "2023-03-22T08:05:50Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Major damage and not safe to drive",
+							"Exterior": "Passenger Rear,Rear",
+							"Interior": "Interior Trim"
+						},
+						"Detail": "Incident alone",
+						"Location": "033 Farmco Road",
+						"LocationCity": "Garden Grove",
+						"LocationState": "CA",
+						"LocationZIP": "92645",
+						"OtherVehicleInsurance": "Liberty Mutual",
+						"OtherVehicleMake": "Bentley",
+						"OtherVehicleModel": "Continental Flying Spur",
+						"OtherVehicleOccupant": "Lindsey Havock",
+						"OtherVehicleOccupant2": null,
+						"OtherVehicleOccupant3": null,
+						"OtherVehicleVIN": "3D73M3CL9BG782036",
+						"Type": "Vehicle incident while driving"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Osgood Dummer",
+						"InsuredSSN": "672-77-7564",
+						"InsuredVIN": "NM0KS6BN4AT244729",
+						"InsuredVehicle": "2014 Volvo V90 Cross Country"
+					},
+					"VehicleRepair": {
+						"Description": "Insured has not started repair",
+						"MechanicAddress": "675 Main Street Los Angeles, CA 90005",
+						"MechanicCompleteDate": "2023-03-22T08:05:50Z",
+						"MechanicCost": 2882,
+						"MechanicName": "Lyons Auto Pro Plus",
+						"MechanicOrderNum": "gpz0ei",
+						"MechanicPhone": "(310) 987-4567",
+						"Status": "Not Started"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-54-652-1207",
 			"incidentDate": "2023-03-05T08:05:50Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-54-652-1207",
@@ -264,7 +1642,60 @@
 			"claimAmount": 543,
 			"claimCreateDate": "2023-05-13T02:40:07Z",
 			"claimStatus": "inInvestigation",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Pembroke Hutable\",\"InsuredSSN\":\"384-82-4952\",\"InsuredVehicle\":\"2013 Ford Edge SE\",\"InsuredVIN\":\"1GT01ZCGXCF035530\"},\"IncidentDetail\":{\"Location\":\"9125 La Follette Park\",\"LocationCity\":\"Santa Barbara\",\"LocationState\":\"CA\",\"LocationZIP\":\"93106\",\"Type\":\"Vehicle incident while parked\",\"Detail\":\"Incident alone\",\"OtherVehicleMake\":\"Chevrolet\",\"OtherVehicleModel\":\"Impala\",\"OtherVehicleVIN\":\"WAUEF98E47A127313\",\"OtherVehicleOccupant\":\"Lind Clines\",\"OtherVehicleOccupant2\":null,\"OtherVehicleOccupant3\":null,\"OtherVehicleInsurance\":\"Travelers\",\"Damage\":{\"Condition\":\"Minor damage and safe to drive\",\"Interior\":\"Seats\",\"Exterior\":\"Front,Driver Side\"}},\"VehicleRepair\":{\"Status\":\"Not Started\",\"Description\":\"Insured has not started repair\",\"MechanicName\":\"Diamond Auto Repair\",\"MechanicPhone\":\"(310) 458-3492\",\"MechanicAddress\":\"1432 Wilshire Blvd. Los Angeles, CA 90010\",\"MechanicOrderNum\":\"lwk0we\",\"MechanicCompleteDate\":\"2023-05-31T02:40:07Z\",\"MechanicCost\":462},\"Activity\":{\"Date1\":\"2023-05-13T02:40:07Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Date2\":\"2023-05-14T02:40:07Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2023-05-19T02:40:07Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2023-05-31T02:40:07Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Scott Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Scott Producer (Producer)",
+						"Date1": "2023-05-13T02:40:07Z",
+						"Date2": "2023-05-14T02:40:07Z",
+						"Date3": "2023-05-19T02:40:07Z",
+						"Date4": "2023-05-31T02:40:07Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Minor damage and safe to drive",
+							"Exterior": "Front,Driver Side",
+							"Interior": "Seats"
+						},
+						"Detail": "Incident alone",
+						"Location": "9125 La Follette Park",
+						"LocationCity": "Santa Barbara",
+						"LocationState": "CA",
+						"LocationZIP": "93106",
+						"OtherVehicleInsurance": "Travelers",
+						"OtherVehicleMake": "Chevrolet",
+						"OtherVehicleModel": "Impala",
+						"OtherVehicleOccupant": "Lind Clines",
+						"OtherVehicleOccupant2": null,
+						"OtherVehicleOccupant3": null,
+						"OtherVehicleVIN": "WAUEF98E47A127313",
+						"Type": "Vehicle incident while parked"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Pembroke Hutable",
+						"InsuredSSN": "384-82-4952",
+						"InsuredVIN": "1GT01ZCGXCF035530",
+						"InsuredVehicle": "2013 Ford Edge SE"
+					},
+					"VehicleRepair": {
+						"Description": "Insured has not started repair",
+						"MechanicAddress": "1432 Wilshire Blvd. Los Angeles, CA 90010",
+						"MechanicCompleteDate": "2023-05-31T02:40:07Z",
+						"MechanicCost": 462,
+						"MechanicName": "Diamond Auto Repair",
+						"MechanicOrderNum": "lwk0we",
+						"MechanicPhone": "(310) 458-3492",
+						"Status": "Not Started"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-81-289-9483",
 			"incidentDate": "2023-05-08T02:40:07Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-81-289-9483",
@@ -274,7 +1705,60 @@
 			"claimAmount": 1894,
 			"claimCreateDate": "2023-02-15T02:07:57Z",
 			"claimStatus": "inEstimation",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Pembroke Hutable\",\"InsuredSSN\":\"562-71-2536\",\"InsuredVehicle\":\"2013 Toyota Camry Hybrid XLE\",\"InsuredVIN\":\"WBAKC6C57AC483249\"},\"IncidentDetail\":{\"Location\":\"9 American Drive\",\"LocationCity\":\"New York City\",\"LocationState\":\"NY\",\"LocationZIP\":\"10060\",\"Type\":\"Vehicle incident while parked\",\"Detail\":\"Incident with single passenger\",\"OtherVehicleMake\":\"Hyundai\",\"OtherVehicleModel\":\"Sonata\",\"OtherVehicleVIN\":\"WBABN53401J001938\",\"OtherVehicleOccupant\":\"Gavin Kempston\",\"OtherVehicleOccupant2\":\"Ileane Odell\",\"OtherVehicleOccupant3\":null,\"OtherVehicleInsurance\":\"Mercury\",\"Damage\":{\"Condition\":\"Major damage and not safe to drive\",\"Interior\":\"Interior Trim\",\"Exterior\":\"Passenger Rear,Rear\"}},\"VehicleRepair\":{\"Status\":\"Not Started\",\"Description\":\"Insured has not started repair\",\"MechanicName\":\"Hyperion Automotive Center\",\"MechanicPhone\":\"(323) 665-7864\",\"MechanicAddress\":\"2938 Hyperion Ave Los Angeles, CA 90027\",\"MechanicOrderNum\":\"gzs3hi\",\"MechanicCompleteDate\":\"2023-03-04T02:07:57Z\",\"MechanicCost\":1610},\"Activity\":{\"Date1\":\"2023-02-15T02:07:57Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Date2\":\"2023-02-17T02:07:57Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2023-02-25T02:07:57Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2023-03-04T02:07:57Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Scott Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Scott Producer (Producer)",
+						"Date1": "2023-02-15T02:07:57Z",
+						"Date2": "2023-02-17T02:07:57Z",
+						"Date3": "2023-02-25T02:07:57Z",
+						"Date4": "2023-03-04T02:07:57Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Major damage and not safe to drive",
+							"Exterior": "Passenger Rear,Rear",
+							"Interior": "Interior Trim"
+						},
+						"Detail": "Incident with single passenger",
+						"Location": "9 American Drive",
+						"LocationCity": "New York City",
+						"LocationState": "NY",
+						"LocationZIP": "10060",
+						"OtherVehicleInsurance": "Mercury",
+						"OtherVehicleMake": "Hyundai",
+						"OtherVehicleModel": "Sonata",
+						"OtherVehicleOccupant": "Gavin Kempston",
+						"OtherVehicleOccupant2": "Ileane Odell",
+						"OtherVehicleOccupant3": null,
+						"OtherVehicleVIN": "WBABN53401J001938",
+						"Type": "Vehicle incident while parked"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Pembroke Hutable",
+						"InsuredSSN": "562-71-2536",
+						"InsuredVIN": "WBAKC6C57AC483249",
+						"InsuredVehicle": "2013 Toyota Camry Hybrid XLE"
+					},
+					"VehicleRepair": {
+						"Description": "Insured has not started repair",
+						"MechanicAddress": "2938 Hyperion Ave Los Angeles, CA 90027",
+						"MechanicCompleteDate": "2023-03-04T02:07:57Z",
+						"MechanicCost": 1610,
+						"MechanicName": "Hyperion Automotive Center",
+						"MechanicOrderNum": "gzs3hi",
+						"MechanicPhone": "(323) 665-7864",
+						"Status": "Not Started"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-07-512-8878",
 			"incidentDate": "2023-02-13T02:07:57Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-07-512-8878",
@@ -284,7 +1768,60 @@
 			"claimAmount": 1373,
 			"claimCreateDate": "2023-08-11T00:50:37Z",
 			"claimStatus": "settled",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Mitzi Barnwall\",\"InsuredSSN\":\"285-05-0222\",\"InsuredVehicle\":\"2017 Toyota Corolla LE\",\"InsuredVIN\":\"JA32X2HU5DU661463\"},\"IncidentDetail\":{\"Location\":\"23920 Scofield Park\",\"LocationCity\":\"Santa Barbara\",\"LocationState\":\"CA\",\"LocationZIP\":\"93150\",\"Type\":\"Vehicle incident while driving\",\"Detail\":\"Incident with more than one passenger\",\"OtherVehicleMake\":\"Chrysler\",\"OtherVehicleModel\":\"Voyager\",\"OtherVehicleVIN\":\"JHMZF1C66ES731487\",\"OtherVehicleOccupant\":\"Adrienne Buey\",\"OtherVehicleOccupant2\":\"Jon Eicke\",\"OtherVehicleOccupant3\":\"Gennie Conkling\",\"OtherVehicleInsurance\":\"Liberty Mutual\",\"Damage\":{\"Condition\":\"Minor damage and safe to drive\",\"Interior\":\"Seats\",\"Exterior\":\"Driver Side, Driver Rear\"}},\"VehicleRepair\":{\"Status\":\"Complete\",\"Description\":\"Insured contacted mechanic and completed repair\",\"MechanicName\":\"Lyons Auto Pro Plus\",\"MechanicPhone\":\"(310) 987-4567\",\"MechanicAddress\":\"675 Main Street Los Angeles, CA 90005\",\"MechanicOrderNum\":\"qtz0jw\",\"MechanicCompleteDate\":\"2023-08-26T00:50:37Z\",\"MechanicCost\":1167},\"Activity\":{\"Date1\":\"2023-08-11T00:50:37Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Date2\":\"2023-08-13T00:50:37Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2023-08-16T00:50:37Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2023-08-26T00:50:37Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Scott Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Scott Producer (Producer)",
+						"Date1": "2023-08-11T00:50:37Z",
+						"Date2": "2023-08-13T00:50:37Z",
+						"Date3": "2023-08-16T00:50:37Z",
+						"Date4": "2023-08-26T00:50:37Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Minor damage and safe to drive",
+							"Exterior": "Driver Side, Driver Rear",
+							"Interior": "Seats"
+						},
+						"Detail": "Incident with more than one passenger",
+						"Location": "23920 Scofield Park",
+						"LocationCity": "Santa Barbara",
+						"LocationState": "CA",
+						"LocationZIP": "93150",
+						"OtherVehicleInsurance": "Liberty Mutual",
+						"OtherVehicleMake": "Chrysler",
+						"OtherVehicleModel": "Voyager",
+						"OtherVehicleOccupant": "Adrienne Buey",
+						"OtherVehicleOccupant2": "Jon Eicke",
+						"OtherVehicleOccupant3": "Gennie Conkling",
+						"OtherVehicleVIN": "JHMZF1C66ES731487",
+						"Type": "Vehicle incident while driving"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Mitzi Barnwall",
+						"InsuredSSN": "285-05-0222",
+						"InsuredVIN": "JA32X2HU5DU661463",
+						"InsuredVehicle": "2017 Toyota Corolla LE"
+					},
+					"VehicleRepair": {
+						"Description": "Insured contacted mechanic and completed repair",
+						"MechanicAddress": "675 Main Street Los Angeles, CA 90005",
+						"MechanicCompleteDate": "2023-08-26T00:50:37Z",
+						"MechanicCost": 1167,
+						"MechanicName": "Lyons Auto Pro Plus",
+						"MechanicOrderNum": "qtz0jw",
+						"MechanicPhone": "(310) 987-4567",
+						"Status": "Complete"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-63-953-3761",
 			"incidentDate": "2023-08-09T00:50:37Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-63-953-3761",
@@ -294,7 +1831,60 @@
 			"claimAmount": 1496,
 			"claimCreateDate": "2022-07-29T20:11:37Z",
 			"claimStatus": "claimSubmitted",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Jessa Capron\",\"InsuredSSN\":\"641-25-3356\",\"InsuredVehicle\":\"2013 Toyota Corolla LE\",\"InsuredVIN\":\"KNAGM4AD1C5509496\"},\"IncidentDetail\":{\"Location\":\"41 Forest Run Pass\",\"LocationCity\":\"San Jose\",\"LocationState\":\"CA\",\"LocationZIP\":\"95155\",\"Type\":\"Vehicle incident while filling fuel\",\"Detail\":\"Incident with single passenger\",\"OtherVehicleMake\":\"Plymouth\",\"OtherVehicleModel\":\"Neon\",\"OtherVehicleVIN\":\"3VW4T7AT6EM509733\",\"OtherVehicleOccupant\":\"Tybi Fussie\",\"OtherVehicleOccupant2\":\"Bernhard Whatman\",\"OtherVehicleOccupant3\":null,\"OtherVehicleInsurance\":\"Liberty Mutual\",\"Damage\":{\"Condition\":\"Minor damage and safe to drive\",\"Interior\":\"Seats\",\"Exterior\":\"Driver Side, Driver Rear\"}},\"VehicleRepair\":{\"Status\":\"Not Started\",\"Description\":\"Insured has not started repair\",\"MechanicName\":\"Lyons Auto Pro Plus\",\"MechanicPhone\":\"(310) 987-4567\",\"MechanicAddress\":\"675 Main Street Los Angeles, CA 90005\",\"MechanicOrderNum\":\"elz7zd\",\"MechanicCompleteDate\":\"2022-08-12T20:11:37Z\",\"MechanicCost\":1272},\"Activity\":{\"Date1\":\"2022-07-29T20:11:37Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Date2\":\"2022-07-30T20:11:37Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2022-08-05T20:11:37Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2022-08-12T20:11:37Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Scott Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Scott Producer (Producer)",
+						"Date1": "2022-07-29T20:11:37Z",
+						"Date2": "2022-07-30T20:11:37Z",
+						"Date3": "2022-08-05T20:11:37Z",
+						"Date4": "2022-08-12T20:11:37Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Minor damage and safe to drive",
+							"Exterior": "Driver Side, Driver Rear",
+							"Interior": "Seats"
+						},
+						"Detail": "Incident with single passenger",
+						"Location": "41 Forest Run Pass",
+						"LocationCity": "San Jose",
+						"LocationState": "CA",
+						"LocationZIP": "95155",
+						"OtherVehicleInsurance": "Liberty Mutual",
+						"OtherVehicleMake": "Plymouth",
+						"OtherVehicleModel": "Neon",
+						"OtherVehicleOccupant": "Tybi Fussie",
+						"OtherVehicleOccupant2": "Bernhard Whatman",
+						"OtherVehicleOccupant3": null,
+						"OtherVehicleVIN": "3VW4T7AT6EM509733",
+						"Type": "Vehicle incident while filling fuel"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Jessa Capron",
+						"InsuredSSN": "641-25-3356",
+						"InsuredVIN": "KNAGM4AD1C5509496",
+						"InsuredVehicle": "2013 Toyota Corolla LE"
+					},
+					"VehicleRepair": {
+						"Description": "Insured has not started repair",
+						"MechanicAddress": "675 Main Street Los Angeles, CA 90005",
+						"MechanicCompleteDate": "2022-08-12T20:11:37Z",
+						"MechanicCost": 1272,
+						"MechanicName": "Lyons Auto Pro Plus",
+						"MechanicOrderNum": "elz7zd",
+						"MechanicPhone": "(310) 987-4567",
+						"Status": "Not Started"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-47-952-6071",
 			"incidentDate": "2022-07-23T20:11:37Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-47-952-6071",
@@ -304,7 +1894,60 @@
 			"claimAmount": 826,
 			"claimCreateDate": "2022-05-13T02:24:11Z",
 			"claimStatus": "claimSubmitted",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Yehudi Mancell\",\"InsuredSSN\":\"219-84-9968\",\"InsuredVehicle\":\"2014 Ford Mustang GT Fastback\",\"InsuredVIN\":\"5XXGM4A73DG205757\"},\"IncidentDetail\":{\"Location\":\"22965 Knutson Lane\",\"LocationCity\":\"Palmdale\",\"LocationState\":\"CA\",\"LocationZIP\":\"93591\",\"Type\":\"Vehicle incident while parking\",\"Detail\":\"Incident with single passenger\",\"OtherVehicleMake\":\"Mitsubishi\",\"OtherVehicleModel\":\"Sigma\",\"OtherVehicleVIN\":\"WBA3C1C59DK979526\",\"OtherVehicleOccupant\":\"Allard Blackadder\",\"OtherVehicleOccupant2\":\"Zara Rummings\",\"OtherVehicleOccupant3\":null,\"OtherVehicleInsurance\":\"Geico\",\"Damage\":{\"Condition\":\"Minor damage and safe to drive\",\"Interior\":\"Wheels & Dashboard\",\"Exterior\":\"Front,Driver Side\"}},\"VehicleRepair\":{\"Status\":\"Not Started\",\"Description\":\"Insured has not started repair\",\"MechanicName\":\"Hyperion Automotive Center\",\"MechanicPhone\":\"(323) 665-7864\",\"MechanicAddress\":\"2938 Hyperion Ave Los Angeles, CA 90027\",\"MechanicOrderNum\":\"ivy7td\",\"MechanicCompleteDate\":\"2022-06-02T02:24:11Z\",\"MechanicCost\":702},\"Activity\":{\"Date1\":\"2022-05-13T02:24:11Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Date2\":\"2022-05-16T02:24:11Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2022-05-17T02:24:11Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2022-06-02T02:24:11Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Scott Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Scott Producer (Producer)",
+						"Date1": "2022-05-13T02:24:11Z",
+						"Date2": "2022-05-16T02:24:11Z",
+						"Date3": "2022-05-17T02:24:11Z",
+						"Date4": "2022-06-02T02:24:11Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Minor damage and safe to drive",
+							"Exterior": "Front,Driver Side",
+							"Interior": "Wheels & Dashboard"
+						},
+						"Detail": "Incident with single passenger",
+						"Location": "22965 Knutson Lane",
+						"LocationCity": "Palmdale",
+						"LocationState": "CA",
+						"LocationZIP": "93591",
+						"OtherVehicleInsurance": "Geico",
+						"OtherVehicleMake": "Mitsubishi",
+						"OtherVehicleModel": "Sigma",
+						"OtherVehicleOccupant": "Allard Blackadder",
+						"OtherVehicleOccupant2": "Zara Rummings",
+						"OtherVehicleOccupant3": null,
+						"OtherVehicleVIN": "WBA3C1C59DK979526",
+						"Type": "Vehicle incident while parking"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Yehudi Mancell",
+						"InsuredSSN": "219-84-9968",
+						"InsuredVIN": "5XXGM4A73DG205757",
+						"InsuredVehicle": "2014 Ford Mustang GT Fastback"
+					},
+					"VehicleRepair": {
+						"Description": "Insured has not started repair",
+						"MechanicAddress": "2938 Hyperion Ave Los Angeles, CA 90027",
+						"MechanicCompleteDate": "2022-06-02T02:24:11Z",
+						"MechanicCost": 702,
+						"MechanicName": "Hyperion Automotive Center",
+						"MechanicOrderNum": "ivy7td",
+						"MechanicPhone": "(323) 665-7864",
+						"Status": "Not Started"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-54-848-2327",
 			"incidentDate": "2022-05-11T02:24:11Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-54-848-2327",
@@ -314,7 +1957,60 @@
 			"claimAmount": 3029,
 			"claimCreateDate": "2022-04-10T18:39:46Z",
 			"claimStatus": "inInvestigation",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Jessa Capron\",\"InsuredSSN\":\"896-60-1628\",\"InsuredVehicle\":\"2013 Ford Edge SE\",\"InsuredVIN\":\"WAUEF48H18K269997\"},\"IncidentDetail\":{\"Location\":\"37 Schiller Court\",\"LocationCity\":\"Sacramento\",\"LocationState\":\"CA\",\"LocationZIP\":\"95865\",\"Type\":\"Vehicle incident while parked\",\"Detail\":\"Incident with more than one passenger\",\"OtherVehicleMake\":\"Kia\",\"OtherVehicleModel\":\"Sephia\",\"OtherVehicleVIN\":\"1C6RD7LP3CS342782\",\"OtherVehicleOccupant\":\"Tailor Edy\",\"OtherVehicleOccupant2\":\"Oswell Dimitresco\",\"OtherVehicleOccupant3\":\"Normy Hadden\",\"OtherVehicleInsurance\":\"Travelers\",\"Damage\":{\"Condition\":\"Minor damage and safe to drive\",\"Interior\":\"Seats\",\"Exterior\":\"Front,Driver Side\"}},\"VehicleRepair\":{\"Status\":\"Not Started\",\"Description\":\"Insured has not started repair\",\"MechanicName\":\"Hyperion Automotive Center\",\"MechanicPhone\":\"(323) 665-7864\",\"MechanicAddress\":\"2938 Hyperion Ave Los Angeles, CA 90027\",\"MechanicOrderNum\":\"fni2bb\",\"MechanicCompleteDate\":\"2022-04-26T18:39:46Z\",\"MechanicCost\":2575},\"Activity\":{\"Date1\":\"2022-04-10T18:39:46Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Date2\":\"2022-04-11T18:39:46Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2022-04-19T18:39:46Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2022-04-26T18:39:46Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Scott Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Scott Producer (Producer)",
+						"Date1": "2022-04-10T18:39:46Z",
+						"Date2": "2022-04-11T18:39:46Z",
+						"Date3": "2022-04-19T18:39:46Z",
+						"Date4": "2022-04-26T18:39:46Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Minor damage and safe to drive",
+							"Exterior": "Front,Driver Side",
+							"Interior": "Seats"
+						},
+						"Detail": "Incident with more than one passenger",
+						"Location": "37 Schiller Court",
+						"LocationCity": "Sacramento",
+						"LocationState": "CA",
+						"LocationZIP": "95865",
+						"OtherVehicleInsurance": "Travelers",
+						"OtherVehicleMake": "Kia",
+						"OtherVehicleModel": "Sephia",
+						"OtherVehicleOccupant": "Tailor Edy",
+						"OtherVehicleOccupant2": "Oswell Dimitresco",
+						"OtherVehicleOccupant3": "Normy Hadden",
+						"OtherVehicleVIN": "1C6RD7LP3CS342782",
+						"Type": "Vehicle incident while parked"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Jessa Capron",
+						"InsuredSSN": "896-60-1628",
+						"InsuredVIN": "WAUEF48H18K269997",
+						"InsuredVehicle": "2013 Ford Edge SE"
+					},
+					"VehicleRepair": {
+						"Description": "Insured has not started repair",
+						"MechanicAddress": "2938 Hyperion Ave Los Angeles, CA 90027",
+						"MechanicCompleteDate": "2022-04-26T18:39:46Z",
+						"MechanicCost": 2575,
+						"MechanicName": "Hyperion Automotive Center",
+						"MechanicOrderNum": "fni2bb",
+						"MechanicPhone": "(323) 665-7864",
+						"Status": "Not Started"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-60-350-1793",
 			"incidentDate": "2022-04-03T18:39:46Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-60-350-1793",
@@ -324,7 +2020,60 @@
 			"claimAmount": 2847,
 			"claimCreateDate": "2022-07-12T06:58:31Z",
 			"claimStatus": "declined",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Osgood Dummer\",\"InsuredSSN\":\"147-74-1657\",\"InsuredVehicle\":\"2014 Volvo XC90 Inscription\",\"InsuredVIN\":\"SCFAD02A08G951219\"},\"IncidentDetail\":{\"Location\":\"7 Logan Plaza\",\"LocationCity\":\"Albany\",\"LocationState\":\"NY\",\"LocationZIP\":\"12237\",\"Type\":\"Vehicle incident while parked\",\"Detail\":\"Incident with more than one passenger\",\"OtherVehicleMake\":\"Audi\",\"OtherVehicleModel\":\"A5\",\"OtherVehicleVIN\":\"WAULV94EX8N138892\",\"OtherVehicleOccupant\":\"Fletcher Meekins\",\"OtherVehicleOccupant2\":\"Helli Bath\",\"OtherVehicleOccupant3\":\"Liva Fursey\",\"OtherVehicleInsurance\":\"Mercury\",\"Damage\":{\"Condition\":\"Good to drive\",\"Interior\":\"Upholstery\",\"Exterior\":\"Passenger Rear,Rear\"}},\"VehicleRepair\":{\"Status\":\"Not Started\",\"Description\":\"Insured has not started repair\",\"MechanicName\":\"Lyons Auto Pro Plus\",\"MechanicPhone\":\"(310) 987-4567\",\"MechanicAddress\":\"675 Main Street Los Angeles, CA 90005\",\"MechanicOrderNum\":\"wmx6vx\",\"MechanicCompleteDate\":\"2022-07-26T06:58:31Z\",\"MechanicCost\":2420},\"Activity\":{\"Date1\":\"2022-07-12T06:58:31Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Date2\":\"2022-07-15T06:58:31Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2022-07-20T06:58:31Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2022-07-26T06:58:31Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Scott Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Scott Producer (Producer)",
+						"Date1": "2022-07-12T06:58:31Z",
+						"Date2": "2022-07-15T06:58:31Z",
+						"Date3": "2022-07-20T06:58:31Z",
+						"Date4": "2022-07-26T06:58:31Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Good to drive",
+							"Exterior": "Passenger Rear,Rear",
+							"Interior": "Upholstery"
+						},
+						"Detail": "Incident with more than one passenger",
+						"Location": "7 Logan Plaza",
+						"LocationCity": "Albany",
+						"LocationState": "NY",
+						"LocationZIP": "12237",
+						"OtherVehicleInsurance": "Mercury",
+						"OtherVehicleMake": "Audi",
+						"OtherVehicleModel": "A5",
+						"OtherVehicleOccupant": "Fletcher Meekins",
+						"OtherVehicleOccupant2": "Helli Bath",
+						"OtherVehicleOccupant3": "Liva Fursey",
+						"OtherVehicleVIN": "WAULV94EX8N138892",
+						"Type": "Vehicle incident while parked"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Osgood Dummer",
+						"InsuredSSN": "147-74-1657",
+						"InsuredVIN": "SCFAD02A08G951219",
+						"InsuredVehicle": "2014 Volvo XC90 Inscription"
+					},
+					"VehicleRepair": {
+						"Description": "Insured has not started repair",
+						"MechanicAddress": "675 Main Street Los Angeles, CA 90005",
+						"MechanicCompleteDate": "2022-07-26T06:58:31Z",
+						"MechanicCost": 2420,
+						"MechanicName": "Lyons Auto Pro Plus",
+						"MechanicOrderNum": "wmx6vx",
+						"MechanicPhone": "(310) 987-4567",
+						"Status": "Not Started"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-27-283-4989",
 			"incidentDate": "2022-07-06T06:58:31Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-27-283-4989",
@@ -334,7 +2083,60 @@
 			"claimAmount": 2667,
 			"claimCreateDate": "2022-08-12T02:34:18Z",
 			"claimStatus": "pendingSettlement",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Jolie Zecchi\",\"InsuredSSN\":\"529-59-4464\",\"InsuredVehicle\":\"2019 Volvo V90 Cross Country\",\"InsuredVIN\":\"1D7RE3BK0BS978259\"},\"IncidentDetail\":{\"Location\":\"2 Steensland Plaza\",\"LocationCity\":\"Bronx\",\"LocationState\":\"NY\",\"LocationZIP\":\"10454\",\"Type\":\"Vehicle incident while parked\",\"Detail\":\"Incident with single passenger\",\"OtherVehicleMake\":\"GMC\",\"OtherVehicleModel\":\"Envoy\",\"OtherVehicleVIN\":\"KMHGH4JF7BU534637\",\"OtherVehicleOccupant\":\"Travers Stanney\",\"OtherVehicleOccupant2\":\"Marjory Miguel\",\"OtherVehicleOccupant3\":null,\"OtherVehicleInsurance\":\"Liberty Mutual\",\"Damage\":{\"Condition\":\"Minor damage and safe to drive\",\"Interior\":\"Interior Trim\",\"Exterior\":\"Driver Side, Driver Rear\"}},\"VehicleRepair\":{\"Status\":\"Not Started\",\"Description\":\"Insured has not started repair\",\"MechanicName\":\"Lyons Auto Pro Plus\",\"MechanicPhone\":\"(310) 987-4567\",\"MechanicAddress\":\"675 Main Street Los Angeles, CA 90005\",\"MechanicOrderNum\":\"smk9ic\",\"MechanicCompleteDate\":\"2022-08-24T02:34:18Z\",\"MechanicCost\":2267},\"Activity\":{\"Date1\":\"2022-08-12T02:34:18Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Marie Producer (Producer)\",\"Date2\":\"2022-08-14T02:34:18Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2022-08-22T02:34:18Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2022-08-24T02:34:18Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Marie Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Marie Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Marie Producer (Producer)",
+						"Date1": "2022-08-12T02:34:18Z",
+						"Date2": "2022-08-14T02:34:18Z",
+						"Date3": "2022-08-22T02:34:18Z",
+						"Date4": "2022-08-24T02:34:18Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Minor damage and safe to drive",
+							"Exterior": "Driver Side, Driver Rear",
+							"Interior": "Interior Trim"
+						},
+						"Detail": "Incident with single passenger",
+						"Location": "2 Steensland Plaza",
+						"LocationCity": "Bronx",
+						"LocationState": "NY",
+						"LocationZIP": "10454",
+						"OtherVehicleInsurance": "Liberty Mutual",
+						"OtherVehicleMake": "GMC",
+						"OtherVehicleModel": "Envoy",
+						"OtherVehicleOccupant": "Travers Stanney",
+						"OtherVehicleOccupant2": "Marjory Miguel",
+						"OtherVehicleOccupant3": null,
+						"OtherVehicleVIN": "KMHGH4JF7BU534637",
+						"Type": "Vehicle incident while parked"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Jolie Zecchi",
+						"InsuredSSN": "529-59-4464",
+						"InsuredVIN": "1D7RE3BK0BS978259",
+						"InsuredVehicle": "2019 Volvo V90 Cross Country"
+					},
+					"VehicleRepair": {
+						"Description": "Insured has not started repair",
+						"MechanicAddress": "675 Main Street Los Angeles, CA 90005",
+						"MechanicCompleteDate": "2022-08-24T02:34:18Z",
+						"MechanicCost": 2267,
+						"MechanicName": "Lyons Auto Pro Plus",
+						"MechanicOrderNum": "smk9ic",
+						"MechanicPhone": "(310) 987-4567",
+						"Status": "Not Started"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-29-447-1413",
 			"incidentDate": "2022-08-09T02:34:18Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-29-447-1413",
@@ -344,7 +2146,60 @@
 			"claimAmount": 302,
 			"claimCreateDate": "2022-10-22T04:27:38Z",
 			"claimStatus": "declined",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Gregor Ferreo\",\"InsuredSSN\":\"595-01-8860\",\"InsuredVehicle\":\"2019 Ford F-150 Super 250 XL\",\"InsuredVIN\":\"3D73Y4CL9BG579142\"},\"IncidentDetail\":{\"Location\":\"512 Mendota Trail\",\"LocationCity\":\"Mountain View\",\"LocationState\":\"CA\",\"LocationZIP\":\"94042\",\"Type\":\"Vehicle incident while parking\",\"Detail\":\"Incident with single passenger\",\"OtherVehicleMake\":\"Ford\",\"OtherVehicleModel\":\"Mustang\",\"OtherVehicleVIN\":\"1C4RDJAG0DC251411\",\"OtherVehicleOccupant\":\"Fitzgerald Earpe\",\"OtherVehicleOccupant2\":\"Robina Dimic\",\"OtherVehicleOccupant3\":null,\"OtherVehicleInsurance\":\"Geico\",\"Damage\":{\"Condition\":\"Good to drive\",\"Interior\":\"Seats\",\"Exterior\":\"Passenger Rear,Rear\"}},\"VehicleRepair\":{\"Status\":\"Not Started\",\"Description\":\"Insured has not started repair\",\"MechanicName\":\"Lyons Auto Pro Plus\",\"MechanicPhone\":\"(310) 987-4567\",\"MechanicAddress\":\"675 Main Street Los Angeles, CA 90005\",\"MechanicOrderNum\":\"uhz0mj\",\"MechanicCompleteDate\":\"2022-11-03T04:27:38Z\",\"MechanicCost\":257},\"Activity\":{\"Date1\":\"2022-10-22T04:27:38Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Date2\":\"2022-10-24T04:27:38Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2022-11-01T04:27:38Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2022-11-03T04:27:38Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Scott Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Scott Producer (Producer)",
+						"Date1": "2022-10-22T04:27:38Z",
+						"Date2": "2022-10-24T04:27:38Z",
+						"Date3": "2022-11-01T04:27:38Z",
+						"Date4": "2022-11-03T04:27:38Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Good to drive",
+							"Exterior": "Passenger Rear,Rear",
+							"Interior": "Seats"
+						},
+						"Detail": "Incident with single passenger",
+						"Location": "512 Mendota Trail",
+						"LocationCity": "Mountain View",
+						"LocationState": "CA",
+						"LocationZIP": "94042",
+						"OtherVehicleInsurance": "Geico",
+						"OtherVehicleMake": "Ford",
+						"OtherVehicleModel": "Mustang",
+						"OtherVehicleOccupant": "Fitzgerald Earpe",
+						"OtherVehicleOccupant2": "Robina Dimic",
+						"OtherVehicleOccupant3": null,
+						"OtherVehicleVIN": "1C4RDJAG0DC251411",
+						"Type": "Vehicle incident while parking"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Gregor Ferreo",
+						"InsuredSSN": "595-01-8860",
+						"InsuredVIN": "3D73Y4CL9BG579142",
+						"InsuredVehicle": "2019 Ford F-150 Super 250 XL"
+					},
+					"VehicleRepair": {
+						"Description": "Insured has not started repair",
+						"MechanicAddress": "675 Main Street Los Angeles, CA 90005",
+						"MechanicCompleteDate": "2022-11-03T04:27:38Z",
+						"MechanicCost": 257,
+						"MechanicName": "Lyons Auto Pro Plus",
+						"MechanicOrderNum": "uhz0mj",
+						"MechanicPhone": "(310) 987-4567",
+						"Status": "Not Started"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-15-542-8250",
 			"incidentDate": "2022-10-20T04:27:38Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-15-542-8250",
@@ -354,7 +2209,60 @@
 			"claimAmount": 4083,
 			"claimCreateDate": "2023-05-15T11:17:54Z",
 			"claimStatus": "settled",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Merrily Phibb\",\"InsuredSSN\":\"378-20-8259\",\"InsuredVehicle\":\"2013 Ford Mustang GT Fastback\",\"InsuredVIN\":\"JH4KB26579C807837\"},\"IncidentDetail\":{\"Location\":\"56 Roxbury Circle\",\"LocationCity\":\"Visalia\",\"LocationState\":\"CA\",\"LocationZIP\":\"93291\",\"Type\":\"Vehicle incident while filling fuel\",\"Detail\":\"Incident alone\",\"OtherVehicleMake\":\"Dodge\",\"OtherVehicleModel\":\"Ram\",\"OtherVehicleVIN\":\"5LMCJ1A91FU496210\",\"OtherVehicleOccupant\":\"Carmelle Castells\",\"OtherVehicleOccupant2\":null,\"OtherVehicleOccupant3\":null,\"OtherVehicleInsurance\":\"Mercury\",\"Damage\":{\"Condition\":\"Good to drive\",\"Interior\":\"Seats\",\"Exterior\":\"Front,Driver Side\"}},\"VehicleRepair\":{\"Status\":\"Complete\",\"Description\":\"Insured contacted mechanic and completed repair\",\"MechanicName\":\"Lyons Auto Pro Plus\",\"MechanicPhone\":\"(310) 987-4567\",\"MechanicAddress\":\"675 Main Street Los Angeles, CA 90005\",\"MechanicOrderNum\":\"dry6ov\",\"MechanicCompleteDate\":\"2023-06-01T11:17:54Z\",\"MechanicCost\":3471},\"Activity\":{\"Date1\":\"2023-05-15T11:17:54Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Date2\":\"2023-05-18T11:17:54Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2023-05-22T11:17:54Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2023-06-01T11:17:54Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Scott Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Scott Producer (Producer)",
+						"Date1": "2023-05-15T11:17:54Z",
+						"Date2": "2023-05-18T11:17:54Z",
+						"Date3": "2023-05-22T11:17:54Z",
+						"Date4": "2023-06-01T11:17:54Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Good to drive",
+							"Exterior": "Front,Driver Side",
+							"Interior": "Seats"
+						},
+						"Detail": "Incident alone",
+						"Location": "56 Roxbury Circle",
+						"LocationCity": "Visalia",
+						"LocationState": "CA",
+						"LocationZIP": "93291",
+						"OtherVehicleInsurance": "Mercury",
+						"OtherVehicleMake": "Dodge",
+						"OtherVehicleModel": "Ram",
+						"OtherVehicleOccupant": "Carmelle Castells",
+						"OtherVehicleOccupant2": null,
+						"OtherVehicleOccupant3": null,
+						"OtherVehicleVIN": "5LMCJ1A91FU496210",
+						"Type": "Vehicle incident while filling fuel"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Merrily Phibb",
+						"InsuredSSN": "378-20-8259",
+						"InsuredVIN": "JH4KB26579C807837",
+						"InsuredVehicle": "2013 Ford Mustang GT Fastback"
+					},
+					"VehicleRepair": {
+						"Description": "Insured contacted mechanic and completed repair",
+						"MechanicAddress": "675 Main Street Los Angeles, CA 90005",
+						"MechanicCompleteDate": "2023-06-01T11:17:54Z",
+						"MechanicCost": 3471,
+						"MechanicName": "Lyons Auto Pro Plus",
+						"MechanicOrderNum": "dry6ov",
+						"MechanicPhone": "(310) 987-4567",
+						"Status": "Complete"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-60-665-7410",
 			"incidentDate": "2023-05-12T11:17:54Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-60-665-7410",
@@ -364,7 +2272,60 @@
 			"claimAmount": 1704,
 			"claimCreateDate": "2023-09-28T12:03:51Z",
 			"claimStatus": "settled",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Cleon Hambribe\",\"InsuredSSN\":\"851-45-5916\",\"InsuredVehicle\":\"2017 Toyota Tundra SR6\",\"InsuredVIN\":\"JH4DC53845S254196\"},\"IncidentDetail\":{\"Location\":\"88837 Dixon Hill\",\"LocationCity\":\"Bronx\",\"LocationState\":\"NY\",\"LocationZIP\":\"10464\",\"Type\":\"Vehicle incident while driving\",\"Detail\":\"Incident with more than one passenger\",\"OtherVehicleMake\":\"Ford\",\"OtherVehicleModel\":\"Tempo\",\"OtherVehicleVIN\":\"1FMJK1F59DE094629\",\"OtherVehicleOccupant\":\"Collie Lamlin\",\"OtherVehicleOccupant2\":\"Krissie Houtby\",\"OtherVehicleOccupant3\":\"Joaquin Joss\",\"OtherVehicleInsurance\":\"Liberty Mutual\",\"Damage\":{\"Condition\":\"Minor damage and safe to drive\",\"Interior\":\"Wheels & Dashboard\",\"Exterior\":\"Front,Driver Side\"}},\"VehicleRepair\":{\"Status\":\"Complete\",\"Description\":\"Insured contacted mechanic and completed repair\",\"MechanicName\":\"Hyperion Automotive Center\",\"MechanicPhone\":\"(323) 665-7864\",\"MechanicAddress\":\"2938 Hyperion Ave Los Angeles, CA 90027\",\"MechanicOrderNum\":\"hxi0kz\",\"MechanicCompleteDate\":\"2023-10-15T12:03:51Z\",\"MechanicCost\":1448},\"Activity\":{\"Date1\":\"2023-09-28T12:03:51Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Date2\":\"2023-09-29T12:03:51Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2023-10-08T12:03:51Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2023-10-15T12:03:51Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Scott Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Scott Producer (Producer)",
+						"Date1": "2023-09-28T12:03:51Z",
+						"Date2": "2023-09-29T12:03:51Z",
+						"Date3": "2023-10-08T12:03:51Z",
+						"Date4": "2023-10-15T12:03:51Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Minor damage and safe to drive",
+							"Exterior": "Front,Driver Side",
+							"Interior": "Wheels & Dashboard"
+						},
+						"Detail": "Incident with more than one passenger",
+						"Location": "88837 Dixon Hill",
+						"LocationCity": "Bronx",
+						"LocationState": "NY",
+						"LocationZIP": "10464",
+						"OtherVehicleInsurance": "Liberty Mutual",
+						"OtherVehicleMake": "Ford",
+						"OtherVehicleModel": "Tempo",
+						"OtherVehicleOccupant": "Collie Lamlin",
+						"OtherVehicleOccupant2": "Krissie Houtby",
+						"OtherVehicleOccupant3": "Joaquin Joss",
+						"OtherVehicleVIN": "1FMJK1F59DE094629",
+						"Type": "Vehicle incident while driving"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Cleon Hambribe",
+						"InsuredSSN": "851-45-5916",
+						"InsuredVIN": "JH4DC53845S254196",
+						"InsuredVehicle": "2017 Toyota Tundra SR6"
+					},
+					"VehicleRepair": {
+						"Description": "Insured contacted mechanic and completed repair",
+						"MechanicAddress": "2938 Hyperion Ave Los Angeles, CA 90027",
+						"MechanicCompleteDate": "2023-10-15T12:03:51Z",
+						"MechanicCost": 1448,
+						"MechanicName": "Hyperion Automotive Center",
+						"MechanicOrderNum": "hxi0kz",
+						"MechanicPhone": "(323) 665-7864",
+						"Status": "Complete"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-41-006-2886",
 			"incidentDate": "2023-09-24T12:03:51Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-41-006-2886",
@@ -374,7 +2335,60 @@
 			"claimAmount": 1969,
 			"claimCreateDate": "2022-04-16T22:29:52Z",
 			"claimStatus": "repair",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Cleon Hambribe\",\"InsuredSSN\":\"829-60-2873\",\"InsuredVehicle\":\"2014 Ford Mustang GT Fastback\",\"InsuredVIN\":\"5FRYD3H99GB359370\"},\"IncidentDetail\":{\"Location\":\"696 Hoard Pass\",\"LocationCity\":\"Ventura\",\"LocationState\":\"CA\",\"LocationZIP\":\"93005\",\"Type\":\"Vehicle incident while parked\",\"Detail\":\"Incident alone\",\"OtherVehicleMake\":\"Buick\",\"OtherVehicleModel\":\"Skylark\",\"OtherVehicleVIN\":\"3GTU1YEJ7DG763018\",\"OtherVehicleOccupant\":\"Jania Dewfall\",\"OtherVehicleOccupant2\":null,\"OtherVehicleOccupant3\":null,\"OtherVehicleInsurance\":\"Travelers\",\"Damage\":{\"Condition\":\"Major damage and not safe to drive\",\"Interior\":\"Wheels & Dashboard\",\"Exterior\":\"Front,Driver Side\"}},\"VehicleRepair\":{\"Status\":\"Pending\",\"Description\":\"Vehicle pending repair\",\"MechanicName\":\"Hyperion Automotive Center\",\"MechanicPhone\":\"(323) 665-7864\",\"MechanicAddress\":\"2938 Hyperion Ave Los Angeles, CA 90027\",\"MechanicOrderNum\":\"pby4dv\",\"MechanicCompleteDate\":\"2022-05-02T22:29:52Z\",\"MechanicCost\":1674},\"Activity\":{\"Date1\":\"2022-04-16T22:29:52Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Date2\":\"2022-04-17T22:29:52Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2022-04-26T22:29:52Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2022-05-02T22:29:52Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Scott Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Scott Producer (Producer)",
+						"Date1": "2022-04-16T22:29:52Z",
+						"Date2": "2022-04-17T22:29:52Z",
+						"Date3": "2022-04-26T22:29:52Z",
+						"Date4": "2022-05-02T22:29:52Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Major damage and not safe to drive",
+							"Exterior": "Front,Driver Side",
+							"Interior": "Wheels & Dashboard"
+						},
+						"Detail": "Incident alone",
+						"Location": "696 Hoard Pass",
+						"LocationCity": "Ventura",
+						"LocationState": "CA",
+						"LocationZIP": "93005",
+						"OtherVehicleInsurance": "Travelers",
+						"OtherVehicleMake": "Buick",
+						"OtherVehicleModel": "Skylark",
+						"OtherVehicleOccupant": "Jania Dewfall",
+						"OtherVehicleOccupant2": null,
+						"OtherVehicleOccupant3": null,
+						"OtherVehicleVIN": "3GTU1YEJ7DG763018",
+						"Type": "Vehicle incident while parked"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Cleon Hambribe",
+						"InsuredSSN": "829-60-2873",
+						"InsuredVIN": "5FRYD3H99GB359370",
+						"InsuredVehicle": "2014 Ford Mustang GT Fastback"
+					},
+					"VehicleRepair": {
+						"Description": "Vehicle pending repair",
+						"MechanicAddress": "2938 Hyperion Ave Los Angeles, CA 90027",
+						"MechanicCompleteDate": "2022-05-02T22:29:52Z",
+						"MechanicCost": 1674,
+						"MechanicName": "Hyperion Automotive Center",
+						"MechanicOrderNum": "pby4dv",
+						"MechanicPhone": "(323) 665-7864",
+						"Status": "Pending"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-06-747-0313",
 			"incidentDate": "2022-04-09T22:29:52Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-06-747-0313",
@@ -384,7 +2398,60 @@
 			"claimAmount": 2099,
 			"claimCreateDate": "2023-04-09T11:08:09Z",
 			"claimStatus": "inEstimation",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Keelby Vaen\",\"InsuredSSN\":\"662-73-5811\",\"InsuredVehicle\":\"2015 Toyota Camry Hybrid XLE\",\"InsuredVIN\":\"WAUGF98K99A921371\"},\"IncidentDetail\":{\"Location\":\"84653 Waubesa Court\",\"LocationCity\":\"Los Angeles\",\"LocationState\":\"CA\",\"LocationZIP\":\"90189\",\"Type\":\"Vehicle incident while filling fuel\",\"Detail\":\"Incident with single passenger\",\"OtherVehicleMake\":\"Chevrolet\",\"OtherVehicleModel\":\"Camaro\",\"OtherVehicleVIN\":\"5N1AT2ML1FC893830\",\"OtherVehicleOccupant\":\"Carlynne Pindell\",\"OtherVehicleOccupant2\":\"Biddy McNicol\",\"OtherVehicleOccupant3\":null,\"OtherVehicleInsurance\":\"Mercury\",\"Damage\":{\"Condition\":\"Major damage and not safe to drive\",\"Interior\":\"Upholstery\",\"Exterior\":\"Passenger Rear,Rear\"}},\"VehicleRepair\":{\"Status\":\"Not Started\",\"Description\":\"Insured has not started repair\",\"MechanicName\":\"Lyons Auto Pro Plus\",\"MechanicPhone\":\"(310) 987-4567\",\"MechanicAddress\":\"675 Main Street Los Angeles, CA 90005\",\"MechanicOrderNum\":\"uls0mj\",\"MechanicCompleteDate\":\"2023-04-20T11:08:09Z\",\"MechanicCost\":1784},\"Activity\":{\"Date1\":\"2023-04-09T11:08:09Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Marie Producer (Producer)\",\"Date2\":\"2023-04-10T11:08:09Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2023-04-17T11:08:09Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2023-04-20T11:08:09Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Marie Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Marie Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Marie Producer (Producer)",
+						"Date1": "2023-04-09T11:08:09Z",
+						"Date2": "2023-04-10T11:08:09Z",
+						"Date3": "2023-04-17T11:08:09Z",
+						"Date4": "2023-04-20T11:08:09Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Major damage and not safe to drive",
+							"Exterior": "Passenger Rear,Rear",
+							"Interior": "Upholstery"
+						},
+						"Detail": "Incident with single passenger",
+						"Location": "84653 Waubesa Court",
+						"LocationCity": "Los Angeles",
+						"LocationState": "CA",
+						"LocationZIP": "90189",
+						"OtherVehicleInsurance": "Mercury",
+						"OtherVehicleMake": "Chevrolet",
+						"OtherVehicleModel": "Camaro",
+						"OtherVehicleOccupant": "Carlynne Pindell",
+						"OtherVehicleOccupant2": "Biddy McNicol",
+						"OtherVehicleOccupant3": null,
+						"OtherVehicleVIN": "5N1AT2ML1FC893830",
+						"Type": "Vehicle incident while filling fuel"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Keelby Vaen",
+						"InsuredSSN": "662-73-5811",
+						"InsuredVIN": "WAUGF98K99A921371",
+						"InsuredVehicle": "2015 Toyota Camry Hybrid XLE"
+					},
+					"VehicleRepair": {
+						"Description": "Insured has not started repair",
+						"MechanicAddress": "675 Main Street Los Angeles, CA 90005",
+						"MechanicCompleteDate": "2023-04-20T11:08:09Z",
+						"MechanicCost": 1784,
+						"MechanicName": "Lyons Auto Pro Plus",
+						"MechanicOrderNum": "uls0mj",
+						"MechanicPhone": "(310) 987-4567",
+						"Status": "Not Started"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-76-477-2427",
 			"incidentDate": "2023-04-08T11:08:09Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-76-477-2427",
@@ -394,7 +2461,60 @@
 			"claimAmount": 1798,
 			"claimCreateDate": "2022-07-02T21:03:02Z",
 			"claimStatus": "settled",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Heidi Bulmer\",\"InsuredSSN\":\"311-64-7727\",\"InsuredVehicle\":\"2017 Volvo V90 Cross Country\",\"InsuredVIN\":\"SALFR2BN8BH844191\"},\"IncidentDetail\":{\"Location\":\"7822 Dakota Way\",\"LocationCity\":\"Syracuse\",\"LocationState\":\"NY\",\"LocationZIP\":\"13210\",\"Type\":\"Vehicle incident while filling fuel\",\"Detail\":\"Incident alone\",\"OtherVehicleMake\":\"Mercedes-Benz\",\"OtherVehicleModel\":\"SL-Class\",\"OtherVehicleVIN\":\"1G4PP5SKXC4138272\",\"OtherVehicleOccupant\":\"Debee McKleod\",\"OtherVehicleOccupant2\":null,\"OtherVehicleOccupant3\":null,\"OtherVehicleInsurance\":\"Geico\",\"Damage\":{\"Condition\":\"Good to drive\",\"Interior\":\"Interior Trim\",\"Exterior\":\"Driver Side, Driver Rear\"}},\"VehicleRepair\":{\"Status\":\"Complete\",\"Description\":\"Insured contacted mechanic and completed repair\",\"MechanicName\":\"Diamond Auto Repair\",\"MechanicPhone\":\"(310) 458-3492\",\"MechanicAddress\":\"1432 Wilshire Blvd. Los Angeles, CA 90010\",\"MechanicOrderNum\":\"enx9jb\",\"MechanicCompleteDate\":\"2022-07-15T21:03:02Z\",\"MechanicCost\":1528},\"Activity\":{\"Date1\":\"2022-07-02T21:03:02Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Date2\":\"2022-07-04T21:03:02Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2022-07-10T21:03:02Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2022-07-15T21:03:02Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Scott Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Scott Producer (Producer)",
+						"Date1": "2022-07-02T21:03:02Z",
+						"Date2": "2022-07-04T21:03:02Z",
+						"Date3": "2022-07-10T21:03:02Z",
+						"Date4": "2022-07-15T21:03:02Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Good to drive",
+							"Exterior": "Driver Side, Driver Rear",
+							"Interior": "Interior Trim"
+						},
+						"Detail": "Incident alone",
+						"Location": "7822 Dakota Way",
+						"LocationCity": "Syracuse",
+						"LocationState": "NY",
+						"LocationZIP": "13210",
+						"OtherVehicleInsurance": "Geico",
+						"OtherVehicleMake": "Mercedes-Benz",
+						"OtherVehicleModel": "SL-Class",
+						"OtherVehicleOccupant": "Debee McKleod",
+						"OtherVehicleOccupant2": null,
+						"OtherVehicleOccupant3": null,
+						"OtherVehicleVIN": "1G4PP5SKXC4138272",
+						"Type": "Vehicle incident while filling fuel"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Heidi Bulmer",
+						"InsuredSSN": "311-64-7727",
+						"InsuredVIN": "SALFR2BN8BH844191",
+						"InsuredVehicle": "2017 Volvo V90 Cross Country"
+					},
+					"VehicleRepair": {
+						"Description": "Insured contacted mechanic and completed repair",
+						"MechanicAddress": "1432 Wilshire Blvd. Los Angeles, CA 90010",
+						"MechanicCompleteDate": "2022-07-15T21:03:02Z",
+						"MechanicCost": 1528,
+						"MechanicName": "Diamond Auto Repair",
+						"MechanicOrderNum": "enx9jb",
+						"MechanicPhone": "(310) 458-3492",
+						"Status": "Complete"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-26-196-7958",
 			"incidentDate": "2022-06-26T21:03:02Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-26-196-7958",
@@ -404,7 +2524,60 @@
 			"claimAmount": 4381,
 			"claimCreateDate": "2022-03-22T06:40:02Z",
 			"claimStatus": "settled",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Merrily Phibb\",\"InsuredSSN\":\"852-92-8208\",\"InsuredVehicle\":\"2018 Ford F-150 Super 250 XL\",\"InsuredVIN\":\"5N1BA0NE8FN969739\"},\"IncidentDetail\":{\"Location\":\"29 Green Ridge Trail\",\"LocationCity\":\"Huntington Beach\",\"LocationState\":\"CA\",\"LocationZIP\":\"92648\",\"Type\":\"Vehicle incident while parking\",\"Detail\":\"Incident with more than one passenger\",\"OtherVehicleMake\":\"Audi\",\"OtherVehicleModel\":\"4000s\",\"OtherVehicleVIN\":\"3FA6P0D91DR405603\",\"OtherVehicleOccupant\":\"Casandra Dayce\",\"OtherVehicleOccupant2\":\"Bailey D'Antuoni\",\"OtherVehicleOccupant3\":\"Jameson McLellan\",\"OtherVehicleInsurance\":\"Geico\",\"Damage\":{\"Condition\":\"Minor damage and safe to drive\",\"Interior\":\"Wheels & Dashboard\",\"Exterior\":\"Passenger Side\"}},\"VehicleRepair\":{\"Status\":\"Complete\",\"Description\":\"Insured contacted mechanic and completed repair\",\"MechanicName\":\"Lyons Auto Pro Plus\",\"MechanicPhone\":\"(310) 987-4567\",\"MechanicAddress\":\"675 Main Street Los Angeles, CA 90005\",\"MechanicOrderNum\":\"tfa3iy\",\"MechanicCompleteDate\":\"2022-04-10T06:40:02Z\",\"MechanicCost\":3724},\"Activity\":{\"Date1\":\"2022-03-22T06:40:02Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Marie Producer (Producer)\",\"Date2\":\"2022-03-23T06:40:02Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2022-03-29T06:40:02Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2022-04-10T06:40:02Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Marie Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Marie Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Marie Producer (Producer)",
+						"Date1": "2022-03-22T06:40:02Z",
+						"Date2": "2022-03-23T06:40:02Z",
+						"Date3": "2022-03-29T06:40:02Z",
+						"Date4": "2022-04-10T06:40:02Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Minor damage and safe to drive",
+							"Exterior": "Passenger Side",
+							"Interior": "Wheels & Dashboard"
+						},
+						"Detail": "Incident with more than one passenger",
+						"Location": "29 Green Ridge Trail",
+						"LocationCity": "Huntington Beach",
+						"LocationState": "CA",
+						"LocationZIP": "92648",
+						"OtherVehicleInsurance": "Geico",
+						"OtherVehicleMake": "Audi",
+						"OtherVehicleModel": "4000s",
+						"OtherVehicleOccupant": "Casandra Dayce",
+						"OtherVehicleOccupant2": "Bailey D'Antuoni",
+						"OtherVehicleOccupant3": "Jameson McLellan",
+						"OtherVehicleVIN": "3FA6P0D91DR405603",
+						"Type": "Vehicle incident while parking"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Merrily Phibb",
+						"InsuredSSN": "852-92-8208",
+						"InsuredVIN": "5N1BA0NE8FN969739",
+						"InsuredVehicle": "2018 Ford F-150 Super 250 XL"
+					},
+					"VehicleRepair": {
+						"Description": "Insured contacted mechanic and completed repair",
+						"MechanicAddress": "675 Main Street Los Angeles, CA 90005",
+						"MechanicCompleteDate": "2022-04-10T06:40:02Z",
+						"MechanicCost": 3724,
+						"MechanicName": "Lyons Auto Pro Plus",
+						"MechanicOrderNum": "tfa3iy",
+						"MechanicPhone": "(310) 987-4567",
+						"Status": "Complete"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-36-827-1445",
 			"incidentDate": "2022-03-15T06:40:02Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-36-827-1445",
@@ -414,7 +2587,60 @@
 			"claimAmount": 2419,
 			"claimCreateDate": "2022-05-31T17:51:18Z",
 			"claimStatus": "repair",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Monah Woolens\",\"InsuredSSN\":\"701-97-2250\",\"InsuredVehicle\":\"2016 Ford F-150 Super 250 XL\",\"InsuredVIN\":\"KNALN4D73E5769046\"},\"IncidentDetail\":{\"Location\":\"85178 Ridgeway Court\",\"LocationCity\":\"Bakersfield\",\"LocationState\":\"CA\",\"LocationZIP\":\"93381\",\"Type\":\"Vehicle incident while parking\",\"Detail\":\"Incident with single passenger\",\"OtherVehicleMake\":\"Toyota\",\"OtherVehicleModel\":\"4Runner\",\"OtherVehicleVIN\":\"3C3CFFDR2DT542690\",\"OtherVehicleOccupant\":\"Jewelle Durgan\",\"OtherVehicleOccupant2\":\"Kenton Gummery\",\"OtherVehicleOccupant3\":null,\"OtherVehicleInsurance\":\"Mercury\",\"Damage\":{\"Condition\":\"Good to drive\",\"Interior\":\"Seats\",\"Exterior\":\"Front,Driver Side\"}},\"VehicleRepair\":{\"Status\":\"Pending\",\"Description\":\"Vehicle pending repair\",\"MechanicName\":\"Hyperion Automotive Center\",\"MechanicPhone\":\"(323) 665-7864\",\"MechanicAddress\":\"2938 Hyperion Ave Los Angeles, CA 90027\",\"MechanicOrderNum\":\"bjs0sa\",\"MechanicCompleteDate\":\"2022-06-13T17:51:18Z\",\"MechanicCost\":2056},\"Activity\":{\"Date1\":\"2022-05-31T17:51:18Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Date2\":\"2022-06-03T17:51:18Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2022-06-08T17:51:18Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2022-06-13T17:51:18Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Scott Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Scott Producer (Producer)",
+						"Date1": "2022-05-31T17:51:18Z",
+						"Date2": "2022-06-03T17:51:18Z",
+						"Date3": "2022-06-08T17:51:18Z",
+						"Date4": "2022-06-13T17:51:18Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Good to drive",
+							"Exterior": "Front,Driver Side",
+							"Interior": "Seats"
+						},
+						"Detail": "Incident with single passenger",
+						"Location": "85178 Ridgeway Court",
+						"LocationCity": "Bakersfield",
+						"LocationState": "CA",
+						"LocationZIP": "93381",
+						"OtherVehicleInsurance": "Mercury",
+						"OtherVehicleMake": "Toyota",
+						"OtherVehicleModel": "4Runner",
+						"OtherVehicleOccupant": "Jewelle Durgan",
+						"OtherVehicleOccupant2": "Kenton Gummery",
+						"OtherVehicleOccupant3": null,
+						"OtherVehicleVIN": "3C3CFFDR2DT542690",
+						"Type": "Vehicle incident while parking"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Monah Woolens",
+						"InsuredSSN": "701-97-2250",
+						"InsuredVIN": "KNALN4D73E5769046",
+						"InsuredVehicle": "2016 Ford F-150 Super 250 XL"
+					},
+					"VehicleRepair": {
+						"Description": "Vehicle pending repair",
+						"MechanicAddress": "2938 Hyperion Ave Los Angeles, CA 90027",
+						"MechanicCompleteDate": "2022-06-13T17:51:18Z",
+						"MechanicCost": 2056,
+						"MechanicName": "Hyperion Automotive Center",
+						"MechanicOrderNum": "bjs0sa",
+						"MechanicPhone": "(323) 665-7864",
+						"Status": "Pending"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-27-857-7605",
 			"incidentDate": "2022-05-30T17:51:18Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-27-857-7605",
@@ -424,7 +2650,60 @@
 			"claimAmount": 3804,
 			"claimCreateDate": "2022-04-03T13:09:39Z",
 			"claimStatus": "settled",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Stevana Casiero\",\"InsuredSSN\":\"203-37-0880\",\"InsuredVehicle\":\"2019 Ford F-150 Super 250 XL\",\"InsuredVIN\":\"19VDE2E55EE400100\"},\"IncidentDetail\":{\"Location\":\"059 Bobwhite Crossing\",\"LocationCity\":\"Los Angeles\",\"LocationState\":\"CA\",\"LocationZIP\":\"90030\",\"Type\":\"Vehicle incident while parking\",\"Detail\":\"Incident with single passenger\",\"OtherVehicleMake\":\"Ford\",\"OtherVehicleModel\":\"Thunderbird\",\"OtherVehicleVIN\":\"5UXFG4C54AL122735\",\"OtherVehicleOccupant\":\"Pauline Duddle\",\"OtherVehicleOccupant2\":\"Ashlie Seivwright\",\"OtherVehicleOccupant3\":null,\"OtherVehicleInsurance\":\"Liberty Mutual\",\"Damage\":{\"Condition\":\"Good to drive\",\"Interior\":\"Interior Trim\",\"Exterior\":\"Front,Driver Side\"}},\"VehicleRepair\":{\"Status\":\"Complete\",\"Description\":\"Insured contacted mechanic and completed repair\",\"MechanicName\":\"Hyperion Automotive Center\",\"MechanicPhone\":\"(323) 665-7864\",\"MechanicAddress\":\"2938 Hyperion Ave Los Angeles, CA 90027\",\"MechanicOrderNum\":\"gjc7xi\",\"MechanicCompleteDate\":\"2022-04-15T13:09:39Z\",\"MechanicCost\":3233},\"Activity\":{\"Date1\":\"2022-04-03T13:09:39Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Marie Producer (Producer)\",\"Date2\":\"2022-04-06T13:09:39Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2022-04-07T13:09:39Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2022-04-15T13:09:39Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Marie Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Marie Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Marie Producer (Producer)",
+						"Date1": "2022-04-03T13:09:39Z",
+						"Date2": "2022-04-06T13:09:39Z",
+						"Date3": "2022-04-07T13:09:39Z",
+						"Date4": "2022-04-15T13:09:39Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Good to drive",
+							"Exterior": "Front,Driver Side",
+							"Interior": "Interior Trim"
+						},
+						"Detail": "Incident with single passenger",
+						"Location": "059 Bobwhite Crossing",
+						"LocationCity": "Los Angeles",
+						"LocationState": "CA",
+						"LocationZIP": "90030",
+						"OtherVehicleInsurance": "Liberty Mutual",
+						"OtherVehicleMake": "Ford",
+						"OtherVehicleModel": "Thunderbird",
+						"OtherVehicleOccupant": "Pauline Duddle",
+						"OtherVehicleOccupant2": "Ashlie Seivwright",
+						"OtherVehicleOccupant3": null,
+						"OtherVehicleVIN": "5UXFG4C54AL122735",
+						"Type": "Vehicle incident while parking"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Stevana Casiero",
+						"InsuredSSN": "203-37-0880",
+						"InsuredVIN": "19VDE2E55EE400100",
+						"InsuredVehicle": "2019 Ford F-150 Super 250 XL"
+					},
+					"VehicleRepair": {
+						"Description": "Insured contacted mechanic and completed repair",
+						"MechanicAddress": "2938 Hyperion Ave Los Angeles, CA 90027",
+						"MechanicCompleteDate": "2022-04-15T13:09:39Z",
+						"MechanicCost": 3233,
+						"MechanicName": "Hyperion Automotive Center",
+						"MechanicOrderNum": "gjc7xi",
+						"MechanicPhone": "(323) 665-7864",
+						"Status": "Complete"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-50-665-3617",
 			"incidentDate": "2022-04-01T13:09:39Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-50-665-3617",
@@ -434,7 +2713,60 @@
 			"claimAmount": 292,
 			"claimCreateDate": "2022-03-21T08:43:57Z",
 			"claimStatus": "approved",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Pembroke Hutable\",\"InsuredSSN\":\"439-41-0874\",\"InsuredVehicle\":\"2013 Volvo S90 R-Design\",\"InsuredVIN\":\"1G6DG577490263282\"},\"IncidentDetail\":{\"Location\":\"5 Gale Way\",\"LocationCity\":\"Long Beach\",\"LocationState\":\"CA\",\"LocationZIP\":\"90831\",\"Type\":\"Vehicle incident while parked\",\"Detail\":\"Incident with single passenger\",\"OtherVehicleMake\":\"Honda\",\"OtherVehicleModel\":\"Prelude\",\"OtherVehicleVIN\":\"WBAYA8C53ED637063\",\"OtherVehicleOccupant\":\"Martha Levington\",\"OtherVehicleOccupant2\":\"Harmonie Botham\",\"OtherVehicleOccupant3\":null,\"OtherVehicleInsurance\":\"Geico\",\"Damage\":{\"Condition\":\"Minor damage and safe to drive\",\"Interior\":\"Seats\",\"Exterior\":\"Driver Side, Driver Rear\"}},\"VehicleRepair\":{\"Status\":\"Pending\",\"Description\":\"Vehicle pending repair\",\"MechanicName\":\"Lyons Auto Pro Plus\",\"MechanicPhone\":\"(310) 987-4567\",\"MechanicAddress\":\"675 Main Street Los Angeles, CA 90005\",\"MechanicOrderNum\":\"sjp5el\",\"MechanicCompleteDate\":\"2022-04-08T08:43:57Z\",\"MechanicCost\":248},\"Activity\":{\"Date1\":\"2022-03-21T08:43:57Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Date2\":\"2022-03-22T08:43:57Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2022-03-31T08:43:57Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2022-04-08T08:43:57Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Scott Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Scott Producer (Producer)",
+						"Date1": "2022-03-21T08:43:57Z",
+						"Date2": "2022-03-22T08:43:57Z",
+						"Date3": "2022-03-31T08:43:57Z",
+						"Date4": "2022-04-08T08:43:57Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Minor damage and safe to drive",
+							"Exterior": "Driver Side, Driver Rear",
+							"Interior": "Seats"
+						},
+						"Detail": "Incident with single passenger",
+						"Location": "5 Gale Way",
+						"LocationCity": "Long Beach",
+						"LocationState": "CA",
+						"LocationZIP": "90831",
+						"OtherVehicleInsurance": "Geico",
+						"OtherVehicleMake": "Honda",
+						"OtherVehicleModel": "Prelude",
+						"OtherVehicleOccupant": "Martha Levington",
+						"OtherVehicleOccupant2": "Harmonie Botham",
+						"OtherVehicleOccupant3": null,
+						"OtherVehicleVIN": "WBAYA8C53ED637063",
+						"Type": "Vehicle incident while parked"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Pembroke Hutable",
+						"InsuredSSN": "439-41-0874",
+						"InsuredVIN": "1G6DG577490263282",
+						"InsuredVehicle": "2013 Volvo S90 R-Design"
+					},
+					"VehicleRepair": {
+						"Description": "Vehicle pending repair",
+						"MechanicAddress": "675 Main Street Los Angeles, CA 90005",
+						"MechanicCompleteDate": "2022-04-08T08:43:57Z",
+						"MechanicCost": 248,
+						"MechanicName": "Lyons Auto Pro Plus",
+						"MechanicOrderNum": "sjp5el",
+						"MechanicPhone": "(310) 987-4567",
+						"Status": "Pending"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-02-464-7849",
 			"incidentDate": "2022-03-16T08:43:57Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-02-464-7849",
@@ -444,7 +2776,60 @@
 			"claimAmount": 4047,
 			"claimCreateDate": "2022-04-23T09:07:57Z",
 			"claimStatus": "inEstimation",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Yehudi Mancell\",\"InsuredSSN\":\"684-69-6805\",\"InsuredVehicle\":\"2015 Volvo S90 R-Design\",\"InsuredVIN\":\"SALVP1BG4FH854154\"},\"IncidentDetail\":{\"Location\":\"9 Jana Park\",\"LocationCity\":\"Bronx\",\"LocationState\":\"NY\",\"LocationZIP\":\"10469\",\"Type\":\"Vehicle incident while driving\",\"Detail\":\"Incident with more than one passenger\",\"OtherVehicleMake\":\"Kia\",\"OtherVehicleModel\":\"Rio\",\"OtherVehicleVIN\":\"YV1672MS2B2507044\",\"OtherVehicleOccupant\":\"Austin Vercruysse\",\"OtherVehicleOccupant2\":\"Gayler Maplethorp\",\"OtherVehicleOccupant3\":\"Roldan Lisamore\",\"OtherVehicleInsurance\":\"Liberty Mutual\",\"Damage\":{\"Condition\":\"Minor damage and safe to drive\",\"Interior\":\"Seats\",\"Exterior\":\"Passenger Side\"}},\"VehicleRepair\":{\"Status\":\"Not Started\",\"Description\":\"Insured has not started repair\",\"MechanicName\":\"Hyperion Automotive Center\",\"MechanicPhone\":\"(323) 665-7864\",\"MechanicAddress\":\"2938 Hyperion Ave Los Angeles, CA 90027\",\"MechanicOrderNum\":\"qus6zv\",\"MechanicCompleteDate\":\"2022-05-07T09:07:57Z\",\"MechanicCost\":3440},\"Activity\":{\"Date1\":\"2022-04-23T09:07:57Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Date2\":\"2022-04-26T09:07:57Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2022-05-02T09:07:57Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2022-05-07T09:07:57Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Scott Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Scott Producer (Producer)",
+						"Date1": "2022-04-23T09:07:57Z",
+						"Date2": "2022-04-26T09:07:57Z",
+						"Date3": "2022-05-02T09:07:57Z",
+						"Date4": "2022-05-07T09:07:57Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Minor damage and safe to drive",
+							"Exterior": "Passenger Side",
+							"Interior": "Seats"
+						},
+						"Detail": "Incident with more than one passenger",
+						"Location": "9 Jana Park",
+						"LocationCity": "Bronx",
+						"LocationState": "NY",
+						"LocationZIP": "10469",
+						"OtherVehicleInsurance": "Liberty Mutual",
+						"OtherVehicleMake": "Kia",
+						"OtherVehicleModel": "Rio",
+						"OtherVehicleOccupant": "Austin Vercruysse",
+						"OtherVehicleOccupant2": "Gayler Maplethorp",
+						"OtherVehicleOccupant3": "Roldan Lisamore",
+						"OtherVehicleVIN": "YV1672MS2B2507044",
+						"Type": "Vehicle incident while driving"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Yehudi Mancell",
+						"InsuredSSN": "684-69-6805",
+						"InsuredVIN": "SALVP1BG4FH854154",
+						"InsuredVehicle": "2015 Volvo S90 R-Design"
+					},
+					"VehicleRepair": {
+						"Description": "Insured has not started repair",
+						"MechanicAddress": "2938 Hyperion Ave Los Angeles, CA 90027",
+						"MechanicCompleteDate": "2022-05-07T09:07:57Z",
+						"MechanicCost": 3440,
+						"MechanicName": "Hyperion Automotive Center",
+						"MechanicOrderNum": "qus6zv",
+						"MechanicPhone": "(323) 665-7864",
+						"Status": "Not Started"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-61-121-5224",
 			"incidentDate": "2022-04-21T09:07:57Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-61-121-5224",
@@ -454,7 +2839,60 @@
 			"claimAmount": 2320,
 			"claimCreateDate": "2022-11-04T07:53:17Z",
 			"claimStatus": "repair",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Bonnie Nevett\",\"InsuredSSN\":\"375-40-8785\",\"InsuredVehicle\":\"2015 Volvo V90 Cross Country\",\"InsuredVIN\":\"19XFB2F57CE915314\"},\"IncidentDetail\":{\"Location\":\"6750 Kingsford Point\",\"LocationCity\":\"Whittier\",\"LocationState\":\"CA\",\"LocationZIP\":\"90605\",\"Type\":\"Vehicle incident while driving\",\"Detail\":\"Incident alone\",\"OtherVehicleMake\":\"Dodge\",\"OtherVehicleModel\":\"Nitro\",\"OtherVehicleVIN\":\"1ZVBP8AM6B5275475\",\"OtherVehicleOccupant\":\"Georgy Addicote\",\"OtherVehicleOccupant2\":null,\"OtherVehicleOccupant3\":null,\"OtherVehicleInsurance\":\"USAA\",\"Damage\":{\"Condition\":\"Major damage and not safe to drive\",\"Interior\":\"Seats\",\"Exterior\":\"Passenger Rear,Rear\"}},\"VehicleRepair\":{\"Status\":\"Pending\",\"Description\":\"Vehicle pending repair\",\"MechanicName\":\"Diamond Auto Repair\",\"MechanicPhone\":\"(310) 458-3492\",\"MechanicAddress\":\"1432 Wilshire Blvd. Los Angeles, CA 90010\",\"MechanicOrderNum\":\"dgq8dt\",\"MechanicCompleteDate\":\"2022-11-18T07:53:17Z\",\"MechanicCost\":1972},\"Activity\":{\"Date1\":\"2022-11-04T07:53:17Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Date2\":\"2022-11-07T07:53:17Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2022-11-08T07:53:17Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2022-11-18T07:53:17Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Scott Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Scott Producer (Producer)",
+						"Date1": "2022-11-04T07:53:17Z",
+						"Date2": "2022-11-07T07:53:17Z",
+						"Date3": "2022-11-08T07:53:17Z",
+						"Date4": "2022-11-18T07:53:17Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Major damage and not safe to drive",
+							"Exterior": "Passenger Rear,Rear",
+							"Interior": "Seats"
+						},
+						"Detail": "Incident alone",
+						"Location": "6750 Kingsford Point",
+						"LocationCity": "Whittier",
+						"LocationState": "CA",
+						"LocationZIP": "90605",
+						"OtherVehicleInsurance": "USAA",
+						"OtherVehicleMake": "Dodge",
+						"OtherVehicleModel": "Nitro",
+						"OtherVehicleOccupant": "Georgy Addicote",
+						"OtherVehicleOccupant2": null,
+						"OtherVehicleOccupant3": null,
+						"OtherVehicleVIN": "1ZVBP8AM6B5275475",
+						"Type": "Vehicle incident while driving"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Bonnie Nevett",
+						"InsuredSSN": "375-40-8785",
+						"InsuredVIN": "19XFB2F57CE915314",
+						"InsuredVehicle": "2015 Volvo V90 Cross Country"
+					},
+					"VehicleRepair": {
+						"Description": "Vehicle pending repair",
+						"MechanicAddress": "1432 Wilshire Blvd. Los Angeles, CA 90010",
+						"MechanicCompleteDate": "2022-11-18T07:53:17Z",
+						"MechanicCost": 1972,
+						"MechanicName": "Diamond Auto Repair",
+						"MechanicOrderNum": "dgq8dt",
+						"MechanicPhone": "(310) 458-3492",
+						"Status": "Pending"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-68-705-6331",
 			"incidentDate": "2022-10-29T07:53:17Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-68-705-6331",
@@ -464,7 +2902,60 @@
 			"claimAmount": 1895,
 			"claimCreateDate": "2022-05-09T20:59:18Z",
 			"claimStatus": "inEstimation",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Shurlocke Letessier\",\"InsuredSSN\":\"372-73-4495\",\"InsuredVehicle\":\"2019 Toyota Camry Hybrid XLE\",\"InsuredVIN\":\"1G4GA5GR7EF773836\"},\"IncidentDetail\":{\"Location\":\"392 High Crossing Point\",\"LocationCity\":\"Irvine\",\"LocationState\":\"CA\",\"LocationZIP\":\"92717\",\"Type\":\"Vehicle incident while driving\",\"Detail\":\"Incident with single passenger\",\"OtherVehicleMake\":\"Chevrolet\",\"OtherVehicleModel\":\"Corvette\",\"OtherVehicleVIN\":\"WA1AY74LX9D152183\",\"OtherVehicleOccupant\":\"Charil Allkins\",\"OtherVehicleOccupant2\":\"Von Halleybone\",\"OtherVehicleOccupant3\":null,\"OtherVehicleInsurance\":\"Liberty Mutual\",\"Damage\":{\"Condition\":\"Major damage and not safe to drive\",\"Interior\":\"Seats\",\"Exterior\":\"Front,Driver Side\"}},\"VehicleRepair\":{\"Status\":\"Not Started\",\"Description\":\"Insured has not started repair\",\"MechanicName\":\"Lyons Auto Pro Plus\",\"MechanicPhone\":\"(310) 987-4567\",\"MechanicAddress\":\"675 Main Street Los Angeles, CA 90005\",\"MechanicOrderNum\":\"mac8fe\",\"MechanicCompleteDate\":\"2022-05-20T20:59:18Z\",\"MechanicCost\":1611},\"Activity\":{\"Date1\":\"2022-05-09T20:59:18Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Date2\":\"2022-05-10T20:59:18Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2022-05-18T20:59:18Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2022-05-20T20:59:18Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Scott Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Scott Producer (Producer)",
+						"Date1": "2022-05-09T20:59:18Z",
+						"Date2": "2022-05-10T20:59:18Z",
+						"Date3": "2022-05-18T20:59:18Z",
+						"Date4": "2022-05-20T20:59:18Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Major damage and not safe to drive",
+							"Exterior": "Front,Driver Side",
+							"Interior": "Seats"
+						},
+						"Detail": "Incident with single passenger",
+						"Location": "392 High Crossing Point",
+						"LocationCity": "Irvine",
+						"LocationState": "CA",
+						"LocationZIP": "92717",
+						"OtherVehicleInsurance": "Liberty Mutual",
+						"OtherVehicleMake": "Chevrolet",
+						"OtherVehicleModel": "Corvette",
+						"OtherVehicleOccupant": "Charil Allkins",
+						"OtherVehicleOccupant2": "Von Halleybone",
+						"OtherVehicleOccupant3": null,
+						"OtherVehicleVIN": "WA1AY74LX9D152183",
+						"Type": "Vehicle incident while driving"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Shurlocke Letessier",
+						"InsuredSSN": "372-73-4495",
+						"InsuredVIN": "1G4GA5GR7EF773836",
+						"InsuredVehicle": "2019 Toyota Camry Hybrid XLE"
+					},
+					"VehicleRepair": {
+						"Description": "Insured has not started repair",
+						"MechanicAddress": "675 Main Street Los Angeles, CA 90005",
+						"MechanicCompleteDate": "2022-05-20T20:59:18Z",
+						"MechanicCost": 1611,
+						"MechanicName": "Lyons Auto Pro Plus",
+						"MechanicOrderNum": "mac8fe",
+						"MechanicPhone": "(310) 987-4567",
+						"Status": "Not Started"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-82-419-3469",
 			"incidentDate": "2022-05-02T20:59:18Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-82-419-3469",
@@ -474,7 +2965,60 @@
 			"claimAmount": 2494,
 			"claimCreateDate": "2023-11-18T22:41:21Z",
 			"claimStatus": "approved",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Vale Vynall\",\"InsuredSSN\":\"194-88-1774\",\"InsuredVehicle\":\"2013 Toyota Camry Hybrid XLE\",\"InsuredVIN\":\"3N1CE2CP7FL257190\"},\"IncidentDetail\":{\"Location\":\"4371 Oak Valley Park\",\"LocationCity\":\"Alhambra\",\"LocationState\":\"CA\",\"LocationZIP\":\"91841\",\"Type\":\"Vehicle incident while parked\",\"Detail\":\"Incident alone\",\"OtherVehicleMake\":\"Jeep\",\"OtherVehicleModel\":\"Cherokee\",\"OtherVehicleVIN\":\"WBASP4C54BC230691\",\"OtherVehicleOccupant\":\"Jemmy Rodolphe\",\"OtherVehicleOccupant2\":null,\"OtherVehicleOccupant3\":null,\"OtherVehicleInsurance\":\"Liberty Mutual\",\"Damage\":{\"Condition\":\"Major damage and not safe to drive\",\"Interior\":\"Seats\",\"Exterior\":\"Driver Side, Driver Rear\"}},\"VehicleRepair\":{\"Status\":\"Pending\",\"Description\":\"Vehicle pending repair\",\"MechanicName\":\"Diamond Auto Repair\",\"MechanicPhone\":\"(310) 458-3492\",\"MechanicAddress\":\"1432 Wilshire Blvd. Los Angeles, CA 90010\",\"MechanicOrderNum\":\"jvs2ih\",\"MechanicCompleteDate\":\"2023-11-29T22:41:21Z\",\"MechanicCost\":2120},\"Activity\":{\"Date1\":\"2023-11-18T22:41:21Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Marie Producer (Producer)\",\"Date2\":\"2023-11-20T22:41:21Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2023-11-22T22:41:21Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2023-11-29T22:41:21Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Marie Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Marie Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Marie Producer (Producer)",
+						"Date1": "2023-11-18T22:41:21Z",
+						"Date2": "2023-11-20T22:41:21Z",
+						"Date3": "2023-11-22T22:41:21Z",
+						"Date4": "2023-11-29T22:41:21Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Major damage and not safe to drive",
+							"Exterior": "Driver Side, Driver Rear",
+							"Interior": "Seats"
+						},
+						"Detail": "Incident alone",
+						"Location": "4371 Oak Valley Park",
+						"LocationCity": "Alhambra",
+						"LocationState": "CA",
+						"LocationZIP": "91841",
+						"OtherVehicleInsurance": "Liberty Mutual",
+						"OtherVehicleMake": "Jeep",
+						"OtherVehicleModel": "Cherokee",
+						"OtherVehicleOccupant": "Jemmy Rodolphe",
+						"OtherVehicleOccupant2": null,
+						"OtherVehicleOccupant3": null,
+						"OtherVehicleVIN": "WBASP4C54BC230691",
+						"Type": "Vehicle incident while parked"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Vale Vynall",
+						"InsuredSSN": "194-88-1774",
+						"InsuredVIN": "3N1CE2CP7FL257190",
+						"InsuredVehicle": "2013 Toyota Camry Hybrid XLE"
+					},
+					"VehicleRepair": {
+						"Description": "Vehicle pending repair",
+						"MechanicAddress": "1432 Wilshire Blvd. Los Angeles, CA 90010",
+						"MechanicCompleteDate": "2023-11-29T22:41:21Z",
+						"MechanicCost": 2120,
+						"MechanicName": "Diamond Auto Repair",
+						"MechanicOrderNum": "jvs2ih",
+						"MechanicPhone": "(310) 458-3492",
+						"Status": "Pending"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-39-022-9968",
 			"incidentDate": "2023-11-11T22:41:21Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-39-022-9968",
@@ -484,7 +3028,60 @@
 			"claimAmount": 4150,
 			"claimCreateDate": "2022-08-05T04:02:03Z",
 			"claimStatus": "pendingSettlement",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Shane Orgen\",\"InsuredSSN\":\"420-76-4970\",\"InsuredVehicle\":\"2017 Volvo S90 R-Design\",\"InsuredVIN\":\"KMHHT6KD5AU027102\"},\"IncidentDetail\":{\"Location\":\"8 Waywood Parkway\",\"LocationCity\":\"Anaheim\",\"LocationState\":\"CA\",\"LocationZIP\":\"92812\",\"Type\":\"Vehicle incident while parked\",\"Detail\":\"Incident with more than one passenger\",\"OtherVehicleMake\":\"Hyundai\",\"OtherVehicleModel\":\"Elantra\",\"OtherVehicleVIN\":\"19XFB2E58CE678186\",\"OtherVehicleOccupant\":\"Judye Rozier\",\"OtherVehicleOccupant2\":\"Filberte Karoly\",\"OtherVehicleOccupant3\":\"Clareta Ravenshaw\",\"OtherVehicleInsurance\":\"Mercury\",\"Damage\":{\"Condition\":\"Minor damage and safe to drive\",\"Interior\":\"Wheels & Dashboard\",\"Exterior\":\"Front,Driver Side\"}},\"VehicleRepair\":{\"Status\":\"Not Started\",\"Description\":\"Insured has not started repair\",\"MechanicName\":\"Diamond Auto Repair\",\"MechanicPhone\":\"(310) 458-3492\",\"MechanicAddress\":\"1432 Wilshire Blvd. Los Angeles, CA 90010\",\"MechanicOrderNum\":\"wmx6pp\",\"MechanicCompleteDate\":\"2022-08-20T04:02:03Z\",\"MechanicCost\":3528},\"Activity\":{\"Date1\":\"2022-08-05T04:02:03Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Date2\":\"2022-08-07T04:02:03Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2022-08-11T04:02:03Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2022-08-20T04:02:03Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Scott Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Scott Producer (Producer)",
+						"Date1": "2022-08-05T04:02:03Z",
+						"Date2": "2022-08-07T04:02:03Z",
+						"Date3": "2022-08-11T04:02:03Z",
+						"Date4": "2022-08-20T04:02:03Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Minor damage and safe to drive",
+							"Exterior": "Front,Driver Side",
+							"Interior": "Wheels & Dashboard"
+						},
+						"Detail": "Incident with more than one passenger",
+						"Location": "8 Waywood Parkway",
+						"LocationCity": "Anaheim",
+						"LocationState": "CA",
+						"LocationZIP": "92812",
+						"OtherVehicleInsurance": "Mercury",
+						"OtherVehicleMake": "Hyundai",
+						"OtherVehicleModel": "Elantra",
+						"OtherVehicleOccupant": "Judye Rozier",
+						"OtherVehicleOccupant2": "Filberte Karoly",
+						"OtherVehicleOccupant3": "Clareta Ravenshaw",
+						"OtherVehicleVIN": "19XFB2E58CE678186",
+						"Type": "Vehicle incident while parked"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Shane Orgen",
+						"InsuredSSN": "420-76-4970",
+						"InsuredVIN": "KMHHT6KD5AU027102",
+						"InsuredVehicle": "2017 Volvo S90 R-Design"
+					},
+					"VehicleRepair": {
+						"Description": "Insured has not started repair",
+						"MechanicAddress": "1432 Wilshire Blvd. Los Angeles, CA 90010",
+						"MechanicCompleteDate": "2022-08-20T04:02:03Z",
+						"MechanicCost": 3528,
+						"MechanicName": "Diamond Auto Repair",
+						"MechanicOrderNum": "wmx6pp",
+						"MechanicPhone": "(310) 458-3492",
+						"Status": "Not Started"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-66-128-8419",
 			"incidentDate": "2022-08-01T04:02:03Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-66-128-8419",
@@ -494,7 +3091,60 @@
 			"claimAmount": 2760,
 			"claimCreateDate": "2023-01-12T08:44:10Z",
 			"claimStatus": "settled",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Jada Lewin\",\"InsuredSSN\":\"782-02-8421\",\"InsuredVehicle\":\"2018 Toyota Camry Hybrid XLE\",\"InsuredVIN\":\"1ZVBP8JZ6D5961546\"},\"IncidentDetail\":{\"Location\":\"4 Forest Run Pass\",\"LocationCity\":\"Albany\",\"LocationState\":\"NY\",\"LocationZIP\":\"12247\",\"Type\":\"Vehicle incident while driving\",\"Detail\":\"Incident with more than one passenger\",\"OtherVehicleMake\":\"Chrysler\",\"OtherVehicleModel\":\"Sebring\",\"OtherVehicleVIN\":\"4USBT53534L608758\",\"OtherVehicleOccupant\":\"Romeo Ottawell\",\"OtherVehicleOccupant2\":\"Celisse Campion\",\"OtherVehicleOccupant3\":\"Francisca Rushbrook\",\"OtherVehicleInsurance\":\"Travelers\",\"Damage\":{\"Condition\":\"Good to drive\",\"Interior\":\"Seats\",\"Exterior\":\"Driver Side, Driver Rear\"}},\"VehicleRepair\":{\"Status\":\"Complete\",\"Description\":\"Insured contacted mechanic and completed repair\",\"MechanicName\":\"Hyperion Automotive Center\",\"MechanicPhone\":\"(323) 665-7864\",\"MechanicAddress\":\"2938 Hyperion Ave Los Angeles, CA 90027\",\"MechanicOrderNum\":\"xzt1nx\",\"MechanicCompleteDate\":\"2023-01-24T08:44:10Z\",\"MechanicCost\":2346},\"Activity\":{\"Date1\":\"2023-01-12T08:44:10Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Marie Producer (Producer)\",\"Date2\":\"2023-01-15T08:44:10Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2023-01-21T08:44:10Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2023-01-24T08:44:10Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Marie Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Marie Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Marie Producer (Producer)",
+						"Date1": "2023-01-12T08:44:10Z",
+						"Date2": "2023-01-15T08:44:10Z",
+						"Date3": "2023-01-21T08:44:10Z",
+						"Date4": "2023-01-24T08:44:10Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Good to drive",
+							"Exterior": "Driver Side, Driver Rear",
+							"Interior": "Seats"
+						},
+						"Detail": "Incident with more than one passenger",
+						"Location": "4 Forest Run Pass",
+						"LocationCity": "Albany",
+						"LocationState": "NY",
+						"LocationZIP": "12247",
+						"OtherVehicleInsurance": "Travelers",
+						"OtherVehicleMake": "Chrysler",
+						"OtherVehicleModel": "Sebring",
+						"OtherVehicleOccupant": "Romeo Ottawell",
+						"OtherVehicleOccupant2": "Celisse Campion",
+						"OtherVehicleOccupant3": "Francisca Rushbrook",
+						"OtherVehicleVIN": "4USBT53534L608758",
+						"Type": "Vehicle incident while driving"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Jada Lewin",
+						"InsuredSSN": "782-02-8421",
+						"InsuredVIN": "1ZVBP8JZ6D5961546",
+						"InsuredVehicle": "2018 Toyota Camry Hybrid XLE"
+					},
+					"VehicleRepair": {
+						"Description": "Insured contacted mechanic and completed repair",
+						"MechanicAddress": "2938 Hyperion Ave Los Angeles, CA 90027",
+						"MechanicCompleteDate": "2023-01-24T08:44:10Z",
+						"MechanicCost": 2346,
+						"MechanicName": "Hyperion Automotive Center",
+						"MechanicOrderNum": "xzt1nx",
+						"MechanicPhone": "(323) 665-7864",
+						"Status": "Complete"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-50-527-9425",
 			"incidentDate": "2023-01-10T08:44:10Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-50-527-9425",
@@ -504,7 +3154,60 @@
 			"claimAmount": 2923,
 			"claimCreateDate": "2023-11-18T04:12:30Z",
 			"claimStatus": "inEstimation",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Ariel Wight\",\"InsuredSSN\":\"254-07-8405\",\"InsuredVehicle\":\"2018 Ford F-150 Super 250 XL\",\"InsuredVIN\":\"1D7CE3GK9AS001778\"},\"IncidentDetail\":{\"Location\":\"5 Forster Trail\",\"LocationCity\":\"Sacramento\",\"LocationState\":\"CA\",\"LocationZIP\":\"95865\",\"Type\":\"Vehicle incident while parking\",\"Detail\":\"Incident with single passenger\",\"OtherVehicleMake\":\"Land Rover\",\"OtherVehicleModel\":\"Defender 90\",\"OtherVehicleVIN\":\"WBAWC7C5XAP453629\",\"OtherVehicleOccupant\":\"Elonore Lavery\",\"OtherVehicleOccupant2\":\"Viviyan Ravenshaw\",\"OtherVehicleOccupant3\":null,\"OtherVehicleInsurance\":\"Liberty Mutual\",\"Damage\":{\"Condition\":\"Good to drive\",\"Interior\":\"Interior Trim\",\"Exterior\":\"Passenger Side\"}},\"VehicleRepair\":{\"Status\":\"Not Started\",\"Description\":\"Insured has not started repair\",\"MechanicName\":\"Hyperion Automotive Center\",\"MechanicPhone\":\"(323) 665-7864\",\"MechanicAddress\":\"2938 Hyperion Ave Los Angeles, CA 90027\",\"MechanicOrderNum\":\"tzo1ph\",\"MechanicCompleteDate\":\"2023-12-06T04:12:30Z\",\"MechanicCost\":2485},\"Activity\":{\"Date1\":\"2023-11-18T04:12:30Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Date2\":\"2023-11-21T04:12:30Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2023-11-26T04:12:30Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2023-12-06T04:12:30Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Scott Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Scott Producer (Producer)",
+						"Date1": "2023-11-18T04:12:30Z",
+						"Date2": "2023-11-21T04:12:30Z",
+						"Date3": "2023-11-26T04:12:30Z",
+						"Date4": "2023-12-06T04:12:30Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Good to drive",
+							"Exterior": "Passenger Side",
+							"Interior": "Interior Trim"
+						},
+						"Detail": "Incident with single passenger",
+						"Location": "5 Forster Trail",
+						"LocationCity": "Sacramento",
+						"LocationState": "CA",
+						"LocationZIP": "95865",
+						"OtherVehicleInsurance": "Liberty Mutual",
+						"OtherVehicleMake": "Land Rover",
+						"OtherVehicleModel": "Defender 90",
+						"OtherVehicleOccupant": "Elonore Lavery",
+						"OtherVehicleOccupant2": "Viviyan Ravenshaw",
+						"OtherVehicleOccupant3": null,
+						"OtherVehicleVIN": "WBAWC7C5XAP453629",
+						"Type": "Vehicle incident while parking"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Ariel Wight",
+						"InsuredSSN": "254-07-8405",
+						"InsuredVIN": "1D7CE3GK9AS001778",
+						"InsuredVehicle": "2018 Ford F-150 Super 250 XL"
+					},
+					"VehicleRepair": {
+						"Description": "Insured has not started repair",
+						"MechanicAddress": "2938 Hyperion Ave Los Angeles, CA 90027",
+						"MechanicCompleteDate": "2023-12-06T04:12:30Z",
+						"MechanicCost": 2485,
+						"MechanicName": "Hyperion Automotive Center",
+						"MechanicOrderNum": "tzo1ph",
+						"MechanicPhone": "(323) 665-7864",
+						"Status": "Not Started"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-84-871-1015",
 			"incidentDate": "2023-11-15T04:12:30Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-84-871-1015",
@@ -514,7 +3217,60 @@
 			"claimAmount": 2275,
 			"claimCreateDate": "2022-12-02T07:45:52Z",
 			"claimStatus": "declined",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Jada Lewin\",\"InsuredSSN\":\"425-69-5356\",\"InsuredVehicle\":\"2019 Toyota Corolla LE\",\"InsuredVIN\":\"1FMEU7FE7AU639422\"},\"IncidentDetail\":{\"Location\":\"17 Scoville Plaza\",\"LocationCity\":\"San Diego\",\"LocationState\":\"CA\",\"LocationZIP\":\"92160\",\"Type\":\"Vehicle incident while driving\",\"Detail\":\"Incident with more than one passenger\",\"OtherVehicleMake\":\"Mitsubishi\",\"OtherVehicleModel\":\"Pajero\",\"OtherVehicleVIN\":\"5FRYD4H64GB879729\",\"OtherVehicleOccupant\":\"Fara Macci\",\"OtherVehicleOccupant2\":\"Sara Elphinston\",\"OtherVehicleOccupant3\":\"Wandis Carrack\",\"OtherVehicleInsurance\":\"Travelers\",\"Damage\":{\"Condition\":\"Minor damage and safe to drive\",\"Interior\":\"Interior Trim\",\"Exterior\":\"Passenger Rear,Rear\"}},\"VehicleRepair\":{\"Status\":\"Not Started\",\"Description\":\"Insured has not started repair\",\"MechanicName\":\"Lyons Auto Pro Plus\",\"MechanicPhone\":\"(310) 987-4567\",\"MechanicAddress\":\"675 Main Street Los Angeles, CA 90005\",\"MechanicOrderNum\":\"cvn4gv\",\"MechanicCompleteDate\":\"2022-12-18T07:45:52Z\",\"MechanicCost\":1934},\"Activity\":{\"Date1\":\"2022-12-02T07:45:52Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Date2\":\"2022-12-03T07:45:52Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2022-12-07T07:45:52Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2022-12-18T07:45:52Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Scott Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Scott Producer (Producer)",
+						"Date1": "2022-12-02T07:45:52Z",
+						"Date2": "2022-12-03T07:45:52Z",
+						"Date3": "2022-12-07T07:45:52Z",
+						"Date4": "2022-12-18T07:45:52Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Minor damage and safe to drive",
+							"Exterior": "Passenger Rear,Rear",
+							"Interior": "Interior Trim"
+						},
+						"Detail": "Incident with more than one passenger",
+						"Location": "17 Scoville Plaza",
+						"LocationCity": "San Diego",
+						"LocationState": "CA",
+						"LocationZIP": "92160",
+						"OtherVehicleInsurance": "Travelers",
+						"OtherVehicleMake": "Mitsubishi",
+						"OtherVehicleModel": "Pajero",
+						"OtherVehicleOccupant": "Fara Macci",
+						"OtherVehicleOccupant2": "Sara Elphinston",
+						"OtherVehicleOccupant3": "Wandis Carrack",
+						"OtherVehicleVIN": "5FRYD4H64GB879729",
+						"Type": "Vehicle incident while driving"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Jada Lewin",
+						"InsuredSSN": "425-69-5356",
+						"InsuredVIN": "1FMEU7FE7AU639422",
+						"InsuredVehicle": "2019 Toyota Corolla LE"
+					},
+					"VehicleRepair": {
+						"Description": "Insured has not started repair",
+						"MechanicAddress": "675 Main Street Los Angeles, CA 90005",
+						"MechanicCompleteDate": "2022-12-18T07:45:52Z",
+						"MechanicCost": 1934,
+						"MechanicName": "Lyons Auto Pro Plus",
+						"MechanicOrderNum": "cvn4gv",
+						"MechanicPhone": "(310) 987-4567",
+						"Status": "Not Started"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-29-197-4437",
 			"incidentDate": "2022-12-01T07:45:52Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-29-197-4437",
@@ -524,7 +3280,60 @@
 			"claimAmount": 553,
 			"claimCreateDate": "2022-05-05T08:30:36Z",
 			"claimStatus": "approved",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Stevana Casiero\",\"InsuredSSN\":\"827-38-3348\",\"InsuredVehicle\":\"2018 Volvo V90 Cross Country\",\"InsuredVIN\":\"WBAUT9C59AA997965\"},\"IncidentDetail\":{\"Location\":\"36982 Redwing Pass\",\"LocationCity\":\"Huntington Beach\",\"LocationState\":\"CA\",\"LocationZIP\":\"92648\",\"Type\":\"Vehicle incident while parking\",\"Detail\":\"Incident with more than one passenger\",\"OtherVehicleMake\":\"Bentley\",\"OtherVehicleModel\":\"Arnage\",\"OtherVehicleVIN\":\"SALVP2BG5FH381161\",\"OtherVehicleOccupant\":\"Gabbie Webbe\",\"OtherVehicleOccupant2\":\"Ramon Lande\",\"OtherVehicleOccupant3\":\"Adler Strippel\",\"OtherVehicleInsurance\":\"Geico\",\"Damage\":{\"Condition\":\"Minor damage and safe to drive\",\"Interior\":\"Seats\",\"Exterior\":\"Passenger Rear,Rear\"}},\"VehicleRepair\":{\"Status\":\"Pending\",\"Description\":\"Vehicle pending repair\",\"MechanicName\":\"Diamond Auto Repair\",\"MechanicPhone\":\"(310) 458-3492\",\"MechanicAddress\":\"1432 Wilshire Blvd. Los Angeles, CA 90010\",\"MechanicOrderNum\":\"wfq2ko\",\"MechanicCompleteDate\":\"2022-05-23T08:30:36Z\",\"MechanicCost\":470},\"Activity\":{\"Date1\":\"2022-05-05T08:30:36Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Date2\":\"2022-05-07T08:30:36Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2022-05-13T08:30:36Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2022-05-23T08:30:36Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Scott Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Scott Producer (Producer)",
+						"Date1": "2022-05-05T08:30:36Z",
+						"Date2": "2022-05-07T08:30:36Z",
+						"Date3": "2022-05-13T08:30:36Z",
+						"Date4": "2022-05-23T08:30:36Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Minor damage and safe to drive",
+							"Exterior": "Passenger Rear,Rear",
+							"Interior": "Seats"
+						},
+						"Detail": "Incident with more than one passenger",
+						"Location": "36982 Redwing Pass",
+						"LocationCity": "Huntington Beach",
+						"LocationState": "CA",
+						"LocationZIP": "92648",
+						"OtherVehicleInsurance": "Geico",
+						"OtherVehicleMake": "Bentley",
+						"OtherVehicleModel": "Arnage",
+						"OtherVehicleOccupant": "Gabbie Webbe",
+						"OtherVehicleOccupant2": "Ramon Lande",
+						"OtherVehicleOccupant3": "Adler Strippel",
+						"OtherVehicleVIN": "SALVP2BG5FH381161",
+						"Type": "Vehicle incident while parking"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Stevana Casiero",
+						"InsuredSSN": "827-38-3348",
+						"InsuredVIN": "WBAUT9C59AA997965",
+						"InsuredVehicle": "2018 Volvo V90 Cross Country"
+					},
+					"VehicleRepair": {
+						"Description": "Vehicle pending repair",
+						"MechanicAddress": "1432 Wilshire Blvd. Los Angeles, CA 90010",
+						"MechanicCompleteDate": "2022-05-23T08:30:36Z",
+						"MechanicCost": 470,
+						"MechanicName": "Diamond Auto Repair",
+						"MechanicOrderNum": "wfq2ko",
+						"MechanicPhone": "(310) 458-3492",
+						"Status": "Pending"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-71-999-0946",
 			"incidentDate": "2022-05-02T08:30:36Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-71-999-0946",
@@ -534,7 +3343,60 @@
 			"claimAmount": 773,
 			"claimCreateDate": "2023-05-14T02:37:07Z",
 			"claimStatus": "pendingSettlement",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Ferrel Sames\",\"InsuredSSN\":\"270-47-4835\",\"InsuredVehicle\":\"2013 Toyota Camry Hybrid XLE\",\"InsuredVIN\":\"SCFFDAAE7CG024369\"},\"IncidentDetail\":{\"Location\":\"751 Sycamore Way\",\"LocationCity\":\"Anaheim\",\"LocationState\":\"CA\",\"LocationZIP\":\"92825\",\"Type\":\"Vehicle incident while parking\",\"Detail\":\"Incident with more than one passenger\",\"OtherVehicleMake\":\"Kia\",\"OtherVehicleModel\":\"Spectra5\",\"OtherVehicleVIN\":\"3C3CFFER7FT436690\",\"OtherVehicleOccupant\":\"Josephine Burley\",\"OtherVehicleOccupant2\":\"Fernando Kilminster\",\"OtherVehicleOccupant3\":\"Orran Thew\",\"OtherVehicleInsurance\":\"Mercury\",\"Damage\":{\"Condition\":\"Minor damage and safe to drive\",\"Interior\":\"Seats\",\"Exterior\":\"Front,Driver Side\"}},\"VehicleRepair\":{\"Status\":\"Not Started\",\"Description\":\"Insured has not started repair\",\"MechanicName\":\"Diamond Auto Repair\",\"MechanicPhone\":\"(310) 458-3492\",\"MechanicAddress\":\"1432 Wilshire Blvd. Los Angeles, CA 90010\",\"MechanicOrderNum\":\"ydq5sh\",\"MechanicCompleteDate\":\"2023-06-02T02:37:07Z\",\"MechanicCost\":657},\"Activity\":{\"Date1\":\"2023-05-14T02:37:07Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Marie Producer (Producer)\",\"Date2\":\"2023-05-16T02:37:07Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2023-05-22T02:37:07Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2023-06-02T02:37:07Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Marie Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Marie Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Marie Producer (Producer)",
+						"Date1": "2023-05-14T02:37:07Z",
+						"Date2": "2023-05-16T02:37:07Z",
+						"Date3": "2023-05-22T02:37:07Z",
+						"Date4": "2023-06-02T02:37:07Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Minor damage and safe to drive",
+							"Exterior": "Front,Driver Side",
+							"Interior": "Seats"
+						},
+						"Detail": "Incident with more than one passenger",
+						"Location": "751 Sycamore Way",
+						"LocationCity": "Anaheim",
+						"LocationState": "CA",
+						"LocationZIP": "92825",
+						"OtherVehicleInsurance": "Mercury",
+						"OtherVehicleMake": "Kia",
+						"OtherVehicleModel": "Spectra5",
+						"OtherVehicleOccupant": "Josephine Burley",
+						"OtherVehicleOccupant2": "Fernando Kilminster",
+						"OtherVehicleOccupant3": "Orran Thew",
+						"OtherVehicleVIN": "3C3CFFER7FT436690",
+						"Type": "Vehicle incident while parking"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Ferrel Sames",
+						"InsuredSSN": "270-47-4835",
+						"InsuredVIN": "SCFFDAAE7CG024369",
+						"InsuredVehicle": "2013 Toyota Camry Hybrid XLE"
+					},
+					"VehicleRepair": {
+						"Description": "Insured has not started repair",
+						"MechanicAddress": "1432 Wilshire Blvd. Los Angeles, CA 90010",
+						"MechanicCompleteDate": "2023-06-02T02:37:07Z",
+						"MechanicCost": 657,
+						"MechanicName": "Diamond Auto Repair",
+						"MechanicOrderNum": "ydq5sh",
+						"MechanicPhone": "(310) 458-3492",
+						"Status": "Not Started"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-65-321-8913",
 			"incidentDate": "2023-05-07T02:37:07Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-65-321-8913",
@@ -544,7 +3406,60 @@
 			"claimAmount": 3678,
 			"claimCreateDate": "2023-07-19T14:17:28Z",
 			"claimStatus": "inInvestigation",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Merrily Phibb\",\"InsuredSSN\":\"606-56-0985\",\"InsuredVehicle\":\"2019 Ford Focus S Sedan\",\"InsuredVIN\":\"WA1WKAFP5BA988771\"},\"IncidentDetail\":{\"Location\":\"66734 Walton Junction\",\"LocationCity\":\"Inglewood\",\"LocationState\":\"CA\",\"LocationZIP\":\"90305\",\"Type\":\"Vehicle incident while parking\",\"Detail\":\"Incident with more than one passenger\",\"OtherVehicleMake\":\"Volkswagen\",\"OtherVehicleModel\":\"Touareg 2\",\"OtherVehicleVIN\":\"KMHCT4AE1CU446379\",\"OtherVehicleOccupant\":\"Filide Crackel\",\"OtherVehicleOccupant2\":\"Kerry Hulse\",\"OtherVehicleOccupant3\":\"Beatrix O'Lochan\",\"OtherVehicleInsurance\":\"State Farm\",\"Damage\":{\"Condition\":\"Major damage and not safe to drive\",\"Interior\":\"Upholstery\",\"Exterior\":\"Front,Driver Side\"}},\"VehicleRepair\":{\"Status\":\"Not Started\",\"Description\":\"Insured has not started repair\",\"MechanicName\":\"Hyperion Automotive Center\",\"MechanicPhone\":\"(323) 665-7864\",\"MechanicAddress\":\"2938 Hyperion Ave Los Angeles, CA 90027\",\"MechanicOrderNum\":\"pzt9zz\",\"MechanicCompleteDate\":\"2023-08-05T14:17:28Z\",\"MechanicCost\":3126},\"Activity\":{\"Date1\":\"2023-07-19T14:17:28Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Marie Producer (Producer)\",\"Date2\":\"2023-07-20T14:17:28Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2023-07-28T14:17:28Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2023-08-05T14:17:28Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Marie Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Marie Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Marie Producer (Producer)",
+						"Date1": "2023-07-19T14:17:28Z",
+						"Date2": "2023-07-20T14:17:28Z",
+						"Date3": "2023-07-28T14:17:28Z",
+						"Date4": "2023-08-05T14:17:28Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Major damage and not safe to drive",
+							"Exterior": "Front,Driver Side",
+							"Interior": "Upholstery"
+						},
+						"Detail": "Incident with more than one passenger",
+						"Location": "66734 Walton Junction",
+						"LocationCity": "Inglewood",
+						"LocationState": "CA",
+						"LocationZIP": "90305",
+						"OtherVehicleInsurance": "State Farm",
+						"OtherVehicleMake": "Volkswagen",
+						"OtherVehicleModel": "Touareg 2",
+						"OtherVehicleOccupant": "Filide Crackel",
+						"OtherVehicleOccupant2": "Kerry Hulse",
+						"OtherVehicleOccupant3": "Beatrix O'Lochan",
+						"OtherVehicleVIN": "KMHCT4AE1CU446379",
+						"Type": "Vehicle incident while parking"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Merrily Phibb",
+						"InsuredSSN": "606-56-0985",
+						"InsuredVIN": "WA1WKAFP5BA988771",
+						"InsuredVehicle": "2019 Ford Focus S Sedan"
+					},
+					"VehicleRepair": {
+						"Description": "Insured has not started repair",
+						"MechanicAddress": "2938 Hyperion Ave Los Angeles, CA 90027",
+						"MechanicCompleteDate": "2023-08-05T14:17:28Z",
+						"MechanicCost": 3126,
+						"MechanicName": "Hyperion Automotive Center",
+						"MechanicOrderNum": "pzt9zz",
+						"MechanicPhone": "(323) 665-7864",
+						"Status": "Not Started"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-03-257-1188",
 			"incidentDate": "2023-07-15T14:17:28Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-03-257-1188",
@@ -554,7 +3469,60 @@
 			"claimAmount": 1725,
 			"claimCreateDate": "2023-05-13T04:43:09Z",
 			"claimStatus": "repair",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Dynah Jordeson\",\"InsuredSSN\":\"762-42-7196\",\"InsuredVehicle\":\"2016 Toyota Tundra SR6\",\"InsuredVIN\":\"WBAVA33578K484872\"},\"IncidentDetail\":{\"Location\":\"22 Mosinee Plaza\",\"LocationCity\":\"Brooklyn\",\"LocationState\":\"NY\",\"LocationZIP\":\"11220\",\"Type\":\"Vehicle incident while filling fuel\",\"Detail\":\"Incident alone\",\"OtherVehicleMake\":\"Kia\",\"OtherVehicleModel\":\"Spectra\",\"OtherVehicleVIN\":\"1N6AA0CA4FN965796\",\"OtherVehicleOccupant\":\"Brigitte Penelli\",\"OtherVehicleOccupant2\":null,\"OtherVehicleOccupant3\":null,\"OtherVehicleInsurance\":\"Geico\",\"Damage\":{\"Condition\":\"Major damage and not safe to drive\",\"Interior\":\"Wheels & Dashboard\",\"Exterior\":\"Front,Driver Side\"}},\"VehicleRepair\":{\"Status\":\"Pending\",\"Description\":\"Vehicle pending repair\",\"MechanicName\":\"Lyons Auto Pro Plus\",\"MechanicPhone\":\"(310) 987-4567\",\"MechanicAddress\":\"675 Main Street Los Angeles, CA 90005\",\"MechanicOrderNum\":\"mpo6fz\",\"MechanicCompleteDate\":\"2023-06-01T04:43:09Z\",\"MechanicCost\":1466},\"Activity\":{\"Date1\":\"2023-05-13T04:43:09Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Date2\":\"2023-05-15T04:43:09Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2023-05-19T04:43:09Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2023-06-01T04:43:09Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Scott Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Scott Producer (Producer)",
+						"Date1": "2023-05-13T04:43:09Z",
+						"Date2": "2023-05-15T04:43:09Z",
+						"Date3": "2023-05-19T04:43:09Z",
+						"Date4": "2023-06-01T04:43:09Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Major damage and not safe to drive",
+							"Exterior": "Front,Driver Side",
+							"Interior": "Wheels & Dashboard"
+						},
+						"Detail": "Incident alone",
+						"Location": "22 Mosinee Plaza",
+						"LocationCity": "Brooklyn",
+						"LocationState": "NY",
+						"LocationZIP": "11220",
+						"OtherVehicleInsurance": "Geico",
+						"OtherVehicleMake": "Kia",
+						"OtherVehicleModel": "Spectra",
+						"OtherVehicleOccupant": "Brigitte Penelli",
+						"OtherVehicleOccupant2": null,
+						"OtherVehicleOccupant3": null,
+						"OtherVehicleVIN": "1N6AA0CA4FN965796",
+						"Type": "Vehicle incident while filling fuel"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Dynah Jordeson",
+						"InsuredSSN": "762-42-7196",
+						"InsuredVIN": "WBAVA33578K484872",
+						"InsuredVehicle": "2016 Toyota Tundra SR6"
+					},
+					"VehicleRepair": {
+						"Description": "Vehicle pending repair",
+						"MechanicAddress": "675 Main Street Los Angeles, CA 90005",
+						"MechanicCompleteDate": "2023-06-01T04:43:09Z",
+						"MechanicCost": 1466,
+						"MechanicName": "Lyons Auto Pro Plus",
+						"MechanicOrderNum": "mpo6fz",
+						"MechanicPhone": "(310) 987-4567",
+						"Status": "Pending"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-98-127-2687",
 			"incidentDate": "2023-05-11T04:43:09Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-98-127-2687",
@@ -564,7 +3532,60 @@
 			"claimAmount": 1050,
 			"claimCreateDate": "2022-04-08T18:29:05Z",
 			"claimStatus": "approved",
-			"dataJSON": "{\"Detail\":{\"InsuranceInfo\":{\"InsuredName\":\"Janeen Orrill\",\"InsuredSSN\":\"485-79-8746\",\"InsuredVehicle\":\"2017 Ford Mustang GT Fastback\",\"InsuredVIN\":\"4T3BA3BBXFU103968\"},\"IncidentDetail\":{\"Location\":\"75 Becker Drive\",\"LocationCity\":\"Albany\",\"LocationState\":\"NY\",\"LocationZIP\":\"12255\",\"Type\":\"Vehicle incident while filling fuel\",\"Detail\":\"Incident with more than one passenger\",\"OtherVehicleMake\":\"Lexus\",\"OtherVehicleModel\":\"RX Hybrid\",\"OtherVehicleVIN\":\"5LMJJ3J55CE559301\",\"OtherVehicleOccupant\":\"Candie Tracey\",\"OtherVehicleOccupant2\":\"Amery Maddocks\",\"OtherVehicleOccupant3\":\"Cayla Binden\",\"OtherVehicleInsurance\":\"Mercury\",\"Damage\":{\"Condition\":\"Major damage and not safe to drive\",\"Interior\":\"Upholstery\",\"Exterior\":\"Passenger Side\"}},\"VehicleRepair\":{\"Status\":\"Pending\",\"Description\":\"Vehicle pending repair\",\"MechanicName\":\"Lyons Auto Pro Plus\",\"MechanicPhone\":\"(310) 987-4567\",\"MechanicAddress\":\"675 Main Street Los Angeles, CA 90005\",\"MechanicOrderNum\":\"iaq2db\",\"MechanicCompleteDate\":\"2022-04-19T18:29:05Z\",\"MechanicCost\":893},\"Activity\":{\"Date1\":\"2022-04-08T18:29:05Z\",\"Desc1\":\"Claim Submitted\",\"By1\":\"Scott Producer (Producer)\",\"Date2\":\"2022-04-11T18:29:05Z\",\"Desc2\":\"Investigation in progress\",\"By2\":\"Jack Johnson (Claim Adjuster)\",\"Date3\":\"2022-04-14T18:29:05Z\",\"Desc3\":\"Estimation complete\",\"By3\":\"Jack Johnson (Claim Adjuster)\",\"Date4\":\"2022-04-19T18:29:05Z\",\"Desc4\":\"Vehicle Repair Complete\",\"By4\":\"Scott Producer (Producer)\"}}}",
+			"dataJSON": {
+				"Detail": {
+					"Activity": {
+						"By1": "Scott Producer (Producer)",
+						"By2": "Jack Johnson (Claim Adjuster)",
+						"By3": "Jack Johnson (Claim Adjuster)",
+						"By4": "Scott Producer (Producer)",
+						"Date1": "2022-04-08T18:29:05Z",
+						"Date2": "2022-04-11T18:29:05Z",
+						"Date3": "2022-04-14T18:29:05Z",
+						"Date4": "2022-04-19T18:29:05Z",
+						"Desc1": "Claim Submitted",
+						"Desc2": "Investigation in progress",
+						"Desc3": "Estimation complete",
+						"Desc4": "Vehicle Repair Complete"
+					},
+					"IncidentDetail": {
+						"Damage": {
+							"Condition": "Major damage and not safe to drive",
+							"Exterior": "Passenger Side",
+							"Interior": "Upholstery"
+						},
+						"Detail": "Incident with more than one passenger",
+						"Location": "75 Becker Drive",
+						"LocationCity": "Albany",
+						"LocationState": "NY",
+						"LocationZIP": "12255",
+						"OtherVehicleInsurance": "Mercury",
+						"OtherVehicleMake": "Lexus",
+						"OtherVehicleModel": "RX Hybrid",
+						"OtherVehicleOccupant": "Candie Tracey",
+						"OtherVehicleOccupant2": "Amery Maddocks",
+						"OtherVehicleOccupant3": "Cayla Binden",
+						"OtherVehicleVIN": "5LMJJ3J55CE559301",
+						"Type": "Vehicle incident while filling fuel"
+					},
+					"InsuranceInfo": {
+						"InsuredName": "Janeen Orrill",
+						"InsuredSSN": "485-79-8746",
+						"InsuredVIN": "4T3BA3BBXFU103968",
+						"InsuredVehicle": "2017 Ford Mustang GT Fastback"
+					},
+					"VehicleRepair": {
+						"Description": "Vehicle pending repair",
+						"MechanicAddress": "675 Main Street Los Angeles, CA 90005",
+						"MechanicCompleteDate": "2022-04-19T18:29:05Z",
+						"MechanicCost": 893,
+						"MechanicName": "Lyons Auto Pro Plus",
+						"MechanicOrderNum": "iaq2db",
+						"MechanicPhone": "(310) 987-4567",
+						"Status": "Pending"
+					}
+				}
+			},
 			"externalReferenceCode": "CL-56-014-6401",
 			"incidentDate": "2022-04-02T18:29:05Z",
 			"r_policyToClaims_c_raylifePolicyERC": "PO-56-014-6401",


### PR DESCRIPTION
If a DTO has a string property called `<name>JSON` there will now be 2
ways of setting it from the payload json:

1. As a string (current way): `{propertyJSON: "{\"property\":\"value\"}"}`
2. As an object (new way): `{propertyJSON: {"property":"value"}}`

Way number 2 is easier to read an to maintain.