### PR TITLE
LPS-177435 Web content field values are lost after editing for ca-ES-VALENCIA

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/test/AcceptLanguageContextProviderTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/test/AcceptLanguageContextProviderTest.java
@@ -78,7 +78,8 @@ public class AcceptLanguageContextProviderTest {
 		CompanyTestUtil.resetCompanyLocales(
 			_company.getCompanyId(),
 			Arrays.asList(
-				LocaleUtil.BRAZIL, LocaleUtil.GERMAN, LocaleUtil.JAPAN,
+				LocaleUtil.BRAZIL, new Locale("ca", "ES", "VALENCIA"),
+				LocaleUtil.GERMAN, LocaleUtil.JAPAN, new Locale("sr_RS_latin"),
 				LocaleUtil.TAIWAN),
 			LocaleUtil.TAIWAN);
 
@@ -132,9 +133,27 @@ public class AcceptLanguageContextProviderTest {
 				new AcceptLanguageMockHttpServletRequest(
 					user, LocaleUtil.JAPAN)));
 
-		// One partial locale
+		// One locale with variant
+
+		Locale caLocale = new Locale("ca", "ES", "VALENCIA");
 
 		AcceptLanguage acceptLanguage = _contextProvider.createContext(
+			new MockMessage(
+				new AcceptLanguageMockHttpServletRequest(user, caLocale)));
+
+		Assert.assertEquals(caLocale, acceptLanguage.getPreferredLocale());
+
+		Locale srLocale = new Locale("sr", "RS", "latin");
+
+		acceptLanguage = _contextProvider.createContext(
+			new MockMessage(
+				new AcceptLanguageMockHttpServletRequest(user, srLocale)));
+
+		Assert.assertEquals(srLocale, acceptLanguage.getPreferredLocale());
+
+		// One partial locale
+
+		acceptLanguage = _contextProvider.createContext(
 			new MockMessage(
 				new AcceptLanguageMockHttpServletRequest(
 					user, new Locale("pt", ""))));


### PR DESCRIPTION
Description
-----------
This PR fix the bug :https://issues.liferay.com/browse/LPS-177435.  

When it is used the Locale.filter method, the method is returned the locale of valencia as ca_ES_valencia and this is cause an issue with the ckeditor of the web content edition fields. So, with this fix we are keeping the locale as it is defined in the portal locales, for valencia language : ca_ES_VALENCIA .