### PR TITLE
LPS-177435 Web content field values are lost after editing for ca-ES-VALENCIA

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/accept/language/AcceptLanguageImpl.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/accept/language/AcceptLanguageImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.vulcan.internal.accept.language;
 
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.exception.NoSuchUserException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
@@ -25,7 +26,6 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -78,25 +78,25 @@ public class AcceptLanguageImpl implements AcceptLanguage {
 				Locale.LanguageRange.parse(acceptLanguage),
 				companyAvailableLocales);
 
-			List<Locale> fixedLocales = new ArrayList<>();
-
-			for (Locale locale : locales) {
-				for (Locale companyAvailableLocale : companyAvailableLocales) {
-					if (LocaleUtil.equals(locale, companyAvailableLocale)) {
-						fixedLocales.add(companyAvailableLocale);
-
-						break;
+			locales = TransformUtil.transform(
+				locales,
+				locale -> {
+					for (Locale availableLocale : companyAvailableLocales) {
+						if (LocaleUtil.equals(locale, availableLocale)) {
+							return availableLocale;
+						}
 					}
-				}
-			}
 
-			if (ListUtil.isEmpty(fixedLocales)) {
+					return null;
+				});
+
+			if (ListUtil.isEmpty(locales)) {
 				throw new NotAcceptableException(
 					"No locales match the accepted languages: " +
 						acceptLanguage);
 			}
 
-			return fixedLocales;
+			return locales;
 		}
 		catch (PortalException portalException) {
 			throw new InternalServerErrorException(

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/test/AcceptLanguageContextProviderTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/test/AcceptLanguageContextProviderTest.java
@@ -78,7 +78,8 @@ public class AcceptLanguageContextProviderTest {
 		CompanyTestUtil.resetCompanyLocales(
 			_company.getCompanyId(),
 			Arrays.asList(
-				LocaleUtil.BRAZIL, LocaleUtil.GERMAN, LocaleUtil.JAPAN,
+				LocaleUtil.BRAZIL, new Locale("ca", "ES", "VALENCIA"),
+				LocaleUtil.GERMAN, LocaleUtil.JAPAN, new Locale("sr_RS_latin"),
 				LocaleUtil.TAIWAN),
 			LocaleUtil.TAIWAN);
 
@@ -132,9 +133,27 @@ public class AcceptLanguageContextProviderTest {
 				new AcceptLanguageMockHttpServletRequest(
 					user, LocaleUtil.JAPAN)));
 
-		// One partial locale
+		// One locale with variant
+
+		Locale caLocale = new Locale("ca", "ES", "VALENCIA");
 
 		AcceptLanguage acceptLanguage = _contextProvider.createContext(
+			new MockMessage(
+				new AcceptLanguageMockHttpServletRequest(user, caLocale)));
+
+		Assert.assertEquals(caLocale, acceptLanguage.getPreferredLocale());
+
+		Locale srLocale = new Locale("sr", "RS", "latin");
+
+		acceptLanguage = _contextProvider.createContext(
+			new MockMessage(
+				new AcceptLanguageMockHttpServletRequest(user, srLocale)));
+
+		Assert.assertEquals(srLocale, acceptLanguage.getPreferredLocale());
+
+		// One partial locale
+
+		acceptLanguage = _contextProvider.createContext(
 			new MockMessage(
 				new AcceptLanguageMockHttpServletRequest(
 					user, new Locale("pt", ""))));


### PR DESCRIPTION
Followed-up PR from: https://github.com/liferay-headless/liferay-portal/pull/1238

---

This PR fix the bug :https://issues.liferay.com/browse/LPS-177435.

When it is used the Locale.filter method, the method is returned the locale of valencia as ca_ES_valencia and this is cause an issue with the ckeditor of the web content edition fields. So, with this fix we are keeping the locale as it is defined in the portal locales, for valencia language : ca_ES_VALENCIA .


cc/ @Mikellorza