### PR TITLE
LPS-164940 | Expose ERC for KB Attachment

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/KnowledgeBaseArticleAPI.macro
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/KnowledgeBaseArticleAPI.macro
@@ -1,0 +1,91 @@
+definition {
+
+	macro _curlKnowledgeBaseArticle {
+		var portalURL = JSONCompany.getPortalURL();
+
+		if (isSet(knowledgeBaseFolderId)) {
+			var api = "knowledge-base-folders/${knowledgeBaseFolderId}/knowledge-base-articles";
+		}
+		else if (isSet(knowledgeBaseArticleId)) {
+			var api = "knowledge-base-articles/${knowledgeBaseArticleId}";
+		}
+		else if (isSet(parentKnowledgeBaseArticleId)) {
+			var api = "knowledge-base-articles/${parentKnowledgeBaseArticleId}/knowledge-base-articles";
+		}
+		else {
+			var siteId = JSONGroupAPI._getGroupIdByNameNoSelenium(
+				groupName = "Guest",
+				site = "true");
+
+			var api = "sites/${siteId}/knowledge-base-articles";
+		}
+
+		if (!(isSet(externalReferenceCode))) {
+			var externalReferenceCode = "";
+		}
+
+		var curl = '''
+			${portalURL}/o/headless-delivery/v1.0/${api} \
+				-u test@liferay.com:test \
+				-H Content-Type: application/json \
+		''';
+		var body = '''"articleBody": "${articleBody}","externalReferenceCode": "${externalReferenceCode}","title": "${title}"''';
+
+		if (isSet(title)) {
+			var curl = StringUtil.add(${curl}, "-d {${body}}", " ");
+		}
+
+		return ${curl};
+	}
+
+	macro createKnowledgeBaseArticle {
+		Variables.assertDefined(parameterList = "${articleBody},${title}");
+
+		var curl = KnowledgeBaseArticleAPI._curlKnowledgeBaseArticle(
+			articleBody = ${articleBody},
+			externalReferenceCode = ${externalReferenceCode},
+			knowledgeBaseFolderId = ${knowledgeBaseFolderId},
+			parentKnowledgeBaseArticleId = ${parentKnowledgeBaseArticleId},
+			title = ${title});
+
+		var response = JSONCurlUtil.post(${curl});
+
+		return ${response};
+	}
+
+	macro deleteKnowledgeBaseArticleById {
+		Variables.assertDefined(parameterList = ${knowledgeBaseArticleId});
+
+		var curl = KnowledgeBaseArticleAPI._curlKnowledgeBaseArticle(knowledgeBaseArticleId = ${knowledgeBaseArticleId});
+
+		JSONCurlUtil.delete(${curl});
+	}
+
+	macro setUpGlobalKnowledgeBaseArticleIdAndErc {
+		var response = KnowledgeBaseArticleAPI.createKnowledgeBaseArticle(
+			articleBody = ${articleBody},
+			externalReferenceCode = ${externalReferenceCode},
+			knowledgeBaseFolderId = ${knowledgeBaseFolderId},
+			parentKnowledgeBaseArticleId = ${parentKnowledgeBaseArticleId},
+			title = ${title});
+
+		if (isSet(parentKnowledgeBaseArticleId)) {
+			var subKBArticleId = JSONPathUtil.getIdValue(response = ${response});
+			var subKBArticleErc = JSONPathUtil.getErcValue(response = ${response});
+			static var staticSubKBArticleId = ${subKBArticleId};
+			static var staticSubKBArticleErc = ${subKBArticleErc};
+
+			return ${staticSubKBArticleId};
+
+			return ${staticSubKBArticleErc};
+		}
+		else {
+			var kBArticleId = JSONPathUtil.getIdValue(response = ${response});
+
+			static var staticKBArticleId = ${kBArticleId};
+
+			return ${staticKBArticleId};
+		}
+	}
+
+}

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/KnowledgeBaseAttachmentAPI.macro
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/KnowledgeBaseAttachmentAPI.macro
@@ -1,0 +1,91 @@
+definition {
+
+	macro _curlKnowledgeBaseAttachment {
+		var portalURL = JSONCompany.getPortalURL();
+
+		if (isSet(knowledgeBaseArticleId)) {
+			var api = "knowledge-base-articles/${knowledgeBaseArticleId}/knowledge-base-attachments";
+		}
+		else if (isSet(knowledgeBaseAttachmentId)) {
+			var api = "knowledge-base-attachments/${knowledgeBaseAttachmentId}";
+		}
+		else {
+			var siteId = JSONGroupAPI._getGroupIdByNameNoSelenium(
+				groupName = "Guest",
+				site = "true");
+
+			var api = "sites/${siteId}/knowledge-base-articles/by-external-reference-code/${knowledgeBaseArticleExternalReferenceCode}/knowledge-base-attachments/by-external-reference-code/${externalReferenceCode}";
+		}
+
+		if (isSet(attachmentPath)) {
+			if (!(isSet(externalReferenceCode))) {
+				var externalReferenceCode = "";
+			}
+
+			var body = '''
+				-u test@liferay.com:test \
+				-H Content-Type: multipart/form-data \
+				-F file=@${attachmentPath} \
+				-F knowledgeBaseAttachment={"externalReferenceCode": "${externalReferenceCode}"}
+			''';
+
+			var curl = StringUtil.add("${portalURL}/o/headless-delivery/v1.0/${api} \"", ${body}, "");
+		}
+		else {
+			var body = '''
+				-u test@liferay.com:test \
+				-H accept: application/json
+			''';
+
+			var curl = StringUtil.add("${portalURL}/o/headless-delivery/v1.0/${api} \"", ${body}, "");
+		}
+
+		return ${curl};
+	}
+
+	macro createKnowledgeBaseAttachment {
+		Variables.assertDefined(parameterList = "${attachmentPath},${knowledgeBaseArticleId}");
+
+		var curl = KnowledgeBaseAttachmentAPI._curlKnowledgeBaseAttachment(
+			attachmentPath = ${attachmentPath},
+			externalReferenceCode = ${externalReferenceCode},
+			knowledgeBaseArticleId = ${knowledgeBaseArticleId});
+
+		var response = JSONCurlUtil.post(${curl});
+
+		return ${response};
+	}
+
+	macro deleteKBAttachmentByKBArticleErcAndKBAttachmentErc {
+		Variables.assertDefined(parameterList = "${kBAttachmentErc},${kBArticleErc}");
+
+		var curl = KnowledgeBaseAttachmentAPI._curlKnowledgeBaseAttachment(
+			externalReferenceCode = ${kBAttachmentErc},
+			knowledgeBaseArticleExternalReferenceCode = ${kBArticleErc});
+
+		var response = JSONCurlUtil.delete(${curl});
+	}
+
+	macro getKBAttachmentById {
+		Variables.assertDefined(parameterList = ${kBAttachmentId});
+
+		var curl = KnowledgeBaseAttachmentAPI._curlKnowledgeBaseAttachment(knowledgeBaseAttachmentId = ${kBAttachmentId});
+
+		var response = JSONCurlUtil.get(${curl});
+
+		return ${response};
+	}
+
+	macro getKBAttachmentByKBArticleErcAndKBAttachmentErc {
+		Variables.assertDefined(parameterList = "${kBAttachmentErc},${kBArticleErc}");
+
+		var curl = KnowledgeBaseAttachmentAPI._curlKnowledgeBaseAttachment(
+			externalReferenceCode = ${kBAttachmentErc},
+			knowledgeBaseArticleExternalReferenceCode = ${kBArticleErc});
+
+		var response = JSONCurlUtil.get(${curl});
+
+		return ${response};
+	}
+
+}

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/KnowledgeBaseFolderAPI.macro
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/KnowledgeBaseFolderAPI.macro
@@ -1,0 +1,81 @@
+definition {
+
+	macro _curlKnowledgeBaseFolder {
+		var portalURL = JSONCompany.getPortalURL();
+
+		if (isSet(parentKnowledgeBaseFolderId)) {
+			var api = "knowledge-base-folders/${parentKnowledgeBaseFolderId}/knowledge-base-folders";
+		}
+		else if (isSet(knowledgeBaseFolderId)) {
+			var api = "knowledge-base-folders/${knowledgeBaseFolderId}";
+		}
+		else {
+			var siteId = JSONGroupAPI._getGroupIdByNameNoSelenium(
+				groupName = "Guest",
+				site = "true");
+
+			var api = "sites/${siteId}/knowledge-base-folders";
+		}
+
+		if (!(isSet(externalReferenceCode))) {
+			var externalReferenceCode = "";
+		}
+
+		var curl = '''
+			${portalURL}/o/headless-delivery/v1.0/${api} \
+				-u test@liferay.com:test \
+				-H Content-Type: application/json \
+		''';
+		var body = '''"externalReferenceCode": "${externalReferenceCode}","name": "${name}"''';
+
+		if (isSet(name)) {
+			var curl = StringUtil.add(${curl}, "-d {${body}}", " ");
+		}
+
+		return ${curl};
+	}
+
+	macro createKnowledgeBaseFolder {
+		Variables.assertDefined(parameterList = ${name});
+
+		var curl = KnowledgeBaseFolderAPI._curlKnowledgeBaseFolder(
+			externalReferenceCode = ${externalReferenceCode},
+			name = ${name},
+			parentKnowledgeBaseFolderId = ${parentKnowledgeBaseFolderId});
+
+		var response = JSONCurlUtil.post(${curl}, "$.id");
+
+		return ${response};
+	}
+
+	macro deleteKnowledgeBaseFolderById {
+		Variables.assertDefined(parameterList = ${knowledgeBaseFolderId});
+
+		var curl = KnowledgeBaseFolderAPI._curlKnowledgeBaseFolder(knowledgeBaseFolderId = ${knowledgeBaseFolderId});
+
+		JSONCurlUtil.delete(${curl});
+	}
+
+	macro setUpGlobalKnowledgeBaseFolderId {
+		var response = KnowledgeBaseFolderAPI.createKnowledgeBaseFolder(
+			externalReferenceCode = ${externalReferenceCode},
+			name = ${name},
+			parentKnowledgeBaseFolderId = ${parentKnowledgeBaseFolderId});
+
+		if (isSet(parentKnowledgeBaseFolderId)) {
+			var subKBFolderId = ${response};
+
+			static var staticSubKBFolderId = ${subKBFolderId};
+
+			return ${staticSubKBFolderId};
+		}
+		else {
+			var kBFolderId = ${response};
+
+			static var staticKBFolderId = ${kBFolderId};
+
+			return ${staticKBFolderId};
+		}
+	}
+
+}

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcForKnowledgeBaseAttachment.testcase
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/tests/ExposeErcForKnowledgeBaseAttachment.testcase
@@ -1,0 +1,374 @@
+@component-name = "portal-lima"
+definition {
+
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.main.component.name = "Lima Headless";
+
+	setUp {
+		TestCase.setUpPortalInstanceNoSelenium();
+
+		task ("Given with postSiteKnowledgeBaseArticle and siteId to create a knowledge base article with externalReferenceCode") {
+			KnowledgeBaseArticleAPI.setUpGlobalKnowledgeBaseArticleIdAndErc(
+				articleBody = "KB Article Content",
+				externalReferenceCode = "KBAErc",
+				title = "KB Article Title");
+		}
+
+		task ("And Given with postKnowledgeBaseArticleKnowledgeBaseAttachment and knowledgeBaseArticleId to upload an attachment with externalReferenceCode to knowledge base article") {
+			var attachmentPath = TestCase.getDependenciesDirPath(fileName = "Document_1.jpeg");
+
+			KnowledgeBaseAttachmentAPI.createKnowledgeBaseAttachment(
+				attachmentPath = ${attachmentPath},
+				externalReferenceCode = "KBAtErc",
+				knowledgeBaseArticleId = ${staticKBArticleId});
+		}
+
+		task ("And Given with postKnowledgeBaseArticleKnowledgeBaseArticle and parentKnowledgeBaseArticleId to create a child knowledge base article") {
+			KnowledgeBaseArticleAPI.setUpGlobalKnowledgeBaseArticleIdAndErc(
+				articleBody = "Sub-KB Article Content",
+				parentKnowledgeBaseArticleId = ${staticKBArticleId},
+				title = "Sub-KB Article Title");
+		}
+
+		task ("And Given with postSiteKnowledgeBaseFolder and siteId to create a knowledgeBaseFolder") {
+			KnowledgeBaseFolderAPI.setUpGlobalKnowledgeBaseFolderId(name = "KB Folder Name");
+		}
+
+		task ("And Given with postKnowledgeBaseFolderKnowledgeBaseFolder and parentKnowledgeBaseFolderId to create a folder inside parent folder") {
+			KnowledgeBaseFolderAPI.setUpGlobalKnowledgeBaseFolderId(
+				name = "Sub-KB Folder Name",
+				parentKnowledgeBaseFolderId = ${staticKBFolderId});
+		}
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if (${testPortalInstance} == "true") {
+			PortalInstances.tearDownCPNoSelenium();
+		}
+		else {
+			KnowledgeBaseArticleAPI.deleteKnowledgeBaseArticleById(knowledgeBaseArticleId = ${staticKBArticleId});
+
+			KnowledgeBaseFolderAPI.deleteKnowledgeBaseFolderById(knowledgeBaseFolderId = ${staticKBFolderId});
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 4
+	test CanCreateAttachmentWithDefaultExternalReferenceCodeForKnowledgeBaseArticle {
+		property portal.acceptance = "true";
+
+		task ("When with postKnowledgeBaseArticleKnowledgeBaseAttachment and knowledgeBaseArticleId to upload an attachment to knowledge base article") {
+			var attachmentPath = TestCase.getDependenciesDirPath(fileName = "Document_2.jpeg");
+
+			var responseFromPost = KnowledgeBaseAttachmentAPI.createKnowledgeBaseAttachment(
+				attachmentPath = ${attachmentPath},
+				knowledgeBaseArticleId = ${staticKBArticleId});
+		}
+
+		task ("Then the knowledgeBaseAttachment with externalReferenceCode is created") {
+			var kBAttachmentId = JSONPathUtil.getIdValue(response = ${responseFromPost});
+			var kBAttachmentErc = JSONPathUtil.getErcValue(response = ${responseFromPost});
+			var responseFromGet = KnowledgeBaseAttachmentAPI.getKBAttachmentById(kBAttachmentId = ${kBAttachmentId});
+
+			var actualValue = JSONPathUtil.getErcValue(response = ${responseFromGet});
+
+			TestUtils.assertEquals(
+				actual = ${actualValue},
+				expected = ${kBAttachmentErc});
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 4
+	test CanCreateAttachmentWithExternalReferenceCodeForChildKnowledgeBaseArticle {
+		property portal.acceptance = "true";
+
+		task ("When with postKnowledgeBaseArticleKnowledgeBaseAttachment and knowledgeBaseArticleId to upload an attachment with custom externalReferenceCode to the child knowledge base article") {
+			var attachmentPath = TestCase.getDependenciesDirPath(fileName = "Document_2.jpeg");
+
+			var responseFromPost = KnowledgeBaseAttachmentAPI.createKnowledgeBaseAttachment(
+				attachmentPath = ${attachmentPath},
+				externalReferenceCode = "SubKBAtErc",
+				knowledgeBaseArticleId = ${staticSubKBArticleId});
+		}
+
+		task ("Then the knowledgeBaseAttachment with custom externalReferenceCode is created") {
+			var kBAttachmentId = JSONPathUtil.getIdValue(response = ${responseFromPost});
+
+			var responseFromGet = KnowledgeBaseAttachmentAPI.getKBAttachmentById(kBAttachmentId = ${kBAttachmentId});
+
+			var actualValue = JSONPathUtil.getErcValue(response = ${responseFromGet});
+
+			TestUtils.assertEquals(
+				actual = ${actualValue},
+				expected = "SubKBAtErc");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 4
+	test CanCreateAttachmentWithExternalReferenceCodeForKnowledgeBaseArticleInChildFolder {
+		property portal.acceptance = "true";
+
+		task ("And Given with postKnowledgeBaseFolderKnowledgeBaseArticle and knowledgeBaseFolderId to create a knowledge base article with externalReferenceCode inside child folder") {
+			var responseFromPost = KnowledgeBaseArticleAPI.createKnowledgeBaseArticle(
+				articleBody = "KBF_1 Article Content",
+				externalReferenceCode = "KBF_1AErc",
+				knowledgeBaseFolderId = ${staticSubKBFolderId},
+				title = "KBF_1 Article Title");
+		}
+
+		task ("When with postKnowledgeBaseArticleKnowledgeBaseAttachment and knowledgeBaseArticleId to upload an attachment with externalReferenceCode to knowledge base article") {
+			var attachmentPath = TestCase.getDependenciesDirPath(fileName = "Document_2.jpeg");
+			var knowledgeBaseArticleId = JSONPathUtil.getIdValue(response = ${responseFromPost});
+
+			var responseFromPost = KnowledgeBaseAttachmentAPI.createKnowledgeBaseAttachment(
+				attachmentPath = ${attachmentPath},
+				externalReferenceCode = "KBF_1AtErc",
+				knowledgeBaseArticleId = ${knowledgeBaseArticleId});
+		}
+
+		task ("Then the knowledgeBaseAttachment with custom externalReferenceCode is created") {
+			var kBAttachmentId = JSONPathUtil.getIdValue(response = ${responseFromPost});
+
+			var responseFromGet = KnowledgeBaseAttachmentAPI.getKBAttachmentById(kBAttachmentId = ${kBAttachmentId});
+
+			var actualValue = JSONPathUtil.getErcValue(response = ${responseFromGet});
+
+			TestUtils.assertEquals(
+				actual = ${actualValue},
+				expected = "KBF_1AtErc");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 4
+	test CanCreateAttachmentWithExternalReferenceCodeForKnowledgeBaseArticleInFolder {
+		property portal.acceptance = "true";
+
+		task ("And Given with postKnowledgeBaseFolderKnowledgeBaseArticle and knowledgeBaseFolderId to create a knowledge base article with externalReferenceCode") {
+			var responseFromPost = KnowledgeBaseArticleAPI.createKnowledgeBaseArticle(
+				articleBody = "KBF Article Content",
+				externalReferenceCode = "KBFAErc",
+				knowledgeBaseFolderId = ${staticKBFolderId},
+				title = "KBF Article Title");
+		}
+
+		task ("When with postKnowledgeBaseArticleKnowledgeBaseAttachment and knowledgeBaseArticleId to upload an attachment with externalReferenceCode to knowledge base article") {
+			var attachmentPath = TestCase.getDependenciesDirPath(fileName = "Document_2.jpeg");
+			var knowledgeBaseArticleId = JSONPathUtil.getIdValue(response = ${responseFromPost});
+
+			var responseFromPost = KnowledgeBaseAttachmentAPI.createKnowledgeBaseAttachment(
+				attachmentPath = ${attachmentPath},
+				externalReferenceCode = "KBFAtErc",
+				knowledgeBaseArticleId = ${knowledgeBaseArticleId});
+		}
+
+		task ("Then the knowledgeBaseAttachment with custom externalReferenceCode is created") {
+			var kBAttachmentId = JSONPathUtil.getIdValue(response = ${responseFromPost});
+
+			var responseFromGet = KnowledgeBaseAttachmentAPI.getKBAttachmentById(kBAttachmentId = ${kBAttachmentId});
+
+			var actualValue = JSONPathUtil.getErcValue(response = ${responseFromGet});
+
+			TestUtils.assertEquals(
+				actual = ${actualValue},
+				expected = "KBFAtErc");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 3
+	test CanDeleteAttachementForKnowledgeBaseArticleByExternalReferenceCode {
+		property portal.acceptance = "true";
+
+		task ("When with deleteSiteKnowledgeBaseArticleByExternalReferenceCodeKnowledgeBaseArticleExternalReferenceCodeKnowledgeBaseAttachmentByExternalReferenceCode and siteId and knowledgeBaseExternalReferenceCode and knowledgeBaseAttachmentExternalReferenceCode to delete the knwoledgeBaseAttachment") {
+			KnowledgeBaseAttachmentAPI.deleteKBAttachmentByKBArticleErcAndKBAttachmentErc(
+				kBArticleErc = "KBAErc",
+				kBAttachmentErc = "KBAtErc");
+		}
+
+		task ("Then the knowledgeBaseAttachment is deleted") {
+			var response = KnowledgeBaseAttachmentAPI.getKBAttachmentByKBArticleErcAndKBAttachmentErc(
+				kBArticleErc = "KBAErc",
+				kBAttachmentErc = "KBAtErc");
+
+			var actualValue = JSONUtil.getWithJSONPath(${response}, "$.title");
+
+			TestUtils.assertPartialEquals(
+				actual = ${actualValue},
+				expected = "No DLFileEntry exists with the key");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 4
+	test CanDeleteAttachmentForKnowledgeBaseArticleInFolderByExternalReferenceCode {
+		property portal.acceptance = "true";
+
+		task ("And Given with postKnowledgeBaseFolderKnowledgeBaseArticle and knowledgeBaseFolderId to create a knowledge base article with externalReferenceCode") {
+			var responseFromPost = KnowledgeBaseArticleAPI.createKnowledgeBaseArticle(
+				articleBody = "KBF Article Content",
+				externalReferenceCode = "KBFAErc",
+				knowledgeBaseFolderId = ${staticKBFolderId},
+				title = "KBF Article Title");
+		}
+
+		task ("And Given with postKnowledgeBaseArticleKnowledgeBaseAttachment and knowledgeBaseArticleId to upload an attachment with externalReferenceCode to knowledge base article in folder") {
+			var attachmentPath = TestCase.getDependenciesDirPath(fileName = "Document_2.jpeg");
+			var knowledgeBaseArticleId = JSONPathUtil.getIdValue(response = ${responseFromPost});
+
+			KnowledgeBaseAttachmentAPI.createKnowledgeBaseAttachment(
+				attachmentPath = ${attachmentPath},
+				externalReferenceCode = "KBFAtErc",
+				knowledgeBaseArticleId = ${knowledgeBaseArticleId});
+		}
+
+		task ("When with deleteSiteKnowledgeBaseArticleByExternalReferenceCodeKnowledgeBaseArticleExternalReferenceCodeKnowledgeBaseAttachmentByExternalReferenceCode and siteId and knowledgeBaseExternalReferenceCode and knowledgeBaseAttachmentExternalReferenceCode to delete the attachment for knowledgeBaseArticle in folder") {
+			KnowledgeBaseAttachmentAPI.deleteKBAttachmentByKBArticleErcAndKBAttachmentErc(
+				kBArticleErc = "KBFAErc",
+				kBAttachmentErc = "KBFAtErc");
+		}
+
+		task ("Then the knowledgeBaseAttachment in folder is deleted") {
+			var response = KnowledgeBaseAttachmentAPI.getKBAttachmentByKBArticleErcAndKBAttachmentErc(
+				kBArticleErc = "KBFAErc",
+				kBAttachmentErc = "KBFAtErc");
+
+			var actualValue = JSONUtil.getWithJSONPath(${response}, "$.title");
+
+			TestUtils.assertPartialEquals(
+				actual = ${actualValue},
+				expected = "No DLFileEntry exists with the key");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 4
+	test CanGetAttachmentForChildKnowledgeBaseArticleByExternalReferenceCode {
+		property portal.acceptance = "true";
+
+		task ("And Given with postKnowledgeBaseArticleKnowledgeBaseAttachment and knowledgeBaseArticleId to upload an attachment with externalReferenceCode to the child knowledge base article") {
+			var attachmentPath = TestCase.getDependenciesDirPath(fileName = "Document_2.jpeg");
+
+			KnowledgeBaseAttachmentAPI.createKnowledgeBaseAttachment(
+				attachmentPath = ${attachmentPath},
+				externalReferenceCode = "SubKBAtErc",
+				knowledgeBaseArticleId = ${staticSubKBArticleId});
+		}
+
+		task ("When with getSiteKnowledgeBaseArticleByExternalReferenceCodeKnowledgeBaseArticleExternalReferenceCodeKnowledgeBaseAttachmentByExternalReferenceCode and knowledgeBaseExternalReferenceCode and knowledgeBaseAttachmentExternalReferenceCode to retrieve the attachment for child knowledgeBaseArticle") {
+			var response = KnowledgeBaseAttachmentAPI.getKBAttachmentByKBArticleErcAndKBAttachmentErc(
+				kBArticleErc = ${staticSubKBArticleErc},
+				kBAttachmentErc = "SubKBAtErc");
+		}
+
+		task ("Then I can see details of the knowledgeBaseAttachment") {
+			var actualValue = JSONUtil.getWithJSONPath(${response}, "$.[?(@.externalReferenceCode=='SubKBAtErc')].title");
+
+			TestUtils.assertEquals(
+				actual = ${actualValue},
+				expected = "Document_2.jpeg");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 4
+	test CanGetAttachmentForKnowledgeBaseArticleByExternalReferenceCode {
+		property portal.acceptance = "true";
+
+		task ("When with getSiteKnowledgeBaseArticleByExternalReferenceCodeKnowledgeBaseArticleExternalReferenceCodeKnowledgeBaseAttachmentByExternalReferenceCode and knowledgeBaseExternalReferenceCode and knowledgeBaseAttachmentExternalReferenceCode to retrieve the knwoledgeBaseAttachment") {
+			var response = KnowledgeBaseAttachmentAPI.getKBAttachmentByKBArticleErcAndKBAttachmentErc(
+				kBArticleErc = "KBAErc",
+				kBAttachmentErc = "KBAtErc");
+		}
+
+		task ("Then I can see details of the knowledgeBaseAttachment") {
+			var actualValue = JSONUtil.getWithJSONPath(${response}, "$.[?(@.externalReferenceCode=='KBAtErc')].title");
+
+			TestUtils.assertEquals(
+				actual = ${actualValue},
+				expected = "Document_1.jpeg");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 4
+	test CanGetAttachmentForKnowledgeBaseArticleInChildFolderByExternalReferenceCode {
+		property portal.acceptance = "true";
+
+		task ("And Given with postKnowledgeBaseFolderKnowledgeBaseArticle and knowledgeBaseFolderId to create a knowledge base article with externalReferenceCode inside child folder") {
+			var responseFromPost = KnowledgeBaseArticleAPI.createKnowledgeBaseArticle(
+				articleBody = "KBF_1 Article Content",
+				externalReferenceCode = "KBF_1AErc",
+				knowledgeBaseFolderId = ${staticSubKBFolderId},
+				title = "KBF_1 Article Title");
+		}
+
+		task ("And Given with postKnowledgeBaseArticleKnowledgeBaseAttachment and knowledgeBaseArticleId to upload an attachment with externalReferenceCode to knowledge base article inside child folder") {
+			var attachmentPath = TestCase.getDependenciesDirPath(fileName = "Document_2.jpeg");
+			var knowledgeBaseArticleId = JSONPathUtil.getIdValue(response = ${responseFromPost});
+
+			KnowledgeBaseAttachmentAPI.createKnowledgeBaseAttachment(
+				attachmentPath = ${attachmentPath},
+				externalReferenceCode = "KBF_1AtErc",
+				knowledgeBaseArticleId = ${knowledgeBaseArticleId});
+		}
+
+		task ("When with getSiteKnowledgeBaseArticleByExternalReferenceCodeKnowledgeBaseArticleExternalReferenceCodeKnowledgeBaseAttachmentByExternalReferenceCode and knowledgeBaseExternalReferenceCode and knowledgeBaseAttachmentExternalReferenceCode to retrieve the attachment for knowledgeBaseArticle inside child folder") {
+			var response = KnowledgeBaseAttachmentAPI.getKBAttachmentByKBArticleErcAndKBAttachmentErc(
+				kBArticleErc = "KBF_1AErc",
+				kBAttachmentErc = "KBF_1AtErc");
+		}
+
+		task ("Then I can see details of the knowledgeBaseAttachment") {
+			var actualValue = JSONUtil.getWithJSONPath(${response}, "$.[?(@.externalReferenceCode=='KBF_1AtErc')].title");
+
+			TestUtils.assertEquals(
+				actual = ${actualValue},
+				expected = "Document_2.jpeg");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 4
+	test CanGetAttachmentForKnowledgeBaseArticleInFolderByExternalReferenceCode {
+		property portal.acceptance = "true";
+
+		task ("And Given with postKnowledgeBaseFolderKnowledgeBaseArticle and knowledgeBaseFolderId to create a knowledge base article with externalReferenceCode") {
+			var responseFromPost = KnowledgeBaseArticleAPI.createKnowledgeBaseArticle(
+				articleBody = "KBF Article Content",
+				externalReferenceCode = "KBFAErc",
+				knowledgeBaseFolderId = ${staticKBFolderId},
+				title = "KBF Article Title");
+		}
+
+		task ("And Given with postKnowledgeBaseArticleKnowledgeBaseAttachment and knowledgeBaseArticleId to upload an attachment with externalReferenceCode to knowledge base article in folder") {
+			var attachmentPath = TestCase.getDependenciesDirPath(fileName = "Document_2.jpeg");
+			var knowledgeBaseArticleId = JSONPathUtil.getIdValue(response = ${responseFromPost});
+
+			KnowledgeBaseAttachmentAPI.createKnowledgeBaseAttachment(
+				attachmentPath = ${attachmentPath},
+				externalReferenceCode = "KBFAtErc",
+				knowledgeBaseArticleId = ${knowledgeBaseArticleId});
+		}
+
+		task ("When with getSiteKnowledgeBaseArticleByExternalReferenceCodeKnowledgeBaseArticleExternalReferenceCodeKnowledgeBaseAttachmentByExternalReferenceCode and knowledgeBaseExternalReferenceCode and knowledgeBaseAttachmentExternalReferenceCode to retrieve the attachment for knowledgeBaseArticle in folder") {
+			var response = KnowledgeBaseAttachmentAPI.getKBAttachmentByKBArticleErcAndKBAttachmentErc(
+				kBArticleErc = "KBFAErc",
+				kBAttachmentErc = "KBFAtErc");
+		}
+
+		task ("Then I can see details of the knowledgeBaseAttachment") {
+			var actualValue = JSONUtil.getWithJSONPath(${response}, "$.[?(@.externalReferenceCode=='KBFAtErc')].title");
+
+			TestUtils.assertEquals(
+				actual = ${actualValue},
+				expected = "Document_2.jpeg");
+		}
+	}
+
+}


### PR DESCRIPTION
**Background:**
Add a testcase to expose ERC for KB Attachment

**Test Plan**
**Background**
Given with postSiteKnowledgeBaseArticle and siteId to create a knowledge base article with externalReferenceCode
And Given with postKnowledgeBaseArticleKnowledgeBaseAttachment and knowledgeBaseArticleId to upload an attachment with externalReferenceCode to knowledge base article
And Given with postKnowledgeBaseArticleKnowledgeBaseArticle and parentKnowledgeBaseArticleId to create a child knowledge base article
And Given with postSiteKnowledgeBaseFolder and siteId to create a knowledgeBaseFolder
And Given with postKnowledgeBaseFolderKnowledgeBaseFolder and parentKnowledgeBaseFolderId to create a folder inside parent folder

CanCreateAttachmentWithDefaultExternalReferenceCodeForKnowledgeBaseArticle
When with postKnowledgeBaseArticleKnowledgeBaseAttachment and knowledgeBaseArticleId to upload an attachment to knowledge base article
Then the knowledgeBaseAttachment with externalReferenceCode is created

CanCreateAttachmentWithExternalReferenceCodeForChildKnowledgeBaseArticle
When with postKnowledgeBaseArticleKnowledgeBaseAttachment and knowledgeBaseArticleId to upload an attachment with custom externalReferenceCode to the child knowledge base article
Then the knowledgeBaseAttachment with custom externalReferenceCode is created

CanCreateAttachmentWithExternalReferenceCodeForKnowledgeBaseArticleInFolder
And Given with postKnowledgeBaseFolderKnowledgeBaseArticle and knowledgeBaseFolderId to create a knowledge base article with externalReferenceCode
When with postKnowledgeBaseArticleKnowledgeBaseAttachment and knowledgeBaseArticleId to upload an attachment with externalReferenceCode to knowledge base article
Then the knowledgeBaseAttachment with custom externalReferenceCode is created

CanCreateAttachmentWithExternalReferenceCodeForKnowledgeBaseArticleInChildFolder
And Given with postKnowledgeBaseFolderKnowledgeBaseArticle and knowledgeBaseFolderId to create a knowledge base article with externalReferenceCode inside child folder
When with postKnowledgeBaseArticleKnowledgeBaseAttachment and knowledgeBaseArticleId to upload an attachment with externalReferenceCode to knowledge base article
Then the knowledgeBaseAttachment with custom externalReferenceCode is created

CanGetAttachmentForKnowledgeBaseArticleByExternalReferenceCode
When with getSiteKnowledgeBaseArticleByExternalReferenceCodeKnowledgeBaseArticleExternalReferenceCodeKnowledgeBaseAttachmentByExternalReferenceCode and knowledgeBaseExternalReferenceCode and knowledgeBaseAttachmentExternalReferenceCode to retrieve the knwoledgeBaseAttachment
Then I can see details of the knowledgeBaseAttachment

CanGetAttachmentForChildKnowledgeBaseArticleByExternalReferenceCode
And Given with postKnowledgeBaseArticleKnowledgeBaseAttachment and knowledgeBaseArticleId to upload an attachment with externalReferenceCode to the child knowledge base article
When with getSiteKnowledgeBaseArticleByExternalReferenceCodeKnowledgeBaseArticleExternalReferenceCodeKnowledgeBaseAttachmentByExternalReferenceCode and knowledgeBaseExternalReferenceCode and knowledgeBaseAttachmentExternalReferenceCode to retrieve the attachment for child knowledgeBaseArticle
Then I can see details of the knowledgeBaseAttachment

CanGetAttachmentForKnowledgeBaseArticleInFolderByExternalReferenceCode
And Given with postKnowledgeBaseFolderKnowledgeBaseArticle and knowledgeBaseFolderId to create a knowledge base article with externalReferenceCode
And Given with postKnowledgeBaseArticleKnowledgeBaseAttachment and knowledgeBaseArticleId to upload an attachment with externalReferenceCode to knowledge base article in folder
When with getSiteKnowledgeBaseArticleByExternalReferenceCodeKnowledgeBaseArticleExternalReferenceCodeKnowledgeBaseAttachmentByExternalReferenceCode and knowledgeBaseExternalReferenceCode and knowledgeBaseAttachmentExternalReferenceCode to retrieve the attachment for knowledgeBaseArticle in folder
Then I can see details of the knowledgeBaseAttachment

CanGetAttachmentForKnowledgeBaseArticleInChildFolderByExternalReferenceCode
And Given with postKnowledgeBaseFolderKnowledgeBaseArticle and knowledgeBaseFolderId to create a knowledge base article with externalReferenceCode inside child folder
And Given with postKnowledgeBaseArticleKnowledgeBaseAttachment and knowledgeBaseArticleId to upload an attachment with externalReferenceCode to knowledge base article inside child folder
When with getSiteKnowledgeBaseArticleByExternalReferenceCodeKnowledgeBaseArticleExternalReferenceCodeKnowledgeBaseAttachmentByExternalReferenceCode and knowledgeBaseExternalReferenceCode and knowledgeBaseAttachmentExternalReferenceCode to retrieve the attachment for knowledgeBaseArticle inside child folder
Then I can see details of the knowledgeBaseAttachment

CanDeleteAttachementForKnowledgeBaseArticleByExternalReferenceCode
When with deleteSiteKnowledgeBaseArticleByExternalReferenceCodeKnowledgeBaseArticleExternalReferenceCodeKnowledgeBaseAttachmentByExternalReferenceCode and siteId and knowledgeBaseExternalReferenceCode and knowledgeBaseAttachmentExternalReferenceCode to delete the knwoledgeBaseAttachment Then the knowledgeBaseAttachment is deleted

CanDeleteAttachmentForKnowledgeBaseArticleInFolderByExternalReferenceCode
And Given with postKnowledgeBaseFolderKnowledgeBaseArticle and knowledgeBaseFolderId to create a knowledge base article with externalReferenceCode And Given with postKnowledgeBaseArticleKnowledgeBaseAttachment and knowledgeBaseArticleId to upload an attachment with externalReferenceCode to knowledge base article in folder When with deleteSiteKnowledgeBaseArticleByExternalReferenceCodeKnowledgeBaseArticleExternalReferenceCodeKnowledgeBaseAttachmentByExternalReferenceCode and siteId and knowledgeBaseExternalReferenceCode and knowledgeBaseAttachmentExternalReferenceCode to delete the attachment for knowledgeBaseArticle in folder Then the knowledgeBaseAttachment in folder is deleted

**Jira ticket:**
https://issues.liferay.com/browse/LPS-164940