### PR TITLE
LPS-186733: Support new PUT functionality in relationships with System Object and Custom Objects

### DIFF
--- a/modules/apps/object/object-rest-api/bnd.bnd
+++ b/modules/apps/object/object-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object REST API
 Bundle-SymbolicName: com.liferay.object.rest.api
-Bundle-Version: 16.0.1
+Bundle-Version: 16.1.0
 Export-Package:\
 	com.liferay.object.rest.dto.v1_0,\
 	com.liferay.object.rest.dto.v1_0.util,\

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/DefaultObjectEntryManager.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/DefaultObjectEntryManager.java
@@ -48,6 +48,12 @@ public interface DefaultObjectEntryManager extends ObjectEntryManager {
 			ObjectDefinition objectDefinition, long objectEntryId)
 		throws Exception;
 
+	public void disassociateRelatedModels(
+			long primaryKey, ObjectDefinition objectDefinition,
+			ObjectRelationship objectRelationship,
+			ObjectDefinition relatedObjectDefinition, long userId)
+		throws Exception;
+
 	public void executeObjectAction(
 			DTOConverterContext dtoConverterContext, String objectActionName,
 			ObjectDefinition objectDefinition, long objectEntryId)

--- a/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/manager/v1_0/packageinfo
+++ b/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/manager/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 11.0.0
+version 11.1.0

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -239,6 +239,46 @@ public class DefaultObjectEntryManagerImpl
 	}
 
 	@Override
+	public void disassociateRelatedModels(
+			long primaryKey, ObjectDefinition objectDefinition,
+			ObjectRelationship objectRelationship,
+			ObjectDefinition relatedObjectDefinition, long userId)
+		throws Exception {
+
+		ObjectRelatedModelsProvider objectRelatedModelsProvider =
+			_objectRelatedModelsProviderRegistry.getObjectRelatedModelsProvider(
+				relatedObjectDefinition.getClassName(),
+				relatedObjectDefinition.getCompanyId(),
+				objectRelationship.getType());
+
+		if ((objectRelationship.getObjectDefinitionId1() !=
+				objectDefinition.getObjectDefinitionId()) &&
+			Objects.equals(
+				ObjectRelationshipConstants.TYPE_MANY_TO_MANY,
+				objectRelationship.getType())) {
+
+			objectRelationship =
+				_objectRelationshipLocalService.getObjectRelationship(
+					objectDefinition.getObjectDefinitionId(),
+					objectRelationship.getName());
+		}
+
+		for (Object objectRelatedModel :
+				objectRelatedModelsProvider.getRelatedModels(
+					GroupThreadLocal.getGroupId(),
+					objectRelationship.getObjectRelationshipId(), primaryKey,
+					-1, -1)) {
+
+			com.liferay.object.model.ObjectEntry relatedObjectEntry =
+				(com.liferay.object.model.ObjectEntry)objectRelatedModel;
+
+			objectRelatedModelsProvider.disassociateRelatedModels(
+				userId, objectRelationship.getObjectRelationshipId(),
+				primaryKey, relatedObjectEntry.getObjectEntryId());
+		}
+	}
+
+	@Override
 	public void executeObjectAction(
 			DTOConverterContext dtoConverterContext, String objectActionName,
 			ObjectDefinition objectDefinition, long objectEntryId)

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/ObjectRelationshipExtensionProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/ObjectRelationshipExtensionProvider.java
@@ -17,6 +17,7 @@ package com.liferay.object.rest.internal.vulcan.extension.v1_0;
 import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectRelationship;
+import com.liferay.object.related.models.ObjectRelatedModelsProviderRegistry;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
 import com.liferay.object.rest.manager.v1_0.DefaultObjectEntryManager;
 import com.liferay.object.rest.manager.v1_0.DefaultObjectEntryManagerProvider;
@@ -221,9 +222,20 @@ public class ObjectRelationshipExtensionProvider
 						relatedObjectDefinition.getCompanyId(),
 						objectRelationship.getType());
 
+			DefaultObjectEntryManager defaultObjectEntryManager =
+				DefaultObjectEntryManagerProvider.provide(
+					_objectEntryManagerRegistry.getObjectEntryManager(
+						objectDefinition.getStorageType()));
+
 			List<ObjectEntry> nestedObjectEntries =
 				objectRelationshipElementsParser.parse(
 					objectRelationship, entry.getValue());
+
+			if (!nestedObjectEntries.isEmpty()) {
+				defaultObjectEntryManager.disassociateRelatedModels(
+					getPrimaryKey(entity), objectDefinition, objectRelationship,
+					relatedObjectDefinition, userId);
+			}
 
 			for (ObjectEntry nestedObjectEntry : nestedObjectEntries) {
 				nestedObjectEntry = objectEntryManager.updateObjectEntry(
@@ -323,6 +335,10 @@ public class ObjectRelationshipExtensionProvider
 
 	@Reference
 	private ObjectEntryManagerRegistry _objectEntryManagerRegistry;
+
+	@Reference
+	private ObjectRelatedModelsProviderRegistry
+		_objectRelatedModelsProviderRegistry;
 
 	@Reference
 	private ObjectRelationshipElementsParserRegistry

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/SystemObjectRelatedObjectEntriesTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/SystemObjectRelatedObjectEntriesTest.java
@@ -493,6 +493,35 @@ public class SystemObjectRelatedObjectEntriesTest {
 	}
 
 	@Test
+	public void testPutSystemObjectEntryWithNestedCustomObjectEntriesByExternalReferenceCode()
+		throws Exception {
+
+		// Many to many relationship
+
+		ObjectRelationship objectRelationship =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_userSystemObjectDefinition, _objectDefinition,
+				_user.getUserId(),
+				ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		_objectRelationships.add(objectRelationship);
+
+		_testPutSystemObjectEntryWithNestedCustomObjectEntriesByExternalReferenceCode(
+			objectRelationship);
+
+		// One to many relationship
+
+		objectRelationship = ObjectRelationshipTestUtil.addObjectRelationship(
+			_userSystemObjectDefinition, _objectDefinition, _user.getUserId(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		_objectRelationships.add(objectRelationship);
+
+		_testPutSystemObjectEntryWithNestedCustomObjectEntriesByExternalReferenceCode(
+			objectRelationship);
+	}
+
+	@Test
 	public void testPutSystemObjectEntryWithNestedCustomObjectEntriesInManyToOneRelationship()
 		throws Exception {
 
@@ -517,6 +546,47 @@ public class SystemObjectRelatedObjectEntriesTest {
 			).build());
 
 		UserAccountTestUtil.updateUserAccountJSONObject(
+			_userSystemObjectDefinitionManager, jsonObject,
+			HashMapBuilder.<String, Serializable>put(
+				objectRelationship.getName(),
+				JSONFactoryUtil.createJSONObject(
+					JSONUtil.put(
+						_OBJECT_FIELD_NAME, _NEW_OBJECT_FIELD_VALUE_1
+					).put(
+						"externalReferenceCode", _ERC_VALUE_1
+					).toString())
+			).build());
+
+		_assertObjectEntryField(
+			_getObjectEntryByExternalReferenceCodeJSONObject(_ERC_VALUE_1),
+			_OBJECT_FIELD_NAME, _NEW_OBJECT_FIELD_VALUE_1);
+	}
+
+	@Test
+	public void testPutSystemObjectEntryWithNestedCustomObjectEntriesInManyToOneRelationshipByExternalReferenceCode()
+		throws Exception {
+
+		ObjectRelationship objectRelationship =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectDefinition, _userSystemObjectDefinition,
+				_user.getUserId(),
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		_objectRelationships.add(objectRelationship);
+
+		JSONObject jsonObject = UserAccountTestUtil.addUserAccountJSONObject(
+			_userSystemObjectDefinitionManager,
+			HashMapBuilder.<String, Serializable>put(
+				objectRelationship.getName(),
+				JSONFactoryUtil.createJSONObject(
+					JSONUtil.put(
+						_OBJECT_FIELD_NAME, RandomTestUtil.randomString()
+					).put(
+						"externalReferenceCode", _ERC_VALUE_1
+					).toString())
+			).build());
+
+		UserAccountTestUtil.updateUserAccountByExternalReferenceCodeJSONObject(
 			_userSystemObjectDefinitionManager, jsonObject,
 			HashMapBuilder.<String, Serializable>put(
 				objectRelationship.getName(),
@@ -819,6 +889,60 @@ public class SystemObjectRelatedObjectEntriesTest {
 					new String[] {_ERC_VALUE_1}, _OBJECT_FIELD_NAME,
 					new String[] {_NEW_OBJECT_FIELD_VALUE_1})
 			).build());
+
+		JSONArray nestedObjectEntriesJSONArray = jsonObject.getJSONArray(
+			objectRelationship.getName());
+
+		Assert.assertEquals(1, nestedObjectEntriesJSONArray.length());
+
+		_assertObjectEntryField(
+			(JSONObject)nestedObjectEntriesJSONArray.get(0), _OBJECT_FIELD_NAME,
+			_NEW_OBJECT_FIELD_VALUE_1);
+
+		jsonObject = HTTPTestUtil.invoke(
+			null,
+			_getLocation(
+				jsonObject.getString("id"), objectRelationship.getName()),
+			Http.Method.GET);
+
+		nestedObjectEntriesJSONArray = jsonObject.getJSONArray(
+			objectRelationship.getName());
+
+		Assert.assertEquals(1, nestedObjectEntriesJSONArray.length());
+
+		_assertObjectEntryField(
+			(JSONObject)nestedObjectEntriesJSONArray.get(0), _OBJECT_FIELD_NAME,
+			_NEW_OBJECT_FIELD_VALUE_1);
+	}
+
+	private void
+			_testPutSystemObjectEntryWithNestedCustomObjectEntriesByExternalReferenceCode(
+				ObjectRelationship objectRelationship)
+		throws Exception {
+
+		JSONObject jsonObject = UserAccountTestUtil.addUserAccountJSONObject(
+			_userSystemObjectDefinitionManager,
+			HashMapBuilder.<String, Serializable>put(
+				objectRelationship.getName(),
+				_createObjectEntriesJSONArray(
+					new String[] {_ERC_VALUE_1, _ERC_VALUE_2},
+					_OBJECT_FIELD_NAME,
+					new String[] {
+						RandomTestUtil.randomString(),
+						RandomTestUtil.randomString()
+					})
+			).build());
+
+		jsonObject =
+			UserAccountTestUtil.
+				updateUserAccountByExternalReferenceCodeJSONObject(
+					_userSystemObjectDefinitionManager, jsonObject,
+					HashMapBuilder.<String, Serializable>put(
+						objectRelationship.getName(),
+						_createObjectEntriesJSONArray(
+							new String[] {_ERC_VALUE_1}, _OBJECT_FIELD_NAME,
+							new String[] {_NEW_OBJECT_FIELD_VALUE_1})
+					).build());
 
 		JSONArray nestedObjectEntriesJSONArray = jsonObject.getJSONArray(
 			objectRelationship.getName());

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/SystemObjectRelatedObjectEntriesTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/SystemObjectRelatedObjectEntriesTest.java
@@ -816,24 +816,18 @@ public class SystemObjectRelatedObjectEntriesTest {
 			HashMapBuilder.<String, Serializable>put(
 				objectRelationship.getName(),
 				_createObjectEntriesJSONArray(
-					new String[] {_ERC_VALUE_1, _ERC_VALUE_2},
-					_OBJECT_FIELD_NAME,
-					new String[] {
-						_NEW_OBJECT_FIELD_VALUE_1, _NEW_OBJECT_FIELD_VALUE_2
-					})
+					new String[] {_ERC_VALUE_1}, _OBJECT_FIELD_NAME,
+					new String[] {_NEW_OBJECT_FIELD_VALUE_1})
 			).build());
 
 		JSONArray nestedObjectEntriesJSONArray = jsonObject.getJSONArray(
 			objectRelationship.getName());
 
-		Assert.assertEquals(2, nestedObjectEntriesJSONArray.length());
+		Assert.assertEquals(1, nestedObjectEntriesJSONArray.length());
 
 		_assertObjectEntryField(
 			(JSONObject)nestedObjectEntriesJSONArray.get(0), _OBJECT_FIELD_NAME,
 			_NEW_OBJECT_FIELD_VALUE_1);
-		_assertObjectEntryField(
-			(JSONObject)nestedObjectEntriesJSONArray.get(1), _OBJECT_FIELD_NAME,
-			_NEW_OBJECT_FIELD_VALUE_2);
 
 		jsonObject = HTTPTestUtil.invoke(
 			null,
@@ -844,14 +838,11 @@ public class SystemObjectRelatedObjectEntriesTest {
 		nestedObjectEntriesJSONArray = jsonObject.getJSONArray(
 			objectRelationship.getName());
 
-		Assert.assertEquals(2, nestedObjectEntriesJSONArray.length());
+		Assert.assertEquals(1, nestedObjectEntriesJSONArray.length());
 
 		_assertObjectEntryField(
 			(JSONObject)nestedObjectEntriesJSONArray.get(0), _OBJECT_FIELD_NAME,
 			_NEW_OBJECT_FIELD_VALUE_1);
-		_assertObjectEntryField(
-			(JSONObject)nestedObjectEntriesJSONArray.get(1), _OBJECT_FIELD_NAME,
-			_NEW_OBJECT_FIELD_VALUE_2);
 	}
 
 	private static final String _ERC_VALUE_1 = RandomTestUtil.randomString();

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/util/UserAccountTestUtil.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/util/UserAccountTestUtil.java
@@ -88,6 +88,25 @@ public class UserAccountTestUtil {
 		};
 	}
 
+	public static JSONObject updateUserAccountByExternalReferenceCodeJSONObject(
+			SystemObjectDefinitionManager systemObjectDefinitionManager,
+			JSONObject userAccountJSONObject, Map<String, Serializable> values)
+		throws Exception {
+
+		UserAccount userAccount = randomUserAccount();
+
+		JaxRsApplicationDescriptor jaxRsApplicationDescriptor =
+			systemObjectDefinitionManager.getJaxRsApplicationDescriptor();
+
+		return HTTPTestUtil.invoke(
+			_toBody(userAccount, values),
+			StringBundler.concat(
+				jaxRsApplicationDescriptor.getRESTContextPath(),
+				"/by-external-reference-code/",
+				userAccountJSONObject.get("externalReferenceCode")),
+			Http.Method.PUT);
+	}
+
 	public static JSONObject updateUserAccountJSONObject(
 			SystemObjectDefinitionManager systemObjectDefinitionManager,
 			JSONObject userAccountJSONObject, Map<String, Serializable> values)


### PR DESCRIPTION
**What is new?**
- Support new PUT functionality in `putByExternalReferenceCode` in System Objects endpoint to update/upsert nested entities.
- Implement `dissasociateRelatedModels` method to dissasociate given a relationship when the nested entity is not indicated in the body part of a request in `DefaultObjectEntryManager`.
- Update some test cases.

**Note**: To test this functionality, it is necessary to have these feature flags activated:
- `feature.flag.LPS-153117=true`
- `feature.flag.LPS-165819=true`

**Note**: This functionality is going to be apply for:
- `Many-to-Many`: System with Custom. 
- `One-to-Many`: System with Custom.
- `Many-to-One`: System with Custom


**How to tests it?**
- Deploy `object-rest-api` and `object-rest-impl`.

**Related JIRA Ticket**
https://issues.liferay.com/browse/LPS-186733
https://issues.liferay.com/browse/LPS-186776