### PR TITLE
LPS-184728 Register the companyId for the Object's VulcanBatchEngineItemDelegate implementation (ObjectEntryResource) when creating/activating a new Object Definition

### DIFF
--- a/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/FieldResourceImpl.java
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/FieldResourceImpl.java
@@ -68,7 +68,8 @@ public class FieldResourceImpl extends BaseFieldResourceImpl {
 		int idx = internalClassName.indexOf(StringPool.POUND);
 
 		if (idx < 0) {
-			return _fieldProvider.getFields(internalClassName);
+			return _fieldProvider.getFields(
+				contextCompany.getCompanyId(), internalClassName);
 		}
 
 		return _fieldProvider.getFields(

--- a/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/PlanResourceImpl.java
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/PlanResourceImpl.java
@@ -78,7 +78,8 @@ public class PlanResourceImpl extends BasePlanResourceImpl {
 		return _getResponse(
 			internalClassName.substring(
 				internalClassName.lastIndexOf(StringPool.PERIOD) + 1),
-			_fieldProvider.getFields(internalClassName));
+			_fieldProvider.getFields(
+				contextCompany.getCompanyId(), internalClassName));
 	}
 
 	@Override

--- a/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/SiteScopeResourceImpl.java
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/SiteScopeResourceImpl.java
@@ -53,7 +53,7 @@ public class SiteScopeResourceImpl extends BaseSiteScopeResourceImpl {
 		List<String> entityScopes = null;
 
 		OpenAPIYAML openAPIYAML = _openAPIYAMLProvider.getOpenAPIYAML(
-			internalClassName);
+			contextCompany.getCompanyId(), internalClassName);
 
 		String simpleInternalClassName = internalClassName.substring(
 			internalClassName.lastIndexOf(StringPool.PERIOD) + 1);

--- a/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/vulcan/batch/engine/FieldProvider.java
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/vulcan/batch/engine/FieldProvider.java
@@ -60,6 +60,20 @@ public class FieldProvider {
 			});
 	}
 
+	public List<Field> getFields(long companyId, String internalClassName)
+		throws Exception {
+
+		OpenAPIYAML openAPIYAML = _openAPIYAMLProvider.getOpenAPIYAML(
+			companyId, internalClassName);
+
+		Map<String, Field> dtoEntityFields = OpenAPIUtil.getDTOEntityFields(
+			internalClassName.substring(
+				internalClassName.lastIndexOf(StringPool.PERIOD) + 1),
+			openAPIYAML);
+
+		return new ArrayList<>(dtoEntityFields.values());
+	}
+
 	public List<Field> getFields(
 			long companyId, String objectDefinitionName, UriInfo uriInfo)
 		throws Exception {
@@ -76,18 +90,6 @@ public class FieldProvider {
 			uriInfo);
 
 		return new ArrayList<>(fields.values());
-	}
-
-	public List<Field> getFields(String internalClassName) throws Exception {
-		OpenAPIYAML openAPIYAML = _openAPIYAMLProvider.getOpenAPIYAML(
-			internalClassName);
-
-		Map<String, Field> dtoEntityFields = OpenAPIUtil.getDTOEntityFields(
-			internalClassName.substring(
-				internalClassName.lastIndexOf(StringPool.PERIOD) + 1),
-			openAPIYAML);
-
-		return new ArrayList<>(dtoEntityFields.values());
 	}
 
 	@Reference

--- a/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/vulcan/yaml/openapi/OpenAPIYAMLProvider.java
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/vulcan/yaml/openapi/OpenAPIYAMLProvider.java
@@ -33,12 +33,13 @@ import org.osgi.service.component.annotations.Reference;
 @Component(service = OpenAPIYAMLProvider.class)
 public class OpenAPIYAMLProvider {
 
-	public OpenAPIYAML getOpenAPIYAML(String internalClassName)
+	public OpenAPIYAML getOpenAPIYAML(long companyId, String internalClassName)
 		throws Exception {
 
 		VulcanBatchEngineTaskItemDelegate vulcanBatchEngineTaskItemDelegate =
 			_vulcanBatchEngineTaskItemDelegateRegistry.
-				getVulcanBatchEngineTaskItemDelegate(internalClassName);
+				getVulcanBatchEngineTaskItemDelegate(
+					companyId, internalClassName);
 
 		Response response = _openAPIResource.getOpenAPI(
 			Collections.singleton(

--- a/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/portlet/action/EditBatchPlannerPlanMVCRenderCommand.java
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/portlet/action/EditBatchPlannerPlanMVCRenderCommand.java
@@ -83,7 +83,7 @@ public class EditBatchPlannerPlanMVCRenderCommand implements MVCRenderCommand {
 				_vulcanBatchEngineTaskItemDelegateRegistry.getEntityClassNames(
 					companyId)) {
 
-			if (!_isBatchPlannerEnabled(entityClassName, export)) {
+			if (!_isBatchPlannerEnabled(entityClassName, export, companyId)) {
 				continue;
 			}
 
@@ -115,15 +115,15 @@ public class EditBatchPlannerPlanMVCRenderCommand implements MVCRenderCommand {
 	}
 
 	private boolean _isBatchPlannerEnabled(
-		String entityClassName, boolean export) {
+		String entityClassName, boolean export, long companyId) {
 
 		if (export) {
 			return _vulcanBatchEngineTaskItemDelegateRegistry.
-				isBatchPlannerExportEnabled(entityClassName);
+				isBatchPlannerExportEnabled(companyId, entityClassName);
 		}
 
 		return _vulcanBatchEngineTaskItemDelegateRegistry.
-			isBatchPlannerImportEnabled(entityClassName);
+			isBatchPlannerImportEnabled(companyId, entityClassName);
 	}
 
 	private boolean _isExport(String value) {

--- a/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/portlet/action/EditBatchPlannerPlanMVCRenderCommand.java
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/portlet/action/EditBatchPlannerPlanMVCRenderCommand.java
@@ -75,13 +75,13 @@ public class EditBatchPlannerPlanMVCRenderCommand implements MVCRenderCommand {
 	}
 
 	private Map<String, String> _getInternalClassNameCategories(
-		boolean export) {
+		boolean export, long companyId) {
 
 		Map<String, String> internalClassNameCategories = new HashMap<>();
 
 		for (String entityClassName :
-				_vulcanBatchEngineTaskItemDelegateRegistry.
-					getEntityClassNames()) {
+				_vulcanBatchEngineTaskItemDelegateRegistry.getEntityClassNames(
+					companyId)) {
 
 			if (!_isBatchPlannerEnabled(entityClassName, export)) {
 				continue;
@@ -90,7 +90,8 @@ public class EditBatchPlannerPlanMVCRenderCommand implements MVCRenderCommand {
 			VulcanBatchEngineTaskItemDelegate
 				vulcanBatchEngineTaskItemDelegate =
 					_vulcanBatchEngineTaskItemDelegateRegistry.
-						getVulcanBatchEngineTaskItemDelegate(entityClassName);
+						getVulcanBatchEngineTaskItemDelegate(
+							companyId, entityClassName);
 
 			internalClassNameCategories.put(
 				entityClassName,
@@ -134,11 +135,13 @@ public class EditBatchPlannerPlanMVCRenderCommand implements MVCRenderCommand {
 	}
 
 	private String _render(RenderRequest renderRequest) throws PortalException {
+		long companyId = _portal.getCompanyId(renderRequest);
+
 		boolean export = _isExport(
 			ParamUtil.getString(renderRequest, "navigation"));
 
 		Map<String, String> internalClassNameCategories =
-			_getInternalClassNameCategories(export);
+			_getInternalClassNameCategories(export, companyId);
 
 		long batchPlannerPlanId = ParamUtil.getLong(
 			renderRequest, "batchPlannerPlanId");
@@ -149,8 +152,8 @@ public class EditBatchPlannerPlanMVCRenderCommand implements MVCRenderCommand {
 					WebKeys.PORTLET_DISPLAY_CONTEXT,
 					new EditBatchPlannerPlanDisplayContext(
 						_batchPlannerPlanService.getBatchPlannerPlans(
-							_portal.getCompanyId(renderRequest), true, true,
-							QueryUtil.ALL_POS, QueryUtil.ALL_POS, null),
+							companyId, true, true, QueryUtil.ALL_POS,
+							QueryUtil.ALL_POS, null),
 						internalClassNameCategories, renderRequest, null));
 
 				return "/export/edit_batch_planner_plan.jsp";

--- a/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/portlet/action/EditBatchPlannerPlanMVCRenderCommand.java
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/portlet/action/EditBatchPlannerPlanMVCRenderCommand.java
@@ -75,7 +75,7 @@ public class EditBatchPlannerPlanMVCRenderCommand implements MVCRenderCommand {
 	}
 
 	private Map<String, String> _getInternalClassNameCategories(
-		boolean export, long companyId) {
+		long companyId, boolean export) {
 
 		Map<String, String> internalClassNameCategories = new HashMap<>();
 
@@ -83,7 +83,7 @@ public class EditBatchPlannerPlanMVCRenderCommand implements MVCRenderCommand {
 				_vulcanBatchEngineTaskItemDelegateRegistry.getEntityClassNames(
 					companyId)) {
 
-			if (!_isBatchPlannerEnabled(entityClassName, export, companyId)) {
+			if (!_isBatchPlannerEnabled(companyId, entityClassName, export)) {
 				continue;
 			}
 
@@ -115,7 +115,7 @@ public class EditBatchPlannerPlanMVCRenderCommand implements MVCRenderCommand {
 	}
 
 	private boolean _isBatchPlannerEnabled(
-		String entityClassName, boolean export, long companyId) {
+		long companyId, String entityClassName, boolean export) {
 
 		if (export) {
 			return _vulcanBatchEngineTaskItemDelegateRegistry.
@@ -141,7 +141,7 @@ public class EditBatchPlannerPlanMVCRenderCommand implements MVCRenderCommand {
 			ParamUtil.getString(renderRequest, "navigation"));
 
 		Map<String, String> internalClassNameCategories =
-			_getInternalClassNameCategories(export, companyId);
+			_getInternalClassNameCategories(companyId, export);
 
 		long batchPlannerPlanId = ParamUtil.getLong(
 			renderRequest, "batchPlannerPlanId");

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -568,6 +568,8 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 					).put(
 						"batch.planner.import.enabled", "true"
 					).put(
+						"companyId", objectDefinition.getCompanyId()
+					).put(
 						"entity.class.name",
 						ObjectEntry.class.getName() + "#" + osgiJaxRsName
 					).put(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -712,18 +712,13 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 			companyIds.remove(String.valueOf(companyId));
 
 			if (!companyIds.isEmpty()) {
-				ServiceRegistration<?> serviceRegistration =
-					_applicationServiceRegistrations.get(restContextPath);
+				_updateServiceRegistrationProperties(
+					restContextPath, _applicationProperties,
+					(Map)_applicationServiceRegistrations);
 
-				serviceRegistration.setProperties(
-					_applicationProperties.get(restContextPath));
-
-				serviceRegistration =
-					_objectEntryResourceServiceRegistrations.get(
-						restContextPath);
-
-				serviceRegistration.setProperties(
-					_objectEntryResourceProperties.get(restContextPath));
+				_updateServiceRegistrationProperties(
+					restContextPath, _objectEntryResourceProperties,
+					(Map)_objectEntryResourceServiceRegistrations);
 			}
 		}
 	}
@@ -800,6 +795,16 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 				serviceRegistration2.unregister();
 			}
 		}
+	}
+
+	private void _updateServiceRegistrationProperties(
+		String key, Map<String, Dictionary<String, Object>> propertiesMap,
+		Map<String, ServiceRegistration<?>> serviceRegistrationMap) {
+
+		ServiceRegistration<?> serviceRegistration = serviceRegistrationMap.get(
+			key);
+
+		serviceRegistration.setProperties(propertiesMap.get(key));
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Vulcan API
 Bundle-SymbolicName: com.liferay.portal.vulcan.api
-Bundle-Version: 35.2.1
+Bundle-Version: 36.0.0
 Export-Package:\
 	com.liferay.portal.vulcan.accept.language,\
 	com.liferay.portal.vulcan.aggregation,\

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/batch/engine/VulcanBatchEngineTaskItemDelegateRegistry.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/batch/engine/VulcanBatchEngineTaskItemDelegateRegistry.java
@@ -21,25 +21,16 @@ import java.util.Set;
  */
 public interface VulcanBatchEngineTaskItemDelegateRegistry {
 
-	public Set<String> getEntityClassNames();
-
 	public Set<String> getEntityClassNames(long companyId);
 
 	public VulcanBatchEngineTaskItemDelegate
 		getVulcanBatchEngineTaskItemDelegate(
 			long companyId, String entityClassName);
 
-	public VulcanBatchEngineTaskItemDelegate
-		getVulcanBatchEngineTaskItemDelegate(String entityClassName);
-
 	public boolean isBatchPlannerExportEnabled(
 		long companyId, String entityClassName);
 
-	public boolean isBatchPlannerExportEnabled(String entityClassName);
-
 	public boolean isBatchPlannerImportEnabled(
 		long companyId, String entityClassName);
-
-	public boolean isBatchPlannerImportEnabled(String entityClassName);
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/batch/engine/VulcanBatchEngineTaskItemDelegateRegistry.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/batch/engine/VulcanBatchEngineTaskItemDelegateRegistry.java
@@ -23,6 +23,12 @@ public interface VulcanBatchEngineTaskItemDelegateRegistry {
 
 	public Set<String> getEntityClassNames();
 
+	public Set<String> getEntityClassNames(long companyId);
+
+	public VulcanBatchEngineTaskItemDelegate
+		getVulcanBatchEngineTaskItemDelegate(
+			long companyId, String entityClassName);
+
 	public VulcanBatchEngineTaskItemDelegate
 		getVulcanBatchEngineTaskItemDelegate(String entityClassName);
 

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/batch/engine/VulcanBatchEngineTaskItemDelegateRegistry.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/batch/engine/VulcanBatchEngineTaskItemDelegateRegistry.java
@@ -32,7 +32,13 @@ public interface VulcanBatchEngineTaskItemDelegateRegistry {
 	public VulcanBatchEngineTaskItemDelegate
 		getVulcanBatchEngineTaskItemDelegate(String entityClassName);
 
+	public boolean isBatchPlannerExportEnabled(
+		long companyId, String entityClassName);
+
 	public boolean isBatchPlannerExportEnabled(String entityClassName);
+
+	public boolean isBatchPlannerImportEnabled(
+		long companyId, String entityClassName);
 
 	public boolean isBatchPlannerImportEnabled(String entityClassName);
 

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/batch/engine/packageinfo
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/batch/engine/packageinfo
@@ -1,1 +1,1 @@
-version 4.4.0
+version 5.0.0

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/batch/engine/VulcanBatchEngineTaskItemDelegateRegistryImpl.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/batch/engine/VulcanBatchEngineTaskItemDelegateRegistryImpl.java
@@ -97,8 +97,42 @@ public class VulcanBatchEngineTaskItemDelegateRegistryImpl
 	}
 
 	@Override
+	public boolean isBatchPlannerExportEnabled(
+		long companyId, String entityClassName) {
+
+		Boolean batchPlannerExportEnabled = _batchPlannerExportEnabledMap.get(
+			entityClassName);
+
+		if (batchPlannerExportEnabled != null) {
+			return batchPlannerExportEnabled;
+		}
+
+		Map<String, Boolean> companyBatchPlannerExportEnabledMap =
+			_companyScopedBatchPlannerExportEnabledMap.get(companyId);
+
+		return companyBatchPlannerExportEnabledMap.get(entityClassName);
+	}
+
+	@Override
 	public boolean isBatchPlannerExportEnabled(String entityClassName) {
 		return _batchPlannerExportEnabledMap.get(entityClassName);
+	}
+
+	@Override
+	public boolean isBatchPlannerImportEnabled(
+		long companyId, String entityClassName) {
+
+		Boolean batchPlannerImportEnabled = _batchPlannerImportEnabledMap.get(
+			entityClassName);
+
+		if (batchPlannerImportEnabled != null) {
+			return batchPlannerImportEnabled;
+		}
+
+		Map<String, Boolean> companyBatchPlannerImportEnabledMap =
+			_companyScopedBatchPlannerImportEnabledMap.get(companyId);
+
+		return companyBatchPlannerImportEnabledMap.get(entityClassName);
 	}
 
 	@Override
@@ -130,6 +164,10 @@ public class VulcanBatchEngineTaskItemDelegateRegistryImpl
 		new HashMap<>();
 	private final Map<String, Boolean> _batchPlannerImportEnabledMap =
 		new HashMap<>();
+	private final Map<Long, Map<String, Boolean>>
+		_companyScopedBatchPlannerExportEnabledMap = new HashMap<>();
+	private final Map<Long, Map<String, Boolean>>
+		_companyScopedBatchPlannerImportEnabledMap = new HashMap<>();
 	private final Map<Long, Map<String, VulcanBatchEngineTaskItemDelegate<?>>>
 		_companyScopedVulcanBatchEngineTaskItemDelegateMap = new HashMap<>();
 	private ServiceTracker<?, ?> _serviceTracker;
@@ -153,27 +191,59 @@ public class VulcanBatchEngineTaskItemDelegateRegistryImpl
 			String entityClassName = (String)serviceReference.getProperty(
 				"entity.class.name");
 
-			_batchPlannerExportEnabledMap.put(
-				entityClassName,
-				GetterUtil.getBoolean(
-					serviceReference.getProperty(
-						"batch.planner.export.enabled")));
-
-			_batchPlannerImportEnabledMap.put(
-				entityClassName,
-				GetterUtil.getBoolean(
-					serviceReference.getProperty(
-						"batch.planner.import.enabled")));
-
 			Object companyIdProperty = serviceReference.getProperty(
 				"companyId");
 
 			if (companyIdProperty == null) {
+				_batchPlannerExportEnabledMap.put(
+					entityClassName,
+					GetterUtil.getBoolean(
+						serviceReference.getProperty(
+							"batch.planner.export.enabled")));
+
+				_batchPlannerImportEnabledMap.put(
+					entityClassName,
+					GetterUtil.getBoolean(
+						serviceReference.getProperty(
+							"batch.planner.import.enabled")));
+
 				_vulcanBatchEngineTaskItemDelegateMap.put(
 					entityClassName, vulcanBatchEngineTaskItemDelegate);
 			}
 			else {
 				long companyId = GetterUtil.getLong(companyIdProperty);
+
+				Map<String, Boolean> companyBatchPlannerExportEnabledMap =
+					_companyScopedBatchPlannerExportEnabledMap.get(companyId);
+
+				if (companyBatchPlannerExportEnabledMap == null) {
+					companyBatchPlannerExportEnabledMap = new HashMap<>();
+
+					_companyScopedBatchPlannerExportEnabledMap.put(
+						companyId, companyBatchPlannerExportEnabledMap);
+				}
+
+				companyBatchPlannerExportEnabledMap.put(
+					entityClassName,
+					GetterUtil.getBoolean(
+						serviceReference.getProperty(
+							"batch.planner.export.enabled")));
+
+				Map<String, Boolean> companyBatchPlannerImportEnabledMap =
+					_companyScopedBatchPlannerImportEnabledMap.get(companyId);
+
+				if (companyBatchPlannerImportEnabledMap == null) {
+					companyBatchPlannerImportEnabledMap = new HashMap<>();
+
+					_companyScopedBatchPlannerImportEnabledMap.put(
+						companyId, companyBatchPlannerImportEnabledMap);
+				}
+
+				companyBatchPlannerImportEnabledMap.put(
+					entityClassName,
+					GetterUtil.getBoolean(
+						serviceReference.getProperty(
+							"batch.planner.import.enabled")));
 
 				Map<String, VulcanBatchEngineTaskItemDelegate<?>>
 					companyVulcanBatchEngineTaskItemDelegateMap =
@@ -213,21 +283,33 @@ public class VulcanBatchEngineTaskItemDelegateRegistryImpl
 			String entityClassName = (String)serviceReference.getProperty(
 				"entity.class.name");
 
-			_batchPlannerExportEnabledMap.remove(entityClassName);
-
-			_batchPlannerImportEnabledMap.remove(entityClassName);
-
 			Object companyIdProperty = serviceReference.getProperty(
 				"companyId");
 
 			if (companyIdProperty == null) {
+				_batchPlannerExportEnabledMap.remove(entityClassName);
+
+				_batchPlannerImportEnabledMap.remove(entityClassName);
+
 				_vulcanBatchEngineTaskItemDelegateMap.remove(entityClassName);
 			}
 			else {
+				long companyId = GetterUtil.getLong(companyIdProperty);
+
+				Map<String, Boolean> companyBatchPlannerExportEnabledMap =
+					_companyScopedBatchPlannerExportEnabledMap.get(companyId);
+
+				companyBatchPlannerExportEnabledMap.remove(entityClassName);
+
+				Map<String, Boolean> companyBatchPlannerImportEnabledMap =
+					_companyScopedBatchPlannerImportEnabledMap.get(companyId);
+
+				companyBatchPlannerImportEnabledMap.remove(entityClassName);
+
 				Map<String, VulcanBatchEngineTaskItemDelegate<?>>
 					companyVulcanBatchEngineTaskItemDelegateMap =
 						_companyScopedVulcanBatchEngineTaskItemDelegateMap.get(
-							GetterUtil.getLong(companyIdProperty));
+							companyId);
 
 				companyVulcanBatchEngineTaskItemDelegateMap.remove(
 					entityClassName);

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/batch/engine/VulcanBatchEngineTaskItemDelegateRegistryImpl.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/batch/engine/VulcanBatchEngineTaskItemDelegateRegistryImpl.java
@@ -20,6 +20,7 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegateR
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -191,10 +192,10 @@ public class VulcanBatchEngineTaskItemDelegateRegistryImpl
 			String entityClassName = (String)serviceReference.getProperty(
 				"entity.class.name");
 
-			Object companyIdProperty = serviceReference.getProperty(
+			List<String> companyIds = (List)serviceReference.getProperty(
 				"companyId");
 
-			if (companyIdProperty == null) {
+			if (companyIds == null) {
 				_batchPlannerExportEnabledMap.put(
 					entityClassName,
 					GetterUtil.getBoolean(
@@ -211,55 +212,60 @@ public class VulcanBatchEngineTaskItemDelegateRegistryImpl
 					entityClassName, vulcanBatchEngineTaskItemDelegate);
 			}
 			else {
-				long companyId = GetterUtil.getLong(companyIdProperty);
+				for (String companyIdString : companyIds) {
+					long companyId = GetterUtil.getLong(companyIdString);
 
-				Map<String, Boolean> companyBatchPlannerExportEnabledMap =
-					_companyScopedBatchPlannerExportEnabledMap.get(companyId);
-
-				if (companyBatchPlannerExportEnabledMap == null) {
-					companyBatchPlannerExportEnabledMap = new HashMap<>();
-
-					_companyScopedBatchPlannerExportEnabledMap.put(
-						companyId, companyBatchPlannerExportEnabledMap);
-				}
-
-				companyBatchPlannerExportEnabledMap.put(
-					entityClassName,
-					GetterUtil.getBoolean(
-						serviceReference.getProperty(
-							"batch.planner.export.enabled")));
-
-				Map<String, Boolean> companyBatchPlannerImportEnabledMap =
-					_companyScopedBatchPlannerImportEnabledMap.get(companyId);
-
-				if (companyBatchPlannerImportEnabledMap == null) {
-					companyBatchPlannerImportEnabledMap = new HashMap<>();
-
-					_companyScopedBatchPlannerImportEnabledMap.put(
-						companyId, companyBatchPlannerImportEnabledMap);
-				}
-
-				companyBatchPlannerImportEnabledMap.put(
-					entityClassName,
-					GetterUtil.getBoolean(
-						serviceReference.getProperty(
-							"batch.planner.import.enabled")));
-
-				Map<String, VulcanBatchEngineTaskItemDelegate<?>>
-					companyVulcanBatchEngineTaskItemDelegateMap =
-						_companyScopedVulcanBatchEngineTaskItemDelegateMap.get(
+					Map<String, Boolean> companyBatchPlannerExportEnabledMap =
+						_companyScopedBatchPlannerExportEnabledMap.get(
 							companyId);
 
-				if (companyVulcanBatchEngineTaskItemDelegateMap == null) {
-					companyVulcanBatchEngineTaskItemDelegateMap =
-						new HashMap<>();
+					if (companyBatchPlannerExportEnabledMap == null) {
+						companyBatchPlannerExportEnabledMap = new HashMap<>();
 
-					_companyScopedVulcanBatchEngineTaskItemDelegateMap.put(
-						companyId, companyVulcanBatchEngineTaskItemDelegateMap);
+						_companyScopedBatchPlannerExportEnabledMap.put(
+							companyId, companyBatchPlannerExportEnabledMap);
+					}
+
+					companyBatchPlannerExportEnabledMap.put(
+						entityClassName,
+						GetterUtil.getBoolean(
+							serviceReference.getProperty(
+								"batch.planner.export.enabled")));
+
+					Map<String, Boolean> companyBatchPlannerImportEnabledMap =
+						_companyScopedBatchPlannerImportEnabledMap.get(
+							companyId);
+
+					if (companyBatchPlannerImportEnabledMap == null) {
+						companyBatchPlannerImportEnabledMap = new HashMap<>();
+
+						_companyScopedBatchPlannerImportEnabledMap.put(
+							companyId, companyBatchPlannerImportEnabledMap);
+					}
+
+					companyBatchPlannerImportEnabledMap.put(
+						entityClassName,
+						GetterUtil.getBoolean(
+							serviceReference.getProperty(
+								"batch.planner.import.enabled")));
+
+					Map<String, VulcanBatchEngineTaskItemDelegate<?>>
+						companyVulcanBatchEngineTaskItemDelegateMap =
+							_companyScopedVulcanBatchEngineTaskItemDelegateMap.
+								get(companyId);
+
+					if (companyVulcanBatchEngineTaskItemDelegateMap == null) {
+						companyVulcanBatchEngineTaskItemDelegateMap =
+							new HashMap<>();
+
+						_companyScopedVulcanBatchEngineTaskItemDelegateMap.put(
+							companyId,
+							companyVulcanBatchEngineTaskItemDelegateMap);
+					}
+
+					companyVulcanBatchEngineTaskItemDelegateMap.put(
+						entityClassName, vulcanBatchEngineTaskItemDelegate);
 				}
-
-				companyVulcanBatchEngineTaskItemDelegateMap.put(
-					entityClassName, vulcanBatchEngineTaskItemDelegate);
 			}
 
 			return vulcanBatchEngineTaskItemDelegate;
@@ -271,6 +277,62 @@ public class VulcanBatchEngineTaskItemDelegateRegistryImpl
 				serviceReference,
 			VulcanBatchEngineTaskItemDelegate<?>
 				vulcanBatchEngineTaskItemDelegate) {
+
+			List<String> companyIds = (List)serviceReference.getProperty(
+				"companyId");
+
+			if (companyIds == null) {
+				return;
+			}
+
+			String entityClassName = (String)serviceReference.getProperty(
+				"entity.class.name");
+
+			for (Map.Entry<Long, Map<String, Boolean>> entry :
+					_companyScopedBatchPlannerExportEnabledMap.entrySet()) {
+
+				if (companyIds.contains(String.valueOf(entry.getKey()))) {
+					continue;
+				}
+
+				Map<String, Boolean> companyBatchPlannerExportEnabledMap =
+					entry.getValue();
+
+				companyBatchPlannerExportEnabledMap.remove(entityClassName);
+			}
+
+			for (Map.Entry<Long, Map<String, Boolean>> entry :
+					_companyScopedBatchPlannerImportEnabledMap.entrySet()) {
+
+				if (companyIds.contains(String.valueOf(entry.getKey()))) {
+					continue;
+				}
+
+				Map<String, Boolean> companyBatchPlannerImportEnabledMap =
+					entry.getValue();
+
+				companyBatchPlannerImportEnabledMap.remove(entityClassName);
+			}
+
+			for (Map.Entry
+					<Long, Map<String, VulcanBatchEngineTaskItemDelegate<?>>>
+						entry :
+							_companyScopedVulcanBatchEngineTaskItemDelegateMap.
+								entrySet()) {
+
+				if (companyIds.contains(String.valueOf(entry.getKey()))) {
+					continue;
+				}
+
+				Map<String, VulcanBatchEngineTaskItemDelegate<?>>
+					companyVulcanBatchEngineTaskItemDelegateMap =
+						entry.getValue();
+
+				companyVulcanBatchEngineTaskItemDelegateMap.remove(
+					entityClassName);
+			}
+
+			addingService(serviceReference);
 		}
 
 		@Override
@@ -283,10 +345,10 @@ public class VulcanBatchEngineTaskItemDelegateRegistryImpl
 			String entityClassName = (String)serviceReference.getProperty(
 				"entity.class.name");
 
-			Object companyIdProperty = serviceReference.getProperty(
+			List<String> companyIds = (List)serviceReference.getProperty(
 				"companyId");
 
-			if (companyIdProperty == null) {
+			if (companyIds == null) {
 				_batchPlannerExportEnabledMap.remove(entityClassName);
 
 				_batchPlannerImportEnabledMap.remove(entityClassName);
@@ -294,25 +356,29 @@ public class VulcanBatchEngineTaskItemDelegateRegistryImpl
 				_vulcanBatchEngineTaskItemDelegateMap.remove(entityClassName);
 			}
 			else {
-				long companyId = GetterUtil.getLong(companyIdProperty);
+				for (String companyIdString : companyIds) {
+					long companyId = GetterUtil.getLong(companyIdString);
 
-				Map<String, Boolean> companyBatchPlannerExportEnabledMap =
-					_companyScopedBatchPlannerExportEnabledMap.get(companyId);
-
-				companyBatchPlannerExportEnabledMap.remove(entityClassName);
-
-				Map<String, Boolean> companyBatchPlannerImportEnabledMap =
-					_companyScopedBatchPlannerImportEnabledMap.get(companyId);
-
-				companyBatchPlannerImportEnabledMap.remove(entityClassName);
-
-				Map<String, VulcanBatchEngineTaskItemDelegate<?>>
-					companyVulcanBatchEngineTaskItemDelegateMap =
-						_companyScopedVulcanBatchEngineTaskItemDelegateMap.get(
+					Map<String, Boolean> companyBatchPlannerExportEnabledMap =
+						_companyScopedBatchPlannerExportEnabledMap.get(
 							companyId);
 
-				companyVulcanBatchEngineTaskItemDelegateMap.remove(
-					entityClassName);
+					companyBatchPlannerExportEnabledMap.remove(entityClassName);
+
+					Map<String, Boolean> companyBatchPlannerImportEnabledMap =
+						_companyScopedBatchPlannerImportEnabledMap.get(
+							companyId);
+
+					companyBatchPlannerImportEnabledMap.remove(entityClassName);
+
+					Map<String, VulcanBatchEngineTaskItemDelegate<?>>
+						companyVulcanBatchEngineTaskItemDelegateMap =
+							_companyScopedVulcanBatchEngineTaskItemDelegateMap.
+								get(companyId);
+
+					companyVulcanBatchEngineTaskItemDelegateMap.remove(
+						entityClassName);
+				}
 			}
 		}
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/batch/engine/VulcanBatchEngineTaskItemDelegateRegistryImpl.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/batch/engine/VulcanBatchEngineTaskItemDelegateRegistryImpl.java
@@ -42,11 +42,6 @@ public class VulcanBatchEngineTaskItemDelegateRegistryImpl
 	implements VulcanBatchEngineTaskItemDelegateRegistry {
 
 	@Override
-	public Set<String> getEntityClassNames() {
-		return _vulcanBatchEngineTaskItemDelegateMap.keySet();
-	}
-
-	@Override
 	public Set<String> getEntityClassNames(long companyId) {
 		Set<String> entityClassNames = new HashSet<>();
 
@@ -91,13 +86,6 @@ public class VulcanBatchEngineTaskItemDelegateRegistryImpl
 	}
 
 	@Override
-	public VulcanBatchEngineTaskItemDelegate<?>
-		getVulcanBatchEngineTaskItemDelegate(String entityClassName) {
-
-		return _vulcanBatchEngineTaskItemDelegateMap.get(entityClassName);
-	}
-
-	@Override
 	public boolean isBatchPlannerExportEnabled(
 		long companyId, String entityClassName) {
 
@@ -115,11 +103,6 @@ public class VulcanBatchEngineTaskItemDelegateRegistryImpl
 	}
 
 	@Override
-	public boolean isBatchPlannerExportEnabled(String entityClassName) {
-		return _batchPlannerExportEnabledMap.get(entityClassName);
-	}
-
-	@Override
 	public boolean isBatchPlannerImportEnabled(
 		long companyId, String entityClassName) {
 
@@ -134,11 +117,6 @@ public class VulcanBatchEngineTaskItemDelegateRegistryImpl
 			_companyScopedBatchPlannerImportEnabledMap.get(companyId);
 
 		return companyBatchPlannerImportEnabledMap.get(entityClassName);
-	}
-
-	@Override
-	public boolean isBatchPlannerImportEnabled(String entityClassName) {
-		return _batchPlannerImportEnabledMap.get(entityClassName);
 	}
 
 	@Activate

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/batch/engine/VulcanBatchEngineTaskItemDelegateRegistryImpl.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/batch/engine/VulcanBatchEngineTaskItemDelegateRegistryImpl.java
@@ -85,6 +85,8 @@ public class VulcanBatchEngineTaskItemDelegateRegistryImpl
 		new HashMap<>();
 	private final Map<String, Boolean> _batchPlannerImportEnabledMap =
 		new HashMap<>();
+	private final Map<Long, Map<String, VulcanBatchEngineTaskItemDelegate<?>>>
+		_companyScopedVulcanBatchEngineTaskItemDelegateMap = new HashMap<>();
 	private ServiceTracker<?, ?> _serviceTracker;
 	private final Map<String, VulcanBatchEngineTaskItemDelegate<?>>
 		_vulcanBatchEngineTaskItemDelegateMap = new HashMap<>();
@@ -118,8 +120,32 @@ public class VulcanBatchEngineTaskItemDelegateRegistryImpl
 					serviceReference.getProperty(
 						"batch.planner.import.enabled")));
 
-			_vulcanBatchEngineTaskItemDelegateMap.put(
-				entityClassName, vulcanBatchEngineTaskItemDelegate);
+			Object companyIdProperty = serviceReference.getProperty(
+				"companyId");
+
+			if (companyIdProperty == null) {
+				_vulcanBatchEngineTaskItemDelegateMap.put(
+					entityClassName, vulcanBatchEngineTaskItemDelegate);
+			}
+			else {
+				long companyId = GetterUtil.getLong(companyIdProperty);
+
+				Map<String, VulcanBatchEngineTaskItemDelegate<?>>
+					companyVulcanBatchEngineTaskItemDelegateMap =
+						_companyScopedVulcanBatchEngineTaskItemDelegateMap.get(
+							companyId);
+
+				if (companyVulcanBatchEngineTaskItemDelegateMap == null) {
+					companyVulcanBatchEngineTaskItemDelegateMap =
+						new HashMap<>();
+
+					_companyScopedVulcanBatchEngineTaskItemDelegateMap.put(
+						companyId, companyVulcanBatchEngineTaskItemDelegateMap);
+				}
+
+				companyVulcanBatchEngineTaskItemDelegateMap.put(
+					entityClassName, vulcanBatchEngineTaskItemDelegate);
+			}
 
 			return vulcanBatchEngineTaskItemDelegate;
 		}
@@ -146,7 +172,21 @@ public class VulcanBatchEngineTaskItemDelegateRegistryImpl
 
 			_batchPlannerImportEnabledMap.remove(entityClassName);
 
-			_vulcanBatchEngineTaskItemDelegateMap.remove(entityClassName);
+			Object companyIdProperty = serviceReference.getProperty(
+				"companyId");
+
+			if (companyIdProperty == null) {
+				_vulcanBatchEngineTaskItemDelegateMap.remove(entityClassName);
+			}
+			else {
+				Map<String, VulcanBatchEngineTaskItemDelegate<?>>
+					companyVulcanBatchEngineTaskItemDelegateMap =
+						_companyScopedVulcanBatchEngineTaskItemDelegateMap.get(
+							GetterUtil.getLong(companyIdProperty));
+
+				companyVulcanBatchEngineTaskItemDelegateMap.remove(
+					entityClassName);
+			}
 		}
 
 		private VulcanBatchEngineTaskItemDelegateServiceTrackerCustomizer(

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/batch/engine/VulcanBatchEngineTaskItemDelegateRegistryImpl.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/batch/engine/VulcanBatchEngineTaskItemDelegateRegistryImpl.java
@@ -170,21 +170,21 @@ public class VulcanBatchEngineTaskItemDelegateRegistryImpl
 			String entityClassName = (String)serviceReference.getProperty(
 				"entity.class.name");
 
+			boolean batchPlannerExportEnabled = GetterUtil.getBoolean(
+				serviceReference.getProperty("batch.planner.export.enabled"));
+
+			boolean batchPlannerImportEnabled = GetterUtil.getBoolean(
+				serviceReference.getProperty("batch.planner.import.enabled"));
+
 			List<String> companyIds = (List)serviceReference.getProperty(
 				"companyId");
 
 			if (companyIds == null) {
 				_batchPlannerExportEnabledMap.put(
-					entityClassName,
-					GetterUtil.getBoolean(
-						serviceReference.getProperty(
-							"batch.planner.export.enabled")));
+					entityClassName, batchPlannerExportEnabled);
 
 				_batchPlannerImportEnabledMap.put(
-					entityClassName,
-					GetterUtil.getBoolean(
-						serviceReference.getProperty(
-							"batch.planner.import.enabled")));
+					entityClassName, batchPlannerImportEnabled);
 
 				_vulcanBatchEngineTaskItemDelegateMap.put(
 					entityClassName, vulcanBatchEngineTaskItemDelegate);
@@ -193,56 +193,46 @@ public class VulcanBatchEngineTaskItemDelegateRegistryImpl
 				for (String companyIdString : companyIds) {
 					long companyId = GetterUtil.getLong(companyIdString);
 
-					Map<String, Boolean> companyBatchPlannerExportEnabledMap =
-						_companyScopedBatchPlannerExportEnabledMap.get(
-							companyId);
+					_companyScopedBatchPlannerExportEnabledMap.compute(
+						companyId,
+						(key, batchPlannerExportEnabledMap) -> {
+							if (batchPlannerExportEnabledMap == null) {
+								batchPlannerExportEnabledMap = new HashMap<>();
+							}
 
-					if (companyBatchPlannerExportEnabledMap == null) {
-						companyBatchPlannerExportEnabledMap = new HashMap<>();
+							batchPlannerExportEnabledMap.put(
+								entityClassName, batchPlannerExportEnabled);
 
-						_companyScopedBatchPlannerExportEnabledMap.put(
-							companyId, companyBatchPlannerExportEnabledMap);
-					}
+							return batchPlannerExportEnabledMap;
+						});
 
-					companyBatchPlannerExportEnabledMap.put(
-						entityClassName,
-						GetterUtil.getBoolean(
-							serviceReference.getProperty(
-								"batch.planner.export.enabled")));
+					_companyScopedBatchPlannerImportEnabledMap.compute(
+						companyId,
+						(key, batchPlannerImportEnabledMap) -> {
+							if (batchPlannerImportEnabledMap == null) {
+								batchPlannerImportEnabledMap = new HashMap<>();
+							}
 
-					Map<String, Boolean> companyBatchPlannerImportEnabledMap =
-						_companyScopedBatchPlannerImportEnabledMap.get(
-							companyId);
+							batchPlannerImportEnabledMap.put(
+								entityClassName, batchPlannerImportEnabled);
 
-					if (companyBatchPlannerImportEnabledMap == null) {
-						companyBatchPlannerImportEnabledMap = new HashMap<>();
+							return batchPlannerImportEnabledMap;
+						});
 
-						_companyScopedBatchPlannerImportEnabledMap.put(
-							companyId, companyBatchPlannerImportEnabledMap);
-					}
+					_companyScopedVulcanBatchEngineTaskItemDelegateMap.compute(
+						companyId,
+						(key, vulcanBatchEngineTaskItemDelegateMap) -> {
+							if (vulcanBatchEngineTaskItemDelegateMap == null) {
+								vulcanBatchEngineTaskItemDelegateMap =
+									new HashMap<>();
+							}
 
-					companyBatchPlannerImportEnabledMap.put(
-						entityClassName,
-						GetterUtil.getBoolean(
-							serviceReference.getProperty(
-								"batch.planner.import.enabled")));
+							vulcanBatchEngineTaskItemDelegateMap.put(
+								entityClassName,
+								vulcanBatchEngineTaskItemDelegate);
 
-					Map<String, VulcanBatchEngineTaskItemDelegate<?>>
-						companyVulcanBatchEngineTaskItemDelegateMap =
-							_companyScopedVulcanBatchEngineTaskItemDelegateMap.
-								get(companyId);
-
-					if (companyVulcanBatchEngineTaskItemDelegateMap == null) {
-						companyVulcanBatchEngineTaskItemDelegateMap =
-							new HashMap<>();
-
-						_companyScopedVulcanBatchEngineTaskItemDelegateMap.put(
-							companyId,
-							companyVulcanBatchEngineTaskItemDelegateMap);
-					}
-
-					companyVulcanBatchEngineTaskItemDelegateMap.put(
-						entityClassName, vulcanBatchEngineTaskItemDelegate);
+							return vulcanBatchEngineTaskItemDelegateMap;
+						});
 				}
 			}
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/batch/engine/VulcanBatchEngineTaskItemDelegateRegistryImpl.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/batch/engine/VulcanBatchEngineTaskItemDelegateRegistryImpl.java
@@ -19,6 +19,7 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegateRegistry;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -42,6 +43,50 @@ public class VulcanBatchEngineTaskItemDelegateRegistryImpl
 	@Override
 	public Set<String> getEntityClassNames() {
 		return _vulcanBatchEngineTaskItemDelegateMap.keySet();
+	}
+
+	@Override
+	public Set<String> getEntityClassNames(long companyId) {
+		Set<String> entityClassNames = new HashSet<>();
+
+		entityClassNames.addAll(_vulcanBatchEngineTaskItemDelegateMap.keySet());
+
+		Map<String, VulcanBatchEngineTaskItemDelegate<?>>
+			companyVulcanBatchEngineTaskItemDelegateMap =
+				_companyScopedVulcanBatchEngineTaskItemDelegateMap.get(
+					companyId);
+
+		if (companyVulcanBatchEngineTaskItemDelegateMap != null) {
+			entityClassNames.addAll(
+				companyVulcanBatchEngineTaskItemDelegateMap.keySet());
+		}
+
+		return entityClassNames;
+	}
+
+	@Override
+	public VulcanBatchEngineTaskItemDelegate<?>
+		getVulcanBatchEngineTaskItemDelegate(
+			long companyId, String entityClassName) {
+
+		VulcanBatchEngineTaskItemDelegate<?> vulcanBatchEngineTaskItemDelegate =
+			_vulcanBatchEngineTaskItemDelegateMap.get(entityClassName);
+
+		if (vulcanBatchEngineTaskItemDelegate != null) {
+			return vulcanBatchEngineTaskItemDelegate;
+		}
+
+		Map<String, VulcanBatchEngineTaskItemDelegate<?>>
+			companyVulcanBatchEngineTaskItemDelegateMap =
+				_companyScopedVulcanBatchEngineTaskItemDelegateMap.get(
+					companyId);
+
+		if (companyVulcanBatchEngineTaskItemDelegateMap != null) {
+			return companyVulcanBatchEngineTaskItemDelegateMap.get(
+				entityClassName);
+		}
+
+		return null;
 	}
 
 	@Override

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/batch/engine/test/VulcanBatchEngineTaskItemDelegateRegistryTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/batch/engine/test/VulcanBatchEngineTaskItemDelegateRegistryTest.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.test.AssertUtils;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.test.rule.Inject;
@@ -80,9 +81,10 @@ public class VulcanBatchEngineTaskItemDelegateRegistryTest {
 	}
 
 	@Test
-	public void testGetEntityClassNames() {
+	public void testGetEntityClassNames() throws Exception {
 		Set<String> entityClassNames =
-			_vulcanBatchEngineTaskItemDelegateRegistry.getEntityClassNames();
+			_vulcanBatchEngineTaskItemDelegateRegistry.getEntityClassNames(
+				TestPropsValues.getCompanyId());
 
 		Assert.assertFalse(entityClassNames.isEmpty());
 
@@ -92,10 +94,11 @@ public class VulcanBatchEngineTaskItemDelegateRegistryTest {
 	}
 
 	@Test
-	public void testGetVulcanBatchEngineTaskItemDelegate() {
+	public void testGetVulcanBatchEngineTaskItemDelegate() throws Exception {
 		VulcanBatchEngineTaskItemDelegate<?> vulcanBatchEngineTaskItemDelegate =
 			_vulcanBatchEngineTaskItemDelegateRegistry.
 				getVulcanBatchEngineTaskItemDelegate(
+					TestPropsValues.getCompanyId(),
 					"com.liferay.headless.delivery.dto.v1_0.StructuredContent");
 
 		Assert.assertNotNull(vulcanBatchEngineTaskItemDelegate);
@@ -110,58 +113,154 @@ public class VulcanBatchEngineTaskItemDelegateRegistryTest {
 	}
 
 	@Test
-	public void testIsBatchPlannerExportEnabled() {
-		_registerVulcanBatchEngineTaskItemDelegate(true, false);
+	public void testIsBatchPlannerExportEnabled() throws Exception {
+		_registerVulcanBatchEngineTaskItemDelegate(null, true, false);
+
+		long companyId = TestPropsValues.getCompanyId();
 
 		Assert.assertTrue(
 			_vulcanBatchEngineTaskItemDelegateRegistry.
 				isBatchPlannerExportEnabled(
+					companyId,
 					TestVulcanBatchEngineTaskItemDelegate.class.getName()));
 		Assert.assertFalse(
 			_vulcanBatchEngineTaskItemDelegateRegistry.
 				isBatchPlannerImportEnabled(
+					companyId,
 					TestVulcanBatchEngineTaskItemDelegate.class.getName()));
 	}
 
 	@Test
-	public void testIsBatchPlannerExportImportDisabled() {
-		_registerVulcanBatchEngineTaskItemDelegate(false, false);
+	public void testIsBatchPlannerExportEnabledCompanyScoped()
+		throws Exception {
 
-		Assert.assertFalse(
+		long companyId = TestPropsValues.getCompanyId();
+
+		_registerVulcanBatchEngineTaskItemDelegate(companyId, true, false);
+
+		Assert.assertTrue(
 			_vulcanBatchEngineTaskItemDelegateRegistry.
 				isBatchPlannerExportEnabled(
+					companyId,
 					TestVulcanBatchEngineTaskItemDelegate.class.getName()));
 		Assert.assertFalse(
 			_vulcanBatchEngineTaskItemDelegateRegistry.
 				isBatchPlannerImportEnabled(
+					companyId,
 					TestVulcanBatchEngineTaskItemDelegate.class.getName()));
 	}
 
 	@Test
-	public void testIsBatchPlannerExportImportEnabled() {
-		_registerVulcanBatchEngineTaskItemDelegate(true, true);
+	public void testIsBatchPlannerExportImportDisabled() throws Exception {
+		_registerVulcanBatchEngineTaskItemDelegate(null, false, false);
 
-		Assert.assertTrue(
-			_vulcanBatchEngineTaskItemDelegateRegistry.
-				isBatchPlannerExportEnabled(
-					TestVulcanBatchEngineTaskItemDelegate.class.getName()));
-		Assert.assertTrue(
-			_vulcanBatchEngineTaskItemDelegateRegistry.
-				isBatchPlannerImportEnabled(
-					TestVulcanBatchEngineTaskItemDelegate.class.getName()));
-	}
-
-	@Test
-	public void testIsBatchPlannerImportEnabled() {
-		_registerVulcanBatchEngineTaskItemDelegate(false, true);
+		long companyId = TestPropsValues.getCompanyId();
 
 		Assert.assertFalse(
 			_vulcanBatchEngineTaskItemDelegateRegistry.
 				isBatchPlannerExportEnabled(
+					companyId,
+					TestVulcanBatchEngineTaskItemDelegate.class.getName()));
+		Assert.assertFalse(
+			_vulcanBatchEngineTaskItemDelegateRegistry.
+				isBatchPlannerImportEnabled(
+					companyId,
+					TestVulcanBatchEngineTaskItemDelegate.class.getName()));
+	}
+
+	@Test
+	public void testIsBatchPlannerExportImportDisabledCompanyScoped()
+		throws Exception {
+
+		long companyId = TestPropsValues.getCompanyId();
+
+		_registerVulcanBatchEngineTaskItemDelegate(companyId, false, false);
+
+		Assert.assertFalse(
+			_vulcanBatchEngineTaskItemDelegateRegistry.
+				isBatchPlannerExportEnabled(
+					companyId,
+					TestVulcanBatchEngineTaskItemDelegate.class.getName()));
+		Assert.assertFalse(
+			_vulcanBatchEngineTaskItemDelegateRegistry.
+				isBatchPlannerImportEnabled(
+					companyId,
+					TestVulcanBatchEngineTaskItemDelegate.class.getName()));
+	}
+
+	@Test
+	public void testIsBatchPlannerExportImportEnabled() throws Exception {
+		_registerVulcanBatchEngineTaskItemDelegate(null, true, true);
+
+		long companyId = TestPropsValues.getCompanyId();
+
+		Assert.assertTrue(
+			_vulcanBatchEngineTaskItemDelegateRegistry.
+				isBatchPlannerExportEnabled(
+					companyId,
 					TestVulcanBatchEngineTaskItemDelegate.class.getName()));
 		Assert.assertTrue(
 			_vulcanBatchEngineTaskItemDelegateRegistry.
 				isBatchPlannerImportEnabled(
+					companyId,
+					TestVulcanBatchEngineTaskItemDelegate.class.getName()));
+	}
+
+	@Test
+	public void testIsBatchPlannerExportImportEnabledCompanyScoped()
+		throws Exception {
+
+		long companyId = TestPropsValues.getCompanyId();
+
+		_registerVulcanBatchEngineTaskItemDelegate(companyId, true, true);
+
+		Assert.assertTrue(
+			_vulcanBatchEngineTaskItemDelegateRegistry.
+				isBatchPlannerExportEnabled(
+					companyId,
+					TestVulcanBatchEngineTaskItemDelegate.class.getName()));
+		Assert.assertTrue(
+			_vulcanBatchEngineTaskItemDelegateRegistry.
+				isBatchPlannerImportEnabled(
+					companyId,
+					TestVulcanBatchEngineTaskItemDelegate.class.getName()));
+	}
+
+	@Test
+	public void testIsBatchPlannerImportEnabled() throws Exception {
+		_registerVulcanBatchEngineTaskItemDelegate(null, false, true);
+
+		long companyId = TestPropsValues.getCompanyId();
+
+		Assert.assertFalse(
+			_vulcanBatchEngineTaskItemDelegateRegistry.
+				isBatchPlannerExportEnabled(
+					companyId,
+					TestVulcanBatchEngineTaskItemDelegate.class.getName()));
+		Assert.assertTrue(
+			_vulcanBatchEngineTaskItemDelegateRegistry.
+				isBatchPlannerImportEnabled(
+					companyId,
+					TestVulcanBatchEngineTaskItemDelegate.class.getName()));
+	}
+
+	@Test
+	public void testIsBatchPlannerImportEnabledCompanyScoped()
+		throws Exception {
+
+		long companyId = TestPropsValues.getCompanyId();
+
+		_registerVulcanBatchEngineTaskItemDelegate(companyId, false, true);
+
+		Assert.assertFalse(
+			_vulcanBatchEngineTaskItemDelegateRegistry.
+				isBatchPlannerExportEnabled(
+					companyId,
+					TestVulcanBatchEngineTaskItemDelegate.class.getName()));
+		Assert.assertTrue(
+			_vulcanBatchEngineTaskItemDelegateRegistry.
+				isBatchPlannerImportEnabled(
+					companyId,
 					TestVulcanBatchEngineTaskItemDelegate.class.getName()));
 	}
 
@@ -169,8 +268,11 @@ public class VulcanBatchEngineTaskItemDelegateRegistryTest {
 	public void testRegistryAndOpenAPIUtilToGetEntityMetadata()
 		throws Exception {
 
+		long companyId = TestPropsValues.getCompanyId();
+
 		Set<String> entityClassNames =
-			_vulcanBatchEngineTaskItemDelegateRegistry.getEntityClassNames();
+			_vulcanBatchEngineTaskItemDelegateRegistry.getEntityClassNames(
+				companyId);
 
 		Assert.assertTrue(
 			entityClassNames.contains(
@@ -179,6 +281,7 @@ public class VulcanBatchEngineTaskItemDelegateRegistryTest {
 		VulcanBatchEngineTaskItemDelegate<?> vulcanBatchEngineTaskItemDelegate =
 			_vulcanBatchEngineTaskItemDelegateRegistry.
 				getVulcanBatchEngineTaskItemDelegate(
+					companyId,
 					"com.liferay.headless.delivery.dto.v1_0.StructuredContent");
 
 		Assert.assertNotNull(vulcanBatchEngineTaskItemDelegate);
@@ -241,7 +344,7 @@ public class VulcanBatchEngineTaskItemDelegateRegistryTest {
 	}
 
 	private void _registerVulcanBatchEngineTaskItemDelegate(
-		boolean exportEnabled, boolean importEnabled) {
+		Long companyId, boolean exportEnabled, boolean importEnabled) {
 
 		Bundle bundle = FrameworkUtil.getBundle(
 			VulcanBatchEngineTaskItemDelegateRegistryTest.class);
@@ -251,12 +354,21 @@ public class VulcanBatchEngineTaskItemDelegateRegistryTest {
 		_serviceRegistration = bundleContext.registerService(
 			VulcanBatchEngineTaskItemDelegate.class,
 			new TestVulcanBatchEngineTaskItemDelegate(),
-			HashMapDictionaryBuilder.put(
+			HashMapDictionaryBuilder.<String, Object>put(
 				"batch.engine.task.item.delegate", "true"
 			).put(
 				"batch.planner.export.enabled", String.valueOf(exportEnabled)
 			).put(
 				"batch.planner.import.enabled", String.valueOf(importEnabled)
+			).put(
+				"companyId",
+				() -> {
+					if (companyId != null) {
+						return Arrays.asList(String.valueOf(companyId));
+					}
+
+					return null;
+				}
 			).put(
 				"entity.class.name",
 				TestVulcanBatchEngineTaskItemDelegate.class.getName()


### PR DESCRIPTION
Followed-up PR from: https://github.com/liferay-headless/liferay-portal/pull/1264

Ticket: [LPS-184728](https://issues.liferay.com/browse/LPS-184728).

The purpose of this PR is to register the `companyId` of the implementations of the `VulcanBatchEngineItemDelegate` interface in Objects.

Apart from that, the interface `VulcanBatchEngineTaskItemDelegateRegistry` and its implementation `VulcanBatchEngineTaskItemDelegateRegistryImpl` has been updated to include the `companyId` for each method. The classes that were using those methods have been updated to provide the companyId in the request too

cc/ @mbowerman


