### PR TITLE
Lps 186695 | Add functional test for LPS-164912 import Liferay entity should be able to partially updated

### DIFF
--- a/modules/apps/batch-planner/batch-planner-test/src/testFunctional/macros/ImportExport.macro
+++ b/modules/apps/batch-planner/batch-planner-test/src/testFunctional/macros/ImportExport.macro
@@ -367,7 +367,7 @@ definition {
 
 		ImportExport.mapImport(fieldMappings = ${fieldMappings});
 
-		ImportExport.startImport();
+		ImportExport.startImportAndWaitForSuccess();
 
 		Click(locator1 = "Button#CLOSE");
 	}
@@ -445,7 +445,7 @@ definition {
 			value1 = ${strategyType});
 	}
 
-	macro startImport {
+	macro startImportAndWaitForSuccess {
 		Button.click(button = "Next");
 
 		Button.click(button = "Start Import");

--- a/modules/apps/batch-planner/batch-planner-test/src/testFunctional/macros/ImportExport.macro
+++ b/modules/apps/batch-planner/batch-planner-test/src/testFunctional/macros/ImportExport.macro
@@ -367,11 +367,7 @@ definition {
 
 		ImportExport.mapImport(fieldMappings = ${fieldMappings});
 
-		Button.click(button = "Next");
-
-		Button.click(button = "Start Import");
-
-		WaitForElementPresent(locator1 = "ImportExport#EXECUTION_SUCCESS");
+		ImportExport.startImport();
 
 		Click(locator1 = "Button#CLOSE");
 	}
@@ -447,6 +443,14 @@ definition {
 		Select(
 			locator1 = "ImportExport#IMPORT_STRATEGY",
 			value1 = ${strategyType});
+	}
+
+	macro startImport {
+		Button.click(button = "Next");
+
+		Button.click(button = "Start Import");
+
+		WaitForElementPresent(locator1 = "ImportExport#EXECUTION_SUCCESS");
 	}
 
 	macro unzipDownloadedExportFile {

--- a/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/ImportEntitiesWithPartiallyUpdate.testcase
+++ b/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/ImportEntitiesWithPartiallyUpdate.testcase
@@ -1,0 +1,171 @@
+@component-name = "portal-batch-engine"
+definition {
+
+	property custom.properties = "feature.flag.COMMERCE-8087=true";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.main.component.name = "Batch Engine";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		BatchPlanner.batchPlannerTearDown();
+
+		AccountAPI.tearDownAllAccounts();
+
+		BlogPostingAPI.deleteAllBlogPostings();
+
+		if (${testPortalInstance} == "true") {
+			PortalInstances.tearDownCP();
+		}
+	}
+
+	@priority = 3
+	test CannotUpdateRecordWithOnlyAddNewRecords {
+		task ("Given a blog posting is created") {
+			var blogPostingId = BlogPostingAPI.getIdOfCreatedBlogPosting(
+				articleBody = "myArticleBody",
+				externalReferenceCode = "myErc",
+				headline = "headline of my blog posting");
+		}
+
+		task ("And Given new import file in import/export center") {
+			ImportExport.openImportExportAdmin();
+
+			ImportExport.gotoImport();
+		}
+
+		task ("And Given "Stop the import on error" unchecked with Only Add New Records and valid JSON file with blog posting entry with existing externalReferenceCode") {
+			ImportExport.configureImport(
+				entityType = "BlogPosting (v1_0 - Liferay Headless Delivery)",
+				fieldMappings = "articleBody:articleBody,headline:headline,externalReferenceCode:externalReferenceCode",
+				fileName = "json_blogPosting_import.json",
+				importStrategy = "Only Add New Records",
+				stopImportOnError = "false");
+		}
+
+		task ("When importing file with Next button") {
+			ImportExport.startImport();
+		}
+
+		task ("Then blog posting is not updated") {
+			var blogPostingData = BlogPostingAPI.getBlogPostingDataToString();
+
+			TestUtils.assertEquals(
+				actual = ${blogPostingData},
+				expected = "headline of my blog posting,myArticleBody,myErc");
+		}
+
+		task ("And Then new blog posting entry is created") {
+			var actualNumberOfBlogPostings = BlogPostingAPI.getNumberOfBlogPostingsCreated();
+
+			TestUtils.assertEquals(
+				actual = ${actualNumberOfBlogPostings},
+				expected = 2);
+		}
+	}
+
+	@priority = 4
+	test CanPartialUpdateAndCreateEntriesFromJsonWithAddOrUpdateRecordsUpdateChangedRecordFields {
+		property portal.acceptance = "true";
+
+		task ("Given an account without description field value is created") {
+			AccountAPI.createAccount(
+				externalReferenceCode = 101,
+				name = "Test Business Account");
+		}
+
+		task ("And Given new import file in import/export center") {
+			ImportExport.openImportExportAdmin();
+
+			ImportExport.gotoImport();
+		}
+
+		task ("And Given Add or Update records with Update Changed Record Fields selectd include uploading valid JSON file with 3 accounts including existing one with only required fields") {
+			ImportExport.configureImport(
+				entityType = "Account (v1_0 - Liferay Headless Admin User)",
+				fieldMappings = "name:name,type:type,externalReferenceCode:externalReferenceCode",
+				fileName = "json_account_import.json",
+				importStrategy = "Add or Update Records",
+				updateStrategy = "Update changed Record Fields");
+		}
+
+		task ("When importing file with Next button") {
+			ImportExport.startImport();
+		}
+
+		task ("Then existing account is updated the description field value not emptied") {
+			var response = AccountAPI.getAccounts();
+
+			var accountDescription = JSONUtil.getWithJSONPath(${response}, "$..items[?(@.name == 'Test Business Account')].description");
+
+			TestUtils.assertEquals(
+				actual = ${accountDescription},
+				expected = "Test Business Account Description");
+		}
+
+		task ("And Then new account is created") {
+			var actualNumberOfAccounts = JSONUtil.getWithJSONPath(${response}, "$..totalCount");
+
+			TestUtils.assertEquals(
+				actual = ${actualNumberOfAccounts},
+				expected = 3);
+		}
+	}
+
+	@priority = 4
+	test CanUpdateAndCreateEntriesFromJsonWithAddOrUpdateRecordsOverwrite {
+		property portal.acceptance = "true";
+
+		task ("Given an account with description field value is created") {
+			AccountAPI.createAccount(
+				description = "Test Business Account Description",
+				externalReferenceCode = 101,
+				name = "Test Business Account");
+		}
+
+		task ("And Given new import file in import/export center") {
+			ImportExport.openImportExportAdmin();
+
+			ImportExport.gotoImport();
+		}
+
+		task ("And Given Add or Update records and Overwrite Records by default selected with uploading valid JSON file with 2 accounts including existing one with only required fields") {
+			ImportExport.configureImport(
+				entityType = "Account (v1_0 - Liferay Headless Admin User)",
+				fieldMappings = "name:name,externalReferenceCode:externalReferenceCode",
+				fileName = "json_account_import_name_only.json",
+				importStrategy = "Add or Update Records",
+				updateStrategy = "Overwrite Records");
+		}
+
+		task ("When importing file with Next button") {
+			ImportExport.startImport();
+		}
+
+		task ("Then existing account is updated with the description field empty") {
+			var response = AccountAPI.getAccounts();
+
+			var accountDescription = JSONUtil.getWithJSONPath(${response}, "$..items[?(@.name == 'Test Business Account')].description");
+
+			TestUtils.assertEquals(
+				actual = ${accountDescription},
+				expected = "");
+		}
+
+		task ("And Then new account is created") {
+			var actualNumberOfAccounts = JSONUtil.getWithJSONPath(${response}, "$..totalCount");
+
+			TestUtils.assertEquals(
+				actual = ${actualNumberOfAccounts},
+				expected = 2);
+		}
+	}
+
+}

--- a/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/ImportEntitiesWithPartiallyUpdate.testcase
+++ b/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/ImportEntitiesWithPartiallyUpdate.testcase
@@ -51,7 +51,7 @@ definition {
 		}
 
 		task ("When importing file with Next button") {
-			ImportExport.startImport();
+			ImportExport.startImportAndWaitForSuccess();
 		}
 
 		task ("Then blog posting is not updated") {
@@ -97,7 +97,7 @@ definition {
 		}
 
 		task ("When importing file with Next button") {
-			ImportExport.startImport();
+			ImportExport.startImportAndWaitForSuccess();
 		}
 
 		task ("Then existing account is updated the description field value not emptied") {
@@ -146,7 +146,7 @@ definition {
 		}
 
 		task ("When importing file with Next button") {
-			ImportExport.startImport();
+			ImportExport.startImportAndWaitForSuccess();
 		}
 
 		task ("Then existing account is updated with the description field empty") {

--- a/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/dependencies/json_account_import_name_only.json
+++ b/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/dependencies/json_account_import_name_only.json
@@ -1,0 +1,9 @@
+[
+	{
+		"externalReferenceCode": "101",
+		"name": "Test Business Account"
+	},
+	{
+		"name": "Test Guest Account"
+	}
+]

--- a/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/dependencies/json_blogPosting_import.json
+++ b/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/dependencies/json_blogPosting_import.json
@@ -1,0 +1,12 @@
+[
+	{
+		"articleBody": "myArticleBody",
+		"externalReferenceCode": "myErc",
+		"headline": "headline of my second blog posting"
+	},
+	{
+		"articleBody": "secondArticleBody",
+		"externalReferenceCode": "secondErc",
+		"headline": "update headline of my blog posting"
+	}
+]

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/BlogPostingAPI.macro
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional/macros/BlogPostingAPI.macro
@@ -327,6 +327,7 @@ definition {
 	macro getIdOfCreatedBlogPosting {
 		var response = BlogPostingAPI._createBlogPosting(
 			articleBody = ${articleBody},
+			externalReferenceCode = ${externalReferenceCode},
 			headline = ${headline});
 
 		var blogPostingId = JSONPathUtil.getIdValue(response = ${response});

--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/AccountAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/AccountAPI.macro
@@ -30,6 +30,14 @@ definition {
 		var curl = AccountAPI._curlAccount();
 		var body = '''"name": "${name}"''';
 
+		if (isSet(externalReferenceCode)) {
+			var body = StringUtil.add(${body}, ",\"externalReferenceCode\":\"${externalReferenceCode}\"", " ");
+		}
+
+		if (isSet(description)) {
+			var body = StringUtil.add(${body}, ",\"description\":\"${description}\"", " ");
+		}
+
 		var curl = StringUtil.add(${curl}, "-d {${body}}", " ");
 
 		var response = JSONCurlUtil.post(${curl});
@@ -45,6 +53,14 @@ definition {
 		var curl = AccountAPI._curlAccount(accountId = ${accountId});
 
 		JSONCurlUtil.delete(${curl});
+	}
+
+	macro getAccounts {
+		var curl = AccountAPI._curlAccount();
+
+		var response = JSONCurlUtil.get(${curl});
+
+		return ${response};
 	}
 
 	macro getRelationshipByAccountId {
@@ -86,6 +102,16 @@ definition {
 		static var staticAccountId = ${accountId};
 
 		return ${staticAccountId};
+	}
+
+	macro tearDownAllAccounts {
+		var response = AccountAPI.getAccounts();
+
+		var accountIds = JSONUtil.getWithJSONPath(${response}, "$..items[*].id");
+
+		for (var accountId : list ${accountIds}) {
+			AccountAPI.deleteAccount(accountId = ${accountId});
+		}
 	}
 
 }


### PR DESCRIPTION
**Background:**
- Add functional tests on import liferay entities should be able to partially updated

**Test Plan:**
- Given a blog posting is created
And Given new import file in import/export center
And Given "Stop the import on error" unchecked with Only Add New Records and valid JSON file with blog posting entry with existing externalReferenceCode
When importing file with Next button
Then blog posting is not updated
And Then new blog posting entry is created
- Given an account without description field value is created
And Given new import file in import/export center
And Given Add or Update records with Update Changed Record Fields selectd include uploading valid JSON file with 3 accounts including existing one with only required fields
When importing file with Next button
Then existing account is updated the description field value not emptied
And Then new account is created
- Given an account with description field value is created
And Given new import file in import/export center
And Given Add or Update records and Overwrite Records by default selected with uploading valid JSON file with 2 accounts including existing one with only required fields
When importing file with Next button
Then existing account is updated with the description field empty
And Then new account is created

**Jira Ticket:**
- https://issues.liferay.com/browse/LPS-186695