### PR TITLE
LPS-177404

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testFunctional/macros/TaxonomyVocabularyAPI.macro
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testFunctional/macros/TaxonomyVocabularyAPI.macro
@@ -211,6 +211,23 @@ definition {
 		}
 	}
 
+	macro deleteAllTaxonomyVocabulary {
+		Variables.assertDefined(parameterList = ${groupName});
+
+		var response = TaxonomyVocabularyAPI.getTaxonomyVocabularyWithDifferentParameters(groupName = ${groupName});
+
+		var taxonomyVocabularyErcList = JSONUtil.getWithJSONPath(${response}, "$..items[*].externalReferenceCode");
+
+		for (var taxonomyVocabularyErc : list ${taxonomyVocabularyErcList}) {
+			var curl = TaxonomyVocabularyAPI._curlTaxonomyVocabulary(
+				depotName = ${depotName},
+				externalReferenceCode = ${taxonomyVocabularyErc},
+				groupName = ${groupName});
+
+			JSONCurlUtil.delete(${curl});
+		}
+	}
+
 	macro deleteTaxonomyVocabularyByErc {
 		Variables.assertDefined(parameterList = ${externalReferenceCode});
 

--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/CustomObjectAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/CustomObjectAPI.macro
@@ -6,7 +6,7 @@ definition {
 		''';
 
 	macro _curlObjectEntries {
-		Variables.assertDefined(parameterList = "${en_US_plural_label},${fieldName},${fieldValue}");
+		Variables.assertDefined(parameterList = ${en_US_plural_label});
 
 		var en_US_plural_label_lowercase = StringUtil.lowerCase(${en_US_plural_label});
 
@@ -32,35 +32,38 @@ definition {
 				var groupName = "Guest";
 			}
 
-			var scopeKey = JSONGroupAPI._getGroupIdByNameNoSelenium(
+			var scopeKey = JSONGroupAPI._getSiteIdByGroupKeyNoSelenium(
 				groupName = ${groupName},
-				site = "true");
+				token = ${token});
 
 			var api = StringUtil.add(${api}, "/scopes/${scopeKey}", "");
 		}
 
-		var curlWithoutBody = StringUtil.add(${api}, " \ ${headers}", "");
-		var body = CustomObjectAPI._setNObjectEntriesBody(
-			alternateName = ${alternateName},
-			emailDomain = ${emailDomain},
-			externalReferenceCode = ${externalReferenceCode},
-			familyName = ${familyName},
-			fieldName = ${fieldName},
-			fieldValue = ${fieldValue},
-			givenName = ${givenName},
-			keywords = ${keywords},
-			nestedField = ${nestedField},
-			numberOfRelatedObjectEntries = ${numberOfRelatedObjectEntries},
-			objectEntryId = ${objectEntryId},
-			oneToManyChild = ${oneToManyChild},
-			relatedEntryExternalReferenceCode = ${relatedEntryExternalReferenceCode},
-			relatedEntryFieldName = ${relatedEntryFieldName},
-			relatedUserAccount = ${relatedUserAccount},
-			secondFieldValue = ${secondFieldValue},
-			taxonomyCategoryIds = ${taxonomyCategoryIds},
-			userExternalReferenceCodes = ${userExternalReferenceCodes});
+		var curl = StringUtil.add(${api}, " \ ${headers}", "");
 
-		var curl = StringUtil.add(${curlWithoutBody}, "-d {${body}}", " ");
+		if (!(isSet(body))) {
+			var body = CustomObjectAPI._setNObjectEntriesBody(
+				alternateName = ${alternateName},
+				emailDomain = ${emailDomain},
+				externalReferenceCode = ${externalReferenceCode},
+				familyName = ${familyName},
+				fieldName = ${fieldName},
+				fieldValue = ${fieldValue},
+				givenName = ${givenName},
+				keywords = ${keywords},
+				nestedField = ${nestedField},
+				numberOfRelatedObjectEntries = ${numberOfRelatedObjectEntries},
+				objectEntryId = ${objectEntryId},
+				oneToManyChild = ${oneToManyChild},
+				relatedEntryExternalReferenceCode = ${relatedEntryExternalReferenceCode},
+				relatedEntryFieldName = ${relatedEntryFieldName},
+				relatedUserAccount = ${relatedUserAccount},
+				secondFieldValue = ${secondFieldValue},
+				taxonomyCategoryIds = ${taxonomyCategoryIds},
+				userExternalReferenceCodes = ${userExternalReferenceCodes});
+
+			var curl = StringUtil.add(${curl}, "-d {${body}}", " ");
+		}
 
 		if (isSet(token)) {
 			var curl = StringUtil.add(${curl}, " -H 'Authorization: Bearer ${token}'", "");
@@ -232,6 +235,21 @@ definition {
 			virtualHost = ${virtualHost});
 
 		var response = JSONCurlUtil.post(${curl});
+
+		return ${response};
+	}
+
+	macro getObjectEntries {
+		Variables.assertDefined(parameterList = ${en_US_plural_label});
+
+		var en_US_plural_label_lowercase = StringUtil.lowerCase(${en_US_plural_label});
+		var curl = CustomObjectAPI._curlObjectEntries(
+			body = "false",
+			en_US_plural_label = ${en_US_plural_label},
+			scopeKey = ${scopeKey},
+			token = ${token});
+
+		var response = JSONCurlUtil.get(${curl});
 
 		return ${response};
 	}

--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/CustomObjectAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/CustomObjectAPI.macro
@@ -28,8 +28,12 @@ definition {
 		}
 
 		if (isSet(scopeKey)) {
+			if (!(isSet(groupName))) {
+				var groupName = "Guest";
+			}
+
 			var scopeKey = JSONGroupAPI._getGroupIdByNameNoSelenium(
-				groupName = "Guest",
+				groupName = ${groupName},
 				site = "true");
 
 			var api = StringUtil.add(${api}, "/scopes/${scopeKey}", "");
@@ -219,6 +223,7 @@ definition {
 			externalReferenceCode = ${externalReferenceCode},
 			fieldName = ${fieldName},
 			fieldValue = ${fieldValue},
+			groupName = ${groupName},
 			keywords = ${keywords},
 			scopeKey = ${scopeKey},
 			secondFieldValue = ${secondFieldValue},

--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectDefinitionAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectDefinitionAPI.macro
@@ -639,6 +639,7 @@ definition {
 			en_US_plural_label = ${en_US_plural_label},
 			name = ${name},
 			requiredStringFieldName = ${requiredStringFieldName},
+			scope = ${scope},
 			token = ${token},
 			virtualHost = ${virtualHost});
 

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/ManageCategoriesForObjectEntries.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/ManageCategoriesForObjectEntries.testcase
@@ -36,9 +36,7 @@ definition {
 
 		ObjectAdmin.deleteAllCustomObjectsViaAPI();
 
-		TaxonomyVocabularyAPI.deleteTaxonomyVocabularyByErc(
-			externalReferenceCode = "erc",
-			groupName = "Guest");
+		TaxonomyVocabularyAPI.deleteAllTaxonomyVocabulary(groupName = "Guest");
 
 		if (${testPortalInstance} == "true") {
 			PortalInstances.tearDownCP();
@@ -86,6 +84,108 @@ definition {
 
 	@disable-webdriver = "true"
 	@priority = 4
+	test CanFilterEntriesByTaxonomyCategory {
+		property portal.acceptance = "true";
+
+		task ("And Given object definition 'Student' with name field created") {
+			ObjectDefinitionAPI.createAndPublishObjectDefinition(
+				en_US_label = "student",
+				en_US_plural_label = "students",
+				name = "Student",
+				requiredStringFieldName = "name");
+		}
+
+		task ("And Given Student entry 'Student1' created with {category_childId} associated") {
+			ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "students",
+				name = "Student1",
+				taxonomyCategoryIds = ${staticChildTaxonomyCategoryId});
+		}
+
+		task ("And Given Student entry 'Student2' created with {category_parentId} associated") {
+			var studentEntryId = ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "students",
+				name = "Student2",
+				taxonomyCategoryIds = ${staticTaxonomyCategoryId});
+		}
+
+		task ("When requesting getStudentsPage with filter taxonomyCategoryIds/any(k:k eq ${taxonomyCategoryId})") {
+			var response = ObjectDefinitionAPI.getObjectEntries(
+				en_US_plural_label = "students",
+				parameter = "filter=taxonomyCategoryIds%2Fany%28k%3Ak%20eq%20${staticTaxonomyCategoryId}%29");
+		}
+
+		task ("Then I can see 'Student2' entry") {
+			var actualValue = JSONUtil.getWithJSONPath(${response}, "$.items..[?(@.id==${studentEntryId})].name");
+
+			TestUtils.assertEquals(
+				actual = ${actualValue},
+				expected = "Student2");
+		}
+
+		task ("And then totalCount of payload is 1") {
+			var actualValue = JSONUtil.getWithJSONPath(${response}, "$..totalCount");
+
+			TestUtils.assertEquals(
+				actual = ${actualValue},
+				expected = 1);
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 4
+	test CanGetEmbeddedTaxonomyCategoryOfEntriesCollection {
+		property portal.acceptance = "true";
+
+		task ("And Given taxonomyVocabulary with name 'terminology' created") {
+			var responseFromVocabulary = TaxonomyVocabularyAPI.createTaxonomyVocabulary(
+				externalReferenceCode = "erc1",
+				groupName = "Guest",
+				name = "terminology");
+		}
+
+		task ("And Given category with name 'term' in 'terminology' created") {
+			var taxonomyVocabularyId = JSONPathUtil.getIdValue(response = ${responseFromVocabulary});
+
+			var responseFromCategory = TaxonomyCategoryAPI.createTaxonomyCategory(
+				name = "term",
+				taxonomyVocabularyId = ${taxonomyVocabularyId});
+		}
+
+		task ("And Given object definition 'Student' with name field created") {
+			ObjectDefinitionAPI.createAndPublishObjectDefinition(
+				en_US_label = "student",
+				en_US_plural_label = "students",
+				name = "Student",
+				requiredStringFieldName = "name");
+		}
+
+		task ("And Given Student entry created with taxonomyCategoryIds of 'term' and 'category_parent'") {
+			var taxonomyCategoryId = JSONPathUtil.getIdValue(response = ${responseFromCategory});
+
+			var studentEntryId = ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "students",
+				name = "Tom",
+				taxonomyCategoryIds = "${staticTaxonomyCategoryId},${taxonomyCategoryId}");
+		}
+
+		task ("When requesting getStudentsPage with nestedFields=embeddedTaxonomyCategory") {
+			var response = ObjectDefinitionAPI.getObjectEntries(
+				en_US_plural_label = "students",
+				parameter = "nestedFields=embeddedTaxonomyCategory");
+		}
+
+		task ("Then I can see the embeddedTaxonomyCategory node with information") {
+			var actualValue = JSONUtil.getWithJSONPath(${response}, "$..items[?(@.id==${studentEntryId})].taxonomyCategoryBriefs..embeddedTaxonomyCategory.name");
+
+			TestUtils.assertEquals(
+				actual = ${actualValue},
+				expected = "category_parent,term");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 4
 	test CanGetTaxonomyCategoryBriefsOfEntriesCollection {
 		property portal.acceptance = "true";
 
@@ -114,6 +214,41 @@ definition {
 			TestUtils.assertEquals(
 				actual = ${actualValue},
 				expected = "category_parent");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 4
+	test CanGetTaxonomyCategoryBriefsOfObjectEntry {
+		property portal.acceptance = "true";
+
+		task ("And Given object definition 'Student' with name field created") {
+			ObjectDefinitionAPI.createAndPublishObjectDefinition(
+				en_US_label = "student",
+				en_US_plural_label = "students",
+				name = "Student",
+				requiredStringFieldName = "name");
+		}
+
+		task ("And Given Student entry created with taxonomyCategoryId of 'category_child'") {
+			var studentEntryId = ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "students",
+				name = "Tom",
+				taxonomyCategoryIds = ${staticChildTaxonomyCategoryId});
+		}
+
+		task ("When requesting getStudent with {studentId}") {
+			var response = CustomObjectAPI.getObjectEntryById(
+				en_US_plural_label = "students",
+				objectEntryId = ${studentEntryId});
+		}
+
+		task ("Then I can see 'category_child' details in the taxonomyCategoryBriefs") {
+			var actualValue = JSONUtil.getWithJSONPath(${response}, "$.[?(@.id==${studentEntryId})].taxonomyCategoryBriefs..taxonomyCategoryName");
+
+			TestUtils.assertEquals(
+				actual = ${actualValue},
+				expected = "category_child");
 		}
 	}
 
@@ -153,6 +288,54 @@ definition {
 		}
 	}
 
+	@description = "LPS-186852. The category to set is not being validated if it belongs to the same site or a parent one"
+	@disable-webdriver = "true"
+	@ignore = "true"
+	@priority = 3
+	test CanUpdateSiteScopedObjectEntryWithTaxonomyCategoryOfDifferentSiteScope {
+		property portal.acceptance = "true";
+
+		task ("And Given object definition 'Student' with name field and Scope: Site created") {
+			ObjectDefinitionAPI.createAndPublishObjectDefinition(
+				en_US_label = "student",
+				en_US_plural_label = "students",
+				name = "Student",
+				requiredStringFieldName = "name",
+				scope = "site");
+		}
+
+		task ("And Given Student entry created") {
+			var responseFromCreate = CustomObjectAPI.createObjectEntryWithFields(
+				en_US_plural_label = "students",
+				fieldName = "name",
+				fieldValue = "Tom",
+				groupName = "Global",
+				scopeKey = "true");
+		}
+
+		task ("When requesting putStudent with {studentId} to associate {category_parentId}") {
+			var studentEntryId = JSONPathUtil.getIdValue(response = ${responseFromCreate});
+
+			CustomObjectAPI.putObjectEntryById(
+				en_US_plural_label = "students",
+				fieldValue = "Tom",
+				objectEntryId = ${studentEntryId},
+				taxonomyCategoryIds = ${staticTaxonomyCategoryId});
+		}
+
+		task ("Then I can see 'category_parent' details in the taxonomyCategoryBriefs of the entry with {studentId}") {
+			var response = CustomObjectAPI.getObjectEntryById(
+				en_US_plural_label = "students",
+				objectEntryId = ${studentEntryId});
+
+			var actualValue = JSONUtil.getWithJSONPath(${response}, "$.[?(@.id==${studentEntryId})].taxonomyCategoryBriefs..taxonomyCategoryName");
+
+			TestUtils.assertEquals(
+				actual = ${actualValue},
+				expected = "category_parent");
+		}
+	}
+
 	@disable-webdriver = "true"
 	@priority = 4
 	test CanUpdateSiteScopedObjectEntryWithTaxonomyCategoryWithinSameScope {
@@ -168,12 +351,16 @@ definition {
 		}
 
 		task ("And Given Student entry created") {
-			var studentEntryId = ObjectDefinitionAPI.createObjectEntryWithName(
+			var responseFromCreate = CustomObjectAPI.createObjectEntryWithFields(
 				en_US_plural_label = "students",
-				name = "Tom");
+				fieldName = "name",
+				fieldValue = "Tom",
+				scopeKey = "true");
 		}
 
 		task ("When requesting putStudent with {studentId} to associate {category_parentId}") {
+			var studentEntryId = JSONPathUtil.getIdValue(response = ${responseFromCreate});
+
 			CustomObjectAPI.putObjectEntryById(
 				en_US_plural_label = "students",
 				fieldValue = "Tom",
@@ -182,9 +369,11 @@ definition {
 		}
 
 		task ("Then I can see 'category_parent' details in the taxonomyCategoryBriefs of the entry with {studentId}") {
-			var response = ObjectDefinitionAPI.getObjectEntries(en_US_plural_label = "students");
+			var response = CustomObjectAPI.getObjectEntryById(
+				en_US_plural_label = "students",
+				objectEntryId = ${studentEntryId});
 
-			var actualValue = JSONUtil.getWithJSONPath(${response}, "$..items[?(@.id==${studentEntryId})].taxonomyCategoryBriefs..taxonomyCategoryName");
+			var actualValue = JSONUtil.getWithJSONPath(${response}, "$.[?(@.id==${studentEntryId})].taxonomyCategoryBriefs..taxonomyCategoryName");
 
 			TestUtils.assertEquals(
 				actual = ${actualValue},

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/ScopeObjectAPIsForDifferentInstances.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/ScopeObjectAPIsForDifferentInstances.testcase
@@ -107,8 +107,8 @@ definition {
 
 		task ("When I use postScopeScopeKey and scopeKey to create an object entry in default instance") {
 			var defaultInstanceToken = OAuth2ForObject.createTokenWithOAuth2Scopes(
-				resourceCheckList = "C_Test.everything",
-				resourcePanels = "C_Test");
+				resourceCheckList = "C_Test.everything,liferay-json-web-services.everything",
+				resourcePanels = "C_Test,Portal Services");
 
 			CustomObjectAPI.createObjectEntryWithFields(
 				en_US_plural_label = "tests",
@@ -119,8 +119,9 @@ definition {
 		}
 
 		task ("Then the object entry created successfully") {
-			var responseToParse = ObjectDefinitionAPI.getObjectEntries(
+			var responseToParse = CustomObjectAPI.getObjectEntries(
 				en_US_plural_label = "tests",
+				scopeKey = "true",
 				token = ${defaultInstanceToken});
 
 			var actualValue = JSONUtil.getWithJSONPath(${responseToParse}, "$.totalCount");

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/ScopeObjectAPIsForDifferentInstances.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/ScopeObjectAPIsForDifferentInstances.testcase
@@ -110,9 +110,10 @@ definition {
 				resourceCheckList = "C_Test.everything",
 				resourcePanels = "C_Test");
 
-			ObjectDefinitionAPI.createObjectEntryWithName(
+			CustomObjectAPI.createObjectEntryWithFields(
 				en_US_plural_label = "tests",
-				name = "Object Entry in Default Instance",
+				fieldName = "name",
+				fieldValue = "Object Entry in Default Instance",
 				scopeKey = "true",
 				token = ${defaultInstanceToken});
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/company/JSONCompany.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/company/JSONCompany.macro
@@ -112,6 +112,10 @@ definition {
 				-u ${creatorEmailAddress}:${creatorPassword}
 		''';
 
+		if (isSet(token)) {
+			var curl = StringUtil.add(${curl}, " -H 'Authorization: Bearer ${token}'", "");
+		}
+
 		var companyId = JSONCurlUtil.get(${curl}, "$['companyId']");
 
 		return ${companyId};

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/group/JSONGroupAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/group/JSONGroupAPI.macro
@@ -531,4 +531,37 @@ definition {
 		return ${groupId};
 	}
 
+	@summary = "Get the groupId from any existing parent or child site by using groupName but not invoking selenium methods"
+	macro _getSiteIdByGroupKeyNoSelenium {
+		Variables.assertDefined(parameterList = ${groupName});
+
+		if (!(isSet(portalURL))) {
+			var portalURL = JSONCompany.getPortalURL();
+		}
+
+		var companyId = JSONCompany.getCompanyIdNoSelenium(
+			portalURL = ${portalURL},
+			token = ${token});
+		var userLoginInfo = JSONUtil2.formatJSONUser();
+
+		var curl = '''
+			${portalURL}/api/jsonws/group/get-group \
+				-u ${userLoginInfo} \
+				-d companyId=${companyId} \
+				-d groupKey=${groupName}
+		''';
+
+		if (isSet(token)) {
+			var curl = StringUtil.add(${curl}, " -H 'Authorization: Bearer ${token}'", "");
+		}
+
+		var groupId = JSONCurlUtil.post(${curl}, "$.[?(@['groupKey'] == '${groupName}')]['groupId']");
+
+		if (${groupId} == "") {
+			fail("FAIL. Cannot find group.");
+		}
+
+		return ${groupId};
+	}
+
 }


### PR DESCRIPTION
**Background:**
Update testcase to manage categories for object entries

**Test Plan**
CanGetTaxonomyCategoryBriefsOfObjectEntry
And Given Student entry created with taxonomyCategoryId of 'category_child'
When requesting getStudent with {studentId}
Then I can see 'category_child' details in the taxonomyCategoryBriefs

CanGetEmbeddedTaxonomyCategoryOfEntriesCollection
And Given taxonomyVocabulary with name 'terminology' created
And Given category with name 'term' in 'terminology' created
And Given Student entry created with taxonomyCategoryIds of 'term' and 'category_parent'
When requesting getStudentsPage with nestedFields=embeddedTaxonomyCategory
Then I can see the embeddedTaxonomyCategory node with information

CanFilterEntriesByTaxonomyCategory
And Given Student entry 'Student1' created with {category_childId} associated
And Given Student entry 'Student2' created with {category_parentId} associated
When requesting getStudentsPage with filter taxonomyCategoryIds/any(k:k eq ${taxonomyCategoryId})
Then I can see 'Student2' entry
And then totalCount of payload is 1

CanUpdateSiteScopedObjectEntryWithTaxonomyCategoryOfDifferentStiteScope
Given current Site is Liferay DXP
Given taxonomyVocabulary with name 'vocabulary' created
And Given category with name 'category_parent' in 'vocabulary' created
And Given object definition 'Student' with name field and Scope: Site created
And Given Student entry created
When requesting putStudent with {studentId} to associate {category_parentId}
Then I can see 'category_parent' details in the taxonomyCategoryBriefs of the entry with {studentId}

**Jira ticket:**
https://issues.liferay.com/browse/LPS-180229