### PR TITLE
Lps 187588 Add tests to update object using Regular role and Account Role with permissions

### DIFF
--- a/modules/apps/account/account-test/src/testFunctional/macros/json/accountEntry/JSONAccountEntryAPI.macro
+++ b/modules/apps/account/account-test/src/testFunctional/macros/json/accountEntry/JSONAccountEntryAPI.macro
@@ -92,7 +92,7 @@ definition {
 			var creatorPassword = "test";
 		}
 
-		var companyId = JSONCompany.getCompanyId();
+		var companyId = JSONCompany.getCompanyIdNoSelenium();
 		var portalURL = JSONCompany.getPortalURL();
 		var userId = JSONUserSetter.setUserId(userEmailAddress = ${creatorEmailAddress});
 		var curl = '''

--- a/modules/apps/account/account-test/src/testFunctional/macros/json/accountEntryUser/JSONAccountEntryUserAPI.macro
+++ b/modules/apps/account/account-test/src/testFunctional/macros/json/accountEntryUser/JSONAccountEntryUserAPI.macro
@@ -37,7 +37,7 @@ definition {
 			var creatorPassword = "test";
 		}
 
-		var companyId = JSONCompany.getCompanyId();
+		var companyId = JSONCompany.getCompanyIdNoSelenium();
 		var portalURL = JSONCompany.getPortalURL();
 
 		var curl = '''

--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/AccountAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/AccountAPI.macro
@@ -55,6 +55,16 @@ definition {
 		JSONCurlUtil.delete(${curl});
 	}
 
+	macro deleteAllAccounts {
+		var response = AccountAPI.getAccounts();
+
+		var accountIdList = JSONUtil.getWithJSONPath(${response}, "$.items..id");
+
+		for (var accountId : list ${accountIdList}) {
+			AccountAPI.deleteAccount(accountId = ${accountId});
+		}
+	}
+
 	macro getAccounts {
 		var curl = AccountAPI._curlAccount();
 

--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/AccountRoleAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/AccountRoleAPI.macro
@@ -1,0 +1,39 @@
+definition {
+
+	macro associateAccountRoleUserAndAccount {
+		Variables.assertDefined(parameterList = "${accountId},${roleName},${userAccountId}");
+
+		var portalURL = JSONCompany.getPortalURL();
+		var idOfRole = AccountRoleAPI.getIdForAccountRoleByAccountId(
+			accountId = ${accountId},
+			roleName = ${roleName});
+
+		var curl = '''
+			${portalURL}/o/headless-admin-user/v1.0/accounts/${accountId}/account-roles/${idOfRole}/user-accounts/${userAccountId}
+				roles/${roleId}/association/user-account/ \
+				-H accept: application/json \
+				-u test@liferay.com:test \
+		''';
+
+		var response = JSONCurlUtil.post(${curl});
+
+		return ${response};
+	}
+
+	macro getIdForAccountRoleByAccountId {
+		Variables.assertDefined(parameterList = "${roleName},${accountId}");
+
+		var portalURL = JSONCompany.getPortalURL();
+
+		var curl = '''
+			${portalURL}/o/headless-admin-user/v1.0/accounts/${accountId}/account-roles
+				-H accept: application/json \
+				-u test@liferay.com:test \
+		''';
+
+		var idOfRole = JSONCurlUtil.get(${curl}, "$.items[?(@['name'] == '${roleName}')]['id']");
+
+		return ${idOfRole};
+	}
+
+}

--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/AccountRoleAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/AccountRoleAPI.macro
@@ -1,10 +1,10 @@
 definition {
 
-	macro associateAccountRoleUserAndAccount {
+	macro associateUserToAccountWithAccountRole {
 		Variables.assertDefined(parameterList = "${accountId},${roleName},${userAccountId}");
 
 		var portalURL = JSONCompany.getPortalURL();
-		var idOfRole = AccountRoleAPI.getIdForAccountRoleByAccountId(
+		var idOfRole = AccountRoleAPI.getAccountRoleIdByAccountId(
 			accountId = ${accountId},
 			roleName = ${roleName});
 
@@ -20,7 +20,7 @@ definition {
 		return ${response};
 	}
 
-	macro getIdForAccountRoleByAccountId {
+	macro getAccountRoleIdByAccountId {
 		Variables.assertDefined(parameterList = "${roleName},${accountId}");
 
 		var portalURL = JSONCompany.getPortalURL();

--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/CustomObjectAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/CustomObjectAPI.macro
@@ -39,6 +39,13 @@ definition {
 			var api = StringUtil.add(${api}, "/scopes/${scopeKey}", "");
 		}
 
+		if (isSet(userEmailAddress)) {
+			var headers = '''
+				-u ${userEmailAddress}:test \
+				-H Content-Type: application/json \
+			''';
+		}
+
 		var curl = StringUtil.add(${api}, " \ ${headers}", "");
 
 		if (!(isSet(body))) {
@@ -239,6 +246,47 @@ definition {
 		return ${response};
 	}
 
+	macro createStudentRelatedToAccount {
+		Variables.assertDefined(parameterList = "${name},${accountId}");
+
+		var portalURL = JSONCompany.getPortalURL();
+
+		var curl = '''
+			${portalURL}/o/c/students \
+				-u test@liferay.com:test \
+				-H Content-Type: application/json \
+				-d {
+					"name": "${name}",
+					"r_accountStudents_accountEntryId": "${accountId}"
+				}
+		''';
+
+		var studentId = JSONCurlUtil.post(${curl}, "$.id");
+
+		return ${studentId};
+	}
+
+	macro createSubjectRelatedToStudentAndAccount {
+		Variables.assertDefined(parameterList = "${name},${accountId},${studentId}");
+
+		var portalURL = JSONCompany.getPortalURL();
+
+		var curl = '''
+			${portalURL}/o/c/subjects \
+				-u test@liferay.com:test \
+				-H Content-Type: application/json \
+				-d {
+					"name": "${name}",
+					"r_accountSubjects_accountEntryId": "${accountId}",
+					"r_studentSubjects_c_studentId": "${studentId}"
+				}
+		''';
+
+		var subjectId = JSONCurlUtil.post(${curl}, "$.id");
+
+		return ${subjectId};
+	}
+
 	macro getObjectEntries {
 		Variables.assertDefined(parameterList = ${en_US_plural_label});
 
@@ -403,6 +451,21 @@ definition {
 		var body = StringUtil.add("${body},", ${entryBody}, "");
 
 		return ${body};
+	}
+
+	macro patchObjectEntryNameById {
+		Variables.assertDefined(parameterList = "${en_US_plural_label},${fieldValue},${objectEntryId}");
+
+		var curl = CustomObjectAPI._curlObjectEntries(
+			en_US_plural_label = ${en_US_plural_label},
+			fieldName = "name",
+			fieldValue = ${fieldValue},
+			objectEntryId = ${objectEntryId},
+			userEmailAddress = ${userEmailAddress});
+
+		var response = JSONCurlUtil.patch(${curl});
+
+		return ${response};
 	}
 
 	macro putObjectEntryById {

--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectDefinitionAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectDefinitionAPI.macro
@@ -823,6 +823,25 @@ definition {
 		ObjectDefinitionAPI._deleteRelationship(relationshipId = ${relationshipId});
 	}
 
+	macro enableAccountRestrictedAndShowWidget {
+		Variables.assertDefined(parameterList = "${objectDefinitionId},${accountRestrictedField}");
+
+		ObjectDefinitionAPI.updateObjectDefinitionById(
+			objectDefinitionId = ${objectDefinitionId},
+			parameter = "accountEntryRestrictedObjectFieldName",
+			parameterValue = ${accountRestrictedField});
+
+		ObjectDefinitionAPI.updateObjectDefinitionById(
+			objectDefinitionId = ${objectDefinitionId},
+			parameter = "accountEntryRestricted",
+			parameterValue = "true");
+
+		ObjectDefinitionAPI.updateObjectDefinitionById(
+			objectDefinitionId = ${objectDefinitionId},
+			parameter = "portlet",
+			parameterValue = "true");
+	}
+
 	macro getIdOfObjectDefinitionExportBatch {
 		var portalURL = JSONCompany.getPortalURL();
 

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/ManageCustomObjectsWithDifferentRoles.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/ManageCustomObjectsWithDifferentRoles.testcase
@@ -223,12 +223,12 @@ definition {
 				accountEntryName = "accountForSubject",
 				userEmailAddress = "test2@liferay.com");
 
-			AccountRoleAPI.associateAccountRoleUserAndAccount(
+			AccountRoleAPI.associateUserToAccountWithAccountRole(
 				accountId = ${studentAccountId},
 				roleName = "Test Account Role",
 				userAccountId = ${userAccountId});
 
-			AccountRoleAPI.associateAccountRoleUserAndAccount(
+			AccountRoleAPI.associateUserToAccountWithAccountRole(
 				accountId = ${subjectAccountId},
 				roleName = "Test Account Role",
 				userAccountId = ${userAccountId});

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/ManageCustomObjectsWithDifferentRoles.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/ManageCustomObjectsWithDifferentRoles.testcase
@@ -1,0 +1,254 @@
+@component-name = "portal-headless"
+definition {
+
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Object";
+	property testray.main.component.name = "Headless";
+
+	setUp {
+		TestCase.setUpPortalInstanceNoSelenium();
+
+		task ("Given Student and Subject object definitions with field 'name' and panelCategoryKey 'Control Panel > Object' created") {
+			ObjectDefinitionAPI.staticStudentObjectId();
+
+			ObjectDefinitionAPI.updateObjectDefinitionById(
+				objectDefinitionId = ${staticStudentObjectId},
+				parameter = "panelCategoryKey",
+				parameterValue = "control_panel.object");
+
+			ObjectDefinitionAPI.staticSubjectObjectId();
+
+			ObjectDefinitionAPI.updateObjectDefinitionById(
+				objectDefinitionId = ${staticSubjectObjectId},
+				parameter = "panelCategoryKey",
+				parameterValue = "control_panel.object");
+		}
+
+		task ("And Given oneToMany relationship studentSubjects created") {
+			ObjectDefinitionAPI.createRelationship(
+				deletionType = "cascade",
+				en_US_label = "StudentSubjects",
+				name = "studentSubjects",
+				objectDefinitionId1 = ${staticStudentObjectId},
+				objectDefinitionId2 = ${staticSubjectObjectId},
+				type = "oneToMany");
+		}
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		ObjectAdmin.deleteAllCustomObjectsViaAPI();
+
+		JSONUser.tearDownNonAdminUsersNoSelenium();
+
+		JSONRole.deleteTestRoles();
+
+		AccountAPI.deleteAllAccounts();
+
+		if (${testPortalInstance} == "true") {
+			PortalInstances.tearDownCPNoSelenium();
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 4
+	test CanUpdateObjectAsRegularRoleWithViewAndUpdatePermissions {
+		property portal.acceptance = "true";
+
+		task ("And Given student and subject entries with relationship created") {
+			CustomObjectAPI.createObjectEntryWithFields(
+				en_US_plural_label = "students",
+				fieldName = "name",
+				fieldValue = "Bob");
+
+			CustomObjectAPI.createObjectEntryWithFields(
+				en_US_plural_label = "subjects",
+				fieldName = "name",
+				fieldValue = "Math");
+
+			var studentId = CustomObjectAPI.getObjectEntryIdByName(
+				en_US_plural_label = "students",
+				name = "Bob");
+			var subjectId = CustomObjectAPI.getObjectEntryIdByName(
+				en_US_plural_label = "subjects",
+				name = "Math");
+
+			ObjectDefinitionAPI.relateObjectEntries(
+				en_US_plural_label = "students",
+				objectEntry1 = ${studentId},
+				objectEntry2 = ${subjectId},
+				relationshipName = "studentSubjects");
+		}
+
+		task ("And Given a regular role with permissios to access Student and Subject is created") {
+			JSONRole.addRegularRole(
+				roleKey = "Test Regular Role",
+				roleTitle = "Test Regular Role");
+
+			for (var resourceAction : list "UPDATE,VIEW") {
+				Permissions.definePermissionViaJSONAPI(
+					resourceAction = ${resourceAction},
+					resourceName = "com.liferay.object.model.ObjectDefinition#${staticStudentObjectId}",
+					roleTitle = "Test Regular Role",
+					roleType = "regular");
+			}
+
+			for (var resourceAction : list "UPDATE,VIEW") {
+				Permissions.definePermissionViaJSONAPI(
+					resourceAction = ${resourceAction},
+					resourceName = "com.liferay.object.model.ObjectDefinition#${staticSubjectObjectId}",
+					roleTitle = "Test Regular Role",
+					roleType = "regular");
+			}
+		}
+
+		task ("And Given create a new user and assign to the role created") {
+			var response = UserAccountAPI.createUserAccount(
+				alternateName = "test2",
+				emailAddress = "test2@liferay.com",
+				familyName = "test2fn",
+				fieldName = "password",
+				fieldValue = "test",
+				givenName = "test2gn");
+
+			JSONRole.assignRoleToUser(
+				roleTitle = "Test Regular Role",
+				userEmailAddress = "test2@liferay.com");
+		}
+
+		task ("When with patchSubject and subjectId to update subject as the new user") {
+			var response = CustomObjectAPI.patchObjectEntryNameById(
+				en_US_plural_label = "subjects",
+				fieldValue = "Able",
+				objectEntryId = ${subjectId},
+				userEmailAddress = "test2@liferay.com");
+		}
+
+		task ("Then the subject is updated successfully") {
+			var actualName = JSONUtil.getWithJSONPath(${response}, "$.name");
+
+			TestUtils.assertEquals(
+				actual = ${actualName},
+				expected = "Able");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = 4
+	test CanUpdateObjectWithAccountRestrictionAsAccountRoleWithPermissions {
+		property portal.acceptance = "true";
+
+		task ("And Given oneToMany relationships are set between Account -> Student and Account -> Subject") {
+			var accountObjectId = ObjectDefinitionAPI.getObjectDefinitionIdByName(name = "AccountEntry");
+
+			ObjectDefinitionAPI.createRelationship(
+				deletionType = "cascade",
+				en_US_label = "AccountStudents",
+				name = "accountStudents",
+				objectDefinitionId1 = ${accountObjectId},
+				objectDefinitionId2 = ${staticStudentObjectId},
+				type = "oneToMany");
+
+			ObjectDefinitionAPI.createRelationship(
+				deletionType = "cascade",
+				en_US_label = "AccountSubjects",
+				name = "accountSubjects",
+				objectDefinitionId1 = ${accountObjectId},
+				objectDefinitionId2 = ${staticSubjectObjectId},
+				type = "oneToMany");
+		}
+
+		task ("And Given Account Restriction enabled for Student and Subject") {
+			ObjectDefinitionAPI.enableAccountRestrictedAndShowWidget(
+				accountRestrictedField = "r_accountStudents_accountEntryId",
+				objectDefinitionId = ${staticStudentObjectId});
+
+			ObjectDefinitionAPI.enableAccountRestrictedAndShowWidget(
+				accountRestrictedField = "r_accountSubjects_accountEntryId",
+				objectDefinitionId = ${staticSubjectObjectId});
+		}
+
+		task ("And Given an Account Role with permissions for Student and Subject is created") {
+			JSONRole.addSharedAccountRole(roleTitle = "Test Account Role");
+
+			for (var resourceAction : list "UPDATE,VIEW") {
+				Permissions.definePermissionViaJSONAPI(
+					resourceAction = ${resourceAction},
+					resourceName = "com.liferay.object.model.ObjectDefinition#${staticStudentObjectId}",
+					roleTitle = "Test Account Role",
+					roleType = "account");
+			}
+
+			for (var resourceAction : list "UPDATE,VIEW") {
+				Permissions.definePermissionViaJSONAPI(
+					resourceAction = ${resourceAction},
+					resourceName = "com.liferay.object.model.ObjectDefinition#${staticSubjectObjectId}",
+					roleTitle = "Test Account Role",
+					roleType = "account");
+			}
+		}
+
+		task ("And Given two new accounts related to Student and Subject created") {
+			var studentAccountId = AccountAPI.createAccount(name = "accountForStudent");
+
+			var studentId = CustomObjectAPI.createStudentRelatedToAccount(
+				accountId = ${studentAccountId},
+				name = "Able");
+			var subjectAccountId = AccountAPI.createAccount(name = "accountForSubject");
+
+			var subjectId = CustomObjectAPI.createSubjectRelatedToStudentAndAccount(
+				accountId = ${subjectAccountId},
+				name = "English",
+				studentId = ${studentId});
+		}
+
+		task ("And Given assign a new user to every account as well as assign Account Role to the user") {
+			var response = UserAccountAPI.createUserAccount(
+				alternateName = "test2",
+				emailAddress = "test2@liferay.com",
+				familyName = "test2fn",
+				fieldName = "password",
+				fieldValue = "test",
+				givenName = "test2gn");
+
+			var userAccountId = JSONPathUtil.getIdValue(response = ${response});
+
+			JSONAccountEntryUser.addExistUsertoAccount(
+				accountEntryName = "accountForStudent",
+				userEmailAddress = "test2@liferay.com");
+
+			JSONAccountEntryUser.addExistUsertoAccount(
+				accountEntryName = "accountForSubject",
+				userEmailAddress = "test2@liferay.com");
+
+			AccountRoleAPI.associateAccountRoleUserAndAccount(
+				accountId = ${studentAccountId},
+				roleName = "Test Account Role",
+				userAccountId = ${userAccountId});
+
+			AccountRoleAPI.associateAccountRoleUserAndAccount(
+				accountId = ${subjectAccountId},
+				roleName = "Test Account Role",
+				userAccountId = ${userAccountId});
+		}
+
+		task ("When with patchSubject and subjectId to update subject as the new user") {
+			var response = CustomObjectAPI.patchObjectEntryNameById(
+				en_US_plural_label = "subjects",
+				fieldValue = "Able-update",
+				objectEntryId = ${subjectId},
+				userEmailAddress = "test2@liferay.com");
+		}
+
+		task ("Then the subject is updated successfully") {
+			var actualName = JSONUtil.getWithJSONPath(${response}, "$.name");
+
+			TestUtils.assertEquals(
+				actual = ${actualName},
+				expected = "Able-update");
+		}
+	}
+
+}

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/user/JSONUserAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/user/JSONUserAPI.macro
@@ -226,7 +226,7 @@ definition {
 	macro _getUserIdByEmailAddress {
 		Variables.assertDefined(parameterList = ${userEmailAddress});
 
-		var companyId = JSONCompany.getCompanyId(
+		var companyId = JSONCompany.getCompanyIdNoSelenium(
 			creatorEmailAddress = ${creatorEmailAddress},
 			creatorPassword = ${creatorPassword},
 			portalInstanceName = ${portalInstanceName});


### PR DESCRIPTION
Background:
- Add test to update object with/without Account Restriction using different Roles with Permissions

Test Plan
- object definition without Account Restriction
oneToMany relationship between custom objects
Regular role with view and update permissions
update object entry
- object definition with Account Restriction and show widget
oneToMany relationships between Account - custom objects, custom - custom objects
Account Role with view and update permissions
update object entry

Jira Ticket:
- https://issues.liferay.com/browse/LPS-187588