### PR TITLE
LPS-187908 Replace Draft application state by Unpublish state

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/resources/com/liferay/headless/builder/internal/batch/headless-builder.json
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/resources/com/liferay/headless/builder/internal/batch/headless-builder.json
@@ -548,7 +548,7 @@
 				{
 					"DBType": "String",
 					"businessType": "Picklist",
-					"defaultValue": "draft",
+					"defaultValue": "unpublished",
 					"externalReferenceCode": "APPLICATION_STATUS",
 					"indexed": true,
 					"indexedAsKeyword": false,
@@ -563,18 +563,18 @@
 							"value": {
 								"objectStates": [
 									{
-										"key": "draft",
+										"key": "published",
 										"objectStateTransitions": [
 											{
-												"key": "published"
+												"key": "unpublished"
 											}
 										]
 									},
 									{
-										"key": "published",
+										"key": "unpublished",
 										"objectStateTransitions": [
 											{
-												"key": "draft"
+												"key": "published"
 											}
 										]
 									}


### PR DESCRIPTION
Related ticket [LPS-187908](https://issues.liferay.com/browse/LPS-187908)
____
## Context
At the moment of this PR creation, there is no Draft feature implemented by Objects. So the Headless Builder does not support draft either because is based on Objects.

In order to avoid confusion the Draft application state is deleted and replaced by Unpublish state. Once the draft feature is implemented, the draft state will be added to the list of states.