### PR TITLE
LPS-186907: Add validation for http method + path  and must be related whith a APIApplication of an APIEndpoint 

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-impl/build.gradle
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/build.gradle
@@ -8,8 +8,10 @@ dependencies {
 	compileOnly project(":apps:headless:headless-builder:headless-builder-api")
 	compileOnly project(":apps:info:info-api")
 	compileOnly project(":apps:object:object-api")
+	compileOnly project(":apps:object:object-rest-api")
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":apps:static:osgi:osgi-util")
 	compileOnly project(":core:osgi-service-tracker-collections")
+	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIEndpointObjectEntryModelListener.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIEndpointObjectEntryModelListener.java
@@ -1,0 +1,173 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.headless.builder.internal.model.listener;
+
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.rest.petra.sql.dsl.expression.FilterPredicateFactory;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.petra.sql.dsl.expression.Predicate;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.exception.ModelListenerException;
+import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.ModelListener;
+
+import java.io.Serializable;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Sergio Jiménez del Coso
+ */
+@Component(service = ModelListener.class)
+public class APIEndpointObjectEntryModelListener
+	extends BaseModelListener<ObjectEntry> {
+
+	@Override
+	public void onBeforeCreate(ObjectEntry objectEntry)
+		throws ModelListenerException {
+
+		if (!_isAPIEndpointObjectDefinition(objectEntry)) {
+			return;
+		}
+
+		_validate(objectEntry);
+	}
+
+	@Override
+	public void onBeforeUpdate(
+			ObjectEntry originalObjectEntry, ObjectEntry objectEntry)
+		throws ModelListenerException {
+
+		if (_isAPIEndpointObjectDefinition(objectEntry) &&
+			_validateNewAPIEndpointValues(originalObjectEntry, objectEntry)) {
+
+			_validate(objectEntry);
+		}
+	}
+
+	private boolean _isAPIEndpointObjectDefinition(ObjectEntry objectEntry) {
+		ObjectDefinition apiEndpointObjectDefinition =
+			_objectDefinitionLocalService.fetchObjectDefinition(
+				objectEntry.getObjectDefinitionId());
+
+		if (Objects.equals(
+				apiEndpointObjectDefinition.getExternalReferenceCode(),
+				"MSOD_API_ENDPOINT")) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	private void _validate(ObjectEntry objectEntry) {
+		ObjectDefinition apiEndpointObjectDefinition =
+			_objectDefinitionLocalService.fetchObjectDefinition(
+				objectEntry.getObjectDefinitionId());
+
+		try {
+			Map<String, Serializable> objectEntryValues =
+				objectEntry.getValues();
+
+			if (!_validateEndpointPath((String)objectEntryValues.get("path"))) {
+				throw new IllegalArgumentException(
+					"Path can have a maximum of 255 alphanumeric characters");
+			}
+
+			String filterString = StringBundler.concat(
+				"id ne '", objectEntry.getObjectEntryId(),
+				"' and httpMethod eq '",
+				(String)objectEntryValues.get("httpMethod"), "' and path eq '",
+				(String)objectEntryValues.get("path"),
+				"' and r_apiApplicationToAPIEndpoints_c_apiApplicationId eq '",
+				(long)objectEntryValues.get(
+					"r_apiApplicationToAPIEndpoints_c_apiApplicationId"),
+				"'");
+
+			Predicate predicate = _filterPredicateFactory.create(
+				filterString,
+				apiEndpointObjectDefinition.getObjectDefinitionId());
+
+			List<Map<String, Serializable>> definedAPIEndpointList =
+				_objectEntryLocalService.getValuesList(
+					objectEntry.getGroupId(), objectEntry.getCompanyId(),
+					objectEntry.getUserId(),
+					apiEndpointObjectDefinition.getObjectDefinitionId(),
+					predicate, null, -1, -1, null);
+
+			if (!definedAPIEndpointList.isEmpty()) {
+				throw new IllegalArgumentException(
+					"There is an endpoint with the same http method and path " +
+						"combination");
+			}
+		}
+		catch (Exception exception) {
+			throw new ModelListenerException(exception);
+		}
+	}
+
+	private boolean _validateEndpointPath(String path) {
+		Matcher matcher = _baseEndpointPathPattern.matcher(path);
+
+		return matcher.matches();
+	}
+
+	private boolean _validateNewAPIEndpointValues(
+		ObjectEntry originalObjectEntry, ObjectEntry objectEntry) {
+
+		Map<String, Serializable> objectEntryValues = objectEntry.getValues();
+		Map<String, Serializable> originalObjectEntryValues =
+			originalObjectEntry.getValues();
+
+		if (Objects.equals(
+				objectEntryValues.get("httpMethod"),
+				originalObjectEntryValues.get("httpMethod")) &&
+			Objects.equals(
+				objectEntryValues.get("path"),
+				originalObjectEntryValues.get("path")) &&
+			Objects.equals(
+				objectEntryValues.get(
+					"r_apiApplicationToAPIEndpoints_c_apiApplicationId"),
+				originalObjectEntryValues.get(
+					"r_apiApplicationToAPIEndpoints_c_apiApplicationId"))) {
+
+			return false;
+		}
+
+		return true;
+	}
+
+	private static final Pattern _baseEndpointPathPattern = Pattern.compile(
+		"[a-zA-Z0-9-/]{1,255}");
+
+	@Reference
+	private FilterPredicateFactory _filterPredicateFactory;
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Reference
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+}

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIEndpointObjectEntryModelListener.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIEndpointObjectEntryModelListener.java
@@ -121,6 +121,13 @@ public class APIEndpointObjectEntryModelListener
 					"There is an endpoint with the same http method and path " +
 						"combination");
 			}
+
+			if ((long)objectEntryValues.get(
+					"r_apiApplicationToAPIEndpoints_c_apiApplicationId") == 0) {
+
+				throw new IllegalArgumentException(
+					"An endpoint must be related to an application");
+			}
 		}
 		catch (Exception exception) {
 			throw new ModelListenerException(exception);

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/test/validation/test/APIApplicationObjectEntryModelListenerTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/test/validation/test/APIApplicationObjectEntryModelListenerTest.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.headless.builder.test.validation.test;
+
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.HTTPTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Sergio Jiménez del Coso
+ */
+@Ignore
+public class APIApplicationObjectEntryModelListenerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws PortalException {
+		_apiApplicationObjectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"MSOD_API_APPLICATION", CompanyThreadLocal.getCompanyId());
+	}
+
+	@Test
+	public void testInvalidBaseURLPathAPIApplication() throws Exception {
+		JSONObject jsonObject = HTTPTestUtil.invoke(
+			JSONUtil.put(
+				"applicationStatus", "published"
+			).put(
+				"baseURL",
+				RandomTestUtil.randomString() + StringPool.FORWARD_SLASH
+			).put(
+				"title", RandomTestUtil.randomString()
+			).toString(),
+			_apiApplicationObjectDefinition.getRESTContextPath(),
+			Http.Method.POST);
+
+		Assert.assertEquals("BAD_REQUEST", jsonObject.get("status"));
+		Assert.assertEquals(
+			"Base URL can have a maximum of 255 alphanumeric characters",
+			jsonObject.get("title"));
+	}
+
+	@Test
+	public void testValidBaseURLPathAPIApplication() throws Exception {
+		JSONObject jsonObject = HTTPTestUtil.invoke(
+			JSONUtil.put(
+				"applicationStatus", "published"
+			).put(
+				"baseURL", RandomTestUtil.randomString()
+			).put(
+				"title", RandomTestUtil.randomString()
+			).toString(),
+			_apiApplicationObjectDefinition.getRESTContextPath(),
+			Http.Method.POST);
+
+		Assert.assertEquals(
+			0,
+			jsonObject.getJSONObject(
+				"status"
+			).get(
+				"code"
+			));
+	}
+
+	private ObjectDefinition _apiApplicationObjectDefinition;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+}

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/test/validation/test/APIEndpointObjectEntryModelListenerTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/test/validation/test/APIEndpointObjectEntryModelListenerTest.java
@@ -1,0 +1,244 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.headless.builder.test.validation.test;
+
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.HTTPTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Sergio Jiménez del Coso
+ */
+@Ignore
+public class APIEndpointObjectEntryModelListenerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws PortalException {
+		_apiApplicationObjectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"MSOD_API_APPLICATION", CompanyThreadLocal.getCompanyId());
+
+		_apiEndpointObjectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"MSOD_API_ENDPOINT", CompanyThreadLocal.getCompanyId());
+	}
+
+	@Test
+	public void testInvalidPathAPIEndpoint() throws Exception {
+		JSONObject jsonObject = HTTPTestUtil.invoke(
+			JSONUtil.put(
+				"httpMethod", "get"
+			).put(
+				"name", RandomTestUtil.randomString()
+			).put(
+				"path",
+				StringBundler.concat(
+					RandomTestUtil.randomString(), StringPool.FORWARD_SLASH,
+					RandomTestUtil.randomString(), StringPool.COMMA)
+			).put(
+				"scope", "company"
+			).toString(),
+			_apiEndpointObjectDefinition.getRESTContextPath(),
+			Http.Method.POST);
+
+		Assert.assertEquals("BAD_REQUEST", jsonObject.get("status"));
+		Assert.assertEquals(
+			"Path can have a maximum of 255 alphanumeric characters",
+			jsonObject.get("title"));
+	}
+
+	@Test
+	public void testPostAPIEndpointNotRelatedWithAPIApplication()
+		throws Exception {
+
+		JSONObject jsonObject = HTTPTestUtil.invoke(
+			JSONUtil.put(
+				"httpMethod", "get"
+			).put(
+				"name", RandomTestUtil.randomString()
+			).put(
+				"path", RandomTestUtil.randomString()
+			).put(
+				"scope", "company"
+			).toString(),
+			_apiEndpointObjectDefinition.getRESTContextPath(),
+			Http.Method.POST);
+
+		Assert.assertEquals("BAD_REQUEST", jsonObject.get("status"));
+		Assert.assertEquals(
+			"An endpoint must be related to an application",
+			jsonObject.get("title"));
+	}
+
+	@Test
+	public void testPostAPIEndpointRelatedWithAPIApplication()
+		throws Exception {
+
+		JSONObject apiApplicationJSONObject = _createAPIApplicationJSONObject();
+
+		JSONObject jsonObject = HTTPTestUtil.invoke(
+			JSONUtil.put(
+				"httpMethod", "get"
+			).put(
+				"name", RandomTestUtil.randomString()
+			).put(
+				"path", RandomTestUtil.randomString()
+			).put(
+				"r_apiApplicationToAPIEndpoints_c_apiApplicationId",
+				apiApplicationJSONObject.getLong("id")
+			).put(
+				"scope", "company"
+			).toString(),
+			_apiEndpointObjectDefinition.getRESTContextPath(),
+			Http.Method.POST);
+
+		Assert.assertEquals(
+			0,
+			jsonObject.getJSONObject(
+				"status"
+			).get(
+				"code"
+			));
+
+		Assert.assertEquals(
+			jsonObject.get("r_apiApplicationToAPIEndpoints_c_apiApplicationId"),
+			apiApplicationJSONObject.get("id"));
+	}
+
+	@Test
+	public void testPostAPIEndpointRelatedWithAPIApplicationWithSamePath()
+		throws Exception {
+
+		String path = RandomTestUtil.randomString();
+
+		JSONObject apiApplicationJSONObject = _createAPIApplicationJSONObject();
+
+		JSONObject jsonObject = HTTPTestUtil.invoke(
+			JSONUtil.put(
+				"httpMethod", "get"
+			).put(
+				"name", RandomTestUtil.randomString()
+			).put(
+				"path", path
+			).put(
+				"r_apiApplicationToAPIEndpoints_c_apiApplicationId",
+				apiApplicationJSONObject.getLong("id")
+			).put(
+				"scope", "company"
+			).toString(),
+			_apiEndpointObjectDefinition.getRESTContextPath(),
+			Http.Method.POST);
+
+		Assert.assertEquals(
+			jsonObject.get("r_apiApplicationToAPIEndpoints_c_apiApplicationId"),
+			apiApplicationJSONObject.get("id"));
+
+		jsonObject = HTTPTestUtil.invoke(
+			JSONUtil.put(
+				"httpMethod", "get"
+			).put(
+				"name", RandomTestUtil.randomString()
+			).put(
+				"path", path
+			).put(
+				"r_apiApplicationToAPIEndpoints_c_apiApplicationId",
+				apiApplicationJSONObject.getLong("id")
+			).put(
+				"scope", "company"
+			).toString(),
+			_apiEndpointObjectDefinition.getRESTContextPath(),
+			Http.Method.POST);
+
+		Assert.assertEquals("BAD_REQUEST", jsonObject.get("status"));
+		Assert.assertEquals(
+			"There is an endpoint with the same http method and path " +
+				"combination",
+			jsonObject.get("title"));
+	}
+
+	@Test
+	public void testValidPathAPIEndpoint() throws Exception {
+		JSONObject apiApplicationJSONObject = _createAPIApplicationJSONObject();
+
+		JSONObject jsonObject = HTTPTestUtil.invoke(
+			JSONUtil.put(
+				"httpMethod", "get"
+			).put(
+				"name", RandomTestUtil.randomString()
+			).put(
+				"path", RandomTestUtil.randomString()
+			).put(
+				"r_apiApplicationToAPIEndpoints_c_apiApplicationId",
+				apiApplicationJSONObject.getLong("id")
+			).put(
+				"scope", "company"
+			).toString(),
+			_apiEndpointObjectDefinition.getRESTContextPath(),
+			Http.Method.POST);
+
+		Assert.assertEquals(
+			0,
+			jsonObject.getJSONObject(
+				"status"
+			).get(
+				"code"
+			));
+	}
+
+	private JSONObject _createAPIApplicationJSONObject() throws Exception {
+		return HTTPTestUtil.invoke(
+			JSONUtil.put(
+				"applicationStatus", "published"
+			).put(
+				"baseURL", RandomTestUtil.randomString()
+			).put(
+				"title", RandomTestUtil.randomString()
+			).toString(),
+			_apiApplicationObjectDefinition.getRESTContextPath(),
+			Http.Method.POST);
+	}
+
+	private ObjectDefinition _apiApplicationObjectDefinition;
+	private ObjectDefinition _apiEndpointObjectDefinition;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+}


### PR DESCRIPTION
**What is new?**
- Create `APIEndpointObjectEntryModelListener` to trigger when a APIEndpoint is going to be created or updated, establishin two validations:

1. The `path` value should be correct
2. The combination of a `httpMethod` and `path` from an Endpoint should be unique in every `APIApplication`.
3. Every APIEndpoint must be related with a APIApplication

- Create some tests cases for APIApplication and APIEndpoint

**How to reproduce it?**

- Deploy `headless-builder-impl`.

**Related JIRA Ticket**
https://liferay.atlassian.net/browse/LPS-186907
https://liferay.atlassian.net/browse/LPS-186913