### PR TITLE
Lps 188142 Add tests for scope object for other virtual instance in import/export center

### DIFF
--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/ScopeObjectAPIsForDifferentInstances.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/ScopeObjectAPIsForDifferentInstances.testcase
@@ -79,19 +79,12 @@ definition {
 
 		OAuth2.deleteApplication(applicationName = "OAuth Application");
 
-		OAuth2.openOAuth2Admin(baseURL = "http://www.able.com:8080");
+		ApplicationsMenu.gotoPortlet(
+			category = "System",
+			panel = "Control Panel",
+			portlet = "Virtual Instances");
 
-		var virtualInstanceToken = OAuth2ForObject.createTokenWithOAuth2Scopes(
-			baseURL = "http://www.able.com:8080",
-			resourceCheckList = "Liferay.Headless.Portal.Instances.everything,Liferay.Object.Admin.REST.everything",
-			resourcePanels = "Liferay.Headless.Portal.Instances,Liferay.Object.Admin.REST");
-
-		ObjectAdmin.deleteObjectViaAPI(
-			objectName = "Test",
-			token = ${virtualInstanceToken},
-			virtualHost = "www.able.com");
-
-		OAuth2.deleteApplication(applicationName = "OAuth Application");
+		PortalInstances.deleteCP(virtualHost = "www.able.com");
 
 		var testPortalInstance = PropsUtil.get("test.portal.instance");
 
@@ -203,6 +196,7 @@ definition {
 	test CanScopeObjectByInstanceInExportTask {
 		property custom.properties = "include-and-override=portal-liferay-online.properties${line.separator}feature.flag.COMMERCE-8087=true";
 		property portal.acceptance = "true";
+		property test.name.skip.portal.instance = "ScopeObjectAPIsForDifferentInstances#CanScopeObjectByInstanceInExportTask";
 
 		task ("And Given an object definition Student with a custom field is created and published on virtual instance") {
 			var virtualInstanceToken = OAuth2ForObject.createTokenWithOAuth2Scopes(

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/ScopeObjectAPIsForDifferentInstances.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/ScopeObjectAPIsForDifferentInstances.testcase
@@ -199,4 +199,35 @@ definition {
 		}
 	}
 
+	@priority = 4
+	test CanScopeObjectByInstanceInExportTask {
+		property custom.properties = "include-and-override=portal-liferay-online.properties${line.separator}feature.flag.COMMERCE-8087=true";
+		property portal.acceptance = "true";
+
+		task ("And Given an object definition Student with a custom field is created and published on virtual instance") {
+			var virtualInstanceToken = OAuth2ForObject.createTokenWithOAuth2Scopes(
+				baseURL = "http://www.able.com:8080",
+				resourceCheckList = "Liferay.Headless.Portal.Instances.everything,Liferay.Object.Admin.REST.everything",
+				resourcePanels = "Liferay.Headless.Portal.Instances,Liferay.Object.Admin.REST");
+
+			ObjectDefinitionAPI.createAndPublishObjectDefinition(
+				en_US_label = "Student",
+				en_US_plural_label = "Students",
+				name = "Student",
+				requiredStringFieldName = "name",
+				token = ${virtualInstanceToken},
+				virtualHost = "www.able.com");
+		}
+
+		task ("When create an export task on default instance") {
+			ImportExport.openImportExportAdmin();
+
+			ImportExport.gotoExport();
+		}
+
+		task ("Then C_Student is not in the available Entity Type list") {
+			AssertTextNotPresent(value1 = "C_Student (v1_0 - Liferay Object REST)");
+		}
+	}
+
 }


### PR DESCRIPTION
Background:
- Add test for scope object for other virtual instance in import/export center

Test Plan
- Given a new virtual instances www.able.com is created
And Given an object definition Student with a custom field is created and published on virtual instance
When create an export task on default instance
Then C_Student is not in the available Entity Type list

Jira Ticket:
- https://liferay.atlassian.net/browse/LPS-188142