### PR TITLE
LPS-161981

### DIFF
--- a/modules/apps/batch-engine/batch-engine-test/src/testFunctional/tests/ExportEntitiesOfJsontIncludeAction.testcase
+++ b/modules/apps/batch-engine/batch-engine-test/src/testFunctional/tests/ExportEntitiesOfJsontIncludeAction.testcase
@@ -81,4 +81,15 @@ definition {
 		}
 	}
 
+	@description = "Ignored due to LPS-176805"
+	@ignore = "true"
+	@priority = 3
+	test CanSelectItemActionsAsFieldToExportWithJSONT {
+		task ("Then actions field is visible to select on the list of fields to include in the export file") {
+			AssertElementPresent(
+				key_checkboxOption = "action",
+				locator1 = "Checkbox#SPECIFIC_CHECKBOX_IN_TABLE");
+		}
+	}
+
 }


### PR DESCRIPTION
Background:
 Update a testcase to add case about select item actions as field to export with JSONT

Test Plan
CanSelectItemActionsAsFieldToExportWithJSONT
Given Stock object definition created
And Given Stock entries created
When in Import/Export: Export File selected as Entity Type C_Stock (v1_0 - Liferay Object REST) in Export File Format: JSONT
Then actions field is visible to select on the list of fields to include in the export file

Jira ticket:
https://liferay.atlassian.net/browse/LPS-188127