### PR TITLE
LPS-188315 Invoke the getPersistedModel method before invoking to the delete method of the LocalService to verify the baseModel exists before hand

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/test/BaseTestCase.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/test/BaseTestCase.java
@@ -17,19 +17,13 @@ package com.liferay.headless.builder.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.batch.engine.unit.BatchEngineUnitProcessor;
 import com.liferay.batch.engine.unit.BatchEngineUnitReader;
-import com.liferay.portal.kernel.json.JSONObject;
-import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
-import com.liferay.portal.kernel.test.util.HTTPTestUtil;
-import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.util.Objects;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -71,31 +65,6 @@ public abstract class BaseTestCase {
 				completableFuture.join();
 			}
 		}
-
-		_externalReferenceCodes = _getExternalReferenceCodes();
-	}
-
-	@After
-	public void tearDown() throws Exception {
-		Set<String> externalReferenceCodes = _getExternalReferenceCodes();
-
-		externalReferenceCodes.removeAll(_externalReferenceCodes);
-
-		for (String externalReferenceCode : externalReferenceCodes) {
-			HTTPTestUtil.invoke(
-				null,
-				"headless-builder/applications/by-external-reference-code/" +
-					externalReferenceCode,
-				Http.Method.DELETE);
-		}
-	}
-
-	private Set<String> _getExternalReferenceCodes() throws Exception {
-		JSONObject jsonObject = HTTPTestUtil.invoke(
-			null, "headless-builder/applications", Http.Method.GET);
-
-		return JSONUtil.toStringSet(
-			jsonObject.getJSONArray("items"), "externalReferenceCode");
 	}
 
 	@Inject
@@ -103,7 +72,5 @@ public abstract class BaseTestCase {
 
 	@Inject
 	private BatchEngineUnitReader _batchEngineUnitReader;
-
-	private Set<String> _externalReferenceCodes;
 
 }

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
@@ -174,7 +174,12 @@ public class DataGuardTestRuleUtil {
 				persistedModelLocalService.deletePersistedModel(persistedModel);
 			}
 			else {
-				deleteMethod.invoke(persistedModelLocalService, persistedModel);
+				BaseModel<?> baseModel = (BaseModel<?>)persistedModel;
+
+				deleteMethod.invoke(
+					persistedModelLocalService,
+					persistedModelLocalService.getPersistedModel(
+						baseModel.getPrimaryKeyObj()));
 			}
 		}
 		catch (Throwable throwable1) {


### PR DESCRIPTION
The purpose of this PR is to avoid invoking the `delete` method of the Local Service if the element does not exist. That is causing some problems as printing error traces in the Liferay log when trying to delete already deleted elements from the Integration Tests.

For that, a previous invocation has been performed to the `getPersistedModel` method. If the persisted model exists (most of the cases), the persisted model will be deleted via `delete` method of the Local Service. Otherwise, an exception will be thrown, avoiding the invocation to the Service Layer.

The `catch` block will be in charge of managing the rest of the deletions as before (such as resource permissions, etc)