### PR TITLE
LPS-188304 Add support for different endpoints in the headless builder resource

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-impl/build.gradle
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/build.gradle
@@ -3,6 +3,8 @@ dependencies {
 	compileOnly group: "io.swagger.core.v3", name: "swagger-models", version: "2.0.6"
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
 	compileOnly group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"
+	compileOnly group: "org.apache.cxf", name: "cxf-core", version: "3.4.10"
+	compileOnly group: "org.apache.cxf", name: "cxf-rt-frontend-jaxrs", version: "3.4.10"
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/application/resource/BaseHeadlessBuilderResourceImpl.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/application/resource/BaseHeadlessBuilderResourceImpl.java
@@ -14,9 +14,14 @@
 
 package com.liferay.headless.builder.internal.application.resource;
 
+import com.liferay.headless.builder.application.APIApplication;
+
+import javax.servlet.http.HttpServletRequest;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 
 /**
@@ -28,5 +33,11 @@ public abstract class BaseHeadlessBuilderResourceImpl {
 	@Path("{any: .*}")
 	@Produces({"application/json", "application/xml"})
 	public abstract Response get() throws Exception;
+
+	@Context
+	protected APIApplication contextAPIApplication;
+
+	@Context
+	protected HttpServletRequest contextHttpServletRequest;
 
 }

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/application/resource/HeadlessBuilderResourceImpl.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/application/resource/HeadlessBuilderResourceImpl.java
@@ -15,6 +15,7 @@
 package com.liferay.headless.builder.internal.application.resource;
 
 import com.liferay.headless.builder.application.APIApplication;
+import com.liferay.headless.builder.internal.util.PathUtil;
 import com.liferay.portal.kernel.exception.NoSuchModelException;
 import com.liferay.portal.kernel.util.StringUtil;
 
@@ -38,14 +39,9 @@ public class HeadlessBuilderResourceImpl
 	}
 
 	private APIApplication.Endpoint _getEndpoint() throws Exception {
-		String requestURI = contextHttpServletRequest.getRequestURI();
-
-		if (requestURI.startsWith("/o/")) {
-			requestURI = requestURI.substring(3);
-		}
-
 		String endpointPath = StringUtil.removeSubstring(
-			requestURI, contextAPIApplication.getBaseURL());
+			PathUtil.sanitize(contextHttpServletRequest.getRequestURI()),
+			contextAPIApplication.getBaseURL());
 
 		for (APIApplication.Endpoint endpoint :
 				contextAPIApplication.getEndpoints()) {

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/application/resource/HeadlessBuilderResourceImpl.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/application/resource/HeadlessBuilderResourceImpl.java
@@ -14,6 +14,12 @@
 
 package com.liferay.headless.builder.internal.application.resource;
 
+import com.liferay.headless.builder.application.APIApplication;
+import com.liferay.portal.kernel.exception.NoSuchModelException;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.util.Objects;
+
 import javax.ws.rs.core.Response;
 
 /**
@@ -24,8 +30,35 @@ public class HeadlessBuilderResourceImpl
 
 	@Override
 	public Response get() throws Exception {
+		APIApplication.Endpoint endpoint = _getEndpoint();
+
 		return Response.ok(
+			endpoint.getPath()
 		).build();
+	}
+
+	private APIApplication.Endpoint _getEndpoint() throws Exception {
+		String requestURI = contextHttpServletRequest.getRequestURI();
+
+		if (requestURI.startsWith("/o/")) {
+			requestURI = requestURI.substring(3);
+		}
+
+		String endpointPath = StringUtil.removeSubstring(
+			requestURI, contextAPIApplication.getBaseURL());
+
+		for (APIApplication.Endpoint endpoint :
+				contextAPIApplication.getEndpoints()) {
+
+			if (Objects.equals(endpoint.getPath(), endpointPath)) {
+				return endpoint;
+			}
+		}
+
+		throw new NoSuchModelException(
+			String.format(
+				"Endpoint %s does not exists on %s", endpointPath,
+				contextAPIApplication.getTitle()));
 	}
 
 }

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/application/resource/HeadlessBuilderResourceImpl.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/application/resource/HeadlessBuilderResourceImpl.java
@@ -31,14 +31,6 @@ public class HeadlessBuilderResourceImpl
 
 	@Override
 	public Response get() throws Exception {
-		APIApplication.Endpoint endpoint = _getEndpoint();
-
-		return Response.ok(
-			endpoint.getPath()
-		).build();
-	}
-
-	private APIApplication.Endpoint _getEndpoint() throws Exception {
 		String endpointPath = StringUtil.removeSubstring(
 			PathUtil.sanitize(contextHttpServletRequest.getRequestURI()),
 			contextAPIApplication.getBaseURL());
@@ -47,7 +39,9 @@ public class HeadlessBuilderResourceImpl
 				contextAPIApplication.getEndpoints()) {
 
 			if (Objects.equals(endpoint.getPath(), endpointPath)) {
-				return endpoint;
+				return Response.ok(
+					endpoint.getPath()
+				).build();
 			}
 		}
 

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/jaxrs/context/provider/APIApplicationContextProvider.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/jaxrs/context/provider/APIApplicationContextProvider.java
@@ -16,6 +16,7 @@ package com.liferay.headless.builder.internal.jaxrs.context.provider;
 
 import com.liferay.headless.builder.application.APIApplication;
 import com.liferay.headless.builder.application.provider.APIApplicationProvider;
+import com.liferay.headless.builder.internal.util.PathUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -60,14 +61,9 @@ public class APIApplicationContextProvider
 			HttpServletRequest httpServletRequest)
 		throws Exception {
 
-		String contextPath = httpServletRequest.getContextPath();
-
-		if (contextPath.startsWith("/o/")) {
-			contextPath = contextPath.substring(3);
-		}
-
 		return _apiApplicationProvider.fetchAPIApplication(
-			contextPath, _portal.getCompanyId(httpServletRequest));
+			PathUtil.sanitize(httpServletRequest.getRequestURI()),
+			_portal.getCompanyId(httpServletRequest));
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/jaxrs/context/provider/APIApplicationContextProvider.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/jaxrs/context/provider/APIApplicationContextProvider.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.headless.builder.internal.jaxrs.context.provider;
+
+import com.liferay.headless.builder.application.APIApplication;
+import com.liferay.headless.builder.application.provider.APIApplicationProvider;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.Portal;
+
+import javax.servlet.http.HttpServletRequest;
+
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.ext.Provider;
+
+import org.apache.cxf.jaxrs.ext.ContextProvider;
+import org.apache.cxf.message.Message;
+
+/**
+ * @author Luis Miguel Barcos
+ */
+@Provider
+public class APIApplicationContextProvider
+	implements ContextProvider<APIApplication> {
+
+	public APIApplicationContextProvider(
+		APIApplicationProvider apiApplicationProvider, Portal portal) {
+
+		_apiApplicationProvider = apiApplicationProvider;
+		_portal = portal;
+	}
+
+	@Override
+	public APIApplication createContext(Message message) {
+		try {
+			return _getApiApplication(
+				(HttpServletRequest)message.getContextualProperty(
+					"HTTP.REQUEST"));
+		}
+		catch (Exception exception) {
+			_log.error(exception);
+
+			throw new NotFoundException(exception.getMessage());
+		}
+	}
+
+	private APIApplication _getApiApplication(
+			HttpServletRequest httpServletRequest)
+		throws Exception {
+
+		String contextPath = httpServletRequest.getContextPath();
+
+		if (contextPath.startsWith("/o/")) {
+			contextPath = contextPath.substring(3);
+		}
+
+		return _apiApplicationProvider.getAPIApplication(
+			contextPath, _portal.getCompanyId(httpServletRequest));
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		APIApplicationContextProvider.class);
+
+	private final APIApplicationProvider _apiApplicationProvider;
+	private final Portal _portal;
+
+}

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/jaxrs/context/provider/APIApplicationContextProvider.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/jaxrs/context/provider/APIApplicationContextProvider.java
@@ -45,7 +45,7 @@ public class APIApplicationContextProvider
 	@Override
 	public APIApplication createContext(Message message) {
 		try {
-			return _getApiApplication(
+			return _fetchApiApplication(
 				(HttpServletRequest)message.getContextualProperty(
 					"HTTP.REQUEST"));
 		}
@@ -56,7 +56,7 @@ public class APIApplicationContextProvider
 		}
 	}
 
-	private APIApplication _getApiApplication(
+	private APIApplication _fetchApiApplication(
 			HttpServletRequest httpServletRequest)
 		throws Exception {
 
@@ -66,7 +66,7 @@ public class APIApplicationContextProvider
 			contextPath = contextPath.substring(3);
 		}
 
-		return _apiApplicationProvider.getAPIApplication(
+		return _apiApplicationProvider.fetchAPIApplication(
 			contextPath, _portal.getCompanyId(httpServletRequest));
 	}
 

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/jaxrs/context/provider/APIApplicationContextProvider.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/jaxrs/context/provider/APIApplicationContextProvider.java
@@ -46,24 +46,19 @@ public class APIApplicationContextProvider
 	@Override
 	public APIApplication createContext(Message message) {
 		try {
-			return _fetchApiApplication(
+			HttpServletRequest httpServletRequest =
 				(HttpServletRequest)message.getContextualProperty(
-					"HTTP.REQUEST"));
+					"HTTP.REQUEST");
+
+			return _apiApplicationProvider.fetchAPIApplication(
+				PathUtil.sanitize(httpServletRequest.getContextPath()),
+				_portal.getCompanyId(httpServletRequest));
 		}
 		catch (Exception exception) {
 			_log.error(exception);
 
 			throw new NotFoundException(exception.getMessage());
 		}
-	}
-
-	private APIApplication _fetchApiApplication(
-			HttpServletRequest httpServletRequest)
-		throws Exception {
-
-		return _apiApplicationProvider.fetchAPIApplication(
-			PathUtil.sanitize(httpServletRequest.getRequestURI()),
-			_portal.getCompanyId(httpServletRequest));
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/util/PathUtil.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/util/PathUtil.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.headless.builder.internal.util;
+
+/**
+ * @author Luis Miguel Barcos
+ */
+public class PathUtil {
+
+	public static String sanitize(String path) {
+		if (path.startsWith("/o/")) {
+			path = path.substring(3);
+		}
+
+		return path;
+	}
+
+}

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/application/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/application/resource/test/HeadlessBuilderResourceTest.java
@@ -20,6 +20,7 @@ import com.liferay.headless.builder.application.publisher.APIApplicationPublishe
 import com.liferay.headless.builder.application.publisher.test.util.APIApplicationPublisherUtil;
 import com.liferay.headless.builder.test.BaseTestCase;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
@@ -56,45 +57,63 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 	@Test
 	public void test() throws Exception {
 		APIApplication apiApplication1 = _addAPIApplication(
-			_API_APPLICATION_ERC_1);
+			_API_APPLICATION_ERC_1, _API_APPLICATION_ENDPOINT_PATH_1);
 		APIApplication apiApplication2 = _addAPIApplication(
-			_API_APPLICATION_ERC_2);
+			_API_APPLICATION_ERC_2, _API_APPLICATION_ENDPOINT_PATH_2);
+
+		String endpointPath1 =
+			apiApplication1.getBaseURL() + _API_APPLICATION_ENDPOINT_PATH_1;
+		String endpointPath2 =
+			apiApplication2.getBaseURL() + _API_APPLICATION_ENDPOINT_PATH_2;
 
 		Assert.assertEquals(
 			404,
-			HTTPTestUtil.invokeHttpCode(
-				null, apiApplication1.getBaseURL(), Http.Method.GET));
+			HTTPTestUtil.invokeHttpCode(null, endpointPath1, Http.Method.GET));
 		Assert.assertEquals(
 			404,
-			HTTPTestUtil.invokeHttpCode(
-				null, apiApplication2.getBaseURL(), Http.Method.GET));
+			HTTPTestUtil.invokeHttpCode(null, endpointPath2, Http.Method.GET));
 
 		APIApplicationPublisherUtil.publishApplications(
 			_apiApplicationPublisher, apiApplication1, apiApplication2);
 
 		Assert.assertEquals(
 			200,
-			HTTPTestUtil.invokeHttpCode(
-				null, apiApplication1.getBaseURL(), Http.Method.GET));
+			HTTPTestUtil.invokeHttpCode(null, endpointPath1, Http.Method.GET));
 		Assert.assertEquals(
 			200,
+			HTTPTestUtil.invokeHttpCode(null, endpointPath2, Http.Method.GET));
+
+		String randomEndpointPath1 =
+			apiApplication1.getBaseURL() + StringPool.SLASH +
+				RandomTestUtil.randomString();
+
+		Assert.assertEquals(
+			404,
 			HTTPTestUtil.invokeHttpCode(
-				null, apiApplication2.getBaseURL(), Http.Method.GET));
+				null, randomEndpointPath1, Http.Method.GET));
+
+		String randomEndpointPath2 =
+			apiApplication2.getBaseURL() + StringPool.SLASH +
+				RandomTestUtil.randomString();
+
+		Assert.assertEquals(
+			404,
+			HTTPTestUtil.invokeHttpCode(
+				null, randomEndpointPath2, Http.Method.GET));
 
 		APIApplicationPublisherUtil.unpublishApplications(
 			_apiApplicationPublisher, apiApplication1);
 
 		Assert.assertEquals(
 			404,
-			HTTPTestUtil.invokeHttpCode(
-				null, apiApplication1.getBaseURL(), Http.Method.GET));
+			HTTPTestUtil.invokeHttpCode(null, endpointPath1, Http.Method.GET));
 		Assert.assertEquals(
 			200,
-			HTTPTestUtil.invokeHttpCode(
-				null, apiApplication2.getBaseURL(), Http.Method.GET));
+			HTTPTestUtil.invokeHttpCode(null, endpointPath2, Http.Method.GET));
 	}
 
-	private APIApplication _addAPIApplication(String externalReferenceCode)
+	private APIApplication _addAPIApplication(
+			String externalReferenceCode, String path)
 		throws Exception {
 
 		String apiEndpointExternalReferenceCode = RandomTestUtil.randomString();
@@ -115,7 +134,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 					).put(
 						"name", "name"
 					).put(
-						"path", "path"
+						"path", path
 					).put(
 						"scope", "company"
 					))
@@ -172,6 +191,12 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 		return _apiApplicationProvider.fetchAPIApplication(
 			baseURL, TestPropsValues.getCompanyId());
 	}
+
+	private static final String _API_APPLICATION_ENDPOINT_PATH_1 =
+		StringPool.SLASH + RandomTestUtil.randomString();
+
+	private static final String _API_APPLICATION_ENDPOINT_PATH_2 =
+		StringPool.SLASH + RandomTestUtil.randomString();
 
 	private static final String _API_APPLICATION_ERC_1 =
 		RandomTestUtil.randomString();


### PR DESCRIPTION
## Dependencies
This should be merged [once this PR is merged](https://github.com/liferay-headless/liferay-portal/pull/1303) and there are no conflicts

## Purpose of this PR
This PR adds the first approximation to handle different endpoints in the REST Applications deployed by the headless builder.
The PR adds a contextProvider to inject the APIApplication into the resource. With that, checks if the endpoint is a valid endpoint on that APIApplication. In that case, returns a dummy response with ok, in another case, returns a 404.