### PR TITLE
LPS-181449 | Expose the actions available in individual entities schemas

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testFunctional/tests/ExposeActionsForAvailableIndividualEntitiesSchemasOfHeadlessAdminTaxonomy.testcase
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testFunctional/tests/ExposeActionsForAvailableIndividualEntitiesSchemasOfHeadlessAdminTaxonomy.testcase
@@ -1,0 +1,146 @@
+@component-name = "portal-headless"
+definition {
+
+	property custom.properties = "feature.flag.LPS-180090=true";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.main.component.name = "Headless";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+
+		task ("Given in Headless Admin Taxonomy of API Explorer") {
+			APIExplorer.navigateToOpenAPI(
+				api = "headless-admin-taxonomy",
+				version = "v1.0");
+		}
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if (${testPortalInstance} == "true") {
+			PortalInstances.tearDownCPNoSelenium();
+		}
+	}
+
+	@priority = 4
+	test CanGetMethodAndHrefForKeywordActions {
+		task ("When I navigate to the Keyword Schema") {
+			APIExplorer.executeAllActionInSchema(
+				actionsList = "subscribe,unsubscribe,get,replace,delete",
+				schema = "Keyword");
+		}
+
+		task ("Then I can see method and href values for all available to an individual Keyword element actions ") {
+			APIExplorer.assertExposedActionsInSchema(
+				method = "PUT",
+				objectHref = "headless-admin-taxonomy/v1.0/keywords/{keywordId}/subscribe",
+				property = "subscribe",
+				schema = "Keyword");
+
+			APIExplorer.assertExposedActionsInSchema(
+				method = "PUT",
+				objectHref = "headless-admin-taxonomy/v1.0/keywords/{keywordId}/unsubscribe",
+				property = "unsubscribe",
+				schema = "Keyword");
+
+			APIExplorer.assertExposedActionsInSchema(
+				method = "GET",
+				objectHref = "headless-admin-taxonomy/v1.0/keywords/{keywordId}",
+				property = "get",
+				schema = "Keyword");
+
+			APIExplorer.assertExposedActionsInSchema(
+				method = "PUT",
+				objectHref = "headless-admin-taxonomy/v1.0/keywords/{keywordId}",
+				property = "replace",
+				schema = "Keyword");
+
+			APIExplorer.assertExposedActionsInSchema(
+				method = "DELETE",
+				objectHref = "headless-admin-taxonomy/v1.0/keywords/{keywordId}",
+				property = "delete",
+				schema = "Keyword");
+		}
+	}
+
+	@priority = 3
+	test CanGetMethodAndHrefForTaxonomyCategoryActions {
+		task ("When I navigate to the TaxonomyCategory Schema") {
+			APIExplorer.executeAllActionInSchema(
+				actionsList = "add-category,get,replace,update,delete",
+				schema = "TaxonomyCategory");
+		}
+
+		task ("Then I can see method and href values for all available to an individual TaxonomyCategory element actions") {
+			APIExplorer.assertExposedActionsInSchema(
+				method = "POST",
+				objectHref = "headless-admin-taxonomy/v1.0/taxonomy-categories/{parentTaxonomyCategoryId}/taxonomy-categories",
+				property = "add-category",
+				schema = "TaxonomyCategory");
+
+			APIExplorer.assertExposedActionsInSchema(
+				method = "GET",
+				objectHref = "headless-admin-taxonomy/v1.0/taxonomy-categories/{taxonomyCategoryId}",
+				property = "get",
+				schema = "TaxonomyCategory");
+
+			APIExplorer.assertExposedActionsInSchema(
+				method = "PUT",
+				objectHref = "headless-admin-taxonomy/v1.0/taxonomy-categories/{taxonomyCategoryId}",
+				property = "replace",
+				schema = "TaxonomyCategory");
+
+			APIExplorer.assertExposedActionsInSchema(
+				method = "PATCH",
+				objectHref = "headless-admin-taxonomy/v1.0/taxonomy-categories/{taxonomyCategoryId}",
+				property = "update",
+				schema = "TaxonomyCategory");
+
+			APIExplorer.assertExposedActionsInSchema(
+				method = "DELETE",
+				objectHref = "headless-admin-taxonomy/v1.0/taxonomy-categories/{taxonomyCategoryId}",
+				property = "delete",
+				schema = "TaxonomyCategory");
+		}
+	}
+
+	@priority = 3
+	test CanGetMethodAndHrefForTaxonomyVocabularyActions {
+		task ("When I navigate to the TaxonomyVocabulary Schema") {
+			APIExplorer.executeAllActionInSchema(
+				actionsList = "get,replace,update,delete",
+				schema = "TaxonomyVocabulary");
+		}
+
+		task ("Then I can see method and href values for all available to an individual TaxonomyVocabulary element actions") {
+			APIExplorer.assertExposedActionsInSchema(
+				method = "GET",
+				objectHref = "headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{taxonomyVocabularyId}",
+				property = "get",
+				schema = "TaxonomyVocabulary");
+
+			APIExplorer.assertExposedActionsInSchema(
+				method = "PUT",
+				objectHref = "headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{taxonomyVocabularyId}",
+				property = "replace",
+				schema = "TaxonomyVocabulary");
+
+			APIExplorer.assertExposedActionsInSchema(
+				method = "PATCH",
+				objectHref = "headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{taxonomyVocabularyId}",
+				property = "update",
+				schema = "TaxonomyVocabulary");
+
+			APIExplorer.assertExposedActionsInSchema(
+				method = "DELETE",
+				objectHref = "headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{taxonomyVocabularyId}",
+				property = "delete",
+				schema = "TaxonomyVocabulary");
+		}
+	}
+
+}

--- a/modules/apps/headless/headless-discovery/headless-discovery-test/src/testFunctional/macros/APIExplorer.macro
+++ b/modules/apps/headless/headless-discovery/headless-discovery-test/src/testFunctional/macros/APIExplorer.macro
@@ -30,7 +30,7 @@ definition {
 			locator1 = "OpenAPI#SCHEMA_PROPERTY",
 			property = ${property},
 			schema = ${schema},
-			value1 = "${property} { method string default: ${method} href string default: ${portalURL}/o/c/${objectHref} }");
+			value1 = "${property} { method string default: ${method} href string default: ${portalURL}/o/${objectHref} }");
 	}
 
 	macro executeAPIMethodWithParameters {

--- a/modules/apps/headless/headless-discovery/headless-discovery-test/src/testFunctional/macros/APIExplorer.macro
+++ b/modules/apps/headless/headless-discovery/headless-discovery-test/src/testFunctional/macros/APIExplorer.macro
@@ -33,6 +33,27 @@ definition {
 			value1 = "${property} { method string default: ${method} href string default: ${portalURL}/o/${objectHref} }");
 	}
 
+	macro executeAllActionInSchema {
+		Variables.assertDefined(parameterList = "${schema},${actionsList}");
+
+		Click(
+			locator1 = "OpenAPI#SCHEMA_COLLAPSED",
+			schema = ${schema});
+
+		Click(
+			field = "actions",
+			locator1 = "OpenAPI#SCHEMA_FIELD_COLLAPSED",
+			schema = ${schema});
+
+		for (var property : list ${actionsList}) {
+			Click(
+				field = "actions",
+				locator1 = "OpenAPI#SCHEMA_PROPERTY_COLLAPSED",
+				property = ${property},
+				schema = ${schema});
+		}
+	}
+
 	macro executeAPIMethodWithParameters {
 		Variables.assertDefined(parameterList = "${service},${method},${parameter}");
 

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/ExposeActionsForIndividualObjectEntriesSchemas.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/ExposeActionsForIndividualObjectEntriesSchemas.testcase
@@ -47,7 +47,7 @@ definition {
 		task ("Then I can see get with DELETE and o/c/students/{studentId}") {
 			APIExplorer.assertExposedActionsInSchema(
 				method = "DELETE",
-				objectHref = "students/{studentId}",
+				objectHref = "c/students/{studentId}",
 				property = "delete",
 				schema = "Student");
 		}
@@ -64,7 +64,7 @@ definition {
 		task ("Then I can see get with GET and o/c/students/{studentId}") {
 			APIExplorer.assertExposedActionsInSchema(
 				method = "GET",
-				objectHref = "students/{studentId}",
+				objectHref = "c/students/{studentId}",
 				property = "get",
 				schema = "Student");
 		}
@@ -83,7 +83,7 @@ definition {
 		task ("Then I can see permissions with GET and o/c/students/{studentId}/permissions") {
 			APIExplorer.assertExposedActionsInSchema(
 				method = "GET",
-				objectHref = "students/{studentId}/permissions",
+				objectHref = "c/students/{studentId}/permissions",
 				property = "permissions",
 				schema = "Student");
 		}
@@ -100,7 +100,7 @@ definition {
 		task ("Then I can see get with PUT and o/c/students/{studentId}") {
 			APIExplorer.assertExposedActionsInSchema(
 				method = "PUT",
-				objectHref = "students/{studentId}",
+				objectHref = "c/students/{studentId}",
 				property = "replace",
 				schema = "Student");
 		}
@@ -137,7 +137,7 @@ definition {
 		task ("Then I can see myCustomAction with PUT and o/c/students/by-external-reference-code/{studentExternalReferenceCode}/object-actions/myCustomAction") {
 			APIExplorer.assertExposedActionsInSchema(
 				method = "PUT",
-				objectHref = "students/by-external-reference-code/{studentExternalReferenceCode}/object-actions/myCustomAction",
+				objectHref = "c/students/by-external-reference-code/{studentExternalReferenceCode}/object-actions/myCustomAction",
 				property = "myCustomAction",
 				schema = "Student");
 		}
@@ -154,7 +154,7 @@ definition {
 		task ("Then I can see get with PATCH and o/c/students/{studentId}") {
 			APIExplorer.assertExposedActionsInSchema(
 				method = "PATCH",
-				objectHref = "students/{studentId}",
+				objectHref = "c/students/{studentId}",
 				property = "update",
 				schema = "Student");
 		}

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/ExposeActionsForObjectCollectionsSchemas.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/ExposeActionsForObjectCollectionsSchemas.testcase
@@ -47,7 +47,7 @@ definition {
 		task ("Then I can see create with POST and /o/c/students/batch") {
 			APIExplorer.assertExposedActionsInSchema(
 				method = "POST",
-				objectHref = "students/batch",
+				objectHref = "c/students/batch",
 				property = "createBatch",
 				schema = "PageStudent");
 		}
@@ -64,7 +64,7 @@ definition {
 		task ("Then I can see create with POST and /o/c/students") {
 			APIExplorer.assertExposedActionsInSchema(
 				method = "POST",
-				objectHref = "students/",
+				objectHref = "c/students/",
 				property = "create",
 				schema = "PageStudent");
 		}
@@ -81,7 +81,7 @@ definition {
 		task ("Then I can see deleteBatch with DELETE and /o/c/students/batch") {
 			APIExplorer.assertExposedActionsInSchema(
 				method = "DELETE",
-				objectHref = "students/batch",
+				objectHref = "c/students/batch",
 				property = "deleteBatch",
 				schema = "PageStudent");
 		}
@@ -100,7 +100,7 @@ definition {
 		task ("Then I can see updateBatch with PUT and /o/c/students/batch") {
 			APIExplorer.assertExposedActionsInSchema(
 				method = "PUT",
-				objectHref = "students/batch",
+				objectHref = "c/students/batch",
 				property = "updateBatch",
 				schema = "PageStudent");
 		}


### PR DESCRIPTION
Background:
Add a testcase to expose the actions available in individual entities schemas

Test Plan
CanGetMethodAndHrefForKeywordActions
Given in Headless Admin Taxonomy of API ExplorerWhen I navigate to the Keyword SchemaThen I can see method and href values for all available to an individual Keyword element actions

CanGetMethodAndHrefForTaxonomyCategoryActions
Given in Headless Admin Taxonomy of API ExplorerWhen I navigate to the TaxonomyCategory SchemaThen I can see method and href values for all available to an individual TaxonomyCategory element actions

CanGetMethodAndHrefForTaxonomyVocabularyActions
Given in Headless Admin Taxonomy of API ExplorerWhen I navigate to the TaxonomyVocabulary SchemaThen I can see method and href values for all available to an individual TaxonomyVocabulary element actions

Jira ticket:
https://liferay.atlassian.net/browse/LPS-186139