### PR TITLE
LPS-188780 Turn taxonomyCategoryUsageCount into a nestedField

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/dto/v1_0/converter/TaxonomyCategoryDTOConverter.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/dto/v1_0/converter/TaxonomyCategoryDTOConverter.java
@@ -36,6 +36,7 @@ import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.vulcan.dto.action.DTOActionProvider;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
+import com.liferay.portal.vulcan.fields.NestedFieldsSupplier;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
 import javax.ws.rs.core.MultivaluedMap;
@@ -172,34 +173,37 @@ public class TaxonomyCategoryDTOConverter
 						};
 					});
 				setTaxonomyCategoryUsageCount(
-					() -> {
-						UriInfo uriInfo = dtoConverterContext.getUriInfo();
+					NestedFieldsSupplier.<Integer>supply(
+						"taxonomyCategoryUsageCount",
+						fieldName -> {
+							UriInfo uriInfo = dtoConverterContext.getUriInfo();
 
-						if (uriInfo != null) {
-							MultivaluedMap<String, String> queryParameters =
-								uriInfo.getQueryParameters();
+							if (uriInfo != null) {
+								MultivaluedMap<String, String> queryParameters =
+									uriInfo.getQueryParameters();
 
-							if (StringUtil.contains(
-									queryParameters.getFirst("restrictFields"),
-									"taxonomyCategoryUsageCount")) {
+								if (StringUtil.contains(
+										queryParameters.getFirst(
+											"restrictFields"),
+										"taxonomyCategoryUsageCount")) {
 
-								return null;
+									return null;
+								}
 							}
-						}
 
-						return (int)_assetEntryLocalService.searchCount(
-							assetCategory.getCompanyId(),
-							new long[] {assetCategory.getGroupId()},
-							assetCategory.getUserId(), null, -1, null,
-							String.valueOf(assetCategory.getCategoryId()), null,
-							false, false,
-							new int[] {
-								WorkflowConstants.STATUS_APPROVED,
-								WorkflowConstants.STATUS_PENDING,
-								WorkflowConstants.STATUS_SCHEDULED
-							},
-							false);
-					});
+							return (int)_assetEntryLocalService.searchCount(
+								assetCategory.getCompanyId(),
+								new long[] {assetCategory.getGroupId()},
+								assetCategory.getUserId(), null, -1, null,
+								String.valueOf(assetCategory.getCategoryId()),
+								null, false, false,
+								new int[] {
+									WorkflowConstants.STATUS_APPROVED,
+									WorkflowConstants.STATUS_PENDING,
+									WorkflowConstants.STATUS_SCHEDULED
+								},
+								false);
+						}));
 			}
 		};
 	}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyCategoryResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyCategoryResourceTest.java
@@ -32,12 +32,15 @@ import com.liferay.headless.admin.taxonomy.client.pagination.Pagination;
 import com.liferay.headless.admin.taxonomy.client.problem.Problem;
 import com.liferay.headless.admin.taxonomy.client.resource.v1_0.TaxonomyCategoryResource;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
+import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.log.LogCapture;
@@ -163,6 +166,17 @@ public class TaxonomyCategoryResourceTest
 					"method", "PATCH"
 				).build()
 			).build());
+
+		Assert.assertNull(postTaxonomyCategory.getTaxonomyCategoryUsageCount());
+
+		JSONObject jsonObject = HTTPTestUtil.invoke(
+			null,
+			"headless-admin-taxonomy/v1.0/taxonomy-categories/" +
+				getTaxonomyCategory.getId() +
+					"?nestedFields=taxonomyCategoryUsageCount",
+			Http.Method.GET);
+
+		Assert.assertNotNull(jsonObject.get("taxonomyCategoryUsageCount"));
 	}
 
 	@Override


### PR DESCRIPTION
Implements story https://liferay.atlassian.net/browse/LPS-188638. 

# How to test
This curl won't return the `taxonomyCategoryUsageCount` field:
```bash
curl -X 'GET' 'http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-categories/<id>' -H 'accept: application/json' -u test@liferay.com:test
```
This one will:
```bash
curl -X 'GET' 'http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-categories/<id>?nestedFields=taxonomyCategoryUsageCount' -H 'accept: application/json' -u test@liferay.com:test
```