### PR TITLE
LPS-189951 Test fix for NestedFieldsContainerRequestFilterTest.testFilter()

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/jaxrs/container/request/filter/NestedFieldsContainerRequestFilterTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/jaxrs/container/request/filter/NestedFieldsContainerRequestFilterTest.java
@@ -89,7 +89,7 @@ public class NestedFieldsContainerRequestFilterTest {
 		NestedFieldsContext nestedFieldsContext =
 			NestedFieldsContextThreadLocal.getNestedFieldsContext();
 
-		Assert.assertNull(nestedFieldsContext);
+		Assert.assertNotNull(nestedFieldsContext);
 
 		queryParameters.putSingle("nestedFields", "skus,productOptions");
 


### PR DESCRIPTION
Background:
- According to [e0d8e617f47fe01b7d66fe84e872a64f8628630dc](https://github.com/liferay/liferay-portal/commit/e0d8e617f47fe01b7d66fe84e872a64f8628630d), the context is not null after created, update to assertNotNull to make the test pass
> The context must be created even if there are no initial field names to
> allow adding new ones when needed.

Jira Ticket:
- https://liferay.atlassian.net/browse/LPS-189951