### PR TITLE
LPS-189728: Change deletionType between API Schema and API Endpoint relationships

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIEndpointRelevantObjectEntryModelListener.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIEndpointRelevantObjectEntryModelListener.java
@@ -98,6 +98,27 @@ public class APIEndpointRelevantObjectEntryModelListener
 		return true;
 	}
 
+	private boolean _isAPISchema(long apiSchemaId) throws Exception {
+		ObjectEntry objectEntry = _objectEntryLocalService.fetchObjectEntry(
+			apiSchemaId);
+
+		if (objectEntry == null) {
+			return false;
+		}
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.getObjectDefinition(
+				objectEntry.getObjectDefinitionId());
+
+		if (!Objects.equals(
+				objectDefinition.getExternalReferenceCode(), "L_API_SCHEMA")) {
+
+			return false;
+		}
+
+		return true;
+	}
+
 	private boolean _isModified(
 		ObjectEntry originalObjectEntry, ObjectEntry objectEntry) {
 
@@ -178,8 +199,32 @@ public class APIEndpointRelevantObjectEntryModelListener
 						"r_apiApplicationToAPIEndpoints_c_apiApplicationId"))) {
 
 				throw new ObjectEntryValuesException.InvalidObjectField(
-					"An API endpoint must be related to a an API application",
+					"An API endpoint must be related to an API application",
 					"an-api-endpoint-must-be-related-to-an-api-application",
+					null);
+			}
+
+			long requestAPISchemaId = (long)values.get(
+				"r_requestAPISchemaToAPIEndpoints_c_apiSchemaId");
+
+			if ((requestAPISchemaId != 0) &&
+				!_isAPISchema(requestAPISchemaId)) {
+
+				throw new ObjectEntryValuesException.InvalidObjectField(
+					"An API endpoint must be related to a valid API schema",
+					"an-api-endpoint-must-be-related-to-a-valid-api-schema",
+					null);
+			}
+
+			long responseAPISchemaId = (long)values.get(
+				"r_responseAPISchemaToAPIEndpoints_c_apiSchemaId");
+
+			if ((responseAPISchemaId != 0) &&
+				!_isAPISchema(responseAPISchemaId)) {
+
+				throw new ObjectEntryValuesException.InvalidObjectField(
+					"An API endpoint must be related to a valid API schema",
+					"an-api-endpoint-must-be-related-to-a-valid-api-schema",
 					null);
 			}
 		}

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/resources/com/liferay/headless/builder/internal/batch/headless-builder.json
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/resources/com/liferay/headless/builder/internal/batch/headless-builder.json
@@ -496,9 +496,9 @@
 					"type": "oneToMany"
 				},
 				{
-					"deletionType": "cascade",
+					"deletionType": "disassociate",
 					"label": {
-						"en_US": "Request API Schema to API Properties"
+						"en_US": "Request API Schema to API Endpoints"
 					},
 					"name": "requestAPISchemaToAPIEndpoints",
 					"objectDefinitionExternalReferenceCode1": "L_API_SCHEMA",
@@ -510,7 +510,7 @@
 					"type": "oneToMany"
 				},
 				{
-					"deletionType": "cascade",
+					"deletionType": "disassociate",
 					"label": {
 						"en_US": "Response API Schema to API Endpoints"
 					},

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APIEndpointRelevantObjectEntryModelListenerTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APIEndpointRelevantObjectEntryModelListenerTest.java
@@ -91,6 +91,17 @@ public class APIEndpointRelevantObjectEntryModelListenerTest
 			).toString(),
 			"headless-builder/applications", Http.Method.POST);
 
+		JSONObject apiSchemaJSONObject = HTTPTestUtil.invoke(
+			JSONUtil.put(
+				"mainObjectDefinitionERC", RandomTestUtil.randomString()
+			).put(
+				"name", RandomTestUtil.randomString()
+			).put(
+				"r_apiApplicationToAPISchemas_c_apiApplicationId",
+				apiApplicationJSONObject.getLong("id")
+			).toString(),
+			"headless-builder/schemas", Http.Method.POST);
+
 		jsonObject = HTTPTestUtil.invoke(
 			JSONUtil.put(
 				"httpMethod", "get"
@@ -101,6 +112,12 @@ public class APIEndpointRelevantObjectEntryModelListenerTest
 			).put(
 				"r_apiApplicationToAPIEndpoints_c_apiApplicationId",
 				apiApplicationJSONObject.getLong("id")
+			).put(
+				"r_requestAPISchemaToAPIEndpoints_c_apiSchemaId",
+				apiSchemaJSONObject.getLong("id")
+			).put(
+				"r_responseAPISchemaToAPIEndpoints_c_apiSchemaId",
+				apiSchemaJSONObject.getLong("id")
 			).put(
 				"scope", "company"
 			).toString(),
@@ -203,6 +220,34 @@ public class APIEndpointRelevantObjectEntryModelListenerTest
 		Assert.assertEquals("BAD_REQUEST", jsonObject.get("status"));
 		Assert.assertEquals(
 			"An API endpoint must be related to an API application.",
+			jsonObject.get("title"));
+
+		// An API endpoint should be related with a valid API schema
+
+		jsonObject = HTTPTestUtil.invoke(
+			JSONUtil.put(
+				"httpMethod", "get"
+			).put(
+				"name", RandomTestUtil.randomString()
+			).put(
+				"path", RandomTestUtil.randomString()
+			).put(
+				"r_apiApplicationToAPIEndpoints_c_apiApplicationId",
+				apiApplicationJSONObject.getLong("id")
+			).put(
+				"r_requestAPISchemaToAPIEndpoints_c_apiSchemaId",
+				RandomTestUtil.nextLong()
+			).put(
+				"r_responseAPISchemaToAPIEndpoints_c_apiSchemaId",
+				RandomTestUtil.nextLong()
+			).put(
+				"scope", "company"
+			).toString(),
+			"headless-builder/endpoints", Http.Method.POST);
+
+		Assert.assertEquals("BAD_REQUEST", jsonObject.get("status"));
+		Assert.assertEquals(
+			"An API endpoint must be related to a valid API schema.",
 			jsonObject.get("title"));
 	}
 

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=An abstract is a brief summary of
 an-account-with-the-same-reference-already-exists=An account with the same reference already exists.
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=An account with {0} as the email address already exists in the portal. Do you want to associate this activity with that account?
 an-anonymous-user-is-already-defined-for-the-company-x=An anonymous user is already defined for the company: {0}
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema.
 an-api-endpoint-must-be-related-to-an-api-application=An API endpoint must be related to an API application.
 an-api-schema-must-be-related-to-an-api-application=An API schema must be related to an API application.
 an-app-that-can-x-x-belongs-here=An app that can {0} {1} belongs here. Please contact the portal administrator or install such an app from the Liferay Marketplace.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=الملخص هو عبارة تل
 an-account-with-the-same-reference-already-exists=يوجد بالفعل حساب بنفس المرجع.
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=يوجد حساب يستخدم {0} كبريد إلكتروني في البوابة. هل تريد أن تربط هذا الإجراء بذلك الحساب؟
 an-anonymous-user-is-already-defined-for-the-company-x=تم تعريف مستخدم مجهول بالفعل لشركة: {0}
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=يجب أن تكون نقطة نهاية API مربوطة بأحد تطبيقات API.
 an-api-schema-must-be-related-to-an-api-application=يجب أن يكون مخطط API مربوطًا بأحد تطبيقات API.
 an-app-that-can-x-x-belongs-here=تطبيق يمكن {0} {1} ينتمي إليها هنا. يُرجى الاتصال بمسؤول موقع البوابة أو تثبيت هذا التطبيق من Liferay Marketplace.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=Резюме на блога. (Au
 an-account-with-the-same-reference-already-exists=Вече съществува акаунт със същата препратка. (Automatic Translation)
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=An account with {0} as the email address already exists in the portal. Do you want to associate this activity with that account? (Automatic Copy)
 an-anonymous-user-is-already-defined-for-the-company-x=An anonymous user is already defined for the company: {0} (Automatic Copy)
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=An API endpoint must be related to an API application. (Automatic Copy)
 an-api-schema-must-be-related-to-an-api-application=An API schema must be related to an API application. (Automatic Copy)
 an-app-that-can-x-x-belongs-here=An app that can {0} {1} belongs here. Please contact the portal administrator or install such an app from the Liferay Marketplace. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=Un abstract és un breu resum d'u
 an-account-with-the-same-reference-already-exists=Ja hi ha un compte amb la mateixa referència.
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=Ja existeix en el portal un compte amb {0} com l'adreça de correu electrònic. Voleu associar aquesta activitat amb aquest compte?
 an-anonymous-user-is-already-defined-for-the-company-x=Ja s'ha definit un usuari anònim per a l'empresa: {0}
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=Un endpoint d'API ha d'estar relacionat amb una aplicació API.
 an-api-schema-must-be-related-to-an-api-application=Un esquema d'API ha d'estar relacionat amb una aplicació API.
 an-app-that-can-x-x-belongs-here=Una app que {0} {1} pot pertànyer aquí. Si us plau, contacteu amb l'administrador del portal o instal·leu una app de Liferay.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=An abstract is a brief summary of
 an-account-with-the-same-reference-already-exists=An account with the same reference already exists. (Automatic Copy)
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=Účet s e-mailovou adresou {0} je již v portálu evidován. Přejete si tuto aktivitu se zmiňovaným účtem propojit?
 an-anonymous-user-is-already-defined-for-the-company-x=An anonymous user is already defined for the company: {0} (Automatic Copy)
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=An API endpoint must be related to an API application. (Automatic Copy)
 an-api-schema-must-be-related-to-an-api-application=An API schema must be related to an API application. (Automatic Copy)
 an-app-that-can-x-x-belongs-here=An app that can {0} {1} belongs here. Please contact the portal administrator or install such an app from the Liferay Marketplace. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=Et resume er en kort oversigt ove
 an-account-with-the-same-reference-already-exists=Der findes allerede en konto med samme reference. (Automatic Translation)
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=An account with {0} as the email adresse already exists in the portal. Do you want to associate this activity with that account?
 an-anonymous-user-is-already-defined-for-the-company-x=An anonymous user is already defined for the company: {0} (Automatic Copy)
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=An API endpoint must be related to an API application. (Automatic Copy)
 an-api-schema-must-be-related-to-an-api-application=An API schema must be related to an API application. (Automatic Copy)
 an-app-that-can-x-x-belongs-here=An app that can {0} {1} belongs here. Please contact the portal administrator or install such an app from the Liferay Marketplace. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=Ein Abstract ist eine kurze Zusam
 an-account-with-the-same-reference-already-exists=Ein Konto mit derselben Referenz existiert bereits.
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=Ein Konto mit {0} als E-Mail-Adresse ist bereits im Portal vorhanden. Möchten Sie diese Aktivität mit dem entsprechenden Konto verknüpfen?
 an-anonymous-user-is-already-defined-for-the-company-x=Ein anonymer Benutzer wurde bereits definiert für das Unternehmen: {0}
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=Ein API-Endpunkt muss mit einer API-Anwendung verbunden sein.
 an-api-schema-must-be-related-to-an-api-application=Ein API-Schema muss mit einer API-Anwendung verbunden sein.
 an-app-that-can-x-x-belongs-here=An dieser Stelle wird eine Anwendung benötigt, die {1} {0} kann. Bitte wenden Sie sich an einen Administrator oder installieren Sie eine solche Applikation vom Liferay Marketplace.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=Μια περίληψη είνα�
 an-account-with-the-same-reference-already-exists=Ένας λογαριασμός με την ίδια αναφορά υπάρχει ήδη. (Automatic Translation)
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=Ένας λογαριασμός με διεύθυνση email {0} ήδη υπάρχει στο portal. Θέλετε να αντιστοιχίσετε αυτήν τη δραστηριότητα με αυτόν το λογαριασμό
 an-anonymous-user-is-already-defined-for-the-company-x=An anonymous user is already defined for the company: {0} (Automatic Copy)
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=An API endpoint must be related to an API application. (Automatic Copy)
 an-api-schema-must-be-related-to-an-api-application=An API schema must be related to an API application. (Automatic Copy)
 an-app-that-can-x-x-belongs-here=An app that can {0} {1} belongs here. Please contact the portal administrator or install such an app from the Liferay Marketplace. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=An abstract is a brief summary of
 an-account-with-the-same-reference-already-exists=An account with the same reference already exists.
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=An account with {0} as the email address already exists in the portal. Do you want to associate this activity with that account?
 an-anonymous-user-is-already-defined-for-the-company-x=An anonymous user is already defined for the company: {0}
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema.
 an-api-endpoint-must-be-related-to-an-api-application=An API endpoint must be related to an API application.
 an-api-schema-must-be-related-to-an-api-application=An API schema must be related to an API application.
 an-app-that-can-x-x-belongs-here=An app that can {0} {1} belongs here. Please contact the portal administrator or install such an app from the Liferay Marketplace.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=An abstract is a brief summary of
 an-account-with-the-same-reference-already-exists=An account with the same reference already exists. (Automatic Copy)
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=An account with {0} as the email address already exists in the portal. Do you want to associate this activity with that account? (Automatic Copy)
 an-anonymous-user-is-already-defined-for-the-company-x=An anonymous user is already defined for the company: {0} (Automatic Copy)
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=An API endpoint must be related to an API application. (Automatic Copy)
 an-api-schema-must-be-related-to-an-api-application=An API schema must be related to an API application. (Automatic Copy)
 an-app-that-can-x-x-belongs-here=An app that can {0} {1} belongs here. Please contact the portal administrator or install such an app from the Liferay Marketplace. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=An abstract is a brief summary of
 an-account-with-the-same-reference-already-exists=An account with the same reference already exists. (Automatic Copy)
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=An account with {0} as the email address already exists in the portal. Do you want to associate this activity with that account? (Automatic Copy)
 an-anonymous-user-is-already-defined-for-the-company-x=An anonymous user is already defined for the company: {0} (Automatic Copy)
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=An API endpoint must be related to an API application. (Automatic Copy)
 an-api-schema-must-be-related-to-an-api-application=An API schema must be related to an API application. (Automatic Copy)
 an-app-that-can-x-x-belongs-here=An app that can {0} {1} belongs here. Please contact the portal administrator or install such an app from the Liferay Marketplace. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=Un resumen es una síntesis de un
 an-account-with-the-same-reference-already-exists=Ya existe una cuenta con la misma referencia.
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=Ya existe una cuenta con la dirección de correos {0}. ¿Quiere asociar esta actividad con dicha cuenta?
 an-anonymous-user-is-already-defined-for-the-company-x=Ya se definió un usuario anónimo para la compañía: {0}
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=Se debe relacionar un endpoint API con una aplicación API.
 an-api-schema-must-be-related-to-an-api-application=Se debe relacionar un esquema API con una aplicación API.
 an-app-that-can-x-x-belongs-here=Una aplicación que puede {0} {1} debe ir aquí. Por favor, póngase en contacto con el administrador del portal o instale esta aplicación del Liferay Marketplace.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=Un resumen es una síntesis de un
 an-account-with-the-same-reference-already-exists=Ya existe una cuenta con la misma referencia.
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=Ya existe una cuenta con la dirección de correos {0}. ¿Quiere asociar esta actividad con dicha cuenta?
 an-anonymous-user-is-already-defined-for-the-company-x=Ya se definió un usuario anónimo para la compañía: {0}
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=An API endpoint must be related to an API application. (Automatic Copy)
 an-api-schema-must-be-related-to-an-api-application=An API schema must be related to an API application. (Automatic Copy)
 an-app-that-can-x-x-belongs-here=Una aplicación que puede {0} {1} debe ir aquí. Por favor, póngase en contacto con el administrador del portal o instale esta aplicación del Liferay Marketplace.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=Un resumen es una síntesis de un
 an-account-with-the-same-reference-already-exists=Ya existe una cuenta con la misma referencia.
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=Ya existe una cuenta con la dirección de correos {0}. ¿Quiere asociar esta actividad con dicha cuenta?
 an-anonymous-user-is-already-defined-for-the-company-x=Ya se definió un usuario anónimo para la compañía: {0}
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=An API endpoint must be related to an API application. (Automatic Copy)
 an-api-schema-must-be-related-to-an-api-application=An API schema must be related to an API application. (Automatic Copy)
 an-app-that-can-x-x-belongs-here=Una aplicación que puede {0} {1} debe ir aquí. Por favor, póngase en contacto con el administrador del portal o instale esta aplicación del Liferay Marketplace.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=Un resumen es una síntesis de un
 an-account-with-the-same-reference-already-exists=Ya existe una cuenta con la misma referencia.
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=Ya existe una cuenta con la dirección de correos {0}. ¿Quiere asociar esta actividad con dicha cuenta?
 an-anonymous-user-is-already-defined-for-the-company-x=Ya se definió un usuario anónimo para la compañía: {0}
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=An API endpoint must be related to an API application. (Automatic Copy)
 an-api-schema-must-be-related-to-an-api-application=An API schema must be related to an API application. (Automatic Copy)
 an-app-that-can-x-x-belongs-here=Una aplicación que puede {0} {1} debe ir aquí. Por favor, póngase en contacto con el administrador del portal o instale esta aplicación del Liferay Marketplace.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=Abstraktne on ajaveebikirje lühi
 an-account-with-the-same-reference-already-exists=Sama viitega konto on juba olemas. (Automatic Translation)
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=An account with {0} as the email address already exists in the portal. Do you want to associate this activity with that account? (Automatic Copy)
 an-anonymous-user-is-already-defined-for-the-company-x=An anonymous user is already defined for the company: {0} (Automatic Copy)
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=An API endpoint must be related to an API application. (Automatic Copy)
 an-api-schema-must-be-related-to-an-api-application=An API schema must be related to an API application. (Automatic Copy)
 an-app-that-can-x-x-belongs-here=An app that can {0} {1} belongs here. Please contact the portal administrator or install such an app from the Liferay Marketplace. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=Blog sarrera hitz gutxitan laburb
 an-account-with-the-same-reference-already-exists=An account with the same reference already exists. (Automatic Copy)
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account={0} helbide elektronikoa duen kontua jadanik existitzen da portalean. Gertaera hau kontu honekin lotu nahi duzu?
 an-anonymous-user-is-already-defined-for-the-company-x=An anonymous user is already defined for the company: {0} (Automatic Copy)
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=An API endpoint must be related to an API application. (Automatic Copy)
 an-api-schema-must-be-related-to-an-api-application=An API schema must be related to an API application. (Automatic Copy)
 an-app-that-can-x-x-belongs-here=An app that can {0} {1} belongs here. Please contact the portal administrator or install such an app from the Liferay Marketplace. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=یک چکیده خلاصه‌ای
 an-account-with-the-same-reference-already-exists=یک حساب با همان مرجع در حال حاضر وجود دارد. (Automatic Translation)
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=یک حساب کاربری با {0} به عنوان ادرس ایمیل در پرتال وجود دارد.. آیا مایل به ارتباط با این حساب کاربری هستید؟
 an-anonymous-user-is-already-defined-for-the-company-x=An anonymous user is already defined for the company: {0} (Automatic Copy)
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=An API endpoint must be related to an API application. (Automatic Copy)
 an-api-schema-must-be-related-to-an-api-application=An API schema must be related to an API application. (Automatic Copy)
 an-app-that-can-x-x-belongs-here=برنامه کاربردی که می‌تواند {0} {1} به اینجا تعلق داشته باشد. لطفا با مدیر سایت تماس گرفته و یا چنین برنامه‌ای را از لایفری دانلود کنید.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=Tiivistetty yhtenveto blogista.
 an-account-with-the-same-reference-already-exists=Tili samalla viitteellä on jo olemassa.
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=Käyttäjätili sähköpostiosoiteella {0} löytyy jo portaalista. Haluatko liittää tämän toiminnan tähän käyttäjätiliin?
 an-anonymous-user-is-already-defined-for-the-company-x=Anonyymi käyttäjä on jo määritetty yritykselle: {0}
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=API-päätepisteen täytyy liittyä API-sovellukseen.
 an-api-schema-must-be-related-to-an-api-application=API-skeeman täytyy liittyä API-sovellukseen.
 an-app-that-can-x-x-belongs-here=Sovellus joka voi {0} {1} kuuluu tähän. Ole hyvä ja otayhteyttä ylläpitäjään tai asenna sovellus Liferay Marketplacesta.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=Un abstract est un résumé succi
 an-account-with-the-same-reference-already-exists=Un compte avec la même référence existe déjà.
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=Un compte avec l'adresse e-mail {0} existe déjà sur ce portail. Voulez-vous associer cette activité avec ce compte ?
 an-anonymous-user-is-already-defined-for-the-company-x=Un utilisateur anonyme est déjà défini pour la société : {0}
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=Un point de terminaison d'API doit être lié à une application d'API.
 an-api-schema-must-be-related-to-an-api-application=Un schéma d'API doit être lié à une application d'API.
 an-app-that-can-x-x-belongs-here=Une application qui peut {0} {1} doit être installée ici. Merci de prendre contact avec l'administrateur du portail ou installez l'application en question à partir du Marketplace Liferay.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=Un abstract est une sommaire succ
 an-account-with-the-same-reference-already-exists=Un compte avec la même référence existe déjà.
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=Un compte avec l'adresse e-mail {0} existe déjà sur ce portail. Voulez-vous associer cette activité avec ce compte ?
 an-anonymous-user-is-already-defined-for-the-company-x=Un utilisateur anonyme est déjà défini pour la société : {0}
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=An API endpoint must be related to an API application. (Automatic Copy)
 an-api-schema-must-be-related-to-an-api-application=An API schema must be related to an API application. (Automatic Copy)
 an-app-that-can-x-x-belongs-here=Une application qui peut {0} {1} doit être installée ici. Merci de prendre contact avec l'administrateur du portail ou installez l'application en question à partir du Marketplace Liferay.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=An abstract is a brief summary of
 an-account-with-the-same-reference-already-exists=An account with the same reference already exists. (Automatic Copy)
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=Unha conta con {0} como enderezo de email xa existe no portal. ¿Queres asociar esta actividade con esa conta?
 an-anonymous-user-is-already-defined-for-the-company-x=An anonymous user is already defined for the company: {0} (Automatic Copy)
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=An API endpoint must be related to an API application. (Automatic Copy)
 an-api-schema-must-be-related-to-an-api-application=An API schema must be related to an API application. (Automatic Copy)
 an-app-that-can-x-x-belongs-here=An app that can {0} {1} belongs here. Please contact the portal administrator or install such an app from the Liferay Marketplace. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=एक अमूर्त ब्�
 an-account-with-the-same-reference-already-exists=उसी संदर्भ वाला खाता पहले से मौजूद है। (Automatic Translation)
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=An account with {0} as the email address already exists in the portal. Do you want to associate this activity with that account? (Automatic Copy)
 an-anonymous-user-is-already-defined-for-the-company-x=An anonymous user is already defined for the company: {0} (Automatic Copy)
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=An API endpoint must be related to an API application. (Automatic Copy)
 an-api-schema-must-be-related-to-an-api-application=An API schema must be related to an API application. (Automatic Copy)
 an-app-that-can-x-x-belongs-here=An app that can {0} {1} belongs here. Please contact the portal administrator or install such an app from the Liferay Marketplace. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=An abstract is a brief summary of
 an-account-with-the-same-reference-already-exists=An account with the same reference already exists. (Automatic Copy)
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=Račun s {0} adresom e-pošte već postoji na portalu. Želite li povezati ovu aktivnost s navedenim računom?
 an-anonymous-user-is-already-defined-for-the-company-x=An anonymous user is already defined for the company: {0} (Automatic Copy)
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=An API endpoint must be related to an API application. (Automatic Copy)
 an-api-schema-must-be-related-to-an-api-application=An API schema must be related to an API application. (Automatic Copy)
 an-app-that-can-x-x-belongs-here=An app that can {0} {1} belongs here. Please contact the portal administrator or install such an app from the Liferay Marketplace. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=Az absztrakt egy rövid összefog
 an-account-with-the-same-reference-already-exists=Már létezik egy ilyen referenciájú fiók.
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=Ezzel az e-mail címmel {0} már regisztráltak. Társítsuk ezt a tevékenységet ehhez a fiókhoz?
 an-anonymous-user-is-already-defined-for-the-company-x=A vállalathoz már van névtelen felhasználó definiálva: {0}
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=Az API végpontnak egy API-alkalmazáshoz kell kapcsolódnia.
 an-api-schema-must-be-related-to-an-api-application=Az API-sémának egy API-alkalmazáshoz kell kapcsolódnia.
 an-app-that-can-x-x-belongs-here=Egy alkalmazás, ami tud {0} {1} tartozik ide. Lépj kapcsolatba a portál rendszergazdájával, vagy telepíts egy ilyen alkalmazást a Liferay piactérről.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=Abstrak adalah ringkasan singkat 
 an-account-with-the-same-reference-already-exists=Akun dengan referensi yang sama sudah ada. (Automatic Translation)
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=Account dengan {0} sebagai alamat email sudah ada dalam portal. Apakah Anda ingin mengasosiasikan kegiatan ini dengan account tersebut?
 an-anonymous-user-is-already-defined-for-the-company-x=An anonymous user is already defined for the company: {0} (Automatic Copy)
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=An API endpoint must be related to an API application. (Automatic Copy)
 an-api-schema-must-be-related-to-an-api-application=An API schema must be related to an API application. (Automatic Copy)
 an-app-that-can-x-x-belongs-here=An app that can {0} {1} belongs here. Please contact the portal administrator or install such an app from the Liferay Marketplace. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
@@ -1410,6 +1410,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=Un sommario è un descrizione sin
 an-account-with-the-same-reference-already-exists=Già esiste un account con lo stesso riferimento.
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=Un account con {0} come indirizzo email è gia presente nel portale. Vuoi associare questa attività con l'account?
 an-anonymous-user-is-already-defined-for-the-company-x=Un utente anonimo è già definito per la company: {0}
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=An API endpoint must be related to an API application. (Automatic Copy)
 an-api-schema-must-be-related-to-an-api-application=An API schema must be related to an API application. (Automatic Copy)
 an-app-that-can-x-x-belongs-here=Una Applicazione può {0} {1} appartenervi. Contatta l'amministratore di portale o installa l'applicazione dal Marketplace Liferay.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=תקציר הוא תיאור קצ
 an-account-with-the-same-reference-already-exists=כבר קיים חשבון עם אותה הפניה. (Automatic Translation)
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=חשבון עם כתובת האימייל {0} כבר קיים בפורטל. האם אתם רוצים לשייך את הפעילות הזאת עם החשבון הנ"ל?
 an-anonymous-user-is-already-defined-for-the-company-x=משתמש אנונימי כבר מוגדר עבור החברה: {0}
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=An API endpoint must be related to an API application. (Automatic Copy)
 an-api-schema-must-be-related-to-an-api-application=An API schema must be related to an API application. (Automatic Copy)
 an-app-that-can-x-x-belongs-here=יישום שיכול {0} {1} משתייך לכאן. אנא צרו קשר עם מנהל הפורטל או התקינו יישום שכזה מ-Liferay Marketplace.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=アブストラクトは、ブロ
 an-account-with-the-same-reference-already-exists=同じ参照を持つアカウントがすでに存在します。
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account={0} のメールアドレスをもつアカウントがすでに存在します。このアクティビティをアカウントと関連付けますか？
 an-anonymous-user-is-already-defined-for-the-company-x=この企業にはすでに匿名ユーザーが定義されています: {0}
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=API エンドポイントは API アプリケーションと関連していなければなりません。
 an-api-schema-must-be-related-to-an-api-application=API スキーマは API アプリケーションと関連していなければなりません。
 an-app-that-can-x-x-belongs-here=アプリは以下のことができます:{0} {1} ポータル管理者に連絡するか、Liferayマーケットプレースからアプリをインストールしてください。

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=An abstract is a brief summary of
 an-account-with-the-same-reference-already-exists=An account with the same reference already exists. (Automatic Copy)
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=An account with {0} as the email address already exists in the portal. Do you want to associate this activity with that account? (Automatic Copy)
 an-anonymous-user-is-already-defined-for-the-company-x=An anonymous user is already defined for the company: {0} (Automatic Copy)
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=An API endpoint must be related to an API application. (Automatic Copy)
 an-api-schema-must-be-related-to-an-api-application=An API schema must be related to an API application. (Automatic Copy)
 an-app-that-can-x-x-belongs-here=An app that can {0} {1} belongs here. Please contact the portal administrator or install such an app from the Liferay Marketplace. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=An abstract is a brief summary of
 an-account-with-the-same-reference-already-exists=An account with the same reference already exists.
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=An account with {0} as the email address already exists in the portal. Do you want to associate this activity with that account?
 an-anonymous-user-is-already-defined-for-the-company-x=An anonymous user is already defined for the company: {0}
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=An API endpoint must be related to an API application. (Automatic Copy)
 an-api-schema-must-be-related-to-an-api-application=An API schema must be related to an API application. (Automatic Copy)
 an-app-that-can-x-x-belongs-here=An app that can {0} {1} belongs here. Please contact the portal administrator or install such an app from the Liferay Marketplace.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=초록은 블로그 게시글의 
 an-account-with-the-same-reference-already-exists=같은 참조를 가진 계정이 있습니다.
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=이메일로 {0}을 가진 계정이 있습니다. 이 활동을 해당 계정에 연관시키시겠습니까?
 an-anonymous-user-is-already-defined-for-the-company-x=회사에 대한 익명 사용자가 이미 정의되었습니다: {0}
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=An API endpoint must be related to an API application. (Automatic Copy)
 an-api-schema-must-be-related-to-an-api-application=An API schema must be related to an API application. (Automatic Copy)
 an-app-that-can-x-x-belongs-here={1} {0} 가능한 앱이 여기에 속합니다. 포탈 관리자에게 연락하거나 라이프레이 마켓플레이스에서 앱을 설치하십시오.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=An abstract is a brief summary of
 an-account-with-the-same-reference-already-exists=An account with the same reference already exists. (Automatic Copy)
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=ບັນຊີກັບ {0} ທີ່ຢູ່ອີເມວແມ່ນມີແລ້ວໃນພ໋ອດເລ໋ດ. ທ່ານຕ້ອງການເຊື່ອມໂຍງກິດຈະກຳຕ່າງໆກັບບັນຊີນີ້ບໍ່?
 an-anonymous-user-is-already-defined-for-the-company-x=An anonymous user is already defined for the company: {0} (Automatic Copy)
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=An API endpoint must be related to an API application. (Automatic Copy)
 an-api-schema-must-be-related-to-an-api-application=An API schema must be related to an API application. (Automatic Copy)
 an-app-that-can-x-x-belongs-here=An app that can {0} {1} belongs here. Please contact the portal administrator or install such an app from the Liferay Marketplace. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=Santrauka yra trumpa internetinio
 an-account-with-the-same-reference-already-exists=Abonementas su ta pačia nuoroda jau yra. (Automatic Translation)
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=An account with {0} as the email address already exists in the portal. Do you want to associate this activity with that account? (Automatic Copy)
 an-anonymous-user-is-already-defined-for-the-company-x=An anonymous user is already defined for the company: {0} (Automatic Copy)
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=An API endpoint must be related to an API application. (Automatic Copy)
 an-api-schema-must-be-related-to-an-api-application=An API schema must be related to an API application. (Automatic Copy)
 an-app-that-can-x-x-belongs-here=An app that can {0} {1} belongs here. Please contact the portal administrator or install such an app from the Liferay Marketplace. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=Abstrak adalah ringkasan ringkas 
 an-account-with-the-same-reference-already-exists=Akaun dengan rujukan yang sama telah pun wujud. (Automatic Translation)
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=An account with {0} as the email address already exists in the portal. Do you want to associate this activity with that account? (Automatic Copy)
 an-anonymous-user-is-already-defined-for-the-company-x=An anonymous user is already defined for the company: {0} (Automatic Copy)
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=An API endpoint must be related to an API application. (Automatic Copy)
 an-api-schema-must-be-related-to-an-api-application=An API schema must be related to an API application. (Automatic Copy)
 an-app-that-can-x-x-belongs-here=An app that can {0} {1} belongs here. Please contact the portal administrator or install such an app from the Liferay Marketplace. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=Et abstrakt er en rask oppsummeri
 an-account-with-the-same-reference-already-exists=Det finnes allerede en konto med samme referanse. (Automatic Translation)
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=En konto med e-postadressen {0} eksisterer allerede i portalen. Ønsker du å assosiere denne aktiviteten med den eksisterende kontoen?
 an-anonymous-user-is-already-defined-for-the-company-x=An anonymous user is already defined for the company: {0} (Automatic Copy)
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=An API endpoint must be related to an API application. (Automatic Copy)
 an-api-schema-must-be-related-to-an-api-application=An API schema must be related to an API application. (Automatic Copy)
 an-app-that-can-x-x-belongs-here=En applikasjon som kan {0} {1} hører til her. Vennligst kontakt portaladministratoren eller installer en slik applikasjon fra Liferay Marketplace.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=Een samenvatting is korte weergav
 an-account-with-the-same-reference-already-exists=Er bestaat al een account met dezelfde referentie.
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=Er bestaat al een account met e-mailadres {0} in de portal. Wilt u deze activiteit aan die account koppelen?
 an-anonymous-user-is-already-defined-for-the-company-x=Er is al een anonieme gebruiker opgegeven voor het bedrijf: {0}
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=Een API-eindpunt moet gerelateerd zijn aan een API-applicatie.
 an-api-schema-must-be-related-to-an-api-application=Een API-schema moet gerelateerd zijn aan een API-applicatie.
 an-app-that-can-x-x-belongs-here=Hier behoort een app die kan {0} {1}. Neem contact op met de portalbeheerder om zo'n app vanuit de Liferay Marketplace te installeren.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=An abstract is a brief summary of
 an-account-with-the-same-reference-already-exists=An account with the same reference already exists. (Automatic Copy)
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=Er bestaat al een account met e-mailadres {0} in de portal. Wilt u deze activiteit aan die account koppelen?
 an-anonymous-user-is-already-defined-for-the-company-x=An anonymous user is already defined for the company: {0} (Automatic Copy)
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=An API endpoint must be related to an API application. (Automatic Copy)
 an-api-schema-must-be-related-to-an-api-application=An API schema must be related to an API application. (Automatic Copy)
 an-app-that-can-x-x-belongs-here=An app that can {0} {1} belongs here. Please contact the portal administrator or install such an app from the Liferay Marketplace. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=Streszczenie to krótkie podsumow
 an-account-with-the-same-reference-already-exists=Konto z tym samym odwołaniem już istnieje. (Automatic Translation)
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=Konto z {0} jako adresem e-mail już istnieje w portalu. Czy chcesz przyporządkować tą aktywność do tego konta?
 an-anonymous-user-is-already-defined-for-the-company-x=An anonymous user is already defined for the company: {0} (Automatic Copy)
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=An API endpoint must be related to an API application. (Automatic Copy)
 an-api-schema-must-be-related-to-an-api-application=An API schema must be related to an API application. (Automatic Copy)
 an-app-that-can-x-x-belongs-here=Aplikacja która może {0} {1} należy tutaj. Skontaktuj się z administratorem portalu albo zainstaluj aplikację z Liferay Marketplace.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=Um resumo é uma síntese de uma 
 an-account-with-the-same-reference-already-exists=Uma conta com a mesma referência já existe.
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=Uma conta com {0} como o endereço de email já existe no portal. Você deseja associar esta atividade com essa conta?
 an-anonymous-user-is-already-defined-for-the-company-x=Um usuário anônimo já está definido para a empresa: {0}
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=Um ponto de extremidade da API deve ser relacionado a uma aplicação da API.
 an-api-schema-must-be-related-to-an-api-application=Um esquema de API deve ser relacionado a uma aplicação da API.
 an-app-that-can-x-x-belongs-here=Um aplicativo que pode {0} {1} estará aqui. Por favor, entre em contato com o administrador do portal ou instale um aplicativo assim do Liferay Marketplace.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=Um resumo é uma síntese de um p
 an-account-with-the-same-reference-already-exists=Uma conta com a mesma referência já existe. (Automatic Translation)
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=Já existe uma conta com {0} como endereço de correio electrónico. Pretende associar esta actividade a essa conta?
 an-anonymous-user-is-already-defined-for-the-company-x=An anonymous user is already defined for the company: {0} (Automatic Copy)
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=An API endpoint must be related to an API application. (Automatic Copy)
 an-api-schema-must-be-related-to-an-api-application=An API schema must be related to an API application. (Automatic Copy)
 an-app-that-can-x-x-belongs-here=Uma aplicação que pode {0} {1} estará aqui. Por favor, contate com o administrador do portal ou instale uma aplicação do Liferay Marketplace.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=Un rezumat este un scurt rezumat 
 an-account-with-the-same-reference-already-exists=Există deja un cont cu aceeași referință. (Automatic Translation)
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=An account with {0} as the email address already exists in the portal. Do you want to associate this activity with that account? (Automatic Copy)
 an-anonymous-user-is-already-defined-for-the-company-x=An anonymous user is already defined for the company: {0} (Automatic Copy)
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=An API endpoint must be related to an API application. (Automatic Copy)
 an-api-schema-must-be-related-to-an-api-application=An API schema must be related to an API application. (Automatic Copy)
 an-app-that-can-x-x-belongs-here=An app that can {0} {1} belongs here. Please contact the portal administrator or install such an app from the Liferay Marketplace. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=Аннотация краткое
 an-account-with-the-same-reference-already-exists=Учетная запись с той же ссылкой уже существует. (Automatic Translation)
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=Учетная запись с {0} в качестве адреса почты уже есть на портале. Вы хотите связать эту активность с той учетной записью?
 an-anonymous-user-is-already-defined-for-the-company-x=An anonymous user is already defined for the company: {0} (Automatic Copy)
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=An API endpoint must be related to an API application. (Automatic Copy)
 an-api-schema-must-be-related-to-an-api-application=An API schema must be related to an API application. (Automatic Copy)
 an-app-that-can-x-x-belongs-here=An app that can {0} {1} belongs here. Please contact the portal administrator or install such an app from the Liferay Marketplace. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=Abstrakt jej krátky sumár blogo
 an-account-with-the-same-reference-already-exists=Konto s rovnakým odkazom už existuje. (Automatic Translation)
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=Účet s e-mailovou adresou {0} už na portáli existuje. Chcete spojiť túto aktivitu so zmieňovaným účtom?
 an-anonymous-user-is-already-defined-for-the-company-x=An anonymous user is already defined for the company: {0} (Automatic Copy)
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=An API endpoint must be related to an API application. (Automatic Copy)
 an-api-schema-must-be-related-to-an-api-application=An API schema must be related to an API application. (Automatic Copy)
 an-app-that-can-x-x-belongs-here=Sem patrí aplikácia, ktorá môže {0} {1}. Kontaktujte, prosím, administrátora portálu alebo nainštalujte takúto aplikáciu z trhoviska.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=Povzetek je kratek povzetek vnosa
 an-account-with-the-same-reference-already-exists=Račun z enakim sklicem že obstaja. (Automatic Translation)
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=An account with {0} as the email address already exists in the portal. Do you want to associate this activity with that account? (Automatic Copy)
 an-anonymous-user-is-already-defined-for-the-company-x=An anonymous user is already defined for the company: {0} (Automatic Copy)
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=An API endpoint must be related to an API application. (Automatic Copy)
 an-api-schema-must-be-related-to-an-api-application=An API schema must be related to an API application. (Automatic Copy)
 an-app-that-can-x-x-belongs-here=An app that can {0} {1} belongs here. Please contact the portal administrator or install such an app from the Liferay Marketplace. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=An abstract is a brief summary of
 an-account-with-the-same-reference-already-exists=An account with the same reference already exists. (Automatic Copy)
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=Налог са {0} е-мејл адресом већ постоји у порталу. Да ли желите да повежете ову активност са тим налогом?
 an-anonymous-user-is-already-defined-for-the-company-x=An anonymous user is already defined for the company: {0} (Automatic Copy)
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=An API endpoint must be related to an API application. (Automatic Copy)
 an-api-schema-must-be-related-to-an-api-application=An API schema must be related to an API application. (Automatic Copy)
 an-app-that-can-x-x-belongs-here=An app that can {0} {1} belongs here. Please contact the portal administrator or install such an app from the Liferay Marketplace. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=An abstract is a brief summary of
 an-account-with-the-same-reference-already-exists=An account with the same reference already exists. (Automatic Copy)
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=Nalog sa {0} e-mejl adresom već postoji u portalu. Da li želite da povežete ovu aktivnost sa tim nalogom?
 an-anonymous-user-is-already-defined-for-the-company-x=An anonymous user is already defined for the company: {0} (Automatic Copy)
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=An API endpoint must be related to an API application. (Automatic Copy)
 an-api-schema-must-be-related-to-an-api-application=An API schema must be related to an API application. (Automatic Copy)
 an-app-that-can-x-x-belongs-here=An app that can {0} {1} belongs here. Please contact the portal administrator or install such an app from the Liferay Marketplace. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=Ett abstrakt är en kort sammanfa
 an-account-with-the-same-reference-already-exists=Det finns redan ett konto med samma referens.
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=Ett konto med e-postadressen {0} finns redan i portalen. Vill du knyta den här aktiviteten till det kontot?
 an-anonymous-user-is-already-defined-for-the-company-x=En anonym användare är redan definierad för företaget: {0}
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=En API-slutpunkt måste vara relaterad till en API-applikation.
 an-api-schema-must-be-related-to-an-api-application=Ett API-schema måste vara relaterat till en API-applikation.
 an-app-that-can-x-x-belongs-here=En app som kan {0} {1} hör hit. Kontakta portaladministratören eller installera en sådan app från Liferay Marketplace.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=An abstract is a brief summary of
 an-account-with-the-same-reference-already-exists=An account with the same reference already exists. (Automatic Copy)
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account={0} மின்னஞ்சல் முகவரி கணக்கு, Portal-லில் ஏற்கனவே உள்ளது. இந்த கணக்கை கொண்டு இணைக்க விரும்புகிறீர்களா?
 an-anonymous-user-is-already-defined-for-the-company-x=இந்த கம்பெனிக்கு யாரோ ஒரு பயனர் ஏற்கனவே வரையறுக்கப்பட்டுள்ளது: {0}
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=An API endpoint must be related to an API application. (Automatic Copy)
 an-api-schema-must-be-related-to-an-api-application=An API schema must be related to an API application. (Automatic Copy)
 an-app-that-can-x-x-belongs-here={0} {1} இங்கு உள்ள ஒரு பயன்பாடு. தயவுசெய்து போர்டல் நிர்வாகிக்கு தொடர்பு கொள்ளுங்கள் அல்லது Liferay Market Place -ல் இருந்து ஒரு பயன்பாட்டை நிறுவவும்.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=การสรุปเป็น
 an-account-with-the-same-reference-already-exists=มีแอคเคาน์ที่มีข้อมูลอ้างอิงเดียวกันอยู่แล้ว
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=แอคเคาน์ที่มี {0} เป็นที่อยู่อีเมลมีอยู่ในพอร์ทัลแล้ว คุณต้องการเชื่อมโยงกิจกรรมนี้กับแอคเคาน์นั้นหรือไม่?
 an-anonymous-user-is-already-defined-for-the-company-x=ผู้ใช้งานแบบไม่ระบุชื่อได้กำหนดไว้แล้วสำหรับบริษัท: {0}
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=An API endpoint must be related to an API application. (Automatic Copy)
 an-api-schema-must-be-related-to-an-api-application=An API schema must be related to an API application. (Automatic Copy)
 an-app-that-can-x-x-belongs-here=แอพที่สามารถ{0}{1}เป็นของที่นี่ กรุณาติดต่อพอร์ทัลแอดมินหรือติดตั้งแอพจาก Liferay Marketplace

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=Özet, blog girdisinin kısa bir 
 an-account-with-the-same-reference-already-exists=Aynı başvuruya sahip bir hesap zaten var. (Automatic Translation)
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=An account with {0} as the email address already exists in the portal. Do you want to associate this activity with that account? (Automatic Copy)
 an-anonymous-user-is-already-defined-for-the-company-x=An anonymous user is already defined for the company: {0} (Automatic Copy)
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=An API endpoint must be related to an API application. (Automatic Copy)
 an-api-schema-must-be-related-to-an-api-application=An API schema must be related to an API application. (Automatic Copy)
 an-app-that-can-x-x-belongs-here=An app that can {0} {1} belongs here. Please contact the portal administrator or install such an app from the Liferay Marketplace. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=Анотація - це коро�
 an-account-with-the-same-reference-already-exists=Обліковий запис із таким посиланням уже існує. (Automatic Translation)
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=An account with {0} as the email address already exists in the portal. Do you want to associate this activity with that account? (Automatic Copy)
 an-anonymous-user-is-already-defined-for-the-company-x=An anonymous user is already defined for the company: {0} (Automatic Copy)
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=An API endpoint must be related to an API application. (Automatic Copy)
 an-api-schema-must-be-related-to-an-api-application=An API schema must be related to an API application. (Automatic Copy)
 an-app-that-can-x-x-belongs-here=An app that can {0} {1} belongs here. Please contact the portal administrator or install such an app from the Liferay Marketplace. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=Tóm tắt là một bản tóm t
 an-account-with-the-same-reference-already-exists=Một tài khoản có cùng tham chiếu đã tồn tại. (Automatic Translation)
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=Một tài khoản với địa chỉ email {0} đã tồn tại trong cổng thông tin. Bạn có muốn liên kết hoạt động này với tài khoản đó không?
 an-anonymous-user-is-already-defined-for-the-company-x=An anonymous user is already defined for the company: {0} (Automatic Copy)
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=An API endpoint must be related to an API application. (Automatic Copy)
 an-api-schema-must-be-related-to-an-api-application=An API schema must be related to an API application. (Automatic Copy)
 an-app-that-can-x-x-belongs-here=Ứng dụng {0} {1} có sẵn. Bạn hãy liên hệ với Quản trị để cài đặt từ chợ Liferay Marketplace.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=摘要是一篇博客的简要介
 an-account-with-the-same-reference-already-exists=具有相同引用的帐户已存在。
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=portal中已存在一个用{0}此邮箱注册的账户。您想把此活动关联到那个账户上吗？
 an-anonymous-user-is-already-defined-for-the-company-x=已为公司定义一个匿名用户：{0}
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=API 端点必须与 API 应用程序相关联。
 an-api-schema-must-be-related-to-an-api-application=API 模式必须与 API 应用程序相关联。
 an-app-that-can-x-x-belongs-here=可以 {0} {1} 的应用程序可以应用于此。请联系您的Portal管理员或从Liferay Marketplace下载安装。

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
@@ -1411,6 +1411,7 @@ an-abstract-is-a-brief-summary-of-a-blog-entry=摘要是部落格條目的簡短
 an-account-with-the-same-reference-already-exists=已存在具有相同參照的帳戶。
 an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account=一個以 {0} 作為電子郵件位址的帳戶已經存在這入口網。您確定要以這個帳戶關聯這個活動？
 an-anonymous-user-is-already-defined-for-the-company-x=已為公司定義一個匿名使用者：{0}
+an-api-endpoint-must-be-related-to-a-valid-api-schema=An API endpoint must be related to a valid API schema. (Automatic Copy)
 an-api-endpoint-must-be-related-to-an-api-application=An API endpoint must be related to an API application. (Automatic Copy)
 an-api-schema-must-be-related-to-an-api-application=An API schema must be related to an API application. (Automatic Copy)
 an-app-that-can-x-x-belongs-here=一個應用程式能{0} {1}屬於這裡。請聯絡站台管理員或從Liferay市集安裝一個應用程式。


### PR DESCRIPTION
**What is new?**
- Change deletion type in two relationships between `API Schema` and `API Endpoint`:
  - `requestAPISchemaToAPIEndpoints`
  - `responseAPISchemaToAPIEndpoints`
-  Add new validation in `API Endpoint`: When user tries to insert an `API Schema` in the `API Endpoint` and it is not valid, an Exception should be thrown.

**How to deploy it?**
- Deploy `headless-builder-api` and `headless-builder-impl`

**JIRA Related Ticket**
https://liferay.atlassian.net/browse/LPS-189728