### PR TITLE
Lrqa 81491 | test fix for GenerateExportEndpointsForHeadlessAPIs#CanGetExportTaskDataFromExportBatchContainingNoParameters

### DIFF
--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-test/src/testFunctional/tests/GenerateExportEndpointsForHeadlessAPIs.testcase
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-test/src/testFunctional/tests/GenerateExportEndpointsForHeadlessAPIs.testcase
@@ -96,9 +96,9 @@ definition {
 			var response = ExportTask.getExportTaskById(exportTaskId = ${exportTaskId});
 		}
 
-		task ("Then processedItemsCount is 7 with executeStatus "COMPLETED"") {
+		task ("Then processedItemsCount is 8 with executeStatus "COMPLETED"") {
 			ExportTask.assertProcessedItemsCountWithCompletedStatus(
-				expectedCount = 7,
+				expectedCount = 8,
 				response = ${response});
 		}
 	}


### PR DESCRIPTION
Background:
- test failed because of [Revert "LPS-186839 Disable OrganizationSystemObjectDefinitionManager" ](https://github.com/liferay/liferay-portal/commit/cd392c6fd7572c44e28ef3a6f91d877519c9b687)

Jira Ticket:
- https://liferay.atlassian.net/browse/LRQA-81491