### PR TITLE
LPS-190590 Apply endpoint filter

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-api/bnd.bnd
+++ b/modules/apps/headless/headless-builder/headless-builder-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Builder API
 Bundle-SymbolicName: com.liferay.headless.builder.api
-Bundle-Version: 3.0.1
+Bundle-Version: 4.0.0
 Export-Package:\
 	com.liferay.headless.builder.application,\
 	com.liferay.headless.builder.application.provider,\

--- a/modules/apps/headless/headless-builder/headless-builder-api/src/main/java/com/liferay/headless/builder/application/APIApplication.java
+++ b/modules/apps/headless/headless-builder/headless-builder-api/src/main/java/com/liferay/headless/builder/application/APIApplication.java
@@ -39,6 +39,8 @@ public interface APIApplication {
 
 	public interface Endpoint {
 
+		public Filter getFilter();
+
 		public Http.Method getMethod();
 
 		public String getPath();
@@ -54,6 +56,12 @@ public interface APIApplication {
 			COMPANY, GROUP
 
 		}
+
+	}
+
+	public interface Filter {
+
+		public String getODataFilter();
 
 	}
 

--- a/modules/apps/headless/headless-builder/headless-builder-api/src/main/java/com/liferay/headless/builder/application/APIApplication.java
+++ b/modules/apps/headless/headless-builder/headless-builder-api/src/main/java/com/liferay/headless/builder/application/APIApplication.java
@@ -61,7 +61,7 @@ public interface APIApplication {
 
 	public interface Filter {
 
-		public String getODataFilter();
+		public String getODataFilterString();
 
 	}
 

--- a/modules/apps/headless/headless-builder/headless-builder-api/src/main/resources/com/liferay/headless/builder/application/packageinfo
+++ b/modules/apps/headless/headless-builder/headless-builder-api/src/main/resources/com/liferay/headless/builder/application/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 4.0.0

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/application/provider/APIApplicationProviderImpl.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/application/provider/APIApplicationProviderImpl.java
@@ -151,7 +151,7 @@ public class APIApplicationProviderImpl implements APIApplicationProvider {
 		return new APIApplication.Filter() {
 
 			@Override
-			public String getODataFilter() {
+			public String getODataFilterString() {
 				return (String)properties.get("oDataFilter");
 			}
 

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/application/provider/APIApplicationProviderImpl.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/application/provider/APIApplicationProviderImpl.java
@@ -25,6 +25,7 @@ import com.liferay.object.rest.dto.v1_0.ObjectEntry;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.MapUtil;
@@ -77,11 +78,16 @@ public class APIApplicationProviderImpl implements APIApplicationProvider {
 				companyId,
 				"apiApplicationToAPIEndpoints/externalReferenceCode eq '" +
 					apiApplicationExternalReferenceCode + "'",
-				"L_API_ENDPOINT"),
+				Arrays.asList("apiEndpointToAPIFilters"), "L_API_ENDPOINT"),
 			objectEntry -> {
 				Map<String, Object> properties = objectEntry.getProperties();
 
 				return new APIApplication.Endpoint() {
+
+					@Override
+					public APIApplication.Filter getFilter() {
+						return _getFilter(properties);
+					}
 
 					@Override
 					public Http.Method getMethod() {
@@ -126,6 +132,30 @@ public class APIApplicationProviderImpl implements APIApplicationProvider {
 
 				};
 			});
+	}
+
+	private APIApplication.Filter _getFilter(
+		Map<String, Object> endpointProperties) {
+
+		ObjectEntry[] filterObjectEntries =
+			(ObjectEntry[])endpointProperties.get("apiEndpointToAPIFilters");
+
+		if (ArrayUtil.isEmpty(filterObjectEntries)) {
+			return null;
+		}
+
+		ObjectEntry filterObjectEntry = filterObjectEntries[0];
+
+		Map<String, Object> properties = filterObjectEntry.getProperties();
+
+		return new APIApplication.Filter() {
+
+			@Override
+			public String getODataFilter() {
+				return (String)properties.get("oDataFilter");
+			}
+
+		};
 	}
 
 	private List<APIApplication.Property> _getProperties(

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/helper/ObjectEntryHelper.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/helper/ObjectEntryHelper.java
@@ -141,7 +141,7 @@ public class ObjectEntryHelper {
 					companyId);
 
 		Page<ObjectEntry> objectEntriesPage = getObjectEntriesPage(
-			companyId, null, pagination,
+			companyId, _getODataFilter(endpoint), pagination,
 			schemaMainObjectDefinition.getExternalReferenceCode());
 
 		for (ObjectEntry objectEntry : objectEntriesPage.getItems()) {
@@ -186,6 +186,16 @@ public class ObjectEntryHelper {
 		).put(
 			"modifiedDate", objectEntry.getDateModified()
 		).build();
+	}
+
+	private String _getODataFilter(APIApplication.Endpoint endpoint) {
+		APIApplication.Filter filter = endpoint.getFilter();
+
+		if (filter == null) {
+			return null;
+		}
+
+		return filter.getODataFilter();
 	}
 
 	@Reference

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/helper/ObjectEntryHelper.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/helper/ObjectEntryHelper.java
@@ -141,7 +141,7 @@ public class ObjectEntryHelper {
 					companyId);
 
 		Page<ObjectEntry> objectEntriesPage = getObjectEntriesPage(
-			companyId, _getODataFilter(endpoint), pagination,
+			companyId, _getODataFilterString(endpoint), pagination,
 			schemaMainObjectDefinition.getExternalReferenceCode());
 
 		for (ObjectEntry objectEntry : objectEntriesPage.getItems()) {
@@ -188,14 +188,14 @@ public class ObjectEntryHelper {
 		).build();
 	}
 
-	private String _getODataFilter(APIApplication.Endpoint endpoint) {
+	private String _getODataFilterString(APIApplication.Endpoint endpoint) {
 		APIApplication.Filter filter = endpoint.getFilter();
 
 		if (filter == null) {
 			return null;
 		}
 
-		return filter.getODataFilter();
+		return filter.getODataFilterString();
 	}
 
 	@Reference

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/resources/com/liferay/headless/builder/internal/batch/headless-builder.json
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/resources/com/liferay/headless/builder/internal/batch/headless-builder.json
@@ -103,21 +103,6 @@
 				{
 					"DBType": "String",
 					"businessType": "Text",
-					"externalReferenceCode": "OBJECT_FIELD_ERC",
-					"indexed": true,
-					"indexedAsKeyword": false,
-					"label": {
-						"en_US": "Object Field ERC"
-					},
-					"name": "objectFieldERC",
-					"required": true,
-					"state": false,
-					"system": false,
-					"type": "String"
-				},
-				{
-					"DBType": "String",
-					"businessType": "Text",
 					"externalReferenceCode": "ODATA_FILTER",
 					"indexed": true,
 					"indexedAsKeyword": false,

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/application/provider/test/APIApplicationProviderTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/application/provider/test/APIApplicationProviderTest.java
@@ -171,7 +171,8 @@ public class APIApplicationProviderTest extends BaseTestCase {
 
 		APIApplication.Filter filter = endpoint.getFilter();
 
-		Assert.assertEquals("name ne 'testName'", filter.getODataFilter());
+		Assert.assertEquals(
+			"name ne 'testName'", filter.getODataFilterString());
 	}
 
 	private static final String _API_APPLICATION_ERC =

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/application/provider/test/APIApplicationProviderTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/application/provider/test/APIApplicationProviderTest.java
@@ -125,6 +125,7 @@ public class APIApplicationProviderTest extends BaseTestCase {
 
 		APIApplication.Endpoint endpoint = endpoints.get(0);
 
+		Assert.assertNull(endpoint.getFilter());
 		Assert.assertEquals(Http.Method.GET, endpoint.getMethod());
 		Assert.assertEquals("path", endpoint.getPath());
 		Assert.assertEquals(schema, endpoint.getRequestSchema());
@@ -142,12 +143,44 @@ public class APIApplicationProviderTest extends BaseTestCase {
 		Assert.assertEquals("name", property.getName());
 		Assert.assertEquals(
 			APIApplication.Property.Type.PICKLIST, property.getType());
+
+		// Filter
+
+		HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				"apiEndpointToAPIFilters",
+				JSONUtil.put(
+					JSONUtil.put(
+						"externalReferenceCode", _API_ENDPOINT_FILTER_ERC
+					).put(
+						"oDataFilter", "name ne 'testName'"
+					))
+			).put(
+				"externalReferenceCode", _API_ENDPOINT_ERC
+			).toString(),
+			"headless-builder/endpoints/by-external-reference-code/" +
+				_API_ENDPOINT_ERC,
+			Http.Method.PATCH);
+
+		apiApplication = _apiApplicationProvider.fetchAPIApplication(
+			"test", TestPropsValues.getCompanyId());
+
+		endpoints = apiApplication.getEndpoints();
+
+		endpoint = endpoints.get(0);
+
+		APIApplication.Filter filter = endpoint.getFilter();
+
+		Assert.assertEquals("name ne 'testName'", filter.getODataFilter());
 	}
 
 	private static final String _API_APPLICATION_ERC =
 		RandomTestUtil.randomString();
 
 	private static final String _API_ENDPOINT_ERC =
+		RandomTestUtil.randomString();
+
+	private static final String _API_ENDPOINT_FILTER_ERC =
 		RandomTestUtil.randomString();
 
 	private static final String _API_SCHEMA_ERC = RandomTestUtil.randomString();

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/application/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/application/resource/test/HeadlessBuilderResourceTest.java
@@ -28,6 +28,8 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
+import javax.ws.rs.core.Response;
+
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -167,13 +169,14 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 				"%s eq '5' or %s eq '7'", _OBJECT_FIELD_NAME,
 				_OBJECT_FIELD_NAME));
 
-		HTTPTestUtil.invokeToJSONObject(
-			JSONUtil.put(
-				"applicationStatus", "published"
-			).toString(),
-			"headless-builder/applications/by-external-reference-code/" +
-				_API_APPLICATION_ERC_1,
-			Http.Method.PATCH);
+		_assertSuccessfulHttpCode(
+			HTTPTestUtil.invokeToHttpCode(
+				JSONUtil.put(
+					"applicationStatus", "published"
+				).toString(),
+				"headless-builder/applications/by-external-reference-code/" +
+					_API_APPLICATION_ERC_1,
+				Http.Method.PATCH));
 
 		for (int i = 0; i <= 25; i++) {
 			_addCustomObjectEntry(String.valueOf(i));
@@ -208,13 +211,14 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			_objectDefinitionJSONObject.getString("externalReferenceCode"),
 			_API_APPLICATION_PATH_1);
 
-		HTTPTestUtil.invokeToJSONObject(
-			JSONUtil.put(
-				"applicationStatus", "published"
-			).toString(),
-			"headless-builder/applications/by-external-reference-code/" +
-				_API_APPLICATION_ERC_1,
-			Http.Method.PATCH);
+		_assertSuccessfulHttpCode(
+			HTTPTestUtil.invokeToHttpCode(
+				JSONUtil.put(
+					"applicationStatus", "published"
+				).toString(),
+				"headless-builder/applications/by-external-reference-code/" +
+					_API_APPLICATION_ERC_1,
+				Http.Method.PATCH));
 
 		for (int i = 0; i <= 25; i++) {
 			_addCustomObjectEntry(String.valueOf(i));
@@ -254,73 +258,78 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 
 		String apiSchemaExternalReferenceCode = RandomTestUtil.randomString();
 
-		HTTPTestUtil.invokeToJSONObject(
-			JSONUtil.put(
-				"apiApplicationToAPIEndpoints",
+		_assertSuccessfulHttpCode(
+			HTTPTestUtil.invokeToHttpCode(
 				JSONUtil.put(
+					"apiApplicationToAPIEndpoints",
 					JSONUtil.put(
-						"description", "description"
-					).put(
-						"externalReferenceCode", endpointExternalReferenceCode
-					).put(
-						"httpMethod", "get"
-					).put(
-						"name", "name"
-					).put(
-						"path", path
-					).put(
-						"scope", "company"
-					))
-			).put(
-				"apiApplicationToAPISchemas",
-				JSONUtil.put(
-					JSONUtil.put(
-						"apiSchemaToAPIProperties",
 						JSONUtil.put(
+							"description", "description"
+						).put(
+							"externalReferenceCode",
+							endpointExternalReferenceCode
+						).put(
+							"httpMethod", "get"
+						).put(
+							"name", "name"
+						).put(
+							"path", path
+						).put(
+							"scope", "company"
+						))
+				).put(
+					"apiApplicationToAPISchemas",
+					JSONUtil.put(
+						JSONUtil.put(
+							"apiSchemaToAPIProperties",
 							JSONUtil.put(
-								"description", "description"
-							).put(
-								"name", "name"
-							).put(
-								"objectFieldERC", _OBJECT_FIELD_ERC
-							))
-					).put(
-						"description", "description"
-					).put(
-						"externalReferenceCode", apiSchemaExternalReferenceCode
-					).put(
-						"mainObjectDefinitionERC",
-						objectDefinitionExternalReferenceCode
-					).put(
-						"name", "name"
-					))
-			).put(
-				"applicationStatus", "unpublished"
-			).put(
-				"baseURL", baseURL
-			).put(
-				"externalReferenceCode", applicationExternalReferenceCode
-			).put(
-				"title", RandomTestUtil.randomString()
-			).toString(),
-			"headless-builder/applications", Http.Method.POST);
+								JSONUtil.put(
+									"description", "description"
+								).put(
+									"name", "name"
+								).put(
+									"objectFieldERC", _OBJECT_FIELD_ERC
+								))
+						).put(
+							"description", "description"
+						).put(
+							"externalReferenceCode",
+							apiSchemaExternalReferenceCode
+						).put(
+							"mainObjectDefinitionERC",
+							objectDefinitionExternalReferenceCode
+						).put(
+							"name", "name"
+						))
+				).put(
+					"applicationStatus", "unpublished"
+				).put(
+					"baseURL", baseURL
+				).put(
+					"externalReferenceCode", applicationExternalReferenceCode
+				).put(
+					"title", RandomTestUtil.randomString()
+				).toString(),
+				"headless-builder/applications", Http.Method.POST));
 
-		HTTPTestUtil.invokeToJSONObject(
-			null,
-			StringBundler.concat(
-				"headless-builder/schemas/by-external-reference-code/",
-				apiSchemaExternalReferenceCode,
-				"/requestAPISchemaToAPIEndpoints/",
-				endpointExternalReferenceCode),
-			Http.Method.PUT);
-		HTTPTestUtil.invokeToJSONObject(
-			null,
-			StringBundler.concat(
-				"headless-builder/schemas/by-external-reference-code/",
-				apiSchemaExternalReferenceCode,
-				"/responseAPISchemaToAPIEndpoints/",
-				endpointExternalReferenceCode),
-			Http.Method.PUT);
+		_assertSuccessfulHttpCode(
+			HTTPTestUtil.invokeToHttpCode(
+				null,
+				StringBundler.concat(
+					"headless-builder/schemas/by-external-reference-code/",
+					apiSchemaExternalReferenceCode,
+					"/requestAPISchemaToAPIEndpoints/",
+					endpointExternalReferenceCode),
+				Http.Method.PUT));
+		_assertSuccessfulHttpCode(
+			HTTPTestUtil.invokeToHttpCode(
+				null,
+				StringBundler.concat(
+					"headless-builder/schemas/by-external-reference-code/",
+					apiSchemaExternalReferenceCode,
+					"/responseAPISchemaToAPIEndpoints/",
+					endpointExternalReferenceCode),
+				Http.Method.PUT));
 	}
 
 	private void _addCustomObjectEntry(String objectFieldValue)
@@ -331,25 +340,27 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 
 		String endpoint = StringUtil.removeSubstring(restContextPath, "/o/");
 
-		HTTPTestUtil.invokeToJSONObject(
-			JSONUtil.put(
-				_OBJECT_FIELD_NAME, objectFieldValue
-			).toString(),
-			endpoint, Http.Method.POST);
+		_assertSuccessfulHttpCode(
+			HTTPTestUtil.invokeToHttpCode(
+				JSONUtil.put(
+					_OBJECT_FIELD_NAME, objectFieldValue
+				).toString(),
+				endpoint, Http.Method.POST));
 	}
 
 	private void _addFilter(
 			String apiEndpointExternalReferenceCode, String filterString)
 		throws Exception {
 
-		HTTPTestUtil.invokeToJSONObject(
-			JSONUtil.put(
-				"oDataFilter", filterString
-			).put(
-				"r_apiEndpointToAPIFilters_c_apiEndpointERC",
-				apiEndpointExternalReferenceCode
-			).toString(),
-			"headless-builder/filters", Http.Method.POST);
+		_assertSuccessfulHttpCode(
+			HTTPTestUtil.invokeToHttpCode(
+				JSONUtil.put(
+					"oDataFilter", filterString
+				).put(
+					"r_apiEndpointToAPIFilters_c_apiEndpointERC",
+					apiEndpointExternalReferenceCode
+				).toString(),
+				"headless-builder/filters", Http.Method.POST));
 	}
 
 	private JSONObject _addObjectDefinition() throws Exception {
@@ -395,6 +406,12 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 				"status", JSONUtil.put("code", 0)
 			).toString(),
 			"object-admin/v1.0/object-definitions", Http.Method.POST);
+	}
+
+	private void _assertSuccessfulHttpCode(int httpCode) {
+		Assert.assertEquals(
+			Response.Status.Family.SUCCESSFUL,
+			Response.Status.Family.familyOf(httpCode));
 	}
 
 	private static final String _API_APPLICATION_ERC_1 =

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/application/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/application/resource/test/HeadlessBuilderResourceTest.java
@@ -78,20 +78,8 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			HTTPTestUtil.invokeToHttpCode(
 				null, endpointPath2, Http.Method.GET));
 
-		HTTPTestUtil.invokeToJSONObject(
-			JSONUtil.put(
-				"applicationStatus", "published"
-			).toString(),
-			"headless-builder/applications/by-external-reference-code/" +
-				_API_APPLICATION_ERC_1,
-			Http.Method.PATCH);
-		HTTPTestUtil.invokeToJSONObject(
-			JSONUtil.put(
-				"applicationStatus", "published"
-			).toString(),
-			"headless-builder/applications/by-external-reference-code/" +
-				_API_APPLICATION_ERC_2,
-			Http.Method.PATCH);
+		_publishAPIApplication(_API_APPLICATION_ERC_1);
+		_publishAPIApplication(_API_APPLICATION_ERC_2);
 
 		Assert.assertEquals(
 			200,
@@ -169,14 +157,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 				"%s eq '5' or %s eq '7'", _OBJECT_FIELD_NAME,
 				_OBJECT_FIELD_NAME));
 
-		_assertSuccessfulHttpCode(
-			HTTPTestUtil.invokeToHttpCode(
-				JSONUtil.put(
-					"applicationStatus", "published"
-				).toString(),
-				"headless-builder/applications/by-external-reference-code/" +
-					_API_APPLICATION_ERC_1,
-				Http.Method.PATCH));
+		_publishAPIApplication(_API_APPLICATION_ERC_1);
 
 		for (int i = 0; i <= 25; i++) {
 			_addCustomObjectEntry(String.valueOf(i));
@@ -211,14 +192,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			_objectDefinitionJSONObject.getString("externalReferenceCode"),
 			_API_APPLICATION_PATH_1);
 
-		_assertSuccessfulHttpCode(
-			HTTPTestUtil.invokeToHttpCode(
-				JSONUtil.put(
-					"applicationStatus", "published"
-				).toString(),
-				"headless-builder/applications/by-external-reference-code/" +
-					_API_APPLICATION_ERC_1,
-				Http.Method.PATCH));
+		_publishAPIApplication(_API_APPLICATION_ERC_1);
 
 		for (int i = 0; i <= 25; i++) {
 			_addCustomObjectEntry(String.valueOf(i));
@@ -412,6 +386,20 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 		Assert.assertEquals(
 			Response.Status.Family.SUCCESSFUL,
 			Response.Status.Family.familyOf(httpCode));
+	}
+
+	private void _publishAPIApplication(
+			String apiApplicationExternalReferenceCode)
+		throws Exception {
+
+		_assertSuccessfulHttpCode(
+			HTTPTestUtil.invokeToHttpCode(
+				JSONUtil.put(
+					"applicationStatus", "published"
+				).toString(),
+				"headless-builder/applications/by-external-reference-code/" +
+					apiApplicationExternalReferenceCode,
+				Http.Method.PATCH));
 	}
 
 	private static final String _API_APPLICATION_ERC_1 =

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/application/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/application/resource/test/HeadlessBuilderResourceTest.java
@@ -51,12 +51,12 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 		_objectDefinitionJSONObject = _addObjectDefinition();
 
 		_addAPIApplication(
-			_API_BASE_URL_1, _API_APPLICATION_ERC_1,
+			_API_APPLICATION_ERC_1, _API_BASE_URL_1, _API_ENDPOINT_ERC_1,
 			_objectDefinitionJSONObject.getString("externalReferenceCode"),
 			_API_APPLICATION_PATH_1);
 
 		_addAPIApplication(
-			_API_BASE_URL_2, _API_APPLICATION_ERC_2,
+			_API_APPLICATION_ERC_2, _API_BASE_URL_2, _API_ENDPOINT_ERC_2,
 			_objectDefinitionJSONObject.getString("externalReferenceCode"),
 			_API_APPLICATION_PATH_2);
 
@@ -180,11 +180,11 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 	}
 
 	private void _addAPIApplication(
-			String baseURL, String externalReferenceCode,
+			String applicationExternalReferenceCode, String baseURL,
+			String endpointExternalReferenceCode,
 			String objectDefinitionExternalReferenceCode, String path)
 		throws Exception {
 
-		String apiEndpointExternalReferenceCode = RandomTestUtil.randomString();
 		String apiSchemaExternalReferenceCode = RandomTestUtil.randomString();
 
 		HTTPTestUtil.invokeToJSONObject(
@@ -194,8 +194,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 					JSONUtil.put(
 						"description", "description"
 					).put(
-						"externalReferenceCode",
-						apiEndpointExternalReferenceCode
+						"externalReferenceCode", endpointExternalReferenceCode
 					).put(
 						"httpMethod", "get"
 					).put(
@@ -233,7 +232,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			).put(
 				"baseURL", baseURL
 			).put(
-				"externalReferenceCode", externalReferenceCode
+				"externalReferenceCode", applicationExternalReferenceCode
 			).put(
 				"title", RandomTestUtil.randomString()
 			).toString(),
@@ -245,7 +244,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 				"headless-builder/schemas/by-external-reference-code/",
 				apiSchemaExternalReferenceCode,
 				"/requestAPISchemaToAPIEndpoints/",
-				apiEndpointExternalReferenceCode),
+				endpointExternalReferenceCode),
 			Http.Method.PUT);
 		HTTPTestUtil.invokeToJSONObject(
 			null,
@@ -253,7 +252,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 				"headless-builder/schemas/by-external-reference-code/",
 				apiSchemaExternalReferenceCode,
 				"/responseAPISchemaToAPIEndpoints/",
-				apiEndpointExternalReferenceCode),
+				endpointExternalReferenceCode),
 			Http.Method.PUT);
 	}
 
@@ -332,6 +331,12 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 	private static final String _API_BASE_URL_1 = RandomTestUtil.randomString();
 
 	private static final String _API_BASE_URL_2 = RandomTestUtil.randomString();
+
+	private static final String _API_ENDPOINT_ERC_1 =
+		RandomTestUtil.randomString();
+
+	private static final String _API_ENDPOINT_ERC_2 =
+		RandomTestUtil.randomString();
 
 	private static final String _OBJECT_FIELD_ERC =
 		RandomTestUtil.randomString();

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/application/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/application/resource/test/HeadlessBuilderResourceTest.java
@@ -140,9 +140,34 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			HTTPTestUtil.invokeToJSONObject(
 				null,
 				String.format(
-					"%s?page=%d&pageSize=%d",
-					_API_BASE_URL_1 + _API_APPLICATION_PATH_1, 2, 5),
+					"%s?page=2&pageSize=5",
+					_API_BASE_URL_1 + _API_APPLICATION_PATH_1),
 				Http.Method.GET
+			).toString(),
+			JSONCompareMode.LENIENT);
+
+		_addFilter(
+			_API_ENDPOINT_ERC_1,
+			String.format(
+				"%s eq '5' or %s eq '7'", _OBJECT_FIELD_NAME,
+				_OBJECT_FIELD_NAME));
+
+		JSONAssert.assertEquals(
+			JSONUtil.put(
+				"items",
+				JSONUtil.putAll(
+					JSONUtil.put("name", "5"), JSONUtil.put("name", "7"))
+			).put(
+				"lastPage", 1
+			).put(
+				"page", 1
+			).put(
+				"pageSize", 20
+			).put(
+				"totalCount", 2
+			).toString(),
+			HTTPTestUtil.invokeToJSONObject(
+				null, _API_BASE_URL_1 + _API_APPLICATION_PATH_1, Http.Method.GET
 			).toString(),
 			JSONCompareMode.LENIENT);
 
@@ -269,6 +294,20 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 				_OBJECT_FIELD_NAME, objectFieldValue
 			).toString(),
 			endpoint, Http.Method.POST);
+	}
+
+	private void _addFilter(
+			String apiEndpointExternalReferenceCode, String filterString)
+		throws Exception {
+
+		HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				"oDataFilter", filterString
+			).put(
+				"r_apiEndpointToAPIFilters_c_apiEndpointERC",
+				apiEndpointExternalReferenceCode
+			).toString(),
+			"headless-builder/filters", Http.Method.POST);
 	}
 
 	private JSONObject _addObjectDefinition() throws Exception {

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryServiceImpl.java
@@ -152,9 +152,11 @@ public class ObjectEntryServiceImpl extends ObjectEntryServiceBaseImpl {
 	public ObjectEntry deleteObjectEntry(long objectEntryId)
 		throws PortalException {
 
-		_checkPermission(
-			ActionKeys.DELETE,
-			objectEntryLocalService.getObjectEntry(objectEntryId));
+		if (!ObjectEntryThreadLocal.isSkipObjectEntryResourcePermission()) {
+			_checkPermission(
+				ActionKeys.DELETE,
+				objectEntryLocalService.getObjectEntry(objectEntryId));
+		}
 
 		return objectEntryLocalService.deleteObjectEntry(objectEntryId);
 	}


### PR DESCRIPTION
Related issue: https://liferay.atlassian.net/browse/LPS-190590

---

The purpose of this PR is to apply the filter that has been associated to the response schema of a given endpoint.

That is, having the following elements of an API Application:

- `SchemaX`
- Endpoint with a response schema `SchemaX` and a filter

Then, all the requests to the endpoint will apply automatically the filter associated to that endpoint.

**NOTE**: The filter is a String that contains a filter in a OData format (see [this link](https://help.liferay.com/hc/es/articles/360036343152-Filter-Sort-and-Search)) and it must contain the internal fields of the Object Definition mapped in the Schema defined.

---

How to test it:

- Deploy the module `modules/apps/object/object-service`
- Deploy the module `modules/apps/headless/headless-builder/headless-builder-api`
- Deploy the module `modules/apps/headless/headless-builder/headless-builder-impl`
- Execute the tests with the command `gw tI --tests HeadlessBuilderResourceTest` in the module `modules/apps/headless/headless-builder/headless-builder-test
`