### PR TITLE
LPS-190450 Avoid errors when importing BatchEngineUnits

### DIFF
--- a/modules/apps/batch-engine/batch-engine-api/bnd.bnd
+++ b/modules/apps/batch-engine/batch-engine-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Batch Engine API
 Bundle-SymbolicName: com.liferay.batch.engine.api
-Bundle-Version: 22.0.1
+Bundle-Version: 23.0.0
 Export-Package:\
 	com.liferay.batch.engine,\
 	com.liferay.batch.engine.action,\

--- a/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/BatchEngineImportTaskExecutor.java
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/BatchEngineImportTaskExecutor.java
@@ -25,6 +25,7 @@ public interface BatchEngineImportTaskExecutor {
 
 	public void execute(
 		BatchEngineImportTask batchEngineImportTask,
-		BatchEngineTaskItemDelegate<?> batchEngineTaskItemDelegate);
+		BatchEngineTaskItemDelegate<?> batchEngineTaskItemDelegate,
+		boolean checkPermissions);
 
 }

--- a/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/unit/BatchEngineUnitConfiguration.java
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/unit/BatchEngineUnitConfiguration.java
@@ -14,6 +14,7 @@
 
 package com.liferay.batch.engine.unit;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -61,12 +62,21 @@ public class BatchEngineUnitConfiguration {
 		return _version;
 	}
 
+	public boolean isCheckPermissions() {
+		return _checkPermissions;
+	}
+
 	public boolean isMultiCompany() {
 		return _multiCompany;
 	}
 
 	public void setCallbackURL(String callbackURL) {
 		_callbackURL = callbackURL;
+	}
+
+	@JsonIgnore
+	public void setCheckPermissions(boolean checkPermissions) {
+		_checkPermissions = checkPermissions;
 	}
 
 	public void setClassName(String className) {
@@ -114,6 +124,8 @@ public class BatchEngineUnitConfiguration {
 	@JsonInclude
 	@JsonProperty("callbackURL")
 	private String _callbackURL;
+
+	private boolean _checkPermissions = true;
 
 	@JsonProperty("className")
 	private String _className;

--- a/modules/apps/batch-engine/batch-engine-api/src/main/resources/com/liferay/batch/engine/packageinfo
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/resources/com/liferay/batch/engine/packageinfo
@@ -1,1 +1,1 @@
-version 6.0.0
+version 7.0.0

--- a/modules/apps/batch-engine/batch-engine-api/src/main/resources/com/liferay/batch/engine/unit/packageinfo
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/resources/com/liferay/batch/engine/unit/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 4.1.0

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineExportTaskExecutorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineExportTaskExecutorImpl.java
@@ -81,7 +81,7 @@ public class BatchEngineExportTaskExecutorImpl
 				batchEngineExportTask);
 
 			BatchEngineTaskExecutorUtil.execute(
-				() -> _exportItems(batchEngineExportTask),
+				true, () -> _exportItems(batchEngineExportTask),
 				_userLocalService.getUser(batchEngineExportTask.getUserId()));
 
 			_updateBatchEngineExportTask(

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineImportTaskExecutorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineImportTaskExecutorImpl.java
@@ -80,13 +80,14 @@ public class BatchEngineImportTaskExecutorImpl
 				batchEngineImportTask.getClassName(),
 				batchEngineImportTask.getTaskItemDelegateName());
 
-		execute(batchEngineImportTask, batchEngineTaskItemDelegate);
+		execute(batchEngineImportTask, batchEngineTaskItemDelegate, true);
 	}
 
 	@Override
 	public void execute(
 		BatchEngineImportTask batchEngineImportTask,
-		BatchEngineTaskItemDelegate<?> batchEngineTaskItemDelegate) {
+		BatchEngineTaskItemDelegate<?> batchEngineTaskItemDelegate,
+		boolean checkPermissions) {
 
 		SafeCloseable safeCloseable = CompanyThreadLocal.setWithSafeCloseable(
 			batchEngineImportTask.getCompanyId());
@@ -110,6 +111,7 @@ public class BatchEngineImportTaskExecutorImpl
 				batchEngineImportTask);
 
 			BatchEngineTaskExecutorUtil.execute(
+				checkPermissions,
 				() -> _importItems(
 					batchEngineImportTask, batchEngineTaskItemDelegate),
 				_userLocalService.getUser(batchEngineImportTask.getUserId()));

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineImportTaskExecutorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineImportTaskExecutorImpl.java
@@ -313,7 +313,7 @@ public class BatchEngineImportTaskExecutorImpl
 
 					processedItemsCount++;
 
-					ItemIndexThreadLocal.put(item, processedItemsCount);
+					ItemIndexThreadLocal.add(processedItemsCount);
 				}
 				catch (Exception exception) {
 					processedItemsCount++;
@@ -330,7 +330,7 @@ public class BatchEngineImportTaskExecutorImpl
 
 					items.clear();
 
-					ItemIndexThreadLocal.remove();
+					ItemIndexThreadLocal.clear();
 				}
 			}
 

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineTaskExecutorUtil.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineTaskExecutorUtil.java
@@ -14,6 +14,7 @@
 
 package com.liferay.batch.engine.internal;
 
+import com.liferay.batch.engine.internal.security.permission.LiberalPermissionChecker;
 import com.liferay.batch.engine.internal.util.ItemIndexThreadLocal;
 import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.portal.kernel.model.User;
@@ -28,14 +29,21 @@ import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 public class BatchEngineTaskExecutorUtil {
 
 	public static void execute(
-			UnsafeRunnable<Throwable> unsafeRunnable, User user)
+			boolean checkPermissions, UnsafeRunnable<Throwable> unsafeRunnable,
+			User user)
 		throws Throwable {
 
 		PermissionChecker permissionChecker =
 			PermissionThreadLocal.getPermissionChecker();
 
-		PermissionThreadLocal.setPermissionChecker(
-			PermissionCheckerFactoryUtil.create(user));
+		if (checkPermissions) {
+			PermissionThreadLocal.setPermissionChecker(
+				PermissionCheckerFactoryUtil.create(user));
+		}
+		else {
+			PermissionThreadLocal.setPermissionChecker(
+				new LiberalPermissionChecker(user));
+		}
 
 		String name = PrincipalThreadLocal.getName();
 

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineTaskExecutorUtil.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineTaskExecutorUtil.java
@@ -45,7 +45,7 @@ public class BatchEngineTaskExecutorUtil {
 			unsafeRunnable.run();
 		}
 		finally {
-			ItemIndexThreadLocal.remove();
+			ItemIndexThreadLocal.clear();
 			PermissionThreadLocal.setPermissionChecker(permissionChecker);
 			PrincipalThreadLocal.setName(name);
 		}

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/bundle/BatchEngineBundleTracker.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/bundle/BatchEngineBundleTracker.java
@@ -24,6 +24,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.instance.lifecycle.BasePortalInstanceLifecycleListener;
 import com.liferay.portal.instance.lifecycle.PortalInstanceLifecycleListener;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
 import com.liferay.portal.kernel.util.FileUtil;
 
 import java.io.File;
@@ -109,6 +110,10 @@ public class BatchEngineBundleTracker {
 
 	private BundleContext _bundleContext;
 	private BundleTracker<Bundle> _bundleTracker;
+
+	@Reference(target = ModuleServiceLifecycle.PORTLETS_INITIALIZED)
+	private ModuleServiceLifecycle _moduleServiceLifecycle;
+
 	private final Map
 		<Bundle, ServiceRegistration<PortalInstanceLifecycleListener>>
 			_serviceRegistrations = new HashMap<>();

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/security/permission/LiberalPermissionChecker.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/security/permission/LiberalPermissionChecker.java
@@ -1,0 +1,206 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.batch.engine.internal.security.permission;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.RoleConstants;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.UserBag;
+import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsUtil;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Carlos Correa
+ */
+public class LiberalPermissionChecker implements PermissionChecker {
+
+	public LiberalPermissionChecker(User user) {
+		init(user);
+	}
+
+	@Override
+	public PermissionChecker clone() {
+		return this;
+	}
+
+	@Override
+	public long getCompanyId() {
+		return _user.getCompanyId();
+	}
+
+	@Override
+	public long[] getGuestUserRoleIds() {
+		return PermissionChecker.DEFAULT_ROLE_IDS;
+	}
+
+	@Override
+	public long getOwnerRoleId() {
+		return _ownerRole.getRoleId();
+	}
+
+	@Override
+	public Map<Object, Object> getPermissionChecksMap() {
+		return new HashMap<>();
+	}
+
+	@Override
+	public long[] getRoleIds(long userId, long groupId) {
+		return PermissionChecker.DEFAULT_ROLE_IDS;
+	}
+
+	@Override
+	public User getUser() {
+		return _user;
+	}
+
+	@Override
+	public UserBag getUserBag() {
+		return null;
+	}
+
+	@Override
+	public long getUserId() {
+		return _user.getUserId();
+	}
+
+	@Override
+	public boolean hasOwnerPermission(
+		long companyId, String name, long primKey, long ownerId,
+		String actionId) {
+
+		return true;
+	}
+
+	@Override
+	public boolean hasOwnerPermission(
+		long companyId, String name, String primKey, long ownerId,
+		String actionId) {
+
+		return true;
+	}
+
+	@Override
+	public boolean hasPermission(
+		Group group, String name, long primKey, String actionId) {
+
+		return true;
+	}
+
+	@Override
+	public boolean hasPermission(
+		Group group, String name, String primKey, String actionId) {
+
+		return true;
+	}
+
+	@Override
+	public boolean hasPermission(
+		long groupId, String name, long primKey, String actionId) {
+
+		return true;
+	}
+
+	@Override
+	public boolean hasPermission(
+		long groupId, String name, String primKey, String actionId) {
+
+		return true;
+	}
+
+	@Override
+	public void init(User user) {
+		_user = user;
+
+		try {
+			_ownerRole = RoleLocalServiceUtil.getRole(
+				user.getCompanyId(), RoleConstants.OWNER);
+		}
+		catch (Exception exception) {
+			_log.error(exception);
+		}
+	}
+
+	@Override
+	public boolean isCheckGuest() {
+		return GetterUtil.getBoolean(
+			PropsUtil.get(PropsKeys.PERMISSIONS_CHECK_GUEST_ENABLED));
+	}
+
+	@Override
+	public boolean isCompanyAdmin() {
+		return true;
+	}
+
+	@Override
+	public boolean isCompanyAdmin(long companyId) {
+		return true;
+	}
+
+	@Override
+	public boolean isContentReviewer(long companyId, long groupId) {
+		return true;
+	}
+
+	@Override
+	public boolean isGroupAdmin(long groupId) {
+		return true;
+	}
+
+	@Override
+	public boolean isGroupMember(long groupId) {
+		return true;
+	}
+
+	@Override
+	public boolean isGroupOwner(long groupId) {
+		return true;
+	}
+
+	@Override
+	public boolean isOmniadmin() {
+		return true;
+	}
+
+	@Override
+	public boolean isOrganizationAdmin(long organizationId) {
+		return true;
+	}
+
+	@Override
+	public boolean isOrganizationOwner(long organizationId) {
+		return true;
+	}
+
+	@Override
+	public boolean isSignedIn() {
+		return true;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		LiberalPermissionChecker.class);
+
+	private Role _ownerRole;
+	private User _user;
+
+}

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/strategy/OnErrorContinueBatchEngineImportStrategy.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/strategy/OnErrorContinueBatchEngineImportStrategy.java
@@ -55,8 +55,11 @@ public class OnErrorContinueBatchEngineImportStrategy
 				batchEngineImportTask.getCompanyId(),
 				batchEngineImportTask.getUserId(),
 				batchEngineImportTask.getBatchEngineImportTaskId(),
-				item.toString(), ItemIndexThreadLocal.get(item),
+				item.toString(), ItemIndexThreadLocal.get(),
 				exception.toString());
+		}
+		finally {
+			ItemIndexThreadLocal.remove();
 		}
 
 		return persistedItem;

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/strategy/OnErrorFailBatchEngineImportStrategy.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/strategy/OnErrorFailBatchEngineImportStrategy.java
@@ -50,10 +50,13 @@ public class OnErrorFailBatchEngineImportStrategy
 				batchEngineImportTask.getCompanyId(),
 				batchEngineImportTask.getUserId(),
 				batchEngineImportTask.getBatchEngineImportTaskId(),
-				item.toString(), ItemIndexThreadLocal.get(item),
+				item.toString(), ItemIndexThreadLocal.get(),
 				exception.toString());
 
 			throw exception;
+		}
+		finally {
+			ItemIndexThreadLocal.remove();
 		}
 	}
 

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/unit/BatchEngineUnitProcessorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/unit/BatchEngineUnitProcessorImpl.java
@@ -203,7 +203,8 @@ public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 				batchEngineTaskItemDelegate);
 
 		_batchEngineImportTaskExecutor.execute(
-			batchEngineImportTask, batchEngineTaskItemDelegate);
+			batchEngineImportTask, batchEngineTaskItemDelegate,
+			batchEngineUnitConfiguration.isCheckPermissions());
 
 		if (_log.isInfoEnabled()) {
 			_log.info(
@@ -289,6 +290,13 @@ public class BatchEngineUnitProcessorImpl implements BatchEngineUnitProcessor {
 
 	private BatchEngineUnitConfiguration _updateBatchEngineUnitConfiguration(
 		BatchEngineUnitConfiguration batchEngineUnitConfiguration) {
+
+		if (batchEngineUnitConfiguration.isCheckPermissions() &&
+			batchEngineUnitConfiguration.isMultiCompany() &&
+			(batchEngineUnitConfiguration.getUserId() == 0)) {
+
+			batchEngineUnitConfiguration.setCheckPermissions(false);
+		}
 
 		if (batchEngineUnitConfiguration.getCompanyId() == 0) {
 			if (_log.isInfoEnabled()) {

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/util/ItemIndexThreadLocal.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/util/ItemIndexThreadLocal.java
@@ -16,32 +16,38 @@ package com.liferay.batch.engine.internal.util;
 
 import com.liferay.petra.lang.CentralizedThreadLocal;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.LinkedList;
+import java.util.Queue;
 
 /**
  * @author Matija Petanjek
  */
 public class ItemIndexThreadLocal {
 
-	public static int get(Object item) {
-		Map<Object, Integer> itemIndexMap = _itemIndexMap.get();
+	public static void add(int itemIndex) {
+		Queue<Integer> indexQueue = _indexQueue.get();
 
-		return itemIndexMap.get(item);
+		indexQueue.add(itemIndex);
 	}
 
-	public static void put(Object item, int itemIndex) {
-		Map<Object, Integer> itemIndexMap = _itemIndexMap.get();
-
-		itemIndexMap.put(item, itemIndex);
+	public static void clear() {
+		_indexQueue.remove();
 	}
 
-	public static void remove() {
-		_itemIndexMap.remove();
+	public static int get() {
+		Queue<Integer> indexQueue = _indexQueue.get();
+
+		return indexQueue.peek();
 	}
 
-	private static final ThreadLocal<Map<Object, Integer>> _itemIndexMap =
+	public static int remove() {
+		Queue<Integer> indexQueue = _indexQueue.get();
+
+		return indexQueue.remove();
+	}
+
+	private static final ThreadLocal<Queue<Integer>> _indexQueue =
 		new CentralizedThreadLocal<>(
-			ItemIndexThreadLocal.class + "._itemIndexMap", HashMap::new);
+			ItemIndexThreadLocal.class + "._indexQueue", LinkedList::new);
 
 }

--- a/modules/apps/batch-engine/batch-engine-service/src/test/java/com/liferay/batch/engine/internal/auto/deploy/AdvancedJSONReaderTest.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/test/java/com/liferay/batch/engine/internal/auto/deploy/AdvancedJSONReaderTest.java
@@ -74,6 +74,9 @@ public class AdvancedJSONReaderTest {
 				245647, batchEngineUnitConfiguration.getUserId());
 			Assert.assertEquals(
 				"v10.0", batchEngineUnitConfiguration.getVersion());
+			Assert.assertTrue(
+				"The checkPermissions parameter must not be parsed",
+				batchEngineUnitConfiguration.isCheckPermissions());
 		}
 	}
 

--- a/modules/apps/batch-engine/batch-engine-service/src/test/resources/com/liferay/batch/engine/internal/auto/deploy/advanced_sample.json
+++ b/modules/apps/batch-engine/batch-engine-service/src/test/resources/com/liferay/batch/engine/internal/auto/deploy/advanced_sample.json
@@ -1,6 +1,7 @@
 {
 	"configuration": {
 		"callbackURL": "http://localserver:8080/callback",
+		"checkPermissions": false,
 		"className": "com.liferay.batch.engine.model.BatchEngineImportTask",
 		"companyId": 2410,
 		"fieldNameMappingMap": {

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineBundleTrackerTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineBundleTrackerTest.java
@@ -19,7 +19,10 @@ import com.liferay.batch.engine.unit.BatchEngineUnit;
 import com.liferay.batch.engine.unit.BatchEngineUnitProcessor;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.BooleanWrapper;
 import com.liferay.portal.kernel.util.IntegerWrapper;
@@ -79,6 +82,12 @@ public class BatchEngineBundleTrackerTest {
 		_testProcessBatchEngineBundle("batch6", 2);
 		_testProcessBatchEngineBundle("batch7", 1);
 		_testProcessBatchEngineBundle("batch8", 3);
+
+		_testProcessBatchEngineBundle("batch9", 1);
+
+		_company = CompanyTestUtil.addCompany();
+
+		_testProcessBatchEngineBundle("batch9", 2);
 	}
 
 	private void _testProcessBatchEngineBundle(
@@ -186,6 +195,9 @@ public class BatchEngineBundleTrackerTest {
 
 	private Bundle _bundle;
 	private BundleContext _bundleContext;
+
+	@DeleteAfterTestRun
+	private Company _company;
 
 	@Inject
 	private ServiceComponentRuntime _serviceComponentRuntime;

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/resources/com/liferay/batch/engine/internal/test/dependencies/batch9/META-INF/MANIFEST.MF
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/resources/com/liferay/batch/engine/internal/test/dependencies/batch9/META-INF/MANIFEST.MF
@@ -1,0 +1,6 @@
+Manifest-Version: 2
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: batch9
+Bundle-Version: 1.0.0
+Liferay-Client-Extension-Batch: batch9
+Created-By: 11.0.17 (Ubuntu)

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/resources/com/liferay/batch/engine/internal/test/dependencies/batch9/batch9/data.batch-engine-data.json
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/resources/com/liferay/batch/engine/internal/test/dependencies/batch9/batch9/data.batch-engine-data.json
@@ -1,0 +1,214 @@
+{
+	"configuration": {
+		"callbackURL": null,
+		"className": "com.liferay.object.admin.rest.dto.v1_0.ObjectDefinition",
+		"multiCompany": true,
+		"parameters": null,
+		"userId": 0,
+		"version": "v1.0"
+	},
+	"items": [
+		{
+			"accountEntryRestricted": false,
+			"accountEntryRestrictedObjectFieldId": 0,
+			"active": true,
+			"dateCreated": "2022-08-16T16:31:41.557+00:00",
+			"dateModified": "2022-08-16T16:31:42.358+00:00",
+			"id": 43442,
+			"label": {
+				"en_US": "Coupon"
+			},
+			"name": "Coupon",
+			"objectActions": [
+			],
+			"objectFields": [
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"defaultValue": "",
+					"externalReferenceCode": "163bc796-569a-3064-6f52-162bd4430296",
+					"id": 43454,
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "en_US",
+					"label": {
+						"en_US": "Code"
+					},
+					"listTypeDefinitionId": 0,
+					"name": "code",
+					"objectFieldSettings": [
+					],
+					"required": true,
+					"state": false,
+					"system": false,
+					"type": "String"
+				},
+				{
+					"DBType": "Date",
+					"businessType": "Date",
+					"defaultValue": "",
+					"externalReferenceCode": "5d81da0f-9005-aa62-9909-dcee60443598",
+					"id": 43446,
+					"indexed": false,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "",
+					"label": {
+						"en_US": "Create Date"
+					},
+					"listTypeDefinitionId": 0,
+					"name": "createDate",
+					"objectFieldSettings": [
+					],
+					"required": false,
+					"state": false,
+					"system": true,
+					"type": "Date"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"defaultValue": "",
+					"externalReferenceCode": "a56b6402-5a3c-75ea-8bb0-bd0ebec1fa6d",
+					"id": 43444,
+					"indexed": false,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "",
+					"label": {
+						"en_US": "Author"
+					},
+					"listTypeDefinitionId": 0,
+					"name": "creator",
+					"objectFieldSettings": [
+					],
+					"required": false,
+					"state": false,
+					"system": true,
+					"type": "String"
+				},
+				{
+					"DBType": "Long",
+					"businessType": "LongInteger",
+					"defaultValue": "",
+					"externalReferenceCode": "a077bf57-d43e-5219-a2ab-a1fecc9e3d29",
+					"id": 43448,
+					"indexed": false,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "",
+					"label": {
+						"en_US": "ID"
+					},
+					"listTypeDefinitionId": 0,
+					"name": "id",
+					"objectFieldSettings": [
+					],
+					"required": false,
+					"state": false,
+					"system": true,
+					"type": "Long"
+				},
+				{
+					"DBType": "Date",
+					"businessType": "Date",
+					"defaultValue": "",
+					"externalReferenceCode": "00d5e25c-150d-2a9c-0c74-ea154040fa33",
+					"id": 43456,
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "",
+					"label": {
+						"en_US": "Issue Date"
+					},
+					"listTypeDefinitionId": 0,
+					"name": "issueDate",
+					"objectFieldSettings": [
+					],
+					"required": false,
+					"state": false,
+					"system": false,
+					"type": "Date"
+				},
+				{
+					"DBType": "Boolean",
+					"businessType": "Boolean",
+					"defaultValue": "",
+					"externalReferenceCode": "f021d24b-80fb-e1a0-b5c5-710efdeb7c94",
+					"id": 43458,
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "",
+					"label": {
+						"en_US": "Issued"
+					},
+					"listTypeDefinitionId": 0,
+					"name": "issued",
+					"objectFieldSettings": [
+					],
+					"required": false,
+					"state": false,
+					"system": false,
+					"type": "Boolean"
+				},
+				{
+					"DBType": "Date",
+					"businessType": "Date",
+					"defaultValue": "",
+					"externalReferenceCode": "27cfcbcd-7694-e3be-b6a2-f791e33e6ecf",
+					"id": 43450,
+					"indexed": false,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "",
+					"label": {
+						"en_US": "Modified Date"
+					},
+					"listTypeDefinitionId": 0,
+					"name": "modifiedDate",
+					"objectFieldSettings": [
+					],
+					"required": false,
+					"state": false,
+					"system": true,
+					"type": "Date"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"defaultValue": "",
+					"externalReferenceCode": "b2c61fa4-2031-a585-9e87-b4e890182c30",
+					"id": 43452,
+					"indexed": false,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "",
+					"label": {
+						"en_US": "Status"
+					},
+					"listTypeDefinitionId": 0,
+					"name": "status",
+					"objectFieldSettings": [
+					],
+					"required": false,
+					"state": false,
+					"system": true,
+					"type": "String"
+				}
+			],
+			"objectLayouts": [
+			],
+			"objectViews": [
+			],
+			"panelCategoryKey": "applications_menu.applications.content",
+			"parameterRequired": false,
+			"pluralLabel": {
+				"en_US": "Coupons"
+			},
+			"portlet": false,
+			"scope": "company",
+			"status": {
+				"code": 0,
+				"label": "approved",
+				"label_i18n": "Approved"
+			},
+			"system": false,
+			"titleObjectFieldId": 0
+		}
+	]
+}


### PR DESCRIPTION
Related issue: https://liferay.atlassian.net/browse/LPS-190450

---

The purposes of this PR are the following ones:

- Currently, the rows of the `ResourceAction` and `ResourcePermission` are being inserted (based on the Portlets deployed in OSGi) by the `PortletTracker` class. Even if the `BatchEngineBundleTracker` component has a dependency with the `ModuleServiceLifecycle` with `target = ModuleServiceLifecycle.PORTLETS_INITIALIZED`, the code of the `PortletTracker` is commonly executed afterwards, making any `PermissionChecker` validations against certain resource permissions fail. For that, for the batch engine imports that are being processed from the bundle deployments are being performed without a permission check.
- Avoiding the NPE that is shown when there is an error when importing ObjectDefinitions using the batch engine and the `Liferay-Client-Extension-Batch` configuration parameter in the bundle configuration file (bnd.bnd). The NullPointerException is printed instead of the original error, making the original error impossible to be detected.
