### PR TITLE
LPS-191592: Endpoint and Schema should only show up in their associated Api application

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APIFilterRelevantObjectEntryModelListenerTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APIFilterRelevantObjectEntryModelListenerTest.java
@@ -6,6 +6,7 @@
 package com.liferay.headless.builder.model.listener.test;
 
 import com.liferay.headless.builder.test.BaseTestCase;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
@@ -41,7 +42,7 @@ public class APIFilterRelevantObjectEntryModelListenerTest
 			).put(
 				"name", RandomTestUtil.randomString()
 			).put(
-				"path", RandomTestUtil.randomString()
+				"path", StringPool.FORWARD_SLASH + RandomTestUtil.randomString()
 			).put(
 				"r_apiApplicationToAPIEndpoints_c_apiApplicationId",
 				apiApplicationJSONObject.getLong("id")

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APISortRelevantObjectEntryModelListenerTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APISortRelevantObjectEntryModelListenerTest.java
@@ -6,6 +6,7 @@
 package com.liferay.headless.builder.model.listener.test;
 
 import com.liferay.headless.builder.test.BaseTestCase;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
@@ -40,7 +41,7 @@ public class APISortRelevantObjectEntryModelListenerTest extends BaseTestCase {
 			).put(
 				"name", RandomTestUtil.randomString()
 			).put(
-				"path", RandomTestUtil.randomString()
+				"path", StringPool.FORWARD_SLASH + RandomTestUtil.randomString()
 			).put(
 				"r_apiApplicationToAPIEndpoints_c_apiApplicationId",
 				apiApplicationJSONObject.getLong("id")

--- a/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/EditAPIApplication.tsx
+++ b/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/EditAPIApplication.tsx
@@ -224,6 +224,7 @@ export default function EditAPIApplication({
 				<APIApplicationsEndpointsTable
 					apiApplicationBaseURL={data.baseURL}
 					apiURLPaths={apiURLPaths}
+					currentApplicationId={currentAPIApplicationID}
 					portletId={portletId}
 					readOnly={false}
 				/>
@@ -231,6 +232,7 @@ export default function EditAPIApplication({
 			{activeTab === 'schemas' && (
 				<APIApplicationsSchemasTable
 					apiURLPaths={apiURLPaths}
+					currentApplicationId={currentAPIApplicationID}
 					portletId={portletId}
 					readOnly={false}
 				/>

--- a/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/FDS/APIApplicationsEndpointsTable.tsx
+++ b/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/FDS/APIApplicationsEndpointsTable.tsx
@@ -6,11 +6,13 @@
 import {FrontendDataSet} from '@liferay/frontend-data-set-web';
 import React from 'react';
 
+import {getFilterRelatedItemURL} from '../utils/urlUtil';
 import {getAPIApplicationsEndpointsFDSProps} from './fdsUtils/endpointsFDSProps';
 
 interface APIApplicationsTableProps {
 	apiApplicationBaseURL: string;
 	apiURLPaths: APIURLPaths;
+	currentApplicationId: string | null;
 	portletId: string;
 	readOnly: boolean;
 }
@@ -18,11 +20,17 @@ interface APIApplicationsTableProps {
 export default function APIApplicationsEndpointsTable({
 	apiApplicationBaseURL,
 	apiURLPaths,
+	currentApplicationId,
 	portletId,
 }: APIApplicationsTableProps) {
 	const createAPIApplicationEndpoint = {
 		label: Liferay.Language.get('add-api-endpoint'),
 	};
+
+	const endpointAPIURLPath = getFilterRelatedItemURL({
+		apiURLPath: apiURLPaths.endpoints,
+		filterQuery: `r_apiApplicationToAPIEndpoints_c_apiApplicationId eq '${currentApplicationId}'`,
+	});
 
 	function onActionDropdownItemClick({
 		action,
@@ -38,7 +46,7 @@ export default function APIApplicationsEndpointsTable({
 	return (
 		<FrontendDataSet
 			{...getAPIApplicationsEndpointsFDSProps(
-				apiURLPaths.endpoints,
+				endpointAPIURLPath,
 				portletId
 			)}
 			creationMenu={{

--- a/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/FDS/APIApplicationsSchemasTable.tsx
+++ b/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/FDS/APIApplicationsSchemasTable.tsx
@@ -6,21 +6,29 @@
 import {FrontendDataSet} from '@liferay/frontend-data-set-web';
 import React from 'react';
 
+import {getFilterRelatedItemURL} from '../utils/urlUtil';
 import {getAPIApplicationsSchemasFDSProps} from './fdsUtils/schemasFDSProps.';
 
 interface APIApplicationsTableProps {
 	apiURLPaths: APIURLPaths;
+	currentApplicationId: string | null;
 	portletId: string;
 	readOnly: boolean;
 }
 
 export default function APIApplicationsSchemasTable({
 	apiURLPaths,
+	currentApplicationId,
 	portletId,
 }: APIApplicationsTableProps) {
 	const createAPIApplicationSchema = {
 		label: Liferay.Language.get('add-new-schema'),
 	};
+
+	const schemaAPIURLPath = getFilterRelatedItemURL({
+		apiURLPath: apiURLPaths.schemas,
+		filterQuery: `r_apiApplicationToAPISchemas_c_apiApplicationId eq '${currentApplicationId}'`,
+	});
 
 	function onActionDropdownItemClick({
 		action,
@@ -33,10 +41,7 @@ export default function APIApplicationsSchemasTable({
 
 	return (
 		<FrontendDataSet
-			{...getAPIApplicationsSchemasFDSProps(
-				apiURLPaths.schemas,
-				portletId
-			)}
+			{...getAPIApplicationsSchemasFDSProps(schemaAPIURLPath, portletId)}
 			creationMenu={{
 				primaryItems: [createAPIApplicationSchema],
 			}}

--- a/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/utils/urlUtil.ts
+++ b/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/utils/urlUtil.ts
@@ -15,6 +15,16 @@ export function getCurrentURLParamValue({
 	return newURLSearchParams.get(`_${portletId}_${paramSufix}`);
 }
 
+export function getFilterRelatedItemURL({
+	apiURLPath,
+	filterQuery,
+}: {
+	apiURLPath: string;
+	filterQuery: string;
+}) {
+	return `${apiURLPath}/?filter=${filterQuery}`;
+}
+
 export function openEditURL({
 	editURL,
 	id,

--- a/modules/apps/headless/headless-builder/headless-builder-web/types/src/main/resources/META-INF/resources/js/components/FDS/APIApplicationsEndpointsTable.d.ts
+++ b/modules/apps/headless/headless-builder/headless-builder-web/types/src/main/resources/META-INF/resources/js/components/FDS/APIApplicationsEndpointsTable.d.ts
@@ -8,12 +8,14 @@
 interface APIApplicationsTableProps {
 	apiApplicationBaseURL: string;
 	apiURLPaths: APIURLPaths;
+	currentApplicationId: string | null;
 	portletId: string;
 	readOnly: boolean;
 }
 export default function APIApplicationsEndpointsTable({
 	apiApplicationBaseURL,
 	apiURLPaths,
+	currentApplicationId,
 	portletId,
 }: APIApplicationsTableProps): JSX.Element;
 export {};

--- a/modules/apps/headless/headless-builder/headless-builder-web/types/src/main/resources/META-INF/resources/js/components/FDS/APIApplicationsSchemasTable.d.ts
+++ b/modules/apps/headless/headless-builder/headless-builder-web/types/src/main/resources/META-INF/resources/js/components/FDS/APIApplicationsSchemasTable.d.ts
@@ -7,11 +7,13 @@
 
 interface APIApplicationsTableProps {
 	apiURLPaths: APIURLPaths;
+	currentApplicationId: string | null;
 	portletId: string;
 	readOnly: boolean;
 }
 export default function APIApplicationsSchemasTable({
 	apiURLPaths,
+	currentApplicationId,
 	portletId,
 }: APIApplicationsTableProps): JSX.Element;
 export {};

--- a/modules/apps/headless/headless-builder/headless-builder-web/types/src/main/resources/META-INF/resources/js/components/utils/urlUtil.d.ts
+++ b/modules/apps/headless/headless-builder/headless-builder-web/types/src/main/resources/META-INF/resources/js/components/utils/urlUtil.d.ts
@@ -10,6 +10,13 @@ export declare function getCurrentURLParamValue({
 	paramSufix: string;
 	portletId: string;
 }): string | null;
+export declare function getFilterRelatedItemURL({
+	apiURLPath,
+	filterQuery,
+}: {
+	apiURLPath: string;
+	filterQuery: string;
+}): string;
 export declare function openEditURL({
 	editURL,
 	id,


### PR DESCRIPTION
**What is new?**
- Create a new function to build the APIURLPath that is needed to filter all `Schemas` and `Endpoints` that belongs to an specific `APIEndpoint`

**How to deploy it?**
- Deploy `headless-builder-web`

**JIRA Related Ticket**
https://liferay.atlassian.net/browse/LPS-191592 