### PR TITLE
LPS-185802 | Unpublish API Application

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/APIBuilderUI.macro
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/APIBuilderUI.macro
@@ -1,0 +1,33 @@
+definition {
+
+	macro changePublicationStatus {
+		ApplicationsMenu.gotoPortlet(
+			category = "Object",
+			panel = "Control Panel",
+			portlet = "API Builder");
+
+		Click(
+			key_title = ${key_title},
+			locator1 = "APIBuilder#DROPDOWN_MENU");
+
+		Click(locator1 = "APIBuilder#CHANGE_PUBLICATION_STATUS_BUTTON");
+
+		if (!(isSet(check))) {
+			Click(locator1 = "Button#UNPUBLISH");
+		}
+	}
+
+	macro goToEditAPIApplicationPage {
+		ApplicationsMenu.gotoPortlet(
+			category = "Object",
+			panel = "Control Panel",
+			portlet = "API Builder");
+
+		Click(
+			key_title = ${key_title},
+			locator1 = "APIBuilder#DROPDOWN_MENU");
+
+		Click(locator1 = "APIBuilder#EDIT_BUTTON");
+	}
+
+}

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/ApplicationAPI.macro
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/ApplicationAPI.macro
@@ -1,0 +1,93 @@
+definition {
+
+	macro _curlAPIApplication {
+		if (isSet(virtualHost)) {
+			if (!(isSet(port))) {
+				var port = 8080;
+			}
+
+			var portalURL = "http://${virtualHost}:${port}";
+		}
+		else {
+			var portalURL = JSONCompany.getPortalURL();
+		}
+
+		if (isSet(aPIApplicationId)) {
+			var api = "headless-builder/applications/${aPIApplicationId}";
+		}
+		else {
+			var api = "headless-builder/applications";
+		}
+
+		var curl = '''
+			${portalURL}/o/${api} \
+				-u test@liferay.com:test \
+				-H Content-Type: application/json
+		''';
+
+		return ${curl};
+	}
+
+	macro createAPIApplication {
+		Variables.assertDefined(parameterList = "${baseURL},${statusKey},${statusName},${title}");
+
+		var curl = ApplicationAPI._curlAPIApplication();
+		var body = '''
+			-d {
+				"applicationStatus": {"key": "${statusKey}","name": "${statusName}"},
+				"baseURL": "${baseURL}",
+				"title": "${title}"
+			}
+		''';
+
+		var curl = StringUtil.add(${curl}, " \ ${body}", "");
+
+		var response = JSONCurlUtil.post(${curl});
+
+		return ${response};
+	}
+
+	macro deleteAllAPIApplication {
+		var getAPIApplicationList = ApplicationAPI.getAPIApplications();
+
+		var aPIApplicationIdList = JSONPathUtil.getProperty(
+			property = "$.items[*].id",
+			response = ${getAPIApplicationList});
+
+		for (var aPIApplicationIdList : list ${aPIApplicationIdList}) {
+			ApplicationAPI.deleteAPIApplicationById(aPIApplicationId = ${aPIApplicationIdList});
+		}
+	}
+
+	macro deleteAPIApplicationById {
+		Variables.assertDefined(parameterList = ${aPIApplicationId});
+
+		var curl = ApplicationAPI._curlAPIApplication(aPIApplicationId = ${aPIApplicationId});
+
+		JSONCurlUtil.delete(${curl});
+	}
+
+	macro getAPIApplications {
+		var curl = ApplicationAPI._curlAPIApplication();
+
+		var response = JSONCurlUtil.get(${curl});
+
+		return ${response};
+	}
+
+	macro updateAPIApplication {
+		Variables.assertDefined(parameterList = "${aPIApplicationId},${parameter},${parameterValue}");
+
+		var curl = ApplicationAPI._curlAPIApplication(aPIApplicationId = ${aPIApplicationId});
+		var body = '''
+			-d {"${parameter}": "${parameterValue}"}
+		''';
+
+		var curl = StringUtil.add(${curl}, " \ ${body}", "");
+
+		var response = JSONCurlUtil.patch(${curl});
+
+		return ${response};
+	}
+
+}

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/paths/APIBuilder.path
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/paths/APIBuilder.path
@@ -1,0 +1,46 @@
+<html>
+<head>
+<title>APIBuilder</title>
+</head>
+
+<body>
+<table border="1" cellpadding="1" cellspacing="1">
+<thead>
+<tr><td rowspan="1" colspan="3">APIBuilder</td></tr>
+</thead>
+
+<tbody>
+<tr>
+	<td>APPLICATION_STATUS</td>
+	<td>//div[@class='table-list-title' and contains(.,'${key_title}')]/../..//div[contains(.,'${key_status}')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>CHANGE_PUBLICATION_STATUS_BUTTON</td>
+	<td>//div[@class='dropdown-menu show']//button[contains(text(),'Change Publication Status')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>DROPDOWN_MENU</td>
+	<td>//div[contains(text(),'${key_title}')]/..//button[@class='dropdown-toggle component-action dropdown-toggle ml-1 btn btn-unstyled']</td>
+	<td></td>
+</tr>
+<tr>
+	<td>EDIT_BUTTON</td>
+	<td>//div[@class='dropdown-menu show']//button[contains(text(),'Edit')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>PUBLISH_BUTTON</td>
+	<td>//button[contains(text(),'Publish')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>UNPUBLISH_API_APPLICATION_WARNING_DIALOG_TITLE</td>
+	<td>//h1[@class='modal-title' and contains(text(),'Unpublish API Application')]</td>
+	<td></td>
+</tr>
+</tbody>
+</table>
+</body>
+</html>

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationsInTheAPIBuilder/UnpublishAPIApplication.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationsInTheAPIBuilder/UnpublishAPIApplication.testcase
@@ -1,0 +1,150 @@
+@component-name = "portal-headless"
+definition {
+
+	property custom.properties = "feature.flag.LPS-184413=true${line.separator}feature.flag.LPS-167253=true${line.separator}feature.flag.LPS-178642=true";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Object";
+	property testray.main.component.name = "Headless Builder";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginUI();
+
+		task ("Given publish an API application") {
+			ApplicationAPI.createAPIApplication(
+				baseURL = "App-test",
+				statusKey = "published",
+				statusName = "published",
+				title = "App-test");
+		}
+	}
+
+	tearDown {
+		ApplicationAPI.deleteAllAPIApplication();
+
+		var testLiferayVirtualInstance = PropsUtil.get("test.liferay.virtual.instance");
+
+		if (${testLiferayVirtualInstance} == "true") {
+			PortalInstances.tearDownCP();
+		}
+	}
+
+	@priority = 4
+	test CanGetUnpublishedStatusInResponse {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+
+		task ("And Given I unpublish it with Change Publication Status") {
+			APIBuilderUI.changePublicationStatus(key_title = "App-test");
+		}
+
+		task ("When with getAPIApplicationsPage to retrieve the api application") {
+			var response = ApplicationAPI.getAPIApplications();
+		}
+
+		task ("Then I can get the unpublished status in response") {
+			var actualValue = JSONUtil.getWithJSONPath(${response}, "$.items..applicationStatus.name");
+
+			TestUtils.assertEquals(
+				actual = ${actualValue},
+				expected = "unpublished");
+		}
+	}
+
+	@priority = 4
+	test CanPromptUnpublishAPIApplicationDialog {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+
+		task ("When I click Change Publication Status") {
+			APIBuilderUI.changePublicationStatus(
+				check = "true",
+				key_title = "App-test");
+		}
+
+		task ("Then the unpublish warning dialog is present") {
+			AssertElementPresent(locator1 = "APIBuilder#UNPUBLISH_API_APPLICATION_WARNING_DIALOG_TITLE");
+		}
+	}
+
+	@priority = 3
+	test CanShowAvailableButtonsAfterUnpublish {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+
+		task ("And Given I unpublish the API application") {
+			APIBuilderUI.changePublicationStatus(key_title = "App-test");
+		}
+
+		task ("When I edit the API application") {
+			APIBuilderUI.goToEditAPIApplicationPage(key_title = "App-test");
+		}
+
+		task ("Then I can see Cancel, Save and Publish buttons are present") {
+			AssertElementPresent(locator1 = "Button#CANCEL");
+
+			AssertElementPresent(locator1 = "Button#SAVE");
+
+			AssertElementPresent(locator1 = "APIBuilder#PUBLISH_BUTTON");
+		}
+	}
+
+	@priority = 4
+	test CanUnpublishThroughAPI {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+
+		task ("When with patchAPIApplication and aPIApplicationId to unpublish the API") {
+			var responseFromGet = ApplicationAPI.getAPIApplications();
+
+			var aPIApplicationId = JSONPathUtil.getProperty(
+				property = "$.items[0].id",
+				response = ${responseFromGet});
+
+			var response = ApplicationAPI.updateAPIApplication(
+				aPIApplicationId = ${aPIApplicationId},
+				parameter = "applicationStatus",
+				parameterValue = "unpublished");
+		}
+
+		task ("Then the status is updated to unpublished in the response") {
+			var actualValue = JSONUtil.getWithJSONPath(${response}, "$..applicationStatus.name");
+
+			TestUtils.assertEquals(
+				actual = ${actualValue},
+				expected = "unpublished");
+		}
+
+		task ("And Then I can see unpublished status in API Builder") {
+			ApplicationsMenu.gotoPortlet(
+				category = "Object",
+				panel = "Control Panel",
+				portlet = "API Builder");
+
+			AssertElementPresent(
+				key_status = "Unpublished",
+				key_title = "App-test",
+				locator1 = "APIBuilder#APPLICATION_STATUS");
+		}
+	}
+
+	@priority = 4
+	test CanUpdatedToUnpublishedStatus {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+
+		task ("When I unpublish it with Change Publication Status") {
+			APIBuilderUI.changePublicationStatus(key_title = "App-test");
+		}
+
+		task ("Then the application status is updated to unpublished") {
+			AssertElementPresent(
+				key_status = "Unpublished",
+				key_title = "App-test",
+				locator1 = "APIBuilder#APPLICATION_STATUS");
+		}
+	}
+
+}

--- a/portal-web/poshi.properties
+++ b/portal-web/poshi.properties
@@ -23,6 +23,7 @@ test.dirs=\
     ../modules/apps/frontend-js/frontend-js-test/src/testFunctional,\
     ../modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testFunctional,\
     ../modules/apps/headless/headless-batch-engine/headless-batch-engine-test/src/testFunctional,\
+    ../modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional,\
     ../modules/apps/headless/headless-delivery/headless-delivery-test/src/testFunctional,\
     ../modules/apps/headless/headless-discovery/headless-discovery-test/src/testFunctional,\
     ../modules/apps/headless/headless-site/headless-site-test/src/testFunctional,\


### PR DESCRIPTION
Background:
Add a testcase to unpublish API Application

Test Plan
CanPromptUnpublishAPIApplicationDialog
When I click Change Publication Status
Then the unpublish warning dialog is present

CanUpdatedToUnpublishedStatus
When I unpublish it with Change Publication Status
Then the application status is updated to unpublished

CanGetUnpublishedStatusInResponse
And Given I unpublish it with Change Publication Status
When with getAPIApplicationsPage to retrieve the api application
Then I can get the unpublished status in response

CanUnpublishThroughAPI
When with patchAPIApplication and aPIApplicationId to unpublish the API
Then the status is updated to unpublished in the response
And Then I can see unpublished status in API Builder

CanShowAvailableButtonsAfterUnpublish
And Given I unpublish the API application
When I edit the API application
Then I can see Cancel, Save and Publish buttons are present

Jira ticket:
https://liferay.atlassian.net/browse/LPS-185802