### PR TITLE
LPS-191664: API Explorer does not show Pagination parameters for an Endpoint

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/vulcan/openapi/contributor/APIApplicationOpenApiContributor.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/vulcan/openapi/contributor/APIApplicationOpenApiContributor.java
@@ -177,6 +177,8 @@ public class APIApplicationOpenApiContributor implements OpenAPIContributor {
 	private String _toCamelCase(String path) {
 		path = path.replaceAll("/\\{.*\\}", StringPool.BLANK);
 
+		path = path.replaceAll(StringPool.MINUS, StringPool.SLASH);
+
 		return CamelCaseUtil.toCamelCase(path, CharPool.SLASH);
 	}
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/resources/com/liferay/headless/builder/application/resource/test/dependencies/expected_openapi.json
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/resources/com/liferay/headless/builder/application/resource/test/dependencies/expected_openapi.json
@@ -251,6 +251,22 @@
 		"/path": {
 			"get": {
 				"operationId": "getPathPage",
+				"parameters": [
+					{
+						"in": "query",
+						"name": "page",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "pageSize",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
 				"responses": {
 					"default": {
 						"content": {


### PR DESCRIPTION
**What is new?**
- Add query parameter for those endpoints that are `GET` and ends with `Page`, in other words pagination endpoints.
- Fix `operationId` naming not accepting any special characters.
- Update `expected_openapi.json` adding the new parameters.

**How to deploy it?**
- Deploy `headless-builder-api` and `headless-builder-impl`.

**JIRA Related Ticket**
https://liferay.atlassian.net/browse/LPS-191664