### PR TITLE
LPS-191774 Changed response message in case the APIEndpoint path doesn't start with forward-slash

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIEndpointRelevantObjectEntryModelListener.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIEndpointRelevantObjectEntryModelListener.java
@@ -239,7 +239,7 @@ public class APIEndpointRelevantObjectEntryModelListener
 	}
 
 	private static final Pattern _pathPattern = Pattern.compile(
-		"^[/][a-zA-Z0-9][a-zA-Z0-9-/]{1,255}");
+		"/[a-zA-Z0-9][a-zA-Z0-9-/]{1,253}");
 
 	@Reference(
 		target = "(filter.factory.key=" + ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT + ")"

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APIEndpointRelevantObjectEntryModelListenerTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APIEndpointRelevantObjectEntryModelListenerTest.java
@@ -16,8 +16,10 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.test.rule.FeatureFlags;
 
-import org.junit.Assert;
 import org.junit.Test;
+
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 
 /**
  * @author Sergio Jiménez del Coso
@@ -28,62 +30,77 @@ public class APIEndpointRelevantObjectEntryModelListenerTest
 
 	@Test
 	public void test() throws Exception {
-		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+		JSONAssert.assertEquals(
 			JSONUtil.put(
-				"httpMethod", "get"
+				"status", "BAD_REQUEST"
 			).put(
-				"name", RandomTestUtil.randomString()
-			).put(
-				"path", StringPool.FORWARD_SLASH + RandomTestUtil.randomString()
-			).put(
-				"scope", "company"
+				"title",
+				"An API endpoint must be related to an API application."
 			).toString(),
-			"headless-builder/endpoints", Http.Method.POST);
+			HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					"httpMethod", "get"
+				).put(
+					"name", RandomTestUtil.randomString()
+				).put(
+					"path",
+					StringPool.FORWARD_SLASH + RandomTestUtil.randomString()
+				).put(
+					"scope", "company"
+				).toString(),
+				"headless-builder/endpoints", Http.Method.POST
+			).toString(),
+			JSONCompareMode.STRICT);
 
-		Assert.assertEquals("BAD_REQUEST", jsonObject.get("status"));
-		Assert.assertEquals(
-			"An API endpoint must be related to an API application.",
-			jsonObject.get("title"));
-
-		jsonObject = HTTPTestUtil.invokeToJSONObject(
+		JSONAssert.assertEquals(
 			JSONUtil.put(
-				"httpMethod", "get"
+				"status", "BAD_REQUEST"
 			).put(
-				"name", RandomTestUtil.randomString()
-			).put(
-				"path", StringPool.FORWARD_SLASH + RandomTestUtil.randomString()
-			).put(
-				"r_apiApplicationToAPIEndpoints_c_apiApplicationId",
-				RandomTestUtil.randomLong()
-			).put(
-				"scope", "company"
+				"title",
+				"An API endpoint must be related to an API application."
 			).toString(),
-			"headless-builder/endpoints", Http.Method.POST);
+			HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					"httpMethod", "get"
+				).put(
+					"name", RandomTestUtil.randomString()
+				).put(
+					"path",
+					StringPool.FORWARD_SLASH + RandomTestUtil.randomString()
+				).put(
+					"r_apiApplicationToAPIEndpoints_c_apiApplicationId",
+					RandomTestUtil.randomLong()
+				).put(
+					"scope", "company"
+				).toString(),
+				"headless-builder/endpoints", Http.Method.POST
+			).toString(),
+			JSONCompareMode.STRICT);
 
-		Assert.assertEquals("BAD_REQUEST", jsonObject.get("status"));
-		Assert.assertEquals(
-			"An API endpoint must be related to an API application.",
-			jsonObject.get("title"));
-
-		jsonObject = HTTPTestUtil.invokeToJSONObject(
+		JSONAssert.assertEquals(
 			JSONUtil.put(
-				"httpMethod", "get"
+				"status", "BAD_REQUEST"
 			).put(
-				"name", RandomTestUtil.randomString()
-			).put(
-				"path", StringPool.FORWARD_SLASH + RandomTestUtil.randomString()
-			).put(
-				"r_apiApplicationToAPIEndpoints_c_apiApplicationId",
-				TestPropsValues.getUserId()
-			).put(
-				"scope", "company"
+				"title",
+				"An API endpoint must be related to an API application."
 			).toString(),
-			"headless-builder/endpoints", Http.Method.POST);
-
-		Assert.assertEquals("BAD_REQUEST", jsonObject.get("status"));
-		Assert.assertEquals(
-			"An API endpoint must be related to an API application.",
-			jsonObject.get("title"));
+			HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					"httpMethod", "get"
+				).put(
+					"name", RandomTestUtil.randomString()
+				).put(
+					"path",
+					StringPool.FORWARD_SLASH + RandomTestUtil.randomString()
+				).put(
+					"r_apiApplicationToAPIEndpoints_c_apiApplicationId",
+					TestPropsValues.getUserId()
+				).put(
+					"scope", "company"
+				).toString(),
+				"headless-builder/endpoints", Http.Method.POST
+			).toString(),
+			JSONCompareMode.STRICT);
 
 		JSONObject apiApplicationJSONObject = HTTPTestUtil.invokeToJSONObject(
 			JSONUtil.put(
@@ -95,72 +112,83 @@ public class APIEndpointRelevantObjectEntryModelListenerTest
 			).toString(),
 			"headless-builder/applications", Http.Method.POST);
 
-		jsonObject = HTTPTestUtil.invokeToJSONObject(
+		JSONAssert.assertEquals(
 			JSONUtil.put(
-				"httpMethod", "get"
+				"status", "BAD_REQUEST"
 			).put(
-				"name", RandomTestUtil.randomString()
-			).put(
-				"path", StringPool.FORWARD_SLASH + RandomTestUtil.randomString()
-			).put(
-				"r_apiApplicationToAPIEndpoints_c_apiApplicationId",
-				apiApplicationJSONObject.getLong("id")
-			).put(
-				"r_requestAPISchemaToAPIEndpoints_c_apiSchemaId",
-				RandomTestUtil.nextLong()
-			).put(
-				"r_responseAPISchemaToAPIEndpoints_c_apiSchemaId",
-				RandomTestUtil.nextLong()
-			).put(
-				"scope", "company"
+				"title", "An API endpoint must be related to an API schema."
 			).toString(),
-			"headless-builder/endpoints", Http.Method.POST);
+			HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					"httpMethod", "get"
+				).put(
+					"name", RandomTestUtil.randomString()
+				).put(
+					"path",
+					StringPool.FORWARD_SLASH + RandomTestUtil.randomString()
+				).put(
+					"r_apiApplicationToAPIEndpoints_c_apiApplicationId",
+					apiApplicationJSONObject.getLong("id")
+				).put(
+					"r_requestAPISchemaToAPIEndpoints_c_apiSchemaId",
+					RandomTestUtil.nextLong()
+				).put(
+					"r_responseAPISchemaToAPIEndpoints_c_apiSchemaId",
+					RandomTestUtil.nextLong()
+				).put(
+					"scope", "company"
+				).toString(),
+				"headless-builder/endpoints", Http.Method.POST
+			).toString(),
+			JSONCompareMode.STRICT);
 
-		Assert.assertEquals("BAD_REQUEST", jsonObject.get("status"));
-		Assert.assertEquals(
-			"An API endpoint must be related to an API schema.",
-			jsonObject.get("title"));
-
-		jsonObject = HTTPTestUtil.invokeToJSONObject(
+		JSONAssert.assertEquals(
 			JSONUtil.put(
-				"httpMethod", "get"
+				"status", "BAD_REQUEST"
 			).put(
-				"name", RandomTestUtil.randomString()
-			).put(
-				"path",
-				StringBundler.concat(
-					StringPool.FORWARD_SLASH, RandomTestUtil.randomString(),
-					StringPool.FORWARD_SLASH, RandomTestUtil.randomString(),
-					StringPool.COMMA)
-			).put(
-				"scope", "company"
+				"title",
+				"Path can have a maximum of 255 alphanumeric characters."
 			).toString(),
-			"headless-builder/endpoints", Http.Method.POST);
+			HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					"httpMethod", "get"
+				).put(
+					"name", RandomTestUtil.randomString()
+				).put(
+					"path",
+					StringBundler.concat(
+						StringPool.FORWARD_SLASH, RandomTestUtil.randomString(),
+						StringPool.FORWARD_SLASH, RandomTestUtil.randomString(),
+						StringPool.COMMA)
+				).put(
+					"scope", "company"
+				).toString(),
+				"headless-builder/endpoints", Http.Method.POST
+			).toString(),
+			JSONCompareMode.STRICT);
 
-		Assert.assertEquals("BAD_REQUEST", jsonObject.get("status"));
-		Assert.assertEquals(
-			"Path can have a maximum of 255 alphanumeric characters.",
-			jsonObject.get("title"));
-
-		jsonObject = HTTPTestUtil.invokeToJSONObject(
+		JSONAssert.assertEquals(
 			JSONUtil.put(
-				"httpMethod", "get"
+				"status", "BAD_REQUEST"
 			).put(
-				"name", RandomTestUtil.randomString()
-			).put(
-				"path",
-				StringBundler.concat(
-					RandomTestUtil.randomString(), StringPool.FORWARD_SLASH,
-					StringPool.COMMA)
-			).put(
-				"scope", "company"
+				"title", "Path must start with the \"/\" character"
 			).toString(),
-			"headless-builder/endpoints", Http.Method.POST);
-
-		Assert.assertEquals("BAD_REQUEST", jsonObject.get("status"));
-		Assert.assertEquals(
-			"Path must start with the \"/\" character",
-			jsonObject.get("title"));
+			HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					"httpMethod", "get"
+				).put(
+					"name", RandomTestUtil.randomString()
+				).put(
+					"path",
+					StringBundler.concat(
+						RandomTestUtil.randomString(), StringPool.FORWARD_SLASH,
+						StringPool.COMMA)
+				).put(
+					"scope", "company"
+				).toString(),
+				"headless-builder/endpoints", Http.Method.POST
+			).toString(),
+			JSONCompareMode.STRICT);
 
 		JSONObject apiSchemaJSONObject = HTTPTestUtil.invokeToJSONObject(
 			JSONUtil.put(
@@ -173,79 +201,84 @@ public class APIEndpointRelevantObjectEntryModelListenerTest
 			).toString(),
 			"headless-builder/schemas", Http.Method.POST);
 
-		jsonObject = HTTPTestUtil.invokeToJSONObject(
+		JSONAssert.assertEquals(
 			JSONUtil.put(
-				"httpMethod", "get"
-			).put(
-				"name", RandomTestUtil.randomString()
-			).put(
-				"path", StringPool.FORWARD_SLASH + RandomTestUtil.randomString()
-			).put(
 				"r_apiApplicationToAPIEndpoints_c_apiApplicationId",
-				apiApplicationJSONObject.getLong("id")
+				apiApplicationJSONObject.get("id")
 			).put(
-				"r_requestAPISchemaToAPIEndpoints_c_apiSchemaId",
-				apiSchemaJSONObject.getLong("id")
-			).put(
-				"r_responseAPISchemaToAPIEndpoints_c_apiSchemaId",
-				apiSchemaJSONObject.getLong("id")
-			).put(
-				"scope", "company"
+				"status", JSONUtil.put("code", 0)
 			).toString(),
-			"headless-builder/endpoints", Http.Method.POST);
-
-		Assert.assertEquals(
-			0,
-			jsonObject.getJSONObject(
-				"status"
-			).get(
-				"code"
-			));
-		Assert.assertEquals(
-			apiApplicationJSONObject.get("id"),
-			jsonObject.get(
-				"r_apiApplicationToAPIEndpoints_c_apiApplicationId"));
+			HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					"httpMethod", "get"
+				).put(
+					"name", RandomTestUtil.randomString()
+				).put(
+					"path",
+					StringPool.FORWARD_SLASH + RandomTestUtil.randomString()
+				).put(
+					"r_apiApplicationToAPIEndpoints_c_apiApplicationId",
+					apiApplicationJSONObject.getLong("id")
+				).put(
+					"r_requestAPISchemaToAPIEndpoints_c_apiSchemaId",
+					apiSchemaJSONObject.getLong("id")
+				).put(
+					"r_responseAPISchemaToAPIEndpoints_c_apiSchemaId",
+					apiSchemaJSONObject.getLong("id")
+				).put(
+					"scope", "company"
+				).toString(),
+				"headless-builder/endpoints", Http.Method.POST
+			).toString(),
+			JSONCompareMode.LENIENT);
 
 		String path = StringPool.FORWARD_SLASH + RandomTestUtil.randomString();
 
-		jsonObject = HTTPTestUtil.invokeToJSONObject(
+		JSONAssert.assertEquals(
 			JSONUtil.put(
-				"httpMethod", "get"
-			).put(
-				"name", RandomTestUtil.randomString()
-			).put(
-				"path", path
-			).put(
 				"r_apiApplicationToAPIEndpoints_c_apiApplicationId",
-				apiApplicationJSONObject.getLong("id")
-			).put(
-				"scope", "company"
+				apiApplicationJSONObject.get("id")
 			).toString(),
-			"headless-builder/endpoints", Http.Method.POST);
+			HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					"httpMethod", "get"
+				).put(
+					"name", RandomTestUtil.randomString()
+				).put(
+					"path", path
+				).put(
+					"r_apiApplicationToAPIEndpoints_c_apiApplicationId",
+					apiApplicationJSONObject.getLong("id")
+				).put(
+					"scope", "company"
+				).toString(),
+				"headless-builder/endpoints", Http.Method.POST
+			).toString(),
+			JSONCompareMode.LENIENT);
 
-		Assert.assertEquals(
-			jsonObject.get("r_apiApplicationToAPIEndpoints_c_apiApplicationId"),
-			apiApplicationJSONObject.get("id"));
-
-		jsonObject = HTTPTestUtil.invokeToJSONObject(
+		JSONAssert.assertEquals(
 			JSONUtil.put(
-				"httpMethod", "get"
+				"status", "BAD_REQUEST"
 			).put(
-				"name", RandomTestUtil.randomString()
-			).put(
-				"path", path
-			).put(
-				"r_apiApplicationToAPIEndpoints_c_apiApplicationId",
-				apiApplicationJSONObject.getLong("id")
-			).put(
-				"scope", "company"
+				"title",
+				"There is an API endpoint with the same HTTP method and path."
 			).toString(),
-			"headless-builder/endpoints", Http.Method.POST);
-
-		Assert.assertEquals("BAD_REQUEST", jsonObject.get("status"));
-		Assert.assertEquals(
-			"There is an API endpoint with the same HTTP method and path.",
-			jsonObject.get("title"));
+			HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					"httpMethod", "get"
+				).put(
+					"name", RandomTestUtil.randomString()
+				).put(
+					"path", path
+				).put(
+					"r_apiApplicationToAPIEndpoints_c_apiApplicationId",
+					apiApplicationJSONObject.getLong("id")
+				).put(
+					"scope", "company"
+				).toString(),
+				"headless-builder/endpoints", Http.Method.POST
+			).toString(),
+			JSONCompareMode.STRICT);
 	}
 
 }

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APIEndpointRelevantObjectEntryModelListenerTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APIEndpointRelevantObjectEntryModelListenerTest.java
@@ -129,8 +129,9 @@ public class APIEndpointRelevantObjectEntryModelListenerTest
 			).put(
 				"path",
 				StringBundler.concat(
-					RandomTestUtil.randomString(), StringPool.FORWARD_SLASH,
-					RandomTestUtil.randomString(), StringPool.COMMA)
+					StringPool.FORWARD_SLASH, RandomTestUtil.randomString(),
+					StringPool.FORWARD_SLASH, RandomTestUtil.randomString(),
+					StringPool.COMMA)
 			).put(
 				"scope", "company"
 			).toString(),
@@ -139,6 +140,26 @@ public class APIEndpointRelevantObjectEntryModelListenerTest
 		Assert.assertEquals("BAD_REQUEST", jsonObject.get("status"));
 		Assert.assertEquals(
 			"Path can have a maximum of 255 alphanumeric characters.",
+			jsonObject.get("title"));
+
+		jsonObject = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				"httpMethod", "get"
+			).put(
+				"name", RandomTestUtil.randomString()
+			).put(
+				"path",
+				StringBundler.concat(
+					RandomTestUtil.randomString(), StringPool.FORWARD_SLASH,
+					StringPool.COMMA)
+			).put(
+				"scope", "company"
+			).toString(),
+			"headless-builder/endpoints", Http.Method.POST);
+
+		Assert.assertEquals("BAD_REQUEST", jsonObject.get("status"));
+		Assert.assertEquals(
+			"Path must start with the \"/\" character",
 			jsonObject.get("title"));
 
 		JSONObject apiSchemaJSONObject = HTTPTestUtil.invokeToJSONObject(

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -20352,6 +20352,7 @@ x-moved-a-web-content-to-a-folder={0} moved a web content to a folder.
 x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle Bin.
 x-moved-down={0} moved down.
 x-moved-up={0} moved up.
+x-must-start-with-the-"/"-character={0} must start with the "/" character
 x-needs-review=A {0} needs review.
 x-needs-to-approve-you-as-her-friend={0} needs to approve you as her friend.
 x-needs-to-approve-you-as-his-friend={0} needs to approve you as his friend.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
@@ -20346,6 +20346,7 @@ x-moved-a-web-content-to-a-folder=نقل {0} محتوى ويب إلى مجلد.
 x-moved-a-web-content-to-the-recycle-bin=نقل {0} محتوى ويب إلى سلة المحذوفات.
 x-moved-down={0} تم نقله لأسفل.
 x-moved-up={0} تم نقله لأعلى.
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review={0} يحتاج إلى مراجعة.
 x-needs-to-approve-you-as-her-friend={0} تحتاج أن توافق على صداقتك.
 x-needs-to-approve-you-as-his-friend={0} يحتاج أن يوافق على صداقتك.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
@@ -20346,6 +20346,7 @@ x-moved-a-web-content-to-a-folder={0} moved a web content to a folder. (Automati
 x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle Bin. (Automatic Copy)
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} трябва да ви одобри за неин приятел.
 x-needs-to-approve-you-as-his-friend={0} трябва да ви одобри за негов приятел.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
@@ -20348,6 +20348,7 @@ x-moved-a-web-content-to-a-folder={0} ha desplaçat un contingut de web a una ca
 x-moved-a-web-content-to-the-recycle-bin={0} ha desplaçat un contingut de web a la paperera de reciclatge.
 x-moved-down={0} s'ha desplaçat cap avall.
 x-moved-up={0} s'ha desplaçat cap amunt.
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=S'ha de revisar un {0}.
 x-needs-to-approve-you-as-her-friend=Cal que {0} us accepti com a amic.
 x-needs-to-approve-you-as-his-friend=Cal que {0} us accepti com a amic.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
@@ -20346,6 +20346,7 @@ x-moved-a-web-content-to-a-folder={0} moved a web content to a folder. (Automati
 x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle Bin. (Automatic Copy)
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend=Uživatelka {0} musí potvrdit, že jste její přítel.
 x-needs-to-approve-you-as-his-friend=Uživatel {0} musí potvrdit, že jste její přítel.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
@@ -20346,6 +20346,7 @@ x-moved-a-web-content-to-a-folder={0} moved a web content to a folder. (Automati
 x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle Bin. (Automatic Copy)
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} needs to approve you as her friend. (Automatic Copy)
 x-needs-to-approve-you-as-his-friend={0} needs to approve you as his friend. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
@@ -20348,6 +20348,7 @@ x-moved-a-web-content-to-a-folder={0} hat Web-Inhalt in einen Ordner verschoben.
 x-moved-a-web-content-to-the-recycle-bin={0} hat Web-Inhalt in den Papierkorb verschoben.
 x-moved-down={0} nach unten verschoben.
 x-moved-up={0} nach oben verschoben.
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=Ein {0} muss überprüft werden.
 x-needs-to-approve-you-as-her-friend={0} muss Sie als ihren Freund bestätigen.
 x-needs-to-approve-you-as-his-friend={0} muss Sie als seinen Freund bestätigen.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
@@ -20346,6 +20346,7 @@ x-moved-a-web-content-to-a-folder={0} moved a web content to a folder. (Automati
 x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle Bin. (Automatic Copy)
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend=Η {0} πρέπει να σάς εγκρίνει ως φίλο/η της.
 x-needs-to-approve-you-as-his-friend=Ο {0} πρέπει να σάς εγκρίνει ως φίλο/η του.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
@@ -20352,6 +20352,7 @@ x-moved-a-web-content-to-a-folder={0} moved a web content to a folder.
 x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle Bin.
 x-moved-down={0} moved down.
 x-moved-up={0} moved up.
+x-must-start-with-the-"/"-character={0} must start with the "/" character
 x-needs-review=A {0} needs review.
 x-needs-to-approve-you-as-her-friend={0} needs to approve you as her friend.
 x-needs-to-approve-you-as-his-friend={0} needs to approve you as his friend.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
@@ -20346,6 +20346,7 @@ x-moved-a-web-content-to-a-folder={0} moved a web content to a folder. (Automati
 x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle Bin. (Automatic Copy)
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} needs to approve you as her friend. (Automatic Copy)
 x-needs-to-approve-you-as-his-friend={0} needs to approve you as his friend. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
@@ -20346,6 +20346,7 @@ x-moved-a-web-content-to-a-folder={0} moved a web content to a folder. (Automati
 x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle Bin. (Automatic Copy)
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} needs to approve you as her friend. (Automatic Copy)
 x-needs-to-approve-you-as-his-friend={0} needs to approve you as his friend. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
@@ -20348,6 +20348,7 @@ x-moved-a-web-content-to-a-folder={0} movió contenido web a una carpeta.
 x-moved-a-web-content-to-the-recycle-bin={0} movió contenido web a la Papelera de reciclaje.
 x-moved-down={0} ha bajado.
 x-moved-up={0} ha subido.
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=Un {0} necesita revisión.
 x-needs-to-approve-you-as-her-friend={0} necesita su aprobación para convertirse en su amigo.
 x-needs-to-approve-you-as-his-friend={0} necesita su aprobación para convertirse en su amigo.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
@@ -20348,6 +20348,7 @@ x-moved-a-web-content-to-a-folder={0} movió contenido web a una carpeta.
 x-moved-a-web-content-to-the-recycle-bin={0} movió contenido web a la Papelera de reciclaje.
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} necesita su aprobación para convertirse en su amigo.
 x-needs-to-approve-you-as-his-friend={0} necesita su aprobación para convertirse en su amigo.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
@@ -20348,6 +20348,7 @@ x-moved-a-web-content-to-a-folder={0} movió contenido web a una carpeta.
 x-moved-a-web-content-to-the-recycle-bin={0} movió contenido web a la Papelera de reciclaje.
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} necesita su aprobación para convertirse en su amigo.
 x-needs-to-approve-you-as-his-friend={0} necesita su aprobación para convertirse en su amigo.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
@@ -20348,6 +20348,7 @@ x-moved-a-web-content-to-a-folder={0} movió contenido web a una carpeta.
 x-moved-a-web-content-to-the-recycle-bin={0} movió contenido web a la Papelera de reciclaje.
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} necesita su aprobación para convertirse en su amigo.
 x-needs-to-approve-you-as-his-friend={0} necesita su aprobación para convertirse en su amigo.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
@@ -20346,6 +20346,7 @@ x-moved-a-web-content-to-a-folder={0} moved a web content to a folder. (Automati
 x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle Bin. (Automatic Copy)
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} peab sind oma sõbraks kinnitama.
 x-needs-to-approve-you-as-his-friend={0} peab sind oma sõbraks kinnitama.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
@@ -20346,6 +20346,7 @@ x-moved-a-web-content-to-a-folder={0} moved a web content to a folder. (Automati
 x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle Bin. (Automatic Copy)
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0}(e)k zure onespena behar du zure laguna izateko.
 x-needs-to-approve-you-as-his-friend={0}(e)k zure onespena behar du zure laguna izateko.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
@@ -20346,6 +20346,7 @@ x-moved-a-web-content-to-a-folder={0} moved a web content to a folder. (Automati
 x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle Bin. (Automatic Copy)
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} نیاز دارد که شما را به عنوان دوست خودش تایید نماید.
 x-needs-to-approve-you-as-his-friend={0} نیاز دارد که شما را به عنوان دوست خودش تایید نماید

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
@@ -20344,6 +20344,7 @@ x-moved-a-web-content-to-a-folder={0} siirsi web-sisällön kansioon.
 x-moved-a-web-content-to-the-recycle-bin={0} siirsi web-sisällön roskakoriin.
 x-moved-down={0} siirtyi alas.
 x-moved-up={0} siirtyi ylös.
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review={0} täytyy tarkistaa.
 x-needs-to-approve-you-as-her-friend={0}n täytyy hyväksyä sinut ystäväkseen.
 x-needs-to-approve-you-as-his-friend={0} täytyy hyväksyä sinut ystäväkseen.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
@@ -20348,6 +20348,7 @@ x-moved-a-web-content-to-a-folder={0} a déplacé un contenu web vers un dossier
 x-moved-a-web-content-to-the-recycle-bin={0} a déplacé un contenu web vers la Corbeille.
 x-moved-down={0} s'est déplacé vers le bas.
 x-moved-up={0} s'est déplacé vers le haut.
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=Un {0} doit être revu.
 x-needs-to-approve-you-as-her-friend={0} a besoin de vous accepter comme ami.
 x-needs-to-approve-you-as-his-friend={0} a besoin de vous accepter comme ami.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
@@ -20346,6 +20346,7 @@ x-moved-a-web-content-to-a-folder={0} a déplacé un contenu web vers un dossier
 x-moved-a-web-content-to-the-recycle-bin={0} a déplacé un contenu web vers la Corbeille.
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} a besoin de vous accepter comme ami.
 x-needs-to-approve-you-as-his-friend={0} a besoin de vous accepter comme ami.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
@@ -20346,6 +20346,7 @@ x-moved-a-web-content-to-a-folder={0} moved a web content to a folder. (Automati
 x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle Bin. (Automatic Copy)
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} necesita a túa aprobación para converterse na túa amiga.
 x-needs-to-approve-you-as-his-friend={0} necesita a túa aprobación para converterse no teu amigo.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
@@ -20346,6 +20346,7 @@ x-moved-a-web-content-to-a-folder={0} moved a web content to a folder. (Automati
 x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle Bin. (Automatic Copy)
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} needs to approve you as her friend. (Automatic Copy)
 x-needs-to-approve-you-as-his-friend={0} needs to approve you as his friend. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
@@ -20346,6 +20346,7 @@ x-moved-a-web-content-to-a-folder={0} moved a web content to a folder. (Automati
 x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle Bin. (Automatic Copy)
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} treba da vam odobri kao njezin prijatelj.
 x-needs-to-approve-you-as-his-friend={0} treba da vam odobri kao njegov prijatelj.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
@@ -20349,6 +20349,7 @@ x-moved-a-web-content-to-a-folder={0} egy webes tartalmat egy mappába mozgatott
 x-moved-a-web-content-to-the-recycle-bin={0} egy webes tartalmat a kukába mozgatott.
 x-moved-down={0} lefelé mozgatva.
 x-moved-up={0} felfelé mozgatva.
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=Egy {0} ellenőrzést igényel.
 x-needs-to-approve-you-as-her-friend={0} vissza kell igazold, hogy a barátja vagy.
 x-needs-to-approve-you-as-his-friend={0} vissza kell igazold, hogy a barátja vagy.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
@@ -20346,6 +20346,7 @@ x-moved-a-web-content-to-a-folder={0} moved a web content to a folder. (Automati
 x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle Bin. (Automatic Copy)
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} diperlukan untuk menyetujui Anda sebagai temannya.
 x-needs-to-approve-you-as-his-friend={0} diperlukan untuk menyetujui Anda sebagai temannya.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
@@ -20347,6 +20347,7 @@ x-moved-a-web-content-to-a-folder={0} moved a web content to a folder. (Automati
 x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle Bin. (Automatic Copy)
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} deve approvarti come suo amico.
 x-needs-to-approve-you-as-his-friend={0} deve approvarti come suo amico.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
@@ -20346,6 +20346,7 @@ x-moved-a-web-content-to-a-folder={0} העביר תוכן אתר אינטרנט 
 x-moved-a-web-content-to-the-recycle-bin={0} העביר תוכן אתר אינטרנט אל סל המיחזור.
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} צריכה לאשר אותך כחברתה
 x-needs-to-approve-you-as-his-friend={0} צריך לאשר אותך כחברו

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
@@ -20348,6 +20348,7 @@ x-moved-a-web-content-to-a-folder={0} がWebコンテンツ記事をフォルダ
 x-moved-a-web-content-to-the-recycle-bin={0} がWebコンテンツ記事をゴミ箱に移動しました。
 x-moved-down={0} が下に移動しました。
 x-moved-up={0} が上に移動しました。
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review={0}がレビューを必要としています。
 x-needs-to-approve-you-as-her-friend=友達になるには、{0}さんの承認が必要です。
 x-needs-to-approve-you-as-his-friend=友達になるには、{0}さんの承認が必要です。

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
@@ -20346,6 +20346,7 @@ x-moved-a-web-content-to-a-folder={0} moved a web content to a folder. (Automati
 x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle Bin. (Automatic Copy)
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} needs to approve you as her friend. (Automatic Copy)
 x-needs-to-approve-you-as-his-friend={0} needs to approve you as his friend. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
@@ -20352,6 +20352,7 @@ x-moved-a-web-content-to-a-folder={0} moved a web content to a folder.
 x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle Bin.
 x-moved-down={0} moved down.
 x-moved-up={0} moved up.
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=A {0} needs review.
 x-needs-to-approve-you-as-her-friend={0} needs to approve you as her friend.
 x-needs-to-approve-you-as-his-friend={0} needs to approve you as his friend.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
@@ -20345,6 +20345,7 @@ x-moved-a-web-content-to-a-folder={0}이(가) 웹 콘텐츠를 폴더로 이동�
 x-moved-a-web-content-to-the-recycle-bin={0}님이 웹 콘텐츠를 휴지통으로 옮겼습니다.
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0}님이 귀하를 친구로 승인해야 합니다.
 x-needs-to-approve-you-as-his-friend={0}님이 귀하를 친구로 승인해야 합니다.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
@@ -20346,6 +20346,7 @@ x-moved-a-web-content-to-a-folder={0} moved a web content to a folder. (Automati
 x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle Bin. (Automatic Copy)
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} ຕ້ອງການຢັ້ງຢືນທ່ານເປັນເພື່ອຂອງລາວກ່ອນ
 x-needs-to-approve-you-as-his-friend={0} ຕ້ອງການຢັ້ງຢືນທ່ານເປັນເພື່ອຂອງລາວກ່ອນ

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
@@ -20346,6 +20346,7 @@ x-moved-a-web-content-to-a-folder={0} moved a web content to a folder. (Automati
 x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle Bin. (Automatic Copy)
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} needs to approve you as her friend. (Automatic Copy)
 x-needs-to-approve-you-as-his-friend={0} needs to approve you as his friend. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
@@ -20346,6 +20346,7 @@ x-moved-a-web-content-to-a-folder={0} moved a web content to a folder. (Automati
 x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle Bin. (Automatic Copy)
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} needs to approve you as her friend. (Automatic Copy)
 x-needs-to-approve-you-as-his-friend={0} needs to approve you as his friend. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
@@ -20346,6 +20346,7 @@ x-moved-a-web-content-to-a-folder={0} flyttet et webinnhold til en mappe.
 x-moved-a-web-content-to-the-recycle-bin={0} flyttet et webinnhold til søppelkassen.
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} må bekrefte deg som din venn.
 x-needs-to-approve-you-as-his-friend={0} må bekrefte deg som din venn.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
@@ -20349,6 +20349,7 @@ x-moved-a-web-content-to-a-folder={0} heeft webinhoud verplaatst naar een map.
 x-moved-a-web-content-to-the-recycle-bin={0} heeft webinhoud verplaatst naar de prullenbak.
 x-moved-down={0} naar beneden verplaatst.
 x-moved-up={0} naar boven verplaatst.
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=Een {0} moet worden gecontroleerd.
 x-needs-to-approve-you-as-her-friend={0} moet uw vriendschap accepteren.
 x-needs-to-approve-you-as-his-friend={0} moet uw vriendschap accepteren.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
@@ -20349,6 +20349,7 @@ x-moved-a-web-content-to-a-folder={0} moved a web content to a folder. (Automati
 x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle Bin. (Automatic Copy)
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} moet jouw vriendschap nog accepteren.
 x-needs-to-approve-you-as-his-friend={0} moet jouw vriendschap nog accepteren.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
@@ -20346,6 +20346,7 @@ x-moved-a-web-content-to-a-folder={0} moved a web content to a folder. (Automati
 x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle Bin. (Automatic Copy)
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} musi zatwierdzić Ciebie jako swojego znajomego.
 x-needs-to-approve-you-as-his-friend={0} musi zatwierdzić Ciebie jako swojego znajomego.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
@@ -20346,6 +20346,7 @@ x-moved-a-web-content-to-a-folder={0} moveu um conteúdo web para uma pasta.
 x-moved-a-web-content-to-the-recycle-bin={0} moveu um conteúdo web para a lixeira.
 x-moved-down={0} foi movido para baixo.
 x-moved-up={0} foi movido para cima.
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=Um {0} precisa de revisão.
 x-needs-to-approve-you-as-her-friend={0} precisa aprovar você como seu amigo.
 x-needs-to-approve-you-as-his-friend={0} precisa aprovar você como sua amiga.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
@@ -20348,6 +20348,7 @@ x-moved-a-web-content-to-a-folder={0} moved a web content to a folder. (Automati
 x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle Bin. (Automatic Copy)
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} tem de o aprovar como sua amiga.
 x-needs-to-approve-you-as-his-friend={0} tem de o aprovar como seu amigo.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
@@ -20346,6 +20346,7 @@ x-moved-a-web-content-to-a-folder={0} moved a web content to a folder. (Automati
 x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle Bin. (Automatic Copy)
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} are nevoie sa te aprobe ca prietenul ei.
 x-needs-to-approve-you-as-his-friend={0} are nevoie sa te aprobe ca prietenul lui.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
@@ -20346,6 +20346,7 @@ x-moved-a-web-content-to-a-folder={0} moved a web content to a folder. (Automati
 x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle Bin. (Automatic Copy)
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} должна подтвердить, что вы ее друг.
 x-needs-to-approve-you-as-his-friend={0} должен подтвердить, что вы ее друг.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
@@ -20346,6 +20346,7 @@ x-moved-a-web-content-to-a-folder={0} moved a web content to a folder. (Automati
 x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle Bin. (Automatic Copy)
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} Vás musí potvrdiť ako svojho priateľa.
 x-needs-to-approve-you-as-his-friend={0} Vás musí potvrdiť ako svojho priateľa.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
@@ -20346,6 +20346,7 @@ x-moved-a-web-content-to-a-folder={0} moved a web content to a folder. (Automati
 x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle Bin. (Automatic Copy)
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} te mora potrditi kot njenega prijatelja.
 x-needs-to-approve-you-as-his-friend={0} te mora potrditi kot njegovega prijatelja.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
@@ -20346,6 +20346,7 @@ x-moved-a-web-content-to-a-folder={0} moved a web content to a folder. (Automati
 x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle Bin. (Automatic Copy)
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} мора да вас одобри као њеног пријатеља.
 x-needs-to-approve-you-as-his-friend={0} мора да вац одобри као свог пријатеља.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
@@ -20346,6 +20346,7 @@ x-moved-a-web-content-to-a-folder={0} moved a web content to a folder. (Automati
 x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle Bin. (Automatic Copy)
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} mora da vas odobri kao njenog prijatelja.
 x-needs-to-approve-you-as-his-friend={0} mora da vac odobri kao svog prijatelja.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
@@ -20346,6 +20346,7 @@ x-moved-a-web-content-to-a-folder={0} har flyttat webbinnehåll till en mapp.
 x-moved-a-web-content-to-the-recycle-bin={0} har flyttat webbinnehåll till papperskorgen.
 x-moved-down={0} flyttade ned.
 x-moved-up={0} flyttade upp.
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=En {0} måste granskas.
 x-needs-to-approve-you-as-her-friend={0} behöver godkänna dig som sin vän.
 x-needs-to-approve-you-as-his-friend={0} behöver godkänna dig som sin vän.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
@@ -20346,6 +20346,7 @@ x-moved-a-web-content-to-a-folder={0} வெப் கன்டன்டை ஃ�
 x-moved-a-web-content-to-the-recycle-bin={0} - ரீசைகிள் பின்-னுக்கு வெப்கன்டன்டைஅனுப்பியுள்ளார்.
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} உங்களை நண்பராக ஏற்றுக்கொள்ள வேண்டும்.
 x-needs-to-approve-you-as-his-friend={0} உங்களை நண்பராக ஏற்றுக்கொள்ள வேண்டும்.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
@@ -20346,6 +20346,7 @@ x-moved-a-web-content-to-a-folder={0} ย้ายเนื้อหาเว็
 x-moved-a-web-content-to-the-recycle-bin={0} ย้ายเนื้อหาเว็บไปยังถังรีไซเคิล
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} ต้องการอนุมัติคุณเป็นเพื่อนของเธอ
 x-needs-to-approve-you-as-his-friend={0} ต้องการอนุมัติคุณเป็นเพื่อนของเขา

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
@@ -20346,6 +20346,7 @@ x-moved-a-web-content-to-a-folder={0} moved a web content to a folder. (Automati
 x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle Bin. (Automatic Copy)
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} sizi arkadaşı olarak onaylaması gerekiyor.
 x-needs-to-approve-you-as-his-friend={0} sizi arkadaşı olarak onaylaması gerekiyor.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
@@ -20346,6 +20346,7 @@ x-moved-a-web-content-to-a-folder={0} moved a web content to a folder. (Automati
 x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle Bin. (Automatic Copy)
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} має підтвердити, що ви її друг.
 x-needs-to-approve-you-as-his-friend={0} має підтвердити, що ви його друг.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
@@ -20346,6 +20346,7 @@ x-moved-a-web-content-to-a-folder={0} moved a web content to a folder. (Automati
 x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle Bin. (Automatic Copy)
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} cần chấp nhận để trở thành bạn của cô ấy.
 x-needs-to-approve-you-as-his-friend={0} cần chấp nhận để trở thành bạn của anh ấy.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
@@ -20348,6 +20348,7 @@ x-moved-a-web-content-to-a-folder={0} 将一篇 web 内容移动到文件夹中�
 x-moved-a-web-content-to-the-recycle-bin={0} 将一篇 web 内容移动到回收站中。
 x-moved-down={0}已向下移动。
 x-moved-up={0}已向上移动。
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=文章 {0} 需要审阅。
 x-needs-to-approve-you-as-her-friend=要想成为{0}的好友，需要经过她的同意。
 x-needs-to-approve-you-as-his-friend=要想成为{0}的好友，需要经过他的同意。

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
@@ -20347,6 +20347,7 @@ x-moved-a-web-content-to-a-folder={0} 已移動網站內容至資料夾。
 x-moved-a-web-content-to-the-recycle-bin={0} 已移除網站內容至資源回收桶。
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
+x-must-start-with-the-"/"-character={0} must start with the "/" character (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} 需要去核准您作為她朋友。
 x-needs-to-approve-you-as-his-friend={0} 需要去核准您作為他朋友。


### PR DESCRIPTION
**What's new:**
- Added new condition to check if the APIEndpoint path parameter doesn't start with forward-slash in which case a new related message is returned.
- Added new test case for the aforementioned condition.
- Modified the tests to reduce and simplify the code
- Executed buildLang in portal-language.

**NOTE**: I've interpreted that in case that both the 255 character limit and the forward-slash validation rules are violated, the second's message is prioritized to appear.

**See the following Jira ticket:** [LPS-191774](https://liferay.atlassian.net/browse/LPS-191774)