### PR TITLE
LPS-191929 Fix Predicate.not operator to have a correct generated SQL

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -304,7 +304,7 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
-	public void testFilterByComparisonOperatorsObjectEntriesByRelatesObjectEntriesFields()
+	public void testFilterByComparisonOperatorsObjectEntriesByRelatedObjectEntriesFields()
 		throws Exception {
 
 		// Many to many relationship, custom object field
@@ -678,7 +678,7 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
-	public void testFilterByComparisonOperatorsObjectEntriesByRelatesObjectEntriesFieldsThroughMultipleRelationships()
+	public void testFilterByComparisonOperatorsObjectEntriesByRelatedObjectEntriesFieldsThroughMultipleRelationships()
 		throws Exception {
 
 		// Many to many relationship, custom object field
@@ -1116,7 +1116,7 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
-	public void testFilterByGroupingOperatorsObjectEntriesByRelatesObjectEntriesFields()
+	public void testFilterByGroupingOperatorsObjectEntriesByRelatedObjectEntriesFields()
 		throws Exception {
 
 		// Many to many relationship, custom object field
@@ -1230,7 +1230,7 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
-	public void testFilterByGroupingOperatorsObjectEntriesByRelatesObjectEntriesFieldsThroughMultipleRelationships()
+	public void testFilterByGroupingOperatorsObjectEntriesByRelatedObjectEntriesFieldsThroughMultipleRelationships()
 		throws Exception {
 
 		// Many to many relationship, custom object field
@@ -1376,7 +1376,7 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
-	public void testFilterByLambdaOperatorsObjectEntriesByRelatesObjectEntriesFields()
+	public void testFilterByLambdaOperatorsObjectEntriesByRelatedObjectEntriesFields()
 		throws Exception {
 
 		_objectEntry1 = ObjectEntryTestUtil.addObjectEntry(
@@ -1691,7 +1691,7 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
-	public void testFilterByLambdaOperatorsObjectEntriesByRelatesObjectEntriesFieldsThroughMultipleRelationships()
+	public void testFilterByLambdaOperatorsObjectEntriesByRelatedObjectEntriesFieldsThroughMultipleRelationships()
 		throws Exception {
 
 		_objectEntry1 = ObjectEntryTestUtil.addObjectEntry(
@@ -2084,7 +2084,7 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
-	public void testFilterByListOperatorsObjectEntriesByRelatesObjectEntriesFields()
+	public void testFilterByListOperatorsObjectEntriesByRelatedObjectEntriesFields()
 		throws Exception {
 
 		// Many to many relationship, custom object field
@@ -2186,7 +2186,7 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
-	public void testFilterByLogicalOperatorsObjectEntriesByRelatesObjectEntriesFields()
+	public void testFilterByLogicalOperatorsObjectEntriesByRelatedObjectEntriesFields()
 		throws Exception {
 
 		// Many to many relationship, custom object field
@@ -2428,7 +2428,7 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
-	public void testFilterByLogicalOperatorsObjectEntriesByRelatesObjectEntriesFieldsThroughMultipleRelationships()
+	public void testFilterByLogicalOperatorsObjectEntriesByRelatedObjectEntriesFieldsThroughMultipleRelationships()
 		throws Exception {
 
 		// Many to many relationship, custom object field
@@ -2746,7 +2746,7 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
-	public void testFilterByStringOperatorsObjectEntriesByRelatesObjectEntriesFields()
+	public void testFilterByStringOperatorsObjectEntriesByRelatedObjectEntriesFields()
 		throws Exception {
 
 		String objectFieldValue1 = String.valueOf(_OBJECT_FIELD_VALUE_1);
@@ -2910,7 +2910,7 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
-	public void testFilterByStringOperatorsObjectEntriesByRelatesObjectEntriesFieldsThroughMultipleRelationships()
+	public void testFilterByStringOperatorsObjectEntriesByRelatedObjectEntriesFieldsThroughMultipleRelationships()
 		throws Exception {
 
 		String objectFieldValue1 = String.valueOf(_OBJECT_FIELD_VALUE_1);
@@ -3133,7 +3133,7 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
-	public void testFilterObjectEntriesByRelatesSystemObjectEntriesFields()
+	public void testFilterObjectEntriesByRelatedSystemObjectEntriesFields()
 		throws Exception {
 
 		// Many to many relationship
@@ -3143,7 +3143,7 @@ public class ObjectEntryResourceTest {
 			_objectEntry1.getPrimaryKey(), _userAccountJSONObject.getLong("id"),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
-		_testFilterObjectEntriesByRelatesSystemObjectEntriesFields(
+		_testFilterObjectEntriesByRelatedSystemObjectEntriesFields(
 			_escape(
 				String.format(
 					"%s/%s eq '%s'", _objectRelationship1.getName(),
@@ -3160,7 +3160,7 @@ public class ObjectEntryResourceTest {
 			_objectEntry1.getPrimaryKey(), _userAccountJSONObject.getLong("id"),
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
-		_testFilterObjectEntriesByRelatesSystemObjectEntriesFields(
+		_testFilterObjectEntriesByRelatedSystemObjectEntriesFields(
 			_escape(
 				String.format(
 					"%s/%s eq '%s'", _objectRelationship1.getName(),
@@ -5332,7 +5332,7 @@ public class ObjectEntryResourceTest {
 			_objectDefinition1.getRESTContextPath(), Http.Method.POST);
 	}
 
-	private void _testFilterObjectEntriesByRelatesSystemObjectEntriesFields(
+	private void _testFilterObjectEntriesByRelatedSystemObjectEntriesFields(
 			String filterString, ObjectDefinition objectDefinition)
 		throws Exception {
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -304,6 +304,103 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
+	public void testFilterByComparisonOperatorsObjectEntries()
+		throws Exception {
+
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s eq '%s'", _OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1)),
+			_objectDefinition1);
+		_assertEmptyPageFilterString(
+			_escape(
+				String.format(
+					"%s eq '%s'", _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1 + 1)),
+			_objectDefinition1);
+
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s ge '%s'", _OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1)),
+			_objectDefinition1);
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s ge '%s'", _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1 - 1)),
+			_objectDefinition1);
+		_assertEmptyPageFilterString(
+			_escape(
+				String.format(
+					"%s ge '%s'", _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1 + 1)),
+			_objectDefinition1);
+
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s gt '%s'", _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1 - 1)),
+			_objectDefinition1);
+		_assertEmptyPageFilterString(
+			_escape(
+				String.format(
+					"%s gt '%s'", _OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1)),
+			_objectDefinition1);
+
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s le '%s'", _OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1)),
+			_objectDefinition1);
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s le '%s'", _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1 + 1)),
+			_objectDefinition1);
+		_assertEmptyPageFilterString(
+			_escape(
+				String.format(
+					"%s le '%s'", _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1 - 1)),
+			_objectDefinition1);
+
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s lt '%s'", _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1 + 1)),
+			_objectDefinition1);
+		_assertEmptyPageFilterString(
+			_escape(
+				String.format(
+					"%s lt '%s'", _OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1)),
+			_objectDefinition1);
+
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s ne '%s'", _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1 - 1)),
+			_objectDefinition1);
+		_assertEmptyPageFilterString(
+			_escape(
+				String.format(
+					"%s ne '%s'", _OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1)),
+			_objectDefinition1);
+	}
+
+	@Test
 	public void testFilterByComparisonOperatorsObjectEntriesByRelatedObjectEntriesFields()
 		throws Exception {
 
@@ -1116,6 +1213,25 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
+	public void testFilterByGroupingOperatorsObjectEntries() throws Exception {
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"(%s le '%s') and (%s gt '%s')", _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1, _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1 - 1)),
+			_objectDefinition1);
+		_assertEmptyPageFilterString(
+			_escape(
+				String.format(
+					"(%s lt '%s') and (%s gt '%s')", _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1, _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1 - 1)),
+			_objectDefinition1);
+	}
+
+	@Test
 	public void testFilterByGroupingOperatorsObjectEntriesByRelatedObjectEntriesFields()
 		throws Exception {
 
@@ -1373,6 +1489,84 @@ public class ObjectEntryResourceTest {
 					_objectRelationship1.getName(),
 					_objectEntry1.getObjectEntryId() - 1)),
 			_objectDefinition3);
+	}
+
+	@Test
+	public void testFilterByLambdaOperatorsObjectEntries() throws Exception {
+		_objectEntry1 = ObjectEntryTestUtil.addObjectEntry(
+			_objectDefinition1,
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1
+			).put(
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST, _LIST_TYPE_ENTRY_KEY
+			).build(),
+			_TAG_1);
+
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/any(k:contains(k,'%s'))",
+					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+					_LIST_TYPE_ENTRY_KEY)),
+			_objectDefinition1);
+		_assertEmptyPageFilterString(
+			_escape(
+				String.format(
+					"%s/any(k:contains(k,'%s'))",
+					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+					RandomTestUtil.randomString())),
+			_objectDefinition1);
+
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/any(k:k eq '%s')",
+					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+					_LIST_TYPE_ENTRY_KEY)),
+			_objectDefinition1);
+		_assertEmptyPageFilterString(
+			_escape(
+				String.format(
+					"%s/any(k:k eq '%s')",
+					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+					RandomTestUtil.randomString())),
+			_objectDefinition1);
+
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/any(k:k in ('%s', '%s'))",
+					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+					_LIST_TYPE_ENTRY_KEY, RandomTestUtil.randomString())),
+			_objectDefinition1);
+		_assertEmptyPageFilterString(
+			_escape(
+				String.format(
+					"%s/any(k:k in ('%s', '%s'))",
+					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+					RandomTestUtil.randomString(),
+					RandomTestUtil.randomString())),
+			_objectDefinition1);
+
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/any(k:startswith(k,'%s'))",
+					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+					_LIST_TYPE_ENTRY_KEY.substring(
+						0, _LIST_TYPE_ENTRY_KEY.length() - 2))),
+			_objectDefinition1);
+		_assertEmptyPageFilterString(
+			_escape(
+				String.format(
+					"%s/any(k:startswith(k,'%s'))",
+					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+					"a" + _LIST_TYPE_ENTRY_KEY)),
+			_objectDefinition1);
 	}
 
 	@Test
@@ -2084,6 +2278,23 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
+	public void testFilterByListOperatorsObjectEntries() throws Exception {
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s in ('%s', '%s')", _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1, RandomTestUtil.randomInt())),
+			_objectDefinition1);
+		_assertEmptyPageFilterString(
+			_escape(
+				String.format(
+					"%s in ('%s', '%s')", _OBJECT_FIELD_NAME_1,
+					RandomTestUtil.randomInt(), RandomTestUtil.randomInt())),
+			_objectDefinition1);
+	}
+
+	@Test
 	public void testFilterByListOperatorsObjectEntriesByRelatedObjectEntriesFields()
 		throws Exception {
 
@@ -2183,6 +2394,55 @@ public class ObjectEntryResourceTest {
 					_objectEntry1.getObjectEntryId(),
 					RandomTestUtil.randomInt())),
 			_objectDefinition2);
+	}
+
+	@Test
+	public void testFilterByLogicalOperatorsObjectEntries() throws Exception {
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s le '%s' and %s gt '%s'", _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1, _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1 - 1)),
+			_objectDefinition1);
+		_assertEmptyPageFilterString(
+			_escape(
+				String.format(
+					"%s le '%s' and %s gt '%s'", _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1 - 1, _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1 - 1)),
+			_objectDefinition1);
+
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s le '%s' or %s gt '%s'", _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1, _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1)),
+			_objectDefinition1);
+		_assertEmptyPageFilterString(
+			_escape(
+				String.format(
+					"%s le '%s' or %s gt '%s'", _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1 - 1, _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1)),
+			_objectDefinition1);
+
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"not (%s eq '%s')", _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1 + 1)),
+			_objectDefinition1);
+		_assertEmptyPageFilterString(
+			_escape(
+				String.format(
+					"not (%s eq '%s')", _OBJECT_FIELD_NAME_1,
+					_OBJECT_FIELD_VALUE_1)),
+			_objectDefinition1);
 	}
 
 	@Test
@@ -2743,6 +3003,38 @@ public class ObjectEntryResourceTest {
 					_objectRelationship1.getName(),
 					_objectEntry1.getObjectEntryId() + 1)),
 			_objectDefinition3);
+	}
+
+	@Test
+	public void testFilterByStringOperatorsObjectEntries() throws Exception {
+		String objectFieldValue = String.valueOf(_OBJECT_FIELD_VALUE_1);
+
+		String objectFieldValueSubstring = objectFieldValue.substring(
+			1, objectFieldValue.length() - 2);
+
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			String.format(
+				"contains(%s,'%s')", _OBJECT_FIELD_NAME_1,
+				objectFieldValueSubstring),
+			_objectDefinition1);
+		_assertEmptyPageFilterString(
+			String.format(
+				"contains(%s,'%s')", _OBJECT_FIELD_NAME_1,
+				"a" + objectFieldValueSubstring),
+			_objectDefinition1);
+
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			String.format(
+				"startswith(%s,'%s')", _OBJECT_FIELD_NAME_1,
+				objectFieldValue.substring(0, 2)),
+			_objectDefinition1);
+		_assertEmptyPageFilterString(
+			String.format(
+				"startswith(%s,'%s')", _OBJECT_FIELD_NAME_1,
+				"a" + objectFieldValue.substring(0, 2)),
+			_objectDefinition1);
 	}
 
 	@Test
@@ -5052,6 +5344,20 @@ public class ObjectEntryResourceTest {
 			TempFileEntryUtil.getTempFileName(title + ".txt"),
 			FileUtil.createTempFile(RandomTestUtil.randomBytes()),
 			ContentTypes.TEXT_PLAIN);
+	}
+
+	private void _assertEmptyPageFilterString(
+			String filterString, ObjectDefinition objectDefinition)
+		throws Exception {
+
+		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+			null,
+			objectDefinition.getRESTContextPath() + "?filter=" + filterString,
+			Http.Method.GET);
+
+		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
+
+		Assert.assertEquals(0, itemsJSONArray.length());
 	}
 
 	private void _assertFilteredObjectEntries(

--- a/modules/core/petra/petra-sql-dsl-api/bnd.bnd
+++ b/modules/core/petra/petra-sql-dsl-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Petra SQL DSL API
 Bundle-SymbolicName: com.liferay.petra.sql.dsl.api
-Bundle-Version: 5.0.1
+Bundle-Version: 6.0.0
 Export-Package:\
 	com.liferay.petra.sql.dsl,\
 	com.liferay.petra.sql.dsl.ast,\

--- a/modules/core/petra/petra-sql-dsl-api/src/main/java/com/liferay/petra/sql/dsl/expression/Predicate.java
+++ b/modules/core/petra/petra-sql-dsl-api/src/main/java/com/liferay/petra/sql/dsl/expression/Predicate.java
@@ -23,7 +23,9 @@ public interface Predicate extends Expression<Boolean> {
 	}
 
 	public static Predicate not(Predicate predicate) {
-		return predicate.not((Expression<Boolean>)withParentheses(predicate));
+		predicate = withParentheses(predicate);
+
+		return predicate.not();
 	}
 
 	public static Predicate or(
@@ -53,14 +55,7 @@ public interface Predicate extends Expression<Boolean> {
 		return and(unsafeSupplier.get());
 	}
 
-	public Predicate not(Expression<Boolean> expression);
-
-	public default <T extends Throwable> Predicate not(
-			UnsafeSupplier<Expression<Boolean>, T> unsafeSupplier)
-		throws T {
-
-		return not(unsafeSupplier.get());
-	}
+	public Predicate not();
 
 	public Predicate or(Expression<Boolean> expression);
 

--- a/modules/core/petra/petra-sql-dsl-api/src/main/resources/com/liferay/petra/sql/dsl/expression/packageinfo
+++ b/modules/core/petra/petra-sql-dsl-api/src/main/resources/com/liferay/petra/sql/dsl/expression/packageinfo
@@ -1,1 +1,1 @@
-version 1.4.0
+version 2.0.0

--- a/modules/core/petra/petra-sql-dsl-spi/bnd.bnd
+++ b/modules/core/petra/petra-sql-dsl-spi/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Petra SQL DSL SPI
 Bundle-SymbolicName: com.liferay.petra.sql.dsl.spi
-Bundle-Version: 3.3.2
+Bundle-Version: 4.0.0
 Export-Package:\
 	com.liferay.petra.sql.dsl.spi,\
 	com.liferay.petra.sql.dsl.spi.ast,\

--- a/modules/core/petra/petra-sql-dsl-spi/src/main/java/com/liferay/petra/sql/dsl/spi/expression/DefaultPredicate.java
+++ b/modules/core/petra/petra-sql-dsl-spi/src/main/java/com/liferay/petra/sql/dsl/spi/expression/DefaultPredicate.java
@@ -55,12 +55,9 @@ public class DefaultPredicate
 	}
 
 	@Override
-	public Predicate not(Expression<Boolean> expression) {
-		if (expression == null) {
-			return this;
-		}
-
-		return new DefaultPredicate(this, Operand.NOT, expression);
+	public Predicate not() {
+		return new DefaultPredicate(
+			EmptyExpression.INSTANCE, Operand.NOT, this);
 	}
 
 	@Override

--- a/modules/core/petra/petra-sql-dsl-spi/src/main/java/com/liferay/petra/sql/dsl/spi/expression/EmptyExpression.java
+++ b/modules/core/petra/petra-sql-dsl-spi/src/main/java/com/liferay/petra/sql/dsl/spi/expression/EmptyExpression.java
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.petra.sql.dsl.spi.expression;
+
+import com.liferay.petra.sql.dsl.ast.ASTNodeListener;
+import com.liferay.petra.sql.dsl.spi.ast.BaseASTNode;
+
+import java.util.function.Consumer;
+
+/**
+ * @author Carlos Correa
+ */
+public class EmptyExpression
+	extends BaseASTNode implements DefaultExpression<Void> {
+
+	public static final EmptyExpression INSTANCE = new EmptyExpression();
+
+	@Override
+	protected void doToSQL(
+		Consumer<String> consumer, ASTNodeListener astNodeListener) {
+	}
+
+	private EmptyExpression() {
+	}
+
+}

--- a/modules/core/petra/petra-sql-dsl-spi/src/main/resources/com/liferay/petra/sql/dsl/spi/expression/packageinfo
+++ b/modules/core/petra/petra-sql-dsl-spi/src/main/resources/com/liferay/petra/sql/dsl/spi/expression/packageinfo
@@ -1,1 +1,1 @@
-version 1.4.0
+version 2.0.0

--- a/modules/core/petra/petra-sql-dsl-spi/src/test/java/com/liferay/petra/sql/dsl/spi/SQLDSLTest.java
+++ b/modules/core/petra/petra-sql-dsl-spi/src/test/java/com/liferay/petra/sql/dsl/spi/SQLDSLTest.java
@@ -959,13 +959,13 @@ public class SQLDSLTest {
 		Assert.assertSame(
 			rightPredicate, defaultPredicate.getRightExpression());
 
-		Assert.assertNotNull(defaultPredicate.not((Expression<Boolean>)null));
 		Assert.assertEquals(
-			"MainExample.mainExampleId >= ? or MainExample.mainExampleId <= " +
-				"? not MainExample.flag = ?",
-			String.valueOf(
-				defaultPredicate.not(
-					MainExampleTable.INSTANCE.flagColumn.eq(0))));
+			"MainExample.mainExampleId >= ? or MainExample.mainExampleId <= ?",
+			String.valueOf(defaultPredicate));
+		Assert.assertEquals(
+			"not (MainExample.mainExampleId >= ? or " +
+				"MainExample.mainExampleId <= ?)",
+			String.valueOf(defaultPredicate.not()));
 	}
 
 	@Test


### PR DESCRIPTION
Related bug: https://liferay.atlassian.net/browse/LPS-191929

---

The purpose of this PR is to fix the `Predicate.not` operator. Before this PR, the `not` method of the `Predicate` interface received one argument, but it does not make sense as the `not` operator must negate the current predicate.

In the `DefaultPredicate.not()` method implemented uses the new `EmptyExpression` as left expression. That causes that the Consumer<String> that contributes to the SQL String is not invoked with the left part, avoiding to include text with invalid SQL syntax.

---

Example:

Given a Predicate (for example, a predicate whose SQL String value would be `O_20096_Student.studentName_ = 'value'`), if we negate the predicate:

**Before the PR**

The SQL String value would be: `O_20096_Student.studentName_ = 'value' not (O_20096_Student.studentName_ = 'value'))` and that causes the following error:

```
java.sql.SQLSyntaxErrorException: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '(O_20096_Student.studentName_ = 'value')  limit 20' at line 1
```

**After the PR**

The SQL String value would be: `not (O_20096_Student.studentName_ = 'value'))`
