### PR TITLE
LPS-191598 | LPS-191789 Rename parameter and check that object relationship name is not empty

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/application/provider/APIApplicationProviderImpl.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/application/provider/APIApplicationProviderImpl.java
@@ -174,7 +174,9 @@ public class APIApplicationProviderImpl implements APIApplicationProvider {
 				String objectRelationshipNames = (String)properties.get(
 					"objectRelationshipNames");
 
-				if (objectRelationshipNames != null) {
+				if ((objectRelationshipNames != null) &&
+					!StringUtil.equals(objectRelationshipNames, "")) {
+
 					objectDefinition =
 						_objectEntryHelper.getPropertyObjectDefinition(
 							objectDefinition,

--- a/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/view.jsp
@@ -17,7 +17,7 @@ HeadlessBuilderWebDisplayContext headlessBuilderWebDisplayContext = (HeadlessBui
 		HashMapBuilder.<String, Object>put(
 			"apiURLPaths", headlessBuilderWebDisplayContext.getAPIURLPaths()
 		).put(
-			"baseURL", HeadlessBuilderConstants.BASE_PATH
+			"basePath", HeadlessBuilderConstants.BASE_PATH
 		).put(
 			"editURL", headlessBuilderWebDisplayContext.getEditorURL()
 		).put(


### PR DESCRIPTION
**What is new?**
- Rename parameter
- Check that empty object relationships must not be deplayed.

**BEFORE PR**
![image](https://github.com/liferay-headless/liferay-portal/assets/44723449/df3f8400-63bf-42bc-a995-1a0821eff0b3)

**AFTER PR**
![Screenshot from 2023-07-27 17-17-50](https://github.com/liferay-headless/liferay-portal/assets/44723449/c040374c-e1cb-489a-92be-bed85768c4e2)


**JIRA Tickets**
https://liferay.atlassian.net/browse/LPS-191598
https://liferay.atlassian.net/browse/LPS-191789

