### PR TITLE
Lps 192275 | Add tests for deploy API Builder object definitions in all instances

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/APIBuilderUI.macro
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/APIBuilderUI.macro
@@ -12,7 +12,7 @@ definition {
 
 		Click(locator1 = "APIBuilder#CHANGE_PUBLICATION_STATUS_BUTTON");
 
-		if (!(isSet(check))) {
+		if (isSet(unpublish)) {
 			Click(locator1 = "Button#UNPUBLISH");
 		}
 	}

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/APIBuilderUI.macro
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/APIBuilderUI.macro
@@ -17,6 +17,23 @@ definition {
 		}
 	}
 
+	macro createAPIApplication {
+		Variables.assertDefined(parameterList = ${title});
+
+		ApplicationsMenu.gotoPortlet(
+			category = "Object",
+			panel = "Control Panel",
+			portlet = "API Builder");
+
+		Click(locator1 = "APIBuilder#ADD_NEW_API_APPLICATION");
+
+		Type(
+			locator1 = "APIBuilder#APPLICATION_TITLE",
+			value1 = ${title});
+
+		Click(locator1 = "APIBuilder#CREATE_BUTTON");
+	}
+
 	macro goToEditAPIApplicationPage {
 		ApplicationsMenu.gotoPortlet(
 			category = "Object",

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/APIBuilderUI.macro
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/APIBuilderUI.macro
@@ -28,7 +28,8 @@ definition {
 		Click(locator1 = "APIBuilder#ADD_NEW_API_APPLICATION");
 
 		Type(
-			locator1 = "APIBuilder#APPLICATION_TITLE",
+			key_fieldLabel = "Title",
+			locator1 = "Modal#INPUT_WITH_LABEL",
 			value1 = ${title});
 
 		Click(locator1 = "APIBuilder#CREATE_BUTTON");

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/ApplicationAPI.macro
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/ApplicationAPI.macro
@@ -31,7 +31,7 @@ definition {
 	macro createAPIApplication {
 		Variables.assertDefined(parameterList = "${baseURL},${statusKey},${statusName},${title}");
 
-		var curl = ApplicationAPI._curlAPIApplication();
+		var curl = ApplicationAPI._curlAPIApplication(virtualHost = ${virtualHost});
 		var body = '''
 			-d {
 				"applicationStatus": {"key": "${statusKey}","name": "${statusName}"},

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/SchemaAPI.macro
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/SchemaAPI.macro
@@ -1,0 +1,53 @@
+definition {
+
+	macro _curlAPISchema {
+		if (isSet(virtualHost)) {
+			if (!(isSet(port))) {
+				var port = 8080;
+			}
+
+			var portalURL = "http://${virtualHost}:${port}";
+		}
+		else {
+			var portalURL = JSONCompany.getPortalURL();
+		}
+
+		var api = "headless-builder/schemas";
+
+		var curl = '''
+			${portalURL}/o/${api} \
+				-u test@liferay.com:test \
+				-H Content-Type: application/json
+		''';
+
+		return ${curl};
+	}
+
+	macro createAPISchema {
+		Variables.assertDefined(parameterList = "${mainObjectDefinitionERC},${name},${apiApplicationId}");
+
+		var curl = ApplicationAPI._curlAPIApplication(virtualHost = ${virtualHost});
+		var body = '''
+			-d {
+				"mainObjectDefinitionERC": "${mainObjectDefinitionERC}",
+				"name": "${name}",
+				"r_apiApplicationToAPISchemas_c_apiApplicationId": ${apiApplicationId}
+			}
+		''';
+
+		var curl = StringUtil.add(${curl}, " \ ${body}", "");
+
+		var response = JSONCurlUtil.post(${curl});
+
+		return ${response};
+	}
+
+	macro getAPISchemas {
+		var curl = ApplicationAPI._curlAPIApplication(virtualHost = ${virtualHost});
+
+		var response = JSONCurlUtil.get(${curl});
+
+		return ${response};
+	}
+
+}

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/paths/APIBuilder.path
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/paths/APIBuilder.path
@@ -16,16 +16,6 @@
 	<td></td>
 </tr>
 <tr>
-	<td>API_APPLICATION</td>
-	<td>//div[@class='table-list-title' and contains(.,'${key_title}')]</td>
-	<td></td>
-</tr>
-<tr>
-	<td>APPLICATION_TITLE</td>
-	<td>//input[contains(@placeholder,'Enter title')]</td>
-	<td></td>
-</tr>
-<tr>
 	<td>CREATE_BUTTON</td>
 	<td>//button[contains(text(),'Create')]</td>
 	<td></td>

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/paths/APIBuilder.path
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/paths/APIBuilder.path
@@ -11,6 +11,26 @@
 
 <tbody>
 <tr>
+	<td>ADD_NEW_API_APPLICATION</td>
+	<td>//button[contains(.,'Add New API Application')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>API_APPLICATION</td>
+	<td>//div[@class='table-list-title' and contains(.,'${key_title}')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>APPLICATION_TITLE</td>
+	<td>//input[contains(@placeholder,'Enter title')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>CREATE_BUTTON</td>
+	<td>//button[contains(text(),'Create')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>APPLICATION_STATUS</td>
 	<td>//div[@class='table-list-title' and contains(.,'${key_title}')]/../..//div[contains(.,'${key_status}')]</td>
 	<td></td>

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/ObjectsStructureForAPIBuilder/DeployAPIBuilderObjectDefinitionsInAllInstances.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/ObjectsStructureForAPIBuilder/DeployAPIBuilderObjectDefinitionsInAllInstances.testcase
@@ -47,8 +47,8 @@ definition {
 			Alert.viewSuccessMessageText(successMessage = "New API Application was created.");
 
 			AssertElementPresent(
-				key_title = "test",
-				locator1 = "APIBuilder#API_APPLICATION");
+				key_name = "test",
+				locator1 = "ObjectAdmin#TABLE_LIST_TITLE");
 		}
 	}
 
@@ -80,8 +80,8 @@ definition {
 				portlet = "API Builder");
 
 			AssertElementPresent(
-				key_title = "test",
-				locator1 = "APIBuilder#API_APPLICATION");
+				key_name = "test",
+				locator1 = "ObjectAdmin#TABLE_LIST_TITLE");
 		}
 	}
 
@@ -106,6 +106,47 @@ definition {
 
 				AssertConsoleTextNotPresent(value1 = "Failed to load API definition");
 			}
+		}
+	}
+
+	@description = "Ignored due to LPS-190834"
+	@ignore = "true"
+	@priority = 5
+	test CannotCreateSchemaWithAPIIdOfOtherInstance {
+		property portal.acceptance = "true";
+
+		task ("And Given create an API application on default instance") {
+			var response = ApplicationAPI.createAPIApplication(
+				baseURL = "test",
+				statusKey = "published",
+				statusName = "published",
+				title = "test");
+		}
+
+		task ("When with postAPISchema and id of API application on default instance to create schema on virtual instance") {
+			var applicationId = JSONUtil.getWithJSONPath(${response}, "$.id");
+
+			var response = SchemaAPI.createAPISchema(
+				apiApplicationId = ${applicationId},
+				mainObjectDefinitionERC = "L_API_APPLICATION",
+				name = "mySchema",
+				virtualHost = "www.able.com");
+		}
+
+		task ("Then I can receive error message") {
+			TestUtils.assertEquals(
+				actual = ${response},
+				expected = "An API schema must be related to an API application.");
+		}
+
+		task ("And Then the schema is not being created") {
+			var response = SchemaAPI.getAPISchemas(virtualHost = "www.able.com");
+
+			var totalCount = JSONUtil.getWithJSONPath(${response}, "$..totalCount");
+
+			TestUtils.assertEquals(
+				actual = ${totalCount},
+				expected = 0);
 		}
 	}
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/ObjectsStructureForAPIBuilder/DeployAPIBuilderObjectDefinitionsInAllInstances.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/ObjectsStructureForAPIBuilder/DeployAPIBuilderObjectDefinitionsInAllInstances.testcase
@@ -1,0 +1,148 @@
+@component-name = "portal-headless"
+definition {
+
+	property custom.properties = "feature.flag.LPS-184413=true${line.separator}feature.flag.LPS-167253=true${line.separator}feature.flag.LPS-178642=true${line.separator}feature.flag.LPS-186757=true";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Object";
+	property testray.main.component.name = "Headless Builder";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginUI();
+
+		task ("Given a new virtual instance is created") {
+			HeadlessPortalInstanceAPI.addPortalInstance(
+				domain = "liferay.com",
+				portalInstanceId = "www.able.com",
+				virtualHost = "www.able.com");
+
+			User.firstLoginUI(
+				password = "test",
+				specificURL = "http://www.able.com:8080",
+				userEmailAddress = "test@liferay.com");
+		}
+	}
+
+	tearDown {
+		HeadlessPortalInstanceAPI.cleanAllPortalInstances();
+
+		var testLiferayVirtualInstance = PropsUtil.get("test.liferay.virtual.instance");
+
+		if (${testLiferayVirtualInstance} == "true") {
+			PortalInstances.tearDownCP();
+		}
+	}
+
+	@priority = 4
+	test CanCreateAPIApplicationWithUIOnVirtualInstance {
+		property portal.acceptance = "true";
+
+		task ("When I create a new API application through Control Panel > Object > API Builder") {
+			APIBuilderUI.createAPIApplication(title = "test");
+		}
+
+		task ("Then the new API application is created successfully") {
+			Alert.viewSuccessMessageText(successMessage = "New API Application was created.");
+
+			AssertElementPresent(
+				key_title = "test",
+				locator1 = "APIBuilder#API_APPLICATION");
+		}
+	}
+
+	@priority = 4
+	test CanCreatePublishedAPIApplicationWithAPIOnVirtualInstance {
+		property portal.acceptance = "true";
+
+		task ("When with postAPIApplication to create a published API application") {
+			var response = ApplicationAPI.createAPIApplication(
+				baseURL = "test",
+				statusKey = "unpublished",
+				statusName = "unpublished",
+				title = "test",
+				virtualHost = "www.able.com");
+		}
+
+		task ("Then the API application is created successfully") {
+			var title = JSONUtil.getWithJSONPath(${response}, "$..title");
+
+			TestUtils.assertEquals(
+				actual = ${title},
+				expected = "test");
+		}
+
+		task ("And Then I can see the newly created API in API Builder") {
+			ApplicationsMenu.gotoPortlet(
+				category = "Object",
+				panel = "Control Panel",
+				portlet = "API Builder");
+
+			AssertElementPresent(
+				key_title = "test",
+				locator1 = "APIBuilder#API_APPLICATION");
+		}
+	}
+
+	@priority = 5
+	test CanLoadHeadlessBuilderAPIsOnVirtualInstance {
+		property portal.acceptance = "true";
+
+		task ("When I navigate to /o/api in the virtual instance") {
+			APIExplorer.navigateToOpenAPI(virtualHost = "www.able.com");
+		}
+
+		task ("Then the headless-builder/applications, headless-builder/endpoints, headless-build/filters, headless-builder/properties, headless-builder/schemas, headless-builder/shemas and headless-builder/sorts are loaded without errors") {
+			for (var applicationName : list "applications,endpoints,filters,properties,schemas,sorts") {
+				APIExplorer.navigateToOpenAPI(
+					api = "headless-builder",
+					version = ${applicationName},
+					virtualHost = "www.able.com");
+
+				AssertTextEquals(
+					locator1 = "Select#HEADLESS_SERVERS",
+					value1 = "http://www.able.com:8080/o/headless-builder/${applicationName}/");
+
+				AssertConsoleTextNotPresent(value1 = "Failed to load API definition");
+			}
+		}
+	}
+
+	@priority = 4
+	test CanPublishAPIApplicationWithUIOnVirtualInstance {
+		property portal.acceptance = "true";
+
+		task ("And Given I create a new API application through Control Panel > Object > API Builder") {
+			APIBuilderUI.createAPIApplication(title = "test");
+		}
+
+		task ("When I click Change Publication Status to publish the API application") {
+			APIBuilderUI.changePublicationStatus(key_title = "test");
+		}
+
+		task ("Then the new API applicatin is published successfully without internal server error") {
+			Alert.viewSuccessMessageText(successMessage = "API Application was published.");
+
+			AssertConsoleTextNotPresent(value1 = "Internal Server Error");
+		}
+	}
+
+	@priority = 5
+	test CanSeeAPIObjectDefinitionsOnVirtualInstance {
+		property portal.acceptance = "true";
+
+		task ("When I navigate to Control Panel > Objects") {
+			ObjectAdmin.openObjectAdmin(baseURL = "http://www.able.com:8080");
+		}
+
+		task ("Then API Application, API Endpoint, API Filter, API Property, API Schema and API Sort are present") {
+			for (var objectName : list "API Application,API Endpoint,API Filter,API Property,API Schema,API Sort") {
+				AssertElementPresent(
+					key_labelName = ${objectName},
+					locator1 = "CreateObject#OBJECT_NAME");
+			}
+		}
+	}
+
+}

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationsInTheAPIBuilder/UnpublishAPIApplication.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationsInTheAPIBuilder/UnpublishAPIApplication.testcase
@@ -37,7 +37,9 @@ definition {
 		property test.liferay.virtual.instance = "false";
 
 		task ("And Given I unpublish it with Change Publication Status") {
-			APIBuilderUI.changePublicationStatus(key_title = "App-test");
+			APIBuilderUI.changePublicationStatus(
+				key_title = "App-test",
+				unpublish = "true");
 		}
 
 		task ("When with getAPIApplicationsPage to retrieve the api application") {
@@ -59,9 +61,7 @@ definition {
 		property test.liferay.virtual.instance = "false";
 
 		task ("When I click Change Publication Status") {
-			APIBuilderUI.changePublicationStatus(
-				check = "true",
-				key_title = "App-test");
+			APIBuilderUI.changePublicationStatus(key_title = "App-test");
 		}
 
 		task ("Then the unpublish warning dialog is present") {
@@ -75,7 +75,9 @@ definition {
 		property test.liferay.virtual.instance = "false";
 
 		task ("And Given I unpublish the API application") {
-			APIBuilderUI.changePublicationStatus(key_title = "App-test");
+			APIBuilderUI.changePublicationStatus(
+				key_title = "App-test",
+				unpublish = "true");
 		}
 
 		task ("When I edit the API application") {
@@ -136,7 +138,9 @@ definition {
 		property test.liferay.virtual.instance = "false";
 
 		task ("When I unpublish it with Change Publication Status") {
-			APIBuilderUI.changePublicationStatus(key_title = "App-test");
+			APIBuilderUI.changePublicationStatus(
+				key_title = "App-test",
+				unpublish = "true");
 		}
 
 		task ("Then the application status is updated to unpublished") {


### PR DESCRIPTION
Background:
- Add tests for story ticket LPS-189447 Deploy API Builder object definitions in all instances

Test Plan:
background: Given a new virtual instance is created
- When I navigate to Control Panel > Objects
Then API Application, API Endpoint, API Filter, API Property, API Schema and API Sort are present
- When I navigate to /o/api in the virtual instance
Then the headless-builder/applications, headless-builder/endpoints, headless-build/filters, headless-builder/properties, headless-builder/schemas, headless-builder/shemas and headless-builder/sorts are loaded without errors
- When I create a new API application through Control Panel > Object > API Builder
Then the new API application is created successfully
- And Given I create a new API application through Control Panel > Object > API Builder
When I click Change Publication Status to publish the API application
Then the new API applicatin is published successfully without internal server error
- When with postAPIApplication to create a published API application
Then the API application is created successfully
And Then I can see the newly created API in API Builder

Jira Ticket:
- https://liferay.atlassian.net/browse/LPS-192275