### PR TITLE
LPS-181694 | Publish Api Application

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/APIBuilderUI.macro
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/APIBuilderUI.macro
@@ -25,7 +25,12 @@ definition {
 			panel = "Control Panel",
 			portlet = "API Builder");
 
-		Click(locator1 = "APIBuilder#ADD_NEW_API_APPLICATION");
+		if (isSet(addByPlus)) {
+			Click(locator1 = "Button#PLUS");
+		}
+		else {
+			Click(locator1 = "APIBuilder#ADD_NEW_API_APPLICATION");
+		}
 
 		Type(
 			key_fieldLabel = "Title",
@@ -46,6 +51,12 @@ definition {
 			locator1 = "APIBuilder#DROPDOWN_MENU");
 
 		Click(locator1 = "APIBuilder#EDIT_BUTTON");
+	}
+
+	macro publishApplication {
+		APIBuilderUI.goToEditAPIApplicationPage(key_title = ${key_title});
+
+		Click(locator1 = "APIBuilder#PUBLISH_BUTTON");
 	}
 
 }

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/paths/APIBuilder.path
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/paths/APIBuilder.path
@@ -31,13 +31,23 @@
 	<td></td>
 </tr>
 <tr>
+	<td>CONTINUE_WITHOUT_SAVING_BUTTON</td>
+	<td>//button[contains(text(),'Continue Without Saving')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>DROPDOWN_MENU</td>
-	<td>//div[contains(text(),'${key_title}')]/..//button[@class='dropdown-toggle component-action dropdown-toggle ml-1 btn btn-unstyled']</td>
+	<td>//div[@class='table-list-title' and contains(.,'${key_title}')]/../..//button[contains(.,'Action')]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>EDIT_BUTTON</td>
 	<td>//div[@class='dropdown-menu show']//button[contains(text(),'Edit')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>ENTER_TITLE</td>
+	<td>//input[(@placeholder='Enter title.')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationsInTheAPIBuilder/PublishAPIApplication.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationsInTheAPIBuilder/PublishAPIApplication.testcase
@@ -1,0 +1,233 @@
+@component-name = "portal-headless"
+definition {
+
+	property custom.properties = "feature.flag.LPS-184413=true${line.separator}feature.flag.LPS-167253=true${line.separator}feature.flag.LPS-178642=true${line.separator}feature.flag.LPS-186757=true";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Object";
+	property testray.main.component.name = "Headless Builder";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginUI();
+
+		task ("Given create an API application through Control Panel > Object > API Builder") {
+			APIBuilderUI.createAPIApplication(
+				addByPlus = "true",
+				title = "App-test");
+		}
+	}
+
+	tearDown {
+		ApplicationAPI.deleteAllAPIApplication();
+
+		var testLiferayVirtualInstance = PropsUtil.get("test.liferay.virtual.instance");
+
+		if (${testLiferayVirtualInstance} == "true") {
+			PortalInstances.tearDownCP();
+		}
+	}
+
+	@priority = 3
+	test CanBackToAPIBuilderAfterCancel {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+
+		task ("And Given I edit the API application") {
+			APIBuilderUI.goToEditAPIApplicationPage(key_title = "App-test");
+		}
+
+		task ("When I click Cancel button") {
+			Click(locator1 = "Button#CANCEL");
+		}
+
+		task ("Then it goes back to the API Builder page") {
+			AssertElementPresent(
+				key_objectLabel = "API Builder",
+				locator1 = "ObjectPortlet#OBJECT_PORTLET_HEADER");
+		}
+	}
+
+	@priority = 4
+	test CanGetPublishedStatusInResponse {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+
+		task ("And given publish the API application in edit application wizard") {
+			APIBuilderUI.publishApplication(key_title = "App-test");
+		}
+
+		task ("When with getAPIApplicationsPage to retrieve the api application") {
+			var response = ApplicationAPI.getAPIApplications();
+		}
+
+		task ("Then I can get the publish status in response") {
+			var actualValue = JSONUtil.getWithJSONPath(${response}, "$.items..applicationStatus.name");
+
+			TestUtils.assertEquals(
+				actual = ${actualValue},
+				expected = "published");
+		}
+	}
+
+	@priority = 4
+	test CanGetUpdatedTitleInResponseAfterPublish {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+
+		task ("Given I publish an API application") {
+			APIBuilderUI.publishApplication(key_title = "App-test");
+		}
+
+		task ("And Given I edit the title and publish the api application again") {
+			APIBuilderUI.goToEditAPIApplicationPage(key_title = "App-test");
+
+			Type(
+				locator1 = "APIBuilder#ENTER_TITLE",
+				value1 = "App-test-1");
+
+			Click(locator1 = "APIBuilder#PUBLISH_BUTTON");
+		}
+
+		task ("When with getAPIApplicationsPage to retrieve the api application") {
+			var response = ApplicationAPI.getAPIApplications();
+		}
+
+		task ("Then I can get the update title in response") {
+			var actualValue = JSONUtil.getWithJSONPath(${response}, "$.items..title");
+
+			TestUtils.assertEquals(
+				actual = ${actualValue},
+				expected = "App-test-1");
+		}
+	}
+
+	@priority = 4
+	test CanPromptCancelChangesDialog {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+
+		task ("And Given I edit the title of the API application") {
+			APIBuilderUI.goToEditAPIApplicationPage(key_title = "App-test");
+
+			Type(
+				locator1 = "APIBuilder#ENTER_TITLE",
+				value1 = "App-test-1");
+		}
+
+		task ("When I click Cancel button") {
+			Click(locator1 = "Button#CANCEL");
+		}
+
+		task ("Then I can see the Cancel Changes dialog with message and Continue Without Saving button") {
+			AssertTextEquals.assertPartialText(
+				locator1 = "Modal#BODY",
+				value1 = "Are you sure you want to continue without saving?");
+
+			AssertElementPresent(locator1 = "APIBuilder#CONTINUE_WITHOUT_SAVING_BUTTON");
+		}
+	}
+
+	@priority = 4
+	test CanPublishAPIApplication {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+
+		task ("When I click Publish button in edit application wizard") {
+			APIBuilderUI.publishApplication(key_title = "App-test");
+		}
+
+		task ("Then the status of the application changed to published") {
+			AssertTextEquals(
+				deployStatus = "Published",
+				locator1 = "AppBuilder#DEPLOY_APP_STATUS",
+				value1 = "Published");
+		}
+	}
+
+	@priority = 4
+	test CanPublishAPIApplicationWithChangePublicationStatus {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+
+		task ("When I click Change Publication Status") {
+			APIBuilderUI.changePublicationStatus(key_title = "App-test");
+		}
+
+		task ("Then the status of the application changed to published") {
+			AssertElementPresent(
+				key_status = "Published",
+				key_title = "App-test",
+				locator1 = "APIBuilder#APPLICATION_STATUS");
+		}
+	}
+
+	@priority = 4
+	test CanUpdateTitleAfterRePublish {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+
+		task ("Given I publish an API application") {
+			APIBuilderUI.publishApplication(key_title = "App-test");
+		}
+
+		task ("And Given I save a changed title") {
+			APIBuilderUI.goToEditAPIApplicationPage(key_title = "App-test");
+
+			Type(
+				locator1 = "APIBuilder#ENTER_TITLE",
+				value1 = "App-test-1");
+		}
+
+		task ("When I republish the api application") {
+			Click(locator1 = "APIBuilder#PUBLISH_BUTTON");
+		}
+
+		task ("Then I can see updated title in API Builder") {
+			ApplicationsMenu.gotoPortlet(
+				category = "Object",
+				panel = "Control Panel",
+				portlet = "API Builder");
+
+			AssertElementPresent(
+				key_name = "App-test-1",
+				locator1 = "ObjectAdmin#TABLE_LIST_TITLE");
+		}
+	}
+
+	@priority = 3
+	test GetAvailableButtonsAfterPublish {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+
+		task ("When I publish the API application in edit application wizard") {
+			APIBuilderUI.publishApplication(key_title = "App-test");
+		}
+
+		task ("Then only Cancel and Publish buttons are visible") {
+			AssertElementPresent(locator1 = "Button#CANCEL");
+
+			AssertElementPresent(locator1 = "APIBuilder#PUBLISH_BUTTON");
+		}
+	}
+
+	@priority = 3
+	test GetAvailableButtonsBeforePublish {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+
+		task ("When I edit the API application") {
+			APIBuilderUI.goToEditAPIApplicationPage(key_title = "App-test");
+		}
+
+		task ("Then I can see Cancel, Save and Publish buttons are visible") {
+			AssertElementPresent(locator1 = "Button#CANCEL");
+
+			AssertElementPresent(locator1 = "Button#SAVE");
+
+			AssertElementPresent(locator1 = "APIBuilder#PUBLISH_BUTTON");
+		}
+	}
+
+}


### PR DESCRIPTION
Background:
Add a testcase to publish API Application

Test Plan
CanPublishAPIApplication
Given create an API application through Control Panel > Object > API Builder
When I click Publish button in edit application wizard
Then the status of the application changed to published

CanPublishAPIApplicationWithChangePublicationStatus
Given create an API application through Control Panel > Object > API Builder
When I click Change Publication Status
Then the status of the application changed to published

CanGetPublishedStatusInResponse
Given create an API application through Control Panel > Object > API Builder
And given publish the API application in edit application wizard
When with getAPIApplicationsPage to retrieve the api application
Then I can get the publish status in response

GetAvailabelButtonsBeforePublish
Given create an API application through Control Panel > Object > API Builder
When I edit the API application
Then Cancel, Save and Publish buttons are visible

GetAvailableButtonsAfterPublish
Given create an API application through Control Panel > Object > API Builder
When I publish the API application in edit application wizard
Then only Cancel and Publish buttons are visible

CanBackToAPIBuilderAfterCancel
Given create an API application through Control Panel > Object > API Builder
And Given I edit the API application
When I click Cancel button
Then it goes back to the API Builder page

CanPromptCancelChangesDialog
Given create an API application through Control Panel > Object > API Builder
And Given I edit the title of the API application
When I click Cancel button
Then I can see the Cancel Changes dialog with message and Continue Without Saving button

CanUpdateTitleAfterRePublish
Given I publish an API application
And Given I save a changed title When I republish the api application
Then I can see updated title in API Builder

CanGetUpdatedTitleInResponseAfterPublish
Given I publish an API application
And Given I edit the title and publish the api application again
When with getAPIApplicationsPage to retrieve the api application
Then I can get the update title in response

Jira ticket:
https://liferay.atlassian.net/browse/LPS-190234

