### PR TITLE
Lps 192570 | Product QA | Functional Automation - LPS-185686 - Create API Definition Objects as the backend of the UI of the Headless Builder

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/ObjectsStructureForAPIBuilder/CreateAPIDefinitionObjectsAsBackendOfAPIBuilder.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/ObjectsStructureForAPIBuilder/CreateAPIDefinitionObjectsAsBackendOfAPIBuilder.testcase
@@ -1,0 +1,258 @@
+@component-name = "portal-headless"
+definition {
+
+	property custom.properties = "feature.flag.LPS-184413=true${line.separator}feature.flag.LPS-167253=true${line.separator}feature.flag.LPS-178642=true${line.separator}feature.flag.LPS-186757=true";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Object";
+	property testray.main.component.name = "Headless Builder";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginUI();
+	}
+
+	tearDown {
+		var testLiferayVirtualInstance = PropsUtil.get("test.liferay.virtual.instance");
+
+		if (${testLiferayVirtualInstance} == "true") {
+			PortalInstances.tearDownCP();
+		}
+	}
+
+	@priority = 5
+	test CanSeeApiApplicationSchema {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+
+		task ("When I navigate to OpenAPI of 'headless-builder/applications' application") {
+			APIExplorer.navigateToOpenAPI(
+				api = "headless-builder",
+				version = "applications");
+		}
+
+		task ("Then I can see schema of APIApplication object") {
+			AssertElementPresent(
+				locator1 = "OpenAPI#SCHEMA_ENTITY",
+				schema = "APIApplication");
+		}
+	}
+
+	@priority = 5
+	test CanSeeApiApplicationSchemaFields {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+
+		task ("When I navigate to OpenAPI of 'headless-builder/applications' application") {
+			APIExplorer.navigateToOpenAPI(
+				api = "headless-builder",
+				version = "applications");
+		}
+
+		task ("Then the fields applicationStatus*, baseURL*, description, title*, version are present") {
+			APIExplorer.assertSchemaFieldsPresent(
+				schemaEntity = "APIApplication",
+				schemaFields = "applicationStatus*,baseURL*,description,title*,version");
+		}
+	}
+
+	@priority = 5
+	test CanSeeApiApplicationSchemaNestedFields {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+
+		task ("When I navigate to OpenAPI of 'headless-builder/applications'") {
+			APIExplorer.navigateToOpenAPI(
+				api = "headless-builder",
+				version = "applications");
+		}
+
+		task ("Then the nestedFields of one-to-many relationships apiApplicationToAPISchemas and apiApplicationToAPIEndpoints are present in the schema") {
+			APIExplorer.assertSchemaFieldsPresent(
+				schemaEntity = "APIApplication",
+				schemaFields = "apiApplicationToAPISchemas,apiApplicationToAPIEndpoints");
+		}
+	}
+
+	@priority = 5
+	test CanSeeApiEndpointSchema {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+
+		task ("When I navigate to OpenAPI 'headless-builder/endpoints' application") {
+			APIExplorer.navigateToOpenAPI(
+				api = "headless-builder",
+				version = "endpoints");
+		}
+
+		task ("Then I can see schema of APIEndpoint object") {
+			AssertElementPresent(
+				locator1 = "OpenAPI#SCHEMA_ENTITY",
+				schema = "APIEndpoint");
+		}
+	}
+
+	@priority = 5
+	test CanSeeApiEndpointSchemaFields {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+
+		task ("When I navigate to OpenAPI 'headless-builder/endpoints' application") {
+			APIExplorer.navigateToOpenAPI(
+				api = "headless-builder",
+				version = "endpoints");
+		}
+
+		task ("Then the fields httpMethod*, name*, path*, scope* are present in the APIEndpoint schema") {
+			APIExplorer.assertSchemaFieldsPresent(
+				schemaEntity = "APIEndpoint",
+				schemaFields = "httpMethod*,name*,path*,scope*");
+		}
+	}
+
+	@priority = 5
+	test CanSeeApiEndpointSchemaNestedFields {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+
+		task ("When I navigate to OpenAPI 'headless-builder/endpoints' application") {
+			APIExplorer.navigateToOpenAPI(
+				api = "headless-builder",
+				version = "endpoints");
+		}
+
+		task ("Then the nestedFields of one-to-many relationships apiEndpointToAPIFilters and apiEndpointToAPISorts are present in the schema") {
+			APIExplorer.assertSchemaFieldsPresent(
+				schemaEntity = "APIEndpoint",
+				schemaFields = "apiEndpointToAPIFilters,apiEndpointToAPISorts");
+		}
+	}
+
+	@priority = 5
+	test CanSeeApiPropertySchema {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+
+		task ("When I navigate to OpenAPI 'headless-builder/properties'") {
+			APIExplorer.navigateToOpenAPI(
+				api = "headless-builder",
+				version = "properties");
+		}
+
+		task ("Then I can see schema of APIProperty object") {
+			AssertElementPresent(
+				locator1 = "OpenAPI#SCHEMA_ENTITY",
+				schema = "APIProperty");
+		}
+	}
+
+	@priority = 5
+	test CanSeeApiPropertySchemaFields {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+
+		task ("When I navigate to OpenAPI 'headless-builder/properties'") {
+			APIExplorer.navigateToOpenAPI(
+				api = "headless-builder",
+				version = "properties");
+		}
+
+		task ("Then the fields description, name*, objectFieldERC*, objectRelationshipIds???, parentAPIPropertyERC are present in the APIProperty schema") {
+			APIExplorer.assertSchemaFieldsPresent(
+				schemaEntity = "APIProperty",
+				schemaFields = "description,name*,objectFieldERC*,objectRelationshipNames,parentAPIPropertyERC");
+		}
+	}
+
+	@priority = 5
+	test CanSeeApiPropertySchemaNestedFields {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+
+		task ("When I navigate to OpenAPI 'headless-builder/properties' application") {
+			APIExplorer.navigateToOpenAPI(
+				api = "headless-builder",
+				version = "properties");
+		}
+
+		task ("Then the nestedFields of many-to-many self relationship apiPropertiesToAPIProperties is present in the schema") {
+			APIExplorer.assertSchemaFieldsPresent(
+				schemaEntity = "APIProperty",
+				schemaFields = "apiPropertiesToAPIProperties");
+		}
+	}
+
+	@priority = 5
+	test CanSeeApiSchemaSchema {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+
+		task ("When I navigate to OpenAPI 'headless-builder/schemas'") {
+			APIExplorer.navigateToOpenAPI(
+				api = "headless-builder",
+				version = "schemas");
+		}
+
+		task ("Then I can see schema of APISchema object") {
+			AssertElementPresent(
+				locator1 = "OpenAPI#SCHEMA_ENTITY",
+				schema = "APISchema");
+		}
+	}
+
+	@priority = 5
+	test CanSeeApiSchemaSchemaFields {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+
+		task ("When I navigate to OpenAPI 'headless-builder/schemas' application") {
+			APIExplorer.navigateToOpenAPI(
+				api = "headless-builder",
+				version = "schemas");
+		}
+
+		task ("Then the fields description, mainObjectDefinitionERC, name* are present in the schema") {
+			APIExplorer.assertSchemaFieldsPresent(
+				schemaEntity = "APISchema",
+				schemaFields = "description,mainObjectDefinitionERC,name*");
+		}
+	}
+
+	@priority = 5
+	test CanSeeApiSchemaSchemaNestedFields {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+
+		task ("When I navigate to OpenAPI 'headless-builder/schemas' application") {
+			APIExplorer.navigateToOpenAPI(
+				api = "headless-builder",
+				version = "schemas");
+		}
+
+		task ("Then the nestedFields of one-to-many relationships apiSchemaToAPIProperties and responseAPISchemaToAPIEndpoints are present in the schema") {
+			APIExplorer.assertSchemaFieldsPresent(
+				schemaEntity = "APISchema",
+				schemaFields = "apiSchemaToAPIProperties,responseAPISchemaToAPIEndpoints");
+		}
+	}
+
+	@priority = 5
+	test CanSeeHeadlessBuilderApplications {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+
+		task ("When I navigate to OpenAPI Explorer") {
+			APIExplorer.navigateToOpenAPI();
+		}
+
+		task ("Then I can see ‘headless-builder/applications’, 'headless-builder/endpoints', 'headless-builder/filters', 'headless-builder/properties', 'headless-builder/schemas', and 'headless-builder/sorts' on the REST Applications list") {
+			for (var restApplication : list "headless-builder/applications,headless-builder/endpoints,headless-builder/filters,headless-builder/properties,headless-builder/schemas,headless-builder/sorts") {
+				AssertElementPresent(
+					locator1 = "Button#BUTTON_WITH_VALUE",
+					value = ${restApplication});
+			}
+		}
+	}
+
+}

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/ObjectsStructureForAPIBuilder/CreateAPIDefinitionObjectsAsBackendOfAPIBuilder.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/ObjectsStructureForAPIBuilder/CreateAPIDefinitionObjectsAsBackendOfAPIBuilder.testcase
@@ -14,10 +14,230 @@ definition {
 	}
 
 	tearDown {
+		ApplicationAPI.deleteAllAPIApplication();
+
 		var testLiferayVirtualInstance = PropsUtil.get("test.liferay.virtual.instance");
 
 		if (${testLiferayVirtualInstance} == "true") {
 			PortalInstances.tearDownCP();
+		}
+	}
+
+	@priority = 4
+	test CanChangeApiApplicationStatus {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+
+		task ("Given API application with applicationStatus 'unpublished', baseURL 'my-app', and title 'My App' created") {
+			var response = ApplicationAPI.createAPIApplication(
+				baseURL = "my-app",
+				statusKey = "unpublished",
+				statusName = "unpublished",
+				title = "My APP");
+		}
+
+		task ("When in ‘headless-builder/applications’ I request putAPIApplication with ${aPIApplicationId}, applicationStatus 'published', baseURL 'my-app', and title 'My App'") {
+			var applicationId = JSONPathUtil.getIdValue(response = ${response});
+
+			APIExplorer.navigateToOpenAPI(
+				api = "headless-builder",
+				version = "applications");
+
+			APIExplorer.executeAPIMethodWithParameters(
+				method = "putAPIApplication",
+				parameter = "aPIApplicationId",
+				requestBody = "{\"applicationStatus\": \"published\", \"baseURL\": \"my-app\", \"title\": \"My App\"}",
+				service = "APIApplication",
+				value = ${applicationId});
+		}
+
+		task ("Then applicationStatus value is changed to 'published'") {
+			var response = ApplicationAPI.getAPIApplications();
+
+			var applicationStatus = JSONUtil.getWithJSONPath(${response}, "$..applicationStatus.key");
+
+			TestUtils.assertEquals(
+				actual = ${applicationStatus},
+				expected = "published");
+		}
+	}
+
+	@priority = 5
+	test CanCreateApiApplicationWithValidBaseUrl {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+
+		task ("When I send request to post API application baseURL 'my-app-1234', and title 'My App'") {
+			APIExplorer.navigateToOpenAPI(
+				api = "headless-builder",
+				version = "applications");
+
+			APIExplorer.executeAPIMethodWithParameters(
+				method = "postAPIApplication",
+				requestBody = "{\"baseURL\": \"my-app-1234\", \"title\": \"My App\"}",
+				service = "APIApplication");
+		}
+
+		task ("Then API application is created") {
+			AssertTextEquals(
+				locator1 = "OpenAPI#RESPONSE_CODE",
+				method = "postAPIApplication",
+				value1 = 200);
+
+			AssertTextEquals.assertPartialText(
+				locator1 = "OpenAPI#RESPONSE_BODY",
+				method = "postAPIApplication",
+				value1 = "\"key\": \"unpublished\"");
+		}
+	}
+
+	@priority = 5
+	test CanCreateUnpublishedApiApplication {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+
+		task ("When in ‘headless-builder/applications’ I request postAPIApplication with applicationStatus 'unpublished', baseURL 'my-app', and title 'My App'") {
+			APIExplorer.navigateToOpenAPI(
+				api = "headless-builder",
+				version = "applications");
+
+			APIExplorer.executeAPIMethodWithParameters(
+				method = "postAPIApplication",
+				requestBody = "{\"applicationStatus\": \"unpublished\", \"baseURL\": \"my-app\", \"title\": \"My App\"}",
+				service = "APIApplication");
+		}
+
+		task ("Then API application is created") {
+			var response = ApplicationAPI.getAPIApplications();
+
+			var totcalCount = JSONUtil.getWithJSONPath(${response}, "$..totalCount");
+
+			TestUtils.assertEquals(
+				actual = ${totcalCount},
+				expected = 1);
+		}
+	}
+
+	@priority = 5
+	test CanDeleteApiApplication {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+
+		task ("Given API application with baseURL 'my-app', and title 'My App' created") {
+			var response = ApplicationAPI.createAPIApplication(
+				baseURL = "my-app",
+				statusKey = "published",
+				statusName = "published",
+				title = "My APP");
+		}
+
+		task ("When I request deleteAPIApplication with ${aPIApplicationId}") {
+			var applicationId = JSONPathUtil.getIdValue(response = ${response});
+
+			APIExplorer.navigateToOpenAPI(
+				api = "headless-builder",
+				version = "applications");
+
+			APIExplorer.executeAPIMethodWithParameters(
+				method = "deleteAPIApplication",
+				parameter = "aPIApplicationId",
+				service = "APIApplication",
+				value = ${applicationId});
+		}
+
+		task ("Then API application is deleted") {
+			AssertTextEquals(
+				locator1 = "OpenAPI#RESPONSE_CODE",
+				method = "deleteAPIApplication",
+				value1 = 204);
+
+			var response = ApplicationAPI.getAPIApplications();
+
+			var totalCount = JSONUtil.getWithJSONPath(${response}, "$..totalCount");
+
+			TestUtils.assertEquals(
+				actual = ${totalCount},
+				expected = 0);
+		}
+	}
+
+	@priority = 5
+	test CannotCreateApiApplicationWithInvalidBaseUrl {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+
+		task ("When I create API application baseURL 'my app 1234', and title 'My App'") {
+			APIExplorer.navigateToOpenAPI(
+				api = "headless-builder",
+				version = "applications");
+
+			APIExplorer.executeAPIMethodWithParameters(
+				method = "postAPIApplication",
+				requestBody = "{\"baseURL\": \"my app 1234\", \"title\": \"My App\"}",
+				service = "APIApplication");
+		}
+
+		task ("Then status code 400 with an error message 'Base URL can have a maximum of 255 alphanumeric characters.'") {
+			AssertTextEquals(
+				locator1 = "OpenAPI#RESPONSE_CODE",
+				method = "postAPIApplication",
+				value1 = 400);
+
+			AssertTextEquals.assertPartialText(
+				locator1 = "OpenAPI#RESPONSE_BODY",
+				method = "postAPIApplication",
+				value1 = "Base URL can have a maximum of 255 alphanumeric characters.");
+		}
+
+		task ("And Then API application is not created") {
+			var response = ApplicationAPI.getAPIApplications();
+
+			var totalCount = JSONUtil.getWithJSONPath(${response}, "$..totalCount");
+
+			TestUtils.assertEquals(
+				actual = ${totalCount},
+				expected = 0);
+		}
+	}
+
+	@priority = 4
+	test CannotModifyApiApplicationWithInvalidStatusValue {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+
+		task ("Given API application with applicationStatus 'unpublished', baseURL 'my-app', and title 'My App' created") {
+			var response = ApplicationAPI.createAPIApplication(
+				baseURL = "my-app",
+				statusKey = "unpublished",
+				statusName = "unpublished",
+				title = "My APP");
+		}
+
+		task ("When in ‘headless-builder/applications’ I request putAPIApplication with {aPIApplicationId}, applicationStatus 'string', baseURL 'my-app', and title 'My App'") {
+			var applicationId = JSONPathUtil.getIdValue(response = ${response});
+
+			APIExplorer.navigateToOpenAPI(
+				api = "headless-builder",
+				version = "applications");
+
+			APIExplorer.executeAPIMethodWithParameters(
+				method = "putAPIApplication",
+				parameter = "aPIApplicationId",
+				requestBody = "{\"applicationStatus\": \"String\", \"baseURL\": \"my-app\", \"title\": \"My App\"}",
+				service = "APIApplication",
+				value = ${applicationId});
+		}
+
+		task ("Then I receive an error 'Object field name \"applicationStatus\" is not mapped to a valid list type entry'") {
+			AssertTextEquals.assertPartialText(
+				locator1 = "OpenAPI#RESPONSE_BODY",
+				method = "putAPIApplication",
+				value1 = "Object field name \\"applicationStatus\\" is not mapped to a valid list type entry");
+
+			AssertTextEquals(
+				locator1 = "OpenAPI#RESPONSE_CODE",
+				method = "putAPIApplication",
+				value1 = 400);
 		}
 	}
 
@@ -122,10 +342,10 @@ definition {
 				version = "endpoints");
 		}
 
-		task ("Then the nestedFields of one-to-many relationships apiEndpointToAPIFilters and apiEndpointToAPISorts are present in the schema") {
+		task ("Then the nestedFields of one-to-many relationships apiApplicationToAPIEndpoints, requestAPISchemaToAPIEndpoints, responseAPISchemaToAPIEndpoints are present in the schema") {
 			APIExplorer.assertSchemaFieldsPresent(
 				schemaEntity = "APIEndpoint",
-				schemaFields = "apiEndpointToAPIFilters,apiEndpointToAPISorts");
+				schemaFields = "apiApplicationToAPIEndpoints,requestAPISchemaToAPIEndpoints,responseAPISchemaToAPIEndpoints");
 		}
 	}
 
@@ -158,7 +378,7 @@ definition {
 				version = "properties");
 		}
 
-		task ("Then the fields description, name*, objectFieldERC*, objectRelationshipIds???, parentAPIPropertyERC are present in the APIProperty schema") {
+		task ("Then the fields description, name*, objectFieldERC*, objectRelationshipNames, parentAPIPropertyERC are present in the APIProperty schema") {
 			APIExplorer.assertSchemaFieldsPresent(
 				schemaEntity = "APIProperty",
 				schemaFields = "description,name*,objectFieldERC*,objectRelationshipNames,parentAPIPropertyERC");

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/ObjectsStructureForAPIBuilder/CreateAPIDefinitionObjectsAsBackendOfAPIBuilder.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/ObjectsStructureForAPIBuilder/CreateAPIDefinitionObjectsAsBackendOfAPIBuilder.testcase
@@ -43,7 +43,7 @@ definition {
 				api = "headless-builder",
 				version = "applications");
 
-			APIExplorer.executeAPIMethodWithParameters(
+			APIExplorer.executeAPIMethod(
 				method = "putAPIApplication",
 				parameter = "aPIApplicationId",
 				requestBody = "{\"applicationStatus\": \"published\", \"baseURL\": \"my-app\", \"title\": \"My App\"}",
@@ -72,7 +72,7 @@ definition {
 				api = "headless-builder",
 				version = "applications");
 
-			APIExplorer.executeAPIMethodWithParameters(
+			APIExplorer.executeAPIMethod(
 				method = "postAPIApplication",
 				requestBody = "{\"baseURL\": \"my-app-1234\", \"title\": \"My App\"}",
 				service = "APIApplication");
@@ -101,7 +101,7 @@ definition {
 				api = "headless-builder",
 				version = "applications");
 
-			APIExplorer.executeAPIMethodWithParameters(
+			APIExplorer.executeAPIMethod(
 				method = "postAPIApplication",
 				requestBody = "{\"applicationStatus\": \"unpublished\", \"baseURL\": \"my-app\", \"title\": \"My App\"}",
 				service = "APIApplication");
@@ -138,7 +138,7 @@ definition {
 				api = "headless-builder",
 				version = "applications");
 
-			APIExplorer.executeAPIMethodWithParameters(
+			APIExplorer.executeAPIMethod(
 				method = "deleteAPIApplication",
 				parameter = "aPIApplicationId",
 				service = "APIApplication",
@@ -171,7 +171,7 @@ definition {
 				api = "headless-builder",
 				version = "applications");
 
-			APIExplorer.executeAPIMethodWithParameters(
+			APIExplorer.executeAPIMethod(
 				method = "postAPIApplication",
 				requestBody = "{\"baseURL\": \"my app 1234\", \"title\": \"My App\"}",
 				service = "APIApplication");
@@ -220,7 +220,7 @@ definition {
 				api = "headless-builder",
 				version = "applications");
 
-			APIExplorer.executeAPIMethodWithParameters(
+			APIExplorer.executeAPIMethod(
 				method = "putAPIApplication",
 				parameter = "aPIApplicationId",
 				requestBody = "{\"applicationStatus\": \"String\", \"baseURL\": \"my-app\", \"title\": \"My App\"}",

--- a/modules/apps/headless/headless-discovery/headless-discovery-test/src/testFunctional/macros/APIExplorer.macro
+++ b/modules/apps/headless/headless-discovery/headless-discovery-test/src/testFunctional/macros/APIExplorer.macro
@@ -33,6 +33,21 @@ definition {
 			value1 = "${property} { method string default: ${method} href string default: ${portalURL}/o/${objectHref} }");
 	}
 
+	macro assertSchemaFieldsPresent {
+		Variables.assertDefined(parameterList = "${schemaEntity},${schemaFields}");
+
+		Click(
+			locator1 = "OpenAPI#SCHEMA_COLLAPSED",
+			schema = ${schemaEntity});
+
+		for (var schemaField : list ${schemaFields}) {
+			AssertElementPresent(
+				field = ${schemaField},
+				locator1 = "OpenAPI#SCHEMA_FIELD",
+				schema = ${schemaEntity});
+		}
+	}
+
 	macro executeAllActionInSchema {
 		Variables.assertDefined(parameterList = "${schema},${actionsList}");
 
@@ -55,35 +70,37 @@ definition {
 	}
 
 	macro executeAPIMethodWithParameters {
-		Variables.assertDefined(parameterList = "${service},${method},${parameter}");
+		Variables.assertDefined(parameterList = "${service},${method}");
 
 		Click(
 			locator1 = "OpenAPI#API_METHOD",
 			method = ${method},
 			service = ${service});
 
-		if (${parameter} == "siteId") {
-			if (!(isSet(groupName))) {
-				var groupName = "Guest";
+		if (isSet(parameter)) {
+			if (${parameter} == "siteId") {
+				if (!(isSet(groupName))) {
+					var groupName = "Guest";
+				}
+
+				var value = JSONGroupAPI._getGroupIdByNameNoSelenium(
+					groupName = ${groupName},
+					site = "true");
 			}
 
-			var value = JSONGroupAPI._getGroupIdByNameNoSelenium(
-				groupName = ${groupName},
-				site = "true");
-		}
-
-		Type(
-			locator1 = "OpenAPI#PARAMETER_UNDER_METHOD",
-			method = ${method},
-			parameter = ${parameter},
-			value1 = ${value});
-
-		if (isSet(parameter_two)) {
 			Type(
 				locator1 = "OpenAPI#PARAMETER_UNDER_METHOD",
 				method = ${method},
-				parameter = ${parameter_two},
-				value1 = ${value_two});
+				parameter = ${parameter},
+				value1 = ${value});
+
+			if (isSet(parameter_two)) {
+				Type(
+					locator1 = "OpenAPI#PARAMETER_UNDER_METHOD",
+					method = ${method},
+					parameter = ${parameter_two},
+					value1 = ${value_two});
+			}
 		}
 
 		if (isSet(requestBody)) {

--- a/modules/apps/headless/headless-discovery/headless-discovery-test/src/testFunctional/macros/APIExplorer.macro
+++ b/modules/apps/headless/headless-discovery/headless-discovery-test/src/testFunctional/macros/APIExplorer.macro
@@ -69,7 +69,7 @@ definition {
 		}
 	}
 
-	macro executeAPIMethodWithParameters {
+	macro executeAPIMethod {
 		Variables.assertDefined(parameterList = "${service},${method}");
 
 		Click(

--- a/modules/apps/headless/headless-discovery/headless-discovery-test/src/testFunctional/tests/HeadlessDiscovery.testcase
+++ b/modules/apps/headless/headless-discovery/headless-discovery-test/src/testFunctional/tests/HeadlessDiscovery.testcase
@@ -218,7 +218,7 @@ definition {
 		}
 
 		task ("When executing getSiteBlogPosingPage with siteID as the parameter") {
-			APIExplorer.executeAPIMethodWithParameters(
+			APIExplorer.executeAPIMethod(
 				method = "getSiteBlogPostingsPage",
 				parameter = "siteId",
 				service = "BlogPosting");
@@ -243,7 +243,7 @@ definition {
 		}
 
 		task ("When executing getSiteKeywordsPage with siteID as the parameter") {
-			APIExplorer.executeAPIMethodWithParameters(
+			APIExplorer.executeAPIMethod(
 				method = "getSiteKeywordsPage",
 				parameter = "siteId",
 				service = "Keyword");
@@ -268,7 +268,7 @@ definition {
 		}
 
 		task ("When executing getSiteStructuredContentsPage with siteID as the parameter") {
-			APIExplorer.executeAPIMethodWithParameters(
+			APIExplorer.executeAPIMethod(
 				method = "getSiteStructuredContentsPage",
 				parameter = "siteId",
 				service = "StructuredContent");
@@ -301,7 +301,7 @@ definition {
 		task ("When executing postSiteTaxonomyVocabulary with siteID as the parameter") {
 			var requestBody = '''{"name": "Vocubulary Name"}''';
 
-			APIExplorer.executeAPIMethodWithParameters(
+			APIExplorer.executeAPIMethod(
 				method = "postSiteTaxonomyVocabulary",
 				parameter = "siteId",
 				requestBody = ${requestBody},
@@ -373,7 +373,7 @@ definition {
 				}
 			''';
 
-			APIExplorer.executeAPIMethodWithParameters(
+			APIExplorer.executeAPIMethod(
 				method = "postSiteStructuredContentDraft",
 				parameter = "siteId",
 				requestBody = ${requestBody},
@@ -445,7 +445,7 @@ definition {
 				}
 			''';
 
-			APIExplorer.executeAPIMethodWithParameters(
+			APIExplorer.executeAPIMethod(
 				method = "postSiteStructuredContent",
 				parameter = "siteId",
 				requestBody = ${requestBody},
@@ -501,7 +501,7 @@ definition {
 		}
 
 		task ("When executing getSiteStructuredContentsPage with siteID as the parameter") {
-			APIExplorer.executeAPIMethodWithParameters(
+			APIExplorer.executeAPIMethod(
 				method = "getSiteStructuredContentsPage",
 				parameter = "siteId",
 				service = "StructuredContent");
@@ -546,7 +546,7 @@ definition {
 		}
 
 		task ("When executing getSiteTaxonomyVocabulariesPage with siteID as the parameter") {
-			APIExplorer.executeAPIMethodWithParameters(
+			APIExplorer.executeAPIMethod(
 				method = "getSiteTaxonomyVocabulariesPage",
 				parameter = "siteId",
 				service = "TaxonomyVocabulary");
@@ -592,7 +592,7 @@ definition {
 		}
 
 		task ("When executing getSiteStructuredContentsPage with siteID as the parameter") {
-			APIExplorer.executeAPIMethodWithParameters(
+			APIExplorer.executeAPIMethod(
 				method = "getSiteStructuredContentsPage",
 				parameter = "siteId",
 				service = "StructuredContent");

--- a/modules/apps/headless/headless-discovery/headless-discovery-test/src/testFunctional/tests/OpenAPIProfile.testcase
+++ b/modules/apps/headless/headless-discovery/headless-discovery-test/src/testFunctional/tests/OpenAPIProfile.testcase
@@ -51,7 +51,7 @@ definition {
 		}
 
 		task ("When executing HeadlessAdminWorkflow.v1.0.getOpenAPI") {
-			APIExplorer.executeAPIMethodWithParameters(
+			APIExplorer.executeAPIMethod(
 				method = "HeadlessAdminWorkflow\.v1\.0\.getOpenAPI",
 				parameter = "type",
 				service = "default",

--- a/modules/apps/headless/headless-discovery/headless-discovery-test/src/testFunctional/tests/QueryParametersInCustomObjects.testcase
+++ b/modules/apps/headless/headless-discovery/headless-discovery-test/src/testFunctional/tests/QueryParametersInCustomObjects.testcase
@@ -93,7 +93,7 @@ definition {
 		task ("When in API Explorer o/c/managers requesting getManagersPage with fields=name,id") {
 			APIExplorer.navigateToOpenAPI(customObjectPlural = "managers");
 
-			APIExplorer.executeAPIMethodWithParameters(
+			APIExplorer.executeAPIMethod(
 				method = "getManagersPage",
 				parameter = "fields",
 				service = "Manager",
@@ -113,7 +113,7 @@ definition {
 		task ("When in API Explorer o/c/departments requesting getDepartmentsPage with fields=non-existing-field") {
 			APIExplorer.navigateToOpenAPI(customObjectPlural = "departments");
 
-			APIExplorer.executeAPIMethodWithParameters(
+			APIExplorer.executeAPIMethod(
 				method = "getDepartmentsPage",
 				parameter = "fields",
 				service = "Department",
@@ -133,7 +133,7 @@ definition {
 		task ("When in API Explorer o/c/employees requesting getEmployeesPage with fields=name") {
 			APIExplorer.navigateToOpenAPI(customObjectPlural = "employees");
 
-			APIExplorer.executeAPIMethodWithParameters(
+			APIExplorer.executeAPIMethod(
 				method = "getEmployeesPage",
 				parameter = "fields",
 				service = "Employee",
@@ -153,7 +153,7 @@ definition {
 		task ("When in API Explorer o/c/employees requesting getEmployee with {employeeId} nestedFields=managersEmployees") {
 			APIExplorer.navigateToOpenAPI(customObjectPlural = "employees");
 
-			APIExplorer.executeAPIMethodWithParameters(
+			APIExplorer.executeAPIMethod(
 				method = "getEmployee",
 				parameter = "employeeId",
 				parameter_two = "nestedFields",
@@ -180,7 +180,7 @@ definition {
 		task ("When in API Explorer o/c/departments requesting getDepartmentsPage with nestedFields=departmentManagers") {
 			APIExplorer.navigateToOpenAPI(customObjectPlural = "departments");
 
-			APIExplorer.executeAPIMethodWithParameters(
+			APIExplorer.executeAPIMethod(
 				method = "getDepartmentsPage",
 				parameter = "nestedFields",
 				service = "Department",
@@ -205,7 +205,7 @@ definition {
 		task ("When in API Explorer o/c/managers requesting getManager with {managerId} with restrictFields=name,id") {
 			APIExplorer.navigateToOpenAPI(customObjectPlural = "managers");
 
-			APIExplorer.executeAPIMethodWithParameters(
+			APIExplorer.executeAPIMethod(
 				method = "getManager",
 				parameter = "managerId",
 				parameter_two = "restrictFields",
@@ -232,7 +232,7 @@ definition {
 		task ("When in API Explorer o/c/employees requesting getEmployee with {employeeId} restrictFields=non-exiting-field") {
 			APIExplorer.navigateToOpenAPI(customObjectPlural = "employees");
 
-			APIExplorer.executeAPIMethodWithParameters(
+			APIExplorer.executeAPIMethod(
 				method = "getEmployee",
 				parameter = "employeeId",
 				service = "Employee",

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portal/openapi/OpenAPI.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portal/openapi/OpenAPI.path
@@ -19,6 +19,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>SCHEMA_ENTITY</td>
+	<td>//div[@id='model-${schema}']</td>
+	<td></td>
+</tr>
+<tr>
 	<td>SCHEMA_FIELD</td>
 	<td>//div[@id='model-${schema}']//td[contains(.,'${field}')]</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/users/cpusersandorganizations/UsersAdmin.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/users/cpusersandorganizations/UsersAdmin.testcase
@@ -1068,7 +1068,7 @@ definition {
 			''';
 			var value = JSONUserAPI._getUserIdByEmailAddress(userEmailAddress = "userea1@liferay.com");
 
-			APIExplorer.executeAPIMethodWithParameters(
+			APIExplorer.executeAPIMethod(
 				method = "patchUserAccount",
 				parameter = "userAccountId",
 				requestBody = ${requestBody},


### PR DESCRIPTION
Background:
- Add automation tests for LPS-185686 - Create API Definition Objects as the backend of the UI of the Headless Builder

Test Plan:
- When I navigate to OpenAPI Explorer
Then I can see ‘headless-builder/applications’, 'headless-builder/endpoints', 'headless-builder/filters', 'headless-builder/properties', 'headless-builder/schemas', and 'headless-builder/sorts' on the REST Applications list
- When I navigate to OpenAPI of 'headless-builder/applications' application
Then I can see schema of APIApplication object
- When I navigate to OpenAPI of 'headless-builder/applications' application
Then the fields applicationStatus*, baseURL*, description, title*, version are present
- When I navigate to OpenAPI of 'headless-builder/applications'
Then the nestedFields of one-to-many relationships apiApplicationToAPISchemas and apiApplicationToAPIEndpoints are present in the schema
- When I navigate to OpenAPI 'headless-builder/schemas'
Then I can see schema of APISchema object
- When I navigate to OpenAPI 'headless-builder/schemas' application
Then the fields description, mainObjectDefinitionERC, name* are present in the schema
- When I navigate to OpenAPI 'headless-builder/schemas' application
Then the nestedFields of one-to-many relationships apiSchemaToAPIProperties and responseAPISchemaToAPIEndpoints are present in the schema
- When I navigate to OpenAPI 'headless-builder/properties'
Then I can see schema of APIProperty object
- When I navigate to OpenAPI 'headless-builder/properties'
Then the fields description, name*, objectFieldERC*,  objectRelationshipIds, parentAPIPropertyERC are present in the APIProperty schema
- When I navigate to OpenAPI 'headless-builder/properties' application
Then the nestedFields of many-to-many self relationship apiPropertiesToAPIProperties is present in the schema
- When I navigate to OpenAPI 'headless-builder/endpoints' application
Then I can see schema of APIEndpoint object
- When I navigate to OpenAPI 'headless-builder/endpoints' application 
Then the fields httpMethod*, name*, path*,  scope* are present in the APIEndpoint schema
- When in ‘headless-builder/applications’ I request postAPIApplication with applicationStatus 'unpublished', baseURL 'my-app', and title 'My App'
Then API application is created
- Given API application with applicationStatus 'unpublished', baseURL 'my-app', and title 'My App' created
When in ‘headless-builder/applications’ I request putAPIApplication with ${aPIApplicationId}, applicationStatus 'published', baseURL 'my-app', and title 'My App'
Then applicationStatus value is changed to 'published'
- Given API application with applicationStatus 'unpublished', baseURL 'my-app', and title 'My App' created
When in ‘headless-builder/applications’ I request putAPIApplication with {aPIApplicationId}, applicationStatus 'string', baseURL 'my-app', and title 'My App'
Then I receive an error 'Object field name \"applicationStatus\" is not mapped to a valid list type entry'
- Given API application with baseURL 'my-app', and title 'My App' created
When I request deleteAPIApplication with ${aPIApplicationId}
Then API application is deleted
- When I send request to post API application baseURL 'my-app-1234', and title 'My App'
Then API application is created
- When I create API application baseURL 'my app 1234', and title 'My App'
Then status code 400 with an error message 'Base URL can have a maximum of 255 alphanumeric characters.'
And Then API application is not created

Jira Ticket:
- https://liferay.atlassian.net/browse/LPS-190236