### PR TITLE
LPS-192379 Added validation that prevents using baseURLs with uppercase letters

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIApplicationRelevantObjectEntryModelListener.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIApplicationRelevantObjectEntryModelListener.java
@@ -14,6 +14,7 @@ import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.StringUtil;
 
 import java.io.Serializable;
 
@@ -80,12 +81,25 @@ public class APIApplicationRelevantObjectEntryModelListener
 					_objectFieldLocalService.getObjectField(
 						objectEntry.getObjectDefinitionId(), "baseURL");
 
+				String message = null;
+				String messageKey = null;
+
+				if (!StringUtil.isLowerCase(baseURL)) {
+					message = "%s must contain only lowercase characters.";
+					messageKey = "x-must-contain-only-lowercase-characters";
+				}
+				else {
+					message =
+						"%s can have a maximum of 255 alphanumeric characters.";
+					messageKey =
+						"x-can-have-a-maximum-of-255-alphanumeric-characters";
+				}
+
+				String label = objectField.getLabel(user.getLocale());
+
 				throw new ObjectEntryValuesException.InvalidObjectField(
-					Arrays.asList(objectField.getLabel(user.getLocale())),
-					String.format(
-						"%s can have a maximum of 255 alphanumeric characters",
-						objectField.getLabel(user.getLocale())),
-					"x-can-have-a-maximum-of-255-alphanumeric-characters");
+					Arrays.asList(label, "\"/\""),
+					String.format(message, label), messageKey);
 			}
 		}
 		catch (Exception exception) {
@@ -94,7 +108,7 @@ public class APIApplicationRelevantObjectEntryModelListener
 	}
 
 	private static final Pattern _baseURLPattern = Pattern.compile(
-		"[a-zA-Z0-9-]{1,255}");
+		"[a-z-0-9-]{1,255}");
 
 	@Reference
 	private ObjectFieldLocalService _objectFieldLocalService;

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationsInTheAPIBuilder/UnpublishAPIApplication.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationsInTheAPIBuilder/UnpublishAPIApplication.testcase
@@ -14,7 +14,7 @@ definition {
 
 		task ("Given publish an API application") {
 			ApplicationAPI.createAPIApplication(
-				baseURL = "App-test",
+				baseURL = "app-test",
 				status = "published",
 				title = "App-test");
 		}

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]DefineAPISchemasWithinAnAPIGroup/ListAPIApplicationSchemas.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]DefineAPISchemasWithinAnAPIGroup/ListAPIApplicationSchemas.testcase
@@ -14,7 +14,7 @@ definition {
 
 		task ("Given an API application is created") {
 			ApplicationAPI.createAPIApplication(
-				baseURL = "My-app",
+				baseURL = "my-app",
 				status = "unpublished",
 				title = "My-app");
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/application/publisher/test/APIApplicationPublisherTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/application/publisher/test/APIApplicationPublisherTest.java
@@ -12,6 +12,7 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.FeatureFlags;
 
 import org.junit.Test;
@@ -133,8 +134,10 @@ public class APIApplicationPublisherTest extends BaseTestCase {
 	private static final String _API_APPLICATION_ERC_2 =
 		RandomTestUtil.randomString();
 
-	private static final String _BASE_URL_1 = RandomTestUtil.randomString();
+	private static final String _BASE_URL_1 = StringUtil.toLowerCase(
+		RandomTestUtil.randomString());
 
-	private static final String _BASE_URL_2 = RandomTestUtil.randomString();
+	private static final String _BASE_URL_2 = StringUtil.toLowerCase(
+		RandomTestUtil.randomString());
 
 }

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/application/resource/test/HeadlessBuilderOpenAPIResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/application/resource/test/HeadlessBuilderOpenAPIResourceTest.java
@@ -528,7 +528,8 @@ public class HeadlessBuilderOpenAPIResourceTest extends BaseTestCase {
 	private static final String _API_APPLICATION_ERC =
 		RandomTestUtil.randomString();
 
-	private static final String _API_BASE_URL = RandomTestUtil.randomString();
+	private static final String _API_BASE_URL = StringUtil.toLowerCase(
+		RandomTestUtil.randomString());
 
 	private static final String _API_ENDPOINT_ERC =
 		RandomTestUtil.randomString();

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/application/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/application/resource/test/HeadlessBuilderResourceTest.java
@@ -58,6 +58,7 @@ import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.URLCodec;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
@@ -1171,9 +1172,11 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 	private static final String _API_SCHEMA_TEXT_FIELD_ERC =
 		RandomTestUtil.randomString();
 
-	private static final String _BASE_URL_1 = RandomTestUtil.randomString();
+	private static final String _BASE_URL_1 = StringUtil.toLowerCase(
+		RandomTestUtil.randomString());
 
-	private static final String _BASE_URL_2 = RandomTestUtil.randomString();
+	private static final String _BASE_URL_2 = StringUtil.toLowerCase(
+		RandomTestUtil.randomString());
 
 	private static DateFormat _dateFormat;
 	private static DateFormat _dateTimeFormat;

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/instance/lifecycle/test/APIApplicationPublisherPortalInstanceLifecycleListenerTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/instance/lifecycle/test/APIApplicationPublisherPortalInstanceLifecycleListenerTest.java
@@ -17,6 +17,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -57,7 +58,7 @@ public class APIApplicationPublisherPortalInstanceLifecycleListenerTest
 				_serviceComponentRuntime.getComponentDescriptionDTO(
 					FrameworkUtil.getBundle(clazz), clazz.getName());
 
-		String baseURL = RandomTestUtil.randomString();
+		String baseURL = StringUtil.toLowerCase(RandomTestUtil.randomString());
 
 		try {
 			_disableComponentDescriptionDTO(

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APIApplicationPublisherObjectEntryModelListenerTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APIApplicationPublisherObjectEntryModelListenerTest.java
@@ -51,7 +51,7 @@ public class APIApplicationPublisherObjectEntryModelListenerTest
 
 	@Test
 	public void test() throws Exception {
-		String baseURL = RandomTestUtil.randomString();
+		String baseURL = StringUtil.toLowerCase(RandomTestUtil.randomString());
 
 		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
 			JSONUtil.put(
@@ -85,7 +85,7 @@ public class APIApplicationPublisherObjectEntryModelListenerTest
 
 		APIApplicationTestUtil.assertNotDeployedAPIApplication(baseURL);
 
-		baseURL = RandomTestUtil.randomString();
+		baseURL = StringUtil.toLowerCase(RandomTestUtil.randomString());
 
 		HTTPTestUtil.invokeToJSONObject(
 			JSONUtil.put(
@@ -109,7 +109,7 @@ public class APIApplicationPublisherObjectEntryModelListenerTest
 
 		APIApplicationTestUtil.assertNotDeployedAPIApplication(baseURL);
 
-		baseURL = RandomTestUtil.randomString();
+		baseURL = StringUtil.toLowerCase(RandomTestUtil.randomString());
 
 		HTTPTestUtil.invokeToJSONObject(
 			JSONUtil.put(

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APIApplicationRelevantObjectEntryModelListenerTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APIApplicationRelevantObjectEntryModelListenerTest.java
@@ -12,10 +12,14 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.FeatureFlags;
 
 import org.junit.Assert;
 import org.junit.Test;
+
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 
 /**
  * @author Sergio Jiménez del Coso
@@ -26,27 +30,74 @@ public class APIApplicationRelevantObjectEntryModelListenerTest
 
 	@Test
 	public void test() throws Exception {
+		JSONAssert.assertEquals(
+			JSONUtil.put(
+				"status", "BAD_REQUEST"
+			).put(
+				"title",
+				"Base URL can have a maximum of 255 alphanumeric characters."
+			).toString(),
+			HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					"applicationStatus", "unpublished"
+				).put(
+					"baseURL",
+					StringUtil.toLowerCase(RandomTestUtil.randomString()) +
+						StringPool.FORWARD_SLASH
+				).put(
+					"title", RandomTestUtil.randomString()
+				).toString(),
+				"headless-builder/applications", Http.Method.POST
+			).toString(),
+			JSONCompareMode.STRICT);
+
+		JSONAssert.assertEquals(
+			JSONUtil.put(
+				"status", "BAD_REQUEST"
+			).put(
+				"title",
+				"Base URL can have a maximum of 255 alphanumeric characters."
+			).toString(),
+			HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					"applicationStatus", "unpublished"
+				).put(
+					"baseURL",
+					StringUtil.toLowerCase(RandomTestUtil.randomString(256)) +
+						StringPool.FORWARD_SLASH
+				).put(
+					"title", RandomTestUtil.randomString()
+				).toString(),
+				"headless-builder/applications", Http.Method.POST
+			).toString(),
+			JSONCompareMode.STRICT);
+
+		JSONAssert.assertEquals(
+			JSONUtil.put(
+				"status", "BAD_REQUEST"
+			).put(
+				"title", "Base URL must contain only lowercase characters."
+			).toString(),
+			HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					"applicationStatus", "unpublished"
+				).put(
+					"baseURL",
+					RandomTestUtil.randomString(
+						255
+					).toUpperCase()
+				).put(
+					"title", RandomTestUtil.randomString()
+				).toString(),
+				"headless-builder/applications", Http.Method.POST
+			).toString(),
+			JSONCompareMode.STRICT);
+
 		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
 			JSONUtil.put(
 				"applicationStatus", "unpublished"
 			).put(
-				"baseURL",
-				RandomTestUtil.randomString() + StringPool.FORWARD_SLASH
-			).put(
-				"title", RandomTestUtil.randomString()
-			).toString(),
-			"headless-builder/applications", Http.Method.POST);
-
-		Assert.assertEquals("BAD_REQUEST", jsonObject.get("status"));
-		Assert.assertEquals(
-			"Base URL can have a maximum of 255 alphanumeric characters.",
-			jsonObject.get("title"));
-
-		jsonObject = HTTPTestUtil.invokeToJSONObject(
-			JSONUtil.put(
-				"applicationStatus", "unpublished"
-			).put(
-				"baseURL", RandomTestUtil.randomString()
+				"baseURL", StringUtil.toLowerCase(RandomTestUtil.randomString())
 			).put(
 				"title", RandomTestUtil.randomString()
 			).toString(),

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APIEndpointRelevantObjectEntryModelListenerTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APIEndpointRelevantObjectEntryModelListenerTest.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.FeatureFlags;
 
 import java.util.Collections;
@@ -125,7 +126,7 @@ public class APIEndpointRelevantObjectEntryModelListenerTest
 			JSONUtil.put(
 				"applicationStatus", "published"
 			).put(
-				"baseURL", RandomTestUtil.randomString()
+				"baseURL", StringUtil.toLowerCase(RandomTestUtil.randomString())
 			).put(
 				"title", RandomTestUtil.randomString()
 			).toString(),

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APIFilterRelevantObjectEntryModelListenerTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APIFilterRelevantObjectEntryModelListenerTest.java
@@ -15,6 +15,7 @@ import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -215,7 +216,7 @@ public class APIFilterRelevantObjectEntryModelListenerTest
 			).put(
 				"applicationStatus", "published"
 			).put(
-				"baseURL", RandomTestUtil.randomString()
+				"baseURL", StringUtil.toLowerCase(RandomTestUtil.randomString())
 			).put(
 				"externalReferenceCode", RandomTestUtil.randomString()
 			).put(

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APIPropertyRelevantObjectEntryModelListenerTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APIPropertyRelevantObjectEntryModelListenerTest.java
@@ -53,7 +53,7 @@ public class APIPropertyRelevantObjectEntryModelListenerTest
 			JSONUtil.put(
 				"applicationStatus", "published"
 			).put(
-				"baseURL", RandomTestUtil.randomString()
+				"baseURL", StringUtil.toLowerCase(RandomTestUtil.randomString())
 			).put(
 				"title", RandomTestUtil.randomString()
 			).toString(),

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APISchemaRelevantObjectEntryModelListenerTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APISchemaRelevantObjectEntryModelListenerTest.java
@@ -15,6 +15,7 @@ import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.FeatureFlags;
 
 import java.util.Collections;
@@ -48,7 +49,7 @@ public class APISchemaRelevantObjectEntryModelListenerTest
 			JSONUtil.put(
 				"applicationStatus", "unpublished"
 			).put(
-				"baseURL", RandomTestUtil.randomString()
+				"baseURL", StringUtil.toLowerCase(RandomTestUtil.randomString())
 			).put(
 				"title", RandomTestUtil.randomString()
 			).toString(),

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APISortRelevantObjectEntryModelListenerTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APISortRelevantObjectEntryModelListenerTest.java
@@ -12,6 +12,7 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.FeatureFlags;
 
 import org.junit.Assert;
@@ -29,7 +30,7 @@ public class APISortRelevantObjectEntryModelListenerTest extends BaseTestCase {
 			JSONUtil.put(
 				"applicationStatus", "published"
 			).put(
-				"baseURL", RandomTestUtil.randomString()
+				"baseURL", StringUtil.toLowerCase(RandomTestUtil.randomString())
 			).put(
 				"title", RandomTestUtil.randomString()
 			).toString(),

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -20422,6 +20422,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle 
 x-moved-down={0} moved down.
 x-moved-up={0} moved up.
 x-ms={0} ms
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters.
 x-must-start-with-the-x-character={0} must start with the {1} character.
 x-needs-review=A {0} needs review.
 x-needs-to-approve-you-as-her-friend={0} needs to approve you as her friend.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
@@ -20416,6 +20416,7 @@ x-moved-a-web-content-to-the-recycle-bin=نقل {0} محتوى ويب إلى س�
 x-moved-down={0} تم نقله لأسفل.
 x-moved-up={0} تم نقله لأعلى.
 x-ms={0} مللي ثانية
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} يجب أن يبدأ بحرف ${1}.
 x-needs-review={0} يحتاج إلى مراجعة.
 x-needs-to-approve-you-as-her-friend={0} تحتاج أن توافق على صداقتك.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
@@ -20416,6 +20416,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle 
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
 x-ms={0} ms (Automatic Copy)
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} must start with the {1} character. (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} трябва да ви одобри за неин приятел.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
@@ -20418,6 +20418,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} ha desplaçat un contingut de web a
 x-moved-down={0} s'ha desplaçat cap avall.
 x-moved-up={0} s'ha desplaçat cap amunt.
 x-ms={0} ms
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} ha de començar amb el caràcter ${1}.
 x-needs-review=S'ha de revisar un {0}.
 x-needs-to-approve-you-as-her-friend=Cal que {0} us accepti com a amic.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
@@ -20416,6 +20416,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle 
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
 x-ms={0} ms (Automatic Copy)
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} must start with the {1} character. (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend=Uživatelka {0} musí potvrdit, že jste její přítel.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
@@ -20416,6 +20416,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle 
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
 x-ms={0} ms (Automatic Copy)
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} must start with the {1} character. (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} needs to approve you as her friend. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
@@ -20418,6 +20418,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} hat Web-Inhalt in den Papierkorb ve
 x-moved-down={0} nach unten verschoben.
 x-moved-up={0} nach oben verschoben.
 x-ms={0} ms
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} must start with the {1} character. (Automatic Copy)
 x-needs-review=Ein {0} muss überprüft werden.
 x-needs-to-approve-you-as-her-friend={0} muss Sie als ihren Freund bestätigen.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
@@ -20416,6 +20416,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle 
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
 x-ms={0} ms (Automatic Copy)
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} must start with the {1} character. (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend=Η {0} πρέπει να σάς εγκρίνει ως φίλο/η της.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
@@ -20422,6 +20422,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle 
 x-moved-down={0} moved down.
 x-moved-up={0} moved up.
 x-ms={0} ms
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters.
 x-must-start-with-the-x-character={0} must start with the {1} character.
 x-needs-review=A {0} needs review.
 x-needs-to-approve-you-as-her-friend={0} needs to approve you as her friend.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
@@ -20416,6 +20416,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle 
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
 x-ms={0} ms (Automatic Copy)
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} must start with the {1} character. (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} needs to approve you as her friend. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
@@ -20416,6 +20416,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle 
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
 x-ms={0} ms (Automatic Copy)
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} must start with the {1} character. (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} needs to approve you as her friend. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
@@ -20418,6 +20418,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} movió contenido web a la Papelera 
 x-moved-down={0} ha bajado.
 x-moved-up={0} ha subido.
 x-ms={0} ms
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} debe comenzar con el caracter ${1}.
 x-needs-review=Un {0} necesita revisión.
 x-needs-to-approve-you-as-her-friend={0} necesita su aprobación para convertirse en su amigo.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
@@ -20418,6 +20418,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} movió contenido web a la Papelera 
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
 x-ms={0} ms (Automatic Copy)
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} must start with the {1} character. (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} necesita su aprobación para convertirse en su amigo.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
@@ -20418,6 +20418,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} movió contenido web a la Papelera 
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
 x-ms={0} ms (Automatic Copy)
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} must start with the {1} character. (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} necesita su aprobación para convertirse en su amigo.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
@@ -20418,6 +20418,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} movió contenido web a la Papelera 
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
 x-ms={0} ms (Automatic Copy)
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} must start with the {1} character. (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} necesita su aprobación para convertirse en su amigo.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
@@ -20416,6 +20416,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle 
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
 x-ms={0} ms (Automatic Copy)
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} must start with the {1} character. (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} peab sind oma sõbraks kinnitama.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
@@ -20416,6 +20416,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle 
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
 x-ms={0} ms (Automatic Copy)
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} must start with the {1} character. (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0}(e)k zure onespena behar du zure laguna izateko.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
@@ -20416,6 +20416,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle 
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
 x-ms={0} ms (Automatic Copy)
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} must start with the {1} character. (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} نیاز دارد که شما را به عنوان دوست خودش تایید نماید.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
@@ -20414,6 +20414,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} siirsi web-sisällön roskakoriin.
 x-moved-down={0} siirtyi alas.
 x-moved-up={0} siirtyi ylös.
 x-ms={0} ms
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} täytyy alkaa ${1}-merkillä.
 x-needs-review={0} täytyy tarkistaa.
 x-needs-to-approve-you-as-her-friend={0}n täytyy hyväksyä sinut ystäväkseen.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
@@ -20418,6 +20418,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} a déplacé un contenu web vers la 
 x-moved-down={0} s'est déplacé vers le bas.
 x-moved-up={0} s'est déplacé vers le haut.
 x-ms={0} ms
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} doit commencer par le caractère ${1}.
 x-needs-review=Un {0} doit être revu.
 x-needs-to-approve-you-as-her-friend={0} a besoin de vous accepter comme ami.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
@@ -20416,6 +20416,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} a déplacé un contenu web vers la 
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
 x-ms={0} ms (Automatic Copy)
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} must start with the {1} character. (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} a besoin de vous accepter comme ami.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
@@ -20416,6 +20416,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle 
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
 x-ms={0} ms (Automatic Copy)
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} must start with the {1} character. (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} necesita a túa aprobación para converterse na túa amiga.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
@@ -20416,6 +20416,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle 
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
 x-ms={0} ms (Automatic Copy)
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} must start with the {1} character. (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} needs to approve you as her friend. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
@@ -20416,6 +20416,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle 
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
 x-ms={0} ms (Automatic Copy)
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} must start with the {1} character. (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} treba da vam odobri kao njezin prijatelj.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
@@ -20419,6 +20419,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} egy webes tartalmat a kukába mozga
 x-moved-down={0} lefelé mozgatva.
 x-moved-up={0} felfelé mozgatva.
 x-ms={0} ms
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} első karaktere ${1} kell, hogy legyen.
 x-needs-review=Egy {0} ellenőrzést igényel.
 x-needs-to-approve-you-as-her-friend={0} vissza kell igazold, hogy a barátja vagy.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
@@ -20416,6 +20416,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle 
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
 x-ms={0} ms (Automatic Copy)
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} must start with the {1} character. (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} diperlukan untuk menyetujui Anda sebagai temannya.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
@@ -20417,6 +20417,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle 
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
 x-ms={0} ms (Automatic Copy)
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} must start with the {1} character. (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} deve approvarti come suo amico.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
@@ -20416,6 +20416,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} העביר תוכן אתר אינט
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
 x-ms={0} ms (Automatic Copy)
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} must start with the {1} character. (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} צריכה לאשר אותך כחברתה

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
@@ -20418,6 +20418,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} がWebコンテンツ記事をゴ�
 x-moved-down={0} が下に移動しました。
 x-moved-up={0} が上に移動しました。
 x-ms={0} ms
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} は ${1} 文字で開始する必要があります。
 x-needs-review={0}がレビューを必要としています。
 x-needs-to-approve-you-as-her-friend=友達になるには、{0}さんの承認が必要です。

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
@@ -20416,6 +20416,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle 
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
 x-ms={0} ms (Automatic Copy)
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} must start with the {1} character. (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} needs to approve you as her friend. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
@@ -20422,6 +20422,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle 
 x-moved-down={0} moved down.
 x-moved-up={0} moved up.
 x-ms={0} ms (Automatic Copy)
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} must start with the {1} character. (Automatic Copy)
 x-needs-review=A {0} needs review.
 x-needs-to-approve-you-as-her-friend={0} needs to approve you as her friend.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
@@ -20415,6 +20415,7 @@ x-moved-a-web-content-to-the-recycle-bin={0}님이 웹 콘텐츠를 휴지통으
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
 x-ms={0} ms (Automatic Copy)
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} must start with the {1} character. (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0}님이 귀하를 친구로 승인해야 합니다.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
@@ -20416,6 +20416,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle 
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
 x-ms={0} ms (Automatic Copy)
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} must start with the {1} character. (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} ຕ້ອງການຢັ້ງຢືນທ່ານເປັນເພື່ອຂອງລາວກ່ອນ

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
@@ -20416,6 +20416,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle 
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
 x-ms={0} ms (Automatic Copy)
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} must start with the {1} character. (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} needs to approve you as her friend. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
@@ -20416,6 +20416,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle 
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
 x-ms={0} ms (Automatic Copy)
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} must start with the {1} character. (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} needs to approve you as her friend. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
@@ -20416,6 +20416,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} flyttet et webinnhold til søppelka
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
 x-ms={0} ms (Automatic Copy)
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} must start with the {1} character. (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} må bekrefte deg som din venn.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
@@ -20419,6 +20419,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} heeft webinhoud verplaatst naar de 
 x-moved-down={0} naar beneden verplaatst.
 x-moved-up={0} naar boven verplaatst.
 x-ms={0} ms
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} moet beginnen met het teken ${1}.
 x-needs-review=Een {0} moet worden gecontroleerd.
 x-needs-to-approve-you-as-her-friend={0} moet uw vriendschap accepteren.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
@@ -20419,6 +20419,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle 
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
 x-ms={0} ms (Automatic Copy)
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} must start with the {1} character. (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} moet jouw vriendschap nog accepteren.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
@@ -20416,6 +20416,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle 
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
 x-ms={0} ms (Automatic Copy)
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} must start with the {1} character. (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} musi zatwierdzić Ciebie jako swojego znajomego.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
@@ -20416,6 +20416,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} moveu um conteúdo web para a lixei
 x-moved-down={0} foi movido para baixo.
 x-moved-up={0} foi movido para cima.
 x-ms={0} ms
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} deve começar com o caracter ${1}.
 x-needs-review=Um {0} precisa de revisão.
 x-needs-to-approve-you-as-her-friend={0} precisa aprovar você como seu amigo.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
@@ -20418,6 +20418,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle 
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
 x-ms={0} ms (Automatic Copy)
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} must start with the {1} character. (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} tem de o aprovar como sua amiga.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
@@ -20416,6 +20416,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle 
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
 x-ms={0} ms (Automatic Copy)
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} must start with the {1} character. (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} are nevoie sa te aprobe ca prietenul ei.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
@@ -20416,6 +20416,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle 
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
 x-ms={0} ms (Automatic Copy)
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} must start with the {1} character. (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} должна подтвердить, что вы ее друг.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
@@ -20416,6 +20416,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle 
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
 x-ms={0} ms (Automatic Copy)
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} must start with the {1} character. (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} Vás musí potvrdiť ako svojho priateľa.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
@@ -20416,6 +20416,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle 
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
 x-ms={0} ms (Automatic Copy)
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} must start with the {1} character. (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} te mora potrditi kot njenega prijatelja.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
@@ -20416,6 +20416,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle 
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
 x-ms={0} ms (Automatic Copy)
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} must start with the {1} character. (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} мора да вас одобри као њеног пријатеља.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
@@ -20416,6 +20416,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle 
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
 x-ms={0} ms (Automatic Copy)
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} must start with the {1} character. (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} mora da vas odobri kao njenog prijatelja.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
@@ -20416,6 +20416,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} har flyttat webbinnehåll till papp
 x-moved-down={0} flyttade ned.
 x-moved-up={0} flyttade upp.
 x-ms={0} ms
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} måste inledas med tecknet ${1}.
 x-needs-review=En {0} måste granskas.
 x-needs-to-approve-you-as-her-friend={0} behöver godkänna dig som sin vän.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
@@ -20416,6 +20416,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} - ரீசைகிள் பி�
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
 x-ms={0} ms (Automatic Copy)
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} must start with the {1} character. (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} உங்களை நண்பராக ஏற்றுக்கொள்ள வேண்டும்.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
@@ -20416,6 +20416,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} ย้ายเนื้อหา�
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
 x-ms={0} ms (Automatic Copy)
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} must start with the {1} character. (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} ต้องการอนุมัติคุณเป็นเพื่อนของเธอ

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
@@ -20416,6 +20416,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle 
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
 x-ms={0} ms (Automatic Copy)
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} must start with the {1} character. (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} sizi arkadaşı olarak onaylaması gerekiyor.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
@@ -20416,6 +20416,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle 
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
 x-ms={0} ms (Automatic Copy)
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} must start with the {1} character. (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} має підтвердити, що ви її друг.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
@@ -20416,6 +20416,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} moved a web content to the Recycle 
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
 x-ms={0} ms (Automatic Copy)
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} must start with the {1} character. (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} cần chấp nhận để trở thành bạn của cô ấy.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
@@ -20418,6 +20418,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} 将一篇 web 内容移动到回收
 x-moved-down={0}已向下移动。
 x-moved-up={0}已向上移动。
 x-ms={0} ms
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} 必须以 ${1} 字符开头。
 x-needs-review=文章 {0} 需要审阅。
 x-needs-to-approve-you-as-her-friend=要想成为{0}的好友，需要经过她的同意。

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
@@ -20417,6 +20417,7 @@ x-moved-a-web-content-to-the-recycle-bin={0} 已移除網站內容至資源回�
 x-moved-down={0} moved down. (Automatic Copy)
 x-moved-up={0} moved up. (Automatic Copy)
 x-ms={0} ms (Automatic Copy)
+x-must-contain-only-lowercase-characters={0} must contain only lowercase characters. (Automatic Copy)
 x-must-start-with-the-x-character={0} must start with the {1} character. (Automatic Copy)
 x-needs-review=A {0} needs review. (Automatic Copy)
 x-needs-to-approve-you-as-her-friend={0} 需要去核准您作為她朋友。


### PR DESCRIPTION
**What's new?**
- Added a new condition that checks if the baseURL is incorrect because it contains a uppercase letter.
- Added a new test condition that checks if the aforementioned validation works as expected.
- Added a new test condition that checks the edge-case of 256 characters baseURL.

**What's changed?**
- The baseURL regular expression no longer allows the usage of uppercase characters.
- The tests now use JSONAssert instead of a HTTP call and then an assertion.

See the following **Jira ticket**: [LPS-192379](https://liferay.atlassian.net/browse/LPS-192379?filter=13054)