### PR TITLE
LPS-181462 | Delete API Application

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/APIBuilderUI.macro
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/APIBuilderUI.macro
@@ -40,6 +40,19 @@ definition {
 		Click(locator1 = "APIBuilder#CREATE_BUTTON");
 	}
 
+	macro deleteAPIApplication {
+		ApplicationsMenu.gotoPortlet(
+			category = "Object",
+			panel = "Control Panel",
+			portlet = "API Builder");
+
+		Click(
+			key_title = ${key_title},
+			locator1 = "APIBuilder#DROPDOWN_MENU");
+
+		Click(locator1 = "APIBuilder#DELETE_IN_DROPDOWN_MENU");
+	}
+
 	macro filterByLastUpdated {
 		Variables.assertDefined(parameterList = "${fromDate},${toDate}");
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/EndpointAPI.macro
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/EndpointAPI.macro
@@ -69,4 +69,12 @@ definition {
 		}
 	}
 
+	macro getAPIEndpoints {
+		var curl = EndpointAPI._curlAPIEndpoint();
+
+		var response = JSONCurlUtil.get(${curl});
+
+		return ${response};
+	}
+
 }

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/SchemaAPI.macro
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/SchemaAPI.macro
@@ -58,7 +58,7 @@ definition {
 	}
 
 	macro getAPISchemas {
-		var curl = ApplicationAPI._curlAPIApplication(virtualHost = ${virtualHost});
+		var curl = SchemaAPI._curlAPISchema(virtualHost = ${virtualHost});
 
 		var response = JSONCurlUtil.get(${curl});
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/paths/APIBuilder.path
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/paths/APIBuilder.path
@@ -106,6 +106,16 @@
 	<td></td>
 </tr>
 <tr>
+	<td>MODAL_DELETE_BUTTON</td>
+	<td>//button[@id='modalDeleteButton']</td>
+	<td></td>
+</tr>
+<tr>
+	<td>TYPE_TITLE_IN_DELETE_MODAL</td>
+	<td>//input[@class='form-control']</td>
+	<td></td>
+</tr>
+<tr>
 	<td>PUBLISH_BUTTON</td>
 	<td>//button[contains(text(),'Publish')]</td>
 	<td></td>
@@ -113,6 +123,11 @@
 <tr>
 	<td>UNPUBLISH_API_APPLICATION_WARNING_DIALOG_TITLE</td>
 	<td>//h1[@class='modal-title' and contains(text(),'Unpublish API Application')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>WARNING_MESSAGE_IN_DELETE_DIALOG</td>
+	<td>//div[@class='form-feedback-item mt-2' and contains(text(),'Please type the API title mentioned above.')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationsInTheAPIBuilder/DeleteAPIApplication.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationsInTheAPIBuilder/DeleteAPIApplication.testcase
@@ -1,0 +1,225 @@
+@component-name = "portal-headless"
+definition {
+
+	property custom.properties = "feature.flag.LPS-184413=true${line.separator}feature.flag.LPS-167253=true${line.separator}feature.flag.LPS-178642=true${line.separator}feature.flag.LPS-186757=true";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Object";
+	property testray.main.component.name = "Headless Builder";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginUI();
+
+		task ("Given create an API application") {
+			ApplicationAPI.createAPIApplication(
+				baseURL = "test",
+				status = "unpublished",
+				title = "test");
+
+			ApplicationAPI.setUpGlobalAPIApplicationId();
+		}
+	}
+
+	tearDown {
+		ApplicationAPI.deleteAllAPIApplication();
+
+		var testLiferayVirtualInstance = PropsUtil.get("test.liferay.virtual.instance");
+
+		if (${testLiferayVirtualInstance} == "true") {
+			PortalInstances.tearDownCP();
+		}
+	}
+
+	@priority = 4
+	test CanDeleteAPIFromApiBuilderAndApi {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+
+		task ("And Given from dropdown menu I click Delete option") {
+			APIBuilderUI.deleteAPIApplication(key_title = "test");
+		}
+
+		task ("When I confirm deletion by typing the API title") {
+			Type(
+				locator1 = "APIBuilder#TYPE_TITLE_IN_DELETE_MODAL",
+				value1 = "test");
+
+			Click(locator1 = "APIBuilder#MODAL_DELETE_BUTTON");
+		}
+
+		task ("Then the API is not present in API Builder") {
+			AssertElementNotPresent(
+				key_name = "test",
+				locator1 = "ObjectAdmin#TABLE_LIST_TITLE");
+		}
+
+		task ("And Then the API is removed from API") {
+			var response = ApplicationAPI.getAPIApplications();
+
+			var totalCount = JSONUtil.getWithJSONPath(${response}, "$..totalCount");
+
+			TestUtils.assertEquals(
+				actual = ${totalCount},
+				expected = 0);
+		}
+	}
+
+	@priority = 4
+	test CanDeletePublishedApiAndAssociatedEntities {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+
+		task ("Given publish an API application in API Builder") {
+			APIBuilderUI.publishApplication(key_title = "test");
+		}
+
+		task ("And Given with postAPISchema to create a Schema associate to the API application") {
+			SchemaAPI.createAPISchema(
+				apiApplicationId = ${staticApplicationId},
+				mainObjectDefinitionERC = "L_API_APPLICATION",
+				name = "mySchema");
+		}
+
+		task ("And Given with postAPIEndpoint to create an Endpoint associate to API application and Schema") {
+			EndpointAPI.createAPIEndpoint(
+				apiApplicationId = ${staticApplicationId},
+				name = "myEndpoint",
+				path = "/myEndpoint");
+		}
+
+		task ("When I delete the API application") {
+			APIBuilderUI.deleteAPIApplication(key_title = "test");
+
+			Type(
+				locator1 = "APIBuilder#TYPE_TITLE_IN_DELETE_MODAL",
+				value1 = "test");
+
+			Click(locator1 = "APIBuilder#MODAL_DELETE_BUTTON");
+		}
+
+		task ("Then the API is not present in API Builder") {
+			AssertElementNotPresent(
+				key_name = "test",
+				locator1 = "ObjectAdmin#TABLE_LIST_TITLE");
+		}
+
+		task ("And Then the associated Endpoint and Schema are deleted") {
+			var responseInSchemas = SchemaAPI.getAPISchemas();
+
+			var totalCountInSchemas = JSONUtil.getWithJSONPath(${responseInSchemas}, "$..totalCount");
+
+			TestUtils.assertEquals(
+				actual = ${totalCountInSchemas},
+				expected = 0);
+
+			var responseInEndpoints = EndpointAPI.getAPIEndpoints();
+
+			var totalCountInEndpoints = JSONUtil.getWithJSONPath(${responseInEndpoints}, "$..totalCount");
+
+			TestUtils.assertEquals(
+				actual = ${totalCountInEndpoints},
+				expected = 0);
+		}
+	}
+
+	@priority = 4
+	test CanDeleteUnpublishedApiAndAssociatedEntities {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+
+		task ("And Given with postAPISchema to create a Schema associate to the API application") {
+			SchemaAPI.createAPISchema(
+				apiApplicationId = ${staticApplicationId},
+				mainObjectDefinitionERC = "L_API_APPLICATION",
+				name = "mySchema");
+		}
+
+		task ("And Given with postAPIEndpoint to create an Endpoint associate to API application and Schema") {
+			EndpointAPI.createAPIEndpoint(
+				apiApplicationId = ${staticApplicationId},
+				name = "myEndpoint",
+				path = "/myEndpoint");
+		}
+
+		task ("When I delete the API application") {
+			APIBuilderUI.deleteAPIApplication(key_title = "test");
+
+			Type(
+				locator1 = "APIBuilder#TYPE_TITLE_IN_DELETE_MODAL",
+				value1 = "test");
+
+			Click(locator1 = "APIBuilder#MODAL_DELETE_BUTTON");
+		}
+
+		task ("Then the API is not present in API Builder") {
+			AssertElementNotPresent(
+				key_name = "test",
+				locator1 = "ObjectAdmin#TABLE_LIST_TITLE");
+		}
+
+		task ("And Then the associated Endpoint and Schema are deleted") {
+			var responseInSchemas = SchemaAPI.getAPISchemas();
+
+			var totalCountInSchemas = JSONUtil.getWithJSONPath(${responseInSchemas}, "$..totalCount");
+
+			TestUtils.assertEquals(
+				actual = ${totalCountInSchemas},
+				expected = 0);
+
+			var responseInEndpoints = EndpointAPI.getAPIEndpoints();
+
+			var totalCountInEndpoints = JSONUtil.getWithJSONPath(${responseInEndpoints}, "$..totalCount");
+
+			TestUtils.assertEquals(
+				actual = ${totalCountInEndpoints},
+				expected = 0);
+		}
+	}
+
+	@priority = 4
+	test CannotDeleteApiWithIncorrectTitleValue {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+
+		task ("And Given from dropdown menu I click Delete option") {
+			APIBuilderUI.deleteAPIApplication(key_title = "test");
+		}
+
+		task ("When I enter 'Test' as the API title") {
+			Type(
+				locator1 = "APIBuilder#TYPE_TITLE_IN_DELETE_MODAL",
+				value1 = "Test");
+		}
+
+		task ("Then I can see message about type the API title") {
+			AssertTextEquals.assertPartialText(
+				locator1 = "APIBuilder#WARNING_MESSAGE_IN_DELETE_DIALOG",
+				value1 = "Please type the API title mentioned above.");
+		}
+
+		task ("And Then Delete button is disabled") {
+			AssertElementPresent(
+				key_text = "modalDeleteButton",
+				locator1 = "Button#ANY_DISABLED");
+		}
+	}
+
+	@priority = 4
+	test CanSeeDeleteApiApplicationDialog {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+
+		task ("When from dropdown menu I click Delete option") {
+			APIBuilderUI.deleteAPIApplication(key_title = "test");
+		}
+
+		task ("Then I can see the prompt message in the Delete API Application dialog") {
+			AssertTextEquals.assertPartialText(
+				locator1 = "Modal#BODY",
+				value1 = "This action cannot be undone and will delete all the related schemas and endpoints within this API.");
+		}
+	}
+
+}


### PR DESCRIPTION
Background:
Add a testcase to delete API Application

Test Plan
CanSeeDeleteApiApplicationDialog
Given create an API application in API Builder
When from dropdown menu I click Delete option
Then I can see the prompt message in the Delete API Application dialog

CannotDeleteApiWithIncorrectTitleValue
Given create an API application in API Builder with title ‘test'
And Given from dropdown menu I click Delete option
When I enter ‘Test’ as the API title
Then I can see message about type the API title
And Then Delete button is disabled

CanDeleteAPIFromApiBuilderAndApi
Given create an API application in API Builder
And Given from dropdown menu I click Delete option
When I confirm deletion by typing the API title
Then the API is not present in API Builder
And Then the API is removed from API

CanDeleteUnpublishedApiAndAssociatedEntities
Given create an API application in API Builder
And Given with postAPISchema to create a Schema associate to the API application
And Given with postAPIEndpoint to create an Endpoint associate to API application and Schema
When I delete the API application
Then the API is not present in API Builder
And Then the associated Endpoint and Schema are deleted

CanDeletePublishedApiAndAssociatedEntities
Given publish an API application in API Builder
And Given with postAPISchema to create a Schema associate to the API application
And Given with postAPIEndpoint to create an Endpoint associate to API application and Schema
When I delete the API application
Then the API is not present in API Builder
And Then the associated Endpoint and Schema are deleted

Jira ticket:
https://liferay.atlassian.net/browse/LPS-181462