### PR TITLE
LPS-192030 Copy URL of an endpoint doesn't work correctly on a virtual instance

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/FDS/fdsUtils/endpointsFDSProps.ts
+++ b/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/FDS/fdsUtils/endpointsFDSProps.ts
@@ -33,11 +33,15 @@ export function getAPIApplicationsEndpointsFDSProps(
 				icon: 'pencil',
 				label: Liferay.Language.get('edit'),
 			},
-			{
-				icon: 'copy',
-				id: 'copyEndpointURL',
-				label: Liferay.Language.get('copy-url'),
-			},
+			...(window.isSecureContext
+				? [
+						{
+							icon: 'copy',
+							id: 'copyEndpointURL',
+							label: Liferay.Language.get('copy-url'),
+						},
+				  ]
+				: []),
 			{
 				icon: 'trash',
 				id: 'deleteAPIApplicationEndpoint',


### PR DESCRIPTION
**Purpose**
The main purpose of this PR is to allow users to use the `Copy URL` action in API Endpoint when the instance is in a secure context. Without this changes, the clipboard object is going to be set as `undefined`. If you want to know more information about that you can check it [here](https://stackoverflow.com/questions/51805395/navigator-clipboard-is-undefined). So, when the context is secured, the action will be displayed.

**JIRA Related Ticket**
https://liferay.atlassian.net/browse/LPS-192030
