### PR TITLE
Master lps 193721 | Add functional tests for generate path structure for api endpoints

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/APIBuilderUI.macro
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/APIBuilderUI.macro
@@ -53,6 +53,35 @@ definition {
 		Click(locator1 = "APIBuilder#CREATE_BUTTON");
 	}
 
+	macro createAPIEndpoint {
+		Variables.assertDefined(parameterList = "${name},${path}");
+
+		Click(locator1 = "Button#PLUS");
+
+		Type(
+			locator1 = "TextInput#NAME",
+			value1 = ${name});
+
+		Type(
+			key_fieldLabel = "Path",
+			locator1 = "TextInput#GENERIC_TEXT_INPUT",
+			value1 = ${path});
+
+		if (isSet(applicationId)) {
+			Click.pauseClickAt(
+				locator1 = "TextInput#ANY_WITH_NAME",
+				name = "r_apiApplicationToAPIEndpoints_c_apiApplicationId");
+
+			Click(
+				applicationId = ${applicationId},
+				locator1 = "APIBuilder#API_APPLICATION_TO_API_ENDPOINTS");
+		}
+
+		AssertClick(
+			locator1 = "Button#SAVE",
+			value1 = "Save");
+	}
+
 	macro deleteAPIApplication {
 		ApplicationsMenu.gotoPortlet(
 			category = "Object",
@@ -115,6 +144,18 @@ definition {
 		KeyPress(
 			locator1 = "TextInput#SEARCH",
 			value1 = "\RETURN");
+	}
+
+	macro setPanelCategoryKeyToObject {
+		Variables.assertDefined(parameterList = ${objectDefinition});
+
+		ObjectAdmin.openObjectAdmin();
+
+		ObjectPortlet.selectCustomObject(label = ${objectDefinition});
+
+		CreateObject.selectPanelCategoryKey(panelCategoryKey = "Control Panel > Object");
+
+		CreateObject.saveObject();
 	}
 
 	macro switchToRelatedEntryInEditApplication {

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/ApplicationAPI.macro
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/ApplicationAPI.macro
@@ -33,14 +33,24 @@ definition {
 
 		var curl = ApplicationAPI._curlAPIApplication(virtualHost = ${virtualHost});
 		var body = '''
-			-d {
-				"applicationStatus": {"key": "${status}","name": "${status}"},
-				"baseURL": "${baseURL}",
-				"title": "${title}"
-			}
+			"applicationStatus": {"key": "${status}","name": "${status}"},
+			"baseURL": "${baseURL}",
+			"title": "${title}"
 		''';
 
-		var curl = StringUtil.add(${curl}, " \ ${body}", "");
+		if (isSet(relatedEndpoint)) {
+			var relatedEndpoint = '''
+				"apiApplicationToAPIEndpoints": [{
+					"httpMethod": "get",
+					"name": "${endpointName}",
+					"path": "${endpointPath}"
+				}]
+			''';
+
+			var body = StringUtil.add(${body}, ", ${relatedEndpoint}", "");
+		}
+
+		var curl = StringUtil.add(${curl}, " -d {${body}}", "");
 
 		var response = JSONCurlUtil.post(${curl});
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/paths/APIBuilder.path
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/paths/APIBuilder.path
@@ -26,6 +26,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>API_APPLICATION_TO_API_ENDPOINTS</td>
+	<td>//button[@class='dropdown-item' and text()='${applicationId}']</td>
+	<td></td>
+</tr>
+<tr>
 	<td>APPLICATION_STATUS</td>
 	<td>//div[@class='table-list-title' and contains(.,'${key_title}')]/../..//div[contains(.,'${key_status}')]</td>
 	<td></td>

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[APIRest]APIGenerator/GeneratePathStructureForEndpoints.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[APIRest]APIGenerator/GeneratePathStructureForEndpoints.testcase
@@ -11,8 +11,6 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginUI();
-
-		SearchAdministration.executeReindex();
 	}
 
 	tearDown {
@@ -31,14 +29,11 @@ definition {
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
-		task ("Given creating an API application in Control Panel > Object > Headless Builder") {
-			APIBuilderUI.createAPIApplication(
-				addByPlus = "true",
+		task ("Given an published API application") {
+			ApplicationAPI.createAPIApplication(
+				baseURL = "app-test",
+				status = "published",
 				title = "App-test");
-		}
-
-		task ("And Given publish the API application by Change Publication Status") {
-			APIBuilderUI.changePublicationStatus(key_title = "App-test");
 		}
 
 		task ("When I go to API Explorer") {
@@ -57,14 +52,11 @@ definition {
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
-		task ("Given creating an API application in Control Panel > Object > Headless Builder") {
-			APIBuilderUI.createAPIApplication(
-				addByPlus = "true",
+		task ("Given an published API application") {
+			ApplicationAPI.createAPIApplication(
+				baseURL = "app-test",
+				status = "published",
 				title = "App-test");
-		}
-
-		task ("And Given publishing the API application by Change Publication Status") {
-			APIBuilderUI.changePublicationStatus(key_title = "App-test");
 		}
 
 		task ("When I navigate to /o/c/{applicationUrl}") {
@@ -92,7 +84,7 @@ definition {
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
-		task ("Given creating an API application in Control Panel > Object > Headless Builder") {
+		task ("Given creating an API application") {
 			var response = ApplicationAPI.createAPIApplication(
 				baseURL = "app-test",
 				status = "unpublished",
@@ -136,14 +128,11 @@ definition {
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
-		task ("Given creating an API application in Control Panel > Object > Headless Builder") {
-			APIBuilderUI.createAPIApplication(
-				addByPlus = "true",
+		task ("Given an published API application") {
+			ApplicationAPI.createAPIApplication(
+				baseURL = "app-test",
+				status = "published",
 				title = "App-test");
-		}
-
-		task ("And Given publishing the API application") {
-			APIBuilderUI.changePublicationStatus(key_title = "App-test");
 		}
 
 		task ("When I navigate to {protocol}//{host}:{port}/o/api?endpoint={protocol}//{host}:{port}/o/c/{applicationUrl}/openapi.json") {
@@ -164,9 +153,10 @@ definition {
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
-		task ("Given creating an API application in Control Panel > Object > Headless Builder") {
-			APIBuilderUI.createAPIApplication(
-				addByPlus = "true",
+		task ("Given creating an API application") {
+			var response = ApplicationAPI.createAPIApplication(
+				baseURL = "app-test",
+				status = "unpublished",
 				title = "App-test");
 		}
 
@@ -263,9 +253,10 @@ definition {
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
-		task ("Given creating an API application in Control Panel > Object > Headless Builder") {
-			APIBuilderUI.createAPIApplication(
-				addByPlus = "true",
+		task ("Given creating an API application") {
+			var response = ApplicationAPI.createAPIApplication(
+				baseURL = "app-test",
+				status = "unpublished",
 				title = "App-test");
 		}
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[APIRest]APIGenerator/GeneratePathStructureForEndpoints.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[APIRest]APIGenerator/GeneratePathStructureForEndpoints.testcase
@@ -1,0 +1,310 @@
+@component-name = "portal-headless"
+definition {
+
+	property custom.properties = "feature.flag.LPS-184413=true${line.separator}feature.flag.LPS-167253=true${line.separator}feature.flag.LPS-178642=true${line.separator}feature.flag.LPS-186757=true";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Object";
+	property testray.main.component.name = "Headless Builder";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginUI();
+
+		SearchAdministration.executeReindex();
+	}
+
+	tearDown {
+		ApplicationAPI.deleteAllAPIApplication();
+
+		var testLiferayVirtualInstance = PropsUtil.get("test.liferay.virtual.instance");
+
+		if (${testLiferayVirtualInstance} == "true") {
+			PortalInstances.tearDownCP();
+		}
+	}
+
+	@priority = 4
+	test APIUrlIsPresentInAPIExplorerRestApplications {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		task ("Given creating an API application in Control Panel > Object > Headless Builder") {
+			APIBuilderUI.createAPIApplication(
+				addByPlus = "true",
+				title = "App-test");
+		}
+
+		task ("And Given publish the API application by Change Publication Status") {
+			APIBuilderUI.changePublicationStatus(key_title = "App-test");
+		}
+
+		task ("When I go to API Explorer") {
+			APIExplorer.navigateToOpenAPI();
+		}
+
+		task ("Then the c/{url} is present in Rest Applications") {
+			AssertElementPresent(
+				locator1 = "Button#BUTTON_WITH_VALUE",
+				value = "c/app-test");
+		}
+	}
+
+	@priority = 3
+	test APIUrlsArePresentInAPIExplorer {
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		task ("Given creating an API application in Control Panel > Object > Headless Builder") {
+			APIBuilderUI.createAPIApplication(
+				addByPlus = "true",
+				title = "App-test");
+		}
+
+		task ("And Given publishing the API application by Change Publication Status") {
+			APIBuilderUI.changePublicationStatus(key_title = "App-test");
+		}
+
+		task ("When I navigate to /o/c/{applicationUrl}") {
+			APIExplorer.navigateToOpenAPI(customObjectPlural = "app-test");
+		}
+
+		task ("Then {protocol}//{host}:{port}/o/c/{applicationUrl}/openapi.json is present") {
+			var portalURL = JSONCompany.getPortalURL();
+
+			AssertTextEquals(
+				locator1 = "OpenAPI#API_URL",
+				value1 = "${portalURL}/o/c/app-test/openapi.json");
+		}
+
+		task ("And Then {protocol}//{host}:{port}/o/c/{applicationUrl} is present in Servers") {
+			AssertTextEquals(
+				locator1 = "Select#HEADLESS_SERVERS",
+				value1 = "${portalURL}/o/c/app-test/");
+		}
+	}
+
+	@priority = 4
+	test CanCreateEndpointWithValidPath {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		task ("Given creating an API application in Control Panel > Object > Headless Builder") {
+			var response = ApplicationAPI.createAPIApplication(
+				baseURL = "app-test",
+				status = "unpublished",
+				title = "App-test");
+		}
+
+		task ("And Given setting Panel Category Key to Control Panel > Object for API Endpoint") {
+			APIBuilderUI.setPanelCategoryKeyToObject(objectDefinition = "API Endpoint");
+		}
+
+		task ("When I create an endpoint with id of API application and valid path") {
+			ApplicationsMenu.gotoPortlet(
+				category = "Object",
+				panel = "Control Panel",
+				portlet = "API Endpoints");
+
+			var applicationId = JSONPathUtil.getIdValue(response = ${response});
+
+			APIBuilderUI.createAPIEndpoint(
+				applicationId = ${applicationId},
+				name = "testEndpoint",
+				path = "/testEndpoint");
+		}
+
+		task ("Then I can see endpoint is created with correct path") {
+			Alert.viewSuccessMessage();
+
+			APIBuilderUI.switchToRelatedEntryInEditApplication(
+				entity = "Endpoints",
+				title = "App-test");
+
+			AssertElementPresent(
+				key_name = "/testEndpoint/",
+				locator1 = "ObjectAdmin#TABLE_LIST_TITLE");
+		}
+	}
+
+	@priority = 4
+	test CanLoadAPIApplicationURL {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		task ("Given creating an API application in Control Panel > Object > Headless Builder") {
+			APIBuilderUI.createAPIApplication(
+				addByPlus = "true",
+				title = "App-test");
+		}
+
+		task ("And Given publishing the API application") {
+			APIBuilderUI.changePublicationStatus(key_title = "App-test");
+		}
+
+		task ("When I navigate to {protocol}//{host}:{port}/o/api?endpoint={protocol}//{host}:{port}/o/c/{applicationUrl}/openapi.json") {
+			APIExplorer.navigateToOpenAPI(customObjectPlural = "app-test");
+		}
+
+		task ("Then the page can load without errors") {
+			WaitForElementPresent(
+				locator1 = "OpenAPI#API_METHOD",
+				method = "getOpenAPI",
+				service = "default");
+		}
+	}
+
+	@priority = 4
+	test CanValidatePathInAPIEndpoint {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		task ("Given creating an API application in Control Panel > Object > Headless Builder") {
+			APIBuilderUI.createAPIApplication(
+				addByPlus = "true",
+				title = "App-test");
+		}
+
+		task ("And Given setting Panel Category Key to Control Panel > Object for API Endpoint") {
+			APIBuilderUI.setPanelCategoryKeyToObject(objectDefinition = "API Endpoint");
+		}
+
+		task ("When I create an endpoint with id of API application and path not start with '/'") {
+			ApplicationsMenu.gotoPortlet(
+				category = "Object",
+				panel = "Control Panel",
+				portlet = "API Endpoints");
+
+			APIBuilderUI.createAPIEndpoint(
+				name = "testEndpoint",
+				path = "testEndpoint");
+		}
+
+		task ("Then I can see error message") {
+			Alert.viewErrorMessage(errorMessage = "Path must start with the \"/\" character.");
+		}
+
+		task ("And Then the endpoint is not being created") {
+			APIBuilderUI.switchToRelatedEntryInEditApplication(
+				entity = "Endpoints",
+				title = "App-test");
+
+			AssertElementNotPresent(
+				key_name = "/testEndpoint/",
+				locator1 = "ObjectAdmin#TABLE_LIST_TITLE");
+		}
+	}
+
+	@priority = 4
+	test PathIsPresentInEndpointsWithEditAPIApplication {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		task ("Given with postAPIApplication including apiApplicationToAPIEndpoints and path to create an API application with its endpoint") {
+			ApplicationAPI.createAPIApplication(
+				baseURL = "app-test",
+				endpointName = "testEndpoint",
+				endpointPath = "/testEndpoint",
+				relatedEndpoint = "true",
+				status = "unpublished",
+				title = "App-test");
+		}
+
+		task ("When I navigate to Endpoints tab in Edit API application") {
+			APIBuilderUI.switchToRelatedEntryInEditApplication(
+				entity = "Endpoints",
+				title = "App-test");
+		}
+
+		task ("Then I can see correct path") {
+			AssertElementPresent(
+				key_name = "/testEndpoint/",
+				locator1 = "ObjectAdmin#TABLE_LIST_TITLE");
+		}
+	}
+
+	@priority = 4
+	test PathIsPresentUnderGetEndpointPage {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		task ("Given with postAPIApplication including apiApplicationToAPIEndpoints and path to create an published API application with its endpoint") {
+			ApplicationAPI.createAPIApplication(
+				baseURL = "app-test",
+				endpointName = "testEndpoint",
+				endpointPath = "/testEndpoint",
+				relatedEndpoint = "true",
+				status = "published",
+				title = "App-test");
+		}
+
+		task ("When I navigate to /o/c/{applicationUrl}") {
+			APIExplorer.navigateToOpenAPI(customObjectPlural = "app-test");
+		}
+
+		task ("Then I can see '/{path}' is present under get{Endpoint}Page") {
+			AssertTextEquals.assertPartialText(
+				locator1 = "OpenAPI#API_METHOD",
+				method = "getTestEndpointPage",
+				service = "default",
+				value1 = "/testEndpoint");
+		}
+	}
+
+	@priority = 3
+	test UrlSubtitleIsPresentInEditAPIApplication {
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		task ("Given creating an API application in Control Panel > Object > Headless Builder") {
+			APIBuilderUI.createAPIApplication(
+				addByPlus = "true",
+				title = "App-test");
+		}
+
+		task ("When Edit the API application") {
+			APIBuilderUI.goToEditAPIApplicationPage(key_title = "App-test");
+		}
+
+		task ("Then I can see label under url is {protocol}//{host}:{port}/o/c") {
+			var portalURL = JSONCompany.getPortalURL();
+
+			AssertTextEquals(
+				locator1 = "APIBuilder#URL_LABEL",
+				value1 = "${portalURL}/o/c/");
+		}
+	}
+
+	@priority = 3
+	test UrlSubtitleIsPresentInNewAPIApplication {
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		task ("Given going to Control Panel > Object > Headless Builder") {
+			ApplicationsMenu.gotoPortlet(
+				category = "Object",
+				panel = "Control Panel",
+				portlet = "API Builder");
+		}
+
+		task ("When I create a new API Application") {
+			Click(locator1 = "Button#PLUS");
+		}
+
+		task ("Then I can see label under url is {protocol}//{host}:{port}/o/c") {
+			var portalURL = JSONCompany.getPortalURL();
+
+			AssertTextEquals(
+				locator1 = "APIBuilder#URL_LABEL",
+				value1 = "${portalURL}/o/c/");
+		}
+	}
+
+}

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portal/openapi/OpenAPI.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portal/openapi/OpenAPI.path
@@ -57,6 +57,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>API_URL</td>
+	<td>//span[@class='url']</td>
+	<td></td>
+</tr>
+<tr>
 	<td>PARAMETER_UNDER_METHOD</td>
 	<td>//div[contains(@id,'${method}')]//input[contains(@placeholder,'${parameter}')]</td>
 	<td></td>


### PR DESCRIPTION
**Background**:
- Add functional tests on generate path structure for endpoints

**Note**:
- `CanCopyUrlOfEndpoint` is already automatated in ListAPIApplicationEndpoints.CanCopyURLOfAPIEndpoint, not going to automate it again in this pr
- Integration test for `CanValidatePathThroughAPI` is already added in APIEndpointRelevantObjectEntryModelListenerTest.test, not going to add it in this pr
- Update to use api to create api application in Given + And Given

**Jira Ticket**:
- https://liferay.atlassian.net/browse/LPS-192114

**Test Plan**:
- Given going to Control Panel > Object > Headless BuilderWhen I create a new API ApplicationThen I can see label under url is {protocol}//{host}:{port}/o/c
- Given creating an API application in Control Panel > Object > Headless BuilderWhen Edit the API applicationThen I can see label under url is {protocol}//{host}:{port}/o/c
- Given creating an API application in Control Panel > Object > Headless BuilderAnd Given publish the API application by Change Publication StatusWhen I can to API ExplorerThen the c/{url} is present in Rest Applications
- Given creating an API application in Control Panel > Object > Headless BuilderAnd Given publishing the API applicationWhen I navigate to {protocol}//{host}:{port}/o/api?endpoint={protocol}//{host}:{port}/o/c/{applicationUrl}/openapi.jsonThen the page can load without errors
- Given creating an API application in Control Panel > Object > Headless BuilderAnd Given publishing the API application by Change Publication StatusWhen I navigate to /o/c/{applicationUrl}Then {protocol}//{host}:{port}/o/c/{applicationUrl}/openapi.json is presentAnd Then {protocol}//{host}:{port}/o/c/{applicationUrl} is present in Servers
- Given with postAPIApplication including apiApplicationToAPIEndpoints and path to create an API application with its endpointAnd Given going to Control Panel > Object > Headless BuilderWhen I navigate to Endpoints tab in Edit API applicationThen I can see correct path
- Given creating an API application in Control Panel > Object > Headless BuilderAnd Given setting Panel Category Key to Control Panel > Object for API EndpointWhen I create an endpoint with id of API application and path not start with '/'Then I can see error messageAnd Then the endpoint is not being created
- Given creating an API application in Control Panel > Object > Headless BuilderAnd Given setting Panel Category Key to Control Panel > Object for API EndpointWhen I create an endpoint with id of API application and valid pathThen I can see endpoint is created with correct path
- Given with postAPIApplication including apiApplicationToAPIEndpoints and path to create an published API application with its endpointWhen I navigate to /o/c/{applicationUrl}Then I can see '/{path}' is present under get{Endpoint}Page


