### PR TITLE
Master lps 190858 | Add tests on generate openAPI for api application definition

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/ApplicationAPI.macro
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/ApplicationAPI.macro
@@ -50,6 +50,17 @@ definition {
 			var body = StringUtil.add(${body}, ", ${relatedEndpoint}", "");
 		}
 
+		if (isSet(relatedSchema)) {
+			var relatedSchema = '''
+				"apiApplicationToAPISchemas": [{
+					"mainObjectDefinitionERC": "${mainObjectDefinitionErc}",
+					"name": "${schemaName}"
+				}]
+			''';
+
+			var body = StringUtil.add(${body}, ", ${relatedSchema}", "");
+		}
+
 		var curl = StringUtil.add(${curl}, " -d {${body}}", "");
 
 		var response = JSONCurlUtil.post(${curl});

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/SchemaAPI.macro
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/SchemaAPI.macro
@@ -14,6 +14,14 @@ definition {
 
 		var api = "headless-builder/schemas";
 
+		if (isSet(requestSchemaId) && isSet(endpointId)) {
+			var api = "${api}/${requestSchemaId}/requestAPISchemaToAPIEndpoints/${endpointId}";
+		}
+
+		if (isSet(responseSchemaId) && isSet(endpointId)) {
+			var api = "${api}/${responseSchemaId}/responseAPISchemaToAPIEndpoints/${endpointId}";
+		}
+
 		var curl = '''
 			${portalURL}/o/${api} \
 				-u test@liferay.com:test \
@@ -63,6 +71,38 @@ definition {
 		var response = JSONCurlUtil.get(${curl});
 
 		return ${response};
+	}
+
+	macro relateRequestSchemaToEndpointByIds {
+		Variables.assertDefined(parameterList = "${requestSchemaId},${endpointId}");
+
+		var curl = SchemaAPI._curlAPISchema(
+			endpointId = ${endpointId},
+			requestSchemaId = ${requestSchemaId});
+
+		var response = JSONCurlUtil.put(${curl});
+
+		var schemaId = JSONUtil.getWithJSONPath(${response}, "$.r_requestAPISchemaToAPIEndpoints_c_apiSchemaId");
+
+		TestUtils.assertEquals(
+			actual = ${schemaId},
+			expected = ${requestSchemaId});
+	}
+
+	macro relateResponseSchemaToEndpointByIds {
+		Variables.assertDefined(parameterList = "${responseSchemaId},${endpointId}");
+
+		var curl = SchemaAPI._curlAPISchema(
+			endpointId = ${endpointId},
+			responseSchemaId = ${responseSchemaId});
+
+		var response = JSONCurlUtil.put(${curl});
+
+		var schemaId = JSONUtil.getWithJSONPath(${response}, "$.r_responseAPISchemaToAPIEndpoints_c_apiSchemaId");
+
+		TestUtils.assertEquals(
+			actual = ${schemaId},
+			expected = ${responseSchemaId});
 	}
 
 }

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[APIRest]APIGenerator/GenerateOpenAPIFromAPIApplicationDefinition.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[APIRest]APIGenerator/GenerateOpenAPIFromAPIApplicationDefinition.testcase
@@ -1,0 +1,208 @@
+@component-name = "portal-headless"
+definition {
+
+	property custom.properties = "feature.flag.LPS-184413=true${line.separator}feature.flag.LPS-167253=true${line.separator}feature.flag.LPS-178642=true${line.separator}feature.flag.LPS-186757=true";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Object";
+	property testray.main.component.name = "Headless Builder";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginUI();
+	}
+
+	tearDown {
+		ApplicationAPI.deleteAllAPIApplication();
+
+		var testLiferayVirtualInstance = PropsUtil.get("test.liferay.virtual.instance");
+
+		if (${testLiferayVirtualInstance} == "true") {
+			PortalInstances.tearDownCP();
+		}
+	}
+
+	@priority = 5
+	test CanGenerateOpenApiFromApiApplicationDefinition {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		task ("Given APIApplication ‘my-app’ with APIEndpoints with related APISchemas created") {
+			var response = ApplicationAPI.createAPIApplication(
+				baseURL = "my-app",
+				endpointName = "testEndpoint",
+				endpointPath = "/testEndpoint",
+				mainObjectDefinitionErc = "L_API_APPLICATION",
+				relatedEndpoint = "true",
+				relatedSchema = "true",
+				schemaName = "testSchema",
+				status = "unpublished",
+				title = "My-app");
+
+			var endpointId = JSONUtil.getWithJSONPath(${response}, "$.apiApplicationToAPIEndpoints[*].id");
+			var schemaId = JSONUtil.getWithJSONPath(${response}, "$.apiApplicationToAPISchemas[*].id");
+			var aPIApplicationId = JSONPathUtil.getIdValue(response = ${response});
+
+			SchemaAPI.relateRequestSchemaToEndpointByIds(
+				endpointId = ${endpointId},
+				requestSchemaId = ${schemaId});
+
+			SchemaAPI.relateResponseSchemaToEndpointByIds(
+				endpointId = ${endpointId},
+				responseSchemaId = ${schemaId});
+		}
+
+		task ("And Given I publish the APIApplication") {
+			ApplicationAPI.updateAPIApplication(
+				aPIApplicationId = ${aPIApplicationId},
+				parameter = "applicationStatus",
+				parameterValue = "published");
+		}
+
+		task ("When I click ‘my-app’ on the REST Applications list of API Explorer") {
+			APIExplorer.navigateToOpenAPI(customObjectPlural = "my-app");
+		}
+
+		task ("Then I am redirected to the OpenApi page with endpoints and schemas details") {
+			AssertTextEquals.assertPartialText(
+				locator1 = "OpenAPI#API_METHOD",
+				method = "getTestEndpointPage",
+				service = "testSchema",
+				value1 = "/testEndpoint");
+
+			AssertElementPresent(
+				locator1 = "OpenAPI#SCHEMA_COLLAPSED",
+				schema = "testSchema");
+		}
+
+		task ("And Then no “Failed to load API definition.” error") {
+			AssertConsoleTextNotPresent(value1 = "Failed to load API definition.");
+		}
+	}
+
+	@priority = 4
+	test CanHideApiApplicationOnRestApplicationsListByUnbublishing {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		task ("Given APIApplication ‘my-app’ of status ‘published’ with APIEndpoints with related APISchemas created") {
+			var response = ApplicationAPI.createAPIApplication(
+				baseURL = "my-app",
+				endpointName = "testEndpoint",
+				endpointPath = "/testEndpoint",
+				mainObjectDefinitionErc = "L_API_APPLICATION",
+				relatedEndpoint = "true",
+				relatedSchema = "true",
+				schemaName = "testSchema",
+				status = "published",
+				title = "My-app");
+		}
+
+		task ("When I change state to ‘unpublish’") {
+			var aPIApplicationId = JSONPathUtil.getIdValue(response = ${response});
+
+			ApplicationAPI.updateAPIApplication(
+				aPIApplicationId = ${aPIApplicationId},
+				parameter = "applicationStatus",
+				parameterValue = "unpublished");
+		}
+
+		task ("Then I cannot see ‘my-app’ on the REST Applications list of API Explorer") {
+			APIExplorer.navigateToOpenAPI();
+
+			AssertElementNotPresent(
+				locator1 = "Button#BUTTON_WITH_VALUE",
+				value = "c/my-app");
+		}
+	}
+
+	@priority = 4
+	test CannotSeeUnpublishedApiApplicationListedAsRestApplication {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		task ("When APIApplication ‘my-app’ of status ‘unpublished’ with APIEndpoints with related APISchemas created") {
+			var response = ApplicationAPI.createAPIApplication(
+				baseURL = "my-app",
+				endpointName = "testEndpoint",
+				endpointPath = "/testEndpoint",
+				mainObjectDefinitionErc = "L_API_APPLICATION",
+				relatedEndpoint = "true",
+				relatedSchema = "true",
+				schemaName = "testSchema",
+				status = "unpublished",
+				title = "My-app");
+
+			var endpointId = JSONUtil.getWithJSONPath(${response}, "$.apiApplicationToAPIEndpoints[*].id");
+			var schemaId = JSONUtil.getWithJSONPath(${response}, "$.apiApplicationToAPISchemas[*].id");
+
+			SchemaAPI.relateRequestSchemaToEndpointByIds(
+				endpointId = ${endpointId},
+				requestSchemaId = ${schemaId});
+
+			SchemaAPI.relateResponseSchemaToEndpointByIds(
+				endpointId = ${endpointId},
+				responseSchemaId = ${schemaId});
+		}
+
+		task ("Then I cannot see ‘my-app’ on the REST Applications list of API Explorer") {
+			APIExplorer.navigateToOpenAPI();
+
+			AssertElementNotPresent(
+				locator1 = "Button#BUTTON_WITH_VALUE",
+				value = "c/my-app");
+		}
+	}
+
+	@priority = 4
+	test CanSeePublishedApiApplicationListedAsRestApplication {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		task ("Given APIApplication ‘my-app’ with APIEndpoints with related APISchemas created") {
+			var response = ApplicationAPI.createAPIApplication(
+				baseURL = "my-app",
+				endpointName = "testEndpoint",
+				endpointPath = "/testEndpoint",
+				mainObjectDefinitionErc = "L_API_APPLICATION",
+				relatedEndpoint = "true",
+				relatedSchema = "true",
+				schemaName = "testSchema",
+				status = "unpublished",
+				title = "My-app");
+
+			var endpointId = JSONUtil.getWithJSONPath(${response}, "$.apiApplicationToAPIEndpoints[*].id");
+			var schemaId = JSONUtil.getWithJSONPath(${response}, "$.apiApplicationToAPISchemas[*].id");
+			var aPIApplicationId = JSONPathUtil.getIdValue(response = ${response});
+
+			SchemaAPI.relateRequestSchemaToEndpointByIds(
+				endpointId = ${endpointId},
+				requestSchemaId = ${schemaId});
+
+			SchemaAPI.relateResponseSchemaToEndpointByIds(
+				endpointId = ${endpointId},
+				responseSchemaId = ${schemaId});
+		}
+
+		task ("When I publish the APIApplication") {
+			ApplicationAPI.updateAPIApplication(
+				aPIApplicationId = ${aPIApplicationId},
+				parameter = "applicationStatus",
+				parameterValue = "published");
+		}
+
+		task ("Then I can see ‘my-app’ on the REST Applications list of API Explorer") {
+			APIExplorer.navigateToOpenAPI();
+
+			AssertElementPresent(
+				locator1 = "Button#BUTTON_WITH_VALUE",
+				value = "c/my-app");
+		}
+	}
+
+}

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[APIRest]APIGenerator/GenerateOpenAPIFromAPIApplicationDefinition.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[APIRest]APIGenerator/GenerateOpenAPIFromAPIApplicationDefinition.testcase
@@ -26,8 +26,6 @@ definition {
 	@priority = 5
 	test CanGenerateOpenApiFromApiApplicationDefinition {
 		property portal.acceptance = "true";
-		property test.liferay.virtual.instance = "false";
-		property test.run.type = "single";
 
 		task ("Given APIApplication ‘my-app’ with APIEndpoints with related APISchemas created") {
 			var response = ApplicationAPI.createAPIApplication(
@@ -85,8 +83,6 @@ definition {
 	@priority = 4
 	test CanHideApiApplicationOnRestApplicationsListByUnbublishing {
 		property portal.acceptance = "true";
-		property test.liferay.virtual.instance = "false";
-		property test.run.type = "single";
 
 		task ("Given APIApplication ‘my-app’ of status ‘published’ with APIEndpoints with related APISchemas created") {
 			var response = ApplicationAPI.createAPIApplication(
@@ -122,8 +118,6 @@ definition {
 	@priority = 4
 	test CannotSeeUnpublishedApiApplicationListedAsRestApplication {
 		property portal.acceptance = "true";
-		property test.liferay.virtual.instance = "false";
-		property test.run.type = "single";
 
 		task ("When APIApplication ‘my-app’ of status ‘unpublished’ with APIEndpoints with related APISchemas created") {
 			var response = ApplicationAPI.createAPIApplication(
@@ -161,8 +155,6 @@ definition {
 	@priority = 4
 	test CanSeePublishedApiApplicationListedAsRestApplication {
 		property portal.acceptance = "true";
-		property test.liferay.virtual.instance = "false";
-		property test.run.type = "single";
 
 		task ("Given APIApplication ‘my-app’ with APIEndpoints with related APISchemas created") {
 			var response = ApplicationAPI.createAPIApplication(


### PR DESCRIPTION
**Background**
- Add functional tests

**Note**
- I've rebased to previous https://github.com/liferay-headless/liferay-portal/pull/1445 since the current test also use relatedEndpoint in ApplicationAPI.macro

**Test Plan**
- Given APIApplication ‘my-app’ with APIEndpoints with related APISchemas created
When I publish the APIApplication 
Then I can see ‘my-app’ on the REST Applications list of API Explorer
- When APIApplication ‘my-app’ of status ‘unpublished’ with APIEndpoints with related APISchemas created
Then I cannot see ‘my-app’ on the REST Applications list of API Explorer
- Given APIApplication ‘my-app’ of status ‘published’ with APIEndpoints with related APISchemas created
When I change state to ‘unpublish’
Then I cannot see ‘my-app’ on the REST Applications list of API Explorer
- Given APIApplication ‘my-app’ with APIEndpoints with related APISchemas created
And Given I publish the APIApplication 
When I click ‘my-app’ on the REST Applications list of API Explorer
Then I am redirected to the OpenApi page with endpoints and schemas details
And Then no “Failed to load API definition.” error

**Jira Ticket:**
- https://liferay.atlassian.net/browse/LPS-194106