### PR TITLE
LPS-182465 | Filter sort and search the list of applications

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/APIBuilderUI.macro
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/APIBuilderUI.macro
@@ -102,13 +102,33 @@ definition {
 
 		Click.pauseClickAt(locator1 = "APIBuilder#LAST_UPDATED_IN_FILTER");
 
-		Type(
+		Type.sendKeys(
 			locator1 = "APIBuilder#FROM_DATE",
 			value1 = ${fromDate});
 
-		Type(
+		Type.sendKeys(
 			locator1 = "APIBuilder#TO_DATE",
 			value1 = ${toDate});
+
+		Click(
+			key_text = "Add Filter",
+			locator1 = "Button#ANY");
+	}
+
+	macro filterByStatus {
+		Variables.assertDefined(parameterList = ${labelName});
+
+		Click.pauseClickAt(locator1 = "Dropdown#FILTER");
+
+		Click.pauseClickAt(locator1 = "APIBuilder#STATUS_IN_FILTER");
+
+		Check.checkNotVisible(
+			locator1 = "Radio#ANY",
+			radioLabel = ${labelName});
+
+		if (isSet(exclude)) {
+			Check.checkToggleSwitch(locator1 = "APIBuilder#EXCLUDE_TOGGLE");
+		}
 
 		Click(
 			key_text = "Add Filter",

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/paths/APIBuilder.path
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/paths/APIBuilder.path
@@ -101,6 +101,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>EXCLUDE_TOGGLE</td>
+	<td>//div[@class='dropdown-menu show']//*[@type="checkbox" and @id='autocomplete-exclude-applicationStatus']</td>
+	<td></td>
+</tr>
+<tr>
 	<td>FROM_DATE</td>
 	<td>//input[contains(@id,'from-dateModified') and @placeholder='yyyy-mm-dd']</td>
 	<td></td>
@@ -118,6 +123,11 @@
 <tr>
 	<td>PUBLISH_BUTTON</td>
 	<td>//button[contains(text(),'Publish')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>STATUS_IN_FILTER</td>
+	<td>//div[contains(@class,'dropdown-menu show')]//button[contains(text(),'Status')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationsInTheAPIBuilder/FilterSortAndSearchTheListOfAPIApplications.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationsInTheAPIBuilder/FilterSortAndSearchTheListOfAPIApplications.testcase
@@ -88,20 +88,9 @@ definition {
 		}
 
 		task ("Then I can see no API Application Found") {
-			AssertElementNotPresent(
-				key_status = "Published",
-				key_title = "test1",
-				locator1 = "APIBuilder#APPLICATION_STATUS");
-
-			AssertElementNotPresent(
-				key_status = "Unpublished",
-				key_title = "test2",
-				locator1 = "APIBuilder#APPLICATION_STATUS");
-
-			AssertElementNotPresent(
-				key_status = "Unpublished",
-				key_title = "test3",
-				locator1 = "APIBuilder#APPLICATION_STATUS");
+			AssertTextEquals(
+				locator1 = "Message#EMPTY_STATE_INFO",
+				value1 = "No API Application Found");
 		}
 	}
 
@@ -159,20 +148,9 @@ definition {
 		}
 
 		task ("Then no API application were found") {
-			AssertElementNotPresent(
-				key_status = "Published",
-				key_title = "test1",
-				locator1 = "APIBuilder#APPLICATION_STATUS");
-
-			AssertElementNotPresent(
-				key_status = "Unpublished",
-				key_title = "test2",
-				locator1 = "APIBuilder#APPLICATION_STATUS");
-
-			AssertElementNotPresent(
-				key_status = "Unpublished",
-				key_title = "test3",
-				locator1 = "APIBuilder#APPLICATION_STATUS");
+			AssertTextEquals(
+				locator1 = "Message#EMPTY_STATE_INFO",
+				value1 = "No API Application Found");
 		}
 	}
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationsInTheAPIBuilder/FilterSortAndSearchTheListOfAPIApplications.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationsInTheAPIBuilder/FilterSortAndSearchTheListOfAPIApplications.testcase
@@ -1,0 +1,230 @@
+@component-name = "portal-headless"
+definition {
+
+	property custom.properties = "feature.flag.LPS-184413=true${line.separator}feature.flag.LPS-167253=true${line.separator}feature.flag.LPS-178642=true${line.separator}feature.flag.LPS-186757=true";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Object";
+	property testray.main.component.name = "Headless Builder";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginUI();
+
+		task ("Given three applications and one of the status of the applications is published") {
+			ApplicationAPI.createAPIApplication(
+				baseURL = "test1",
+				status = "published",
+				title = "test1");
+
+			ApplicationAPI.createAPIApplication(
+				baseURL = "test2",
+				status = "unpublished",
+				title = "test2");
+
+			ApplicationAPI.createAPIApplication(
+				baseURL = "test3",
+				status = "unpublished",
+				title = "test3");
+
+			ApplicationsMenu.gotoPortlet(
+				category = "Object",
+				panel = "Control Panel",
+				portlet = "API Builder");
+		}
+	}
+
+	tearDown {
+		ApplicationAPI.deleteAllAPIApplication();
+
+		var testLiferayVirtualInstance = PropsUtil.get("test.liferay.virtual.instance");
+
+		if (${testLiferayVirtualInstance} == "true") {
+			PortalInstances.tearDownCP();
+		}
+	}
+
+	@priority = 4
+	test CanFilterAPIsByExcludeStatus {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		task ("When I filter by Published status with exclude enabled") {
+			APIBuilderUI.filterByStatus(
+				exclude = "true",
+				labelName = "Published");
+		}
+
+		task ("Then two unpublished APIs are listed") {
+			AssertElementPresent(
+				key_status = "Unpublished",
+				key_title = "test2",
+				locator1 = "APIBuilder#APPLICATION_STATUS");
+
+			AssertElementPresent(
+				key_status = "Unpublished",
+				key_title = "test3",
+				locator1 = "APIBuilder#APPLICATION_STATUS");
+
+			AssertElementNotPresent(
+				key_status = "Published",
+				key_title = "test1",
+				locator1 = "APIBuilder#APPLICATION_STATUS");
+		}
+	}
+
+	@priority = 4
+	test CanFilterAPIsByLastUpdated {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		task ("When I filter by Last updated From 06/30/2023 to 06/30/2023") {
+			APIBuilderUI.filterByLastUpdated(
+				fromDate = "06/30/2023",
+				toDate = "06/30/2023");
+		}
+
+		task ("Then I can see no API Application Found") {
+			AssertElementNotPresent(
+				key_status = "Published",
+				key_title = "test1",
+				locator1 = "APIBuilder#APPLICATION_STATUS");
+
+			AssertElementNotPresent(
+				key_status = "Unpublished",
+				key_title = "test2",
+				locator1 = "APIBuilder#APPLICATION_STATUS");
+
+			AssertElementNotPresent(
+				key_status = "Unpublished",
+				key_title = "test3",
+				locator1 = "APIBuilder#APPLICATION_STATUS");
+		}
+	}
+
+	@priority = 4
+	test CanFilterAPIsByStatus {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		task ("When I filter by Published status") {
+			APIBuilderUI.filterByStatus(labelName = "Published");
+		}
+
+		task ("Then only the published API is listed") {
+			AssertElementPresent(
+				key_status = "Published",
+				key_title = "test1",
+				locator1 = "APIBuilder#APPLICATION_STATUS");
+
+			AssertElementNotPresent(
+				key_status = "Unpublished",
+				key_title = "test2",
+				locator1 = "APIBuilder#APPLICATION_STATUS");
+
+			AssertElementNotPresent(
+				key_status = "Unpublished",
+				key_title = "test3",
+				locator1 = "APIBuilder#APPLICATION_STATUS");
+		}
+	}
+
+	@priority = 4
+	test CanSearchAPIsByTitle {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		task ("When I search the API applications with a valid title") {
+			APIBuilderUI.searchItem(value = "test1");
+		}
+
+		task ("Then I can retrieve all available API applications") {
+			APIBuilderUI.viewItemsInOrder(itemList = "test1");
+		}
+	}
+
+	@priority = 4
+	test CanSearchAPIsWithoutAvailableOnes {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		task ("When I search the API applications with unrelated word") {
+			APIBuilderUI.searchItem(value = "Application");
+		}
+
+		task ("Then no API application were found") {
+			AssertElementNotPresent(
+				key_status = "Published",
+				key_title = "test1",
+				locator1 = "APIBuilder#APPLICATION_STATUS");
+
+			AssertElementNotPresent(
+				key_status = "Unpublished",
+				key_title = "test2",
+				locator1 = "APIBuilder#APPLICATION_STATUS");
+
+			AssertElementNotPresent(
+				key_status = "Unpublished",
+				key_title = "test3",
+				locator1 = "APIBuilder#APPLICATION_STATUS");
+		}
+	}
+
+	@priority = 4
+	test CanSortAPIsByLastUpdated {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		task ("When I sort the APIs by Last Updated") {
+			Click(
+				locator1 = "APIBuilder#DND_TR_BUTTON",
+				value = "Last updated");
+		}
+
+		task ("Then the APIs are sorted by Last Updated") {
+			APIBuilderUI.viewItemsInOrder(itemList = "test1,test2,test3");
+		}
+	}
+
+	@priority = 4
+	test CanSortAPIsByStatus {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		task ("When I sort the APIs by Status") {
+			Click(
+				locator1 = "APIBuilder#DND_TR_BUTTON",
+				value = "Status");
+		}
+
+		task ("Then the APIs are sorted by Status") {
+			APIBuilderUI.viewItemsInOrder(itemList = "test1,test2,test3");
+		}
+	}
+
+	@priority = 4
+	test CanSortAPIsByTitle {
+		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		task ("When I sort the APIs by Title") {
+			Click(
+				locator1 = "APIBuilder#DND_TR_BUTTON",
+				value = "Title");
+		}
+
+		task ("Then the APIs are sorted by Title") {
+			APIBuilderUI.viewItemsInOrder(itemList = "test1,test2,test3");
+		}
+	}
+
+}


### PR DESCRIPTION
**Background:**
Add a testcase to filter sort and search the list of applications

**Test Plan**
CanFilterAPIsByStatus
When I filter by Published status
Then only the published API is listed

CanFilterAPIsByExcludeStatus
When I filter by Published status with exclude enabled
Then two unpublished APIs are listed

CanFilterAPIsByLastUpdated
When I filter by Last updated From 06/30/2023 to 06/30/2023
Then I can see no API Application Found

CanSortAPIsByTitle
When I sort the APIs by Title
Then the APIs are sorted by Title

CanSortAPIsByLastUpdated
When I sort the APIs by Last Updated
Then the APIs are sorted by Last Updated

CanSortAPIsByStatus
When I sort the APIs by Status
Then the APIs are sorted by Status

CanSearchAPIsWithoutAvailableOnes
When I search the API applications with unrelated word
Then no API application were found

CanSearchAPIsByTitle
When I search the API applications with a valid title
Then I can retrieve all available API applications

**Jira ticket:**
https://liferay.atlassian.net/browse/LPS-189822