### PR TITLE
LPS-194670 / LPP-50563 Fix fot the 'talend' tab found in Job Scheduler

### DIFF
--- a/modules/apps/dispatch/dispatch-talend-web/bnd.bnd
+++ b/modules/apps/dispatch/dispatch-talend-web/bnd.bnd
@@ -2,3 +2,4 @@ Bundle-Name: Liferay Dispatch Talend Web
 Bundle-SymbolicName: com.liferay.dispatch.talend.web
 Bundle-Version: 3.0.31
 Web-ContextPath: /dispatch-talend-web
+-dsannotations-options: inherit


### PR DESCRIPTION
What's changed?:
- Added in the dispatch-talend-web `bnd.bnd ` a clausule so that through inheritance, OSGI components can be used.

See the following Jira tickets: [LPP-50563](https://liferay.atlassian.net/browse/LPP-50563) / [LPS-194670](https://liferay.atlassian.net/browse/LPS-194670)