### PR TITLE
LPS-194745 Uncomment test

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
@@ -798,11 +798,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			"integerProperty", 2,
 			"integerProperty gt 1 or integerProperty lt 1");
 
-		// TODO Uncomment the following test when LPS-191929 is fixed
-
-		//_assertFilterString(
-
-		// "integerProperty", 1, "not (integerProperty ge 2)");
+		_assertFilterString("integerProperty", 1, "not (integerProperty ge 2)");
 
 		// String functions
 


### PR DESCRIPTION
Related issue: https://liferay.atlassian.net/browse/LPS-194745

The purpose of this PR is to uncomment the existing test that was commented as I opened a [bug](https://liferay.atlassian.net/browse/LPS-191929). As [the bug](https://liferay.atlassian.net/browse/LPS-191929) has been fixed, the test might be uncommented.