### PR TITLE
LPS-194127 Multitenancy in Headless Builder

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/application/publisher/APIApplicationPublisherImpl.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/application/publisher/APIApplicationPublisherImpl.java
@@ -9,7 +9,9 @@ import com.liferay.headless.builder.application.APIApplication;
 import com.liferay.headless.builder.application.publisher.APIApplicationPublisher;
 import com.liferay.headless.builder.constants.HeadlessBuilderConstants;
 import com.liferay.headless.builder.internal.application.endpoint.EndpointMatcher;
+import com.liferay.headless.builder.internal.application.registry.ApiApplicationRegistry;
 import com.liferay.headless.builder.internal.helper.EndpointHelper;
+import com.liferay.headless.builder.internal.jaxrs.application.ApiApplicationJaxrsApplication;
 import com.liferay.headless.builder.internal.resource.HeadlessBuilderResourceImpl;
 import com.liferay.headless.builder.internal.resource.OpenAPIResourceImpl;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
@@ -46,6 +48,10 @@ public class APIApplicationPublisherImpl implements APIApplicationPublisher {
 				"APIApplicationPublisher not available");
 		}
 
+		if (_existsApplication(apiApplication)) {
+			return;
+		}
+
 		String osgiJaxRsName = _getOSGiJaxRsName(apiApplication);
 
 		_serviceRegistrationsMap.computeIfAbsent(
@@ -62,7 +68,6 @@ public class APIApplicationPublisherImpl implements APIApplicationPublisher {
 							osgiJaxRsName, HeadlessBuilderResourceImpl.class,
 							() -> new HeadlessBuilderResourceImpl(
 								_endpointHelper, endpointMatcher)));
-
 					add(
 						_registerResource(
 							osgiJaxRsName, OpenAPIResourceImpl.class,
@@ -103,6 +108,18 @@ public class APIApplicationPublisherImpl implements APIApplicationPublisher {
 		_serviceRegistrationsMap.clear();
 	}
 
+	private boolean _existsApplication(APIApplication apiApplication) {
+		APIApplication currentAPIApplication =
+			_apiApplicationRegistry.fetchApiApplication(
+				apiApplication.getBaseURL(), apiApplication.getCompanyId());
+
+		if (currentAPIApplication != null) {
+			return true;
+		}
+
+		return false;
+	}
+
 	private String _getOSGiJaxRsName(APIApplication apiApplication) {
 		return _getOSGiJaxRsName(
 			apiApplication.getBaseURL(), apiApplication.getCompanyId());
@@ -116,7 +133,8 @@ public class APIApplicationPublisherImpl implements APIApplicationPublisher {
 		APIApplication apiApplication, String osgiJaxRsName) {
 
 		return _bundleContext.registerService(
-			Application.class, new Application(),
+			Application.class,
+			new ApiApplicationJaxrsApplication(apiApplication),
 			HashMapDictionaryBuilder.<String, Object>put(
 				"companyId", apiApplication.getCompanyId()
 			).put(
@@ -182,6 +200,9 @@ public class APIApplicationPublisherImpl implements APIApplicationPublisher {
 	}
 
 	private static BundleContext _bundleContext;
+
+	@Reference
+	private ApiApplicationRegistry _apiApplicationRegistry;
 
 	@Reference
 	private EndpointHelper _endpointHelper;

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/application/publisher/APIApplicationPublisherImpl.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/application/publisher/APIApplicationPublisherImpl.java
@@ -12,6 +12,7 @@ import com.liferay.headless.builder.internal.application.endpoint.EndpointMatche
 import com.liferay.headless.builder.internal.application.registry.ApiApplicationRegistry;
 import com.liferay.headless.builder.internal.helper.EndpointHelper;
 import com.liferay.headless.builder.internal.jaxrs.application.ApiApplicationJaxrsApplication;
+import com.liferay.headless.builder.internal.jaxrs.context.provider.APIApplicationContextProvider;
 import com.liferay.headless.builder.internal.resource.HeadlessBuilderResourceImpl;
 import com.liferay.headless.builder.internal.resource.OpenAPIResourceImpl;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
@@ -25,6 +26,8 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 import javax.ws.rs.core.Application;
+
+import org.apache.cxf.jaxrs.ext.ContextProvider;
 
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
@@ -59,15 +62,14 @@ public class APIApplicationPublisherImpl implements APIApplicationPublisher {
 			key -> new ArrayList<ServiceRegistration<?>>() {
 				{
 					add(_registerApplication(apiApplication, osgiJaxRsName));
-
-					EndpointMatcher endpointMatcher = new EndpointMatcher(
-						apiApplication.getEndpoints());
-
+					add(_registerContextProvider(osgiJaxRsName));
 					add(
 						_registerResource(
 							osgiJaxRsName, HeadlessBuilderResourceImpl.class,
 							() -> new HeadlessBuilderResourceImpl(
-								_endpointHelper, endpointMatcher)));
+								_endpointHelper,
+								new EndpointMatcher(
+									apiApplication.getEndpoints()))));
 					add(
 						_registerResource(
 							osgiJaxRsName, OpenAPIResourceImpl.class,
@@ -152,6 +154,23 @@ public class APIApplicationPublisherImpl implements APIApplicationPublisher {
 				"(osgi.jaxrs.name=Liferay.Vulcan)"
 			).put(
 				"osgi.jaxrs.name", osgiJaxRsName
+			).build());
+	}
+
+	private ServiceRegistration<?> _registerContextProvider(
+		String osgiJaxRsName) {
+
+		return _bundleContext.registerService(
+			ContextProvider.class,
+			new APIApplicationContextProvider(_apiApplicationRegistry),
+			HashMapDictionaryBuilder.<String, Object>put(
+				"osgi.jaxrs.application.select",
+				"(osgi.jaxrs.name=" + osgiJaxRsName + ")"
+			).put(
+				"osgi.jaxrs.extension", "true"
+			).put(
+				"osgi.jaxrs.name",
+				osgiJaxRsName + "APIApplicationContextProvider"
 			).build());
 	}
 

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/application/registry/ApiApplicationRegistry.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/application/registry/ApiApplicationRegistry.java
@@ -1,0 +1,82 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.builder.internal.application.registry;
+
+import com.liferay.headless.builder.application.APIApplication;
+import com.liferay.headless.builder.internal.jaxrs.application.ApiApplicationJaxrsApplication;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+
+import java.util.Objects;
+
+import javax.ws.rs.core.Application;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.util.tracker.ServiceTracker;
+
+/**
+ * @author Luis Miguel Barcos
+ */
+@Component(service = ApiApplicationRegistry.class)
+public class ApiApplicationRegistry {
+
+	public APIApplication fetchApiApplication(String baseURL, long companyId) {
+		for (Object service :
+				ListUtil.fromArray(_serviceTracker.getServices())) {
+
+			APIApplication apiApplication = (APIApplication)service;
+
+			if (Objects.equals(apiApplication.getBaseURL(), baseURL) &&
+				Objects.equals(apiApplication.getCompanyId(), companyId)) {
+
+				return apiApplication;
+			}
+		}
+
+		return null;
+	}
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_serviceTracker = new ServiceTracker<Application, APIApplication>(
+			bundleContext, Application.class, null) {
+
+			@Override
+			public APIApplication addingService(
+				ServiceReference<Application> serviceReference) {
+
+				if (GetterUtil.getBoolean(
+						serviceReference.getProperty(
+							"liferay.headless.builder.application"))) {
+
+					ApiApplicationJaxrsApplication
+						apiApplicationJaxrsApplication =
+							(ApiApplicationJaxrsApplication)
+								bundleContext.getService(serviceReference);
+
+					return apiApplicationJaxrsApplication.getApiApplication();
+				}
+
+				return null;
+			}
+
+		};
+
+		_serviceTracker.open();
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_serviceTracker.close();
+	}
+
+	private ServiceTracker<Application, APIApplication> _serviceTracker;
+
+}

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/jaxrs/application/ApiApplicationJaxrsApplication.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/jaxrs/application/ApiApplicationJaxrsApplication.java
@@ -1,0 +1,27 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.builder.internal.jaxrs.application;
+
+import com.liferay.headless.builder.application.APIApplication;
+
+import javax.ws.rs.core.Application;
+
+/**
+ * @author Luis Miguel Barcos
+ */
+public class ApiApplicationJaxrsApplication extends Application {
+
+	public ApiApplicationJaxrsApplication(APIApplication apiApplication) {
+		_apiApplication = apiApplication;
+	}
+
+	public APIApplication getApiApplication() {
+		return _apiApplication;
+	}
+
+	private final APIApplication _apiApplication;
+
+}

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/jaxrs/context/provider/APIApplicationContextProvider.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/jaxrs/context/provider/APIApplicationContextProvider.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/jaxrs/context/provider/APIApplicationContextProvider.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/jaxrs/context/provider/APIApplicationContextProvider.java
@@ -1,0 +1,61 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.builder.internal.jaxrs.context.provider;
+
+import com.liferay.headless.builder.application.APIApplication;
+import com.liferay.headless.builder.internal.application.registry.ApiApplicationRegistry;
+import com.liferay.headless.builder.internal.util.PathUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+
+import javax.servlet.http.HttpServletRequest;
+
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.ext.Provider;
+
+import org.apache.cxf.jaxrs.ext.ContextProvider;
+import org.apache.cxf.message.Message;
+
+/**
+ * @author Luis Miguel Barcos
+ */
+@Provider
+public class APIApplicationContextProvider
+	implements ContextProvider<APIApplication> {
+
+	public APIApplicationContextProvider(
+		ApiApplicationRegistry apiApplicationRegistry) {
+
+		_apiApplicationRegistry = apiApplicationRegistry;
+	}
+
+	@Override
+	public APIApplication createContext(Message message) {
+		HttpServletRequest httpServletRequest = _getHttpServletRequest(message);
+
+		APIApplication apiApplication =
+			_apiApplicationRegistry.fetchApiApplication(
+				_getBaseURL(httpServletRequest),
+				PortalUtil.getCompanyId(httpServletRequest));
+
+		if (apiApplication != null) {
+			return apiApplication;
+		}
+
+		throw new NotFoundException();
+	}
+
+	private String _getBaseURL(HttpServletRequest httpServletRequest) {
+		return PathUtil.removeBasePath(httpServletRequest.getContextPath());
+	}
+
+	private HttpServletRequest _getHttpServletRequest(Message message) {
+		return (HttpServletRequest)message.getContextualProperty(
+			"HTTP.REQUEST");
+	}
+
+	private final ApiApplicationRegistry _apiApplicationRegistry;
+
+}

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/resource/HeadlessBuilderResourceImpl.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/resource/HeadlessBuilderResourceImpl.java
@@ -112,6 +112,9 @@ public class HeadlessBuilderResourceImpl {
 	private AcceptLanguage _acceptLanguage;
 
 	@Context
+	private APIApplication _apiApplication;
+
+	@Context
 	private Company _company;
 
 	private final EndpointHelper _endpointHelper;

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/util/PathUtil.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/util/PathUtil.java
@@ -22,4 +22,12 @@ public class PathUtil {
 		return StringPool.BLANK;
 	}
 
+	public static String removeBasePath(String path) {
+		if (path.startsWith(HeadlessBuilderConstants.BASE_PATH)) {
+			path = path.substring(HeadlessBuilderConstants.BASE_PATH.length());
+		}
+
+		return path;
+	}
+
 }

--- a/modules/apps/headless/headless-builder/headless-builder-test/build.gradle
+++ b/modules/apps/headless/headless-builder/headless-builder-test/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:list-type:list-type-api")
 	testIntegrationImplementation project(":apps:object:object-api")
 	testIntegrationImplementation project(":apps:object:object-rest-test-util")
+	testIntegrationImplementation project(":apps:portal-instances:portal-instances-api")
 	testIntegrationImplementation project(":apps:portal-vulcan:portal-vulcan-api")
 	testIntegrationImplementation project(":apps:portal:portal-instance-lifecycle-api")
 	testIntegrationImplementation project(":apps:static:osgi:osgi-util")

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
@@ -236,39 +236,51 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			JSONCompareMode.LENIENT);
 
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-			"com.liferay.batch.engine.internal.BatchEngineImportTaskExecutorImpl",
-			LoggerTestUtil.ERROR)) {
+				"com.liferay.batch.engine.internal." +
+					"BatchEngineImportTaskExecutorImpl",
+				LoggerTestUtil.ERROR)) {
 
 			String webId = "www.able.com";
 
-			Company company =
-				_companyLocalService.addCompany(null, webId, webId, webId, 0,
-					true, null, null, null, null, null, null);
+			Company company = _companyLocalService.addCompany(
+				null, webId, webId, webId, 0, true, null, null, null, null,
+				null, null);
 
-			HTTPTestUtil.Customizer
-				httpUtilCustomizer = new HTTPTestUtil.Customizer();
-			httpUtilCustomizer
-				.company(company)
-				.credentials("test@" + company.getMx(), "test")
-				.apply(() -> {
-					ObjectDefinition companyObjectDefinition1 = _addObjectDefinition(
-						1, ObjectDefinitionConstants.SCOPE_COMPANY);
-					ObjectDefinition companyObjectDefinition2 = _addObjectDefinition(
-						2, ObjectDefinitionConstants.SCOPE_COMPANY);
+			HTTPTestUtil.Customizer httpUtilCustomizer =
+				new HTTPTestUtil.Customizer();
+
+			httpUtilCustomizer.company(
+				company
+			).credentials(
+				"test@" + company.getMx(), "test"
+			).apply(
+				() -> {
+					ObjectDefinition companyObjectDefinition1 =
+						_addObjectDefinition(
+							1, ObjectDefinitionConstants.SCOPE_COMPANY);
+					ObjectDefinition companyObjectDefinition2 =
+						_addObjectDefinition(
+							2, ObjectDefinitionConstants.SCOPE_COMPANY);
 
 					ObjectRelationship objectRelationship =
-						_addObjectRelationship(companyObjectDefinition1,
-							companyObjectDefinition2);
+						_addObjectRelationship(
+							companyObjectDefinition1, companyObjectDefinition2);
 
 					_addAPIApplication(
-						_API_APPLICATION_ERC_1, _API_ENDPOINT_ERC_1, _BASE_URL_1,
+						_API_APPLICATION_ERC_1, _API_ENDPOINT_ERC_1,
+						_BASE_URL_1,
 						companyObjectDefinition1.getExternalReferenceCode(),
-						objectRelationship.getName(), companyObjectDefinition2.getName(),
-						_API_APPLICATION_PATH_1, null, "collection", APIApplication.Endpoint.Scope.COMPANY);
+						objectRelationship.getName(),
+						companyObjectDefinition2.getName(),
+						_API_APPLICATION_PATH_1, null, "collection",
+						APIApplication.Endpoint.Scope.COMPANY);
 
-					_addCustomObjectEntry(1, null, companyObjectDefinition1, "newCompanyValue1");
-					_addCustomObjectEntry(2, null, companyObjectDefinition1, "newCompanyValue2");
-					_addCustomObjectEntry(3, null, companyObjectDefinition1, "newCompanyValue3");
+					_addCustomObjectEntry(
+						1, null, companyObjectDefinition1, "newCompanyValue1");
+					_addCustomObjectEntry(
+						2, null, companyObjectDefinition1, "newCompanyValue2");
+					_addCustomObjectEntry(
+						3, null, companyObjectDefinition1, "newCompanyValue3");
 
 					_publishAPIApplication(_API_APPLICATION_ERC_1);
 
@@ -276,16 +288,20 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 						JSONUtil.put(
 							"items",
 							JSONUtil.putAll(
-								JSONUtil.put("textProperty", "newCompanyValue1"),
-								JSONUtil.put("textProperty", "newCompanyValue2"),
-								JSONUtil.put("textProperty", "newCompanyValue3"))
+								JSONUtil.put(
+									"textProperty", "newCompanyValue1"),
+								JSONUtil.put(
+									"textProperty", "newCompanyValue2"),
+								JSONUtil.put(
+									"textProperty", "newCompanyValue3"))
 						).toString(),
 						HTTPTestUtil.invokeToJSONObject(
 							null, "c/" + _BASE_URL_1 + _API_APPLICATION_PATH_1,
 							Http.Method.GET
 						).toString(),
 						JSONCompareMode.LENIENT);
-				});
+				}
+			);
 		}
 	}
 
@@ -1758,6 +1774,9 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 	private static DateFormat _dateTimeFormat;
 
 	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@Inject
 	private DLFileEntryLocalService _dlFileEntryLocalService;
 
 	private DocumentResource _documentResource;
@@ -1782,6 +1801,9 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 	private ObjectRelationship _objectRelationship1;
 	private ObjectRelationship _objectRelationship2;
 
+	@Inject
+	private PortalInstancesLocalService _portalInstancesLocalService;
+
 	@DeleteAfterTestRun
 	private ObjectDefinition _siteScopedObjectDefinition1;
 
@@ -1799,11 +1821,5 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 		VALUE1, VALUE2, VALUE3
 
 	}
-
-	@Inject
-	private CompanyLocalService _companyLocalService;
-
-	@Inject
-	private PortalInstancesLocalService _portalInstancesLocalService;
 
 }

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
@@ -45,11 +45,14 @@ import com.liferay.object.service.ObjectFieldSettingLocalService;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.instances.service.PortalInstancesLocalService;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.test.constants.TestDataConstants;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DataGuard;
@@ -65,6 +68,8 @@ import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.URLCodec;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -199,6 +204,89 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 				Http.Method.GET
 			).toString(),
 			JSONCompareMode.LENIENT);
+	}
+
+	@Test
+	public void testGetSameApplicationInDifferentInstances() throws Exception {
+		_addAPIApplication(
+			_API_APPLICATION_ERC_1, _API_ENDPOINT_ERC_1, _BASE_URL_1,
+			_objectDefinition1.getExternalReferenceCode(),
+			_objectRelationship1.getName(), _objectRelationship2.getName(),
+			_API_APPLICATION_PATH_1, null, "collection",
+			APIApplication.Endpoint.Scope.COMPANY);
+
+		_addCustomObjectEntry(1, null, _objectDefinition1, "value1");
+		_addCustomObjectEntry(2, null, _objectDefinition1, "value2");
+		_addCustomObjectEntry(3, null, _objectDefinition1, "value3");
+
+		_publishAPIApplication(_API_APPLICATION_ERC_1);
+
+		JSONAssert.assertEquals(
+			JSONUtil.put(
+				"items",
+				JSONUtil.putAll(
+					JSONUtil.put("textProperty", "value1"),
+					JSONUtil.put("textProperty", "value2"),
+					JSONUtil.put("textProperty", "value3"))
+			).toString(),
+			HTTPTestUtil.invokeToJSONObject(
+				null, "c/" + _BASE_URL_1 + _API_APPLICATION_PATH_1,
+				Http.Method.GET
+			).toString(),
+			JSONCompareMode.LENIENT);
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+			"com.liferay.batch.engine.internal.BatchEngineImportTaskExecutorImpl",
+			LoggerTestUtil.ERROR)) {
+
+			String webId = "www.able.com";
+
+			Company company =
+				_companyLocalService.addCompany(null, webId, webId, webId, 0,
+					true, null, null, null, null, null, null);
+
+			HTTPTestUtil.Customizer
+				httpUtilCustomizer = new HTTPTestUtil.Customizer();
+			httpUtilCustomizer
+				.company(company)
+				.credentials("test@" + company.getMx(), "test")
+				.apply(() -> {
+					ObjectDefinition companyObjectDefinition1 = _addObjectDefinition(
+						1, ObjectDefinitionConstants.SCOPE_COMPANY);
+					ObjectDefinition companyObjectDefinition2 = _addObjectDefinition(
+						2, ObjectDefinitionConstants.SCOPE_COMPANY);
+
+					ObjectRelationship objectRelationship =
+						_addObjectRelationship(companyObjectDefinition1,
+							companyObjectDefinition2);
+
+					_addAPIApplication(
+						_API_APPLICATION_ERC_1, _API_ENDPOINT_ERC_1, _BASE_URL_1,
+						companyObjectDefinition1.getExternalReferenceCode(),
+						objectRelationship.getName(), companyObjectDefinition2.getName(),
+						_API_APPLICATION_PATH_1, null, "collection", APIApplication.Endpoint.Scope.COMPANY);
+
+					_addCustomObjectEntry(1, null, companyObjectDefinition1, "newCompanyValue1");
+					_addCustomObjectEntry(2, null, companyObjectDefinition1, "newCompanyValue2");
+					_addCustomObjectEntry(3, null, companyObjectDefinition1, "newCompanyValue3");
+
+					_publishAPIApplication(_API_APPLICATION_ERC_1);
+
+					JSONAssert.assertEquals(
+						JSONUtil.put(
+							"items",
+							JSONUtil.putAll(
+								JSONUtil.put("textProperty", "newCompanyValue1"),
+								JSONUtil.put("textProperty", "newCompanyValue2"),
+								JSONUtil.put("textProperty", "newCompanyValue3"))
+						).toString(),
+						HTTPTestUtil.invokeToJSONObject(
+							null, "c/" + _BASE_URL_1 + _API_APPLICATION_PATH_1,
+							Http.Method.GET
+						).toString(),
+						JSONCompareMode.LENIENT);
+				});
+		}
 	}
 
 	@Test
@@ -1711,5 +1799,11 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 		VALUE1, VALUE2, VALUE3
 
 	}
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@Inject
+	private PortalInstancesLocalService _portalInstancesLocalService;
 
 }

--- a/portal-test/bnd.bnd
+++ b/portal-test/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 21.0.1
+Bundle-Version: 21.1.0
 Export-Package:\
 	com.liferay.portal.kernel.dao.db.test,\
 	com.liferay.portal.kernel.test,\

--- a/portal-test/src/com/liferay/portal/kernel/test/util/HTTPTestUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/HTTPTestUtil.java
@@ -7,8 +7,11 @@ package com.liferay.portal.kernel.test.util;
 
 import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.ContentTypes;
@@ -62,8 +65,40 @@ public class HTTPTestUtil {
 		}
 	}
 
+	public static class Customizer {
+		public Customizer credentials(String emailAddress, String password) {
+			_newCredentials = emailAddress + StringPool.COLON + password;
+
+			return this;
+		}
+
+		public Customizer company(Company company){
+			_newCompany = company;
+
+			return this;
+		}
+
+		public <T extends Throwable> void apply(UnsafeRunnable<T> unsafeRunnable) throws T {
+			Company defaultCompany = _company;
+			_company = _newCompany;
+
+			String defaultCredentials = _credentials;
+			_credentials = _newCredentials;
+
+			try {
+				unsafeRunnable.run();
+			} finally {
+				_company = defaultCompany;
+				_credentials = defaultCredentials;
+			}
+		}
+
+		private Company _newCompany = _company;
+		private String _newCredentials = _credentials;
+	}
+
 	private static Http.Options _getHttpOptions(
-		String body, String endpoint, Http.Method httpMethod) {
+		String body, String endpoint, Http.Method httpMethod) throws Exception {
 
 		Http.Options options = new Http.Options();
 
@@ -71,7 +106,7 @@ public class HTTPTestUtil {
 			HttpHeaders.CONTENT_TYPE, ContentTypes.APPLICATION_JSON);
 		options.addHeader(
 			"Authorization", "Basic " + Base64.encode(_credentials.getBytes()));
-		options.setLocation("http://localhost:8080/o/" + endpoint);
+		options.setLocation(_company.getPortalURL(_company.getGroupId())+"/o/" + endpoint);
 		options.setMethod(httpMethod);
 
 		if (body != null) {
@@ -84,5 +119,17 @@ public class HTTPTestUtil {
 	}
 
 	private static String _credentials = "test@liferay.com:test";
+
+	private static Company _company;
+
+	static {
+		try {
+			_company =
+				CompanyLocalServiceUtil.getCompanyById(TestPropsValues.getCompanyId());
+		}
+		catch (PortalException e) {
+			throw new RuntimeException(e);
+		}
+	}
 
 }

--- a/portal-test/src/com/liferay/portal/kernel/test/util/HTTPTestUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/HTTPTestUtil.java
@@ -66,19 +66,11 @@ public class HTTPTestUtil {
 	}
 
 	public static class Customizer {
-		public Customizer credentials(String emailAddress, String password) {
-			_newCredentials = emailAddress + StringPool.COLON + password;
 
-			return this;
-		}
+		public <T extends Throwable> void apply(
+				UnsafeRunnable<T> unsafeRunnable)
+			throws T {
 
-		public Customizer company(Company company){
-			_newCompany = company;
-
-			return this;
-		}
-
-		public <T extends Throwable> void apply(UnsafeRunnable<T> unsafeRunnable) throws T {
 			Company defaultCompany = _company;
 			_company = _newCompany;
 
@@ -87,18 +79,33 @@ public class HTTPTestUtil {
 
 			try {
 				unsafeRunnable.run();
-			} finally {
+			}
+			finally {
 				_company = defaultCompany;
 				_credentials = defaultCredentials;
 			}
 		}
 
+		public Customizer company(Company company) {
+			_newCompany = company;
+
+			return this;
+		}
+
+		public Customizer credentials(String emailAddress, String password) {
+			_newCredentials = emailAddress + StringPool.COLON + password;
+
+			return this;
+		}
+
 		private Company _newCompany = _company;
 		private String _newCredentials = _credentials;
+
 	}
 
 	private static Http.Options _getHttpOptions(
-		String body, String endpoint, Http.Method httpMethod) throws Exception {
+			String body, String endpoint, Http.Method httpMethod)
+		throws Exception {
 
 		Http.Options options = new Http.Options();
 
@@ -106,7 +113,8 @@ public class HTTPTestUtil {
 			HttpHeaders.CONTENT_TYPE, ContentTypes.APPLICATION_JSON);
 		options.addHeader(
 			"Authorization", "Basic " + Base64.encode(_credentials.getBytes()));
-		options.setLocation(_company.getPortalURL(_company.getGroupId())+"/o/" + endpoint);
+		options.setLocation(
+			_company.getPortalURL(_company.getGroupId()) + "/o/" + endpoint);
 		options.setMethod(httpMethod);
 
 		if (body != null) {
@@ -118,17 +126,16 @@ public class HTTPTestUtil {
 		return options;
 	}
 
-	private static String _credentials = "test@liferay.com:test";
-
 	private static Company _company;
+	private static String _credentials = "test@liferay.com:test";
 
 	static {
 		try {
-			_company =
-				CompanyLocalServiceUtil.getCompanyById(TestPropsValues.getCompanyId());
+			_company = CompanyLocalServiceUtil.getCompanyById(
+				TestPropsValues.getCompanyId());
 		}
-		catch (PortalException e) {
-			throw new RuntimeException(e);
+		catch (PortalException portalException) {
+			throw new RuntimeException(portalException);
 		}
 	}
 

--- a/portal-test/src/com/liferay/portal/kernel/test/util/packageinfo
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 6.1.0
+version 6.2.0


### PR DESCRIPTION
Related ticket -> https://liferay.atlassian.net/browse/LPS-194127
_____
I'm sorry to open this as a draft instead of an actual functional PR but has been impossible for me to make the tests work because of a lot of different problems 😢 

# Purpose of the PR
The PR adds the logic to make REST APIs generated with the Headless Builder isolated by instance.
To do that, the following files have been created/modified:
* ApiApplicationRegistry: This will have a registry of all ApiApplications of the Liferay installation, which means that has the registry for the ApiApplication of the whole instances.
* ApiApplicationJaxrsApplication: Custom JAX-RS application with the associated ApiApplication. Each ApiApplication will be deployed with its ApiApplication attached and will it be accessible through the ApiApplicationRegistry.
* ApiApplicationContextProvider: I've added this file again so every call we can make sure that the ApiApplication exists when a request is made.
* HeadlessBuilderResource: Get the ApiApplication through context instead of through the constructor. The EndpointMatcher has been passed through the constructor too instead of generating on the resource. This last part is the same as this other PR (https://github.com/brianchandotcom/liferay-portal/pull/139949)
* HTTPTestUtil: The PR creates a "Customizer". This is because to make a request against a new instance it is necessary to change the hostname and the credentials. There is already a `withCredentials` method that modifies the credentials. The customizer follows that pattern but with the ability to modify the credentials, the company, or both. So, an example of use could be:
```
new HTTPTestUtil.Customizer()
  .company(newCompany)
  .credentials(email, pass)
  .apply(() -> {
    // My HTTPTestUtil calls that I want made. These calls will be made with the company and the credentials set on the customizer.
})
```
* HeadlessBuilderResourceTest: Contains the test that I cannot make work. The test could be wrong but, at first instance, I can't even create an ApiApplication in the new instance. Note that the new instance is `www.able.com`. According to this [slack thread](https://liferay.slack.com/archives/C03U66A6NNN/p1693236250797719), the CI has some predefined instances to make tests. To test it locally, ensure that you are adding `www.able.com` to your `hosts` file. If not, an `InvalidHost` error will be thrown.

## Next steps
The next step with this PR is to finish the testing. It would be great if we could test creating the same and different ApiApplications in different instances and ensure that each one returns the proper data. Again, I'm sorry I couldn't finish this task 😢 

## How to test it
Deploy the following modules:
* `headless-builder-impl`: With only this module it would be possible to test the functionality manually.
* `headless-builder-test` & `portal-test`: To execute the tests

#### Manual testing
In the default instance, execute the following request in this order:
## Create Custom Object
```
curl -X "POST" "http://localhost:8080/o/object-admin/v1.0/object-definitions" \
     -H 'Content-Type: application/json' \
     -u 'test@liferay.com:test' \
     -d $'{
  "active": true,
  "status": {
    "code": 0
  },
  "objectFields": [
    {
      "DBType": "String",
      "indexed": true,
      "indexedLanguageId": "",
      "externalReferenceCode": "university-name",
      "listTypeDefinitionId": 0,
      "label": {
        "en_US": "University name"
      },
      "type": "String",
      "required": true,
      "name": "universityName",
      "indexedAsKeyword": false
    }
  ],
  "pluralLabel": {
    "en-US": "Universities"
  },
  "portlet": true,
  "scope": "company",
  "label": {
    "en-US": "University"
  },
  "externalReferenceCode": "University",
  "name": "University"
}'
```
## Populate custom object
```
curl -X "POST" "http://localhost:8080/o/c/universities/batch" \
     -H 'Content-Type: application/json' \
     -u 'test@liferay.com:test' \
     -d $'[
  {
    "universityName": "Oxford"
  },
  {
    "universityName": "Cambridge"
  }
]'
```
## Create API Application
```
curl -X "POST" "http://localhost:8080/o/headless-builder/applications/" \
     -H 'Content-Type: application/json' \
     -u 'test@liferay.com:test' \
     -d $'{
  "baseURL": "my-application",
  "title": "My application",
  "externalReferenceCode": "my-application",
  "apiApplicationToAPIEndpoints": [
    {
      "path": "/my-endpoint",
      "scope": "company",
      "externalReferenceCode": "my-endpoint",
      "name": "name",
      "description": "description",
      "httpMethod": "get"
    }
  ],
  "applicationStatus": "unpublished",
  "apiApplicationToAPISchemas": [
    {
      "externalReferenceCode": "my-schema",
      "mainObjectDefinitionERC": "University",
      "description": "description",
      "name": "MySchema",
      "apiSchemaToAPIProperties": [
        {
          "objectFieldERC": "university-name",
          "name": "name",
          "description": "description"
        }
      ]
    }
  ]
}'
```
## Add response to endpoint
```
curl -X "PUT" "http://localhost:8080/o/headless-builder/schemas/by-external-reference-code/my-schema/responseAPISchemaToAPIEndpoints/my-endpoint" \
     -H 'Content-Type: application/json' \
     -u 'test@liferay.com:test'
```
## Publish API Application
```
curl -X "PATCH" "http://localhost:8080/o/headless-builder/applications/by-external-reference-code/my-application" \
     -H 'Content-Type: application/json' \
     -u 'test@liferay.com:test' \
     -d $'{
  "applicationStatus": "published"
}'
```
## Test API Application
```
curl "http://localhost:8080/o/c/my-application/my-endpoint" \
     -u 'test@liferay.com:test'
```
The result should be something like:
```
{
  "actions": {},
  "facets": [],
  "items": [
    {
      "name": "Oxford"
    },
    {
      "name": "Cambridge"
    }
  ],
  "lastPage": 1,
  "page": 1,
  "pageSize": 20,
  "totalCount": 2
}
```

Now, create a new instance (in my case: www.luismi.com) and execute the exact same requests but against the new instance. To ensure that the information is getting from the right instance, it is possible to change the `populate custom object` request to add other values, for example:
```
curl -X "POST" "http://www.luismi.com:8080/o/c/universities/batch" \
     -H 'Content-Type: application/json' \
     -u 'test@luismi.com:test' \
     -d $'[
  {
    "universityName": "UPNA"
  },
  {
    "universityName": "UNAV"
  }
]'
```
