### PR TITLE
LPS-194865 Update api builder tests not run on virtual instances until LPS-188159

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/ObjectsStructureForAPIBuilder/DeployAPIBuilderObjectDefinitionsInAllInstances.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/ObjectsStructureForAPIBuilder/DeployAPIBuilderObjectDefinitionsInAllInstances.testcase
@@ -38,6 +38,8 @@ definition {
 	@priority = 4
 	test CanCreateAPIApplicationWithUIOnVirtualInstance {
 		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
 
 		task ("When I create a new API application through Control Panel > Object > API Builder") {
 			APIBuilderUI.createAPIApplication(title = "test");
@@ -55,6 +57,8 @@ definition {
 	@priority = 4
 	test CanCreatePublishedAPIApplicationWithAPIOnVirtualInstance {
 		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
 
 		task ("When with postAPIApplication to create a published API application") {
 			var response = ApplicationAPI.createAPIApplication(
@@ -87,6 +91,8 @@ definition {
 	@priority = 5
 	test CanLoadHeadlessBuilderAPIsOnVirtualInstance {
 		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
 
 		task ("When I navigate to /o/api in the virtual instance") {
 			APIExplorer.navigateToOpenAPI(virtualHost = "www.able.com");
@@ -113,6 +119,8 @@ definition {
 	@priority = 5
 	test CannotCreateSchemaWithAPIIdOfOtherInstance {
 		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
 
 		task ("And Given create an API application on default instance") {
 			var response = ApplicationAPI.createAPIApplication(
@@ -151,6 +159,8 @@ definition {
 	@priority = 4
 	test CanPublishAPIApplicationWithUIOnVirtualInstance {
 		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
 
 		task ("And Given I create a new API application through Control Panel > Object > API Builder") {
 			APIBuilderUI.createAPIApplication(title = "test");
@@ -170,6 +180,8 @@ definition {
 	@priority = 5
 	test CanSeeAPIObjectDefinitionsOnVirtualInstance {
 		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
 
 		task ("When I navigate to Control Panel > Objects") {
 			ObjectAdmin.openObjectAdmin(baseURL = "http://www.able.com:8080");

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[APIRest]APIGenerator/GenerateOpenAPIFromAPIApplicationDefinition.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[APIRest]APIGenerator/GenerateOpenAPIFromAPIApplicationDefinition.testcase
@@ -26,6 +26,8 @@ definition {
 	@priority = 5
 	test CanGenerateOpenApiFromApiApplicationDefinition {
 		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
 
 		task ("Given APIApplication ‘my-app’ with APIEndpoints with related APISchemas created") {
 			var response = ApplicationAPI.createAPIApplication(
@@ -83,6 +85,8 @@ definition {
 	@priority = 4
 	test CanHideApiApplicationOnRestApplicationsListByUnbublishing {
 		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
 
 		task ("Given APIApplication ‘my-app’ of status ‘published’ with APIEndpoints with related APISchemas created") {
 			var response = ApplicationAPI.createAPIApplication(
@@ -118,6 +122,8 @@ definition {
 	@priority = 4
 	test CannotSeeUnpublishedApiApplicationListedAsRestApplication {
 		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
 
 		task ("When APIApplication ‘my-app’ of status ‘unpublished’ with APIEndpoints with related APISchemas created") {
 			var response = ApplicationAPI.createAPIApplication(
@@ -155,6 +161,8 @@ definition {
 	@priority = 4
 	test CanSeePublishedApiApplicationListedAsRestApplication {
 		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
 
 		task ("Given APIApplication ‘my-app’ with APIEndpoints with related APISchemas created") {
 			var response = ApplicationAPI.createAPIApplication(

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]DefineAPISchemasWithinAnAPIGroup/ListAPIApplicationSchemas.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]DefineAPISchemasWithinAnAPIGroup/ListAPIApplicationSchemas.testcase
@@ -35,6 +35,8 @@ definition {
 	@priority = 5
 	test CanClickAddNewSchemaButtons {
 		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
 
 		task ("When I switch to Schemas in edit API application") {
 			APIBuilderUI.switchToRelatedEntryInEditApplication(
@@ -56,6 +58,8 @@ definition {
 	@priority = 4
 	test CanFilterSchemaByCreationDateAsLastUpdated {
 		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
 
 		task ("And Given I create a schema associate to the API application") {
 			SchemaAPI.createAPISchema(
@@ -87,6 +91,8 @@ definition {
 	@priority = 4
 	test CanFilterSchemaByDateBeforeCreationAsLastUpdated {
 		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
 
 		task ("And Given I create a schema associate to the API application") {
 			SchemaAPI.createAPISchema(
@@ -117,6 +123,8 @@ definition {
 	@priority = 5
 	test CanListExistingSchemaInEditAPIApplication {
 		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
 
 		task ("And Given with postAPISchema to create a schema associate to the API application") {
 			SchemaAPI.createAPISchema(
@@ -141,6 +149,8 @@ definition {
 	@priority = 4
 	test CanOrderSchemasByLastUpdated {
 		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
 
 		task ("And Given with postAPISchema to create two schemas associate to the API application") {
 			SchemaAPI.createNAPISchemas(
@@ -170,6 +180,8 @@ definition {
 	@priority = 4
 	test CanOrderSchemasByName {
 		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
 
 		task ("And Given with postAPISchema to create two schemas associate to the API application") {
 			SchemaAPI.createNAPISchemas(
@@ -199,6 +211,8 @@ definition {
 	@priority = 4
 	test CanPaginateAPISchemas {
 		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
 
 		task ("And Given with postAPISchema to create 11 schemas associate to the API application") {
 			SchemaAPI.createNAPISchemas(
@@ -236,6 +250,8 @@ definition {
 	@priority = 4
 	test CanSearchAPISchema {
 		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
 
 		task ("And Given I create a schema associate to the API application") {
 			SchemaAPI.createAPISchema(
@@ -260,6 +276,8 @@ definition {
 	@priority = 5
 	test CanSeeAvailableFieldsAndActions {
 		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
 
 		task ("When I create a schema associate to the API application") {
 			SchemaAPI.createAPISchema(
@@ -298,6 +316,8 @@ definition {
 	@priority = 4
 	test CanSeeNoAPISchemaAndAddSchemaButton {
 		property portal.acceptance = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
 
 		task ("When I switch to Schemas in edit API application") {
 			APIBuilderUI.switchToRelatedEntryInEditApplication(


### PR DESCRIPTION
Background:
- Update tests to not run on a virtual instance since there is a bug on loading API Builder which we'll fix in LPS-188159