### PR TITLE
LPS-194127 Getting the endpoint matcher for the current company or 404

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/application/endpoint/EndpointMatcher.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/application/endpoint/EndpointMatcher.java
@@ -47,8 +47,14 @@ public class EndpointMatcher {
 		}
 	}
 
-	public APIApplication.Endpoint getEndpoint(String path) {
+	public APIApplication.Endpoint getEndpoint(
+		String path, APIApplication.Endpoint.Scope scope) {
+
 		for (APIApplication.Endpoint endpoint : _endpoints) {
+			if (scope != endpoint.getScope()) {
+				continue;
+			}
+
 			Predicate<String> predicate = _predicates.get(endpoint);
 
 			if (predicate.test(path)) {

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/application/publisher/APIApplicationPublisherImpl.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/application/publisher/APIApplicationPublisherImpl.java
@@ -54,14 +54,19 @@ public class APIApplicationPublisherImpl implements APIApplicationPublisher {
 				{
 					add(_registerApplication(apiApplication, osgiJaxRsName));
 
-					EndpointMatcher endpointMatcher = new EndpointMatcher(
-						apiApplication.getEndpoints());
+					_endpointMatchersMap.put(
+						osgiJaxRsName,
+						new EndpointMatcher(apiApplication.getEndpoints()));
 
 					add(
 						_registerResource(
 							osgiJaxRsName, HeadlessBuilderResourceImpl.class,
 							() -> new HeadlessBuilderResourceImpl(
-								_endpointHelper, endpointMatcher)));
+								_endpointHelper,
+								companyId -> _endpointMatchersMap.get(
+									_getOSGiJaxRsName(
+										apiApplication.getBaseURL(),
+										companyId)))));
 
 					add(
 						_registerResource(
@@ -85,6 +90,8 @@ public class APIApplicationPublisherImpl implements APIApplicationPublisher {
 		if (serviceRegistrations != null) {
 			_unregisterServiceRegistrations(serviceRegistrations);
 		}
+
+		_endpointMatchersMap.remove(_getOSGiJaxRsName(baseURL, companyId));
 	}
 
 	@Activate
@@ -185,6 +192,9 @@ public class APIApplicationPublisherImpl implements APIApplicationPublisher {
 
 	@Reference
 	private EndpointHelper _endpointHelper;
+
+	private final Map<String, EndpointMatcher> _endpointMatchersMap =
+		new HashMap<>();
 
 	@Reference
 	private OpenAPIResource _openAPIResource;

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/resource/HeadlessBuilderResourceImpl.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/resource/HeadlessBuilderResourceImpl.java
@@ -15,6 +15,8 @@ import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
+import java.util.function.Function;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -29,10 +31,11 @@ import javax.ws.rs.core.Response;
 public class HeadlessBuilderResourceImpl {
 
 	public HeadlessBuilderResourceImpl(
-		EndpointHelper endpointHelper, EndpointMatcher endpointMatcher) {
+		EndpointHelper endpointHelper,
+		Function<Long, EndpointMatcher> endpointMatcherFunction) {
 
 		_endpointHelper = endpointHelper;
-		_endpointMatcher = endpointMatcher;
+		_endpointMatcherFunction = endpointMatcherFunction;
 	}
 
 	@GET
@@ -90,7 +93,16 @@ public class HeadlessBuilderResourceImpl {
 				successUnsafeFunction)
 		throws Exception {
 
-		APIApplication.Endpoint endpoint = _endpointMatcher.getEndpoint(
+		EndpointMatcher endpointMatcher = _endpointMatcherFunction.apply(
+			_company.getCompanyId());
+
+		if (endpointMatcher == null) {
+			return Response.status(
+				Response.Status.NOT_FOUND
+			).build();
+		}
+
+		APIApplication.Endpoint endpoint = endpointMatcher.getEndpoint(
 			"/" + path);
 
 		if ((endpoint == null) || (endpoint.getScope() != scope)) {
@@ -115,6 +127,6 @@ public class HeadlessBuilderResourceImpl {
 	private Company _company;
 
 	private final EndpointHelper _endpointHelper;
-	private final EndpointMatcher _endpointMatcher;
+	private final Function<Long, EndpointMatcher> _endpointMatcherFunction;
 
 }

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/resource/HeadlessBuilderResourceImpl.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/resource/HeadlessBuilderResourceImpl.java
@@ -103,9 +103,9 @@ public class HeadlessBuilderResourceImpl {
 		}
 
 		APIApplication.Endpoint endpoint = endpointMatcher.getEndpoint(
-			"/" + path);
+			"/" + path, scope);
 
-		if ((endpoint == null) || (endpoint.getScope() != scope)) {
+		if (endpoint == null) {
 			throw new NoSuchModelException(
 				"Endpoint /%s does not exist for " + path);
 		}

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/test/java/com/liferay/headless/builder/internal/application/endpoint/EndpointMatcherTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/test/java/com/liferay/headless/builder/internal/application/endpoint/EndpointMatcherTest.java
@@ -36,13 +36,16 @@ public class EndpointMatcherTest {
 
 		EndpointMatcher endpointMatcher = new EndpointMatcher(endpoints);
 
-		Assert.assertNull(endpointMatcher.getEndpoint("/path"));
+		Assert.assertNull(endpointMatcher.getEndpoint("/path", null));
+		Assert.assertNull(
+			endpointMatcher.getEndpoint(
+				"/path-name", APIApplication.Endpoint.Scope.GROUP));
 		Assert.assertEquals(
-			endpoints.get(0), endpointMatcher.getEndpoint("/path-name"));
+			endpoints.get(0), endpointMatcher.getEndpoint("/path-name", null));
 		Assert.assertEquals(
-			endpoints.get(1), endpointMatcher.getEndpoint("/path-name2"));
+			endpoints.get(1), endpointMatcher.getEndpoint("/path-name2", null));
 		Assert.assertEquals(
-			endpoints.get(2), endpointMatcher.getEndpoint("/path/1234"));
+			endpoints.get(2), endpointMatcher.getEndpoint("/path/1234", null));
 	}
 
 	private APIApplication.Endpoint _getEndpoint(


### PR DESCRIPTION
From https://github.com/liferay-headless/liferay-portal/pull/1468.

Like in objects, the first JAXRS app registered will be the one processing the response.

To ensure the response is processed by the right endpoints we need to retrieve them by the current companyId (calculated form the host name).

As described in the previous PR, we're having issues to write the integration tests so I created https://liferay.atlassian.net/browse/LPS-195122 to do it independently (I will look into it today).

To test this PR manually

1. Enable the headless builder feature flags:
   ```feature.flag.LPS-167253=true
   feature.flag.LPS-178642=true
   feature.flag.LPS-184413=true
   feature.flag.LPS-186757=true
   feature.flag.LPS-190834=true
   feature.flag.LPS-191929=true
   feature.flag.LPS-192832=true
   ```
3. Deploy the `headless-builder-impl` module.
4. Execute the following request in this order:

#### Create Custom Object
```
curl -X "POST" "http://localhost:8080/o/object-admin/v1.0/object-definitions" \
     -H 'Content-Type: application/json' \
     -u 'test@liferay.com:test' \
     -d $'{
  "active": true,
  "status": {
    "code": 0
  },
  "objectFields": [
    {
      "DBType": "String",
      "indexed": true,
      "indexedLanguageId": "",
      "externalReferenceCode": "university-name",
      "listTypeDefinitionId": 0,
      "label": {
        "en_US": "University name"
      },
      "type": "String",
      "required": true,
      "name": "universityName",
      "indexedAsKeyword": false
    }
  ],
  "pluralLabel": {
    "en-US": "Universities"
  },
  "portlet": true,
  "scope": "company",
  "label": {
    "en-US": "University"
  },
  "externalReferenceCode": "University",
  "name": "University"
}'
```
#### Populate custom object
```
curl -X "POST" "http://localhost:8080/o/c/universities/batch" \
     -H 'Content-Type: application/json' \
     -u 'test@liferay.com:test' \
     -d $'[
  {
    "universityName": "Oxford"
  },
  {
    "universityName": "Cambridge"
  }
]'
```
#### Create API Application
```
curl -X "POST" "http://localhost:8080/o/headless-builder/applications/" \
     -H 'Content-Type: application/json' \
     -u 'test@liferay.com:test' \
     -d $'{
  "baseURL": "my-application",
  "title": "My application",
  "externalReferenceCode": "my-application",
  "apiApplicationToAPIEndpoints": [
    {
      "path": "/my-endpoint",
      "scope": "company",
      "externalReferenceCode": "my-endpoint",
      "name": "name",
      "description": "description",
      "httpMethod": "get"
    }
  ],
  "applicationStatus": "unpublished",
  "apiApplicationToAPISchemas": [
    {
      "externalReferenceCode": "my-schema",
      "mainObjectDefinitionERC": "University",
      "description": "description",
      "name": "MySchema",
      "apiSchemaToAPIProperties": [
        {
          "objectFieldERC": "university-name",
          "name": "name",
          "description": "description"
        }
      ]
    }
  ]
}'
```
#### Add response to endpoint
```
curl -X "PUT" "http://localhost:8080/o/headless-builder/schemas/by-external-reference-code/my-schema/responseAPISchemaToAPIEndpoints/my-endpoint" \
     -H 'Content-Type: application/json' \
     -u 'test@liferay.com:test'
```
#### Publish API Application
```
curl -X "PATCH" "http://localhost:8080/o/headless-builder/applications/by-external-reference-code/my-application" \
     -H 'Content-Type: application/json' \
     -u 'test@liferay.com:test' \
     -d $'{
  "applicationStatus": "published"
}'
```
#### Test API Application
```
curl "http://localhost:8080/o/c/my-application/my-endpoint" \
     -u 'test@liferay.com:test'
```
The result should be something like:
```
{
  "actions": {},
  "facets": [],
  "items": [
    {
      "name": "Oxford"
    },
    {
      "name": "Cambridge"
    }
  ],
  "lastPage": 1,
  "page": 1,
  "pageSize": 20,
  "totalCount": 2
}
```

Now, create a new instance (in my case: liferay.local) and run the same query:
```
curl "http://liferay.local:8080/o/c/my-application/my-endpoint" \
     -u 'test@liferay.local:test'
```
Without the changes in this PR, the request will be run against the application from the other company and we will get a response with no elements (because luckily the db queries are using the right companyId):
```
{
  "actions" : { },
  "facets" : [ ],
  "items" : [ ],
  "lastPage" : 1,
  "page" : 1,
  "pageSize" : 20,
  "totalCount" : 0
}
```
However with the changes from this PR the request will not be run at all and return a 404:
```
curl -I "http://liferay.local:8080/o/c/my-application/my-endpoint" \
     -u 'test@liferay.local:test'
```
```
HTTP/1.1 404 
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
Set-Cookie: JSESSIONID=3551AEBF11EF5C5BCAAAE2316428455E; Path=/; HttpOnly
Date: Fri, 01 Sep 2023 07:31:20 GMT
Cache-Control: no-cache, no-store
Content-Length: 0
```
You can also execute all the other requests but against the new instance. To ensure that the information is getting from the right instance, it is possible to change the `populate custom object` request to add other values, for example:
```
curl -X "POST" "http://liferay.local:8080/o/c/universities/batch" \
     -H 'Content-Type: application/json' \
     -u 'test@liferay.local:test' \
     -d $'[
  {
    "universityName": "UPNA"
  },
  {
    "universityName": "UNAV"
  }
]'
```