### PR TITLE
LPS-194130 Adapt endpoints to have the same prefix from the root parent

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -135,7 +135,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 				objectDefinition.getRESTContextPath(), objectDefinitions);
 		}
 
-		_excludeScopedMethods(objectDefinition, objectScopeProvider);
+		_excludeMethods(objectDefinition, objectScopeProvider);
 
 		_initCustomObjectDefinition(objectDefinition);
 
@@ -213,7 +213,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		}
 	}
 
-	private void _excludeScopedMethods(
+	private void _excludeMethods(
 		ObjectDefinition objectDefinition,
 		ObjectScopeProvider objectScopeProvider) {
 
@@ -244,7 +244,9 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 
 				if ((!groupAware && hasScope) ||
 					(groupAware && !hasScope &&
-					 !value.startsWith("/{objectEntryId}"))) {
+					 !value.startsWith("/{objectEntryId}")) ||
+					(objectDefinition.isRootDescendantNode() &&
+					 value.endsWith("/permissions"))) {
 
 					excludedOperationIds.add(method.getName());
 				}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectDefinitionImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectDefinitionImpl.java
@@ -7,7 +7,9 @@ package com.liferay.object.model.impl;
 
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.internal.definition.util.ObjectDefinitionUtil;
+import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectFolder;
+import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
 import com.liferay.object.service.ObjectFolderLocalServiceUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -125,8 +127,22 @@ public class ObjectDefinitionImpl extends ObjectDefinitionBaseImpl {
 				getModifiableSystemObjectDefinitionRESTContextPath(getName());
 		}
 
-		return "/c/" +
-			TextFormatter.formatPlural(StringUtil.toLowerCase(getShortName()));
+		String shortName = TextFormatter.formatPlural(
+			StringUtil.toLowerCase(getShortName()));
+
+		if (!isRootDescendantNode()) {
+			return "/c/" + shortName;
+		}
+
+		ObjectDefinition rootObjectDefinition =
+			ObjectDefinitionLocalServiceUtil.fetchObjectDefinition(
+				getRootObjectDefinitionId());
+
+		return StringBundler.concat(
+			"/c/",
+			TextFormatter.formatPlural(
+				StringUtil.toLowerCase(rootObjectDefinition.getShortName())),
+			StringPool.SLASH, shortName);
 	}
 
 	@Override


### PR DESCRIPTION
**Related Issue**: https://liferay.atlassian.net/browse/LPS-194130

**How to reproduce**:

1. Enable the FF `feature.flag.LPS-187142`
2. Create two custom objects: `Parent` and `Child`
3. Create a One to Many relationship between `Parent` and `Child`
4. Go to the `Child` object and set the relationship field as mandatory
5. Go to the `Child` drop-down options and select `Bind` 
![image](https://github.com/liferay-headless/liferay-portal/assets/34186632/ca7c5b56-cc2b-4675-8af4-7fa69a55bd3e)
6. In the `Bind` modal, select the `Parent` object as the **Root Object Path**
7. Publish the two objects
9. Go to the API Explorer
![image](https://github.com/liferay-headless/liferay-portal/assets/34186632/9a94d3d2-59e0-402c-b4de-f5047fe2a4a4)

