### PR TITLE
LPS 195122

### DIFF
--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/bundle/BatchEngineBundleTracker.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/bundle/BatchEngineBundleTracker.java
@@ -17,6 +17,7 @@ import com.liferay.portal.instance.lifecycle.PortalInstanceLifecycleListener;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
 import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 
 import java.io.File;
 import java.io.IOException;
@@ -176,7 +177,9 @@ public class BatchEngineBundleTracker {
 						}
 
 					},
-					null));
+					HashMapDictionaryBuilder.<String, Object>put(
+						"service.ranking", Integer.MIN_VALUE
+					).build()));
 
 			return bundle;
 		}

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/application/endpoint/EndpointMatcher.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/application/endpoint/EndpointMatcher.java
@@ -47,8 +47,14 @@ public class EndpointMatcher {
 		}
 	}
 
-	public APIApplication.Endpoint getEndpoint(String path) {
+	public APIApplication.Endpoint getEndpoint(
+		String path, APIApplication.Endpoint.Scope scope) {
+
 		for (APIApplication.Endpoint endpoint : _endpoints) {
+			if (scope != endpoint.getScope()) {
+				continue;
+			}
+
 			Predicate<String> predicate = _predicates.get(endpoint);
 
 			if (predicate.test(path)) {

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/application/publisher/APIApplicationPublisherImpl.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/application/publisher/APIApplicationPublisherImpl.java
@@ -54,14 +54,19 @@ public class APIApplicationPublisherImpl implements APIApplicationPublisher {
 				{
 					add(_registerApplication(apiApplication, osgiJaxRsName));
 
-					EndpointMatcher endpointMatcher = new EndpointMatcher(
-						apiApplication.getEndpoints());
+					_endpointMatchersMap.put(
+						osgiJaxRsName,
+						new EndpointMatcher(apiApplication.getEndpoints()));
 
 					add(
 						_registerResource(
 							osgiJaxRsName, HeadlessBuilderResourceImpl.class,
 							() -> new HeadlessBuilderResourceImpl(
-								_endpointHelper, endpointMatcher)));
+								_endpointHelper,
+								companyId -> _endpointMatchersMap.get(
+									_getOSGiJaxRsName(
+										apiApplication.getBaseURL(),
+										companyId)))));
 
 					add(
 						_registerResource(
@@ -85,6 +90,8 @@ public class APIApplicationPublisherImpl implements APIApplicationPublisher {
 		if (serviceRegistrations != null) {
 			_unregisterServiceRegistrations(serviceRegistrations);
 		}
+
+		_endpointMatchersMap.remove(_getOSGiJaxRsName(baseURL, companyId));
 	}
 
 	@Activate
@@ -185,6 +192,9 @@ public class APIApplicationPublisherImpl implements APIApplicationPublisher {
 
 	@Reference
 	private EndpointHelper _endpointHelper;
+
+	private final Map<String, EndpointMatcher> _endpointMatchersMap =
+		new HashMap<>();
 
 	@Reference
 	private OpenAPIResource _openAPIResource;

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/resource/HeadlessBuilderResourceImpl.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/resource/HeadlessBuilderResourceImpl.java
@@ -15,6 +15,8 @@ import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
+import java.util.function.Function;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -29,10 +31,11 @@ import javax.ws.rs.core.Response;
 public class HeadlessBuilderResourceImpl {
 
 	public HeadlessBuilderResourceImpl(
-		EndpointHelper endpointHelper, EndpointMatcher endpointMatcher) {
+		EndpointHelper endpointHelper,
+		Function<Long, EndpointMatcher> endpointMatcherFunction) {
 
 		_endpointHelper = endpointHelper;
-		_endpointMatcher = endpointMatcher;
+		_endpointMatcherFunction = endpointMatcherFunction;
 	}
 
 	@GET
@@ -90,7 +93,16 @@ public class HeadlessBuilderResourceImpl {
 				successUnsafeFunction)
 		throws Exception {
 
-		APIApplication.Endpoint endpoint = _endpointMatcher.getEndpoint(
+		EndpointMatcher endpointMatcher = _endpointMatcherFunction.apply(
+			_company.getCompanyId());
+
+		if (endpointMatcher == null) {
+			return Response.status(
+				Response.Status.NOT_FOUND
+			).build();
+		}
+
+		APIApplication.Endpoint endpoint = endpointMatcher.getEndpoint(
 			"/" + path);
 
 		if ((endpoint == null) || (endpoint.getScope() != scope)) {
@@ -115,6 +127,6 @@ public class HeadlessBuilderResourceImpl {
 	private Company _company;
 
 	private final EndpointHelper _endpointHelper;
-	private final EndpointMatcher _endpointMatcher;
+	private final Function<Long, EndpointMatcher> _endpointMatcherFunction;
 
 }

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/resource/HeadlessBuilderResourceImpl.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/resource/HeadlessBuilderResourceImpl.java
@@ -103,9 +103,9 @@ public class HeadlessBuilderResourceImpl {
 		}
 
 		APIApplication.Endpoint endpoint = endpointMatcher.getEndpoint(
-			"/" + path);
+			"/" + path, scope);
 
-		if ((endpoint == null) || (endpoint.getScope() != scope)) {
+		if (endpoint == null) {
 			throw new NoSuchModelException(
 				"Endpoint /%s does not exist for " + path);
 		}

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/test/java/com/liferay/headless/builder/internal/application/endpoint/EndpointMatcherTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/test/java/com/liferay/headless/builder/internal/application/endpoint/EndpointMatcherTest.java
@@ -36,13 +36,16 @@ public class EndpointMatcherTest {
 
 		EndpointMatcher endpointMatcher = new EndpointMatcher(endpoints);
 
-		Assert.assertNull(endpointMatcher.getEndpoint("/path"));
+		Assert.assertNull(endpointMatcher.getEndpoint("/path", null));
+		Assert.assertNull(
+			endpointMatcher.getEndpoint(
+				"/path-name", APIApplication.Endpoint.Scope.GROUP));
 		Assert.assertEquals(
-			endpoints.get(0), endpointMatcher.getEndpoint("/path-name"));
+			endpoints.get(0), endpointMatcher.getEndpoint("/path-name", null));
 		Assert.assertEquals(
-			endpoints.get(1), endpointMatcher.getEndpoint("/path-name2"));
+			endpoints.get(1), endpointMatcher.getEndpoint("/path-name2", null));
 		Assert.assertEquals(
-			endpoints.get(2), endpointMatcher.getEndpoint("/path/1234"));
+			endpoints.get(2), endpointMatcher.getEndpoint("/path/1234", null));
 	}
 
 	private APIApplication.Endpoint _getEndpoint(

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
@@ -187,6 +187,13 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			null, "c/" + _BASE_URL_1 + _API_APPLICATION_PATH_1,
 			Http.Method.GET);
 
+		Assert.assertTrue(
+			HTTPTestUtil.invokeToJSONObject(
+				null, "openapi", Http.Method.GET
+			).has(
+				"/c/" + _BASE_URL_1
+			));
+
 		HTTPTestUtil.invokeToJSONObject(
 			JSONUtil.put(
 				"domain", "able.com"
@@ -204,11 +211,19 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 		).withCredentials(
 			"test@able.com", "test"
 		).apply(
-			() -> Assert.assertEquals(
-				404,
-				HTTPTestUtil.invokeToHttpCode(
-					null, "c/" + _BASE_URL_1 + _API_APPLICATION_PATH_1,
-					Http.Method.GET))
+			() -> {
+				Assert.assertEquals(
+					404,
+					HTTPTestUtil.invokeToHttpCode(
+						null, "c/" + _BASE_URL_1 + _API_APPLICATION_PATH_1,
+						Http.Method.GET));
+				Assert.assertFalse(
+					HTTPTestUtil.invokeToJSONObject(
+						null, "openapi", Http.Method.GET
+					).has(
+						"/c/" + _BASE_URL_1
+					));
+			}
 		);
 	}
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
@@ -174,6 +174,45 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 	}
 
 	@Test
+	public void testGetInDifferentInstance() throws Exception {
+		_addAPIApplication(
+			_API_APPLICATION_ERC_1, _API_ENDPOINT_ERC_1, _BASE_URL_1,
+			_objectDefinition1.getExternalReferenceCode(),
+			_objectRelationship1.getName(), _objectRelationship2.getName(),
+			_API_APPLICATION_PATH_1, null, "collection",
+			APIApplication.Endpoint.Scope.COMPANY);
+		_publishAPIApplication(_API_APPLICATION_ERC_1);
+
+		assertSuccessfulHttpCode(
+			null, "c/" + _BASE_URL_1 + _API_APPLICATION_PATH_1,
+			Http.Method.GET);
+
+		HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				"domain", "able.com"
+			).put(
+				"portalInstanceId", "able.com"
+			).put(
+				"virtualHost", "www.able.com"
+			).toString(),
+			"headless-portal-instances/v1.0/portal-instances",
+			Http.Method.POST);
+
+		HTTPTestUtil.customize(
+		).withBaseURL(
+			"http://www.able.com:8080"
+		).withCredentials(
+			"test@able.com", "test"
+		).apply(
+			() -> Assert.assertEquals(
+				404,
+				HTTPTestUtil.invokeToHttpCode(
+					null, "c/" + _BASE_URL_1 + _API_APPLICATION_PATH_1,
+					Http.Method.GET))
+		);
+	}
+
+	@Test
 	public void testGetIndividualEndpoint() throws Exception {
 		_addAPIApplication(
 			_API_APPLICATION_ERC_1, _API_ENDPOINT_ERC_1, _BASE_URL_1,

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
@@ -357,9 +357,12 @@ public class ObjectEntryRelatedObjectsResourceTest {
 			String.valueOf(_objectEntry2.getPrimaryKey()), role.getRoleId(),
 			new String[] {ActionKeys.VIEW});
 
-		HTTPTestUtil.withCredentials(
-			user.getEmailAddress(), password,
-			this::testGetRelatedCustomObjectEntriesWhenRelationExists);
+		HTTPTestUtil.customize(
+		).withCredentials(
+			user.getEmailAddress(), password
+		).apply(
+			this::testGetRelatedCustomObjectEntriesWhenRelationExists
+		);
 	}
 
 	@Test

--- a/portal-test/bnd.bnd
+++ b/portal-test/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 21.0.1
+Bundle-Version: 22.0.0
 Export-Package:\
 	com.liferay.portal.kernel.dao.db.test,\
 	com.liferay.portal.kernel.test,\

--- a/portal-test/src/com/liferay/portal/kernel/test/util/packageinfo
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 6.1.0
+version 7.0.0


### PR DESCRIPTION
- LPS-194127 Getting the endpoint matcher for the current company or 404
- LPS-194127 Avoiding unnecessary regex if the scope does not match
- LPS-195140 Showing only in the right companies
- LPS-195122 Customizing also baseURL
- LPS-195122 Testing app returns 404 on different company
- LPS-195122 Testing also api explorer visibility
- LPS-194865 Making sure this is run after all other listeners
