### PR TITLE
LPS-195045 Fix the Import CSV Template returned for Custom Objects

### DIFF
--- a/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/FieldResourceImpl.java
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/FieldResourceImpl.java
@@ -8,7 +8,6 @@ package com.liferay.batch.planner.rest.internal.resource.v1_0;
 import com.liferay.batch.planner.rest.dto.v1_0.Field;
 import com.liferay.batch.planner.rest.internal.vulcan.batch.engine.FieldProvider;
 import com.liferay.batch.planner.rest.resource.v1_0.FieldResource;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.vulcan.pagination.Page;
 
@@ -34,7 +33,9 @@ public class FieldResourceImpl extends BaseFieldResourceImpl {
 		throws Exception {
 
 		List<com.liferay.portal.vulcan.batch.engine.Field> vulcanFields =
-			_getVulcanFields(internalClassName);
+			_fieldProvider.getFields(
+				contextCompany.getCompanyId(), internalClassName,
+				contextUriInfo);
 
 		if (GetterUtil.getBoolean(export)) {
 			vulcanFields = _fieldProvider.filter(
@@ -50,22 +51,6 @@ public class FieldResourceImpl extends BaseFieldResourceImpl {
 		vulcanFields.sort(Comparator.comparing(field -> field.getName()));
 
 		return Page.of(transform(vulcanFields, this::_toField));
-	}
-
-	private List<com.liferay.portal.vulcan.batch.engine.Field> _getVulcanFields(
-			String internalClassName)
-		throws Exception {
-
-		int idx = internalClassName.indexOf(StringPool.POUND);
-
-		if (idx < 0) {
-			return _fieldProvider.getFields(
-				contextCompany.getCompanyId(), internalClassName);
-		}
-
-		return _fieldProvider.getFields(
-			contextCompany.getCompanyId(), internalClassName.substring(idx + 1),
-			contextUriInfo);
 	}
 
 	private Field _toField(

--- a/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/PlanResourceImpl.java
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/PlanResourceImpl.java
@@ -70,7 +70,8 @@ public class PlanResourceImpl extends BasePlanResourceImpl {
 			internalClassName.substring(
 				internalClassName.lastIndexOf(StringPool.PERIOD) + 1),
 			_fieldProvider.getFields(
-				contextCompany.getCompanyId(), internalClassName));
+				contextCompany.getCompanyId(), internalClassName,
+				contextUriInfo));
 	}
 
 	@Override

--- a/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/vulcan/batch/engine/FieldProvider.java
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/vulcan/batch/engine/FieldProvider.java
@@ -13,12 +13,12 @@ import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.vulcan.batch.engine.Field;
 import com.liferay.portal.vulcan.util.OpenAPIUtil;
 import com.liferay.portal.vulcan.yaml.openapi.OpenAPIYAML;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -64,12 +64,11 @@ public class FieldProvider {
 			OpenAPIYAML openAPIYAML = _openAPIYAMLProvider.getOpenAPIYAML(
 				companyId, internalClassName);
 
-			Map<String, Field> dtoEntityFields = OpenAPIUtil.getDTOEntityFields(
-				internalClassName.substring(
-					internalClassName.lastIndexOf(StringPool.PERIOD) + 1),
-				openAPIYAML);
-
-			return new ArrayList<>(dtoEntityFields.values());
+			return ListUtil.fromMapValues(
+				OpenAPIUtil.getDTOEntityFields(
+					StringUtil.extractLast(
+						internalClassName, StringPool.PERIOD),
+					openAPIYAML));
 		}
 
 		ObjectDefinition objectDefinition =

--- a/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/vulcan/batch/engine/FieldProvider.java
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/vulcan/batch/engine/FieldProvider.java
@@ -54,27 +54,27 @@ public class FieldProvider {
 			});
 	}
 
-	public List<Field> getFields(long companyId, String internalClassName)
-		throws Exception {
-
-		OpenAPIYAML openAPIYAML = _openAPIYAMLProvider.getOpenAPIYAML(
-			companyId, internalClassName);
-
-		Map<String, Field> dtoEntityFields = OpenAPIUtil.getDTOEntityFields(
-			internalClassName.substring(
-				internalClassName.lastIndexOf(StringPool.PERIOD) + 1),
-			openAPIYAML);
-
-		return new ArrayList<>(dtoEntityFields.values());
-	}
-
 	public List<Field> getFields(
-			long companyId, String objectDefinitionName, UriInfo uriInfo)
+			long companyId, String internalClassName, UriInfo uriInfo)
 		throws Exception {
+
+		int idx = internalClassName.indexOf(StringPool.POUND);
+
+		if (idx < 0) {
+			OpenAPIYAML openAPIYAML = _openAPIYAMLProvider.getOpenAPIYAML(
+				companyId, internalClassName);
+
+			Map<String, Field> dtoEntityFields = OpenAPIUtil.getDTOEntityFields(
+				internalClassName.substring(
+					internalClassName.lastIndexOf(StringPool.PERIOD) + 1),
+				openAPIYAML);
+
+			return new ArrayList<>(dtoEntityFields.values());
+		}
 
 		ObjectDefinition objectDefinition =
 			_objectDefinitionLocalService.fetchObjectDefinition(
-				companyId, objectDefinitionName);
+				companyId, internalClassName.substring(idx + 1));
 
 		ObjectEntryOpenAPIResource objectEntryOpenAPIResource =
 			_objectEntryOpenAPIResourceProvider.getObjectEntryOpenAPIResource(

--- a/modules/apps/batch-planner/batch-planner-rest-test/build.gradle
+++ b/modules/apps/batch-planner/batch-planner-rest-test/build.gradle
@@ -6,6 +6,8 @@ dependencies {
 	testIntegrationImplementation project(":apps:batch-planner:batch-planner-api")
 	testIntegrationImplementation project(":apps:batch-planner:batch-planner-rest-api")
 	testIntegrationImplementation project(":apps:batch-planner:batch-planner-rest-client")
+	testIntegrationImplementation project(":apps:object:object-api")
+	testIntegrationImplementation project(":apps:object:object-rest-test-util")
 	testIntegrationImplementation project(":apps:portal-odata:portal-odata-api")
 	testIntegrationImplementation project(":apps:portal-vulcan:portal-vulcan-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")

--- a/modules/apps/batch-planner/batch-planner-rest-test/src/testIntegration/java/com/liferay/batch/planner/rest/resource/v1_0/test/PlanResourceTest.java
+++ b/modules/apps/batch-planner/batch-planner-rest-test/src/testIntegration/java/com/liferay/batch/planner/rest/resource/v1_0/test/PlanResourceTest.java
@@ -7,10 +7,20 @@ package com.liferay.batch.planner.rest.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.batch.planner.rest.client.dto.v1_0.Plan;
+import com.liferay.batch.planner.rest.client.http.HttpInvoker;
+import com.liferay.object.field.builder.TextObjectFieldBuilder;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.rest.test.util.ObjectDefinitionTestUtil;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.URLCodec;
+import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
+import java.util.Collections;
+
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -28,6 +38,35 @@ public class PlanResourceTest extends BasePlanResourceTestCase {
 			200,
 			planResource.getPlanTemplateHttpResponse(
 				"com.liferay.headless.admin.user.dto.v1_0.Account"));
+
+		String fieldName = "a" + RandomTestUtil.randomString();
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				Collections.singletonList(
+					new TextObjectFieldBuilder(
+					).labelMap(
+						LocalizedMapUtil.getLocalizedMap(
+							RandomTestUtil.randomString())
+					).name(
+						fieldName
+					).build()));
+
+		HttpInvoker.HttpResponse response =
+			planResource.getPlanTemplateHttpResponse(
+				"com.liferay.object.rest.dto.v1_0.ObjectEntry" +
+					URLCodec.encodeURL("#") + objectDefinition.getName());
+
+		Assert.assertEquals(200, response.getStatusCode());
+
+		String[] lines = StringUtil.split(
+			response.getContent(), System.lineSeparator());
+
+		Assert.assertTrue(
+			StringBundler.concat(
+				"The first line '", lines[0], "' does not contain the field '",
+				fieldName, "'"),
+			StringUtil.contains(lines[0], fieldName));
 	}
 
 	@Override


### PR DESCRIPTION
Related bug: https://liferay.atlassian.net/browse/LPS-195045

---

The purpose of this PR is to fix the CSV template file returned by the `/plans/{internalClassName}/template` endpoint for Custom Objects.

---

**How to test it:**

Create a Custom Object Definition:

```
curl -X "POST" "http://localhost:8080/o/object-admin/v1.0/object-definitions" \
     -H 'Content-Type: application/json' \
     -u 'test@liferay.com:test' \
     -d $'{
  "active": true,
  "status": {
    "code": 0
  },
  "objectFields": [
    {
      "DBType": "String",
      "indexed": true,
      "indexedLanguageId": "",
      "externalReferenceCode": "university-name",
      "listTypeDefinitionId": 0,
      "label": {
        "en_US": "University name"
      },
      "type": "String",
      "required": true,
      "name": "universityName",
      "indexedAsKeyword": false
    }
  ],
  "pluralLabel": {
    "en-US": "Universities"
  },
  "portlet": true,
  "scope": "company",
  "label": {
    "en-US": "University"
  },
  "externalReferenceCode": "University",
  "name": "University"
}'
```

Perform the following request:

```
curl -X "GET" "http://localhost:8080/o/batch-planner/v1.0/plans/com.liferay.object.rest.dto.v1_0.ObjectEntry%23C_University/template" \
     -u 'test@liferay.com:test'
```

**Before this PR:**

The response is empty:

```

```


**After this PR:**

The response contains an example in CSV format containing an example:

```
universityName,keywords,externalReferenceCode,taxonomyCategoryIds
string,array,string,array
```
