### PR TITLE
LPS-195543: Manage unrelated API Properties that are going to be patched from an API Schema

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIPropertyRelevantObjectEntryModelListener.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIPropertyRelevantObjectEntryModelListener.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 
 import java.io.Serializable;
@@ -46,7 +47,11 @@ public class APIPropertyRelevantObjectEntryModelListener
 	public void onBeforeCreate(ObjectEntry objectEntry)
 		throws ModelListenerException {
 
-		_validate(objectEntry.getValues());
+		Map<String, Serializable> values = objectEntry.getValues();
+
+		_validate(
+			(long)values.get("r_apiSchemaToAPIProperties_c_apiSchemaId"),
+			values);
 	}
 
 	@Override
@@ -56,47 +61,18 @@ public class APIPropertyRelevantObjectEntryModelListener
 
 		Map<String, Serializable> values = objectEntry.getValues();
 
-		long apiSchemaId = (long)values.get(
-			"r_apiSchemaToAPIProperties_c_apiSchemaId");
+		long apiSchemaId = MapUtil.getLong(
+			values, "r_apiSchemaToAPIProperties_c_apiSchemaId");
 
 		if (apiSchemaId != 0) {
-			_validate(values);
+			_validate(apiSchemaId, values);
 		}
-
-		_scheduleAPIProperties(objectEntry.getObjectEntryId());
+		else {
+			_scheduleOrphanAPIPropertyDeletion(objectEntry.getObjectEntryId());
+		}
 	}
 
-	private void _scheduleAPIProperties(long apiPropertyId) {
-		_pendingAPIProperties.add(apiPropertyId);
-
-		TransactionCommitCallbackUtil.registerCallback(
-			() -> {
-				if (_pendingAPIProperties.remove(apiPropertyId)) {
-					ObjectEntry apiPropertyObjectEntry =
-						_objectEntryLocalService.fetchObjectEntry(
-							apiPropertyId);
-
-					if (apiPropertyObjectEntry == null) {
-						return null;
-					}
-
-					Map<String, Serializable> values =
-						apiPropertyObjectEntry.getValues();
-
-					long apiSchemaId = (long)values.get(
-						"r_apiSchemaToAPIProperties_c_apiSchemaId");
-
-					if (apiSchemaId == 0) {
-						_objectEntryLocalService.deleteObjectEntry(
-							apiPropertyId);
-					}
-				}
-
-				return null;
-			});
-	}
-
-	private boolean _validate(
+	private boolean _isValidAPIPropertyFields(
 			long apiSchemaId, String objectFieldExternalReferenceCode,
 			String objectRelationshipName)
 		throws Exception {
@@ -139,11 +115,36 @@ public class APIPropertyRelevantObjectEntryModelListener
 		return true;
 	}
 
-	private void _validate(Map<String, Serializable> objectEntryValues) {
-		try {
-			long apiSchemaId = (long)objectEntryValues.get(
-				"r_apiSchemaToAPIProperties_c_apiSchemaId");
+	private void _scheduleOrphanAPIPropertyDeletion(long apiPropertyId) {
+		_pendingAPIProperties.add(apiPropertyId);
 
+		TransactionCommitCallbackUtil.registerCallback(
+			() -> {
+				if (_pendingAPIProperties.remove(apiPropertyId)) {
+					ObjectEntry apiPropertyObjectEntry =
+						_objectEntryLocalService.fetchObjectEntry(
+							apiPropertyId);
+
+					if (apiPropertyObjectEntry == null) {
+						return null;
+					}
+
+					long apiSchemaId = MapUtil.getLong(
+						apiPropertyObjectEntry.getValues(),
+						"r_apiSchemaToAPIProperties_c_apiSchemaId");
+
+					if (apiSchemaId == 0) {
+						_objectEntryLocalService.deleteObjectEntry(
+							apiPropertyId);
+					}
+				}
+
+				return null;
+			});
+	}
+
+	private void _validate(long apiSchemaId, Map<String, Serializable> values) {
+		try {
 			if (!_objectEntryHelper.isValidObjectEntry(
 					apiSchemaId, "L_API_SCHEMA")) {
 
@@ -152,10 +153,9 @@ public class APIPropertyRelevantObjectEntryModelListener
 					"an-api-property-must-be-related-to-an-api-schema");
 			}
 
-			if (!_validate(
-					apiSchemaId,
-					(String)objectEntryValues.get("objectFieldERC"),
-					(String)objectEntryValues.get("objectRelationshipNames"))) {
+			if (!_isValidAPIPropertyFields(
+					apiSchemaId, (String)values.get("objectFieldERC"),
+					(String)values.get("objectRelationshipNames"))) {
 
 				throw new ObjectEntryValuesException.InvalidObjectField(
 					null,

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIPropertyRelevantObjectEntryModelListener.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIPropertyRelevantObjectEntryModelListener.java
@@ -16,12 +16,15 @@ import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 
 import java.io.Serializable;
 
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -43,7 +46,7 @@ public class APIPropertyRelevantObjectEntryModelListener
 	public void onBeforeCreate(ObjectEntry objectEntry)
 		throws ModelListenerException {
 
-		_validate(objectEntry);
+		_validate(objectEntry.getValues());
 	}
 
 	@Override
@@ -51,7 +54,46 @@ public class APIPropertyRelevantObjectEntryModelListener
 			ObjectEntry originalObjectEntry, ObjectEntry objectEntry)
 		throws ModelListenerException {
 
-		_validate(objectEntry);
+		Map<String, Serializable> values = objectEntry.getValues();
+
+		long apiSchemaId = (long)values.get(
+			"r_apiSchemaToAPIProperties_c_apiSchemaId");
+
+		if (apiSchemaId != 0) {
+			_validate(values);
+		}
+
+		_scheduleAPIProperties(objectEntry.getObjectEntryId());
+	}
+
+	private void _scheduleAPIProperties(long apiPropertyId) {
+		_pendingAPIProperties.add(apiPropertyId);
+
+		TransactionCommitCallbackUtil.registerCallback(
+			() -> {
+				if (_pendingAPIProperties.remove(apiPropertyId)) {
+					ObjectEntry apiPropertyObjectEntry =
+						_objectEntryLocalService.fetchObjectEntry(
+							apiPropertyId);
+
+					if (apiPropertyObjectEntry == null) {
+						return null;
+					}
+
+					Map<String, Serializable> values =
+						apiPropertyObjectEntry.getValues();
+
+					long apiSchemaId = (long)values.get(
+						"r_apiSchemaToAPIProperties_c_apiSchemaId");
+
+					if (apiSchemaId == 0) {
+						_objectEntryLocalService.deleteObjectEntry(
+							apiPropertyId);
+					}
+				}
+
+				return null;
+			});
 	}
 
 	private boolean _validate(
@@ -97,11 +139,9 @@ public class APIPropertyRelevantObjectEntryModelListener
 		return true;
 	}
 
-	private void _validate(ObjectEntry objectEntry) {
+	private void _validate(Map<String, Serializable> objectEntryValues) {
 		try {
-			Map<String, Serializable> values = objectEntry.getValues();
-
-			long apiSchemaId = (long)values.get(
+			long apiSchemaId = (long)objectEntryValues.get(
 				"r_apiSchemaToAPIProperties_c_apiSchemaId");
 
 			if (!_objectEntryHelper.isValidObjectEntry(
@@ -113,8 +153,9 @@ public class APIPropertyRelevantObjectEntryModelListener
 			}
 
 			if (!_validate(
-					apiSchemaId, (String)values.get("objectFieldERC"),
-					(String)values.get("objectRelationshipNames"))) {
+					apiSchemaId,
+					(String)objectEntryValues.get("objectFieldERC"),
+					(String)objectEntryValues.get("objectRelationshipNames"))) {
 
 				throw new ObjectEntryValuesException.InvalidObjectField(
 					null,
@@ -140,5 +181,7 @@ public class APIPropertyRelevantObjectEntryModelListener
 
 	@Reference
 	private ObjectFieldLocalService _objectFieldLocalService;
+
+	private final Set<Long> _pendingAPIProperties = new CopyOnWriteArraySet<>();
 
 }

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APISchemaRelevantObjectEntryModelListenerTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APISchemaRelevantObjectEntryModelListenerTest.java
@@ -9,6 +9,8 @@ import com.liferay.headless.builder.test.BaseTestCase;
 import com.liferay.headless.builder.util.ObjectDefinitionTestUtil;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectField;
+import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -18,7 +20,7 @@ import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.FeatureFlags;
 
-import java.util.Collections;
+import java.util.Arrays;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -35,16 +37,114 @@ public class APISchemaRelevantObjectEntryModelListenerTest
 	public void setUp() throws Exception {
 		super.setUp();
 
+		_objectField1 = ObjectFieldUtil.createObjectField(
+			"Text", "String", true, true, null, RandomTestUtil.randomString(),
+			"x" + RandomTestUtil.randomString(), false);
+
+		_objectField2 = ObjectFieldUtil.createObjectField(
+			"Text", "String", true, true, null, RandomTestUtil.randomString(),
+			"x" + RandomTestUtil.randomString(), false);
+
+		_objectField1.setExternalReferenceCode(RandomTestUtil.randomString());
+
+		_objectField2.setExternalReferenceCode(RandomTestUtil.randomString());
+
 		_objectDefinition = ObjectDefinitionTestUtil.publishObjectDefinition(
-			Collections.singletonList(
-				ObjectFieldUtil.createObjectField(
-					"Text", "String", true, true, null,
-					RandomTestUtil.randomString(),
-					"x" + RandomTestUtil.randomString(), false)));
+			Arrays.asList(_objectField1, _objectField2));
 	}
 
 	@Test
-	public void test() throws Exception {
+	public void testPatchSchemaWithRelatedProperties() throws Exception {
+		JSONObject apiApplicationJSONObject = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				"applicationStatus", "unpublished"
+			).put(
+				"baseURL", StringUtil.toLowerCase(RandomTestUtil.randomString())
+			).put(
+				"title", RandomTestUtil.randomString()
+			).toString(),
+			"headless-builder/applications", Http.Method.POST);
+
+		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				"apiSchemaToAPIProperties",
+				JSONUtil.putAll(
+					JSONUtil.put(
+						"description", "description"
+					).put(
+						"name", "name"
+					).put(
+						"objectFieldERC",
+						_objectField1.getExternalReferenceCode()
+					),
+					JSONUtil.put(
+						"description", "description"
+					).put(
+						"name", "name"
+					).put(
+						"objectFieldERC",
+						_objectField2.getExternalReferenceCode()
+					))
+			).put(
+				"mainObjectDefinitionERC",
+				_objectDefinition.getExternalReferenceCode()
+			).put(
+				"name", _API_SCHEMA_NAME
+			).put(
+				"r_apiApplicationToAPISchemas_c_apiApplicationId",
+				apiApplicationJSONObject.getLong("id")
+			).toString(),
+			"headless-builder/schemas", Http.Method.POST);
+
+		long apiSchemaId = jsonObject.getLong("id");
+
+		Assert.assertEquals(
+			0,
+			jsonObject.getJSONObject(
+				"status"
+			).get(
+				"code"
+			));
+
+		jsonObject = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				"apiSchemaToAPIProperties",
+				JSONUtil.put(
+					JSONUtil.put(
+						"description", "description"
+					).put(
+						"name", "name"
+					).put(
+						"objectFieldERC",
+						_objectField1.getExternalReferenceCode()
+					))
+			).put(
+				"mainObjectDefinitionERC",
+				_objectDefinition.getExternalReferenceCode()
+			).put(
+				"name", _API_SCHEMA_NAME
+			).put(
+				"r_apiApplicationToAPISchemas_c_apiApplicationId",
+				apiApplicationJSONObject.getLong("id")
+			).toString(),
+			"headless-builder/schemas/" + apiSchemaId, Http.Method.PATCH);
+
+		Assert.assertEquals(
+			0,
+			jsonObject.getJSONObject(
+				"status"
+			).get(
+				"code"
+			));
+
+		JSONArray jsonArray = jsonObject.getJSONArray(
+			"apiSchemaToAPIProperties");
+
+		Assert.assertEquals(1, jsonArray.length());
+	}
+
+	@Test
+	public void testPostSchema() throws Exception {
 		JSONObject apiApplicationJSONObject = HTTPTestUtil.invokeToJSONObject(
 			JSONUtil.put(
 				"applicationStatus", "unpublished"
@@ -159,5 +259,11 @@ public class APISchemaRelevantObjectEntryModelListenerTest
 
 	@DeleteAfterTestRun
 	private ObjectDefinition _objectDefinition;
+
+	@DeleteAfterTestRun
+	private ObjectField _objectField1;
+
+	@DeleteAfterTestRun
+	private ObjectField _objectField2;
 
 }


### PR DESCRIPTION
**What is new**

- Create function to manage those API Properties that are not going to be related from its API Schema
- Just enable and allow validations in `onBeforeUpdate` when its API Schema is not 0
- Add a test case for that use case

**JIRA Ticket Related**
https://liferay.atlassian.net/browse/LPS-195543