### PR TITLE
LPS-195609 API application in virtual instance should be deleted on API Explorer even if same name of API application exist in another instance

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/application/publisher/APIApplicationPublisherImpl.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/application/publisher/APIApplicationPublisherImpl.java
@@ -97,7 +97,7 @@ public class APIApplicationPublisherImpl implements APIApplicationPublisher {
 				"APIApplicationPublisher not available");
 		}
 
-		_endpointMatchersMap.remove(baseURL + companyId);
+		_endpointMatchersMap.remove(_getEndpointMatcherKey(baseURL, companyId));
 
 		Set<Long> companyIds = _getCompanyIds(baseURL);
 

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/instance/lifecycle/APIApplicationPublisherPortalInstanceLifecycleListener.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/instance/lifecycle/APIApplicationPublisherPortalInstanceLifecycleListener.java
@@ -20,7 +20,10 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Alejandro Tardín
  */
-@Component(service = PortalInstanceLifecycleListener.class)
+@Component(
+	property = "service.ranking:Integer=" + Integer.MIN_VALUE,
+	service = PortalInstanceLifecycleListener.class
+)
 public class APIApplicationPublisherPortalInstanceLifecycleListener
 	extends BasePortalInstanceLifecycleListener
 	implements EveryNodeEveryStartup {

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
@@ -223,6 +223,40 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 					).has(
 						"/c/" + _BASE_URL_1
 					));
+
+				String externalReferenceCode = RandomTestUtil.randomString();
+
+				assertSuccessfulHttpCode(
+					JSONUtil.put(
+						"applicationStatus", "published"
+					).put(
+						"baseURL", _BASE_URL_1
+					).put(
+						"externalReferenceCode", externalReferenceCode
+					).put(
+						"title", "test-app"
+					).toString(),
+					"headless-builder/applications", Http.Method.POST);
+
+				Assert.assertTrue(
+					HTTPTestUtil.invokeToJSONObject(
+						null, "openapi", Http.Method.GET
+					).has(
+						"/c/" + _BASE_URL_1
+					));
+
+				assertSuccessfulHttpCode(
+					null,
+					"headless-builder/applications/by-external-reference-code" +
+						"/" + externalReferenceCode,
+					Http.Method.DELETE);
+
+				Assert.assertFalse(
+					HTTPTestUtil.invokeToJSONObject(
+						null, "openapi", Http.Method.GET
+					).has(
+						"/c/" + _BASE_URL_1
+					));
 			}
 		);
 	}


### PR DESCRIPTION
Fixes https://liferay.atlassian.net/browse/LPS-195609.

We were not removing the companyId of an application on unpublish.