### PR TITLE
LPS-186772 | Add a testcase to publish a REST API Application

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[APIRest]APIGenerator/PublishARESTAPIApplication.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[APIRest]APIGenerator/PublishARESTAPIApplication.testcase
@@ -1,0 +1,123 @@
+@component-name = "portal-headless"
+definition {
+
+	property custom.properties = "feature.flag.LPS-184413=true${line.separator}feature.flag.LPS-167253=true${line.separator}feature.flag.LPS-178642=true${line.separator}feature.flag.LPS-186757=true";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Object";
+	property testray.main.component.name = "Headless Builder";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginUI();
+
+		task ("Given an API Application 'App-test' of status 'published' by post request postAPIApplication") {
+			ApplicationAPI.createAPIApplication(
+				baseURL = "app-test",
+				status = "published",
+				title = "App-test");
+
+			ApplicationAPI.setUpGlobalAPIApplicationId();
+		}
+	}
+
+	tearDown {
+		ApplicationAPI.deleteAllAPIApplication();
+
+		var testLiferayVirtualInstance = PropsUtil.get("test.liferay.virtual.instance");
+
+		if (${testLiferayVirtualInstance} == "true") {
+			PortalInstances.tearDownCP();
+		}
+	}
+
+	@priority = 4
+	test CanSeeNewApiEndpointAndApiSchemaInPublishedApiApplicationPage {
+		property portal.acceptance = "true";
+
+		task ("And Given an API Schema 'AppTest' related to an Application by post request postAPISchema") {
+			var response = SchemaAPI.createAPISchema(
+				apiApplicationId = ${staticApplicationId},
+				mainObjectDefinitionERC = "L_API_APPLICATION",
+				name = "AppTest");
+		}
+
+		task ("And Given an API endpoint in an API Application and set Response API Schema to API endpoints with the created Schema by postAPIEndpoint") {
+			var schemaId = JSONPathUtil.getIdValue(response = ${response});
+
+			EndpointAPI.createAPIEndpoint(
+				apiApplicationId = ${staticApplicationId},
+				name = "AppTest",
+				path = "/AppTest",
+				responseSchemaId = ${schemaId});
+		}
+
+		task ("When I can navigate to App-test page in API Explorer") {
+			APIExplorer.navigateToOpenAPI(customObjectPlural = "app-test");
+		}
+
+		task ("Then the page load successfully") {
+			AssertConsoleTextNotPresent(value1 = "Failed to load API definition.");
+		}
+
+		task ("And Then I can see a new schema and an endpoint appear in the page") {
+			WaitForElementPresent(
+				locator1 = "OpenAPI#SCHEMA_TITLE",
+				schema = "AppTest");
+
+			WaitForElementPresent(
+				locator1 = "OpenAPI#API_METHOD",
+				method = "getAppTestPage",
+				service = "AppTest");
+		}
+	}
+
+	@priority = 4
+	test CanSeeNewApiEndpointInPublishedApiApplcationPage {
+		property portal.acceptance = "true";
+
+		task ("And Given an API endpoint 'AppTest' related to an Application by post request postAPIEndpoint") {
+			EndpointAPI.createAPIEndpoint(
+				apiApplicationId = ${staticApplicationId},
+				name = "AppTest",
+				path = "/AppTest");
+		}
+
+		task ("When I can navigate to App-test page in API Explorer") {
+			APIExplorer.navigateToOpenAPI(customObjectPlural = "app-test");
+		}
+
+		task ("Then I can see a new endpoint appear in the page without an error") {
+			AssertConsoleTextNotPresent(value1 = "Failed to load API definition.");
+
+			WaitForElementPresent(
+				locator1 = "OpenAPI#API_METHOD",
+				method = "getAppTestPage",
+				service = "default");
+		}
+	}
+
+	@priority = 4
+	test CanSeeNewSchemaInPublishedApiApplcationPage {
+		property portal.acceptance = "true";
+
+		task ("And Given an API Schema 'AppTest' related to an Application by post request postAPISchema") {
+			SchemaAPI.createAPISchema(
+				apiApplicationId = ${staticApplicationId},
+				mainObjectDefinitionERC = "L_API_APPLICATION",
+				name = "AppTest");
+		}
+
+		task ("When I can navigate to App-test page in API Explorer") {
+			APIExplorer.navigateToOpenAPI(customObjectPlural = "app-test");
+		}
+
+		task ("Then I can see a new schema appear in the page") {
+			WaitForElementPresent(
+				locator1 = "OpenAPI#SCHEMA_TITLE",
+				schema = "AppTest");
+		}
+	}
+
+}


### PR DESCRIPTION
Background:
Add a testcase to publish a REST API Application

Test Plan
CanSeeNewSchemaInPublishedApiApplcationPage
Given an API Application 'App-test' of status ‘published’ by post request postAPIApplication
And Given an API Schema 'AppTest' related to an Application by post request postAPISchema
When I can navigate to App-test page in API Explorer
Then I can see a new schema appear in the page

CanSeeNewApiEndpointInPublishedApiApplcationPage
Given an API Application 'App-test' of status ‘published’ by post request postAPIApplication
And Given an API EndPoint 'AppTest' related to an Application by post request postAPIEndpoint
When I can navigate to App-test page in API Explorer
Then I can see a new endpoint appear in the page without an error

CanSeeNewApiEndpointAndApiSchemaInPublishedApiApplicationPage
Given an API Application 'App-test' of status ‘published’ by post request postAPIApplication
And Given an API Schema 'AppTest' related to an Application by post request postAPISchema
And Given an API EndPoint in an API Application and set Response API Schema to API Endpoints with the created Schema by postAPIEndpoint
When I can navigate to App-test page in API Explorer
Then the page load successfully
And Then I can see a new schema and an endPoint appear in the page

Jira ticket:
https://liferay.atlassian.net/browse/LPS-191033