### PR TITLE
LPS-194572: Actions node missing in JSONL and JSON formats

### DIFF
--- a/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/vulcan/batch/engine/FieldProvider.java
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/vulcan/batch/engine/FieldProvider.java
@@ -46,7 +46,7 @@ public class FieldProvider {
 
 				String name = dtoEntityField.getName();
 
-				if (name.equals("actions") || name.startsWith("x-")) {
+				if (name.startsWith("x-")) {
 					return false;
 				}
 

--- a/modules/apps/batch-planner/batch-planner-test/src/testIntegration/java/com/liferay/batch/planner/batch/engine/broker/test/BatchEngineBrokerTest.java
+++ b/modules/apps/batch-planner/batch-planner-test/src/testIntegration/java/com/liferay/batch/planner/batch/engine/broker/test/BatchEngineBrokerTest.java
@@ -76,6 +76,7 @@ import com.liferay.portal.kernel.util.MimeTypesUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 import com.liferay.portal.vulcan.jackson.databind.ser.VulcanPropertyFilter;
@@ -139,6 +140,8 @@ public class BatchEngineBrokerTest {
 			TestPropsValues.getUserId());
 
 		_company2 = CompanyTestUtil.addCompany();
+
+		PortalInstances.initCompany(_company2);
 
 		User user = UserTestUtil.getAdminUser(_company2.getCompanyId());
 
@@ -223,14 +226,29 @@ public class BatchEngineBrokerTest {
 			ServiceContextTestUtil.getServiceContext(companyId, 0, userId));
 	}
 
+	private void _assertActionsContentNotNull(JsonNode actionJsonNode) {
+		String[] actionKeys = {"delete", "get", "permissions", "update"};
+
+		for (String actionKey : actionKeys) {
+			JsonNode jsonNode = actionJsonNode.get(actionKey);
+
+			Assert.assertTrue(!jsonNode.isEmpty());
+		}
+	}
+
 	private void _assertEquals(JsonNode expectedJsonNode, JsonNode jsonNode) {
 		for (String fieldName : _fieldNames) {
 			JsonNode expectedFieldJsonNode = expectedJsonNode.get(fieldName);
 
 			JsonNode fieldJsonNode = jsonNode.get(fieldName);
 
-			Assert.assertEquals(
-				expectedFieldJsonNode.toString(), fieldJsonNode.toString());
+			if (Objects.equals(fieldName, "actions")) {
+				_assertActionsContentNotNull(fieldJsonNode);
+			}
+			else {
+				Assert.assertEquals(
+					expectedFieldJsonNode.toString(), fieldJsonNode.toString());
+			}
 		}
 	}
 
@@ -489,7 +507,7 @@ public class BatchEngineBrokerTest {
 	}
 
 	private static final List<String> _fieldNames = Arrays.asList(
-		"dateCreated", "dateModified", "externalReferenceCode", "id",
+		"actions", "dateCreated", "dateModified", "externalReferenceCode", "id",
 		"testAttachmentField", "testBooleanField", "testDateField",
 		"testDateTimeField", "testDecimalField", "testIntegerField",
 		"testLongIntegerField", "testLongTextField",


### PR DESCRIPTION
**What is new?**
- Include actions when export a Custom Object Definition for `JSON` and `JSONL`.
- Create new test case validation to determine that actions property is not empty.
- Fix Company init when creating a new one.


**JIRA Related Ticke**
https://liferay.atlassian.net/browse/LPS-194572