### PR TITLE
LPS-195627 Remove [createDate, modifiedDate] Object Definition internal fields from the OpenAPI

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/openapi/v1_0/ObjectEntryOpenAPIResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/openapi/v1_0/ObjectEntryOpenAPIResourceImpl.java
@@ -187,6 +187,20 @@ public class ObjectEntryOpenAPIResourceImpl
 				}
 			};
 		}
+		else if (Objects.equals(
+					objectField.getBusinessType(),
+					ObjectFieldConstants.BUSINESS_TYPE_DATE) &&
+				 _fieldNameMappings.containsKey(objectField.getName())) {
+
+			return new DTOProperty(
+				null, _fieldNameMappings.get(objectField.getName()),
+				ObjectFieldConstants.BUSINESS_TYPE_DATE_TIME) {
+
+				{
+					setRequired(objectField.isRequired());
+				}
+			};
+		}
 
 		if (objectField.getListTypeDefinitionId() != 0) {
 			DTOProperty dtoProperty = new DTOProperty(
@@ -419,6 +433,11 @@ public class ObjectEntryOpenAPIResourceImpl
 
 	private final BundleContext _bundleContext;
 	private final DTOConverterRegistry _dtoConverterRegistry;
+	private final Map<String, String> _fieldNameMappings = HashMapBuilder.put(
+		"createDate", "dateCreated"
+	).put(
+		"modifiedDate", "dateModified"
+	).build();
 	private final ObjectActionLocalService _objectActionLocalService;
 	private final ObjectDefinition _objectDefinition;
 	private final ObjectDefinitionLocalService _objectDefinitionLocalService;

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/openapi/contributor/ObjectEntryOpenAPIContributor.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/openapi/contributor/ObjectEntryOpenAPIContributor.java
@@ -95,9 +95,19 @@ public class ObjectEntryOpenAPIContributor extends BaseOpenAPIContributor {
 		Map<ObjectRelationship, ObjectDefinition> relatedObjectDefinitionsMap =
 			_getRelatedObjectDefinitionsMap();
 
+		Components components = openAPI.getComponents();
+
+		Map<String, Schema> schemas = components.getSchemas();
+
+		Schema objectDefinitionSchema = schemas.get(
+			_objectDefinition.getShortName());
+
+		Map<String, Schema> objectDefinitionSchemaProperties =
+			objectDefinitionSchema.getProperties();
+
 		Paths paths = openAPI.getPaths();
 
-		for (String key : new ArrayList<>(paths.keySet())) {
+		for (String key : ListUtil.fromMapKeys(paths)) {
 			if (!key.contains("objectActionName") &&
 				!key.contains("objectRelationshipName")) {
 
@@ -144,26 +154,14 @@ public class ObjectEntryOpenAPIContributor extends BaseOpenAPIContributor {
 						_setSchemaDescription(
 							objectRelationship, openAPI, relatedSchemaName);
 
-						openAPI.getComponents(
-						).getSchemas(
-						).get(
-							_objectDefinition.getShortName()
-						).getProperties(
-						).put(
+						objectDefinitionSchemaProperties.put(
 							objectRelationship.getName(),
-							_getSchema(objectRelationship, relatedSchemaName)
-						);
+							_getSchema(objectRelationship, relatedSchemaName));
 					}
 					else {
-						openAPI.getComponents(
-						).getSchemas(
-						).get(
-							_objectDefinition.getShortName()
-						).getProperties(
-						).put(
+						objectDefinitionSchemaProperties.put(
 							objectRelationship.getName(),
-							_getSchema(objectRelationship, null)
-						);
+							_getSchema(objectRelationship, null));
 					}
 				}
 			}
@@ -172,19 +170,9 @@ public class ObjectEntryOpenAPIContributor extends BaseOpenAPIContributor {
 		}
 
 		if (!_objectDefinition.isEnableCategorization()) {
-			Components components = openAPI.getComponents();
-
-			Map<String, Schema> schemas = components.getSchemas();
-
-			Schema objectDefinitionSchema = schemas.get(
-				_objectDefinition.getShortName());
-
-			Map<String, Schema> properties =
-				objectDefinitionSchema.getProperties();
-
-			properties.remove("keywords");
-			properties.remove("taxonomyCategoryBriefs");
-			properties.remove("taxonomyCategoryIds");
+			objectDefinitionSchemaProperties.remove("keywords");
+			objectDefinitionSchemaProperties.remove("taxonomyCategoryBriefs");
+			objectDefinitionSchemaProperties.remove("taxonomyCategoryIds");
 
 			schemas.remove("TaxonomyCategoryBrief");
 		}

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/OpenAPIResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/OpenAPIResourceTest.java
@@ -139,54 +139,7 @@ public class OpenAPIResourceTest {
 					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME, false)),
 			ObjectDefinitionConstants.SCOPE_COMPANY, _user.getUserId());
 
-		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
-			null, "/openapi", Http.Method.GET);
-
-		JSONArray jsonArray = jsonObject.getJSONArray(
-			_objectDefinition1.getRESTContextPath());
-
-		Assert.assertEquals(1, jsonArray.length());
-		Assert.assertEquals(
-			"http://localhost:8080/o" +
-				_objectDefinition1.getRESTContextPath() + "/openapi.yaml",
-			jsonArray.get(0));
-
-		jsonObject = HTTPTestUtil.invokeToJSONObject(
-			null, _objectDefinition1.getRESTContextPath() + "/openapi.json",
-			Http.Method.GET);
-
-		Assert.assertNotNull(jsonObject.getString("openapi"));
-		Assert.assertNull(
-			jsonObject.getJSONArray(_objectDefinition2.getRESTContextPath()));
-
-		JSONObject schemasJSONObject = jsonObject.getJSONObject(
-			"components"
-		).getJSONObject(
-			"schemas"
-		);
-
-		Assert.assertNotNull(
-			schemasJSONObject.getJSONObject("TaxonomyCategoryBrief"));
-
-		JSONObject propertiesJSONObject = schemasJSONObject.getJSONObject(
-			_objectDefinition1.getShortName()
-		).getJSONObject(
-			"properties"
-		);
-
-		Assert.assertNull(propertiesJSONObject.getJSONObject("createDate"));
-		Assert.assertNotNull(propertiesJSONObject.getJSONObject("keywords"));
-		Assert.assertNull(propertiesJSONObject.getJSONObject("modifiedDate"));
-		Assert.assertNotNull(
-			propertiesJSONObject.getJSONObject("taxonomyCategoryBriefs"));
-		Assert.assertNotNull(
-			propertiesJSONObject.getJSONObject("taxonomyCategoryIds"));
-
-		jsonObject = HTTPTestUtil.invokeToJSONObject(
-			null, _objectDefinition2.getRESTContextPath() + "/openapi.json",
-			Http.Method.GET);
-
-		Assert.assertEquals("NOT_FOUND", jsonObject.getString("status"));
+		_testGetOpenAPI(_objectDefinition1, _objectDefinition2);
 	}
 
 	@Test
@@ -338,6 +291,61 @@ public class OpenAPIResourceTest {
 			_getNestedEntitySchema(
 				jsonObject, objectRelationship, _objectDefinition2),
 			_objectDefinition1.getShortName());
+	}
+
+	private void _testGetOpenAPI(
+			ObjectDefinition objectDefinition1,
+			ObjectDefinition objectDefinition2)
+		throws Exception {
+
+		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+			null, "/openapi", Http.Method.GET);
+
+		JSONArray jsonArray = jsonObject.getJSONArray(
+			objectDefinition1.getRESTContextPath());
+
+		Assert.assertEquals(1, jsonArray.length());
+		Assert.assertEquals(
+			"http://localhost:8080/o" + objectDefinition1.getRESTContextPath() +
+				"/openapi.yaml",
+			jsonArray.get(0));
+
+		jsonObject = HTTPTestUtil.invokeToJSONObject(
+			null, objectDefinition1.getRESTContextPath() + "/openapi.json",
+			Http.Method.GET);
+
+		Assert.assertNotNull(jsonObject.getString("openapi"));
+		Assert.assertNull(
+			jsonObject.getJSONArray(objectDefinition2.getRESTContextPath()));
+
+		JSONObject schemasJSONObject = jsonObject.getJSONObject(
+			"components"
+		).getJSONObject(
+			"schemas"
+		);
+
+		Assert.assertNotNull(
+			schemasJSONObject.getJSONObject("TaxonomyCategoryBrief"));
+
+		JSONObject propertiesJSONObject = schemasJSONObject.getJSONObject(
+			objectDefinition1.getShortName()
+		).getJSONObject(
+			"properties"
+		);
+
+		Assert.assertNull(propertiesJSONObject.getJSONObject("createDate"));
+		Assert.assertNotNull(propertiesJSONObject.getJSONObject("keywords"));
+		Assert.assertNull(propertiesJSONObject.getJSONObject("modifiedDate"));
+		Assert.assertNotNull(
+			propertiesJSONObject.getJSONObject("taxonomyCategoryBriefs"));
+		Assert.assertNotNull(
+			propertiesJSONObject.getJSONObject("taxonomyCategoryIds"));
+
+		jsonObject = HTTPTestUtil.invokeToJSONObject(
+			null, objectDefinition2.getRESTContextPath() + "/openapi.json",
+			Http.Method.GET);
+
+		Assert.assertEquals("NOT_FOUND", jsonObject.getString("status"));
 	}
 
 	private static final String _OBJECT_FIELD_NAME =

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/OpenAPIResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/OpenAPIResourceTest.java
@@ -140,6 +140,18 @@ public class OpenAPIResourceTest {
 			ObjectDefinitionConstants.SCOPE_COMPANY, _user.getUserId());
 
 		_testGetOpenAPI(_objectDefinition1, _objectDefinition2);
+
+		_siteScopedObjectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				Collections.singletonList(
+					ObjectFieldUtil.createObjectField(
+						"Text", "String", true, true, null,
+						RandomTestUtil.randomString(), _OBJECT_FIELD_NAME,
+						false)),
+				ObjectDefinitionConstants.SCOPE_SITE,
+				TestPropsValues.getUserId());
+
+		_testGetOpenAPI(_siteScopedObjectDefinition, _objectDefinition2);
 	}
 
 	@Test
@@ -364,6 +376,9 @@ public class OpenAPIResourceTest {
 
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@DeleteAfterTestRun
+	private ObjectDefinition _siteScopedObjectDefinition;
 
 	@DeleteAfterTestRun
 	private User _user;

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/OpenAPIResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/OpenAPIResourceTest.java
@@ -174,7 +174,9 @@ public class OpenAPIResourceTest {
 			"properties"
 		);
 
+		Assert.assertNull(propertiesJSONObject.getJSONObject("createDate"));
 		Assert.assertNotNull(propertiesJSONObject.getJSONObject("keywords"));
+		Assert.assertNull(propertiesJSONObject.getJSONObject("modifiedDate"));
 		Assert.assertNotNull(
 			propertiesJSONObject.getJSONObject("taxonomyCategoryBriefs"));
 		Assert.assertNotNull(

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/resource/OpenAPIResourceImpl.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/resource/OpenAPIResourceImpl.java
@@ -1146,7 +1146,8 @@ public class OpenAPIResourceImpl implements OpenAPIResource {
 					schema.setFormat("date-time");
 					schema.setType("string");
 
-					if (StringUtil.equals(
+					if ((dtoProperty.getExtensions() != null) &&
+						StringUtil.equals(
 							MapUtil.getString(
 								dtoProperty.getExtensions(), "x-timeStorage"),
 							"useInputAsEntered")) {


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPS-195627

---

The purpose of this PR is:

- To remove the internal object fields `createDate` and `modifiedDate` from the OpenAPI, as both fields are translated into the `dateCreated` and `dateModified` fields. This change applies to all the Object Entries, independently of the Object Definition type.
