### PR TITLE
LPS-186938: Don't show related Object Definitions schemas and properties if it is not active

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/openapi/contributor/ObjectEntryOpenAPIContributor.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/openapi/contributor/ObjectEntryOpenAPIContributor.java
@@ -124,9 +124,13 @@ public class ObjectEntryOpenAPIContributor extends BaseOpenAPIContributor {
 				for (Map.Entry<ObjectRelationship, ObjectDefinition> entry :
 						relatedObjectDefinitionsMap.entrySet()) {
 
-					ObjectRelationship objectRelationship = entry.getKey();
-
 					ObjectDefinition relatedObjectDefinition = entry.getValue();
+
+					if (!relatedObjectDefinition.isActive()) {
+						continue;
+					}
+
+					ObjectRelationship objectRelationship = entry.getKey();
 
 					String relatedSchemaName = getSchemaName(
 						relatedObjectDefinition);

--- a/modules/apps/object/object-rest-test-util/bnd.bnd
+++ b/modules/apps/object/object-rest-test-util/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Object REST Test Utilities
 Bundle-SymbolicName: com.liferay.object.rest.test.util
-Bundle-Version: 1.2.1
+Bundle-Version: 1.3.0
 Export-Package: com.liferay.object.rest.test.util

--- a/modules/apps/object/object-rest-test-util/src/main/java/com/liferay/object/rest/test/util/ObjectDefinitionTestUtil.java
+++ b/modules/apps/object/object-rest-test-util/src/main/java/com/liferay/object/rest/test/util/ObjectDefinitionTestUtil.java
@@ -20,6 +20,19 @@ import java.util.List;
  */
 public class ObjectDefinitionTestUtil {
 
+	public static ObjectDefinition addCustomObjectDefinition(
+			List<ObjectField> objectFields)
+		throws Exception {
+
+		return ObjectDefinitionLocalServiceUtil.addCustomObjectDefinition(
+			TestPropsValues.getUserId(), 0, false, false, false,
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			"A" + RandomTestUtil.randomString(), null, null,
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			true, ObjectDefinitionConstants.SCOPE_COMPANY,
+			ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT, objectFields);
+	}
+
 	public static ObjectDefinition publishObjectDefinition(
 			List<ObjectField> objectFields)
 		throws Exception {

--- a/modules/apps/object/object-rest-test-util/src/main/resources/com/liferay/object/rest/test/util/packageinfo
+++ b/modules/apps/object/object-rest-test-util/src/main/resources/com/liferay/object/rest/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 1.3.0


### PR DESCRIPTION
**What is new?**
- Make a condition to determine that if the related Object Definition is active, then the OpenAPI will contain its Schema and realted properties. As well as, it will generate the Object Relationship endpoints.
- Create new test case to check this use case.

**How to test it**

1. Create a Custom Object called Student with a custom text field and publish the object
2. Create a Custom Object called Subject with a custom text field but do not publish the object.
3. Create a many to many relationship between Student and Subject called studentsSubjects
4. Access to the Student OpenAPI via API Explorer (http://localhost:8080/o/api?endpoint=http://localhost:8080/o/c/students/openapi.json)
5. Expand the "Student" schema inside the OpenAPI shown.

:heavy_check_mark:  `Expected behavior` 

The Subject schema should not be shown as well as the property `studentsSubjects`

:negative_squared_cross_mark:  Current behaviour 

Once the "Student" schema is expanded, the following error is shown in the top of the OpenAPI


**Related JIRA Ticket**
https://liferay.atlassian.net/browse/LPS-186938