### PR TITLE
LPS-187288 Fix Export template management for Objects

### DIFF
--- a/modules/apps/batch-planner/batch-planner-api/bnd.bnd
+++ b/modules/apps/batch-planner/batch-planner-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Batch Planner API
 Bundle-SymbolicName: com.liferay.batch.planner.api
-Bundle-Version: 13.2.2
+Bundle-Version: 14.0.0
 Export-Package:\
 	com.liferay.batch.planner.batch.engine.broker,\
 	com.liferay.batch.planner.batch.engine.task,\

--- a/modules/apps/batch-planner/batch-planner-api/src/main/java/com/liferay/batch/planner/batch/engine/task/TaskItemUtil.java
+++ b/modules/apps/batch-planner/batch-planner-api/src/main/java/com/liferay/batch/planner/batch/engine/task/TaskItemUtil.java
@@ -46,4 +46,15 @@ public class TaskItemUtil {
 		return internalClassName + StringPool.POUND + taskItemDelegateName;
 	}
 
+	public static String getSimpleClassName(String internalClassNameKey) {
+		int idx = internalClassNameKey.indexOf(StringPool.POUND);
+
+		if (idx < 0) {
+			return StringUtil.extractLast(
+				internalClassNameKey, StringPool.PERIOD);
+		}
+
+		return getDelegateName(internalClassNameKey);
+	}
+
 }

--- a/modules/apps/batch-planner/batch-planner-api/src/main/java/com/liferay/batch/planner/batch/engine/task/TaskItemUtil.java
+++ b/modules/apps/batch-planner/batch-planner-api/src/main/java/com/liferay/batch/planner/batch/engine/task/TaskItemUtil.java
@@ -14,24 +14,14 @@ import com.liferay.portal.kernel.util.Validator;
  */
 public class TaskItemUtil {
 
-	public static String getDelegateName(String internalClassName) {
-		int idx = internalClassName.indexOf(StringPool.POUND);
+	public static String getInternalClassName(String internalClassNameKey) {
+		int idx = internalClassNameKey.indexOf(StringPool.POUND);
 
 		if (idx < 0) {
-			return "DEFAULT";
+			return internalClassNameKey;
 		}
 
-		return internalClassName.substring(idx + 1);
-	}
-
-	public static String getInternalClassName(String internalClassName) {
-		int idx = internalClassName.indexOf(StringPool.POUND);
-
-		if (idx < 0) {
-			return internalClassName;
-		}
-
-		return internalClassName.substring(0, idx);
+		return internalClassNameKey.substring(0, idx);
 	}
 
 	public static String getInternalClassNameKey(
@@ -54,7 +44,17 @@ public class TaskItemUtil {
 				internalClassNameKey, StringPool.PERIOD);
 		}
 
-		return getDelegateName(internalClassNameKey);
+		return getTaskItemDelegateName(internalClassNameKey);
+	}
+
+	public static String getTaskItemDelegateName(String internalClassNameKey) {
+		int idx = internalClassNameKey.indexOf(StringPool.POUND);
+
+		if (idx < 0) {
+			return "DEFAULT";
+		}
+
+		return internalClassNameKey.substring(idx + 1);
 	}
 
 }

--- a/modules/apps/batch-planner/batch-planner-api/src/main/java/com/liferay/batch/planner/batch/engine/task/TaskItemUtil.java
+++ b/modules/apps/batch-planner/batch-planner-api/src/main/java/com/liferay/batch/planner/batch/engine/task/TaskItemUtil.java
@@ -6,6 +6,8 @@
 package com.liferay.batch.planner.batch.engine.task;
 
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 
 /**
  * @author Igor Beslic
@@ -30,6 +32,18 @@ public class TaskItemUtil {
 		}
 
 		return internalClassName.substring(0, idx);
+	}
+
+	public static String getInternalClassNameKey(
+		String internalClassName, String taskItemDelegateName) {
+
+		if (Validator.isBlank(taskItemDelegateName) ||
+			StringUtil.equals(taskItemDelegateName, "DEFAULT")) {
+
+			return internalClassName;
+		}
+
+		return internalClassName + StringPool.POUND + taskItemDelegateName;
 	}
 
 }

--- a/modules/apps/batch-planner/batch-planner-api/src/main/resources/com/liferay/batch/planner/batch/engine/task/packageinfo
+++ b/modules/apps/batch-planner/batch-planner-api/src/main/resources/com/liferay/batch/planner/batch/engine/task/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 2.0.0

--- a/modules/apps/batch-planner/batch-planner-api/src/test/java/com/liferay/batch/planner/batch/engine/task/TaskItemUtilTest.java
+++ b/modules/apps/batch-planner/batch-planner-api/src/test/java/com/liferay/batch/planner/batch/engine/task/TaskItemUtilTest.java
@@ -1,0 +1,121 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.batch.planner.batch.engine.task;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Carlos Correa
+ */
+public class TaskItemUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testGetDelegateName() {
+		Assert.assertEquals(
+			"DEFAULT",
+			TaskItemUtil.getTaskItemDelegateName(
+				RandomTestUtil.randomString()));
+	}
+
+	@Test
+	public void testGetDelegateNameWithPound() {
+		String taskItemDelegateName = RandomTestUtil.randomString();
+
+		String internalClassNameKey =
+			RandomTestUtil.randomString() + StringPool.POUND +
+				taskItemDelegateName;
+
+		Assert.assertEquals(
+			taskItemDelegateName,
+			TaskItemUtil.getTaskItemDelegateName(internalClassNameKey));
+	}
+
+	@Test
+	public void testGetInternalClassName() {
+		String internalClassNameKey = RandomTestUtil.randomString();
+
+		Assert.assertEquals(
+			internalClassNameKey,
+			TaskItemUtil.getInternalClassName(internalClassNameKey));
+	}
+
+	@Test
+	public void testGetInternalClassNameKey() {
+		String internalClassName = RandomTestUtil.randomString();
+
+		Assert.assertEquals(
+			internalClassName,
+			TaskItemUtil.getInternalClassNameKey(internalClassName, null));
+		Assert.assertEquals(
+			internalClassName,
+			TaskItemUtil.getInternalClassNameKey(internalClassName, ""));
+		Assert.assertEquals(
+			internalClassName,
+			TaskItemUtil.getInternalClassNameKey(internalClassName, "DEFAULT"));
+	}
+
+	@Test
+	public void testGetInternalClassNameKeyWithDelegateName() {
+		String taskItemDelegateName = RandomTestUtil.randomString();
+		String internalClassName = RandomTestUtil.randomString();
+
+		Assert.assertEquals(
+			internalClassName + StringPool.POUND + taskItemDelegateName,
+			TaskItemUtil.getInternalClassNameKey(
+				internalClassName, taskItemDelegateName));
+	}
+
+	@Test
+	public void testGetInternalClassNameWithPound() {
+		String internalClassName = RandomTestUtil.randomString();
+
+		String internalClassNameKey =
+			internalClassName + StringPool.POUND +
+				RandomTestUtil.randomString();
+
+		Assert.assertEquals(
+			internalClassName,
+			TaskItemUtil.getInternalClassName(internalClassNameKey));
+	}
+
+	@Test
+	public void testGetSimpleClassName() {
+		String simpleClassName = RandomTestUtil.randomString();
+
+		Assert.assertEquals(
+			simpleClassName,
+			TaskItemUtil.getSimpleClassName(
+				RandomTestUtil.randomString() + StringPool.PERIOD +
+					simpleClassName));
+	}
+
+	@Test
+	public void testGetSimpleClassNameWithPound() {
+		String taskItemDelegateName = RandomTestUtil.randomString();
+
+		Assert.assertEquals(
+			taskItemDelegateName,
+			TaskItemUtil.getSimpleClassName(
+				StringBundler.concat(
+					RandomTestUtil.randomString(), StringPool.PERIOD,
+					RandomTestUtil.randomString(), StringPool.POUND,
+					taskItemDelegateName)));
+	}
+
+}

--- a/modules/apps/batch-planner/batch-planner-rest-api/bnd.bnd
+++ b/modules/apps/batch-planner/batch-planner-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Batch Planner REST API
 Bundle-SymbolicName: com.liferay.batch.planner.rest.api
-Bundle-Version: 4.2.1
+Bundle-Version: 5.0.0
 Export-Package:\
 	com.liferay.batch.planner.rest.dto.v1_0,\
 	com.liferay.batch.planner.rest.resource.v1_0

--- a/modules/apps/batch-planner/batch-planner-rest-api/src/main/java/com/liferay/batch/planner/rest/dto/v1_0/Plan.java
+++ b/modules/apps/batch-planner/batch-planner-rest-api/src/main/java/com/liferay/batch/planner/rest/dto/v1_0/Plan.java
@@ -216,6 +216,34 @@ public class Plan implements Serializable {
 	protected String internalClassName;
 
 	@Schema
+	public String getInternalClassNameKey() {
+		return internalClassNameKey;
+	}
+
+	public void setInternalClassNameKey(String internalClassNameKey) {
+		this.internalClassNameKey = internalClassNameKey;
+	}
+
+	@JsonIgnore
+	public void setInternalClassNameKey(
+		UnsafeSupplier<String, Exception> internalClassNameKeyUnsafeSupplier) {
+
+		try {
+			internalClassNameKey = internalClassNameKeyUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String internalClassNameKey;
+
+	@Schema
 	@Valid
 	public Mapping[] getMappings() {
 		return mappings;
@@ -532,6 +560,20 @@ public class Plan implements Serializable {
 			sb.append("\"");
 
 			sb.append(_escape(internalClassName));
+
+			sb.append("\"");
+		}
+
+		if (internalClassNameKey != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"internalClassNameKey\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(internalClassNameKey));
 
 			sb.append("\"");
 		}

--- a/modules/apps/batch-planner/batch-planner-rest-api/src/main/java/com/liferay/batch/planner/rest/resource/v1_0/FieldResource.java
+++ b/modules/apps/batch-planner/batch-planner-rest-api/src/main/java/com/liferay/batch/planner/rest/resource/v1_0/FieldResource.java
@@ -44,8 +44,8 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface FieldResource {
 
-	public Page<Field> getPlanInternalClassNameFieldsPage(
-			String internalClassName, Boolean export)
+	public Page<Field> getPlanInternalClassNameKeyFieldsPage(
+			String internalClassNameKey, Boolean export)
 		throws Exception;
 
 	public default void setContextAcceptLanguage(

--- a/modules/apps/batch-planner/batch-planner-rest-api/src/main/java/com/liferay/batch/planner/rest/resource/v1_0/PlanResource.java
+++ b/modules/apps/batch-planner/batch-planner-rest-api/src/main/java/com/liferay/batch/planner/rest/resource/v1_0/PlanResource.java
@@ -50,7 +50,8 @@ public interface PlanResource {
 
 	public Plan postPlan(Plan plan) throws Exception;
 
-	public Response getPlanTemplate(String internalClassName) throws Exception;
+	public Response getPlanTemplate(String internalClassNameKey)
+		throws Exception;
 
 	public void deletePlan(Long planId) throws Exception;
 

--- a/modules/apps/batch-planner/batch-planner-rest-api/src/main/java/com/liferay/batch/planner/rest/resource/v1_0/SiteScopeResource.java
+++ b/modules/apps/batch-planner/batch-planner-rest-api/src/main/java/com/liferay/batch/planner/rest/resource/v1_0/SiteScopeResource.java
@@ -44,8 +44,8 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface SiteScopeResource {
 
-	public Page<SiteScope> getPlanInternalClassNameSiteScopesPage(
-			String internalClassName, Boolean export)
+	public Page<SiteScope> getPlanInternalClassNameKeySiteScopesPage(
+			String internalClassNameKey, Boolean export)
 		throws Exception;
 
 	public default void setContextAcceptLanguage(

--- a/modules/apps/batch-planner/batch-planner-rest-api/src/main/java/com/liferay/batch/planner/rest/resource/v1_0/StrategyResource.java
+++ b/modules/apps/batch-planner/batch-planner-rest-api/src/main/java/com/liferay/batch/planner/rest/resource/v1_0/StrategyResource.java
@@ -44,8 +44,8 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface StrategyResource {
 
-	public Page<Strategy> getPlanInternalClassNameStrategiesPage(
-			String internalClassName)
+	public Page<Strategy> getPlanInternalClassNameKeyStrategiesPage(
+			String internalClassNameKey)
 		throws Exception;
 
 	public default void setContextAcceptLanguage(

--- a/modules/apps/batch-planner/batch-planner-rest-api/src/main/resources/com/liferay/batch/planner/rest/dto/v1_0/packageinfo
+++ b/modules/apps/batch-planner/batch-planner-rest-api/src/main/resources/com/liferay/batch/planner/rest/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 2.3.0
+version 2.4.0

--- a/modules/apps/batch-planner/batch-planner-rest-api/src/main/resources/com/liferay/batch/planner/rest/resource/v1_0/packageinfo
+++ b/modules/apps/batch-planner/batch-planner-rest-api/src/main/resources/com/liferay/batch/planner/rest/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 4.2.0
+version 5.0.0

--- a/modules/apps/batch-planner/batch-planner-rest-client/src/main/java/com/liferay/batch/planner/rest/client/dto/v1_0/Plan.java
+++ b/modules/apps/batch-planner/batch-planner-rest-client/src/main/java/com/liferay/batch/planner/rest/client/dto/v1_0/Plan.java
@@ -149,6 +149,27 @@ public class Plan implements Cloneable, Serializable {
 
 	protected String internalClassName;
 
+	public String getInternalClassNameKey() {
+		return internalClassNameKey;
+	}
+
+	public void setInternalClassNameKey(String internalClassNameKey) {
+		this.internalClassNameKey = internalClassNameKey;
+	}
+
+	public void setInternalClassNameKey(
+		UnsafeSupplier<String, Exception> internalClassNameKeyUnsafeSupplier) {
+
+		try {
+			internalClassNameKey = internalClassNameKeyUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String internalClassNameKey;
+
 	public Mapping[] getMappings() {
 		return mappings;
 	}

--- a/modules/apps/batch-planner/batch-planner-rest-client/src/main/java/com/liferay/batch/planner/rest/client/resource/v1_0/FieldResource.java
+++ b/modules/apps/batch-planner/batch-planner-rest-client/src/main/java/com/liferay/batch/planner/rest/client/resource/v1_0/FieldResource.java
@@ -31,13 +31,13 @@ public interface FieldResource {
 		return new Builder();
 	}
 
-	public Page<Field> getPlanInternalClassNameFieldsPage(
-			String internalClassName, Boolean export)
+	public Page<Field> getPlanInternalClassNameKeyFieldsPage(
+			String internalClassNameKey, Boolean export)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			getPlanInternalClassNameFieldsPageHttpResponse(
-				String internalClassName, Boolean export)
+			getPlanInternalClassNameKeyFieldsPageHttpResponse(
+				String internalClassNameKey, Boolean export)
 		throws Exception;
 
 	public static class Builder {
@@ -144,13 +144,13 @@ public interface FieldResource {
 
 	public static class FieldResourceImpl implements FieldResource {
 
-		public Page<Field> getPlanInternalClassNameFieldsPage(
-				String internalClassName, Boolean export)
+		public Page<Field> getPlanInternalClassNameKeyFieldsPage(
+				String internalClassNameKey, Boolean export)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				getPlanInternalClassNameFieldsPageHttpResponse(
-					internalClassName, export);
+				getPlanInternalClassNameKeyFieldsPageHttpResponse(
+					internalClassNameKey, export);
 
 			String content = httpResponse.getContent();
 
@@ -212,8 +212,8 @@ public interface FieldResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				getPlanInternalClassNameFieldsPageHttpResponse(
-					String internalClassName, Boolean export)
+				getPlanInternalClassNameKeyFieldsPageHttpResponse(
+					String internalClassNameKey, Boolean export)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -244,9 +244,9 @@ public interface FieldResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/batch-planner/v1.0/plans/{internalClassName}/fields");
+						"/o/batch-planner/v1.0/plans/{internalClassNameKey}/fields");
 
-			httpInvoker.path("internalClassName", internalClassName);
+			httpInvoker.path("internalClassNameKey", internalClassNameKey);
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);

--- a/modules/apps/batch-planner/batch-planner-rest-client/src/main/java/com/liferay/batch/planner/rest/client/resource/v1_0/PlanResource.java
+++ b/modules/apps/batch-planner/batch-planner-rest-client/src/main/java/com/liferay/batch/planner/rest/client/resource/v1_0/PlanResource.java
@@ -43,10 +43,10 @@ public interface PlanResource {
 	public HttpInvoker.HttpResponse postPlanHttpResponse(Plan plan)
 		throws Exception;
 
-	public void getPlanTemplate(String internalClassName) throws Exception;
+	public void getPlanTemplate(String internalClassNameKey) throws Exception;
 
 	public HttpInvoker.HttpResponse getPlanTemplateHttpResponse(
-			String internalClassName)
+			String internalClassNameKey)
 		throws Exception;
 
 	public void deletePlan(Long planId) throws Exception;
@@ -374,9 +374,11 @@ public interface PlanResource {
 			return httpInvoker.invoke();
 		}
 
-		public void getPlanTemplate(String internalClassName) throws Exception {
+		public void getPlanTemplate(String internalClassNameKey)
+			throws Exception {
+
 			HttpInvoker.HttpResponse httpResponse = getPlanTemplateHttpResponse(
-				internalClassName);
+				internalClassNameKey);
 
 			String content = httpResponse.getContent();
 
@@ -427,7 +429,7 @@ public interface PlanResource {
 		}
 
 		public HttpInvoker.HttpResponse getPlanTemplateHttpResponse(
-				String internalClassName)
+				String internalClassNameKey)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -454,9 +456,9 @@ public interface PlanResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/batch-planner/v1.0/plans/{internalClassName}/template");
+						"/o/batch-planner/v1.0/plans/{internalClassNameKey}/template");
 
-			httpInvoker.path("internalClassName", internalClassName);
+			httpInvoker.path("internalClassNameKey", internalClassNameKey);
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);

--- a/modules/apps/batch-planner/batch-planner-rest-client/src/main/java/com/liferay/batch/planner/rest/client/resource/v1_0/SiteScopeResource.java
+++ b/modules/apps/batch-planner/batch-planner-rest-client/src/main/java/com/liferay/batch/planner/rest/client/resource/v1_0/SiteScopeResource.java
@@ -31,13 +31,13 @@ public interface SiteScopeResource {
 		return new Builder();
 	}
 
-	public Page<SiteScope> getPlanInternalClassNameSiteScopesPage(
-			String internalClassName, Boolean export)
+	public Page<SiteScope> getPlanInternalClassNameKeySiteScopesPage(
+			String internalClassNameKey, Boolean export)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			getPlanInternalClassNameSiteScopesPageHttpResponse(
-				String internalClassName, Boolean export)
+			getPlanInternalClassNameKeySiteScopesPageHttpResponse(
+				String internalClassNameKey, Boolean export)
 		throws Exception;
 
 	public static class Builder {
@@ -144,13 +144,13 @@ public interface SiteScopeResource {
 
 	public static class SiteScopeResourceImpl implements SiteScopeResource {
 
-		public Page<SiteScope> getPlanInternalClassNameSiteScopesPage(
-				String internalClassName, Boolean export)
+		public Page<SiteScope> getPlanInternalClassNameKeySiteScopesPage(
+				String internalClassNameKey, Boolean export)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				getPlanInternalClassNameSiteScopesPageHttpResponse(
-					internalClassName, export);
+				getPlanInternalClassNameKeySiteScopesPageHttpResponse(
+					internalClassNameKey, export);
 
 			String content = httpResponse.getContent();
 
@@ -212,8 +212,8 @@ public interface SiteScopeResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				getPlanInternalClassNameSiteScopesPageHttpResponse(
-					String internalClassName, Boolean export)
+				getPlanInternalClassNameKeySiteScopesPageHttpResponse(
+					String internalClassNameKey, Boolean export)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -244,9 +244,9 @@ public interface SiteScopeResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/batch-planner/v1.0/plans/{internalClassName}/site-scopes");
+						"/o/batch-planner/v1.0/plans/{internalClassNameKey}/site-scopes");
 
-			httpInvoker.path("internalClassName", internalClassName);
+			httpInvoker.path("internalClassNameKey", internalClassNameKey);
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);

--- a/modules/apps/batch-planner/batch-planner-rest-client/src/main/java/com/liferay/batch/planner/rest/client/resource/v1_0/StrategyResource.java
+++ b/modules/apps/batch-planner/batch-planner-rest-client/src/main/java/com/liferay/batch/planner/rest/client/resource/v1_0/StrategyResource.java
@@ -31,13 +31,13 @@ public interface StrategyResource {
 		return new Builder();
 	}
 
-	public Page<Strategy> getPlanInternalClassNameStrategiesPage(
-			String internalClassName)
+	public Page<Strategy> getPlanInternalClassNameKeyStrategiesPage(
+			String internalClassNameKey)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			getPlanInternalClassNameStrategiesPageHttpResponse(
-				String internalClassName)
+			getPlanInternalClassNameKeyStrategiesPageHttpResponse(
+				String internalClassNameKey)
 		throws Exception;
 
 	public static class Builder {
@@ -144,13 +144,13 @@ public interface StrategyResource {
 
 	public static class StrategyResourceImpl implements StrategyResource {
 
-		public Page<Strategy> getPlanInternalClassNameStrategiesPage(
-				String internalClassName)
+		public Page<Strategy> getPlanInternalClassNameKeyStrategiesPage(
+				String internalClassNameKey)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				getPlanInternalClassNameStrategiesPageHttpResponse(
-					internalClassName);
+				getPlanInternalClassNameKeyStrategiesPageHttpResponse(
+					internalClassNameKey);
 
 			String content = httpResponse.getContent();
 
@@ -212,8 +212,8 @@ public interface StrategyResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				getPlanInternalClassNameStrategiesPageHttpResponse(
-					String internalClassName)
+				getPlanInternalClassNameKeyStrategiesPageHttpResponse(
+					String internalClassNameKey)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -240,9 +240,9 @@ public interface StrategyResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/batch-planner/v1.0/plans/{internalClassName}/strategies");
+						"/o/batch-planner/v1.0/plans/{internalClassNameKey}/strategies");
 
-			httpInvoker.path("internalClassName", internalClassName);
+			httpInvoker.path("internalClassNameKey", internalClassNameKey);
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);

--- a/modules/apps/batch-planner/batch-planner-rest-client/src/main/java/com/liferay/batch/planner/rest/client/serdes/v1_0/PlanSerDes.java
+++ b/modules/apps/batch-planner/batch-planner-rest-client/src/main/java/com/liferay/batch/planner/rest/client/serdes/v1_0/PlanSerDes.java
@@ -118,6 +118,20 @@ public class PlanSerDes {
 			sb.append("\"");
 		}
 
+		if (plan.getInternalClassNameKey() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"internalClassNameKey\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(plan.getInternalClassNameKey()));
+
+			sb.append("\"");
+		}
+
 		if (plan.getMappings() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -288,6 +302,15 @@ public class PlanSerDes {
 				String.valueOf(plan.getInternalClassName()));
 		}
 
+		if (plan.getInternalClassNameKey() == null) {
+			map.put("internalClassNameKey", null);
+		}
+		else {
+			map.put(
+				"internalClassNameKey",
+				String.valueOf(plan.getInternalClassNameKey()));
+		}
+
 		if (plan.getMappings() == null) {
 			map.put("mappings", null);
 		}
@@ -394,6 +417,13 @@ public class PlanSerDes {
 			else if (Objects.equals(jsonParserFieldName, "internalClassName")) {
 				if (jsonParserFieldValue != null) {
 					plan.setInternalClassName((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "internalClassNameKey")) {
+
+				if (jsonParserFieldValue != null) {
+					plan.setInternalClassNameKey((String)jsonParserFieldValue);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "mappings")) {

--- a/modules/apps/batch-planner/batch-planner-rest-impl/rest-openapi.yaml
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/rest-openapi.yaml
@@ -153,12 +153,12 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Plan"
             tags: ["Plan"]
-    /plans/{internalClassName}/fields:
+    /plans/{internalClassNameKey}/fields:
         get:
-            operationId: getPlanInternalClassNameFieldsPage
+            operationId: getPlanInternalClassNameKeyFieldsPage
             parameters:
                 - in: path
-                  name: internalClassName
+                  name: internalClassNameKey
                   required: true
                   schema:
                       type: string
@@ -181,12 +181,12 @@ paths:
                                     $ref: "#/components/schemas/Field"
                                 type: array
             tags: ["Field"]
-    /plans/{internalClassName}/site-scopes:
+    /plans/{internalClassNameKey}/site-scopes:
         get:
-            operationId: getPlanInternalClassNameSiteScopesPage
+            operationId: getPlanInternalClassNameKeySiteScopesPage
             parameters:
                 - in: path
-                  name: internalClassName
+                  name: internalClassNameKey
                   required: true
                   schema:
                       type: string
@@ -209,12 +209,12 @@ paths:
                                     $ref: "#/components/schemas/SiteScope"
                                 type: array
             tags: ["SiteScope"]
-    /plans/{internalClassName}/strategies:
+    /plans/{internalClassNameKey}/strategies:
         get:
-            operationId: getPlanInternalClassNameStrategiesPage
+            operationId: getPlanInternalClassNameKeyStrategiesPage
             parameters:
                 - in: path
-                  name: internalClassName
+                  name: internalClassNameKey
                   required: true
                   schema:
                       type: string
@@ -232,12 +232,12 @@ paths:
                                     $ref: "#/components/schemas/Strategy"
                                 type: array
             tags: ["Strategy"]
-    /plans/{internalClassName}/template:
+    /plans/{internalClassNameKey}/template:
         get:
             operationId: getPlanTemplate
             parameters:
                 - in: path
-                  name: internalClassName
+                  name: internalClassNameKey
                   required: true
                   schema:
                       type: string

--- a/modules/apps/batch-planner/batch-planner-rest-impl/rest-openapi.yaml
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/rest-openapi.yaml
@@ -44,6 +44,9 @@ components:
                     type: integer
                 internalClassName:
                     type: string
+                internalClassNameKey:
+                    readOnly: true
+                    type: string
                 mappings:
                     items:
                         $ref: "#/components/schemas/Mapping"

--- a/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/BaseFieldResourceImpl.java
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/BaseFieldResourceImpl.java
@@ -47,13 +47,13 @@ public abstract class BaseFieldResourceImpl implements FieldResource {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/batch-planner/v1.0/plans/{internalClassName}/fields'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/batch-planner/v1.0/plans/{internalClassNameKey}/fields'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
-				name = "internalClassName"
+				name = "internalClassNameKey"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -65,14 +65,14 @@ public abstract class BaseFieldResourceImpl implements FieldResource {
 		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Field")}
 	)
 	@javax.ws.rs.GET
-	@javax.ws.rs.Path("/plans/{internalClassName}/fields")
+	@javax.ws.rs.Path("/plans/{internalClassNameKey}/fields")
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<Field> getPlanInternalClassNameFieldsPage(
+	public Page<Field> getPlanInternalClassNameKeyFieldsPage(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.validation.constraints.NotNull
-			@javax.ws.rs.PathParam("internalClassName")
-			String internalClassName,
+			@javax.ws.rs.PathParam("internalClassNameKey")
+			String internalClassNameKey,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.ws.rs.QueryParam("export")
 			Boolean export)

--- a/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/BasePlanResourceImpl.java
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/BasePlanResourceImpl.java
@@ -97,13 +97,13 @@ public abstract class BasePlanResourceImpl implements PlanResource {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/batch-planner/v1.0/plans/{internalClassName}/template'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/batch-planner/v1.0/plans/{internalClassNameKey}/template'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
-				name = "internalClassName"
+				name = "internalClassNameKey"
 			)
 		}
 	)
@@ -111,14 +111,14 @@ public abstract class BasePlanResourceImpl implements PlanResource {
 		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Plan")}
 	)
 	@javax.ws.rs.GET
-	@javax.ws.rs.Path("/plans/{internalClassName}/template")
+	@javax.ws.rs.Path("/plans/{internalClassNameKey}/template")
 	@javax.ws.rs.Produces("application/octet-stream")
 	@Override
 	public Response getPlanTemplate(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.validation.constraints.NotNull
-			@javax.ws.rs.PathParam("internalClassName")
-			String internalClassName)
+			@javax.ws.rs.PathParam("internalClassNameKey")
+			String internalClassNameKey)
 		throws Exception {
 
 		Response.ResponseBuilder responseBuilder = Response.ok();

--- a/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/BaseSiteScopeResourceImpl.java
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/BaseSiteScopeResourceImpl.java
@@ -47,13 +47,13 @@ public abstract class BaseSiteScopeResourceImpl implements SiteScopeResource {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/batch-planner/v1.0/plans/{internalClassName}/site-scopes'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/batch-planner/v1.0/plans/{internalClassNameKey}/site-scopes'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
-				name = "internalClassName"
+				name = "internalClassNameKey"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -65,14 +65,14 @@ public abstract class BaseSiteScopeResourceImpl implements SiteScopeResource {
 		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "SiteScope")}
 	)
 	@javax.ws.rs.GET
-	@javax.ws.rs.Path("/plans/{internalClassName}/site-scopes")
+	@javax.ws.rs.Path("/plans/{internalClassNameKey}/site-scopes")
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<SiteScope> getPlanInternalClassNameSiteScopesPage(
+	public Page<SiteScope> getPlanInternalClassNameKeySiteScopesPage(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.validation.constraints.NotNull
-			@javax.ws.rs.PathParam("internalClassName")
-			String internalClassName,
+			@javax.ws.rs.PathParam("internalClassNameKey")
+			String internalClassNameKey,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.ws.rs.QueryParam("export")
 			Boolean export)

--- a/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/BaseStrategyResourceImpl.java
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/BaseStrategyResourceImpl.java
@@ -47,13 +47,13 @@ public abstract class BaseStrategyResourceImpl implements StrategyResource {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/batch-planner/v1.0/plans/{internalClassName}/strategies'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/batch-planner/v1.0/plans/{internalClassNameKey}/strategies'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
-				name = "internalClassName"
+				name = "internalClassNameKey"
 			)
 		}
 	)
@@ -61,14 +61,14 @@ public abstract class BaseStrategyResourceImpl implements StrategyResource {
 		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Strategy")}
 	)
 	@javax.ws.rs.GET
-	@javax.ws.rs.Path("/plans/{internalClassName}/strategies")
+	@javax.ws.rs.Path("/plans/{internalClassNameKey}/strategies")
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<Strategy> getPlanInternalClassNameStrategiesPage(
+	public Page<Strategy> getPlanInternalClassNameKeyStrategiesPage(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.validation.constraints.NotNull
-			@javax.ws.rs.PathParam("internalClassName")
-			String internalClassName)
+			@javax.ws.rs.PathParam("internalClassNameKey")
+			String internalClassNameKey)
 		throws Exception {
 
 		return Page.of(Collections.emptyList());

--- a/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/FieldResourceImpl.java
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/FieldResourceImpl.java
@@ -28,13 +28,13 @@ import org.osgi.service.component.annotations.ServiceScope;
 public class FieldResourceImpl extends BaseFieldResourceImpl {
 
 	@Override
-	public Page<Field> getPlanInternalClassNameFieldsPage(
-			String internalClassName, Boolean export)
+	public Page<Field> getPlanInternalClassNameKeyFieldsPage(
+			String internalClassNameKey, Boolean export)
 		throws Exception {
 
 		List<com.liferay.portal.vulcan.batch.engine.Field> vulcanFields =
 			_fieldProvider.getFields(
-				contextCompany.getCompanyId(), internalClassName,
+				contextCompany.getCompanyId(), internalClassNameKey,
 				contextUriInfo);
 
 		if (GetterUtil.getBoolean(export)) {

--- a/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/PlanResourceImpl.java
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/PlanResourceImpl.java
@@ -70,8 +70,7 @@ public class PlanResourceImpl extends BasePlanResourceImpl {
 		throws Exception {
 
 		return _getResponse(
-			internalClassNameKey.substring(
-				internalClassNameKey.lastIndexOf(StringPool.PERIOD) + 1),
+			TaskItemUtil.getSimpleClassName(internalClassNameKey),
 			_fieldProvider.getFields(
 				contextCompany.getCompanyId(), internalClassNameKey,
 				contextUriInfo));

--- a/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/PlanResourceImpl.java
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/PlanResourceImpl.java
@@ -5,6 +5,7 @@
 
 package com.liferay.batch.planner.rest.internal.resource.v1_0;
 
+import com.liferay.batch.planner.batch.engine.task.TaskItemUtil;
 import com.liferay.batch.planner.model.BatchPlannerMapping;
 import com.liferay.batch.planner.model.BatchPlannerPlan;
 import com.liferay.batch.planner.model.BatchPlannerPolicy;
@@ -202,6 +203,9 @@ public class PlanResourceImpl extends BasePlanResourceImpl {
 				externalURL = batchPlannerPlan.getExternalURL();
 				id = batchPlannerPlan.getBatchPlannerPlanId();
 				internalClassName = batchPlannerPlan.getInternalClassName();
+				internalClassNameKey = TaskItemUtil.getInternalClassNameKey(
+					batchPlannerPlan.getInternalClassName(),
+					batchPlannerPlan.getTaskItemDelegateName());
 				mappings = transformToArray(
 					_batchPlannerMappingService.getBatchPlannerMappings(
 						batchPlannerPlan.getBatchPlannerPlanId()),

--- a/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/PlanResourceImpl.java
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/PlanResourceImpl.java
@@ -65,12 +65,14 @@ public class PlanResourceImpl extends BasePlanResourceImpl {
 	}
 
 	@Override
-	public Response getPlanTemplate(String internalClassName) throws Exception {
+	public Response getPlanTemplate(String internalClassNameKey)
+		throws Exception {
+
 		return _getResponse(
-			internalClassName.substring(
-				internalClassName.lastIndexOf(StringPool.PERIOD) + 1),
+			internalClassNameKey.substring(
+				internalClassNameKey.lastIndexOf(StringPool.PERIOD) + 1),
 			_fieldProvider.getFields(
-				contextCompany.getCompanyId(), internalClassName,
+				contextCompany.getCompanyId(), internalClassNameKey,
 				contextUriInfo));
 	}
 

--- a/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/SiteScopeResourceImpl.java
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/SiteScopeResourceImpl.java
@@ -37,17 +37,17 @@ import org.osgi.service.component.annotations.ServiceScope;
 public class SiteScopeResourceImpl extends BaseSiteScopeResourceImpl {
 
 	@Override
-	public Page<SiteScope> getPlanInternalClassNameSiteScopesPage(
-			String internalClassName, Boolean export)
+	public Page<SiteScope> getPlanInternalClassNameKeySiteScopesPage(
+			String internalClassNameKey, Boolean export)
 		throws Exception {
 
 		List<String> entityScopes = null;
 
 		OpenAPIYAML openAPIYAML = _openAPIYAMLProvider.getOpenAPIYAML(
-			contextCompany.getCompanyId(), internalClassName);
+			contextCompany.getCompanyId(), internalClassNameKey);
 
-		String simpleInternalClassName = internalClassName.substring(
-			internalClassName.lastIndexOf(StringPool.PERIOD) + 1);
+		String simpleInternalClassName = internalClassNameKey.substring(
+			internalClassNameKey.lastIndexOf(StringPool.PERIOD) + 1);
 
 		if (GetterUtil.getBoolean(export)) {
 			entityScopes = OpenAPIUtil.getReadEntityScopes(

--- a/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/StrategyResourceImpl.java
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/StrategyResourceImpl.java
@@ -38,7 +38,7 @@ public class StrategyResourceImpl extends BaseStrategyResourceImpl {
 		BatchEngineTaskItemDelegate<?> batchEngineTaskItemDelegate =
 			_batchEngineTaskItemDelegateRegistry.getBatchEngineTaskItemDelegate(
 				TaskItemUtil.getInternalClassName(internalClassNameKey),
-				TaskItemUtil.getDelegateName(internalClassNameKey));
+				TaskItemUtil.getTaskItemDelegateName(internalClassNameKey));
 
 		for (String createStrategy :
 				batchEngineTaskItemDelegate.getAvailableCreateStrategies()) {

--- a/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/StrategyResourceImpl.java
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/StrategyResourceImpl.java
@@ -29,16 +29,16 @@ import org.osgi.service.component.annotations.ServiceScope;
 public class StrategyResourceImpl extends BaseStrategyResourceImpl {
 
 	@Override
-	public Page<Strategy> getPlanInternalClassNameStrategiesPage(
-			String internalClassName)
+	public Page<Strategy> getPlanInternalClassNameKeyStrategiesPage(
+			String internalClassNameKey)
 		throws Exception {
 
 		List<Strategy> strategies = new ArrayList<>();
 
 		BatchEngineTaskItemDelegate<?> batchEngineTaskItemDelegate =
 			_batchEngineTaskItemDelegateRegistry.getBatchEngineTaskItemDelegate(
-				TaskItemUtil.getInternalClassName(internalClassName),
-				TaskItemUtil.getDelegateName(internalClassName));
+				TaskItemUtil.getInternalClassName(internalClassNameKey),
+				TaskItemUtil.getDelegateName(internalClassNameKey));
 
 		for (String createStrategy :
 				batchEngineTaskItemDelegate.getAvailableCreateStrategies()) {

--- a/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/vulcan/batch/engine/FieldProvider.java
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/vulcan/batch/engine/FieldProvider.java
@@ -55,25 +55,25 @@ public class FieldProvider {
 	}
 
 	public List<Field> getFields(
-			long companyId, String internalClassName, UriInfo uriInfo)
+			long companyId, String internalClassNameKey, UriInfo uriInfo)
 		throws Exception {
 
-		int index = internalClassName.indexOf(StringPool.POUND);
+		int index = internalClassNameKey.indexOf(StringPool.POUND);
 
 		if (index < 0) {
 			OpenAPIYAML openAPIYAML = _openAPIYAMLProvider.getOpenAPIYAML(
-				companyId, internalClassName);
+				companyId, internalClassNameKey);
 
 			return ListUtil.fromMapValues(
 				OpenAPIUtil.getDTOEntityFields(
 					StringUtil.extractLast(
-						internalClassName, StringPool.PERIOD),
+						internalClassNameKey, StringPool.PERIOD),
 					openAPIYAML));
 		}
 
 		ObjectDefinition objectDefinition =
 			_objectDefinitionLocalService.fetchObjectDefinition(
-				companyId, internalClassName.substring(index + 1));
+				companyId, internalClassNameKey.substring(index + 1));
 
 		ObjectEntryOpenAPIResource objectEntryOpenAPIResource =
 			_objectEntryOpenAPIResourceProvider.getObjectEntryOpenAPIResource(

--- a/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/vulcan/yaml/openapi/OpenAPIYAMLProvider.java
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/vulcan/yaml/openapi/OpenAPIYAMLProvider.java
@@ -24,13 +24,14 @@ import org.osgi.service.component.annotations.Reference;
 @Component(service = OpenAPIYAMLProvider.class)
 public class OpenAPIYAMLProvider {
 
-	public OpenAPIYAML getOpenAPIYAML(long companyId, String internalClassName)
+	public OpenAPIYAML getOpenAPIYAML(
+			long companyId, String internalClassNameKey)
 		throws Exception {
 
 		VulcanBatchEngineTaskItemDelegate vulcanBatchEngineTaskItemDelegate =
 			_vulcanBatchEngineTaskItemDelegateRegistry.
 				getVulcanBatchEngineTaskItemDelegate(
-					companyId, internalClassName);
+					companyId, internalClassNameKey);
 
 		Response response = _openAPIResource.getOpenAPI(
 			Collections.singleton(
@@ -40,7 +41,7 @@ public class OpenAPIYAMLProvider {
 		if (response.getStatus() != 200) {
 			throw new IllegalArgumentException(
 				"Unable to find OpenAPI specification for " +
-					internalClassName);
+					internalClassNameKey);
 		}
 
 		return YAMLUtil.loadOpenAPIYAML((String)response.getEntity());

--- a/modules/apps/batch-planner/batch-planner-rest-test/src/testIntegration/java/com/liferay/batch/planner/rest/resource/v1_0/test/BaseFieldResourceTestCase.java
+++ b/modules/apps/batch-planner/batch-planner-rest-test/src/testIntegration/java/com/liferay/batch/planner/rest/resource/v1_0/test/BaseFieldResourceTestCase.java
@@ -185,24 +185,24 @@ public abstract class BaseFieldResourceTestCase {
 	}
 
 	@Test
-	public void testGetPlanInternalClassNameFieldsPage() throws Exception {
-		String internalClassName =
-			testGetPlanInternalClassNameFieldsPage_getInternalClassName();
-		String irrelevantInternalClassName =
-			testGetPlanInternalClassNameFieldsPage_getIrrelevantInternalClassName();
+	public void testGetPlanInternalClassNameKeyFieldsPage() throws Exception {
+		String internalClassNameKey =
+			testGetPlanInternalClassNameKeyFieldsPage_getInternalClassNameKey();
+		String irrelevantInternalClassNameKey =
+			testGetPlanInternalClassNameKeyFieldsPage_getIrrelevantInternalClassNameKey();
 
-		Page<Field> page = fieldResource.getPlanInternalClassNameFieldsPage(
-			internalClassName, null);
+		Page<Field> page = fieldResource.getPlanInternalClassNameKeyFieldsPage(
+			internalClassNameKey, null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 
-		if (irrelevantInternalClassName != null) {
+		if (irrelevantInternalClassNameKey != null) {
 			Field irrelevantField =
-				testGetPlanInternalClassNameFieldsPage_addField(
-					irrelevantInternalClassName, randomIrrelevantField());
+				testGetPlanInternalClassNameKeyFieldsPage_addField(
+					irrelevantInternalClassNameKey, randomIrrelevantField());
 
-			page = fieldResource.getPlanInternalClassNameFieldsPage(
-				irrelevantInternalClassName, null);
+			page = fieldResource.getPlanInternalClassNameKeyFieldsPage(
+				irrelevantInternalClassNameKey, null);
 
 			Assert.assertEquals(1, page.getTotalCount());
 
@@ -210,18 +210,18 @@ public abstract class BaseFieldResourceTestCase {
 				Arrays.asList(irrelevantField), (List<Field>)page.getItems());
 			assertValid(
 				page,
-				testGetPlanInternalClassNameFieldsPage_getExpectedActions(
-					irrelevantInternalClassName));
+				testGetPlanInternalClassNameKeyFieldsPage_getExpectedActions(
+					irrelevantInternalClassNameKey));
 		}
 
-		Field field1 = testGetPlanInternalClassNameFieldsPage_addField(
-			internalClassName, randomField());
+		Field field1 = testGetPlanInternalClassNameKeyFieldsPage_addField(
+			internalClassNameKey, randomField());
 
-		Field field2 = testGetPlanInternalClassNameFieldsPage_addField(
-			internalClassName, randomField());
+		Field field2 = testGetPlanInternalClassNameKeyFieldsPage_addField(
+			internalClassNameKey, randomField());
 
-		page = fieldResource.getPlanInternalClassNameFieldsPage(
-			internalClassName, null);
+		page = fieldResource.getPlanInternalClassNameKeyFieldsPage(
+			internalClassNameKey, null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -229,13 +229,13 @@ public abstract class BaseFieldResourceTestCase {
 			Arrays.asList(field1, field2), (List<Field>)page.getItems());
 		assertValid(
 			page,
-			testGetPlanInternalClassNameFieldsPage_getExpectedActions(
-				internalClassName));
+			testGetPlanInternalClassNameKeyFieldsPage_getExpectedActions(
+				internalClassNameKey));
 	}
 
 	protected Map<String, Map<String, String>>
-			testGetPlanInternalClassNameFieldsPage_getExpectedActions(
-				String internalClassName)
+			testGetPlanInternalClassNameKeyFieldsPage_getExpectedActions(
+				String internalClassNameKey)
 		throws Exception {
 
 		Map<String, Map<String, String>> expectedActions = new HashMap<>();
@@ -243,8 +243,8 @@ public abstract class BaseFieldResourceTestCase {
 		return expectedActions;
 	}
 
-	protected Field testGetPlanInternalClassNameFieldsPage_addField(
-			String internalClassName, Field field)
+	protected Field testGetPlanInternalClassNameKeyFieldsPage_addField(
+			String internalClassNameKey, Field field)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -252,7 +252,7 @@ public abstract class BaseFieldResourceTestCase {
 	}
 
 	protected String
-			testGetPlanInternalClassNameFieldsPage_getInternalClassName()
+			testGetPlanInternalClassNameKeyFieldsPage_getInternalClassNameKey()
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -260,7 +260,7 @@ public abstract class BaseFieldResourceTestCase {
 	}
 
 	protected String
-			testGetPlanInternalClassNameFieldsPage_getIrrelevantInternalClassName()
+			testGetPlanInternalClassNameKeyFieldsPage_getIrrelevantInternalClassNameKey()
 		throws Exception {
 
 		return null;

--- a/modules/apps/batch-planner/batch-planner-rest-test/src/testIntegration/java/com/liferay/batch/planner/rest/resource/v1_0/test/BasePlanResourceTestCase.java
+++ b/modules/apps/batch-planner/batch-planner-rest-test/src/testIntegration/java/com/liferay/batch/planner/rest/resource/v1_0/test/BasePlanResourceTestCase.java
@@ -175,6 +175,7 @@ public abstract class BasePlanResourceTestCase {
 		plan.setExternalType(regex);
 		plan.setExternalURL(regex);
 		plan.setInternalClassName(regex);
+		plan.setInternalClassNameKey(regex);
 		plan.setName(regex);
 		plan.setTaskItemDelegateName(regex);
 
@@ -187,6 +188,7 @@ public abstract class BasePlanResourceTestCase {
 		Assert.assertEquals(regex, plan.getExternalType());
 		Assert.assertEquals(regex, plan.getExternalURL());
 		Assert.assertEquals(regex, plan.getInternalClassName());
+		Assert.assertEquals(regex, plan.getInternalClassNameKey());
 		Assert.assertEquals(regex, plan.getName());
 		Assert.assertEquals(regex, plan.getTaskItemDelegateName());
 	}
@@ -458,6 +460,16 @@ public abstract class BasePlanResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals(
+					"internalClassNameKey", additionalAssertFieldName)) {
+
+				if (plan.getInternalClassNameKey() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("mappings", additionalAssertFieldName)) {
 				if (plan.getMappings() == null) {
 					valid = false;
@@ -689,6 +701,19 @@ public abstract class BasePlanResourceTestCase {
 				if (!Objects.deepEquals(
 						plan1.getInternalClassName(),
 						plan2.getInternalClassName())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"internalClassNameKey", additionalAssertFieldName)) {
+
+				if (!Objects.deepEquals(
+						plan1.getInternalClassNameKey(),
+						plan2.getInternalClassNameKey())) {
 
 					return false;
 				}
@@ -1027,6 +1052,52 @@ public abstract class BasePlanResourceTestCase {
 			return sb.toString();
 		}
 
+		if (entityFieldName.equals("internalClassNameKey")) {
+			Object object = plan.getInternalClassNameKey();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
 		if (entityFieldName.equals("mappings")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
@@ -1204,6 +1275,8 @@ public abstract class BasePlanResourceTestCase {
 					RandomTestUtil.randomString());
 				id = RandomTestUtil.randomLong();
 				internalClassName = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				internalClassNameKey = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
 				name = StringUtil.toLowerCase(RandomTestUtil.randomString());
 				size = RandomTestUtil.randomInt();

--- a/modules/apps/batch-planner/batch-planner-rest-test/src/testIntegration/java/com/liferay/batch/planner/rest/resource/v1_0/test/BaseSiteScopeResourceTestCase.java
+++ b/modules/apps/batch-planner/batch-planner-rest-test/src/testIntegration/java/com/liferay/batch/planner/rest/resource/v1_0/test/BaseSiteScopeResourceTestCase.java
@@ -182,25 +182,28 @@ public abstract class BaseSiteScopeResourceTestCase {
 	}
 
 	@Test
-	public void testGetPlanInternalClassNameSiteScopesPage() throws Exception {
-		String internalClassName =
-			testGetPlanInternalClassNameSiteScopesPage_getInternalClassName();
-		String irrelevantInternalClassName =
-			testGetPlanInternalClassNameSiteScopesPage_getIrrelevantInternalClassName();
+	public void testGetPlanInternalClassNameKeySiteScopesPage()
+		throws Exception {
+
+		String internalClassNameKey =
+			testGetPlanInternalClassNameKeySiteScopesPage_getInternalClassNameKey();
+		String irrelevantInternalClassNameKey =
+			testGetPlanInternalClassNameKeySiteScopesPage_getIrrelevantInternalClassNameKey();
 
 		Page<SiteScope> page =
-			siteScopeResource.getPlanInternalClassNameSiteScopesPage(
-				internalClassName, null);
+			siteScopeResource.getPlanInternalClassNameKeySiteScopesPage(
+				internalClassNameKey, null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 
-		if (irrelevantInternalClassName != null) {
+		if (irrelevantInternalClassNameKey != null) {
 			SiteScope irrelevantSiteScope =
-				testGetPlanInternalClassNameSiteScopesPage_addSiteScope(
-					irrelevantInternalClassName, randomIrrelevantSiteScope());
+				testGetPlanInternalClassNameKeySiteScopesPage_addSiteScope(
+					irrelevantInternalClassNameKey,
+					randomIrrelevantSiteScope());
 
-			page = siteScopeResource.getPlanInternalClassNameSiteScopesPage(
-				irrelevantInternalClassName, null);
+			page = siteScopeResource.getPlanInternalClassNameKeySiteScopesPage(
+				irrelevantInternalClassNameKey, null);
 
 			Assert.assertEquals(1, page.getTotalCount());
 
@@ -209,20 +212,20 @@ public abstract class BaseSiteScopeResourceTestCase {
 				(List<SiteScope>)page.getItems());
 			assertValid(
 				page,
-				testGetPlanInternalClassNameSiteScopesPage_getExpectedActions(
-					irrelevantInternalClassName));
+				testGetPlanInternalClassNameKeySiteScopesPage_getExpectedActions(
+					irrelevantInternalClassNameKey));
 		}
 
 		SiteScope siteScope1 =
-			testGetPlanInternalClassNameSiteScopesPage_addSiteScope(
-				internalClassName, randomSiteScope());
+			testGetPlanInternalClassNameKeySiteScopesPage_addSiteScope(
+				internalClassNameKey, randomSiteScope());
 
 		SiteScope siteScope2 =
-			testGetPlanInternalClassNameSiteScopesPage_addSiteScope(
-				internalClassName, randomSiteScope());
+			testGetPlanInternalClassNameKeySiteScopesPage_addSiteScope(
+				internalClassNameKey, randomSiteScope());
 
-		page = siteScopeResource.getPlanInternalClassNameSiteScopesPage(
-			internalClassName, null);
+		page = siteScopeResource.getPlanInternalClassNameKeySiteScopesPage(
+			internalClassNameKey, null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -231,13 +234,13 @@ public abstract class BaseSiteScopeResourceTestCase {
 			(List<SiteScope>)page.getItems());
 		assertValid(
 			page,
-			testGetPlanInternalClassNameSiteScopesPage_getExpectedActions(
-				internalClassName));
+			testGetPlanInternalClassNameKeySiteScopesPage_getExpectedActions(
+				internalClassNameKey));
 	}
 
 	protected Map<String, Map<String, String>>
-			testGetPlanInternalClassNameSiteScopesPage_getExpectedActions(
-				String internalClassName)
+			testGetPlanInternalClassNameKeySiteScopesPage_getExpectedActions(
+				String internalClassNameKey)
 		throws Exception {
 
 		Map<String, Map<String, String>> expectedActions = new HashMap<>();
@@ -245,8 +248,9 @@ public abstract class BaseSiteScopeResourceTestCase {
 		return expectedActions;
 	}
 
-	protected SiteScope testGetPlanInternalClassNameSiteScopesPage_addSiteScope(
-			String internalClassName, SiteScope siteScope)
+	protected SiteScope
+			testGetPlanInternalClassNameKeySiteScopesPage_addSiteScope(
+				String internalClassNameKey, SiteScope siteScope)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -254,7 +258,7 @@ public abstract class BaseSiteScopeResourceTestCase {
 	}
 
 	protected String
-			testGetPlanInternalClassNameSiteScopesPage_getInternalClassName()
+			testGetPlanInternalClassNameKeySiteScopesPage_getInternalClassNameKey()
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -262,7 +266,7 @@ public abstract class BaseSiteScopeResourceTestCase {
 	}
 
 	protected String
-			testGetPlanInternalClassNameSiteScopesPage_getIrrelevantInternalClassName()
+			testGetPlanInternalClassNameKeySiteScopesPage_getIrrelevantInternalClassNameKey()
 		throws Exception {
 
 		return null;

--- a/modules/apps/batch-planner/batch-planner-rest-test/src/testIntegration/java/com/liferay/batch/planner/rest/resource/v1_0/test/BaseStrategyResourceTestCase.java
+++ b/modules/apps/batch-planner/batch-planner-rest-test/src/testIntegration/java/com/liferay/batch/planner/rest/resource/v1_0/test/BaseStrategyResourceTestCase.java
@@ -184,25 +184,27 @@ public abstract class BaseStrategyResourceTestCase {
 	}
 
 	@Test
-	public void testGetPlanInternalClassNameStrategiesPage() throws Exception {
-		String internalClassName =
-			testGetPlanInternalClassNameStrategiesPage_getInternalClassName();
-		String irrelevantInternalClassName =
-			testGetPlanInternalClassNameStrategiesPage_getIrrelevantInternalClassName();
+	public void testGetPlanInternalClassNameKeyStrategiesPage()
+		throws Exception {
+
+		String internalClassNameKey =
+			testGetPlanInternalClassNameKeyStrategiesPage_getInternalClassNameKey();
+		String irrelevantInternalClassNameKey =
+			testGetPlanInternalClassNameKeyStrategiesPage_getIrrelevantInternalClassNameKey();
 
 		Page<Strategy> page =
-			strategyResource.getPlanInternalClassNameStrategiesPage(
-				internalClassName);
+			strategyResource.getPlanInternalClassNameKeyStrategiesPage(
+				internalClassNameKey);
 
 		Assert.assertEquals(0, page.getTotalCount());
 
-		if (irrelevantInternalClassName != null) {
+		if (irrelevantInternalClassNameKey != null) {
 			Strategy irrelevantStrategy =
-				testGetPlanInternalClassNameStrategiesPage_addStrategy(
-					irrelevantInternalClassName, randomIrrelevantStrategy());
+				testGetPlanInternalClassNameKeyStrategiesPage_addStrategy(
+					irrelevantInternalClassNameKey, randomIrrelevantStrategy());
 
-			page = strategyResource.getPlanInternalClassNameStrategiesPage(
-				irrelevantInternalClassName);
+			page = strategyResource.getPlanInternalClassNameKeyStrategiesPage(
+				irrelevantInternalClassNameKey);
 
 			Assert.assertEquals(1, page.getTotalCount());
 
@@ -211,20 +213,20 @@ public abstract class BaseStrategyResourceTestCase {
 				(List<Strategy>)page.getItems());
 			assertValid(
 				page,
-				testGetPlanInternalClassNameStrategiesPage_getExpectedActions(
-					irrelevantInternalClassName));
+				testGetPlanInternalClassNameKeyStrategiesPage_getExpectedActions(
+					irrelevantInternalClassNameKey));
 		}
 
 		Strategy strategy1 =
-			testGetPlanInternalClassNameStrategiesPage_addStrategy(
-				internalClassName, randomStrategy());
+			testGetPlanInternalClassNameKeyStrategiesPage_addStrategy(
+				internalClassNameKey, randomStrategy());
 
 		Strategy strategy2 =
-			testGetPlanInternalClassNameStrategiesPage_addStrategy(
-				internalClassName, randomStrategy());
+			testGetPlanInternalClassNameKeyStrategiesPage_addStrategy(
+				internalClassNameKey, randomStrategy());
 
-		page = strategyResource.getPlanInternalClassNameStrategiesPage(
-			internalClassName);
+		page = strategyResource.getPlanInternalClassNameKeyStrategiesPage(
+			internalClassNameKey);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -233,13 +235,13 @@ public abstract class BaseStrategyResourceTestCase {
 			(List<Strategy>)page.getItems());
 		assertValid(
 			page,
-			testGetPlanInternalClassNameStrategiesPage_getExpectedActions(
-				internalClassName));
+			testGetPlanInternalClassNameKeyStrategiesPage_getExpectedActions(
+				internalClassNameKey));
 	}
 
 	protected Map<String, Map<String, String>>
-			testGetPlanInternalClassNameStrategiesPage_getExpectedActions(
-				String internalClassName)
+			testGetPlanInternalClassNameKeyStrategiesPage_getExpectedActions(
+				String internalClassNameKey)
 		throws Exception {
 
 		Map<String, Map<String, String>> expectedActions = new HashMap<>();
@@ -247,8 +249,9 @@ public abstract class BaseStrategyResourceTestCase {
 		return expectedActions;
 	}
 
-	protected Strategy testGetPlanInternalClassNameStrategiesPage_addStrategy(
-			String internalClassName, Strategy strategy)
+	protected Strategy
+			testGetPlanInternalClassNameKeyStrategiesPage_addStrategy(
+				String internalClassNameKey, Strategy strategy)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -256,7 +259,7 @@ public abstract class BaseStrategyResourceTestCase {
 	}
 
 	protected String
-			testGetPlanInternalClassNameStrategiesPage_getInternalClassName()
+			testGetPlanInternalClassNameKeyStrategiesPage_getInternalClassNameKey()
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -264,7 +267,7 @@ public abstract class BaseStrategyResourceTestCase {
 	}
 
 	protected String
-			testGetPlanInternalClassNameStrategiesPage_getIrrelevantInternalClassName()
+			testGetPlanInternalClassNameKeyStrategiesPage_getIrrelevantInternalClassNameKey()
 		throws Exception {
 
 		return null;

--- a/modules/apps/batch-planner/batch-planner-rest-test/src/testIntegration/java/com/liferay/batch/planner/rest/resource/v1_0/test/PlanResourceTest.java
+++ b/modules/apps/batch-planner/batch-planner-rest-test/src/testIntegration/java/com/liferay/batch/planner/rest/resource/v1_0/test/PlanResourceTest.java
@@ -6,6 +6,7 @@
 package com.liferay.batch.planner.rest.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.batch.planner.batch.engine.task.TaskItemUtil;
 import com.liferay.batch.planner.rest.client.dto.v1_0.Plan;
 import com.liferay.batch.planner.rest.client.http.HttpInvoker;
 import com.liferay.object.field.builder.TextObjectFieldBuilder;
@@ -62,6 +63,40 @@ public class PlanResourceTest extends BasePlanResourceTestCase {
 			httpResponse.getContent(), System.lineSeparator());
 
 		Assert.assertTrue(StringUtil.contains(lines[0], fieldName));
+	}
+
+	@Override
+	@Test
+	public void testPostPlan() throws Exception {
+		super.testPostPlan();
+
+		Plan randomPlan = randomPlan();
+
+		randomPlan.setTaskItemDelegateName(RandomTestUtil.randomString());
+
+		Plan postPlan = testPostPlan_addPlan(randomPlan);
+
+		assertEquals(randomPlan, postPlan);
+		assertValid(postPlan);
+
+		randomPlan = randomPlan();
+
+		randomPlan.setTaskItemDelegateName("DEFAULT");
+
+		postPlan = testPostPlan_addPlan(randomPlan);
+
+		assertEquals(randomPlan, postPlan);
+		assertValid(postPlan);
+	}
+
+	@Override
+	protected void assertEquals(Plan plan1, Plan plan2) {
+		super.assertEquals(plan1, plan2);
+
+		Assert.assertEquals(
+			TaskItemUtil.getInternalClassNameKey(
+				plan1.getInternalClassName(), plan1.getTaskItemDelegateName()),
+			plan2.getInternalClassNameKey());
 	}
 
 	@Override

--- a/modules/apps/batch-planner/batch-planner-rest-test/src/testIntegration/java/com/liferay/batch/planner/rest/resource/v1_0/test/PlanResourceTest.java
+++ b/modules/apps/batch-planner/batch-planner-rest-test/src/testIntegration/java/com/liferay/batch/planner/rest/resource/v1_0/test/PlanResourceTest.java
@@ -65,9 +65,19 @@ public class PlanResourceTest extends BasePlanResourceTestCase {
 	}
 
 	@Override
+	protected String[] getAdditionalAssertFieldNames() {
+		return new String[] {
+			"active", "externalType", "externalURL", "internalClassName",
+			"name", "template"
+		};
+	}
+
+	@Override
 	protected Plan randomPatchPlan() {
 		Plan plan = randomPlan();
 
+		plan.setActive(true);
+		plan.setExternalURL(_plan.getExternalURL());
 		plan.setTemplate(true);
 
 		return plan;
@@ -77,7 +87,7 @@ public class PlanResourceTest extends BasePlanResourceTestCase {
 	protected Plan randomPlan() {
 		return new Plan() {
 			{
-				active = RandomTestUtil.randomBoolean();
+				active = true;
 				export = RandomTestUtil.randomBoolean();
 				externalType = "JSON";
 				externalURL = StringUtil.toLowerCase(
@@ -92,35 +102,37 @@ public class PlanResourceTest extends BasePlanResourceTestCase {
 
 	@Override
 	protected Plan testDeletePlan_addPlan() throws Exception {
-		return _addPlan();
+		return _addPlan(randomPlan());
 	}
 
 	@Override
 	protected Plan testGetPlan_addPlan() throws Exception {
-		return _addPlan();
+		return _addPlan(randomPlan());
 	}
 
 	@Override
 	protected Plan testGetPlansPage_addPlan(Plan plan) throws Exception {
-		return planResource.postPlan(plan);
+		return _addPlan(plan);
 	}
 
 	@Override
 	protected Plan testPatchPlan_addPlan() throws Exception {
-		Plan plan = randomPlan();
+		_plan = randomPlan();
 
-		plan.setTemplate(true);
+		_plan.setTemplate(true);
 
-		return planResource.postPlan(plan);
+		return _addPlan(_plan);
 	}
 
 	@Override
 	protected Plan testPostPlan_addPlan(Plan plan) throws Exception {
-		return _addPlan();
+		return _addPlan(plan);
 	}
 
-	private Plan _addPlan() throws Exception {
-		return planResource.postPlan(randomPlan());
+	private Plan _addPlan(Plan plan) throws Exception {
+		return planResource.postPlan(plan);
 	}
+
+	private Plan _plan;
 
 }

--- a/modules/apps/batch-planner/batch-planner-service/src/main/java/com/liferay/batch/planner/service/impl/BatchPlannerPlanLocalServiceImpl.java
+++ b/modules/apps/batch-planner/batch-planner-service/src/main/java/com/liferay/batch/planner/service/impl/BatchPlannerPlanLocalServiceImpl.java
@@ -5,6 +5,7 @@
 
 package com.liferay.batch.planner.service.impl;
 
+import com.liferay.batch.planner.batch.engine.task.TaskItemUtil;
 import com.liferay.batch.planner.constants.BatchPlannerPlanConstants;
 import com.liferay.batch.planner.exception.BatchPlannerPlanExternalTypeException;
 import com.liferay.batch.planner.exception.BatchPlannerPlanInternalClassNameException;
@@ -59,7 +60,7 @@ public class BatchPlannerPlanLocalServiceImpl
 		_validateInternalClassName(internalClassName);
 
 		if (Validator.isNull(name) && !template) {
-			name = _generateName(internalClassName);
+			name = _generateName(internalClassName, taskItemDelegateName);
 		}
 
 		User user = _userLocalService.getUser(userId);
@@ -177,9 +178,15 @@ public class BatchPlannerPlanLocalServiceImpl
 		return batchPlannerPlanPersistence.update(batchPlannerPlan);
 	}
 
-	private String _generateName(String value) {
-		return value.substring(value.lastIndexOf(StringPool.PERIOD) + 1) +
-			" Plan Execution " + System.currentTimeMillis();
+	private String _generateName(
+		String internalClassName, String taskItemDelegateName) {
+
+		String simpleClassName = TaskItemUtil.getSimpleClassName(
+			TaskItemUtil.getInternalClassNameKey(
+				internalClassName, taskItemDelegateName));
+
+		return simpleClassName + " Plan Execution " +
+			System.currentTimeMillis();
 	}
 
 	private void _validateExternalType(String externalType)

--- a/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/display/BatchPlannerPlanDisplay.java
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/display/BatchPlannerPlanDisplay.java
@@ -30,8 +30,8 @@ public class BatchPlannerPlanDisplay {
 		return _failedItemsCount;
 	}
 
-	public String getInternalClassName() {
-		return _internalClassName;
+	public String getInternalClassNameKey() {
+		return _internalClassNameKey;
 	}
 
 	public Date getModifiedDate() {
@@ -95,7 +95,7 @@ public class BatchPlannerPlanDisplay {
 		public BatchPlannerPlanDisplay build() {
 			return new BatchPlannerPlanDisplay(
 				_action, _batchPlannerPlanId, _createDate, _export,
-				_failedItemsCount, _internalClassName, _modifiedDate,
+				_failedItemsCount, _internalClassNameKey, _modifiedDate,
 				_processedItemsCount, _status, _title, _totalItemsCount,
 				_userId);
 		}
@@ -118,8 +118,8 @@ public class BatchPlannerPlanDisplay {
 			return this;
 		}
 
-		public Builder internalClassName(String internalClassName) {
-			_internalClassName = internalClassName;
+		public Builder internalClassNameKey(String internalClassNameKey) {
+			_internalClassNameKey = internalClassNameKey;
 
 			return this;
 		}
@@ -165,7 +165,7 @@ public class BatchPlannerPlanDisplay {
 		private Date _createDate;
 		private boolean _export;
 		private int _failedItemsCount;
-		private String _internalClassName;
+		private String _internalClassNameKey;
 		private Date _modifiedDate;
 		private int _processedItemsCount;
 		private int _status;
@@ -177,7 +177,7 @@ public class BatchPlannerPlanDisplay {
 
 	private BatchPlannerPlanDisplay(
 		String action, long batchPlannerPlanId, Date createDate, boolean export,
-		int failedItemsCount, String internalClassName, Date modifiedDate,
+		int failedItemsCount, String internalClassNameKey, Date modifiedDate,
 		int processedItemsCount, int status, String title, int totalItemsCount,
 		long userId) {
 
@@ -186,7 +186,7 @@ public class BatchPlannerPlanDisplay {
 		_createDate = createDate;
 		_export = export;
 		_failedItemsCount = failedItemsCount;
-		_internalClassName = internalClassName;
+		_internalClassNameKey = internalClassNameKey;
 		_modifiedDate = modifiedDate;
 		_processedItemsCount = processedItemsCount;
 		_status = status;
@@ -200,7 +200,7 @@ public class BatchPlannerPlanDisplay {
 	private Date _createDate;
 	private boolean _export;
 	private int _failedItemsCount;
-	private String _internalClassName;
+	private String _internalClassNameKey;
 	private Date _modifiedDate;
 	private int _processedItemsCount;
 	private int _status;

--- a/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/display/BatchPlannerPlanTemplateDisplay.java
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/display/BatchPlannerPlanTemplateDisplay.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/display/BatchPlannerPlanTemplateDisplay.java
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/display/BatchPlannerPlanTemplateDisplay.java
@@ -1,0 +1,138 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.batch.planner.web.internal.display;
+
+import java.util.Date;
+
+/**
+ * @author Carlos Correa
+ */
+public class BatchPlannerPlanTemplateDisplay {
+
+	public String getAction() {
+		return _action;
+	}
+
+	public long getBatchPlannerPlanId() {
+		return _batchPlannerPlanId;
+	}
+
+	public Date getCreateDate() {
+		return _createDate;
+	}
+
+	public String getExternalType() {
+		return _externalType;
+	}
+
+	public String getInternalClassNameKey() {
+		return _internalClassNameKey;
+	}
+
+	public String getTitle() {
+		return _title;
+	}
+
+	public String getUserName() {
+		return _userName;
+	}
+
+	public boolean isExport() {
+		return _export;
+	}
+
+	public static class Builder {
+
+		public Builder action(String action) {
+			_action = action;
+
+			return this;
+		}
+
+		public Builder batchPlannerPlanId(long batchPlannerPlanId) {
+			_batchPlannerPlanId = batchPlannerPlanId;
+
+			return this;
+		}
+
+		public BatchPlannerPlanTemplateDisplay build() {
+			return new BatchPlannerPlanTemplateDisplay(
+				_action, _batchPlannerPlanId, _createDate, _export,
+				_externalType, _internalClassNameKey, _title, _userName);
+		}
+
+		public Builder createDate(Date createDate) {
+			_createDate = createDate;
+
+			return this;
+		}
+
+		public Builder export(boolean export) {
+			_export = export;
+
+			return this;
+		}
+
+		public Builder externalType(String externalType) {
+			_externalType = externalType;
+
+			return this;
+		}
+
+		public Builder internalClassNameKey(String internalClassNameKey) {
+			_internalClassNameKey = internalClassNameKey;
+
+			return this;
+		}
+
+		public Builder title(String title) {
+			_title = title;
+
+			return this;
+		}
+
+		public Builder userName(String userName) {
+			_userName = userName;
+
+			return this;
+		}
+
+		private String _action;
+		private long _batchPlannerPlanId;
+		private Date _createDate;
+		private boolean _export;
+		private String _externalType;
+		private String _internalClassNameKey;
+		private String _title;
+		private String _userName;
+
+	}
+
+	private BatchPlannerPlanTemplateDisplay(
+		String action, long batchPlannerPlanId, Date createDate, boolean export,
+		String externalType, String internalClassNameKey, String title,
+		String userName) {
+
+		_action = action;
+		_batchPlannerPlanId = batchPlannerPlanId;
+		_createDate = createDate;
+		_export = export;
+		_externalType = externalType;
+		_internalClassNameKey = internalClassNameKey;
+		_title = title;
+		_userName = userName;
+	}
+
+	private String _action;
+	private long _batchPlannerPlanId;
+	private Date _createDate;
+	private boolean _export;
+	private String _externalType;
+	private String _internalClassNameKey;
+	private String _title;
+	private String _userName;
+
+}

--- a/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/display/context/BaseDisplayContext.java
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/display/context/BaseDisplayContext.java
@@ -5,9 +5,9 @@
 
 package com.liferay.batch.planner.web.internal.display.context;
 
+import com.liferay.batch.planner.batch.engine.task.TaskItemUtil;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItemListBuilder;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -64,9 +64,8 @@ public abstract class BaseDisplayContext {
 		).build();
 	}
 
-	public String getSimpleInternalClassName(String internalClassName) {
-		return internalClassName.substring(
-			internalClassName.lastIndexOf(StringPool.PERIOD) + 1);
+	public String getSimpleClassName(String internalClassNameKey) {
+		return TaskItemUtil.getSimpleClassName(internalClassNameKey);
 	}
 
 	protected boolean isExport(String navigation) {

--- a/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/display/context/BatchPlannerPlanDisplayContext.java
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/display/context/BatchPlannerPlanDisplayContext.java
@@ -10,6 +10,7 @@ import com.liferay.batch.engine.model.BatchEngineExportTask;
 import com.liferay.batch.engine.model.BatchEngineImportTask;
 import com.liferay.batch.engine.service.BatchEngineExportTaskLocalServiceUtil;
 import com.liferay.batch.engine.service.BatchEngineImportTaskLocalServiceUtil;
+import com.liferay.batch.planner.batch.engine.task.TaskItemUtil;
 import com.liferay.batch.planner.constants.BatchPlannerPlanConstants;
 import com.liferay.batch.planner.constants.BatchPlannerPortletKeys;
 import com.liferay.batch.planner.model.BatchPlannerPlan;
@@ -184,8 +185,10 @@ public class BatchPlannerPlanDisplayContext extends BaseDisplayContext {
 			batchPlannerPlan.getCreateDate()
 		).export(
 			batchPlannerPlan.isExport()
-		).internalClassName(
-			batchPlannerPlan.getInternalClassName()
+		).internalClassNameKey(
+			TaskItemUtil.getInternalClassNameKey(
+				batchPlannerPlan.getInternalClassName(),
+				batchPlannerPlan.getTaskItemDelegateName())
 		).title(
 			batchPlannerPlan.getName()
 		).userId(

--- a/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/display/context/BatchPlannerPlanTemplateDisplayContext.java
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/display/context/BatchPlannerPlanTemplateDisplayContext.java
@@ -5,9 +5,12 @@
 
 package com.liferay.batch.planner.web.internal.display.context;
 
+import com.liferay.batch.planner.batch.engine.task.TaskItemUtil;
 import com.liferay.batch.planner.constants.BatchPlannerPortletKeys;
 import com.liferay.batch.planner.model.BatchPlannerPlan;
 import com.liferay.batch.planner.service.BatchPlannerPlanServiceUtil;
+import com.liferay.batch.planner.web.internal.display.BatchPlannerPlanTemplateDisplay;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.dao.search.EmptyOnClickRowChecker;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -50,7 +53,9 @@ public class BatchPlannerPlanTemplateDisplayContext extends BaseDisplayContext {
 		).buildPortletURL();
 	}
 
-	public SearchContainer<BatchPlannerPlan> getSearchContainer() {
+	public SearchContainer<BatchPlannerPlanTemplateDisplay>
+		getSearchContainer() {
+
 		try {
 			return _getSearchContainer();
 		}
@@ -62,6 +67,14 @@ public class BatchPlannerPlanTemplateDisplayContext extends BaseDisplayContext {
 
 		return new SearchContainer<>(
 			renderRequest, getPortletURL(), null, "no-items-were-found");
+	}
+
+	private String _getAction(boolean export) {
+		if (export) {
+			return "export";
+		}
+
+		return "import";
 	}
 
 	private String _getOrderByCol() {
@@ -88,7 +101,8 @@ public class BatchPlannerPlanTemplateDisplayContext extends BaseDisplayContext {
 		return _orderByType;
 	}
 
-	private SearchContainer<BatchPlannerPlan> _getSearchContainer()
+	private SearchContainer<BatchPlannerPlanTemplateDisplay>
+			_getSearchContainer()
 		throws PortalException {
 
 		if (_searchContainer != null) {
@@ -98,7 +112,8 @@ public class BatchPlannerPlanTemplateDisplayContext extends BaseDisplayContext {
 		_searchContainer = new SearchContainer<>(
 			renderRequest, getPortletURL(), null, "no-items-were-found");
 
-		_searchContainer.setId("batchPlannerPlanTemplateSearchContainer");
+		_searchContainer.setId(
+			"batchPlannerPlanTemplateDisplaySearchContainer");
 		_searchContainer.setOrderByCol(_getOrderByCol());
 		_searchContainer.setOrderByType(_getOrderByType());
 
@@ -111,13 +126,16 @@ public class BatchPlannerPlanTemplateDisplayContext extends BaseDisplayContext {
 
 		if (navigation.equals("all")) {
 			_searchContainer.setResultsAndTotal(
-				() -> BatchPlannerPlanServiceUtil.getBatchPlannerPlans(
-					companyId, true, searchByKeyword,
-					_searchContainer.getStart(), _searchContainer.getEnd(),
-					OrderByComparatorFactoryUtil.create(
-						"BatchPlannerPlan", _searchContainer.getOrderByCol(),
-						Objects.equals(
-							_searchContainer.getOrderByType(), "asc"))),
+				() -> TransformUtil.transform(
+					BatchPlannerPlanServiceUtil.getBatchPlannerPlans(
+						companyId, true, searchByKeyword,
+						_searchContainer.getStart(), _searchContainer.getEnd(),
+						OrderByComparatorFactoryUtil.create(
+							"BatchPlannerPlan",
+							_searchContainer.getOrderByCol(),
+							Objects.equals(
+								_searchContainer.getOrderByType(), "asc"))),
+					this::_toBatchPlannerPlanTemplateDisplay),
 				BatchPlannerPlanServiceUtil.getBatchPlannerPlansCount(
 					companyId, true, searchByKeyword));
 		}
@@ -125,13 +143,16 @@ public class BatchPlannerPlanTemplateDisplayContext extends BaseDisplayContext {
 			boolean export = isExport(navigation);
 
 			_searchContainer.setResultsAndTotal(
-				() -> BatchPlannerPlanServiceUtil.getBatchPlannerPlans(
-					companyId, export, true, searchByKeyword,
-					_searchContainer.getStart(), _searchContainer.getEnd(),
-					OrderByComparatorFactoryUtil.create(
-						"BatchPlannerPlan", _searchContainer.getOrderByCol(),
-						Objects.equals(
-							_searchContainer.getOrderByType(), "asc"))),
+				() -> TransformUtil.transform(
+					BatchPlannerPlanServiceUtil.getBatchPlannerPlans(
+						companyId, export, true, searchByKeyword,
+						_searchContainer.getStart(), _searchContainer.getEnd(),
+						OrderByComparatorFactoryUtil.create(
+							"BatchPlannerPlan",
+							_searchContainer.getOrderByCol(),
+							Objects.equals(
+								_searchContainer.getOrderByType(), "asc"))),
+					this::_toBatchPlannerPlanTemplateDisplay),
 				BatchPlannerPlanServiceUtil.getBatchPlannerPlansCount(
 					companyId, export, true, searchByKeyword));
 		}
@@ -142,8 +163,34 @@ public class BatchPlannerPlanTemplateDisplayContext extends BaseDisplayContext {
 		return _searchContainer;
 	}
 
+	private BatchPlannerPlanTemplateDisplay _toBatchPlannerPlanTemplateDisplay(
+			BatchPlannerPlan batchPlannerPlan)
+		throws PortalException {
+
+		return new BatchPlannerPlanTemplateDisplay.Builder(
+		).action(
+			_getAction(batchPlannerPlan.isExport())
+		).batchPlannerPlanId(
+			batchPlannerPlan.getBatchPlannerPlanId()
+		).createDate(
+			batchPlannerPlan.getCreateDate()
+		).export(
+			batchPlannerPlan.isExport()
+		).externalType(
+			batchPlannerPlan.getExternalType()
+		).internalClassNameKey(
+			TaskItemUtil.getInternalClassNameKey(
+				batchPlannerPlan.getInternalClassName(),
+				batchPlannerPlan.getTaskItemDelegateName())
+		).title(
+			batchPlannerPlan.getName()
+		).userName(
+			batchPlannerPlan.getUserName()
+		).build();
+	}
+
 	private String _orderByCol;
 	private String _orderByType;
-	private SearchContainer<BatchPlannerPlan> _searchContainer;
+	private SearchContainer<BatchPlannerPlanTemplateDisplay> _searchContainer;
 
 }

--- a/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/display/context/EditBatchPlannerPlanDisplayContext.java
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/display/context/EditBatchPlannerPlanDisplayContext.java
@@ -197,9 +197,7 @@ public class EditBatchPlannerPlanDisplayContext {
 				new SelectOption(
 					String.format(
 						"%s (%s - %s)",
-						TaskItemUtil.getSimpleClassName(
-							internalClassNameKeyParts
-								[internalClassNameKeyParts.length - 1]),
+						TaskItemUtil.getSimpleClassName(internalClassNameKey),
 						internalClassNameKeyParts
 							[internalClassNameKeyParts.length - 2],
 						entry.getValue()),

--- a/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/display/context/EditBatchPlannerPlanDisplayContext.java
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/display/context/EditBatchPlannerPlanDisplayContext.java
@@ -197,7 +197,7 @@ public class EditBatchPlannerPlanDisplayContext {
 				new SelectOption(
 					String.format(
 						"%s (%s - %s)",
-						_resolveSimpleClassName(
+						TaskItemUtil.getSimpleClassName(
 							internalClassNameKeyParts
 								[internalClassNameKeyParts.length - 1]),
 						internalClassNameKeyParts
@@ -250,16 +250,6 @@ public class EditBatchPlannerPlanDisplayContext {
 		}
 
 		return templateSelectOptions;
-	}
-
-	private String _resolveSimpleClassName(String internalClassNameKey) {
-		int index = internalClassNameKey.indexOf(StringPool.POUND);
-
-		if (index < 0) {
-			return internalClassNameKey;
-		}
-
-		return internalClassNameKey.substring(index + 1);
 	}
 
 	private final HttpServletRequest _httpServletRequest;

--- a/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/display/context/EditBatchPlannerPlanDisplayContext.java
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/display/context/EditBatchPlannerPlanDisplayContext.java
@@ -8,6 +8,7 @@ package com.liferay.batch.planner.web.internal.display.context;
 import com.liferay.batch.engine.BatchEngineTaskContentType;
 import com.liferay.batch.engine.constants.CreateStrategy;
 import com.liferay.batch.engine.constants.UpdateStrategy;
+import com.liferay.batch.planner.batch.engine.task.TaskItemUtil;
 import com.liferay.batch.planner.model.BatchPlannerMapping;
 import com.liferay.batch.planner.model.BatchPlannerPlan;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.SelectOption;
@@ -39,21 +40,22 @@ public class EditBatchPlannerPlanDisplayContext {
 
 	public EditBatchPlannerPlanDisplayContext(
 			List<BatchPlannerPlan> batchPlannerPlans,
-			Map<String, String> internalClassNameCategories,
+			Map<String, String> internalClassNameKeyCategories,
 			RenderRequest renderRequest,
 			BatchPlannerPlan selectedBatchPlannerPlan)
 		throws PortalException {
 
 		_httpServletRequest = PortalUtil.getHttpServletRequest(renderRequest);
-		_internalClassNameSelectOptions = _getInternalClassNameSelectOptions(
-			internalClassNameCategories);
+		_internalClassNameKeySelectOptions =
+			_getInternalClassNameKeySelectOptions(
+				internalClassNameKeyCategories);
 
 		if (selectedBatchPlannerPlan == null) {
 			_selectedBatchPlannerMappings = new HashMap<>();
 			_selectedBatchPlannerPlanId = 0;
 			_selectedBatchPlannerPlanName = StringPool.BLANK;
 			_selectedExternalType = StringPool.BLANK;
-			_selectedInternalClassName = StringPool.BLANK;
+			_selectedInternalClassNameKey = StringPool.BLANK;
 		}
 		else {
 			_selectedBatchPlannerMappings = _getSelectedBatchPlannerMappings(
@@ -62,8 +64,10 @@ public class EditBatchPlannerPlanDisplayContext {
 				selectedBatchPlannerPlan.getBatchPlannerPlanId();
 			_selectedBatchPlannerPlanName = selectedBatchPlannerPlan.getName();
 			_selectedExternalType = selectedBatchPlannerPlan.getExternalType();
-			_selectedInternalClassName =
-				selectedBatchPlannerPlan.getInternalClassName();
+			_selectedInternalClassNameKey =
+				TaskItemUtil.getInternalClassNameKey(
+					selectedBatchPlannerPlan.getInternalClassName(),
+					selectedBatchPlannerPlan.getTaskItemDelegateName());
 		}
 
 		_templateSelectOptions = _getTemplateSelectOptions(batchPlannerPlans);
@@ -112,8 +116,8 @@ public class EditBatchPlannerPlanDisplayContext {
 		return selectOptions;
 	}
 
-	public List<SelectOption> getInternalClassNameSelectOptions() {
-		return _internalClassNameSelectOptions;
+	public List<SelectOption> getInternalClassNameKeySelectOptions() {
+		return _internalClassNameKeySelectOptions;
 	}
 
 	public Locale getLocale() {
@@ -142,8 +146,8 @@ public class EditBatchPlannerPlanDisplayContext {
 		return _selectedExternalType;
 	}
 
-	public String getSelectedInternalClassName() {
-		return _selectedInternalClassName;
+	public String getSelectedInternalClassNameKey() {
+		return _selectedInternalClassNameKey;
 	}
 
 	public List<SelectOption> getTemplateSelectOptions() {
@@ -172,39 +176,40 @@ public class EditBatchPlannerPlanDisplayContext {
 		return selectOptions;
 	}
 
-	private List<SelectOption> _getInternalClassNameSelectOptions(
-		Map<String, String> internalClassNameCategories) {
+	private List<SelectOption> _getInternalClassNameKeySelectOptions(
+		Map<String, String> internalClassNameKeyCategories) {
 
-		List<SelectOption> internalClassNameSelectOptions = new ArrayList<>();
+		List<SelectOption> internalClassNameKeySelectOptions =
+			new ArrayList<>();
 
-		internalClassNameSelectOptions.add(
+		internalClassNameKeySelectOptions.add(
 			new SelectOption(StringPool.BLANK, StringPool.BLANK));
 
 		for (Map.Entry<String, String> entry :
-				internalClassNameCategories.entrySet()) {
+				internalClassNameKeyCategories.entrySet()) {
 
-			String internalClassName = entry.getKey();
+			String internalClassNameKey = entry.getKey();
 
-			String[] internalClassNameParts = StringUtil.split(
-				internalClassName, StringPool.PERIOD);
+			String[] internalClassNameKeyParts = StringUtil.split(
+				internalClassNameKey, StringPool.PERIOD);
 
-			internalClassNameSelectOptions.add(
+			internalClassNameKeySelectOptions.add(
 				new SelectOption(
 					String.format(
 						"%s (%s - %s)",
-						_resolveInternalClassName(
-							internalClassNameParts
-								[internalClassNameParts.length - 1]),
-						internalClassNameParts
-							[internalClassNameParts.length - 2],
+						_resolveSimpleClassName(
+							internalClassNameKeyParts
+								[internalClassNameKeyParts.length - 1]),
+						internalClassNameKeyParts
+							[internalClassNameKeyParts.length - 2],
 						entry.getValue()),
-					internalClassName));
+					internalClassNameKey));
 		}
 
-		internalClassNameSelectOptions.sort(
+		internalClassNameKeySelectOptions.sort(
 			Comparator.comparing(SelectOption::getLabel));
 
-		return internalClassNameSelectOptions;
+		return internalClassNameKeySelectOptions;
 	}
 
 	private Map<String, String> _getSelectedBatchPlannerMappings(
@@ -247,24 +252,24 @@ public class EditBatchPlannerPlanDisplayContext {
 		return templateSelectOptions;
 	}
 
-	private String _resolveInternalClassName(String internalClassName) {
-		int index = internalClassName.indexOf(StringPool.POUND);
+	private String _resolveSimpleClassName(String internalClassNameKey) {
+		int index = internalClassNameKey.indexOf(StringPool.POUND);
 
 		if (index < 0) {
-			return internalClassName;
+			return internalClassNameKey;
 		}
 
-		return internalClassName.substring(index + 1);
+		return internalClassNameKey.substring(index + 1);
 	}
 
 	private final HttpServletRequest _httpServletRequest;
-	private final List<SelectOption> _internalClassNameSelectOptions;
+	private final List<SelectOption> _internalClassNameKeySelectOptions;
 	private Locale _locale;
 	private final Map<String, String> _selectedBatchPlannerMappings;
 	private final long _selectedBatchPlannerPlanId;
 	private final String _selectedBatchPlannerPlanName;
 	private final String _selectedExternalType;
-	private final String _selectedInternalClassName;
+	private final String _selectedInternalClassNameKey;
 	private final List<SelectOption> _templateSelectOptions;
 	private ThemeDisplay _themeDisplay;
 

--- a/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/helper/BatchPlannerPlanHelper.java
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/helper/BatchPlannerPlanHelper.java
@@ -54,16 +54,16 @@ public class BatchPlannerPlanHelper {
 
 		String externalType = ParamUtil.getString(
 			portletRequest, "externalType");
-		String internalClassName = _resolveInternalClassName(
-			ParamUtil.getString(portletRequest, "internalClassName"));
 		String taskItemDelegateName = TaskItemUtil.getDelegateName(
 			ParamUtil.getString(portletRequest, "internalClassName"));
 		boolean template = ParamUtil.getBoolean(portletRequest, "template");
 
 		BatchPlannerPlan batchPlannerPlan =
 			_batchPlannerPlanService.addBatchPlannerPlan(
-				true, externalType, StringPool.SLASH, internalClassName, name,
-				0, taskItemDelegateName, template);
+				true, externalType, StringPool.SLASH,
+				TaskItemUtil.getInternalClassName(
+					ParamUtil.getString(portletRequest, "internalClassName")),
+				name, 0, taskItemDelegateName, template);
 
 		_addBatchPlannerPolicies(
 			batchPlannerPlan.getBatchPlannerPlanId(),
@@ -90,7 +90,7 @@ public class BatchPlannerPlanHelper {
 
 		String externalType = ParamUtil.getString(
 			portletRequest, "externalType", "CSV");
-		String internalClassName = _resolveInternalClassName(
+		String internalClassName = TaskItemUtil.getInternalClassName(
 			ParamUtil.getString(portletRequest, "internalClassName"));
 		String taskItemDelegateName = TaskItemUtil.getDelegateName(
 			ParamUtil.getString(portletRequest, "internalClassName"));
@@ -329,16 +329,6 @@ public class BatchPlannerPlanHelper {
 		}
 
 		return batchPlannerMappings;
-	}
-
-	private String _resolveInternalClassName(String internalClassName) {
-		int index = internalClassName.indexOf(StringPool.POUND);
-
-		if (index < 0) {
-			return internalClassName;
-		}
-
-		return internalClassName.substring(0, index);
 	}
 
 	private BatchPlannerPlan _updateBatchPlannerPlan(

--- a/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/helper/BatchPlannerPlanHelper.java
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/helper/BatchPlannerPlanHelper.java
@@ -55,14 +55,15 @@ public class BatchPlannerPlanHelper {
 		String externalType = ParamUtil.getString(
 			portletRequest, "externalType");
 		String taskItemDelegateName = TaskItemUtil.getDelegateName(
-			ParamUtil.getString(portletRequest, "internalClassName"));
+			ParamUtil.getString(portletRequest, "internalClassNameKey"));
 		boolean template = ParamUtil.getBoolean(portletRequest, "template");
 
 		BatchPlannerPlan batchPlannerPlan =
 			_batchPlannerPlanService.addBatchPlannerPlan(
 				true, externalType, StringPool.SLASH,
 				TaskItemUtil.getInternalClassName(
-					ParamUtil.getString(portletRequest, "internalClassName")),
+					ParamUtil.getString(
+						portletRequest, "internalClassNameKey")),
 				name, 0, taskItemDelegateName, template);
 
 		_addBatchPlannerPolicies(
@@ -91,9 +92,9 @@ public class BatchPlannerPlanHelper {
 		String externalType = ParamUtil.getString(
 			portletRequest, "externalType", "CSV");
 		String internalClassName = TaskItemUtil.getInternalClassName(
-			ParamUtil.getString(portletRequest, "internalClassName"));
+			ParamUtil.getString(portletRequest, "internalClassNameKey"));
 		String taskItemDelegateName = TaskItemUtil.getDelegateName(
-			ParamUtil.getString(portletRequest, "internalClassName"));
+			ParamUtil.getString(portletRequest, "internalClassNameKey"));
 		boolean template = ParamUtil.getBoolean(portletRequest, "template");
 
 		int size = 0;
@@ -343,7 +344,7 @@ public class BatchPlannerPlanHelper {
 		String externalType = ParamUtil.getString(
 			portletRequest, "externalType");
 		String internalClassName = ParamUtil.getString(
-			portletRequest, "internalClassName");
+			portletRequest, "internalClassNameKey");
 		String name = ParamUtil.getString(portletRequest, "name");
 
 		BatchPlannerPlan batchPlannerPlan =

--- a/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/helper/BatchPlannerPlanHelper.java
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/helper/BatchPlannerPlanHelper.java
@@ -54,8 +54,6 @@ public class BatchPlannerPlanHelper {
 
 		String externalType = ParamUtil.getString(
 			portletRequest, "externalType");
-		String taskItemDelegateName = TaskItemUtil.getTaskItemDelegateName(
-			ParamUtil.getString(portletRequest, "internalClassNameKey"));
 		boolean template = ParamUtil.getBoolean(portletRequest, "template");
 
 		BatchPlannerPlan batchPlannerPlan =
@@ -64,7 +62,11 @@ public class BatchPlannerPlanHelper {
 				TaskItemUtil.getInternalClassName(
 					ParamUtil.getString(
 						portletRequest, "internalClassNameKey")),
-				name, 0, taskItemDelegateName, template);
+				name, 0,
+				TaskItemUtil.getTaskItemDelegateName(
+					ParamUtil.getString(
+						portletRequest, "internalClassNameKey")),
+				template);
 
 		_addBatchPlannerPolicies(
 			batchPlannerPlan.getBatchPlannerPlanId(),

--- a/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/helper/BatchPlannerPlanHelper.java
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/helper/BatchPlannerPlanHelper.java
@@ -54,7 +54,7 @@ public class BatchPlannerPlanHelper {
 
 		String externalType = ParamUtil.getString(
 			portletRequest, "externalType");
-		String taskItemDelegateName = TaskItemUtil.getDelegateName(
+		String taskItemDelegateName = TaskItemUtil.getTaskItemDelegateName(
 			ParamUtil.getString(portletRequest, "internalClassNameKey"));
 		boolean template = ParamUtil.getBoolean(portletRequest, "template");
 
@@ -93,7 +93,7 @@ public class BatchPlannerPlanHelper {
 			portletRequest, "externalType", "CSV");
 		String internalClassName = TaskItemUtil.getInternalClassName(
 			ParamUtil.getString(portletRequest, "internalClassNameKey"));
-		String taskItemDelegateName = TaskItemUtil.getDelegateName(
+		String taskItemDelegateName = TaskItemUtil.getTaskItemDelegateName(
 			ParamUtil.getString(portletRequest, "internalClassNameKey"));
 		boolean template = ParamUtil.getBoolean(portletRequest, "template");
 

--- a/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/portlet/action/EditBatchPlannerPlanMVCRenderCommand.java
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/portlet/action/EditBatchPlannerPlanMVCRenderCommand.java
@@ -65,10 +65,10 @@ public class EditBatchPlannerPlanMVCRenderCommand implements MVCRenderCommand {
 		return "/view.jsp";
 	}
 
-	private Map<String, String> _getInternalClassNameCategories(
+	private Map<String, String> _getInternalClassNameKeyCategories(
 		long companyId, boolean export) {
 
-		Map<String, String> internalClassNameCategories = new HashMap<>();
+		Map<String, String> internalClassNameKeyCategories = new HashMap<>();
 
 		for (String entityClassName :
 				_vulcanBatchEngineTaskItemDelegateRegistry.getEntityClassNames(
@@ -84,17 +84,17 @@ public class EditBatchPlannerPlanMVCRenderCommand implements MVCRenderCommand {
 						getVulcanBatchEngineTaskItemDelegate(
 							companyId, entityClassName);
 
-			internalClassNameCategories.put(
+			internalClassNameKeyCategories.put(
 				entityClassName,
-				_getInternalClassNameCategory(
+				_getInternalClassNameKeyCategory(
 					FrameworkUtil.getBundle(
 						vulcanBatchEngineTaskItemDelegate.getClass())));
 		}
 
-		return internalClassNameCategories;
+		return internalClassNameKeyCategories;
 	}
 
-	private String _getInternalClassNameCategory(Bundle bundle) {
+	private String _getInternalClassNameKeyCategory(Bundle bundle) {
 		Dictionary<String, String> headers = bundle.getHeaders(
 			StringPool.BLANK);
 
@@ -131,8 +131,8 @@ public class EditBatchPlannerPlanMVCRenderCommand implements MVCRenderCommand {
 		boolean export = _isExport(
 			ParamUtil.getString(renderRequest, "navigation"));
 
-		Map<String, String> internalClassNameCategories =
-			_getInternalClassNameCategories(companyId, export);
+		Map<String, String> internalClassNameKeyCategories =
+			_getInternalClassNameKeyCategories(companyId, export);
 
 		long batchPlannerPlanId = ParamUtil.getLong(
 			renderRequest, "batchPlannerPlanId");
@@ -145,7 +145,7 @@ public class EditBatchPlannerPlanMVCRenderCommand implements MVCRenderCommand {
 						_batchPlannerPlanService.getBatchPlannerPlans(
 							companyId, true, true, QueryUtil.ALL_POS,
 							QueryUtil.ALL_POS, null),
-						internalClassNameCategories, renderRequest, null));
+						internalClassNameKeyCategories, renderRequest, null));
 
 				return "/export/edit_batch_planner_plan.jsp";
 			}
@@ -156,7 +156,7 @@ public class EditBatchPlannerPlanMVCRenderCommand implements MVCRenderCommand {
 					_batchPlannerPlanService.getBatchPlannerPlans(
 						_portal.getCompanyId(renderRequest), false, true,
 						QueryUtil.ALL_POS, QueryUtil.ALL_POS, null),
-					internalClassNameCategories, renderRequest, null));
+					internalClassNameKeyCategories, renderRequest, null));
 
 			return "/import/edit_batch_planner_plan.jsp";
 		}
@@ -171,7 +171,7 @@ public class EditBatchPlannerPlanMVCRenderCommand implements MVCRenderCommand {
 					_batchPlannerPlanService.getBatchPlannerPlans(
 						_portal.getCompanyId(renderRequest), true, true,
 						QueryUtil.ALL_POS, QueryUtil.ALL_POS, null),
-					internalClassNameCategories, renderRequest,
+					internalClassNameKeyCategories, renderRequest,
 					batchPlannerPlan));
 
 			return "/export/edit_batch_planner_plan.jsp";
@@ -183,7 +183,8 @@ public class EditBatchPlannerPlanMVCRenderCommand implements MVCRenderCommand {
 				_batchPlannerPlanService.getBatchPlannerPlans(
 					_portal.getCompanyId(renderRequest), false, true,
 					QueryUtil.ALL_POS, QueryUtil.ALL_POS, null),
-				internalClassNameCategories, renderRequest, batchPlannerPlan));
+				internalClassNameKeyCategories, renderRequest,
+				batchPlannerPlan));
 
 		return "/import/edit_batch_planner_plan.jsp";
 	}

--- a/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/batch_planner_plan_template_action.jsp
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/batch_planner_plan_template_action.jsp
@@ -10,7 +10,7 @@
 <%
 ResultRow resultRow = (ResultRow)request.getAttribute(WebKeys.SEARCH_CONTAINER_RESULT_ROW);
 
-BatchPlannerPlan batchPlannerPlan = (BatchPlannerPlan)resultRow.getObject();
+BatchPlannerPlanTemplateDisplay batchPlannerPlanTemplateDisplay = (BatchPlannerPlanTemplateDisplay)resultRow.getObject();
 %>
 
 <liferay-ui:icon-menu
@@ -20,11 +20,11 @@ BatchPlannerPlan batchPlannerPlan = (BatchPlannerPlan)resultRow.getObject();
 	message="<%= StringPool.BLANK %>"
 	showWhenSingleIcon="<%= true %>"
 >
-	<c:if test="<%= BatchPlannerPlanPermission.contains(permissionChecker, batchPlannerPlan, ActionKeys.PERMISSIONS) %>">
+	<c:if test="<%= BatchPlannerPlanPermission.contains(permissionChecker, batchPlannerPlanTemplateDisplay.getBatchPlannerPlanId(), ActionKeys.PERMISSIONS) %>">
 		<liferay-security:permissionsURL
 			modelResource="<%= BatchPlannerPlan.class.getName() %>"
-			modelResourceDescription="<%= batchPlannerPlan.getName() %>"
-			resourcePrimKey="<%= String.valueOf(batchPlannerPlan.getBatchPlannerPlanId()) %>"
+			modelResourceDescription="<%= batchPlannerPlanTemplateDisplay.getTitle() %>"
+			resourcePrimKey="<%= String.valueOf(batchPlannerPlanTemplateDisplay.getBatchPlannerPlanId()) %>"
 			var="permissionsURL"
 			windowState="<%= LiferayWindowState.POP_UP.toString() %>"
 		/>
@@ -37,11 +37,11 @@ BatchPlannerPlan batchPlannerPlan = (BatchPlannerPlan)resultRow.getObject();
 		/>
 	</c:if>
 
-	<c:if test="<%= BatchPlannerPlanPermission.contains(permissionChecker, batchPlannerPlan, ActionKeys.DELETE) %>">
+	<c:if test="<%= BatchPlannerPlanPermission.contains(permissionChecker, batchPlannerPlanTemplateDisplay.getBatchPlannerPlanId(), ActionKeys.DELETE) %>">
 		<portlet:actionURL name="/batch_planner/delete_batch_planner_plan_template" var="deleteURL">
 			<portlet:param name="<%= Constants.CMD %>" value="<%= Constants.DELETE %>" />
 			<portlet:param name="redirect" value="<%= currentURL %>" />
-			<portlet:param name="batchPlannerPlanId" value="<%= String.valueOf(batchPlannerPlan.getBatchPlannerPlanId()) %>" />
+			<portlet:param name="batchPlannerPlanId" value="<%= String.valueOf(batchPlannerPlanTemplateDisplay.getBatchPlannerPlanId()) %>" />
 		</portlet:actionURL>
 
 		<liferay-ui:icon-delete

--- a/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/export/edit_batch_planner_plan.jsp
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/export/edit_batch_planner_plan.jsp
@@ -37,10 +37,10 @@ renderResponse.setTitle(editable ? LanguageUtil.get(request, "edit-template") : 
 							md="6"
 						>
 							<clay:select
-								id='<%= liferayPortletResponse.getNamespace() + "internalClassName" %>'
+								id='<%= liferayPortletResponse.getNamespace() + "internalClassNameKey" %>'
 								label="entity-type"
-								name="internalClassName"
-								options="<%= editBatchPlannerPlanDisplayContext.getInternalClassNameSelectOptions() %>"
+								name="internalClassNameKey"
+								options="<%= editBatchPlannerPlanDisplayContext.getInternalClassNameKeySelectOptions() %>"
 							/>
 						</clay:col>
 
@@ -168,7 +168,7 @@ renderResponse.setTitle(editable ? LanguageUtil.get(request, "edit-template") : 
 		HashMapBuilder.<String, Object>put(
 			"initialExternalType", editBatchPlannerPlanDisplayContext.getSelectedExternalType()
 		).put(
-			"initialTemplateClassName", editBatchPlannerPlanDisplayContext.getSelectedInternalClassName()
+			"initialTemplateClassName", editBatchPlannerPlanDisplayContext.getSelectedInternalClassNameKey()
 		).put(
 			"initialTemplateMapping", editBatchPlannerPlanDisplayContext.getSelectedBatchPlannerPlanMappings()
 		).put(

--- a/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/import/edit_batch_planner_plan.jsp
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/import/edit_batch_planner_plan.jsp
@@ -47,10 +47,10 @@ renderResponse.setTitle(editable ? LanguageUtil.get(request, "edit-template") : 
 									md="6"
 								>
 									<clay:select
-										id='<%= liferayPortletResponse.getNamespace() + "internalClassName" %>'
+										id='<%= liferayPortletResponse.getNamespace() + "internalClassNameKey" %>'
 										label='<%= LanguageUtil.get(request, "entity-type") %>'
-										name="internalClassName"
-										options="<%= editBatchPlannerPlanDisplayContext.getInternalClassNameSelectOptions() %>"
+										name="internalClassNameKey"
+										options="<%= editBatchPlannerPlanDisplayContext.getInternalClassNameKeySelectOptions() %>"
 									/>
 								</clay:col>
 							</clay:row>
@@ -194,7 +194,7 @@ renderResponse.setTitle(editable ? LanguageUtil.get(request, "edit-template") : 
 <liferay-frontend:component
 	context='<%=
 		HashMapBuilder.<String, Object>put(
-			"initialTemplateClassName", editBatchPlannerPlanDisplayContext.getSelectedInternalClassName()
+			"initialTemplateClassName", editBatchPlannerPlanDisplayContext.getSelectedInternalClassNameKey()
 		).put(
 			"initialTemplateMapping", editBatchPlannerPlanDisplayContext.getSelectedBatchPlannerPlanMappings()
 		).put(

--- a/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/init.jsp
@@ -21,6 +21,7 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 page import="com.liferay.batch.planner.exception.BatchPlannerPlanInternalClassNameException" %><%@
 page import="com.liferay.batch.planner.model.BatchPlannerPlan" %><%@
 page import="com.liferay.batch.planner.web.internal.display.BatchPlannerPlanDisplay" %><%@
+page import="com.liferay.batch.planner.web.internal.display.BatchPlannerPlanTemplateDisplay" %><%@
 page import="com.liferay.batch.planner.web.internal.display.context.BatchPlannerPlanDisplayContext" %><%@
 page import="com.liferay.batch.planner.web.internal.display.context.BatchPlannerPlanManagementToolbarDisplayContext" %><%@
 page import="com.liferay.batch.planner.web.internal.display.context.BatchPlannerPlanTemplateDisplayContext" %><%@

--- a/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/BatchPlannerPlanTemplateManagementToolbarPropsTransformer.js
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/BatchPlannerPlanTemplateManagementToolbarPropsTransformer.js
@@ -22,7 +22,7 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 					);
 
 					const searchContainer = document.getElementById(
-						`${portletNamespace}batchPlannerPlanTemplateSearchContainer`
+						`${portletNamespace}batchPlannerPlanTemplateDisplaySearchContainer`
 					);
 
 					if (form && searchContainer) {

--- a/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/DownloadHelper.js
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/DownloadHelper.js
@@ -56,7 +56,7 @@ export default function ({
 
 			if (type === 'batchPlannerTemplate') {
 				const valueElement = document.getElementById(
-					`${namespace}internalClassName`
+					`${namespace}internalClassNameKey`
 				);
 
 				externalReferenceCode =

--- a/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/TemplateSelect.js
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/TemplateSelect.js
@@ -89,7 +89,7 @@ const TemplateSelect = ({
 		Liferay.fire(TEMPLATE_SELECTED_EVENT, {
 			template: {
 				externalType: templateDetails.externalType,
-				internalClassName: templateDetails.internalClassName,
+				internalClassNameKey: templateDetails.internalClassNameKey,
 				mappings: templateDetails.mappings.reduce(
 					(mappings, mapping) => ({
 						...mappings,

--- a/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/edit_batch_planner_plan.js
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/edit_batch_planner_plan.js
@@ -51,8 +51,8 @@ export default function ({
 	namespace,
 	templatesOptions,
 }) {
-	const internalClassNameSelect = document.querySelector(
-		`#${namespace}internalClassName`
+	const internalClassNameKeySelect = document.querySelector(
+		`#${namespace}internalClassNameKey`
 	);
 	const externalTypeInput = document.querySelector(
 		`#${namespace}externalType`
@@ -93,9 +93,9 @@ export default function ({
 				externalTypeInput.value = template.externalType;
 			}
 
-			const selectedClassNameValue = template.internalClassName;
+			const selectedClassNameValue = template.internalClassNameKey;
 
-			const internalClassTemplateOption = internalClassNameSelect.querySelector(
+			const internalClassTemplateOption = internalClassNameKeySelect.querySelector(
 				`option[value='${selectedClassNameValue}']`
 			);
 			internalClassTemplateOption.selected = true;
@@ -110,13 +110,13 @@ export default function ({
 		}
 
 		const selectedOption =
-			internalClassNameSelect.options[
-				internalClassNameSelect.selectedIndex
+			internalClassNameKeySelect.options[
+				internalClassNameKeySelect.selectedIndex
 			];
 
-		const internalClassNameValue = trimPackage(selectedOption.value);
+		const internalClassNameKeyValue = trimPackage(selectedOption.value);
 
-		if (!internalClassNameValue) {
+		if (!internalClassNameKeyValue) {
 			Liferay.fire(SCHEMA_SELECTED_EVENT, {
 				schema: null,
 			});
@@ -157,7 +157,7 @@ export default function ({
 
 	Liferay.on(TEMPLATE_SELECTED_EVENT, handleTemplateSelectedEvent);
 
-	internalClassNameSelect.addEventListener(
+	internalClassNameKeySelect.addEventListener(
 		'change',
 		handleClassNameSelectChange
 	);
@@ -167,7 +167,7 @@ export default function ({
 	if (initialTemplateClassName && initialTemplateMapping) {
 		initialTemplate = {
 			externalType: initialExternalType,
-			internalClassName: initialTemplateClassName,
+			internalClassNameKey: initialTemplateClassName,
 			mapping: initialTemplateMapping,
 		};
 	}

--- a/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/view.jsp
@@ -57,7 +57,7 @@ SearchContainer<BatchPlannerPlanDisplay> batchPlannerPlanDisplaySearchContainer 
 
 			<liferay-ui:search-container-column-text
 				name="type"
-				value="<%= batchPlannerPlanDisplayContext.getSimpleInternalClassName(batchPlannerPlanDisplay.getInternalClassNameKey()) %>"
+				value="<%= batchPlannerPlanDisplayContext.getSimpleClassName(batchPlannerPlanDisplay.getInternalClassNameKey()) %>"
 			/>
 
 			<liferay-ui:search-container-column-text

--- a/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/view.jsp
@@ -57,7 +57,7 @@ SearchContainer<BatchPlannerPlanDisplay> batchPlannerPlanDisplaySearchContainer 
 
 			<liferay-ui:search-container-column-text
 				name="type"
-				value="<%= batchPlannerPlanDisplayContext.getSimpleInternalClassName(batchPlannerPlanDisplay.getInternalClassName()) %>"
+				value="<%= batchPlannerPlanDisplayContext.getSimpleInternalClassName(batchPlannerPlanDisplay.getInternalClassNameKey()) %>"
 			/>
 
 			<liferay-ui:search-container-column-text

--- a/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/view_batch_planner_plan_templates.jsp
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/view_batch_planner_plan_templates.jsp
@@ -71,7 +71,7 @@ BatchPlannerPlanTemplateManagementToolbarDisplayContext batchPlannerPlanTemplate
 
 				<liferay-ui:search-container-column-text
 					name="type"
-					value="<%= batchPlannerPlanTemplateDisplayContext.getSimpleInternalClassName(batchPlannerPlanTemplateDisplay.getInternalClassNameKey()) %>"
+					value="<%= batchPlannerPlanTemplateDisplayContext.getSimpleClassName(batchPlannerPlanTemplateDisplay.getInternalClassNameKey()) %>"
 				/>
 
 				<liferay-ui:search-container-column-text

--- a/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/view_batch_planner_plan_templates.jsp
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/view_batch_planner_plan_templates.jsp
@@ -10,9 +10,9 @@
 <%
 BatchPlannerPlanTemplateDisplayContext batchPlannerPlanTemplateDisplayContext = (BatchPlannerPlanTemplateDisplayContext)request.getAttribute(WebKeys.PORTLET_DISPLAY_CONTEXT);
 
-SearchContainer<BatchPlannerPlan> batchPlannerPlanTemplateSearchContainer = batchPlannerPlanTemplateDisplayContext.getSearchContainer();
+SearchContainer<BatchPlannerPlanTemplateDisplay> batchPlannerPlanTemplateDisplaySearchContainer = batchPlannerPlanTemplateDisplayContext.getSearchContainer();
 
-BatchPlannerPlanTemplateManagementToolbarDisplayContext batchPlannerPlanTemplateManagementToolbarDisplayContext = new BatchPlannerPlanTemplateManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, batchPlannerPlanTemplateSearchContainer);
+BatchPlannerPlanTemplateManagementToolbarDisplayContext batchPlannerPlanTemplateManagementToolbarDisplayContext = new BatchPlannerPlanTemplateManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, batchPlannerPlanTemplateDisplaySearchContainer);
 %>
 
 <clay:navigation-bar
@@ -32,12 +32,12 @@ BatchPlannerPlanTemplateManagementToolbarDisplayContext batchPlannerPlanTemplate
 		<aui:input name="batchPlannerPlanIds" type="hidden" />
 
 		<liferay-ui:search-container
-			searchContainer="<%= batchPlannerPlanTemplateSearchContainer %>"
+			searchContainer="<%= batchPlannerPlanTemplateDisplaySearchContainer %>"
 		>
 			<liferay-ui:search-container-row
-				className="com.liferay.batch.planner.model.BatchPlannerPlan"
+				className="com.liferay.batch.planner.web.internal.display.BatchPlannerPlanTemplateDisplay"
 				keyProperty="batchPlannerPlanId"
-				modelVar="batchPlannerPlan"
+				modelVar="batchPlannerPlanTemplateDisplay"
 			>
 
 				<%
@@ -50,38 +50,38 @@ BatchPlannerPlanTemplateManagementToolbarDisplayContext batchPlannerPlanTemplate
 				<liferay-ui:search-container-column-text
 					cssClass="code"
 					name="id"
-					value="<%= String.valueOf(batchPlannerPlan.getBatchPlannerPlanId()) %>"
+					value="<%= String.valueOf(batchPlannerPlanTemplateDisplay.getBatchPlannerPlanId()) %>"
 				/>
 
 				<liferay-ui:search-container-column-text
 					cssClass="font-weight-bold"
 					name="name"
-					value="<%= HtmlUtil.escape(batchPlannerPlan.getName()) %>"
+					value="<%= HtmlUtil.escape(batchPlannerPlanTemplateDisplay.getTitle()) %>"
 				/>
 
 				<liferay-ui:search-container-column-text
 					name="create-date"
-					value="<%= dateFormatDateTime.format(batchPlannerPlan.getCreateDate()) %>"
+					value="<%= dateFormatDateTime.format(batchPlannerPlanTemplateDisplay.getCreateDate()) %>"
 				/>
 
 				<liferay-ui:search-container-column-text
 					name="action"
-					value='<%= LanguageUtil.get(request, batchPlannerPlan.isExport() ? "export" : "import") %>'
+					value='<%= LanguageUtil.get(request, batchPlannerPlanTemplateDisplay.isExport() ? "export" : "import") %>'
 				/>
 
 				<liferay-ui:search-container-column-text
 					name="type"
-					value="<%= batchPlannerPlanTemplateDisplayContext.getSimpleInternalClassName(batchPlannerPlan.getInternalClassName()) %>"
+					value="<%= batchPlannerPlanTemplateDisplayContext.getSimpleInternalClassName(batchPlannerPlanTemplateDisplay.getInternalClassNameKey()) %>"
 				/>
 
 				<liferay-ui:search-container-column-text
 					name="format"
-					value="<%= batchPlannerPlan.getExternalType() %>"
+					value="<%= batchPlannerPlanTemplateDisplay.getExternalType() %>"
 				/>
 
 				<liferay-ui:search-container-column-text
 					name="user"
-					value="<%= batchPlannerPlan.getUserName() %>"
+					value="<%= batchPlannerPlanTemplateDisplay.getUserName() %>"
 				/>
 
 				<liferay-ui:search-container-column-jsp

--- a/modules/apps/batch-planner/batch-planner-web/test/components/TemplateSelect/TemplateSelect.js
+++ b/modules/apps/batch-planner/batch-planner-web/test/components/TemplateSelect/TemplateSelect.js
@@ -23,6 +23,7 @@ const BASE_PROPS = {
 };
 const internalClassName =
 	'com.liferay.headless.commerce.admin.channel.dto.v1_0.Channel';
+const internalClassNameKey = internalClassName;
 const mockedMapping = {
 	currencyCode: 'currencyCode',
 	id: 'externalReferenceCode',
@@ -33,7 +34,7 @@ const mockedMapping = {
 
 const initialTemplate = {
 	externalType: 'JSONL',
-	internalClassName,
+	internalClassNameKey,
 	mappings: mockedMapping,
 };
 const mockPlanId = 106902;
@@ -88,7 +89,7 @@ describe('TemplateSelect', () => {
 		const {getByLabelText} = render(
 			<TemplateSelect
 				{...BASE_PROPS}
-				selectedTemplateClassName={internalClassName}
+				selectedTemplateClassName={internalClassNameKey}
 				selectedTemplateMapping={mockedMapping}
 			/>
 		);
@@ -140,6 +141,7 @@ const mockGetPlan = {
 	externalURL: '/',
 	id: 106902,
 	internalClassName,
+	internalClassNameKey,
 	mappings: [
 		{
 			externalFieldName: 'type',


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPS-187288

---

The purpose of this PR is to fix the Export template management for Objects. For that:

- A new field `internalClassNameKey` has been included in the `Plan` schema of the Batch Planner REST API. The purpose of this field is to have a unique key by concatenating the `internalClassName` and `taskItemDelegateName` (if the `taskItemDelegateName` is not null or `DEFAULT`). This has been included because for Objects, the value of the `internalClassName` is always the same (`com.liferay.object.rest.dto.v1_0.ObjectEntry`).
- Use the new field in the Batch Planner Web module.
- The Simple Class Name calculation has been modified for the Object case; the taskItemDelegateName is returned if it is not null or `DEFAULT`, as it contains the information about the Object Definition that is being managed.

---

### SELECT THE STUDENT (OBJECTS) TEMPLATE

**Before the PR:**

![image](https://github.com/liferay-headless/liferay-portal/assets/32699538/ce1d4aaf-5592-4c2a-b502-829e667eca04)

**After the PR:**

![image](https://github.com/liferay-headless/liferay-portal/assets/32699538/f012297c-c334-4090-8c42-a28ae39c8b53)

---

### SHOW THE EXPORTS EXECUTED

**Before the PR:**

![image](https://github.com/liferay-headless/liferay-portal/assets/32699538/7d8a2d19-a17b-453f-be6c-763548c3aa54)

**After the PR:**

![image](https://github.com/liferay-headless/liferay-portal/assets/32699538/0442fb78-306a-4b6d-9129-25b1a5a51452)

---

### SHOW THE TEMPLATES

**Before the PR:**

![image](https://github.com/liferay-headless/liferay-portal/assets/32699538/b8082fc2-c237-4b1d-8c34-ea02a32269cf)

**After the PR:**

![image](https://github.com/liferay-headless/liferay-portal/assets/32699538/c885ddc7-711d-417c-af98-c5f824370da7)
