### PR TITLE
LPS-196277 Throw an IOException instead of a WebApplicationException when an error happens when setting the extended properties to avoid returning a 500 error always

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -806,6 +806,10 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 
 		_undeployScopedServiceRegistrationsMap(
 			objectDefinition.getCompanyId(), restContextPath);
+
+		if (_shouldUnregisterApplication(restContextPath)) {
+			_unregisterApplication(restContextPath);
+		}
 	}
 
 	private void _unregisterApplication(String restContextPath) {

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -649,6 +649,118 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 						"osgi.jaxrs.resource", "true"
 					).build())));
 
+		String applicationName =
+			jaxRsApplicationDescriptor.getApplicationName();
+
+		_serviceRegistrationsMap.computeIfAbsent(
+			jaxRsApplicationDescriptor.getRESTContextPath(),
+			key -> Arrays.asList(
+				_bundleContext.registerService(
+					ExceptionMapper.class,
+					new ObjectAssetCategoryExceptionMapper(),
+					HashMapDictionaryBuilder.<String, Object>put(
+						"osgi.jaxrs.application.select",
+						"(osgi.jaxrs.name=" + applicationName + ")"
+					).put(
+						"osgi.jaxrs.extension", "true"
+					).put(
+						"osgi.jaxrs.name",
+						objectDefinition.getOSGiJaxRsName(
+							"ObjectAssetCategoryExceptionMapper")
+					).build()),
+				_bundleContext.registerService(
+					ExceptionMapper.class,
+					new ObjectEntryManagerHttpExceptionMapper(),
+					HashMapDictionaryBuilder.<String, Object>put(
+						"osgi.jaxrs.application.select",
+						"(osgi.jaxrs.name=" + applicationName + ")"
+					).put(
+						"osgi.jaxrs.extension", "true"
+					).put(
+						"osgi.jaxrs.name",
+						objectDefinition.getOSGiJaxRsName(
+							"ObjectEntryManagerHttpExceptionMapper")
+					).build()),
+				_bundleContext.registerService(
+					ExceptionMapper.class,
+					new ObjectEntryStatusExceptionMapper(_language),
+					HashMapDictionaryBuilder.<String, Object>put(
+						"osgi.jaxrs.application.select",
+						"(osgi.jaxrs.name=" + applicationName + ")"
+					).put(
+						"osgi.jaxrs.extension", "true"
+					).put(
+						"osgi.jaxrs.name",
+						objectDefinition.getOSGiJaxRsName(
+							"ObjectEntryStatusExceptionMapper")
+					).build()),
+				_bundleContext.registerService(
+					ExceptionMapper.class,
+					new ObjectEntryValuesExceptionMapper(_language),
+					HashMapDictionaryBuilder.<String, Object>put(
+						"osgi.jaxrs.application.select",
+						"(osgi.jaxrs.name=" + applicationName + ")"
+					).put(
+						"osgi.jaxrs.extension", "true"
+					).put(
+						"osgi.jaxrs.name",
+						objectDefinition.getOSGiJaxRsName(
+							"ObjectEntryValuesExceptionMapper")
+					).build()),
+				_bundleContext.registerService(
+					ExceptionMapper.class,
+					new ObjectRelationshipDeletionTypeExceptionMapper(),
+					HashMapDictionaryBuilder.<String, Object>put(
+						"osgi.jaxrs.application.select",
+						"(osgi.jaxrs.name=" + applicationName + ")"
+					).put(
+						"osgi.jaxrs.extension", "true"
+					).put(
+						"osgi.jaxrs.name",
+						objectDefinition.getOSGiJaxRsName(
+							"ObjectRelationshipDeletionTypeExceptionMapper")
+					).build()),
+				_bundleContext.registerService(
+					ExceptionMapper.class,
+					new ObjectValidationRuleEngineExceptionMapper(
+						_jsonFactory, _language),
+					HashMapDictionaryBuilder.<String, Object>put(
+						"osgi.jaxrs.application.select",
+						"(osgi.jaxrs.name=" + applicationName + ")"
+					).put(
+						"osgi.jaxrs.extension", "true"
+					).put(
+						"osgi.jaxrs.name",
+						objectDefinition.getOSGiJaxRsName(
+							"ObjectValidationRuleEngineExceptionMapper")
+					).build()),
+				_bundleContext.registerService(
+					ExceptionMapper.class,
+					new RequiredObjectRelationshipExceptionMapper(),
+					HashMapDictionaryBuilder.<String, Object>put(
+						"osgi.jaxrs.application.select",
+						"(osgi.jaxrs.name=" + applicationName + ")"
+					).put(
+						"osgi.jaxrs.extension", "true"
+					).put(
+						"osgi.jaxrs.name",
+						objectDefinition.getOSGiJaxRsName(
+							"RequiredObjectRelationshipExceptionMapper")
+					).build()),
+				_bundleContext.registerService(
+					ExceptionMapper.class,
+					new UnsupportedOperationExceptionMapper(),
+					HashMapDictionaryBuilder.<String, Object>put(
+						"osgi.jaxrs.application.select",
+						"(osgi.jaxrs.name=" + applicationName + ")"
+					).put(
+						"osgi.jaxrs.extension", "true"
+					).put(
+						"osgi.jaxrs.name",
+						objectDefinition.getOSGiJaxRsName(
+							"UnsupportedOperationExceptionMapper")
+					).build())));
+
 		_scopedServiceRegistrationsMap.compute(
 			jaxRsApplicationDescriptor.getRESTContextPath(),
 			(key1, serviceRegistrationsMap) -> {

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -439,185 +439,84 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 
 		_serviceRegistrationsMap.computeIfAbsent(
 			restContextPath,
-			key -> Arrays.asList(
-				_bundleContext.registerService(
-					ContextProvider.class,
-					new ObjectDefinitionContextProvider(this, _portal),
-					HashMapDictionaryBuilder.<String, Object>put(
-						"enabled", "false"
-					).put(
-						"osgi.jaxrs.application.select",
-						"(osgi.jaxrs.name=" + osgiJaxRsName + ")"
-					).put(
-						"osgi.jaxrs.extension", "true"
-					).put(
-						"osgi.jaxrs.name",
-						objectDefinition.getOSGiJaxRsName(
-							"ObjectDefinitionContextProvider")
-					).build()),
-				_bundleContext.registerService(
-					ExceptionMapper.class,
-					new ObjectAssetCategoryExceptionMapper(),
-					HashMapDictionaryBuilder.<String, Object>put(
-						"osgi.jaxrs.application.select",
-						"(osgi.jaxrs.name=" + osgiJaxRsName + ")"
-					).put(
-						"osgi.jaxrs.extension", "true"
-					).put(
-						"osgi.jaxrs.name",
-						objectDefinition.getOSGiJaxRsName(
-							"ObjectAssetCategoryExceptionMapper")
-					).build()),
-				_bundleContext.registerService(
-					ExceptionMapper.class,
-					new ObjectEntryManagerHttpExceptionMapper(),
-					HashMapDictionaryBuilder.<String, Object>put(
-						"osgi.jaxrs.application.select",
-						"(osgi.jaxrs.name=" + osgiJaxRsName + ")"
-					).put(
-						"osgi.jaxrs.extension", "true"
-					).put(
-						"osgi.jaxrs.name",
-						objectDefinition.getOSGiJaxRsName(
-							"ObjectEntryManagerHttpExceptionMapper")
-					).build()),
-				_bundleContext.registerService(
-					ExceptionMapper.class,
-					new ObjectEntryStatusExceptionMapper(_language),
-					HashMapDictionaryBuilder.<String, Object>put(
-						"osgi.jaxrs.application.select",
-						"(osgi.jaxrs.name=" + osgiJaxRsName + ")"
-					).put(
-						"osgi.jaxrs.extension", "true"
-					).put(
-						"osgi.jaxrs.name",
-						objectDefinition.getOSGiJaxRsName(
-							"ObjectEntryStatusExceptionMapper")
-					).build()),
-				_bundleContext.registerService(
-					ExceptionMapper.class,
-					new ObjectEntryValuesExceptionMapper(_language),
-					HashMapDictionaryBuilder.<String, Object>put(
-						"osgi.jaxrs.application.select",
-						"(osgi.jaxrs.name=" + osgiJaxRsName + ")"
-					).put(
-						"osgi.jaxrs.extension", "true"
-					).put(
-						"osgi.jaxrs.name",
-						objectDefinition.getOSGiJaxRsName(
-							"ObjectEntryValuesExceptionMapper")
-					).build()),
-				_bundleContext.registerService(
-					ExceptionMapper.class,
-					new ObjectRelationshipDeletionTypeExceptionMapper(),
-					HashMapDictionaryBuilder.<String, Object>put(
-						"osgi.jaxrs.application.select",
-						"(osgi.jaxrs.name=" + osgiJaxRsName + ")"
-					).put(
-						"osgi.jaxrs.extension", "true"
-					).put(
-						"osgi.jaxrs.name",
-						objectDefinition.getOSGiJaxRsName(
-							"ObjectRelationshipDeletionTypeExceptionMapper")
-					).build()),
-				_bundleContext.registerService(
-					ExceptionMapper.class,
-					new ObjectValidationRuleEngineExceptionMapper(
-						_jsonFactory, _language),
-					HashMapDictionaryBuilder.<String, Object>put(
-						"osgi.jaxrs.application.select",
-						"(osgi.jaxrs.name=" + osgiJaxRsName + ")"
-					).put(
-						"osgi.jaxrs.extension", "true"
-					).put(
-						"osgi.jaxrs.name",
-						objectDefinition.getOSGiJaxRsName(
-							"ObjectValidationRuleEngineExceptionMapper")
-					).build()),
-				_bundleContext.registerService(
-					ExceptionMapper.class,
-					new RequiredObjectRelationshipExceptionMapper(),
-					HashMapDictionaryBuilder.<String, Object>put(
-						"osgi.jaxrs.application.select",
-						"(osgi.jaxrs.name=" + osgiJaxRsName + ")"
-					).put(
-						"osgi.jaxrs.extension", "true"
-					).put(
-						"osgi.jaxrs.name",
-						objectDefinition.getOSGiJaxRsName(
-							"RequiredObjectRelationshipExceptionMapper")
-					).build()),
-				_bundleContext.registerService(
-					ExceptionMapper.class,
-					new UnsupportedOperationExceptionMapper(),
-					HashMapDictionaryBuilder.<String, Object>put(
-						"osgi.jaxrs.application.select",
-						"(osgi.jaxrs.name=" + osgiJaxRsName + ")"
-					).put(
-						"osgi.jaxrs.extension", "true"
-					).put(
-						"osgi.jaxrs.name",
-						objectDefinition.getOSGiJaxRsName(
-							"UnsupportedOperationExceptionMapper")
-					).build()),
-				_bundleContext.registerService(
-					ObjectEntryRelatedObjectsResourceImpl.class,
-					new PrototypeServiceFactory
-						<ObjectEntryRelatedObjectsResourceImpl>() {
+			key -> ListUtil.concat(
+				Arrays.asList(
+					_bundleContext.registerService(
+						ContextProvider.class,
+						new ObjectDefinitionContextProvider(this, _portal),
+						HashMapDictionaryBuilder.<String, Object>put(
+							"enabled", "false"
+						).put(
+							"osgi.jaxrs.application.select",
+							"(osgi.jaxrs.name=" + osgiJaxRsName + ")"
+						).put(
+							"osgi.jaxrs.extension", "true"
+						).put(
+							"osgi.jaxrs.name",
+							objectDefinition.getOSGiJaxRsName(
+								"ObjectDefinitionContextProvider")
+						).build()),
+					_bundleContext.registerService(
+						ObjectEntryRelatedObjectsResourceImpl.class,
+						new PrototypeServiceFactory
+							<ObjectEntryRelatedObjectsResourceImpl>() {
 
-						@Override
-						public ObjectEntryRelatedObjectsResourceImpl getService(
-							Bundle bundle,
-							ServiceRegistration
-								<ObjectEntryRelatedObjectsResourceImpl>
-									serviceRegistration) {
+							@Override
+							public ObjectEntryRelatedObjectsResourceImpl
+								getService(
+									Bundle bundle,
+									ServiceRegistration
+										<ObjectEntryRelatedObjectsResourceImpl>
+											serviceRegistration) {
 
-							return new ObjectEntryRelatedObjectsResourceImpl(
-								_objectDefinitionLocalService,
-								_objectEntryManagerRegistry,
-								_objectRelatedModelsProviderRegistry,
-								_objectRelationshipLocalService,
-								_persistedModelLocalServiceRegistry);
-						}
+								return new ObjectEntryRelatedObjectsResourceImpl(
+									_objectDefinitionLocalService,
+									_objectEntryManagerRegistry,
+									_objectRelatedModelsProviderRegistry,
+									_objectRelationshipLocalService,
+									_persistedModelLocalServiceRegistry);
+							}
 
-						@Override
-						public void ungetService(
-							Bundle bundle,
-							ServiceRegistration
-								<ObjectEntryRelatedObjectsResourceImpl>
-									serviceRegistration,
-							ObjectEntryRelatedObjectsResourceImpl
-								objectEntryRelatedObjectsResourceImpl) {
-						}
+							@Override
+							public void ungetService(
+								Bundle bundle,
+								ServiceRegistration
+									<ObjectEntryRelatedObjectsResourceImpl>
+										serviceRegistration,
+								ObjectEntryRelatedObjectsResourceImpl
+									objectEntryRelatedObjectsResourceImpl) {
+							}
 
-					},
-					HashMapDictionaryBuilder.<String, Object>put(
-						"api.version", "v1.0"
-					).put(
-						"entity.class.name",
-						ObjectEntry.class.getName() + "#" +
-							objectDefinition.getName()
-					).put(
-						"osgi.jaxrs.application.select",
-						"(osgi.jaxrs.name=" + osgiJaxRsName + ")"
-					).put(
-						"osgi.jaxrs.resource", "true"
-					).build()),
-				_bundleContext.registerService(
-					ObjectEntryResource.Factory.class,
-					new ObjectEntryResourceFactoryImpl(
-						_companyLocalService, _defaultPermissionCheckerFactory,
-						_expressionConvert, _filterParserProvider,
-						_groupLocalService, objectDefinition,
-						this::_createObjectEntryResourceImpl,
-						_resourceActionLocalService,
-						_resourcePermissionLocalService, _roleLocalService,
-						_sortParserProvider, _userLocalService),
-					HashMapDictionaryBuilder.<String, Object>put(
-						"resource.locator.key",
-						objectDefinition.getRESTContextPath() + "/" +
-							objectDefinition.getShortName()
-					).build())));
+						},
+						HashMapDictionaryBuilder.<String, Object>put(
+							"api.version", "v1.0"
+						).put(
+							"entity.class.name",
+							ObjectEntry.class.getName() + "#" +
+								objectDefinition.getName()
+						).put(
+							"osgi.jaxrs.application.select",
+							"(osgi.jaxrs.name=" + osgiJaxRsName + ")"
+						).put(
+							"osgi.jaxrs.resource", "true"
+						).build()),
+					_bundleContext.registerService(
+						ObjectEntryResource.Factory.class,
+						new ObjectEntryResourceFactoryImpl(
+							_companyLocalService,
+							_defaultPermissionCheckerFactory,
+							_expressionConvert, _filterParserProvider,
+							_groupLocalService, objectDefinition,
+							this::_createObjectEntryResourceImpl,
+							_resourceActionLocalService,
+							_resourcePermissionLocalService, _roleLocalService,
+							_sortParserProvider, _userLocalService),
+						HashMapDictionaryBuilder.<String, Object>put(
+							"resource.locator.key",
+							objectDefinition.getRESTContextPath() + "/" +
+								objectDefinition.getShortName()
+						).build())),
+				_registerExceptionMappers(osgiJaxRsName, objectDefinition)));
 	}
 
 	private void _initSystemObjectDefinition(
@@ -649,117 +548,11 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 						"osgi.jaxrs.resource", "true"
 					).build())));
 
-		String applicationName =
-			jaxRsApplicationDescriptor.getApplicationName();
-
 		_serviceRegistrationsMap.computeIfAbsent(
 			jaxRsApplicationDescriptor.getRESTContextPath(),
-			key -> Arrays.asList(
-				_bundleContext.registerService(
-					ExceptionMapper.class,
-					new ObjectAssetCategoryExceptionMapper(),
-					HashMapDictionaryBuilder.<String, Object>put(
-						"osgi.jaxrs.application.select",
-						"(osgi.jaxrs.name=" + applicationName + ")"
-					).put(
-						"osgi.jaxrs.extension", "true"
-					).put(
-						"osgi.jaxrs.name",
-						objectDefinition.getOSGiJaxRsName(
-							"ObjectAssetCategoryExceptionMapper")
-					).build()),
-				_bundleContext.registerService(
-					ExceptionMapper.class,
-					new ObjectEntryManagerHttpExceptionMapper(),
-					HashMapDictionaryBuilder.<String, Object>put(
-						"osgi.jaxrs.application.select",
-						"(osgi.jaxrs.name=" + applicationName + ")"
-					).put(
-						"osgi.jaxrs.extension", "true"
-					).put(
-						"osgi.jaxrs.name",
-						objectDefinition.getOSGiJaxRsName(
-							"ObjectEntryManagerHttpExceptionMapper")
-					).build()),
-				_bundleContext.registerService(
-					ExceptionMapper.class,
-					new ObjectEntryStatusExceptionMapper(_language),
-					HashMapDictionaryBuilder.<String, Object>put(
-						"osgi.jaxrs.application.select",
-						"(osgi.jaxrs.name=" + applicationName + ")"
-					).put(
-						"osgi.jaxrs.extension", "true"
-					).put(
-						"osgi.jaxrs.name",
-						objectDefinition.getOSGiJaxRsName(
-							"ObjectEntryStatusExceptionMapper")
-					).build()),
-				_bundleContext.registerService(
-					ExceptionMapper.class,
-					new ObjectEntryValuesExceptionMapper(_language),
-					HashMapDictionaryBuilder.<String, Object>put(
-						"osgi.jaxrs.application.select",
-						"(osgi.jaxrs.name=" + applicationName + ")"
-					).put(
-						"osgi.jaxrs.extension", "true"
-					).put(
-						"osgi.jaxrs.name",
-						objectDefinition.getOSGiJaxRsName(
-							"ObjectEntryValuesExceptionMapper")
-					).build()),
-				_bundleContext.registerService(
-					ExceptionMapper.class,
-					new ObjectRelationshipDeletionTypeExceptionMapper(),
-					HashMapDictionaryBuilder.<String, Object>put(
-						"osgi.jaxrs.application.select",
-						"(osgi.jaxrs.name=" + applicationName + ")"
-					).put(
-						"osgi.jaxrs.extension", "true"
-					).put(
-						"osgi.jaxrs.name",
-						objectDefinition.getOSGiJaxRsName(
-							"ObjectRelationshipDeletionTypeExceptionMapper")
-					).build()),
-				_bundleContext.registerService(
-					ExceptionMapper.class,
-					new ObjectValidationRuleEngineExceptionMapper(
-						_jsonFactory, _language),
-					HashMapDictionaryBuilder.<String, Object>put(
-						"osgi.jaxrs.application.select",
-						"(osgi.jaxrs.name=" + applicationName + ")"
-					).put(
-						"osgi.jaxrs.extension", "true"
-					).put(
-						"osgi.jaxrs.name",
-						objectDefinition.getOSGiJaxRsName(
-							"ObjectValidationRuleEngineExceptionMapper")
-					).build()),
-				_bundleContext.registerService(
-					ExceptionMapper.class,
-					new RequiredObjectRelationshipExceptionMapper(),
-					HashMapDictionaryBuilder.<String, Object>put(
-						"osgi.jaxrs.application.select",
-						"(osgi.jaxrs.name=" + applicationName + ")"
-					).put(
-						"osgi.jaxrs.extension", "true"
-					).put(
-						"osgi.jaxrs.name",
-						objectDefinition.getOSGiJaxRsName(
-							"RequiredObjectRelationshipExceptionMapper")
-					).build()),
-				_bundleContext.registerService(
-					ExceptionMapper.class,
-					new UnsupportedOperationExceptionMapper(),
-					HashMapDictionaryBuilder.<String, Object>put(
-						"osgi.jaxrs.application.select",
-						"(osgi.jaxrs.name=" + applicationName + ")"
-					).put(
-						"osgi.jaxrs.extension", "true"
-					).put(
-						"osgi.jaxrs.name",
-						objectDefinition.getOSGiJaxRsName(
-							"UnsupportedOperationExceptionMapper")
-					).build())));
+			key -> _registerExceptionMappers(
+				jaxRsApplicationDescriptor.getApplicationName(),
+				objectDefinition));
 
 		_scopedServiceRegistrationsMap.compute(
 			jaxRsApplicationDescriptor.getRESTContextPath(),
@@ -788,6 +581,116 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 
 				return serviceRegistrationsMap;
 			});
+	}
+
+	private List<ServiceRegistration<?>> _registerExceptionMappers(
+		String jaxRsApplicationName, ObjectDefinition objectDefinition) {
+
+		return Arrays.asList(
+			_bundleContext.registerService(
+				ExceptionMapper.class, new ObjectAssetCategoryExceptionMapper(),
+				HashMapDictionaryBuilder.<String, Object>put(
+					"osgi.jaxrs.application.select",
+					"(osgi.jaxrs.name=" + jaxRsApplicationName + ")"
+				).put(
+					"osgi.jaxrs.extension", "true"
+				).put(
+					"osgi.jaxrs.name",
+					objectDefinition.getOSGiJaxRsName(
+						"ObjectAssetCategoryExceptionMapper")
+				).build()),
+			_bundleContext.registerService(
+				ExceptionMapper.class,
+				new ObjectEntryManagerHttpExceptionMapper(),
+				HashMapDictionaryBuilder.<String, Object>put(
+					"osgi.jaxrs.application.select",
+					"(osgi.jaxrs.name=" + jaxRsApplicationName + ")"
+				).put(
+					"osgi.jaxrs.extension", "true"
+				).put(
+					"osgi.jaxrs.name",
+					objectDefinition.getOSGiJaxRsName(
+						"ObjectEntryManagerHttpExceptionMapper")
+				).build()),
+			_bundleContext.registerService(
+				ExceptionMapper.class,
+				new ObjectEntryStatusExceptionMapper(_language),
+				HashMapDictionaryBuilder.<String, Object>put(
+					"osgi.jaxrs.application.select",
+					"(osgi.jaxrs.name=" + jaxRsApplicationName + ")"
+				).put(
+					"osgi.jaxrs.extension", "true"
+				).put(
+					"osgi.jaxrs.name",
+					objectDefinition.getOSGiJaxRsName(
+						"ObjectEntryStatusExceptionMapper")
+				).build()),
+			_bundleContext.registerService(
+				ExceptionMapper.class,
+				new ObjectEntryValuesExceptionMapper(_language),
+				HashMapDictionaryBuilder.<String, Object>put(
+					"osgi.jaxrs.application.select",
+					"(osgi.jaxrs.name=" + jaxRsApplicationName + ")"
+				).put(
+					"osgi.jaxrs.extension", "true"
+				).put(
+					"osgi.jaxrs.name",
+					objectDefinition.getOSGiJaxRsName(
+						"ObjectEntryValuesExceptionMapper")
+				).build()),
+			_bundleContext.registerService(
+				ExceptionMapper.class,
+				new ObjectRelationshipDeletionTypeExceptionMapper(),
+				HashMapDictionaryBuilder.<String, Object>put(
+					"osgi.jaxrs.application.select",
+					"(osgi.jaxrs.name=" + jaxRsApplicationName + ")"
+				).put(
+					"osgi.jaxrs.extension", "true"
+				).put(
+					"osgi.jaxrs.name",
+					objectDefinition.getOSGiJaxRsName(
+						"ObjectRelationshipDeletionTypeExceptionMapper")
+				).build()),
+			_bundleContext.registerService(
+				ExceptionMapper.class,
+				new ObjectValidationRuleEngineExceptionMapper(
+					_jsonFactory, _language),
+				HashMapDictionaryBuilder.<String, Object>put(
+					"osgi.jaxrs.application.select",
+					"(osgi.jaxrs.name=" + jaxRsApplicationName + ")"
+				).put(
+					"osgi.jaxrs.extension", "true"
+				).put(
+					"osgi.jaxrs.name",
+					objectDefinition.getOSGiJaxRsName(
+						"ObjectValidationRuleEngineExceptionMapper")
+				).build()),
+			_bundleContext.registerService(
+				ExceptionMapper.class,
+				new RequiredObjectRelationshipExceptionMapper(),
+				HashMapDictionaryBuilder.<String, Object>put(
+					"osgi.jaxrs.application.select",
+					"(osgi.jaxrs.name=" + jaxRsApplicationName + ")"
+				).put(
+					"osgi.jaxrs.extension", "true"
+				).put(
+					"osgi.jaxrs.name",
+					objectDefinition.getOSGiJaxRsName(
+						"RequiredObjectRelationshipExceptionMapper")
+				).build()),
+			_bundleContext.registerService(
+				ExceptionMapper.class,
+				new UnsupportedOperationExceptionMapper(),
+				HashMapDictionaryBuilder.<String, Object>put(
+					"osgi.jaxrs.application.select",
+					"(osgi.jaxrs.name=" + jaxRsApplicationName + ")"
+				).put(
+					"osgi.jaxrs.extension", "true"
+				).put(
+					"osgi.jaxrs.name",
+					objectDefinition.getOSGiJaxRsName(
+						"UnsupportedOperationExceptionMapper")
+				).build()));
 	}
 
 	private boolean _shouldUnregisterApplication(String restContextPath) {

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/SystemObjectRelatedObjectEntriesTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/SystemObjectRelatedObjectEntriesTest.java
@@ -52,7 +52,6 @@ import java.io.Serializable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.After;
@@ -79,13 +78,19 @@ public class SystemObjectRelatedObjectEntriesTest {
 	@Before
 	public void setUp() throws Exception {
 		_objectDefinition = ObjectDefinitionTestUtil.publishObjectDefinition(
-			Collections.singletonList(
+			Arrays.asList(
 				ObjectFieldUtil.createObjectField(
-					"Text", "String", true, true, null,
-					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME, false)));
+					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+					ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
+					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME_1, false),
+				ObjectFieldUtil.createObjectField(
+					ObjectFieldConstants.BUSINESS_TYPE_INTEGER,
+					ObjectFieldConstants.DB_TYPE_INTEGER, true, true, null,
+					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME_2,
+					false)));
 
 		_objectEntry = ObjectEntryTestUtil.addObjectEntry(
-			_objectDefinition, _OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE);
+			_objectDefinition, _OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE);
 
 		_user = TestPropsValues.getUser();
 
@@ -142,7 +147,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 			null, objectRelationship.getName(),
 			new String[][] {
 				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
-				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
+				{_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE}
 			},
 			Type.MANY_TO_MANY);
 
@@ -150,7 +155,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 			1, objectRelationship.getName(),
 			new String[][] {
 				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
-				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
+				{_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE}
 			},
 			Type.MANY_TO_MANY);
 
@@ -158,7 +163,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 			2, objectRelationship.getName(),
 			new String[][] {
 				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
-				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
+				{_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE},
 				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE}
 			},
 			Type.MANY_TO_MANY);
@@ -167,11 +172,11 @@ public class SystemObjectRelatedObjectEntriesTest {
 			5, objectRelationship.getName(),
 			new String[][] {
 				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
-				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
+				{_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE},
 				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
-				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
+				{_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE},
 				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
-				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
+				{_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE}
 			},
 			Type.MANY_TO_MANY);
 
@@ -179,11 +184,11 @@ public class SystemObjectRelatedObjectEntriesTest {
 			6, objectRelationship.getName(),
 			new String[][] {
 				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
-				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
+				{_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE},
 				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
-				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
+				{_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE},
 				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
-				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
+				{_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE}
 			},
 			Type.MANY_TO_MANY);
 
@@ -198,7 +203,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 			null, objectRelationship.getName(),
 			new String[][] {
 				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
-				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
+				{_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE}
 			},
 			Type.MANY_TO_MANY);
 
@@ -206,7 +211,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 			1, objectRelationship.getName(),
 			new String[][] {
 				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
-				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
+				{_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE}
 			},
 			Type.MANY_TO_MANY);
 
@@ -214,7 +219,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 			2, objectRelationship.getName(),
 			new String[][] {
 				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
-				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
+				{_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE},
 				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE}
 			},
 			Type.MANY_TO_MANY);
@@ -223,11 +228,11 @@ public class SystemObjectRelatedObjectEntriesTest {
 			5, objectRelationship.getName(),
 			new String[][] {
 				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
-				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
+				{_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE},
 				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
-				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
+				{_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE},
 				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
-				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
+				{_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE}
 			},
 			Type.MANY_TO_MANY);
 
@@ -235,11 +240,11 @@ public class SystemObjectRelatedObjectEntriesTest {
 			6, objectRelationship.getName(),
 			new String[][] {
 				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
-				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
+				{_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE},
 				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
-				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
+				{_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE},
 				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
-				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
+				{_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE}
 			},
 			Type.MANY_TO_MANY);
 	}
@@ -284,7 +289,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 			null, objectRelationship.getName(),
 			new String[][] {
 				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
-				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
+				{_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE}
 			},
 			Type.ONE_TO_MANY);
 
@@ -292,7 +297,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 			1, objectRelationship.getName(),
 			new String[][] {
 				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
-				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE}
+				{_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE}
 			},
 			Type.ONE_TO_MANY);
 
@@ -300,7 +305,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 			2, objectRelationship.getName(),
 			new String[][] {
 				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE},
-				{_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE},
+				{_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE},
 				{_SYSTEM_OBJECT_FIELD_NAME, _SYSTEM_OBJECT_FIELD_VALUE}
 			},
 			Type.ONE_TO_MANY);
@@ -465,7 +470,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 				objectRelationship.getName(),
 				JSONFactoryUtil.createJSONObject(
 					JSONUtil.put(
-						_OBJECT_FIELD_NAME, RandomTestUtil.randomString()
+						_OBJECT_FIELD_NAME_1, RandomTestUtil.randomString()
 					).put(
 						"externalReferenceCode", _ERC_VALUE_1
 					).toString())
@@ -559,7 +564,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 				objectRelationship.getName(),
 				JSONFactoryUtil.createJSONObject(
 					JSONUtil.put(
-						_OBJECT_FIELD_NAME, RandomTestUtil.randomString()
+						_OBJECT_FIELD_NAME_1, RandomTestUtil.randomString()
 					).put(
 						"externalReferenceCode", _ERC_VALUE_1
 					).toString())
@@ -571,7 +576,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 				objectRelationship.getName(),
 				JSONFactoryUtil.createJSONObject(
 					JSONUtil.put(
-						_OBJECT_FIELD_NAME, _NEW_OBJECT_FIELD_VALUE_1
+						_OBJECT_FIELD_NAME_1, _NEW_OBJECT_FIELD_VALUE_1
 					).put(
 						"externalReferenceCode", _ERC_VALUE_1
 					).toString())
@@ -579,7 +584,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 
 		_assertObjectEntryField(
 			_getObjectEntryByExternalReferenceCodeJSONObject(_ERC_VALUE_1),
-			_OBJECT_FIELD_NAME, _NEW_OBJECT_FIELD_VALUE_1);
+			_OBJECT_FIELD_NAME_1, _NEW_OBJECT_FIELD_VALUE_1);
 	}
 
 	@Test
@@ -600,7 +605,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 				objectRelationship.getName(),
 				JSONFactoryUtil.createJSONObject(
 					JSONUtil.put(
-						_OBJECT_FIELD_NAME, RandomTestUtil.randomString()
+						_OBJECT_FIELD_NAME_1, RandomTestUtil.randomString()
 					).put(
 						"externalReferenceCode", _ERC_VALUE_1
 					).toString())
@@ -612,7 +617,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 				objectRelationship.getName(),
 				JSONFactoryUtil.createJSONObject(
 					JSONUtil.put(
-						_OBJECT_FIELD_NAME, _NEW_OBJECT_FIELD_VALUE_1
+						_OBJECT_FIELD_NAME_1, _NEW_OBJECT_FIELD_VALUE_1
 					).put(
 						"externalReferenceCode", _ERC_VALUE_1
 					).toString())
@@ -620,7 +625,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 
 		_assertObjectEntryField(
 			_getObjectEntryByExternalReferenceCodeJSONObject(_ERC_VALUE_1),
-			_OBJECT_FIELD_NAME, _NEW_OBJECT_FIELD_VALUE_1);
+			_OBJECT_FIELD_NAME_1, _NEW_OBJECT_FIELD_VALUE_1);
 	}
 
 	private ObjectRelationship _addObjectRelationship(
@@ -816,11 +821,27 @@ public class SystemObjectRelatedObjectEntriesTest {
 					objectRelationship.getName(),
 					_createObjectEntriesJSONArray(
 						new String[] {_ERC_VALUE_1, _ERC_VALUE_2},
-						_OBJECT_FIELD_NAME,
+						_OBJECT_FIELD_NAME_1,
 						new String[] {
 							_NEW_OBJECT_FIELD_VALUE_1, _NEW_OBJECT_FIELD_VALUE_2
 						})
 				).build());
+
+			Assert.assertEquals("BAD_REQUEST", jsonObject.get("status"));
+
+			jsonObject = UserAccountTestUtil.addUserAccountJSONObject(
+				_userSystemObjectDefinitionManager,
+				HashMapBuilder.<String, Serializable>put(
+					objectRelationship.getName(),
+					JSONFactoryUtil.createJSONObject(
+						JSONUtil.put(
+							_OBJECT_FIELD_NAME_2, RandomTestUtil.randomString()
+						).put(
+							"externalReferenceCode", _ERC_VALUE_1
+						).toString())
+				).build());
+
+			Assert.assertEquals("BAD_REQUEST", jsonObject.get("status"));
 		}
 		else {
 			jsonObject = UserAccountTestUtil.addUserAccountJSONObject(
@@ -832,9 +853,24 @@ public class SystemObjectRelatedObjectEntriesTest {
 							"externalReferenceCode", _ERC_VALUE_1
 						).toString())
 				).build());
-		}
 
-		Assert.assertEquals("BAD_REQUEST", jsonObject.get("status"));
+			Assert.assertEquals("BAD_REQUEST", jsonObject.get("status"));
+
+			jsonObject = UserAccountTestUtil.addUserAccountJSONObject(
+				_userSystemObjectDefinitionManager,
+				HashMapBuilder.<String, Serializable>put(
+					objectRelationship.getName(),
+					_createObjectEntriesJSONArray(
+						new String[] {_ERC_VALUE_1, _ERC_VALUE_2},
+						_OBJECT_FIELD_NAME_2,
+						new String[] {
+							RandomTestUtil.randomString(),
+							RandomTestUtil.randomString()
+						})
+				).build());
+
+			Assert.assertEquals("BAD_REQUEST", jsonObject.get("status"));
+		}
 	}
 
 	private void _testPostSystemObjectEntryWithNestedCustomObjectEntries(
@@ -849,7 +885,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 					if (manyToOne) {
 						return JSONFactoryUtil.createJSONObject(
 							JSONUtil.put(
-								_OBJECT_FIELD_NAME, _NEW_OBJECT_FIELD_VALUE_1
+								_OBJECT_FIELD_NAME_1, _NEW_OBJECT_FIELD_VALUE_1
 							).put(
 								"externalReferenceCode", _ERC_VALUE_1
 							).toString());
@@ -857,7 +893,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 
 					return _createObjectEntriesJSONArray(
 						new String[] {_ERC_VALUE_1, _ERC_VALUE_2},
-						_OBJECT_FIELD_NAME,
+						_OBJECT_FIELD_NAME_1,
 						new String[] {
 							_NEW_OBJECT_FIELD_VALUE_1, _NEW_OBJECT_FIELD_VALUE_2
 						});
@@ -867,7 +903,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 		if (manyToOne) {
 			_assertObjectEntryField(
 				jsonObject.getJSONObject(objectRelationship.getName()),
-				_OBJECT_FIELD_NAME, _NEW_OBJECT_FIELD_VALUE_1);
+				_OBJECT_FIELD_NAME_1, _NEW_OBJECT_FIELD_VALUE_1);
 
 			Assert.assertEquals(
 				jsonObject.getString(
@@ -886,10 +922,10 @@ public class SystemObjectRelatedObjectEntriesTest {
 
 			_assertObjectEntryField(
 				(JSONObject)nestedObjectEntriesJSONArray.get(0),
-				_OBJECT_FIELD_NAME, _NEW_OBJECT_FIELD_VALUE_1);
+				_OBJECT_FIELD_NAME_1, _NEW_OBJECT_FIELD_VALUE_1);
 			_assertObjectEntryField(
 				(JSONObject)nestedObjectEntriesJSONArray.get(1),
-				_OBJECT_FIELD_NAME, _NEW_OBJECT_FIELD_VALUE_2);
+				_OBJECT_FIELD_NAME_1, _NEW_OBJECT_FIELD_VALUE_2);
 
 			jsonObject = HTTPTestUtil.invokeToJSONObject(
 				null,
@@ -904,10 +940,10 @@ public class SystemObjectRelatedObjectEntriesTest {
 
 			_assertObjectEntryField(
 				(JSONObject)nestedObjectEntriesJSONArray.get(0),
-				_OBJECT_FIELD_NAME, _NEW_OBJECT_FIELD_VALUE_1);
+				_OBJECT_FIELD_NAME_1, _NEW_OBJECT_FIELD_VALUE_1);
 			_assertObjectEntryField(
 				(JSONObject)nestedObjectEntriesJSONArray.get(1),
-				_OBJECT_FIELD_NAME, _NEW_OBJECT_FIELD_VALUE_2);
+				_OBJECT_FIELD_NAME_1, _NEW_OBJECT_FIELD_VALUE_2);
 		}
 	}
 
@@ -921,7 +957,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 				objectRelationship.getName(),
 				_createObjectEntriesJSONArray(
 					new String[] {_ERC_VALUE_1, _ERC_VALUE_2},
-					_OBJECT_FIELD_NAME,
+					_OBJECT_FIELD_NAME_1,
 					new String[] {
 						RandomTestUtil.randomString(),
 						RandomTestUtil.randomString()
@@ -950,7 +986,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 				objectRelationship.getName(),
 				_createObjectEntriesJSONArray(
 					new String[] {_ERC_VALUE_1, _ERC_VALUE_2},
-					_OBJECT_FIELD_NAME,
+					_OBJECT_FIELD_NAME_1,
 					new String[] {
 						RandomTestUtil.randomString(),
 						RandomTestUtil.randomString()
@@ -962,7 +998,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 			HashMapBuilder.<String, Serializable>put(
 				objectRelationship.getName(),
 				_createObjectEntriesJSONArray(
-					new String[] {_ERC_VALUE_1}, _OBJECT_FIELD_NAME,
+					new String[] {_ERC_VALUE_1}, _OBJECT_FIELD_NAME_1,
 					new String[] {_NEW_OBJECT_FIELD_VALUE_1})
 			).build());
 
@@ -972,8 +1008,8 @@ public class SystemObjectRelatedObjectEntriesTest {
 		Assert.assertEquals(1, nestedObjectEntriesJSONArray.length());
 
 		_assertObjectEntryField(
-			(JSONObject)nestedObjectEntriesJSONArray.get(0), _OBJECT_FIELD_NAME,
-			_NEW_OBJECT_FIELD_VALUE_1);
+			(JSONObject)nestedObjectEntriesJSONArray.get(0),
+			_OBJECT_FIELD_NAME_1, _NEW_OBJECT_FIELD_VALUE_1);
 
 		jsonObject = HTTPTestUtil.invokeToJSONObject(
 			null,
@@ -987,8 +1023,8 @@ public class SystemObjectRelatedObjectEntriesTest {
 		Assert.assertEquals(1, nestedObjectEntriesJSONArray.length());
 
 		_assertObjectEntryField(
-			(JSONObject)nestedObjectEntriesJSONArray.get(0), _OBJECT_FIELD_NAME,
-			_NEW_OBJECT_FIELD_VALUE_1);
+			(JSONObject)nestedObjectEntriesJSONArray.get(0),
+			_OBJECT_FIELD_NAME_1, _NEW_OBJECT_FIELD_VALUE_1);
 	}
 
 	private void
@@ -1002,7 +1038,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 				objectRelationship.getName(),
 				_createObjectEntriesJSONArray(
 					new String[] {_ERC_VALUE_1, _ERC_VALUE_2},
-					_OBJECT_FIELD_NAME,
+					_OBJECT_FIELD_NAME_1,
 					new String[] {
 						RandomTestUtil.randomString(),
 						RandomTestUtil.randomString()
@@ -1016,7 +1052,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 					HashMapBuilder.<String, Serializable>put(
 						objectRelationship.getName(),
 						_createObjectEntriesJSONArray(
-							new String[] {_ERC_VALUE_1}, _OBJECT_FIELD_NAME,
+							new String[] {_ERC_VALUE_1}, _OBJECT_FIELD_NAME_1,
 							new String[] {_NEW_OBJECT_FIELD_VALUE_1})
 					).build());
 
@@ -1026,8 +1062,8 @@ public class SystemObjectRelatedObjectEntriesTest {
 		Assert.assertEquals(1, nestedObjectEntriesJSONArray.length());
 
 		_assertObjectEntryField(
-			(JSONObject)nestedObjectEntriesJSONArray.get(0), _OBJECT_FIELD_NAME,
-			_NEW_OBJECT_FIELD_VALUE_1);
+			(JSONObject)nestedObjectEntriesJSONArray.get(0),
+			_OBJECT_FIELD_NAME_1, _NEW_OBJECT_FIELD_VALUE_1);
 
 		jsonObject = HTTPTestUtil.invokeToJSONObject(
 			null,
@@ -1041,8 +1077,8 @@ public class SystemObjectRelatedObjectEntriesTest {
 		Assert.assertEquals(1, nestedObjectEntriesJSONArray.length());
 
 		_assertObjectEntryField(
-			(JSONObject)nestedObjectEntriesJSONArray.get(0), _OBJECT_FIELD_NAME,
-			_NEW_OBJECT_FIELD_VALUE_1);
+			(JSONObject)nestedObjectEntriesJSONArray.get(0),
+			_OBJECT_FIELD_NAME_1, _NEW_OBJECT_FIELD_VALUE_1);
 	}
 
 	private static final String _ERC_VALUE_1 = RandomTestUtil.randomString();
@@ -1055,7 +1091,10 @@ public class SystemObjectRelatedObjectEntriesTest {
 	private static final String _NEW_OBJECT_FIELD_VALUE_2 =
 		"x" + RandomTestUtil.randomString();
 
-	private static final String _OBJECT_FIELD_NAME =
+	private static final String _OBJECT_FIELD_NAME_1 =
+		"x" + RandomTestUtil.randomString();
+
+	private static final String _OBJECT_FIELD_NAME_2 =
 		"x" + RandomTestUtil.randomString();
 
 	private static final String _OBJECT_FIELD_VALUE =

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/container/response/filter/EntityExtensionContainerResponseFilter.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/container/response/filter/EntityExtensionContainerResponseFilter.java
@@ -5,8 +5,6 @@
 
 package com.liferay.portal.vulcan.internal.jaxrs.container.response.filter;
 
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.vulcan.extension.EntityExtensionHandler;
@@ -20,7 +18,6 @@ import java.util.Map;
 import javax.annotation.Priority;
 
 import javax.ws.rs.Priorities;
-import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
@@ -80,9 +77,7 @@ public class EntityExtensionContainerResponseFilter
 				containerResponseContext.getEntity(), extendedProperties);
 		}
 		catch (Exception exception) {
-			_log.error(exception);
-
-			throw new WebApplicationException(exception);
+			throw new IOException(exception);
 		}
 		finally {
 			EntityExtensionThreadLocal.clearExtendedProperties();
@@ -107,9 +102,6 @@ public class EntityExtensionContainerResponseFilter
 
 		return entityExtensionHandler;
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		EntityExtensionContainerResponseFilter.class);
 
 	@Context
 	private Company _company;

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/extension/test/EntityExtensionTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/extension/test/EntityExtensionTest.java
@@ -132,7 +132,7 @@ public class EntityExtensionTest {
 
 		try (LogCapture logCapture1 = LoggerTestUtil.configureLog4JLogger(
 				"com.liferay.portal.vulcan.internal.jaxrs.exception.mapper." +
-					"WebApplicationExceptionMapper",
+					"ExceptionMapper",
 				LoggerTestUtil.ERROR);
 			LogCapture logCapture2 = LoggerTestUtil.configureLog4JLogger(
 				"com.liferay.portal.vulcan.internal.jaxrs.container.response." +


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPS-196277

---

The purpose of this PR is to avoid returning an Internal Server Error 500 when the `entityExtensionHandler.setExtendedProperties` invocation of the `EntityExtensionContainerResponseFilter` class fails. The http error code is returned as the exception thrown is `WebApplicationException`. As there is a `WebApplicationExceptionMapper` that maps the exception into the 500 code, we need another approach.

As the `filter` method of the `ContainerResponseFilter` throws an IOException, we have encapsulated the caught exception into an IOException and then, the [ExceptionMapper](https://github.com/liferay/liferay-portal/blob/6ce0b9eb049e99a50285a324a3bd4afd76d340ab/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/exception/mapper/ExceptionMapper.java#L20) will manage the exception and based on the cause, it gets the ExceptionMapper that must manage the cause exception and will return the HTTP code and the message body that applies to that case.

In order to make available all the ExceptionMappers Object Entries related, we deploy also the ExceptionMappers, apart from the Custom Object REST APIs, into the Unmodifiable System Object REST APIs. That means the ExceptionMapper will be available for every REST APIs of Objects, not only Custom Objects but also Unmodifiable System Objects.


cc/ @jgarcialr
