### PR TITLE
LPS-196598 Columns in the ObjectEntry table should never be dropped

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
@@ -1094,7 +1094,8 @@ public class ObjectFieldLocalServiceImpl
 			!objectField.compareBusinessType(
 				ObjectFieldConstants.BUSINESS_TYPE_AGGREGATION) &&
 			!objectField.compareBusinessType(
-				ObjectFieldConstants.BUSINESS_TYPE_FORMULA)) {
+				ObjectFieldConstants.BUSINESS_TYPE_FORMULA) &&
+			!Objects.equals(objectField.getDBTableName(), "ObjectEntry")) {
 
 			_alterTableDropColumn(
 				objectField.getDBTableName(), objectField.getDBColumnName());


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-196598.

This was causing fields like objectEntryId, createDate... to be deleted when a company is deleted by DataGuard in the tests.

This also had the potential to happen in production code.
