### PR TITLE
LPS-196858 Remove readOnly flag from externalReferenceCode ObjectEntry field

### DIFF
--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/ObjectEntry.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/ObjectEntry.java
@@ -230,7 +230,7 @@ public class ObjectEntry implements Serializable {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String externalReferenceCode;
 
 	@Schema

--- a/modules/apps/object/object-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-rest-impl/rest-openapi.yaml
@@ -83,7 +83,6 @@ components:
                     format: date
                     type: string
                 externalReferenceCode:
-                    readOnly: true
                     type: string
                 id:
                     format: int64

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/BaseObjectRelationshipElementsParserImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/BaseObjectRelationshipElementsParserImpl.java
@@ -9,6 +9,7 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
 import com.liferay.object.rest.manager.v1_0.ObjectRelationshipElementsParser;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
 
 import java.util.Arrays;
 import java.util.List;
@@ -61,14 +62,8 @@ public abstract class BaseObjectRelationshipElementsParserImpl<T>
 	protected ObjectEntry toObjectEntry(
 		Map<String, Object> nestedObjectEntryProperties) {
 
-		ObjectEntry objectEntry = new ObjectEntry();
-
-		objectEntry.setExternalReferenceCode(
-			(String)nestedObjectEntryProperties.remove(
-				"externalReferenceCode"));
-		objectEntry.setProperties(nestedObjectEntryProperties);
-
-		return objectEntry;
+		return ObjectMapperUtil.readValue(
+			ObjectEntry.class, nestedObjectEntryProperties);
 	}
 
 	protected void validateOne(Object object) {

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryResourceImpl.java
@@ -416,6 +416,11 @@ public abstract class BaseObjectEntryResourceImpl
 			existingObjectEntry.setDateModified(objectEntry.getDateModified());
 		}
 
+		if (objectEntry.getExternalReferenceCode() != null) {
+			existingObjectEntry.setExternalReferenceCode(
+				objectEntry.getExternalReferenceCode());
+		}
+
 		if (objectEntry.getKeywords() != null) {
 			existingObjectEntry.setKeywords(objectEntry.getKeywords());
 		}
@@ -625,6 +630,11 @@ public abstract class BaseObjectEntryResourceImpl
 
 		if (objectEntry.getDateModified() != null) {
 			existingObjectEntry.setDateModified(objectEntry.getDateModified());
+		}
+
+		if (objectEntry.getExternalReferenceCode() != null) {
+			existingObjectEntry.setExternalReferenceCode(
+				objectEntry.getExternalReferenceCode());
 		}
 
 		if (objectEntry.getKeywords() != null) {
@@ -860,6 +870,11 @@ public abstract class BaseObjectEntryResourceImpl
 
 		if (objectEntry.getDateModified() != null) {
 			existingObjectEntry.setDateModified(objectEntry.getDateModified());
+		}
+
+		if (objectEntry.getExternalReferenceCode() != null) {
+			existingObjectEntry.setExternalReferenceCode(
+				objectEntry.getExternalReferenceCode());
 		}
 
 		if (objectEntry.getKeywords() != null) {


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPS-196857

---

The purpose of this PR is to remove the `readOnly: true` parameter of the ObjectEntry schema of the Custom Objects REST API as the field is not currently read only. Furthermore, the ObjectMapper is not parsing the field when deserializing as it is marked as read only