### PR TITLE
LPS-181576 | Create an API Application Schema

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/APIBuilderUI.macro
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/APIBuilderUI.macro
@@ -97,6 +97,26 @@ definition {
 			value1 = "Save");
 	}
 
+	macro createAPISchema {
+		Variables.assertDefined(parameterList = "${name},${objectDefinitionName}");
+
+		Click(locator1 = "APIBuilder#ADD_NEW_SCHEMA");
+
+		Type(
+			locator1 = "TextInput#NAME",
+			value1 = ${name});
+
+		Click(locator1 = "APIBuilder#SELECT_AN_OBJECT_DEFINITION");
+
+		Click(
+			key_kebabOption = ${objectDefinitionName},
+			locator1 = "ObjectAdmin#KEBAB_MENU_OPTION");
+
+		if (isSet(confirmCreation)) {
+			Click(locator1 = "APIBuilder#CREATE_BUTTON");
+		}
+	}
+
 	macro deleteAPIApplication {
 		ApplicationsMenu.gotoPortlet(
 			category = "Object",

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/ApplicationAPI.macro
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/ApplicationAPI.macro
@@ -35,15 +35,16 @@ definition {
 
 		var curl = ApplicationAPI._curlAPIApplication(virtualHost = ${virtualHost});
 
-		if (!(isSet(externalReferenceCodeApp))) {
+		if (!(isSet(externalReferenceCode))) {
 			var title = StringUtil.removeSpaces(${title});
 
-			var externalReferenceCodeApp = ${title};
+			var externalReferenceCode = ${title};
 		}
 
 		var body = '''
 			"applicationStatus": {"key": "${status}","name": "${status}"},
 			"baseURL": "${baseURL}",
+			"externalReferenceCode": "${externalReferenceCode}",
 			"title": "${title}"
 		''';
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/EndpointAPI.macro
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/EndpointAPI.macro
@@ -24,7 +24,7 @@ definition {
 	}
 
 	macro createAPIEndpoint {
-		Variables.assertDefined(parameterList = "${apiApplicationId},${name},${path}");
+		Variables.assertDefined(parameterList = "${externalReferenceCode},${name},${path}");
 
 		var curl = EndpointAPI._curlAPIEndpoint(virtualHost = ${virtualHost});
 
@@ -36,7 +36,7 @@ definition {
 			"httpMethod": "${httpMethod}",
 			"name": "${name}",
 			"path": "${path}",
-			"r_apiApplicationToAPIEndpoints_c_apiApplicationId": ${apiApplicationId}
+			"r_apiApplicationToAPIEndpoints_c_apiApplicationERC": "${externalReferenceCode}"
 		''';
 
 		if (isSet(requestSchemaId)) {
@@ -55,7 +55,7 @@ definition {
 	}
 
 	macro createNAPIEndpoints {
-		Variables.assertDefined(parameterList = "${apiApplicationId},${name},${numberOfEndpoints},${path}");
+		Variables.assertDefined(parameterList = "${externalReferenceCode},${name},${numberOfEndpoints},${path}");
 
 		var i = 0;
 
@@ -63,7 +63,7 @@ definition {
 			var i = ${i} + 1;
 
 			EndpointAPI.createAPIEndpoint(
-				apiApplicationId = ${apiApplicationId},
+				externalReferenceCode = ${externalReferenceCode},
 				name = "${name}${i}",
 				path = "${path}${i}");
 		}

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/SchemaAPI.macro
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/SchemaAPI.macro
@@ -40,14 +40,14 @@ definition {
 	}
 
 	macro createAPISchema {
-		Variables.assertDefined(parameterList = "${mainObjectDefinitionERC},${name},${apiApplicationId}");
+		Variables.assertDefined(parameterList = "${mainObjectDefinitionERC},${name},${externalReferenceCode}");
 
 		var curl = SchemaAPI._curlAPISchema(virtualHost = ${virtualHost});
 		var body = '''
 			-d {
 				"mainObjectDefinitionERC": "${mainObjectDefinitionERC}",
 				"name": "${name}",
-				"r_apiApplicationToAPISchemas_c_apiApplicationId": ${apiApplicationId}
+				"r_apiApplicationToAPISchemas_c_apiApplicationERC": "${externalReferenceCode}"
 			}
 		''';
 
@@ -59,7 +59,7 @@ definition {
 	}
 
 	macro createNAPISchemas {
-		Variables.assertDefined(parameterList = "${numberOfSchemas},${mainObjectDefinitionERC},${name},${apiApplicationId}");
+		Variables.assertDefined(parameterList = "${numberOfSchemas},${mainObjectDefinitionERC},${name},${externalReferenceCode}");
 
 		var i = 0;
 
@@ -67,7 +67,7 @@ definition {
 			var i = ${i} + 1;
 
 			SchemaAPI.createAPISchema(
-				apiApplicationId = ${apiApplicationId},
+				externalReferenceCode = ${externalReferenceCode},
 				mainObjectDefinitionERC = ${mainObjectDefinitionERC},
 				name = "${name}${i}");
 		}

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/paths/APIBuilder.path
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/paths/APIBuilder.path
@@ -96,6 +96,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>ENTER_NAME</td>
+	<td>//input[(@placeholder='Enter name.')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>ENTER_TITLE</td>
 	<td>//input[(@placeholder='Enter title.')]</td>
 	<td></td>
@@ -123,6 +128,11 @@
 <tr>
 	<td>PUBLISH_BUTTON</td>
 	<td>//button[contains(text(),'Publish')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>SELECT_AN_OBJECT_DEFINITION</td>
+	<td>//div[contains(@class,'dropdown-toggle')]//button[contains(text(),'Select an Object Definition') or contains(text(),'${objectDefinitionName}')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/APIBuilder-Multitenant/SupportMultitenancyForHeadlessBuilderRESTAPI.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/APIBuilder-Multitenant/SupportMultitenancyForHeadlessBuilderRESTAPI.testcase
@@ -23,8 +23,6 @@ definition {
 				schemaName = "testSchema",
 				status = "published",
 				title = "My-app");
-
-			ApplicationAPI.setUpGlobalAPIApplicationId();
 		}
 
 		task ("And Given a virtual instance is created") {

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[APIRest]APIGenerator/PublishARESTAPIApplication.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[APIRest]APIGenerator/PublishARESTAPIApplication.testcase
@@ -17,8 +17,6 @@ definition {
 				baseURL = "app-test",
 				status = "published",
 				title = "App-test");
-
-			ApplicationAPI.setUpGlobalAPIApplicationId();
 		}
 	}
 
@@ -38,7 +36,7 @@ definition {
 
 		task ("And Given an API Schema 'AppTest' related to an Application by post request postAPISchema") {
 			var response = SchemaAPI.createAPISchema(
-				apiApplicationId = ${staticApplicationId},
+				externalReferenceCode = "App-test",
 				mainObjectDefinitionERC = "L_API_APPLICATION",
 				name = "AppTest");
 		}
@@ -47,7 +45,7 @@ definition {
 			var schemaId = JSONPathUtil.getIdValue(response = ${response});
 
 			EndpointAPI.createAPIEndpoint(
-				apiApplicationId = ${staticApplicationId},
+				externalReferenceCode = "App-test",
 				name = "AppTest",
 				path = "/AppTest",
 				responseSchemaId = ${schemaId});
@@ -79,7 +77,7 @@ definition {
 
 		task ("And Given an API endpoint 'AppTest' related to an Application by post request postAPIEndpoint") {
 			EndpointAPI.createAPIEndpoint(
-				apiApplicationId = ${staticApplicationId},
+				externalReferenceCode = "App-test",
 				name = "AppTest",
 				path = "/AppTest");
 		}
@@ -104,7 +102,7 @@ definition {
 
 		task ("And Given an API Schema 'AppTest' related to an Application by post request postAPISchema") {
 			SchemaAPI.createAPISchema(
-				apiApplicationId = ${staticApplicationId},
+				externalReferenceCode = "App-test",
 				mainObjectDefinitionERC = "L_API_APPLICATION",
 				name = "AppTest");
 		}

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationEndpoints/AllowUsersToDefineEndpointsForObjectsWithSiteScope.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationEndpoints/AllowUsersToDefineEndpointsForObjectsWithSiteScope.testcase
@@ -117,7 +117,7 @@ definition {
 			var apiApplicationId = JSONPathUtil.getIdValue(response = ${response});
 
 			EndpointAPI.createAPIEndpoint(
-				apiApplicationId = ${apiApplicationId},
+				externalReferenceCode = "My-app",
 				name = "myEndpoint",
 				path = "/myEndpoint");
 		}
@@ -171,10 +171,8 @@ definition {
 				endpointId = ${endpointId1},
 				responseSchemaId = ${schemaId1});
 
-			var apiApplicationId = JSONPathUtil.getIdValue(response = ${responseFromApplication});
-
 			var responseFromEndpoint = EndpointAPI.createAPIEndpoint(
-				apiApplicationId = ${apiApplicationId},
+				externalReferenceCode = "My-app",
 				name = "myEndpoint",
 				path = "/myEndpoint");
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationEndpoints/ListAPIApplicationEndpoints.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationEndpoints/ListAPIApplicationEndpoints.testcase
@@ -87,7 +87,7 @@ definition {
 
 			AssertTextEquals(
 				locator1 = "TextInput#SEARCH",
-				value1 = "${portalURL}/o/c/my-app/myEndpoint/");
+				value1 = "${portalURL}/o/c/my-app/myEndpoint");
 		}
 	}
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationEndpoints/ListAPIApplicationEndpoints.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationEndpoints/ListAPIApplicationEndpoints.testcase
@@ -17,8 +17,6 @@ definition {
 				baseURL = "my-app",
 				status = "unpublished",
 				title = "My-app");
-
-			ApplicationAPI.setUpGlobalAPIApplicationId();
 		}
 	}
 
@@ -63,7 +61,7 @@ definition {
 
 		task ("And Given I create an endpoint associate to the API application") {
 			EndpointAPI.createAPIEndpoint(
-				apiApplicationId = ${staticApplicationId},
+				externalReferenceCode = "My-app",
 				name = "myEndpoint",
 				path = "/myEndpoint");
 		}
@@ -101,7 +99,7 @@ definition {
 
 		task ("And Given I create an endpoint associate to the API application") {
 			EndpointAPI.createAPIEndpoint(
-				apiApplicationId = ${staticApplicationId},
+				externalReferenceCode = "My-app",
 				name = "myEndpoint",
 				path = "/myEndpoint");
 		}
@@ -133,7 +131,7 @@ definition {
 
 		task ("And Given I create an endpoint associate to the API application") {
 			EndpointAPI.createAPIEndpoint(
-				apiApplicationId = ${staticApplicationId},
+				externalReferenceCode = "My-app",
 				name = "myEndpoint",
 				path = "/myEndpoint");
 		}
@@ -166,7 +164,7 @@ definition {
 
 		task ("And Given with postEndpointAPI to create an endpoint associate to the API application") {
 			EndpointAPI.createAPIEndpoint(
-				apiApplicationId = ${staticApplicationId},
+				externalReferenceCode = "My-app",
 				name = "myEndpoint",
 				path = "/myEndpoint");
 		}
@@ -196,7 +194,7 @@ definition {
 
 		task ("And Given with postEndpointAPI to create two endpoints associate to the API application") {
 			EndpointAPI.createNAPIEndpoints(
-				apiApplicationId = ${staticApplicationId},
+				externalReferenceCode = "My-app",
 				name = "myEndpoint",
 				numberOfEndpoints = 2,
 				path = "/myEndpoint");
@@ -227,7 +225,7 @@ definition {
 
 		task ("And Given postAPIEndpoint to create 11 endpoints associate to the API application") {
 			EndpointAPI.createNAPIEndpoints(
-				apiApplicationId = ${staticApplicationId},
+				externalReferenceCode = "My-app",
 				name = "myEndpoint",
 				numberOfEndpoints = 11,
 				path = "/myEndpoint");
@@ -266,7 +264,7 @@ definition {
 
 		task ("And Given I create an edpoint associate to the API application") {
 			EndpointAPI.createAPIEndpoint(
-				apiApplicationId = ${staticApplicationId},
+				externalReferenceCode = "My-app",
 				name = "myEndpoint",
 				path = "/myEndpoint");
 		}
@@ -294,7 +292,7 @@ definition {
 
 		task ("When I create an endpoint associate to the API application") {
 			EndpointAPI.createAPIEndpoint(
-				apiApplicationId = ${staticApplicationId},
+				externalReferenceCode = "My-app",
 				name = "myEndpoint",
 				path = "/myEndpoint");
 		}

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationsInTheAPIBuilder/DeleteAPIApplication.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationsInTheAPIBuilder/DeleteAPIApplication.testcase
@@ -17,8 +17,6 @@ definition {
 				baseURL = "test",
 				status = "unpublished",
 				title = "test");
-
-			ApplicationAPI.setUpGlobalAPIApplicationId();
 		}
 	}
 
@@ -77,14 +75,14 @@ definition {
 
 		task ("And Given with postAPISchema to create a Schema associate to the API application") {
 			SchemaAPI.createAPISchema(
-				apiApplicationId = ${staticApplicationId},
+				externalReferenceCode = "test",
 				mainObjectDefinitionERC = "L_API_APPLICATION",
 				name = "mySchema");
 		}
 
 		task ("And Given with postAPIEndpoint to create an Endpoint associate to API application and Schema") {
 			EndpointAPI.createAPIEndpoint(
-				apiApplicationId = ${staticApplicationId},
+				externalReferenceCode = "test",
 				name = "myEndpoint",
 				path = "/myEndpoint");
 		}
@@ -131,14 +129,14 @@ definition {
 
 		task ("And Given with postAPISchema to create a Schema associate to the API application") {
 			SchemaAPI.createAPISchema(
-				apiApplicationId = ${staticApplicationId},
+				externalReferenceCode = "test",
 				mainObjectDefinitionERC = "L_API_APPLICATION",
 				name = "mySchema");
 		}
 
 		task ("And Given with postAPIEndpoint to create an Endpoint associate to API application and Schema") {
 			EndpointAPI.createAPIEndpoint(
-				apiApplicationId = ${staticApplicationId},
+				externalReferenceCode = "test",
 				name = "myEndpoint",
 				path = "/myEndpoint");
 		}

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]DefineAPISchemasWithinAnAPIGroup/CreateAPIApplicationSchema.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]DefineAPISchemasWithinAnAPIGroup/CreateAPIApplicationSchema.testcase
@@ -47,7 +47,7 @@ definition {
 				category = "Object",
 				panel = "Control Panel",
 				portlet = "Objects");
-			
+
 			var i = 0;
 
 			WaitForElementPresent(locator1 = "Pagination#RESULTS");
@@ -100,10 +100,10 @@ definition {
 			Click(locator1 = "APIBuilder#SELECT_AN_OBJECT_DEFINITION");
 		}
 
-		task ("Then all object deinifition entities from Objects are listed inluding the one placed on 2nd page of Objects") {				
-				AssertElementPresent(
-					index = 21,
-					locator1 = "ObjectAdmin#KEBAB_MENU_OPTION_BY_INDEX");
+		task ("Then all object deinifition entities from Objects are listed inluding the one placed on 2nd page of Objects") {
+			AssertElementPresent(
+				index = 21,
+				locator1 = "ObjectAdmin#KEBAB_MENU_OPTION_BY_INDEX");
 		}
 	}
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]DefineAPISchemasWithinAnAPIGroup/CreateAPIApplicationSchema.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]DefineAPISchemasWithinAnAPIGroup/CreateAPIApplicationSchema.testcase
@@ -1,0 +1,194 @@
+@component-name = "portal-headless"
+definition {
+
+	property custom.properties = "feature.flag.LPS-167253=true${line.separator}feature.flag.LPS-178642=true";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Object";
+	property testray.main.component.name = "Headless Builder";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+
+		task ("Given New API Application created") {
+			ApplicationAPI.createAPIApplication(
+				baseURL = "my-app",
+				status = "unpublished",
+				title = "My-app");
+		}
+
+		task ("And Given I go to the Schemas tab of API Application edition") {
+			APIBuilderUI.switchToRelatedEntryInEditApplication(
+				entity = "Schemas",
+				title = "My-app");
+		}
+	}
+
+	tearDown {
+		ApplicationAPI.deleteAllAPIApplication();
+
+		JSONObject.deleteAllCustomObjects(pageSize = 22);
+
+		var testLiferayVirtualInstance = PropsUtil.get("test.liferay.virtual.instance");
+
+		if (${testLiferayVirtualInstance} == "true") {
+			PortalInstances.tearDownCP();
+		}
+	}
+
+	@priority = 5
+	test AllObjectDefinitionsAreAvailableInTheObjectMenu {
+		property portal.acceptance = "true";
+
+		task ("Given multiple custom object definitions created without publishing") {
+			ObjectDefinitionAPI.createNUnpublishedObjectDefinitions(
+				numberOfEndpoints = 8,
+				objectDefinitionName = "Student",
+				requiredStringFieldName = "name");
+		}
+
+		task ("And Given all 20+ object deinifition entities available in Objects") {
+			ApplicationsMenu.gotoPortlet(
+				category = "Object",
+				panel = "Control Panel",
+				portlet = "Objects");
+
+			AssertTextEquals(
+				locator1 = "Pagination#RESULTS",
+				value1 = "Showing 1 to 20 of 22 entries.");
+		}
+
+		task ("And Given one of object definitions on 2nd page") {
+			Click(locator1 = "DigitalSignatureListView#DIGITAL_SIGNATURE_NAVIGATE_NEXT");
+
+			AssertElementPresent(
+				key_name = "Student8",
+				locator1 = "ObjectAdmin#TABLE_LIST_TITLE");
+		}
+
+		task ("And Given I go to the Schemas tab of API Application edition") {
+			APIBuilderUI.switchToRelatedEntryInEditApplication(
+				entity = "Schemas",
+				title = "My-app");
+		}
+
+		task ("And Given I click Add New Schema") {
+			Click(locator1 = "APIBuilder#ADD_NEW_SCHEMA");
+		}
+
+		task ("When I click Object field") {
+			Click(locator1 = "APIBuilder#SELECT_AN_OBJECT_DEFINITION");
+		}
+
+		task ("Then all object deinifition entities from Objects are listed inluding the one placed on 2nd page of Objects") {
+			var list1 = "Address,AccountEntry,APISort,Bookmark,APIFilter,APIEndpoint,APIProperty,APISchema,APIApplication";
+			var list2 = "CommercePricingClass,CPDefinition,CommerceOrder,Organization,User,";
+			var list3 = "Student1,Student2,Student3,Student4,Student5,Student6,Student7,Student8";
+
+			for (var objectDefinitionName : list "${list1},${list2},${list3}") {
+				AssertElementPresent(
+					key_kebabOption = ${objectDefinitionName},
+					locator1 = "ObjectAdmin#KEBAB_MENU_OPTION");
+			}
+		}
+	}
+
+	@priority = 5
+	test CanCreateMultipleSchemasInApplication {
+		property portal.acceptance = "true";
+
+		task ("And Given a Schema created in the API Application") {
+			SchemaAPI.createAPISchema(
+				externalReferenceCode = "My-app",
+				mainObjectDefinitionERC = "L_API_APPLICATION",
+				name = "testSchema_1");
+		}
+
+		task ("When I click Add New Schema") {
+			APIBuilderUI.createAPISchema(
+				confirmCreation = "true",
+				name = "testSchema_2",
+				objectDefinitionName = "APIApplication");
+		}
+
+		task ("Then I'm able to create another schema for the API Application") {
+			APIBuilderUI.switchToRelatedEntryInEditApplication(
+				entity = "Schemas",
+				title = "My-app");
+
+			APIBuilderUI.viewItemsInOrder(itemList = "testSchema_1,testSchema_2");
+		}
+	}
+
+	@priority = 4
+	test CanSeeInfoOfCreatedSchema {
+		property portal.acceptance = "true";
+
+		task ("When I create a schema with valid Name and Object") {
+			APIBuilderUI.createAPISchema(
+				confirmCreation = "true",
+				name = "testSchema",
+				objectDefinitionName = "APIApplication");
+		}
+
+		task ("Then I can see details info of the created schema") {
+			AssertTextEquals(
+				locator1 = "APIBuilder#ENTER_NAME",
+				value1 = "testSchema");
+
+			AssertTextEquals(
+				locator1 = "APIBuilder#SELECT_AN_OBJECT_DEFINITION",
+				objectDefinitionName = "APIApplication",
+				value1 = "APIApplication");
+		}
+	}
+
+	@priority = 5
+	test SchemaIsNotCreatedAfterClickingCancel {
+		property portal.acceptance = "true";
+
+		task ("And Given I fill in valid Name and Object fields") {
+			APIBuilderUI.createAPISchema(
+				name = "testSchema",
+				objectDefinitionName = "APIApplication");
+		}
+
+		task ("When I click Cancel button") {
+			Click(locator1 = "Button#CANCEL");
+		}
+
+		task ("Then no new schema on the list of schemas") {
+			AssertElementNotPresent(
+				key_name = "testSchema",
+				locator1 = "ObjectAdmin#TABLE_LIST_TITLE");
+		}
+	}
+
+	@priority = 5
+	test SchemaNameMustBeUnique {
+		property portal.acceptance = "true";
+
+		task ("And Given a Schema 'new' created in the API Application") {
+			SchemaAPI.createAPISchema(
+				externalReferenceCode = "My-app",
+				mainObjectDefinitionERC = "L_API_APPLICATION",
+				name = "new");
+		}
+
+		task ("When I try creating another schema with name 'new'") {
+			APIBuilderUI.createAPISchema(
+				confirmCreation = "true",
+				name = "new",
+				objectDefinitionName = "APIApplication");
+		}
+
+		task ("Then an error message 'There is an API schema with the same name in the API application' blocks schema from being created") {
+			AssertElementPresent(
+				locator1 = "Message#ERROR_DISMISSIBLE",
+				value = "There is an API schema with the same name in the API application.");
+		}
+	}
+
+}

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]DefineAPISchemasWithinAnAPIGroup/CreateAPIApplicationSchema.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]DefineAPISchemasWithinAnAPIGroup/CreateAPIApplicationSchema.testcase
@@ -29,7 +29,7 @@ definition {
 	tearDown {
 		ApplicationAPI.deleteAllAPIApplication();
 
-		JSONObject.deleteAllCustomObjects(pageSize = 22);
+		JSONObject.deleteAllCustomObjects(pageSize = 21);
 
 		var testLiferayVirtualInstance = PropsUtil.get("test.liferay.virtual.instance");
 
@@ -43,10 +43,32 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given multiple custom object definitions created without publishing") {
-			ObjectDefinitionAPI.createNUnpublishedObjectDefinitions(
-				numberOfEndpoints = 8,
-				objectDefinitionName = "Student",
-				requiredStringFieldName = "name");
+			ApplicationsMenu.gotoPortlet(
+				category = "Object",
+				panel = "Control Panel",
+				portlet = "Objects");
+			
+			var i = 0;
+
+			WaitForElementPresent(locator1 = "Pagination#RESULTS");
+
+			var moreThanTwenty = selenium.getText("Pagination#RESULTS");
+
+			while (${moreThanTwenty} != "Showing 1 to 20 of 21 entries.") {
+				var i = ${i} + 1;
+
+				ObjectDefinitionAPI.createObjectDefinition(
+					en_US_label = "Student${i}",
+					en_US_plural_label = "Student${i}s",
+					name = "Student${i}",
+					requiredStringFieldName = "name");
+
+				Refresh();
+
+				WaitForElementPresent(locator1 = "Pagination#RESULTS");
+
+				var moreThanTwenty = selenium.getText("Pagination#RESULTS");
+			}
 		}
 
 		task ("And Given all 20+ object deinifition entities available in Objects") {
@@ -57,15 +79,11 @@ definition {
 
 			AssertTextEquals(
 				locator1 = "Pagination#RESULTS",
-				value1 = "Showing 1 to 20 of 22 entries.");
+				value1 = "Showing 1 to 20 of 21 entries.");
 		}
 
 		task ("And Given one of object definitions on 2nd page") {
 			Click(locator1 = "DigitalSignatureListView#DIGITAL_SIGNATURE_NAVIGATE_NEXT");
-
-			AssertElementPresent(
-				key_name = "Student8",
-				locator1 = "ObjectAdmin#TABLE_LIST_TITLE");
 		}
 
 		task ("And Given I go to the Schemas tab of API Application edition") {
@@ -82,16 +100,10 @@ definition {
 			Click(locator1 = "APIBuilder#SELECT_AN_OBJECT_DEFINITION");
 		}
 
-		task ("Then all object deinifition entities from Objects are listed inluding the one placed on 2nd page of Objects") {
-			var list1 = "Address,AccountEntry,APISort,Bookmark,APIFilter,APIEndpoint,APIProperty,APISchema,APIApplication";
-			var list2 = "CommercePricingClass,CPDefinition,CommerceOrder,Organization,User,";
-			var list3 = "Student1,Student2,Student3,Student4,Student5,Student6,Student7,Student8";
-
-			for (var objectDefinitionName : list "${list1},${list2},${list3}") {
+		task ("Then all object deinifition entities from Objects are listed inluding the one placed on 2nd page of Objects") {				
 				AssertElementPresent(
-					key_kebabOption = ${objectDefinitionName},
-					locator1 = "ObjectAdmin#KEBAB_MENU_OPTION");
-			}
+					index = 21,
+					locator1 = "ObjectAdmin#KEBAB_MENU_OPTION_BY_INDEX");
 		}
 	}
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]DefineAPISchemasWithinAnAPIGroup/DeleteAPIApplicationSchema.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]DefineAPISchemasWithinAnAPIGroup/DeleteAPIApplicationSchema.testcase
@@ -20,8 +20,6 @@ definition {
 				schemaName = "testSchema",
 				status = "published",
 				title = "My-app");
-
-			ApplicationAPI.setUpGlobalAPIApplicationId();
 		}
 	}
 
@@ -87,7 +85,7 @@ definition {
 
 		task ("And Given create an API Endpoint in the Application") {
 			EndpointAPI.createAPIEndpoint(
-				apiApplicationId = ${staticApplicationId},
+				externalReferenceCode = "My-app",
 				name = "myEndpoint",
 				path = "/myEndpoint");
 		}

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]DefineAPISchemasWithinAnAPIGroup/ListAPIApplicationSchemas.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]DefineAPISchemasWithinAnAPIGroup/ListAPIApplicationSchemas.testcase
@@ -17,8 +17,6 @@ definition {
 				baseURL = "my-app",
 				status = "unpublished",
 				title = "My-app");
-
-			ApplicationAPI.setUpGlobalAPIApplicationId();
 		}
 	}
 
@@ -63,7 +61,7 @@ definition {
 
 		task ("And Given I create a schema associate to the API application") {
 			SchemaAPI.createAPISchema(
-				apiApplicationId = ${staticApplicationId},
+				externalReferenceCode = "My-app",
 				mainObjectDefinitionERC = "L_API_APPLICATION",
 				name = "mySchema");
 		}
@@ -96,7 +94,7 @@ definition {
 
 		task ("And Given I create a schema associate to the API application") {
 			SchemaAPI.createAPISchema(
-				apiApplicationId = ${staticApplicationId},
+				externalReferenceCode = "My-app",
 				mainObjectDefinitionERC = "L_API_APPLICATION",
 				name = "mySchema");
 		}
@@ -128,7 +126,7 @@ definition {
 
 		task ("And Given with postAPISchema to create a schema associate to the API application") {
 			SchemaAPI.createAPISchema(
-				apiApplicationId = ${staticApplicationId},
+				externalReferenceCode = "My-app",
 				mainObjectDefinitionERC = "L_API_APPLICATION",
 				name = "mySchema");
 		}
@@ -154,7 +152,7 @@ definition {
 
 		task ("And Given with postAPISchema to create two schemas associate to the API application") {
 			SchemaAPI.createNAPISchemas(
-				apiApplicationId = ${staticApplicationId},
+				externalReferenceCode = "My-app",
 				mainObjectDefinitionERC = "L_API_APPLICATION",
 				name = "testSchema",
 				numberOfSchemas = 2);
@@ -185,7 +183,7 @@ definition {
 
 		task ("And Given with postAPISchema to create two schemas associate to the API application") {
 			SchemaAPI.createNAPISchemas(
-				apiApplicationId = ${staticApplicationId},
+				externalReferenceCode = "My-app",
 				mainObjectDefinitionERC = "L_API_APPLICATION",
 				name = "testSchema",
 				numberOfSchemas = 2);
@@ -216,7 +214,7 @@ definition {
 
 		task ("And Given with postAPISchema to create 11 schemas associate to the API application") {
 			SchemaAPI.createNAPISchemas(
-				apiApplicationId = ${staticApplicationId},
+				externalReferenceCode = "My-app",
 				mainObjectDefinitionERC = "L_API_APPLICATION",
 				name = "testSchema",
 				numberOfSchemas = 11);
@@ -255,7 +253,7 @@ definition {
 
 		task ("And Given I create a schema associate to the API application") {
 			SchemaAPI.createAPISchema(
-				apiApplicationId = ${staticApplicationId},
+				externalReferenceCode = "My-app",
 				mainObjectDefinitionERC = "L_API_APPLICATION",
 				name = "testSchema");
 		}
@@ -281,7 +279,7 @@ definition {
 
 		task ("When I create a schema associate to the API application") {
 			SchemaAPI.createAPISchema(
-				apiApplicationId = ${staticApplicationId},
+				externalReferenceCode = "My-app",
 				mainObjectDefinitionERC = "L_API_APPLICATION",
 				name = "mySchema");
 		}

--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectDefinitionAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectDefinitionAPI.macro
@@ -624,6 +624,22 @@ definition {
 		return ${managerId};
 	}
 
+	macro createNUnpublishedObjectDefinitions {
+		Variables.assertDefined(parameterList = "${numberOfEndpoints},${objectDefinitionName},${requiredStringFieldName}");
+
+		var i = 0;
+
+		while (${i} != ${numberOfEndpoints}) {
+			var i = ${i} + 1;
+
+			ObjectDefinitionAPI.createObjectDefinition(
+				en_US_label = "${objectDefinitionName}${i}",
+				en_US_plural_label = "${objectDefinitionName}${i}s",
+				name = "${objectDefinitionName}${i}",
+				requiredStringFieldName = ${requiredStringFieldName});
+		}
+	}
+
 	macro createObjectDefinition {
 		Variables.assertDefined(parameterList = "${name},${en_US_plural_label}");
 

--- a/modules/apps/object/object-test/src/testFunctional/macros/json/JSONObject.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/json/JSONObject.macro
@@ -673,8 +673,15 @@ definition {
 			var userPassword = "test";
 		}
 
+		if (isSet(pageSize)) {
+			var url = "object-admin/v1.0/object-definitions?pageSize=${pageSize}";
+		}
+		else {
+			var url = "object-admin/v1.0/object-definitions";
+		}
+
 		var curl = '''
-			${portalURL}/o/object-admin/v1.0/object-definitions \
+			${portalURL}/o/${url} \
 				-u ${userEmailAddress}:${userPassword}
 		''';
 

--- a/modules/apps/object/object-test/src/testFunctional/paths/ObjectAdmin.path
+++ b/modules/apps/object/object-test/src/testFunctional/paths/ObjectAdmin.path
@@ -441,6 +441,11 @@
 		<td></td>
 	</tr>
 	<tr>
+		<td>KEBAB_MENU_OPTION_BY_INDEX</td>
+		<td>xpath=(//*[@class='dropdown-menu show']//*[(@class='dropdown-item' and @role='menuitem')])[${index}]</td>
+		<td></td>
+	</tr>
+	<tr>
 		<td>BODY_VERTICAL_ELLIPSIS</td>
 		<td>//div[contains(@class,'table-list-title')]/../../../*[contains(.,'${key_value}')]//*[name()='svg'][contains(@class,'icon-ellipsis')]</td>
 		<td></td>


### PR DESCRIPTION
Background:
Add a testcase to Create an API Application Schema

Test Plan
SchemaIsNotCreatedAfterClickingCancel
And Given I fill in valid Name and Object fields
When I click Cancel button
Then no new schema on the list of schemas

CanSeeInfoOfCreatedSchema
When I create a schema with valid Name and Object
Then I can see details info of the created schema

AllObjectDefinitionsAreAvailableInTheObjectMenu
Given multiple custom object definitions created without publishing
And Given all 20+ object deinifition entities available in Objects
And Given one of object definitions on 2nd page
And Given New API Application created in API Builder
And Given I go to the Schemas tab of API Application edition
And Given I click Add New Schema
When I click Object field
Then all object deinifition entities from Objects are listed inluding the one placed on 2nd page of Objects

SchemaNameMustBeUnique
Given New API Application created
And Given a Schema ‘new’ created in the API Application
When I try creating another schema with name 'new'
Then an error message 'There is an API schema with the same name in the API application' blocks schema from being created

CanCreateMultipleSchemasInApplication
Given New API Application created
And Given a Schema created in the API Application
When I click Add New Schema
Then I'm able to create another schema for the API Application

Jira ticket:
https://liferay.atlassian.net/browse/LPS-181576