### PR TITLE
LPS-181945 Fix some race conditions and configure multiCompany for Bookmarks Modifiable System Objects creation

### DIFF
--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/instance/lifecycle/MultiCompanyBatchEngineUnitPortalInstanceLifecycleListener.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/instance/lifecycle/MultiCompanyBatchEngineUnitPortalInstanceLifecycleListener.java
@@ -18,7 +18,10 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Alejandro Tardín
  */
-@Component(service = PortalInstanceLifecycleListener.class)
+@Component(
+	property = "service.ranking:Integer=" + Integer.MIN_VALUE,
+	service = PortalInstanceLifecycleListener.class
+)
 public class MultiCompanyBatchEngineUnitPortalInstanceLifecycleListener
 	extends BasePortalInstanceLifecycleListener {
 
@@ -39,5 +42,8 @@ public class MultiCompanyBatchEngineUnitPortalInstanceLifecycleListener
 	@Reference
 	private MultiCompanyBatchEngineUnitProcessor
 		_multiCompanyBatchEngineUnitProcessor;
+
+	@Reference(target = "(type=liferay.objects)")
+	private PortalInstanceLifecycleListener _portalInstanceLifecycleListener;
 
 }

--- a/modules/apps/object/object-api/bnd.bnd
+++ b/modules/apps/object/object-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object API
 Bundle-SymbolicName: com.liferay.object.api
-Bundle-Version: 76.0.2
+Bundle-Version: 77.0.0
 Export-Package:\
 	com.liferay.object.action.engine,\
 	com.liferay.object.action.executor,\

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectFolderLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectFolderLocalService.java
@@ -79,7 +79,8 @@ public interface ObjectFolderLocalService
 			Map<Locale, String> labelMap, String name)
 		throws PortalException;
 
-	public ObjectFolder addOrGetUncategorizedObjectFolder(long companyId)
+	@Indexable(type = IndexableType.REINDEX)
+	public ObjectFolder addUncategorizedObjectFolder(long companyId)
 		throws PortalException;
 
 	/**
@@ -232,6 +233,9 @@ public interface ObjectFolderLocalService
 		String uuid, long companyId);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public ObjectFolder fetchUncategorizedObjectFolder(long companyId);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ActionableDynamicQuery getActionableDynamicQuery();
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
@@ -309,6 +313,10 @@ public interface ObjectFolderLocalService
 	@Override
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public PersistedModel getPersistedModel(Serializable primaryKeyObj)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public ObjectFolder getUncategorizedObjectFolder(long companyId)
 		throws PortalException;
 
 	/**

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectFolderLocalServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectFolderLocalServiceUtil.java
@@ -60,10 +60,10 @@ public class ObjectFolderLocalServiceUtil {
 			externalReferenceCode, userId, labelMap, name);
 	}
 
-	public static ObjectFolder addOrGetUncategorizedObjectFolder(long companyId)
+	public static ObjectFolder addUncategorizedObjectFolder(long companyId)
 		throws PortalException {
 
-		return getService().addOrGetUncategorizedObjectFolder(companyId);
+		return getService().addUncategorizedObjectFolder(companyId);
 	}
 
 	/**
@@ -250,6 +250,10 @@ public class ObjectFolderLocalServiceUtil {
 			uuid, companyId);
 	}
 
+	public static ObjectFolder fetchUncategorizedObjectFolder(long companyId) {
+		return getService().fetchUncategorizedObjectFolder(companyId);
+	}
+
 	public static com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery
 		getActionableDynamicQuery() {
 
@@ -353,6 +357,12 @@ public class ObjectFolderLocalServiceUtil {
 		throws PortalException {
 
 		return getService().getPersistedModel(primaryKeyObj);
+	}
+
+	public static ObjectFolder getUncategorizedObjectFolder(long companyId)
+		throws PortalException {
+
+		return getService().getUncategorizedObjectFolder(companyId);
 	}
 
 	/**

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectFolderLocalServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectFolderLocalServiceWrapper.java
@@ -57,11 +57,11 @@ public class ObjectFolderLocalServiceWrapper
 	}
 
 	@Override
-	public com.liferay.object.model.ObjectFolder
-			addOrGetUncategorizedObjectFolder(long companyId)
+	public com.liferay.object.model.ObjectFolder addUncategorizedObjectFolder(
+			long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
-		return _objectFolderLocalService.addOrGetUncategorizedObjectFolder(
+		return _objectFolderLocalService.addUncategorizedObjectFolder(
 			companyId);
 	}
 
@@ -287,6 +287,14 @@ public class ObjectFolderLocalServiceWrapper
 	}
 
 	@Override
+	public com.liferay.object.model.ObjectFolder fetchUncategorizedObjectFolder(
+		long companyId) {
+
+		return _objectFolderLocalService.fetchUncategorizedObjectFolder(
+			companyId);
+	}
+
+	@Override
 	public com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery
 		getActionableDynamicQuery() {
 
@@ -407,6 +415,15 @@ public class ObjectFolderLocalServiceWrapper
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _objectFolderLocalService.getPersistedModel(primaryKeyObj);
+	}
+
+	@Override
+	public com.liferay.object.model.ObjectFolder getUncategorizedObjectFolder(
+			long companyId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _objectFolderLocalService.getUncategorizedObjectFolder(
+			companyId);
 	}
 
 	/**

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/packageinfo
@@ -1,1 +1,1 @@
-version 51.0.0
+version 52.0.0

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/instance/lifecycle/SystemObjectDefinitionManagerPortalInstanceLifecycleListener.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/instance/lifecycle/SystemObjectDefinitionManagerPortalInstanceLifecycleListener.java
@@ -252,8 +252,15 @@ public class SystemObjectDefinitionManagerPortalInstanceLifecycleListener
 	}
 
 	private ObjectFolder _getUncategorizedObjectFolder(long companyId) {
+		ObjectFolder objectFolder =
+			_objectFolderLocalService.fetchUncategorizedObjectFolder(companyId);
+
+		if (objectFolder != null) {
+			return objectFolder;
+		}
+
 		try {
-			return _objectFolderLocalService.addOrGetUncategorizedObjectFolder(
+			return _objectFolderLocalService.addUncategorizedObjectFolder(
 				companyId);
 		}
 		catch (Exception exception) {

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/instance/lifecycle/SystemObjectDefinitionManagerPortalInstanceLifecycleListener.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/instance/lifecycle/SystemObjectDefinitionManagerPortalInstanceLifecycleListener.java
@@ -77,10 +77,15 @@ public class SystemObjectDefinitionManagerPortalInstanceLifecycleListener
 			_log.debug("Registered portal instance " + company);
 		}
 
+		ObjectFolder objectFolder = _getUncategorizedObjectFolder(
+			company.getCompanyId());
+
 		for (SystemObjectDefinitionManager systemObjectDefinitionManager :
 				_serviceTrackerList) {
 
-			_apply(company.getCompanyId(), systemObjectDefinitionManager);
+			_apply(
+				company.getCompanyId(), objectFolder,
+				systemObjectDefinitionManager);
 		}
 	}
 
@@ -117,7 +122,9 @@ public class SystemObjectDefinitionManagerPortalInstanceLifecycleListener
 					if (!_openingThreadLocal.get()) {
 						_companyLocalService.forEachCompanyId(
 							companyId -> _apply(
-								companyId, systemObjectDefinitionManager));
+								companyId,
+								_getUncategorizedObjectFolder(companyId),
+								systemObjectDefinitionManager));
 					}
 
 					return systemObjectDefinitionManager;
@@ -152,7 +159,7 @@ public class SystemObjectDefinitionManagerPortalInstanceLifecycleListener
 	}
 
 	private void _apply(
-		long companyId,
+		long companyId, ObjectFolder objectFolder,
 		SystemObjectDefinitionManager systemObjectDefinitionManager) {
 
 		if (_log.isDebugEnabled()) {
@@ -170,10 +177,6 @@ public class SystemObjectDefinitionManagerPortalInstanceLifecycleListener
 			if ((objectDefinition == null) ||
 				(objectDefinition.getVersion() !=
 					systemObjectDefinitionManager.getVersion())) {
-
-				ObjectFolder objectFolder =
-					_objectFolderLocalService.addOrGetUncategorizedObjectFolder(
-						companyId);
 
 				objectDefinition =
 					_objectDefinitionLocalService.
@@ -245,6 +248,16 @@ public class SystemObjectDefinitionManagerPortalInstanceLifecycleListener
 		}
 		catch (PortalException portalException) {
 			_log.error(portalException);
+		}
+	}
+
+	private ObjectFolder _getUncategorizedObjectFolder(long companyId) {
+		try {
+			return _objectFolderLocalService.addOrGetUncategorizedObjectFolder(
+				companyId);
+		}
+		catch (Exception exception) {
+			throw new RuntimeException(exception);
 		}
 	}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/instance/lifecycle/SystemObjectDefinitionManagerPortalInstanceLifecycleListener.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/instance/lifecycle/SystemObjectDefinitionManagerPortalInstanceLifecycleListener.java
@@ -63,7 +63,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Marco Leo
  * @author Brian Wing Shun Chan
  */
-@Component(service = PortalInstanceLifecycleListener.class)
+@Component(
+	property = "type=liferay.objects",
+	service = PortalInstanceLifecycleListener.class
+)
 public class SystemObjectDefinitionManagerPortalInstanceLifecycleListener
 	extends BasePortalInstanceLifecycleListener
 	implements EveryNodeEveryStartup {

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/model/listener/ObjectFolderModelListener.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/model/listener/ObjectFolderModelListener.java
@@ -35,7 +35,7 @@ public class ObjectFolderModelListener extends BaseModelListener<ObjectFolder> {
 
 		try {
 			ObjectFolder uncategorizedObjectFolder =
-				_objectFolderLocalService.addOrGetUncategorizedObjectFolder(
+				_objectFolderLocalService.getUncategorizedObjectFolder(
 					objectFolder.getCompanyId());
 
 			for (ObjectDefinition objectDefinition :

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/security/permission/resource/ObjectFolderModelResourcePermission.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/security/permission/resource/ObjectFolderModelResourcePermission.java
@@ -63,7 +63,7 @@ public class ObjectFolderModelResourcePermission
 
 		if (objectFolderId == 0) {
 			objectFolder =
-				_objectFolderLocalService.addOrGetUncategorizedObjectFolder(
+				_objectFolderLocalService.getUncategorizedObjectFolder(
 					permissionChecker.getCompanyId());
 		}
 		else {

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -1622,7 +1622,7 @@ public class ObjectDefinitionLocalServiceImpl
 
 		if (objectFolderId == 0) {
 			ObjectFolder objectFolder =
-				_objectFolderLocalService.addOrGetUncategorizedObjectFolder(
+				_objectFolderLocalService.getUncategorizedObjectFolder(
 					companyId);
 
 			return objectFolder.getObjectFolderId();

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFolderLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFolderLocalServiceImpl.java
@@ -77,32 +77,17 @@ public class ObjectFolderLocalServiceImpl
 		return objectFolder;
 	}
 
+	@Indexable(type = IndexableType.REINDEX)
 	@Override
-	public ObjectFolder addOrGetUncategorizedObjectFolder(long companyId)
+	public ObjectFolder addUncategorizedObjectFolder(long companyId)
 		throws PortalException {
 
-		ObjectFolder objectFolder = fetchObjectFolder(
-			companyId, ObjectFolderConstants.NAME_UNCATEGORIZED);
-
-		if (objectFolder != null) {
-			return objectFolder;
-		}
-
-		synchronized (this) {
-			objectFolder = fetchObjectFolder(
-				companyId, ObjectFolderConstants.NAME_UNCATEGORIZED);
-
-			if (objectFolder != null) {
-				return objectFolder;
-			}
-
-			return objectFolderLocalService.addObjectFolder(
-				ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_UNCATEGORIZED,
-				_userLocalService.getGuestUserId(companyId),
-				LocalizedMapUtil.getLocalizedMap(
-					ObjectFolderConstants.NAME_UNCATEGORIZED),
-				ObjectFolderConstants.NAME_UNCATEGORIZED);
-		}
+		return objectFolderLocalService.addObjectFolder(
+			ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_UNCATEGORIZED,
+			_userLocalService.getGuestUserId(companyId),
+			LocalizedMapUtil.getLocalizedMap(
+				ObjectFolderConstants.NAME_UNCATEGORIZED),
+			ObjectFolderConstants.NAME_UNCATEGORIZED);
 	}
 
 	@Override
@@ -161,10 +146,24 @@ public class ObjectFolderLocalServiceImpl
 	}
 
 	@Override
+	public ObjectFolder fetchUncategorizedObjectFolder(long companyId) {
+		return fetchObjectFolder(
+			companyId, ObjectFolderConstants.NAME_UNCATEGORIZED);
+	}
+
+	@Override
 	public ObjectFolder getObjectFolder(long companyId, String name)
 		throws PortalException {
 
 		return objectFolderPersistence.findByC_N(companyId, name);
+	}
+
+	@Override
+	public ObjectFolder getUncategorizedObjectFolder(long companyId)
+		throws PortalException {
+
+		return getObjectFolder(
+			companyId, ObjectFolderConstants.NAME_UNCATEGORIZED);
 	}
 
 	@Indexable(type = IndexableType.REINDEX)

--- a/modules/apps/object/object-service/src/main/resources/com/liferay/object/internal/batch/bookmarks.batch-engine-data.json
+++ b/modules/apps/object/object-service/src/main/resources/com/liferay/object/internal/batch/bookmarks.batch-engine-data.json
@@ -7,7 +7,7 @@
 	},
 	"configuration": {
 		"className": "com.liferay.object.admin.rest.dto.v1_0.ObjectDefinition",
-		"companyId": 0,
+		"multiCompany": true,
 		"parameters": {
 			"containsHeaders": "true",
 			"createStrategy": "UPSERT",

--- a/modules/apps/object/object-service/src/main/resources/com/liferay/object/internal/batch/bookmarks.batch-engine-data.json
+++ b/modules/apps/object/object-service/src/main/resources/com/liferay/object/internal/batch/bookmarks.batch-engine-data.json
@@ -1,10 +1,4 @@
 {
-	"actions": {
-		"createBatch": {
-			"href": "/o/object-admin/v1.0/import-task/com.liferay.object.admin.rest.dto.v1_0.ObjectDefinition",
-			"method": "POST"
-		}
-	},
 	"configuration": {
 		"className": "com.liferay.object.admin.rest.dto.v1_0.ObjectDefinition",
 		"multiCompany": true,


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPS-181945

---

The purpose of this PR is to fix [this bug](https://liferay.atlassian.net/browse/LPS-181945). The reason is because the Bookmarks Object Definitions were only created for the default company (so with the current functionality, that means with permissions checker for the default user). As it is a modifiable system object, it must be created in all the companies, that is why we have modified the multiCompany flag to true.

With that, the Permission Checker used is the Liberal one, as "Liferay" is the one creating the Object definitions.

Furthermore, we need to ensure that the `MultiCompanyBatchEngineUnitPortalInstanceLifecycleListener` component is always executed after every `PortalInstanceLifecycleListener`, as in Objects module there is one component that is creating a default Object Folder for each company.

Now, we are:

1. Registering with the lowest possible service.ranking, as we need to ensure everything that depends on the PortalInstanceLifecycleListener is executed to avoid race conditions.
2. Registering with an object based dependency, to ensure everything has been created before starting with the Batch import/export operations