### PR TITLE
LPS-197432 Fix indirect and direct related properties in API Builder

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/helper/EndpointHelper.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/helper/EndpointHelper.java
@@ -18,7 +18,6 @@ import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -153,15 +152,15 @@ public class EndpointHelper {
 
 		Map<String, Object> properties = objectEntry.getProperties();
 
-		ObjectEntry[] relatedObjectEntries = new ObjectEntry[0];
+		Object item = properties.get(relationshipsNames.remove(0));
 
-		Object relatedEntity = properties.get(relationshipsNames.remove(0));
+		List<ObjectEntry> relatedObjectEntries = new ArrayList<>();
 
-		if(relatedEntity instanceof ObjectEntry[]){
-			relatedObjectEntries = (ObjectEntry[]) relatedEntity;
-		} else {
-			relatedObjectEntries = Arrays.copyOf(relatedObjectEntries, relatedObjectEntries.length + 1);
-			relatedObjectEntries[relatedObjectEntries.length - 1] = (ObjectEntry) relatedEntity;
+		if (item instanceof ObjectEntry[]) {
+			relatedObjectEntries = ListUtil.fromArray((ObjectEntry[])item);
+		}
+		else {
+			relatedObjectEntries.add((ObjectEntry)item);
 		}
 
 		for (ObjectEntry relatedObjectEntry : relatedObjectEntries) {
@@ -200,10 +199,16 @@ public class EndpointHelper {
 				continue;
 			}
 
-			responseEntityMap.put(
-				property.getName(),
-				_getRelatedObjectValue(
-					objectEntry, property, objectRelationshipNames));
+			Object relatedObjectValue = _getRelatedObjectValue(
+				objectEntry, property, objectRelationshipNames);
+
+			if ((relatedObjectValue instanceof Collection<?>) &&
+				((Collection<?>)relatedObjectValue).isEmpty()) {
+
+				continue;
+			}
+
+			responseEntityMap.put(property.getName(), relatedObjectValue);
 		}
 
 		return responseEntityMap;

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/helper/EndpointHelper.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/helper/EndpointHelper.java
@@ -154,13 +154,13 @@ public class EndpointHelper {
 
 		Object item = properties.get(relationshipsNames.remove(0));
 
-		List<ObjectEntry> relatedObjectEntries = new ArrayList<>();
+		ObjectEntry[] relatedObjectEntries = null;
 
 		if (item instanceof ObjectEntry[]) {
-			relatedObjectEntries = ListUtil.fromArray((ObjectEntry[])item);
+			relatedObjectEntries = (ObjectEntry[])item;
 		}
 		else {
-			relatedObjectEntries.add((ObjectEntry)item);
+			relatedObjectEntries = new ObjectEntry[] {(ObjectEntry)item};
 		}
 
 		for (ObjectEntry relatedObjectEntry : relatedObjectEntries) {

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/helper/EndpointHelper.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/helper/EndpointHelper.java
@@ -18,6 +18,7 @@ import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -152,8 +153,16 @@ public class EndpointHelper {
 
 		Map<String, Object> properties = objectEntry.getProperties();
 
-		ObjectEntry[] relatedObjectEntries = (ObjectEntry[])properties.get(
-			relationshipsNames.remove(0));
+		ObjectEntry[] relatedObjectEntries = new ObjectEntry[0];
+
+		Object relatedEntity = properties.get(relationshipsNames.remove(0));
+
+		if(relatedEntity instanceof ObjectEntry[]){
+			relatedObjectEntries = (ObjectEntry[]) relatedEntity;
+		} else {
+			relatedObjectEntries = Arrays.copyOf(relatedObjectEntries, relatedObjectEntries.length + 1);
+			relatedObjectEntries[relatedObjectEntries.length - 1] = (ObjectEntry) relatedEntity;
+		}
 
 		for (ObjectEntry relatedObjectEntry : relatedObjectEntries) {
 			Object value = _getRelatedObjectValue(

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/helper/EndpointHelper.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/helper/EndpointHelper.java
@@ -199,16 +199,10 @@ public class EndpointHelper {
 				continue;
 			}
 
-			Object relatedObjectValue = _getRelatedObjectValue(
-				objectEntry, property, objectRelationshipNames);
-
-			if ((relatedObjectValue instanceof Collection<?>) &&
-				((Collection<?>)relatedObjectValue).isEmpty()) {
-
-				continue;
-			}
-
-			responseEntityMap.put(property.getName(), relatedObjectValue);
+			responseEntityMap.put(
+				property.getName(),
+				_getRelatedObjectValue(
+					objectEntry, property, objectRelationshipNames));
 		}
 
 		return responseEntityMap;

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/helper/EndpointHelper.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/helper/EndpointHelper.java
@@ -152,15 +152,18 @@ public class EndpointHelper {
 
 		Map<String, Object> properties = objectEntry.getProperties();
 
-		Object item = properties.get(relationshipsNames.remove(0));
+		Object relationshipNameValue = properties.get(
+			relationshipsNames.remove(0));
 
 		ObjectEntry[] relatedObjectEntries = null;
 
-		if (item instanceof ObjectEntry[]) {
-			relatedObjectEntries = (ObjectEntry[])item;
+		if (relationshipNameValue instanceof ObjectEntry[]) {
+			relatedObjectEntries = (ObjectEntry[])relationshipNameValue;
 		}
 		else {
-			relatedObjectEntries = new ObjectEntry[] {(ObjectEntry)item};
+			relatedObjectEntries = new ObjectEntry[] {
+				(ObjectEntry)relationshipNameValue
+			};
 		}
 
 		for (ObjectEntry relatedObjectEntry : relatedObjectEntries) {

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
@@ -930,6 +930,79 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 	}
 
 	@Test
+	public void testGetWithIndirectlyRelatedProperty() throws Exception {
+		JSONObject apiApplicationJSONObject = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				"applicationStatus", "published"
+			).put(
+				"baseURL", StringUtil.toLowerCase(RandomTestUtil.randomString())
+			).put(
+				"title", RandomTestUtil.randomString()
+			).toString(),
+			"headless-builder/applications", Http.Method.POST);
+
+		JSONObject apiEndpointJSONObject = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				"description", RandomTestUtil.randomString()
+			).put(
+				"httpMethod", "get"
+			).put(
+				"name", RandomTestUtil.randomString()
+			).put(
+				"name", RandomTestUtil.randomString()
+			).put(
+				"path", StringPool.FORWARD_SLASH + RandomTestUtil.randomString()
+			).put(
+				"r_apiApplicationToAPIEndpoints_c_apiApplicationId",
+				apiApplicationJSONObject.getLong("id")
+			).put(
+				"responseAPISchemaToAPIEndpoints",
+				JSONUtil.put(
+					"apiSchemaToAPIProperties",
+					JSONUtil.putAll(
+						JSONUtil.put(
+							"description", RandomTestUtil.randomString()
+						).put(
+							"name", RandomTestUtil.randomString()
+						).put(
+							"objectFieldERC", "NAME"
+						),
+						JSONUtil.put(
+							"description", RandomTestUtil.randomString()
+						).put(
+							"name", RandomTestUtil.randomString()
+						).put(
+							"objectFieldERC", "NAME"
+						).put(
+							"objectRelationshipNames",
+							"apiApplicationToAPIEndpoints,apiApplicationToAPI" +
+								"Schemas"
+						))
+				).put(
+					"description", RandomTestUtil.randomString()
+				).put(
+					"mainObjectDefinitionERC", "L_API_ENDPOINT"
+				).put(
+					"name", RandomTestUtil.randomString()
+				).put(
+					"r_apiApplicationToAPISchemas_c_apiApplicationId",
+					apiApplicationJSONObject.getLong("id")
+				)
+			).put(
+				"retrieveType", "collection"
+			).put(
+				"scope", "company"
+			).toString(),
+			"headless-builder/endpoints", Http.Method.POST);
+
+		assertSuccessfulHttpCode(
+			null,
+			"c/" + apiApplicationJSONObject.getString("baseURL") +
+				apiEndpointJSONObject.getString("path"),
+			Http.Method.GET);
+	}
+
+	@Test
 	public void testGetWithPagination() throws Exception {
 		_addAPIApplication(
 			_API_APPLICATION_ERC_1, _API_ENDPOINT_ERC_1, _BASE_URL_1,


### PR DESCRIPTION
## Aim of this PR
Changes from this [PR](https://github.com/liferay-headless/liferay-portal/pull/1550)

The aim of this PR is to solve direct and indirect API Properties from different Object Definitions. Apparently, it is not possible to create Object Entries with null object fields because it throws an Exception. However, it is possible to return API Properties where hasn't any related API Properties and this is retrieving in a empty array, this use case is control.

**Changes**
- Changes in the EndpointHelper to retrieve not null related object values

**Steps to reproduce**
1. Go to this [JIRA Ticket ](https://liferay.atlassian.net/browse/LPS-197432)and reproduce all the steps.

**Related JIRA Ticket**
https://liferay.atlassian.net/browse/LPS-197432