### PR TITLE
LRQA-83316 | Test fix for missing error message

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[APIRest]APIGenerator/GeneratePathStructureForEndpoints.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[APIRest]APIGenerator/GeneratePathStructureForEndpoints.testcase
@@ -165,12 +165,15 @@ definition {
 		}
 
 		task ("When I create an endpoint with id of API application and path not start with '/'") {
+			var applicationId = JSONPathUtil.getIdValue(response = ${response});
+
 			ApplicationsMenu.gotoPortlet(
 				category = "Object",
 				panel = "Control Panel",
 				portlet = "API Endpoints");
 
 			APIBuilderUI.createAPIEndpoint(
+				applicationId = ${applicationId},
 				name = "testEndpoint",
 				path = "testEndpoint");
 		}


### PR DESCRIPTION
Background:
Test fix for missing error message in GeneratePathStructureForEndpoints#CanValidatePathInAPIEndpoint

Jira ticket:
https://liferay.atlassian.net/browse/LRQA-83316