### PR TITLE
LPS-181945 Move UncategorizedObjectFolder creation to a new PortalInstanceLifecycleListener and move Object dependencies out of Batch Engine

### DIFF
--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/instance/lifecycle/MultiCompanyBatchEngineUnitPortalInstanceLifecycleListener.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/instance/lifecycle/MultiCompanyBatchEngineUnitPortalInstanceLifecycleListener.java
@@ -44,7 +44,7 @@ public class MultiCompanyBatchEngineUnitPortalInstanceLifecycleListener
 		_multiCompanyBatchEngineUnitProcessor;
 
 	@Reference(
-		target = "(component.name=com.liferay.object.internal.instance.lifecycle.SystemObjectDefinitionManagerPortalInstanceLifecycleListener)"
+		target = "(component.name=com.liferay.object.internal.instance.lifecycle.UncategorizedObjectFolderPortalInstanceLifecycleListener)"
 	)
 	private PortalInstanceLifecycleListener _portalInstanceLifecycleListener;
 

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectFolderLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectFolderLocalService.java
@@ -79,8 +79,7 @@ public interface ObjectFolderLocalService
 			Map<Locale, String> labelMap, String name)
 		throws PortalException;
 
-	@Indexable(type = IndexableType.REINDEX)
-	public ObjectFolder addUncategorizedObjectFolder(long companyId)
+	public ObjectFolder addOrGetUncategorizedObjectFolder(long companyId)
 		throws PortalException;
 
 	/**

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectFolderLocalServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectFolderLocalServiceUtil.java
@@ -60,10 +60,10 @@ public class ObjectFolderLocalServiceUtil {
 			externalReferenceCode, userId, labelMap, name);
 	}
 
-	public static ObjectFolder addUncategorizedObjectFolder(long companyId)
+	public static ObjectFolder addOrGetUncategorizedObjectFolder(long companyId)
 		throws PortalException {
 
-		return getService().addUncategorizedObjectFolder(companyId);
+		return getService().addOrGetUncategorizedObjectFolder(companyId);
 	}
 
 	/**

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectFolderLocalServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectFolderLocalServiceWrapper.java
@@ -57,11 +57,11 @@ public class ObjectFolderLocalServiceWrapper
 	}
 
 	@Override
-	public com.liferay.object.model.ObjectFolder addUncategorizedObjectFolder(
-			long companyId)
+	public com.liferay.object.model.ObjectFolder
+			addOrGetUncategorizedObjectFolder(long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
-		return _objectFolderLocalService.addUncategorizedObjectFolder(
+		return _objectFolderLocalService.addOrGetUncategorizedObjectFolder(
 			companyId);
 	}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/instance/lifecycle/SystemObjectDefinitionManagerPortalInstanceLifecycleListener.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/instance/lifecycle/SystemObjectDefinitionManagerPortalInstanceLifecycleListener.java
@@ -52,8 +52,6 @@ import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 
-import java.util.function.Supplier;
-
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.annotations.Activate;
@@ -76,29 +74,10 @@ public class SystemObjectDefinitionManagerPortalInstanceLifecycleListener
 			_log.debug("Registered portal instance " + company);
 		}
 
-		Supplier<ObjectFolder> objectFolderSupplier =
-			new Supplier<ObjectFolder>() {
-
-				@Override
-				public ObjectFolder get() {
-					if (_objectFolder == null) {
-						_objectFolder = _getUncategorizedObjectFolder(
-							company.getCompanyId());
-					}
-
-					return _objectFolder;
-				}
-
-				private ObjectFolder _objectFolder;
-
-			};
-
 		for (SystemObjectDefinitionManager systemObjectDefinitionManager :
 				_serviceTrackerList) {
 
-			_apply(
-				company.getCompanyId(), objectFolderSupplier,
-				systemObjectDefinitionManager);
+			_apply(company.getCompanyId(), systemObjectDefinitionManager);
 		}
 	}
 
@@ -135,9 +114,7 @@ public class SystemObjectDefinitionManagerPortalInstanceLifecycleListener
 					if (!_openingThreadLocal.get()) {
 						_companyLocalService.forEachCompanyId(
 							companyId -> _apply(
-								companyId,
-								() -> _getUncategorizedObjectFolder(companyId),
-								systemObjectDefinitionManager));
+								companyId, systemObjectDefinitionManager));
 					}
 
 					return systemObjectDefinitionManager;
@@ -172,7 +149,7 @@ public class SystemObjectDefinitionManagerPortalInstanceLifecycleListener
 	}
 
 	private void _apply(
-		long companyId, Supplier<ObjectFolder> objectFolderSupplier,
+		long companyId,
 		SystemObjectDefinitionManager systemObjectDefinitionManager) {
 
 		if (_log.isDebugEnabled()) {
@@ -191,7 +168,9 @@ public class SystemObjectDefinitionManagerPortalInstanceLifecycleListener
 				(objectDefinition.getVersion() !=
 					systemObjectDefinitionManager.getVersion())) {
 
-				ObjectFolder objectFolder = objectFolderSupplier.get();
+				ObjectFolder objectFolder =
+					_objectFolderLocalService.addOrGetUncategorizedObjectFolder(
+						companyId);
 
 				objectDefinition =
 					_objectDefinitionLocalService.
@@ -262,23 +241,6 @@ public class SystemObjectDefinitionManagerPortalInstanceLifecycleListener
 		}
 		catch (PortalException portalException) {
 			_log.error(portalException);
-		}
-	}
-
-	private ObjectFolder _getUncategorizedObjectFolder(long companyId) {
-		ObjectFolder objectFolder =
-			_objectFolderLocalService.fetchUncategorizedObjectFolder(companyId);
-
-		if (objectFolder != null) {
-			return objectFolder;
-		}
-
-		try {
-			return _objectFolderLocalService.addUncategorizedObjectFolder(
-				companyId);
-		}
-		catch (Exception exception) {
-			throw new RuntimeException(exception);
 		}
 	}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/instance/lifecycle/UncategorizedObjectFolderPortalInstanceLifecycleListener.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/instance/lifecycle/UncategorizedObjectFolderPortalInstanceLifecycleListener.java
@@ -1,0 +1,32 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.internal.instance.lifecycle;
+
+import com.liferay.object.service.ObjectFolderLocalService;
+import com.liferay.portal.instance.lifecycle.BasePortalInstanceLifecycleListener;
+import com.liferay.portal.instance.lifecycle.PortalInstanceLifecycleListener;
+import com.liferay.portal.kernel.model.Company;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Carlos Correa
+ */
+@Component(service = PortalInstanceLifecycleListener.class)
+public class UncategorizedObjectFolderPortalInstanceLifecycleListener
+	extends BasePortalInstanceLifecycleListener {
+
+	@Override
+	public void portalInstanceRegistered(Company company) throws Exception {
+		_objectFolderLocalService.addOrGetUncategorizedObjectFolder(
+			company.getCompanyId());
+	}
+
+	@Reference
+	private ObjectFolderLocalService _objectFolderLocalService;
+
+}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFolderLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFolderLocalServiceImpl.java
@@ -77,10 +77,16 @@ public class ObjectFolderLocalServiceImpl
 		return objectFolder;
 	}
 
-	@Indexable(type = IndexableType.REINDEX)
 	@Override
-	public ObjectFolder addUncategorizedObjectFolder(long companyId)
+	public ObjectFolder addOrGetUncategorizedObjectFolder(long companyId)
 		throws PortalException {
+
+		ObjectFolder objectFolder = fetchObjectFolder(
+			companyId, ObjectFolderConstants.NAME_UNCATEGORIZED);
+
+		if (objectFolder != null) {
+			return objectFolder;
+		}
 
 		return objectFolderLocalService.addObjectFolder(
 			ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_UNCATEGORIZED,


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPS-181945

---

The purpose of this PR is to fix the problems that we are finding when the UncategorizedObjectFolder is being created because of race condition problems.

cc/ @shuyangzhou 