### PR TITLE
LPS-197691 Fixed creation of properties that come from model definition of a related object

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-impl/build.gradle
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/build.gradle
@@ -19,6 +19,7 @@ dependencies {
 	compileOnly project(":apps:static:osgi:osgi-util")
 	compileOnly project(":core:osgi-service-tracker-collections")
 	compileOnly project(":core:petra:petra-function")
+	compileOnly project(":core:petra:petra-reflect")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/helper/EndpointHelper.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/helper/EndpointHelper.java
@@ -9,6 +9,7 @@ import com.liferay.headless.builder.application.APIApplication;
 import com.liferay.headless.builder.constants.HeadlessBuilderConstants;
 import com.liferay.object.exception.NoSuchObjectEntryException;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -16,6 +17,8 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+
+import java.lang.reflect.Field;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -138,14 +141,25 @@ public class EndpointHelper {
 	}
 
 	private Object _getRelatedObjectValue(
-		ObjectEntry objectEntry, APIApplication.Property property,
-		List<String> relationshipsNames) {
+			ObjectEntry objectEntry, APIApplication.Property property,
+			List<String> relationshipsNames)
+		throws Exception {
 
 		if (relationshipsNames.isEmpty()) {
 			Map<String, Object> objectEntryProperties =
 				objectEntry.getProperties();
 
-			return objectEntryProperties.get(property.getSourceFieldName());
+			Object object = objectEntryProperties.get(
+				property.getSourceFieldName());
+
+			if (object == null) {
+				Field declaredField = ReflectionUtil.getDeclaredField(
+					ObjectEntry.class, property.getSourceFieldName());
+
+				return declaredField.get(objectEntry);
+			}
+
+			return object;
 		}
 
 		List<Object> values = new ArrayList<>();
@@ -183,7 +197,8 @@ public class EndpointHelper {
 	}
 
 	private Map<String, Object> _getResponseEntityMap(
-		ObjectEntry objectEntry, APIApplication.Schema schema) {
+			ObjectEntry objectEntry, APIApplication.Schema schema)
+		throws Exception {
 
 		Map<String, Object> responseEntityMap = new HashMap<>();
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
@@ -41,6 +41,8 @@ import com.liferay.object.rest.test.util.ObjectDefinitionTestUtil;
 import com.liferay.object.rest.test.util.ObjectEntryTestUtil;
 import com.liferay.object.rest.test.util.ObjectFieldTestUtil;
 import com.liferay.object.rest.test.util.ObjectRelationshipTestUtil;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectFieldSettingLocalService;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
@@ -1049,6 +1051,87 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 	}
 
 	@Test
+	public void testGetWithRelatedModelProperty() throws Exception {
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_API_ENDPOINT", TestPropsValues.getCompanyId());
+
+		ObjectField objectField = _objectFieldLocalService.getObjectField(
+			objectDefinition.getObjectDefinitionId(), "externalReferenceCode");
+
+		JSONObject apiApplicationJSONObject = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				"applicationStatus", "published"
+			).put(
+				"baseURL", StringUtil.toLowerCase(RandomTestUtil.randomString())
+			).put(
+				"title", RandomTestUtil.randomString()
+			).toString(),
+			"headless-builder/applications", Http.Method.POST);
+
+		JSONObject apiEndpointJSONObject = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				"description", RandomTestUtil.randomString()
+			).put(
+				"httpMethod", "get"
+			).put(
+				"name", RandomTestUtil.randomString()
+			).put(
+				"path", StringPool.FORWARD_SLASH + RandomTestUtil.randomString()
+			).put(
+				"r_apiApplicationToAPIEndpoints_c_apiApplicationId",
+				apiApplicationJSONObject.getLong("id")
+			).put(
+				"responseAPISchemaToAPIEndpoints",
+				JSONUtil.put(
+					"apiSchemaToAPIProperties",
+					JSONUtil.putAll(
+						JSONUtil.put(
+							"description", RandomTestUtil.randomString()
+						).put(
+							"name", "APIEndpointsERC"
+						).put(
+							"objectFieldERC",
+							objectField.getExternalReferenceCode()
+						).put(
+							"objectRelationshipNames",
+							"apiApplicationToAPIEndpoints"
+						))
+				).put(
+					"description", RandomTestUtil.randomString()
+				).put(
+					"mainObjectDefinitionERC", "L_API_APPLICATION"
+				).put(
+					"name", RandomTestUtil.randomString()
+				).put(
+					"r_apiApplicationToAPISchemas_c_apiApplicationId",
+					apiApplicationJSONObject.getLong("id")
+				)
+			).put(
+				"retrieveType", "collection"
+			).put(
+				"scope", "company"
+			).toString(),
+			"headless-builder/endpoints", Http.Method.POST);
+
+		JSONObject responseJSONObject = HTTPTestUtil.invokeToJSONObject(
+			null,
+			"c/" + apiApplicationJSONObject.getString("baseURL") +
+				apiEndpointJSONObject.getString("path"),
+			Http.Method.GET);
+
+		JSONArray itemsJSONArray = responseJSONObject.getJSONArray("items");
+
+		JSONObject firstItemJSONObject = itemsJSONArray.getJSONObject(0);
+
+		JSONArray apiEndpointsERCJSONArray = firstItemJSONObject.getJSONArray(
+			"APIEndpointsERC");
+
+		Assert.assertNotEquals("", apiEndpointsERCJSONArray.getString(0));
+	}
+
+	@Test
 	public void testGetWithRequestFilter() throws Exception {
 		_addAPIApplication(
 			_API_APPLICATION_ERC_1, _API_ENDPOINT_ERC_1, _BASE_URL_1,
@@ -2049,6 +2132,12 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 
 	@DeleteAfterTestRun
 	private ObjectDefinition _objectDefinition3;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private ObjectFieldLocalService _objectFieldLocalService;
 
 	@Inject
 	private ObjectFieldSettingLocalService _objectFieldSettingLocalService;


### PR DESCRIPTION
**What's changed?:**
- Added new code that, in case the field of the related object searched is not found in the object properties, acceses the Object Definition model fields.

**What's new?**
- Added new tests that checks if the behavior is fixed.

See the following **Jira Ticket**: [LPS-197691](https://liferay.atlassian.net/browse/LPS-197691)