### PR TITLE
LPS-198510 Prevent ConcurrentModificationException by creating copies of entrySets

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -143,6 +143,7 @@ import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -619,7 +620,7 @@ public class ObjectDefinitionLocalServiceImpl
 		for (Map.Entry
 				<ObjectDefinitionDeployer,
 				 Map<Long, List<ServiceRegistration<?>>>> entry :
-					_serviceRegistrationsMaps.entrySet()) {
+					new HashSet<>(_serviceRegistrationsMaps.entrySet())) {
 
 			ObjectDefinitionDeployer objectDefinitionDeployer = entry.getKey();
 			Map<Long, List<ServiceRegistration<?>>> serviceRegistrationsMap =
@@ -1032,7 +1033,7 @@ public class ObjectDefinitionLocalServiceImpl
 		for (Map.Entry
 				<ObjectDefinitionDeployer,
 				 Map<Long, List<ServiceRegistration<?>>>> entry :
-					_serviceRegistrationsMaps.entrySet()) {
+					new HashSet<>(_serviceRegistrationsMaps.entrySet())) {
 
 			ObjectDefinitionDeployer objectDefinitionDeployer = entry.getKey();
 


### PR DESCRIPTION
What's changed?:
- Both deploy and undeploy methods from the ObjectDefinitionLocalService now use a copy of the same EntrySet in order to prevent the concurrent modification exception by accessing the same reference

See the following **Jira ticket**: [LPS-198510](https://liferay.atlassian.net/browse/LPS-198510)