### PR TITLE
LPS-198554 Support Maps (complex type) in GraphQL mutations

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -1803,6 +1803,10 @@ public class GraphQLServletExtender {
 				public Object parseLiteral(Object value)
 					throws CoercingParseLiteralException {
 
+					if (value instanceof ObjectValue) {
+						return _parseObjectValue((ObjectValue)value);
+					}
+
 					return value;
 				}
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -704,6 +704,64 @@ public class GraphQLServletExtender {
 		).build();
 	}
 
+	private static Object _parseLiteral(Object value)
+		throws CoercingParseLiteralException {
+
+		if (value instanceof ArrayValue) {
+			ArrayValue arrayValue = (ArrayValue)value;
+
+			return TransformUtil.transform(
+				arrayValue.getValues(), GraphQLServletExtender::_parseLiteral);
+		}
+		else if (value instanceof BooleanValue) {
+			BooleanValue booleanValue = (BooleanValue)value;
+
+			return booleanValue.isValue();
+		}
+		else if (value instanceof EnumValue) {
+			EnumValue enumValue = (EnumValue)value;
+
+			return enumValue.getName();
+		}
+		else if (value instanceof FloatValue) {
+			FloatValue floatValue = (FloatValue)value;
+
+			return floatValue.getValue();
+		}
+		else if (value instanceof IntValue) {
+			IntValue intValue = (IntValue)value;
+
+			return intValue.getValue();
+		}
+		else if (value instanceof NullValue) {
+			return null;
+		}
+		else if (value instanceof ObjectValue) {
+			return _parseObjectValue((ObjectValue)value);
+		}
+		else if (value instanceof StringValue) {
+			StringValue stringValue = (StringValue)value;
+
+			return stringValue.getValue();
+		}
+
+		throw new CoercingSerializeException("Unable to parse " + value);
+	}
+
+	private static Map<String, Object> _parseObjectValue(
+		ObjectValue objectValue) {
+
+		return new HashMap<String, Object>() {
+			{
+				for (ObjectField objectField : objectValue.getObjectFields()) {
+					put(
+						objectField.getName(),
+						_parseLiteral(objectField.getValue()));
+				}
+			}
+		};
+	}
+
 	private GraphQLArgument _addGraphQLArgument(
 		GraphQLInputType graphQLInputType, String name) {
 
@@ -1776,58 +1834,7 @@ public class GraphQLServletExtender {
 				public Object parseLiteral(Object value)
 					throws CoercingParseLiteralException {
 
-					if (value instanceof ArrayValue) {
-						ArrayValue arrayValue = (ArrayValue)value;
-
-						return TransformUtil.transform(
-							arrayValue.getValues(), this::parseLiteral);
-					}
-					else if (value instanceof BooleanValue) {
-						BooleanValue booleanValue = (BooleanValue)value;
-
-						return booleanValue.isValue();
-					}
-					else if (value instanceof EnumValue) {
-						EnumValue enumValue = (EnumValue)value;
-
-						return enumValue.getName();
-					}
-					else if (value instanceof FloatValue) {
-						FloatValue floatValue = (FloatValue)value;
-
-						return floatValue.getValue();
-					}
-					else if (value instanceof IntValue) {
-						IntValue intValue = (IntValue)value;
-
-						return intValue.getValue();
-					}
-					else if (value instanceof NullValue) {
-						return null;
-					}
-					else if (value instanceof ObjectValue) {
-						return new HashMap<String, Object>() {
-							{
-								ObjectValue objectValue = (ObjectValue)value;
-
-								for (ObjectField objectField :
-										objectValue.getObjectFields()) {
-
-									put(
-										objectField.getName(),
-										parseLiteral(objectField.getValue()));
-								}
-							}
-						};
-					}
-					else if (value instanceof StringValue) {
-						StringValue stringValue = (StringValue)value;
-
-						return stringValue.getValue();
-					}
-
-					throw new CoercingSerializeException(
-						"Unable to parse " + value);
+					return _parseLiteral(value);
 				}
 
 				@Override


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPS-198554

---

The purpose of this PR is to support Maps in GraphQL mutations. For that, the `public Object parseLiteral(Object value)` method of the `_mapGraphQLScalarType` `Coercing` has been modified in order to return a `Map<String, Object>` if the value passed by argument is an instance of an `ObjectValue` class. 