### PR TITLE
LPS-188951 Fixing test by using a valid hostname

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/test/ReverseProxyTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/test/ReverseProxyTest.java
@@ -52,13 +52,15 @@ public class ReverseProxyTest {
 				PropsValuesTestUtil.swapWithSafeCloseable(
 					"WEB_SERVER_FORWARDED_PROTOCOL_ENABLED", true)) {
 
-			urlConnection.addRequestProperty("X-Forwarded-Host", "myHost");
+			urlConnection.addRequestProperty(
+				"X-Forwarded-Host", "[0:0:0:0:0:0:0:1]");
 			urlConnection.addRequestProperty("X-Forwarded-Port", "12345");
 			urlConnection.addRequestProperty("X-Forwarded-Proto", "https");
 
 			String href = _getHref(urlConnection);
 
-			Assert.assertTrue(href, href.startsWith("https://myHost:12345"));
+			Assert.assertTrue(
+				href, href.startsWith("https://[0:0:0:0:0:0:0:1]:12345"));
 		}
 	}
 


### PR DESCRIPTION
The issue is that "myhost" was being rejected by this function:

https://github.com/liferay/liferay-portal/blob/a0adbd0ee3089689565155be61dc8caf47896b5e/portal-impl/src/com/liferay/portal/util/PortalImpl.java#L5977
