### PR TITLE
LPS-186757 | Expose query parameters in API Explorer for generated API

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/ApplicationAPI.macro
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/ApplicationAPI.macro
@@ -57,25 +57,40 @@ definition {
 				var externalReferenceCodeEndpoint = ${endpointName};
 			}
 
-			var relatedEndpoint = '''
+			if (isSet(retrieveType)) {
+				var relatedEndpoint = '''
 				"apiApplicationToAPIEndpoints": [{
-					"externalReferenceCode": "${externalReferenceCodeEndpoint}",
-					"httpMethod": "get",
-					"name": "${endpointName}",
-					"path": "${endpointPath}",
-					"scope": {"key": "${scopeKey}"}
-				}]
+						"externalReferenceCode": "${externalReferenceCodeEndpoint}",
+						"httpMethod": "get",
+						"name": "${endpointName}",
+						"path": "${endpointPath}",
+						"pathParameter": "${pathParameter}",
+						"retrieveType": "${retrieveType}",
+						"scope": {"key": "${scopeKey}"}
+					}]
 			''';
+			}
+			else {
+				var relatedEndpoint = '''
+				"apiApplicationToAPIEndpoints": [{
+						"externalReferenceCode": "${externalReferenceCodeEndpoint}",
+						"httpMethod": "get",
+						"name": "${endpointName}",
+						"path": "${endpointPath}",
+						"scope": {"key": "${scopeKey}"}
+					}]
+			''';
+			}
 
 			var body = StringUtil.add(${body}, ", ${relatedEndpoint}", "");
 		}
 
+		if (!(isSet(externalReferenceCodeSchema))) {
+			var externalReferenceCodeSchema = ${schemaName};
+		}
+
 		if (isSet(relatedSchema)) {
 			if (isSet(objectFieldErc) && isSet(mainObjectDefinitionErc)) {
-				if (!(isSet(externalReferenceCodeSchema))) {
-					var externalReferenceCodeSchema = ${schemaName};
-				}
-
 				var relatedSchema = '''
 				"apiApplicationToAPISchemas": [
     				{
@@ -97,6 +112,7 @@ definition {
 			else {
 				var relatedSchema = '''
 				"apiApplicationToAPISchemas": [{
+					"externalReferenceCode": "${externalReferenceCodeSchema}",
 					"mainObjectDefinitionERC": "${mainObjectDefinitionErc}",
 					"name": "${schemaName}"
 				}]

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/ApplicationAPI.macro
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/ApplicationAPI.macro
@@ -59,7 +59,7 @@ definition {
 
 			if (isSet(retrieveType)) {
 				var relatedEndpoint = '''
-				"apiApplicationToAPIEndpoints": [{
+					"apiApplicationToAPIEndpoints": [{
 						"externalReferenceCode": "${externalReferenceCodeEndpoint}",
 						"httpMethod": "get",
 						"name": "${endpointName}",
@@ -68,18 +68,18 @@ definition {
 						"retrieveType": "${retrieveType}",
 						"scope": {"key": "${scopeKey}"}
 					}]
-			''';
+				''';
 			}
 			else {
 				var relatedEndpoint = '''
-				"apiApplicationToAPIEndpoints": [{
+					"apiApplicationToAPIEndpoints": [{
 						"externalReferenceCode": "${externalReferenceCodeEndpoint}",
 						"httpMethod": "get",
 						"name": "${endpointName}",
 						"path": "${endpointPath}",
 						"scope": {"key": "${scopeKey}"}
 					}]
-			''';
+				''';
 			}
 
 			var body = StringUtil.add(${body}, ", ${relatedEndpoint}", "");
@@ -92,26 +92,26 @@ definition {
 		if (isSet(relatedSchema)) {
 			if (isSet(objectFieldErc) && isSet(mainObjectDefinitionErc)) {
 				var relatedSchema = '''
-				"apiApplicationToAPISchemas": [{
-					"apiSchemaToAPIProperties": [{
-						"objectFieldERC": "${objectFieldErc}",
-						"name": "${objectFieldErc}",
+					"apiApplicationToAPISchemas": [{
+						"apiSchemaToAPIProperties": [{
+							"objectFieldERC": "${objectFieldErc}",
+							"name": "${objectFieldErc}",
+							"description": "description"
+						}],
+						"externalReferenceCode": "${externalReferenceCodeSchema}",
+						"mainObjectDefinitionERC": "${mainObjectDefinitionErc}",
+						"name": "${schemaName}",
 						"description": "description"
-					}],
-					"externalReferenceCode": "${externalReferenceCodeSchema}",
-					"mainObjectDefinitionERC": "${mainObjectDefinitionErc}",
-					"name": "${schemaName}",
-					"description": "description"
-				}]
+					}]
 				''';
 			}
 			else {
 				var relatedSchema = '''
-				"apiApplicationToAPISchemas": [{
-					"externalReferenceCode": "${externalReferenceCodeSchema}",
-					"mainObjectDefinitionERC": "${mainObjectDefinitionErc}",
-					"name": "${schemaName}"
-				}]
+					"apiApplicationToAPISchemas": [{
+						"externalReferenceCode": "${externalReferenceCodeSchema}",
+						"mainObjectDefinitionERC": "${mainObjectDefinitionErc}",
+						"name": "${schemaName}"
+					}]
 				''';
 			}
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/ApplicationAPI.macro
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/ApplicationAPI.macro
@@ -92,21 +92,17 @@ definition {
 		if (isSet(relatedSchema)) {
 			if (isSet(objectFieldErc) && isSet(mainObjectDefinitionErc)) {
 				var relatedSchema = '''
-				"apiApplicationToAPISchemas": [
-    				{
-    				  "apiSchemaToAPIProperties": [
-    				    {
-    				      "objectFieldERC": "${objectFieldErc}",
-    				      "name": "${objectFieldErc}",
-    				      "description": "description"
-    				    }
-    				  ],
-					  "externalReferenceCode": "${externalReferenceCodeSchema}",
-    				  "mainObjectDefinitionERC": "${mainObjectDefinitionErc}",
-    				  "name": "${schemaName}",
-    				  "description": "description"
-    				}
-  				]
+				"apiApplicationToAPISchemas": [{
+					"apiSchemaToAPIProperties": [{
+						"objectFieldERC": "${objectFieldErc}",
+						"name": "${objectFieldErc}",
+						"description": "description"
+					}],
+					"externalReferenceCode": "${externalReferenceCodeSchema}",
+					"mainObjectDefinitionERC": "${mainObjectDefinitionErc}",
+					"name": "${schemaName}",
+					"description": "description"
+				}]
 				''';
 			}
 			else {

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/FilterAPI.macro
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/FilterAPI.macro
@@ -1,0 +1,42 @@
+definition {
+
+	macro _curlAPIFilter {
+		if (isSet(virtualHost)) {
+			if (!(isSet(port))) {
+				var port = 8080;
+			}
+
+			var portalURL = "http://${virtualHost}:${port}";
+		}
+		else {
+			var portalURL = JSONCompany.getPortalURL();
+		}
+
+		var api = "headless-builder/filters";
+
+		var curl = '''
+			${portalURL}/o/${api} \
+				-u test@liferay.com:test \
+				-H Content-Type: application/json
+		''';
+
+		return ${curl};
+	}
+
+	macro createAPIFilter {
+		Variables.assertDefined(parameterList = "${filterValue},${endpointId}");
+
+		var curl = FilterAPI._curlAPIFilter(virtualHost = ${virtualHost});
+		var body = '''
+			"oDataFilter": "${filterValue}",
+			"r_apiEndpointToAPIFilters_c_apiEndpointId": ${endpointId}
+		''';
+
+		var curl = StringUtil.add(${curl}, " -d { ${body} }", "");
+
+		var response = JSONCurlUtil.post(${curl});
+
+		return ${response};
+	}
+
+}

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/PropertyAPI.macro
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/PropertyAPI.macro
@@ -1,0 +1,43 @@
+definition {
+
+	macro _curlAPIProperty {
+		if (isSet(virtualHost)) {
+			if (!(isSet(port))) {
+				var port = 8080;
+			}
+
+			var portalURL = "http://${virtualHost}:${port}";
+		}
+		else {
+			var portalURL = JSONCompany.getPortalURL();
+		}
+
+		var api = "headless-builder/properties";
+
+		var curl = '''
+			${portalURL}/o/${api} \
+				-u test@liferay.com:test \
+				-H Content-Type: application/json
+		''';
+
+		return ${curl};
+	}
+
+	macro createAPIProperty {
+		Variables.assertDefined(parameterList = "${objectFieldERC},${name},${schemaId}");
+
+		var curl = PropertyAPI._curlAPIProperty(virtualHost = ${virtualHost});
+		var body = '''
+			"name": "${name}",
+			"objectFieldERC": "${objectFieldERC}",
+			"r_apiSchemaToAPIProperties_c_apiSchemaId": "${schemaId}"
+		''';
+
+		var curl = StringUtil.add(${curl}, " -d { ${body} }", "");
+
+		var response = JSONCurlUtil.post(${curl});
+
+		return ${response};
+	}
+
+}

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/SortAPI.macro
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/SortAPI.macro
@@ -1,0 +1,42 @@
+definition {
+
+	macro _curlAPISort {
+		if (isSet(virtualHost)) {
+			if (!(isSet(port))) {
+				var port = 8080;
+			}
+
+			var portalURL = "http://${virtualHost}:${port}";
+		}
+		else {
+			var portalURL = JSONCompany.getPortalURL();
+		}
+
+		var api = "headless-builder/sorts";
+
+		var curl = '''
+			${portalURL}/o/${api} \
+				-u test@liferay.com:test \
+				-H Content-Type: application/json
+		''';
+
+		return ${curl};
+	}
+
+	macro createAPISort {
+		Variables.assertDefined(parameterList = "${sortValue},${endpointId}");
+
+		var curl = SortAPI._curlAPISort(virtualHost = ${virtualHost});
+		var body = '''
+			"oDataSort": "${sortValue}",
+			"r_apiEndpointToAPISorts_c_apiEndpointId": ${endpointId}
+		''';
+
+		var curl = StringUtil.add(${curl}, " -d { ${body} }", "");
+
+		var response = JSONCurlUtil.post(${curl});
+
+		return ${response};
+	}
+
+}

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[APIRest]APIGenerator/ExposeQueryParametersInAPIExplorerForGeneratedAPI.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[APIRest]APIGenerator/ExposeQueryParametersInAPIExplorerForGeneratedAPI.testcase
@@ -1,0 +1,452 @@
+@component-name = "portal-headless"
+definition {
+
+	property custom.properties = "feature.flag.LPS-167253=true${line.separator}feature.flag.LPS-178642=true";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Object";
+	property testray.main.component.name = "Headless Builder";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+
+		task ("Given custom object Student with name text field is created and published") {
+			ObjectDefinitionAPI.createAndPublishObjectDefinition(
+				en_US_label = "Student",
+				en_US_plural_label = "Students",
+				name = "Student",
+				objectDefinitionExternalReferenceCode = "student",
+				requiredStringFieldName = "name",
+				requiredStringFieldNameExternalReferenceCode = "studentName");
+		}
+
+		task ("And Given Students Able, Tom and Test are created") {
+			ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "Students",
+				name = "Able");
+
+			ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "Students",
+				name = "Tom");
+
+			ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "Students",
+				name = "Test");
+		}
+	}
+
+	tearDown {
+		ApplicationAPI.deleteAllAPIApplication();
+
+		JSONObject.deleteAllCustomObjects();
+
+		var testLiferayVirtualInstance = PropsUtil.get("test.liferay.virtual.instance");
+
+		if (${testLiferayVirtualInstance} == "true") {
+			PortalInstances.tearDownCP();
+		}
+	}
+
+	@priority = 5
+	test CanApplyFilterParameter {
+		property portal.acceptance = "true";
+
+		task ("And Given an published API application with endpoint with related schema with Student as the main object") {
+			var response = ApplicationAPI.createAPIApplication(
+				baseURL = "my-app",
+				endpointName = "testEndpoint",
+				endpointPath = "/testEndpoint",
+				mainObjectDefinitionErc = "student",
+				relatedEndpoint = "true",
+				relatedSchema = "true",
+				schemaName = "testSchema",
+				status = "published",
+				title = "My-app");
+
+			SchemaAPI.relateRequestSchemaToEndpointByErc(
+				endpointErc = "testEndpoint",
+				requestSchemaErc = "testSchema");
+
+			SchemaAPI.relateResponseSchemaToEndpointByErc(
+				endpointErc = "testEndpoint",
+				responseSchemaErc = "testSchema");
+		}
+
+		task ("And Given I create schema a property with erc of name field") {
+			var schemaId = JSONUtil.getWithJSONPath(${response}, "$.apiApplicationToAPISchemas[*].id");
+
+			PropertyAPI.createAPIProperty(
+				name = "entryName",
+				objectFieldERC = "studentName",
+				schemaId = ${schemaId});
+		}
+
+		task ("When execute get{Endpoint}Page with filter={property} eq 'Able' in API Explorer") {
+			APIExplorer.navigateToOpenAPI(customObjectPlural = "my-app");
+
+			APIExplorer.executeAPIMethod(
+				method = "getTestEndpointPage",
+				parameter = "filter",
+				service = "testSchema",
+				value = "entryName eq 'Able'");
+		}
+
+		task ("Then I can see correct response with property equals to Able") {
+			AssertTextEquals.assertPartialText(
+				locator1 = "OpenAPI#RESPONSE_BODY",
+				method = "getTestEndpointPage",
+				value1 = "\"items\": [     {       \"entryName\": \"Able\"     }   ]");
+		}
+	}
+
+	@priority = 4
+	test CanApplyFilterParameterAndPreFilter {
+		property portal.acceptance = "true";
+
+		task ("And Given an published API application with endpoint with related schema with Student as the main object") {
+			var response = ApplicationAPI.createAPIApplication(
+				baseURL = "my-app",
+				endpointName = "testEndpoint",
+				endpointPath = "/testEndpoint",
+				mainObjectDefinitionErc = "student",
+				relatedEndpoint = "true",
+				relatedSchema = "true",
+				schemaName = "testSchema",
+				status = "published",
+				title = "My-app");
+
+			SchemaAPI.relateRequestSchemaToEndpointByErc(
+				endpointErc = "testEndpoint",
+				requestSchemaErc = "testSchema");
+
+			SchemaAPI.relateResponseSchemaToEndpointByErc(
+				endpointErc = "testEndpoint",
+				responseSchemaErc = "testSchema");
+		}
+
+		task ("And Given I create schema a property with erc of name field") {
+			var schemaId = JSONUtil.getWithJSONPath(${response}, "$.apiApplicationToAPISchemas[*].id");
+
+			PropertyAPI.createAPIProperty(
+				name = "entryName",
+				objectFieldERC = "studentName",
+				schemaId = ${schemaId});
+		}
+
+		task ("And Given I create endpoint a filter with name ne 'Test'") {
+			var endpointId = JSONUtil.getWithJSONPath(${response}, "$.apiApplicationToAPIEndpoints[*].id");
+
+			FilterAPI.createAPIFilter(
+				endpointId = ${endpointId},
+				filterValue = "name ne '\''Test'\''");
+		}
+
+		task ("When execute get{Endpoint}Page with filter={property} ne 'Able' in API Explorer") {
+			APIExplorer.navigateToOpenAPI(customObjectPlural = "my-app");
+
+			APIExplorer.executeAPIMethod(
+				method = "getTestEndpointPage",
+				parameter = "filter",
+				service = "testSchema",
+				value = "entryName ne 'Able'");
+		}
+
+		task ("Then only Tom returned in response") {
+			AssertTextEquals.assertPartialText(
+				locator1 = "OpenAPI#RESPONSE_BODY",
+				method = "getTestEndpointPage",
+				value1 = "\"items\": [     {       \"entryName\": \"Tom\"     }   ]");
+		}
+	}
+
+	@priority = 4
+	test CanApplyFilterSortAndPreFilterWithSiteScopedEndpoint {
+		property portal.acceptance = "true";
+
+		task ("And Given an published API application with site scoped endpoint with related schema with Student as the main object") {
+			var response = ApplicationAPI.createAPIApplication(
+				baseURL = "my-app",
+				endpointName = "testEndpoint",
+				endpointPath = "/testEndpoint",
+				mainObjectDefinitionErc = "student",
+				relatedEndpoint = "true",
+				relatedSchema = "true",
+				schemaName = "testSchema",
+				scopeKey = "group",
+				status = "published",
+				title = "My-app");
+
+			SchemaAPI.relateRequestSchemaToEndpointByErc(
+				endpointErc = "testEndpoint",
+				requestSchemaErc = "testSchema");
+
+			SchemaAPI.relateResponseSchemaToEndpointByErc(
+				endpointErc = "testEndpoint",
+				responseSchemaErc = "testSchema");
+		}
+
+		task ("And Given I create schema a property with erc of name field") {
+			var schemaId = JSONUtil.getWithJSONPath(${response}, "$.apiApplicationToAPISchemas[*].id");
+
+			PropertyAPI.createAPIProperty(
+				name = "entryName",
+				objectFieldERC = "studentName",
+				schemaId = ${schemaId});
+		}
+
+		task ("And Given I create endpoint a filter with name ne 'Test'") {
+			var endpointId = JSONUtil.getWithJSONPath(${response}, "$.apiApplicationToAPIEndpoints[*].id");
+
+			FilterAPI.createAPIFilter(
+				endpointId = ${endpointId},
+				filterValue = "name ne '\''Test'\''");
+		}
+
+		task ("When execute getScopeScopeKey{Endpoint}Page with scopeKey and ?filter={property} ne 'Test'&sort={property}:desc in API Explorer") {
+			var scopeKey = JSONGroupAPI._getGroupIdByNameNoSelenium(
+				groupName = "Guest",
+				site = "true");
+
+			APIExplorer.navigateToOpenAPI(customObjectPlural = "my-app");
+
+			APIExplorer.executeAPIMethod(
+				method = "getScopeScopeKeyTestEndpointPage",
+				parameter = "filter",
+				parameter_two = "sort",
+				scopeKey = ${scopeKey},
+				service = "testSchema",
+				value = "entryName ne 'Test'",
+				value_two = "entryName:desc");
+		}
+
+		task ("Then I can get correct response with items in desc {Tom, Able}") {
+			AssertTextEquals.assertPartialText(
+				locator1 = "OpenAPI#RESPONSE_BODY",
+				method = "getScopeScopeKeyTestEndpointPage",
+				value1 = "\"items\": [     {       \"entryName\": \"Tom\"     },     {       \"entryName\": \"Able\"     }   ]");
+		}
+	}
+
+	@priority = 5
+	test CanApplySortParameter {
+		property portal.acceptance = "true";
+
+		task ("And Given an published API application with endpoint with related schema with Student as the main object") {
+			var response = ApplicationAPI.createAPIApplication(
+				baseURL = "my-app",
+				endpointName = "testEndpoint",
+				endpointPath = "/testEndpoint",
+				mainObjectDefinitionErc = "student",
+				relatedEndpoint = "true",
+				relatedSchema = "true",
+				schemaName = "testSchema",
+				status = "published",
+				title = "My-app");
+
+			SchemaAPI.relateRequestSchemaToEndpointByErc(
+				endpointErc = "testEndpoint",
+				requestSchemaErc = "testSchema");
+
+			SchemaAPI.relateResponseSchemaToEndpointByErc(
+				endpointErc = "testEndpoint",
+				responseSchemaErc = "testSchema");
+		}
+
+		task ("And Given I create schema a property with erc of name field") {
+			var schemaId = JSONUtil.getWithJSONPath(${response}, "$.apiApplicationToAPISchemas[*].id");
+
+			PropertyAPI.createAPIProperty(
+				name = "entryName",
+				objectFieldERC = "studentName",
+				schemaId = ${schemaId});
+		}
+
+		task ("When execute get{Endpoint}Page with sort={property}:desc in API Explorer") {
+			APIExplorer.navigateToOpenAPI(customObjectPlural = "my-app");
+
+			APIExplorer.executeAPIMethod(
+				method = "getTestEndpointPage",
+				parameter = "sort",
+				service = "testSchema",
+				value = "entryName:desc");
+		}
+
+		task ("Then I can see correct response with items in desc {Test,Tom,Able}") {
+			AssertTextEquals.assertPartialText(
+				locator1 = "OpenAPI#RESPONSE_BODY",
+				method = "getTestEndpointPage",
+				value1 = "\"items\": [     {       \"entryName\": \"Tom\"     },     {       \"entryName\": \"Test\"     },     {       \"entryName\": \"Able\"     }   ]");
+		}
+	}
+
+	@priority = 4
+	test CanApplySortParameterAndPreSort {
+		property portal.acceptance = "true";
+
+		task ("And Given an published API application with endpoint with related schema with Student as the main object") {
+			var response = ApplicationAPI.createAPIApplication(
+				baseURL = "my-app",
+				endpointName = "testEndpoint",
+				endpointPath = "/testEndpoint",
+				mainObjectDefinitionErc = "student",
+				relatedEndpoint = "true",
+				relatedSchema = "true",
+				schemaName = "testSchema",
+				status = "published",
+				title = "My-app");
+
+			SchemaAPI.relateRequestSchemaToEndpointByErc(
+				endpointErc = "testEndpoint",
+				requestSchemaErc = "testSchema");
+
+			SchemaAPI.relateResponseSchemaToEndpointByErc(
+				endpointErc = "testEndpoint",
+				responseSchemaErc = "testSchema");
+		}
+
+		task ("And Given I create schema a property with erc of name field") {
+			var schemaId = JSONUtil.getWithJSONPath(${response}, "$.apiApplicationToAPISchemas[*].id");
+
+			PropertyAPI.createAPIProperty(
+				name = "entryName",
+				objectFieldERC = "studentName",
+				schemaId = ${schemaId});
+		}
+
+		task ("And Given I create endpoint a sort with name:asc") {
+			var endpointId = JSONUtil.getWithJSONPath(${response}, "$.apiApplicationToAPIEndpoints[*].id");
+
+			SortAPI.createAPISort(
+				endpointId = ${endpointId},
+				sortValue = "name:asc");
+		}
+
+		task ("When execute get{Endpoint}Page with sort {property}:desc in API Explorer") {
+			APIExplorer.navigateToOpenAPI(customObjectPlural = "my-app");
+
+			APIExplorer.executeAPIMethod(
+				method = "getTestEndpointPage",
+				parameter = "sort",
+				service = "testSchema",
+				value = "entryName:desc");
+		}
+
+		task ("Then I can see items in desc sort order in response") {
+			AssertTextEquals.assertPartialText(
+				locator1 = "OpenAPI#RESPONSE_BODY",
+				method = "getTestEndpointPage",
+				value1 = "\"items\": [     {       \"entryName\": \"Tom\"     },     {       \"entryName\": \"Test\"     },     {       \"entryName\": \"Able\"     }   ]");
+		}
+	}
+
+	@priority = 4
+	test CannotSeeFilterAndSortParametersForSingleElementEndpoint {
+		property portal.acceptance = "true";
+
+		task ("Given an published API application with singleElement endpoint") {
+			ApplicationAPI.createAPIApplication(
+				baseURL = "my-app",
+				endpointName = "testEndpoint",
+				endpointPath = "/testEndpoint/{id}",
+				pathParameter = "ID",
+				relatedEndpoint = "true",
+				retrieveType = "singleElement",
+				status = "published",
+				title = "My-app");
+		}
+
+		task ("When I expand get{EndpointPath} in /o/c/{aPIApplication}") {
+			APIExplorer.navigateToOpenAPI(customObjectPlural = "my-app");
+
+			APIExplorer.expandAPIMethod(
+				method = "getTestEndpointId",
+				service = "default");
+		}
+
+		task ("Then filter and sort parameters are not present") {
+			AssertElementNotPresent(
+				locator1 = "OpenAPI#PARAMETER_UNDER_METHOD",
+				method = "getTestEndpointId",
+				parameter = "filter");
+
+			AssertElementNotPresent(
+				locator1 = "OpenAPI#PARAMETER_UNDER_METHOD",
+				method = "getTestEndpointId",
+				parameter = "sort");
+		}
+	}
+
+	@priority = 4
+	test CanSeeFilterAndSortParametersInComapnyScopedEndpoint {
+		property portal.acceptance = "true";
+
+		task ("Given an published API application with company scoped endpoint") {
+			ApplicationAPI.createAPIApplication(
+				baseURL = "my-app",
+				endpointName = "testEndpoint",
+				endpointPath = "/testEndpoint",
+				relatedEndpoint = "true",
+				status = "published",
+				title = "My-app");
+		}
+
+		task ("When I expand get{endpoint}Page in /o/c/{aPIApplication}") {
+			APIExplorer.navigateToOpenAPI(customObjectPlural = "my-app");
+
+			APIExplorer.expandAPIMethod(
+				method = "getTestEndpointPage",
+				service = "default");
+		}
+
+		task ("Then I can see filter and sort parameters with string type are present") {
+			AssertElementPresent(
+				locator1 = "OpenAPI#PARAMETER_TYPE",
+				parameter = "filter",
+				type = "string");
+
+			AssertElementPresent(
+				locator1 = "OpenAPI#PARAMETER_TYPE",
+				parameter = "sort",
+				type = "string");
+		}
+	}
+
+	@priority = 4
+	test CanSeeFilterAndSortParametersInSiteScopedEndpoint {
+		property portal.acceptance = "true";
+
+		task ("Given an published API application with site scoped endpoint") {
+			ApplicationAPI.createAPIApplication(
+				baseURL = "my-app",
+				endpointName = "testEndpoint",
+				endpointPath = "/testEndpoint",
+				relatedEndpoint = "true",
+				scopeKey = "group",
+				status = "published",
+				title = "My-app");
+		}
+
+		task ("When I expand getscopeScopeKey{Endpoint}Page in /o/c/{aPIApplication}") {
+			APIExplorer.navigateToOpenAPI(customObjectPlural = "my-app");
+
+			APIExplorer.expandAPIMethod(
+				method = "getScopeScopeKeyTestEndpointPage",
+				service = "default");
+		}
+
+		task ("Then I can see filter and sort parameters with string type are present") {
+			AssertElementPresent(
+				locator1 = "OpenAPI#PARAMETER_TYPE",
+				parameter = "filter",
+				type = "string");
+
+			AssertElementPresent(
+				locator1 = "OpenAPI#PARAMETER_TYPE",
+				parameter = "sort",
+				type = "string");
+		}
+	}
+
+}

--- a/modules/apps/headless/headless-discovery/headless-discovery-test/src/testFunctional/macros/APIExplorer.macro
+++ b/modules/apps/headless/headless-discovery/headless-discovery-test/src/testFunctional/macros/APIExplorer.macro
@@ -72,8 +72,7 @@ definition {
 	macro executeAPIMethod {
 		Variables.assertDefined(parameterList = "${service},${method}");
 
-		Click(
-			locator1 = "OpenAPI#API_METHOD",
+		APIExplorer.expandAPIMethod(
 			method = ${method},
 			service = ${service});
 
@@ -100,6 +99,14 @@ definition {
 					method = ${method},
 					parameter = ${parameter_two},
 					value1 = ${value_two});
+			}
+
+			if (isSet(scopeKey)) {
+				Type(
+					locator1 = "OpenAPI#PARAMETER_UNDER_METHOD",
+					method = ${method},
+					parameter = "scopeKey",
+					value1 = ${scopeKey});
 			}
 		}
 
@@ -137,6 +144,15 @@ definition {
 		Click(
 			locator1 = "Button#BUTTON_WITH_VALUE",
 			value = "Execute Query (Ctrl-Enter)");
+	}
+
+	macro expandAPIMethod {
+		Variables.assertDefined(parameterList = "${service},${method}");
+
+		Click(
+			locator1 = "OpenAPI#API_METHOD",
+			method = ${method},
+			service = ${service});
 	}
 
 	macro expandPropertyInActionsSchema {

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portal/openapi/OpenAPI.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portal/openapi/OpenAPI.path
@@ -72,6 +72,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>PARAMETER_TYPE</td>
+	<td>//td[@class='parameters-col_name' and contains(.,'${parameter}') and contains(.,'${type}')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>RESPONSE_CODE</td>
 	<td>//div[contains(@id,'${method}')]//tbody//td[contains(@class,'response-col_status')][1]</td>
 	<td></td>


### PR DESCRIPTION
Background:
Add a testcase to expose query parameters in API Explorer for generated API

Test Plan
CanSeeFilterAndSortParametersInComapnyScopedEndpoint
Given an published API application with company scoped endpoint
When I expand get{endpoint}Page in /o/c/{aPIApplication}
Then I can see filter and sort parameters with string type are present

CanSeeFilterAndSortParametersInSiteScopedEndpoint
Given an published API application with site scoped endpoint
When I expand getscopeScopeKey{Endpoint}Page in /o/c/{aPIApplication}
Then I can see filter and sort parameters with string type are present

CannotSeeFilterAndSortParametersForSingleElementEndpoint
Given an published API application with singleElement endpoint
When I expand get{EndpointPath} in /o/c/{aPIApplication}
Then filter and sort parameters are not present

CanApplyFilterParameter
When execute get{Endpoint}Page with filter={property} eq 'Able' in API Explorer
Then I can see correct response with property equals to Able

CanApplySortParameter
When execute get{Endpoint}Page with sort={property}:desc in API Explorer
Then I can see correct response with items in desc {Test,Tom,Able}

CanApplyFilterParameterAndPreFilter
And Given I create endpoint a filter with name ne 'Test'
When execute get{Endpoint}Page with filter={property} ne 'Able' in API Explorer
Then only Tom returned in response

CanApplySortParameterAndPreSort
And Given I create endpoint a sort with name:asc
When execute get{Endpoint}Page with sort {property}:desc in API Explorer
Then I can see items in desc sort order in response

CanApplyFilterSortAndPreFilterWithSiteScopedEndpoint
Given custom object Student with name text field is created and published
And Given Students Able, Tom and Test are created
And Given an published API application with site scoped endpoint with related schema with Student as the main object   
And Given I create schema a property with erc of name field
And Given I create endpoint a filter with name ne 'Test'
When execute getScopeScopeKey{Endpoint}Page with scopeKey and ?filter={property} ne 'Test'&sort={property}:desc in API Explorer
Then I can get correct response with items in desc {Tom, Able}

Jira ticket:
https://liferay.atlassian.net/browse/LPS-195507