### PR TITLE
LPS-199071: Capital letter should not be allowed in path when creating an endpoint 

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIEndpointRelevantObjectEntryModelListener.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIEndpointRelevantObjectEntryModelListener.java
@@ -166,7 +166,12 @@ public class APIEndpointRelevantObjectEntryModelListener
 					String message = null;
 					String messageKey = null;
 
-					if (pathString.startsWith(StringPool.FORWARD_SLASH)) {
+					if (!StringUtil.isLowerCase(pathString)) {
+						message = "%s must contain only lower case characters";
+						messageKey =
+							"x-must-contain-only-lower-case-characters";
+					}
+					else if (pathString.startsWith(StringPool.FORWARD_SLASH)) {
 						message =
 							"%s can have a maximum of 255 alphanumeric " +
 								"characters";
@@ -314,6 +319,18 @@ public class APIEndpointRelevantObjectEntryModelListener
 				"single-element-id-endpoint-cannot-be-scoped-by-group");
 		}
 
+		String pathInParameterString = StringUtil.extractLast(
+			pathString, StringPool.FORWARD_SLASH);
+
+		if (!StringUtil.isLowerCase(
+				StringUtil.extractFirst(pathString, pathInParameterString))) {
+
+			throw new ObjectEntryValuesException.InvalidObjectField(
+				Arrays.asList(objectField.getLabel(user.getLocale())),
+				"%s must contain only lower case characters",
+				"x-must-contain-only-lower-case-characters");
+		}
+
 		Matcher singleElementPathMatcher = _singleElementPathPattern.matcher(
 			pathString);
 
@@ -323,9 +340,6 @@ public class APIEndpointRelevantObjectEntryModelListener
 				"%s can have a maximum of 255 alphanumeric characters",
 				"x-can-have-a-maximum-of-255-alphanumeric-characters");
 		}
-
-		String pathInParameterString = StringUtil.extractLast(
-			pathString, StringPool.FORWARD_SLASH);
 
 		Matcher curlyBraceMatcher = _curlyBracePattern.matcher(
 			pathInParameterString);
@@ -341,7 +355,7 @@ public class APIEndpointRelevantObjectEntryModelListener
 	private static final Pattern _curlyBracePattern = Pattern.compile(
 		"^\\{[a-zA-Z0-9]+\\}$");
 	private static final Pattern _pathPattern = Pattern.compile(
-		"/[a-zA-Z0-9][a-zA-Z0-9-/]{1,253}");
+		"/[a-z0-9][a-z0-9-/]{1,253}");
 	private static final Pattern _singleElementPathPattern = Pattern.compile(
 		"/[a-zA-Z0-9][a-zA-Z0-9-/-{\\-}]{1,253}");
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/APIBuilder-Multitenant/SupportMultitenancyForHeadlessBuilderRESTAPI.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/APIBuilder-Multitenant/SupportMultitenancyForHeadlessBuilderRESTAPI.testcase
@@ -15,8 +15,8 @@ definition {
 		task ("Given an published API application with endpoint and schema created in default instance") {
 			ApplicationAPI.createAPIApplication(
 				baseURL = "my-app",
-				endpointName = "testEndpoint",
-				endpointPath = "/testEndpoint",
+				endpointName = "testendpoint",
+				endpointPath = "/testendpoint",
 				mainObjectDefinitionErc = "L_API_APPLICATION",
 				relatedEndpoint = "true",
 				relatedSchema = "true",

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/Clustering/ChangePublicationStatusOnClusterNodes.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/Clustering/ChangePublicationStatusOnClusterNodes.testcase
@@ -80,8 +80,8 @@ definition {
 		task ("And Given APIApplication with endpoint created on the default node") {
 			var response = ApplicationAPI.createAPIApplication(
 				baseURL = "my-app",
-				endpointName = "testEndpoint",
-				endpointPath = "/testEndpoint",
+				endpointName = "testendpoint",
+				endpointPath = "/testendpoint",
 				mainObjectDefinitionErc = "Student",
 				objectFieldErc = "nameStudent",
 				relatedEndpoint = "true",
@@ -91,18 +91,18 @@ definition {
 				title = "My-app");
 
 			SchemaAPI.relateRequestSchemaToEndpointByErc(
-				endpointErc = "testEndpoint",
+				endpointErc = "testendpoint",
 				requestSchemaErc = "testSchema");
 
 			SchemaAPI.relateResponseSchemaToEndpointByErc(
-				endpointErc = "testEndpoint",
+				endpointErc = "testendpoint",
 				responseSchemaErc = "testSchema");
 		}
 
 		task ("When executing the endpoint on second node") {
 			var response = APIApplicationEndpoint.getEndpoint(
 				baseURL = "my-app",
-				path = "/testEndpoint",
+				path = "/testendpoint",
 				portalURL = "http://localhost:9080");
 		}
 
@@ -144,8 +144,8 @@ definition {
 		task ("And Given APIApplication with endpoint created on the second node") {
 			var response = ApplicationAPI.createAPIApplication(
 				baseURL = "my-app",
-				endpointName = "testEndpoint",
-				endpointPath = "/testEndpoint",
+				endpointName = "testendpoint",
+				endpointPath = "/testendpoint",
 				mainObjectDefinitionErc = "Student",
 				objectFieldErc = "nameStudent",
 				portalURL = "http://localhost:9080",
@@ -156,12 +156,12 @@ definition {
 				title = "My-app");
 
 			SchemaAPI.relateRequestSchemaToEndpointByErc(
-				endpointErc = "testEndpoint",
+				endpointErc = "testendpoint",
 				portalURL = "http://localhost:9080",
 				requestSchemaErc = "testSchema");
 
 			SchemaAPI.relateResponseSchemaToEndpointByErc(
-				endpointErc = "testEndpoint",
+				endpointErc = "testendpoint",
 				portalURL = "http://localhost:9080",
 				responseSchemaErc = "testSchema");
 		}
@@ -169,7 +169,7 @@ definition {
 		task ("When executing the endpoint on the default node") {
 			var response = APIApplicationEndpoint.getEndpoint(
 				baseURL = "my-app",
-				path = "/testEndpoint",
+				path = "/testendpoint",
 				portalURL = "http://localhost:8080");
 		}
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[APIRest]APIGenerator/ExposeQueryParametersInAPIExplorerForGeneratedAPI.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[APIRest]APIGenerator/ExposeQueryParametersInAPIExplorerForGeneratedAPI.testcase
@@ -56,8 +56,8 @@ definition {
 		task ("And Given an published API application with endpoint with related schema with Student as the main object") {
 			var response = ApplicationAPI.createAPIApplication(
 				baseURL = "my-app",
-				endpointName = "testEndpoint",
-				endpointPath = "/testEndpoint",
+				endpointName = "testendpoint",
+				endpointPath = "/testendpoint",
 				mainObjectDefinitionErc = "student",
 				relatedEndpoint = "true",
 				relatedSchema = "true",
@@ -66,11 +66,11 @@ definition {
 				title = "My-app");
 
 			SchemaAPI.relateRequestSchemaToEndpointByErc(
-				endpointErc = "testEndpoint",
+				endpointErc = "testendpoint",
 				requestSchemaErc = "testSchema");
 
 			SchemaAPI.relateResponseSchemaToEndpointByErc(
-				endpointErc = "testEndpoint",
+				endpointErc = "testendpoint",
 				responseSchemaErc = "testSchema");
 		}
 
@@ -87,7 +87,7 @@ definition {
 			APIExplorer.navigateToOpenAPI(customObjectPlural = "my-app");
 
 			APIExplorer.executeAPIMethod(
-				method = "getTestEndpointPage",
+				method = "getTestendpointPage",
 				parameter = "filter",
 				service = "testSchema",
 				value = "entryName eq 'Able'");
@@ -96,7 +96,7 @@ definition {
 		task ("Then I can see correct response with property equals to Able") {
 			AssertTextEquals.assertPartialText(
 				locator1 = "OpenAPI#RESPONSE_BODY",
-				method = "getTestEndpointPage",
+				method = "getTestendpointPage",
 				value1 = "\"items\": [     {       \"entryName\": \"Able\"     }   ]");
 		}
 	}
@@ -108,8 +108,8 @@ definition {
 		task ("And Given an published API application with endpoint with related schema with Student as the main object") {
 			var response = ApplicationAPI.createAPIApplication(
 				baseURL = "my-app",
-				endpointName = "testEndpoint",
-				endpointPath = "/testEndpoint",
+				endpointName = "testendpoint",
+				endpointPath = "/testendpoint",
 				mainObjectDefinitionErc = "student",
 				relatedEndpoint = "true",
 				relatedSchema = "true",
@@ -118,11 +118,11 @@ definition {
 				title = "My-app");
 
 			SchemaAPI.relateRequestSchemaToEndpointByErc(
-				endpointErc = "testEndpoint",
+				endpointErc = "testendpoint",
 				requestSchemaErc = "testSchema");
 
 			SchemaAPI.relateResponseSchemaToEndpointByErc(
-				endpointErc = "testEndpoint",
+				endpointErc = "testendpoint",
 				responseSchemaErc = "testSchema");
 		}
 
@@ -147,7 +147,7 @@ definition {
 			APIExplorer.navigateToOpenAPI(customObjectPlural = "my-app");
 
 			APIExplorer.executeAPIMethod(
-				method = "getTestEndpointPage",
+				method = "getTestendpointPage",
 				parameter = "filter",
 				service = "testSchema",
 				value = "entryName ne 'Able'");
@@ -156,7 +156,7 @@ definition {
 		task ("Then only Tom returned in response") {
 			AssertTextEquals.assertPartialText(
 				locator1 = "OpenAPI#RESPONSE_BODY",
-				method = "getTestEndpointPage",
+				method = "getTestendpointPage",
 				value1 = "\"items\": [     {       \"entryName\": \"Tom\"     }   ]");
 		}
 	}
@@ -168,8 +168,8 @@ definition {
 		task ("And Given an published API application with site scoped endpoint with related schema with Student as the main object") {
 			var response = ApplicationAPI.createAPIApplication(
 				baseURL = "my-app",
-				endpointName = "testEndpoint",
-				endpointPath = "/testEndpoint",
+				endpointName = "testendpoint",
+				endpointPath = "/testendpoint",
 				mainObjectDefinitionErc = "student",
 				relatedEndpoint = "true",
 				relatedSchema = "true",
@@ -179,11 +179,11 @@ definition {
 				title = "My-app");
 
 			SchemaAPI.relateRequestSchemaToEndpointByErc(
-				endpointErc = "testEndpoint",
+				endpointErc = "testendpoint",
 				requestSchemaErc = "testSchema");
 
 			SchemaAPI.relateResponseSchemaToEndpointByErc(
-				endpointErc = "testEndpoint",
+				endpointErc = "testendpoint",
 				responseSchemaErc = "testSchema");
 		}
 
@@ -212,7 +212,7 @@ definition {
 			APIExplorer.navigateToOpenAPI(customObjectPlural = "my-app");
 
 			APIExplorer.executeAPIMethod(
-				method = "getScopeScopeKeyTestEndpointPage",
+				method = "getScopeScopeKeyTestendpointPage",
 				parameter = "filter",
 				parameter_two = "sort",
 				scopeKey = ${scopeKey},
@@ -224,7 +224,7 @@ definition {
 		task ("Then I can get correct response with items in desc {Tom, Able}") {
 			AssertTextEquals.assertPartialText(
 				locator1 = "OpenAPI#RESPONSE_BODY",
-				method = "getScopeScopeKeyTestEndpointPage",
+				method = "getScopeScopeKeyTestendpointPage",
 				value1 = "\"items\": [     {       \"entryName\": \"Tom\"     },     {       \"entryName\": \"Able\"     }   ]");
 		}
 	}
@@ -236,8 +236,8 @@ definition {
 		task ("And Given an published API application with endpoint with related schema with Student as the main object") {
 			var response = ApplicationAPI.createAPIApplication(
 				baseURL = "my-app",
-				endpointName = "testEndpoint",
-				endpointPath = "/testEndpoint",
+				endpointName = "testendpoint",
+				endpointPath = "/testendpoint",
 				mainObjectDefinitionErc = "student",
 				relatedEndpoint = "true",
 				relatedSchema = "true",
@@ -246,11 +246,11 @@ definition {
 				title = "My-app");
 
 			SchemaAPI.relateRequestSchemaToEndpointByErc(
-				endpointErc = "testEndpoint",
+				endpointErc = "testendpoint",
 				requestSchemaErc = "testSchema");
 
 			SchemaAPI.relateResponseSchemaToEndpointByErc(
-				endpointErc = "testEndpoint",
+				endpointErc = "testendpoint",
 				responseSchemaErc = "testSchema");
 		}
 
@@ -267,7 +267,7 @@ definition {
 			APIExplorer.navigateToOpenAPI(customObjectPlural = "my-app");
 
 			APIExplorer.executeAPIMethod(
-				method = "getTestEndpointPage",
+				method = "getTestendpointPage",
 				parameter = "sort",
 				service = "testSchema",
 				value = "entryName:desc");
@@ -276,7 +276,7 @@ definition {
 		task ("Then I can see correct response with items in desc {Test,Tom,Able}") {
 			AssertTextEquals.assertPartialText(
 				locator1 = "OpenAPI#RESPONSE_BODY",
-				method = "getTestEndpointPage",
+				method = "getTestendpointPage",
 				value1 = "\"items\": [     {       \"entryName\": \"Tom\"     },     {       \"entryName\": \"Test\"     },     {       \"entryName\": \"Able\"     }   ]");
 		}
 	}
@@ -288,8 +288,8 @@ definition {
 		task ("And Given an published API application with endpoint with related schema with Student as the main object") {
 			var response = ApplicationAPI.createAPIApplication(
 				baseURL = "my-app",
-				endpointName = "testEndpoint",
-				endpointPath = "/testEndpoint",
+				endpointName = "testendpoint",
+				endpointPath = "/testendpoint",
 				mainObjectDefinitionErc = "student",
 				relatedEndpoint = "true",
 				relatedSchema = "true",
@@ -298,11 +298,11 @@ definition {
 				title = "My-app");
 
 			SchemaAPI.relateRequestSchemaToEndpointByErc(
-				endpointErc = "testEndpoint",
+				endpointErc = "testendpoint",
 				requestSchemaErc = "testSchema");
 
 			SchemaAPI.relateResponseSchemaToEndpointByErc(
-				endpointErc = "testEndpoint",
+				endpointErc = "testendpoint",
 				responseSchemaErc = "testSchema");
 		}
 
@@ -327,7 +327,7 @@ definition {
 			APIExplorer.navigateToOpenAPI(customObjectPlural = "my-app");
 
 			APIExplorer.executeAPIMethod(
-				method = "getTestEndpointPage",
+				method = "getTestendpointPage",
 				parameter = "sort",
 				service = "testSchema",
 				value = "entryName:desc");
@@ -336,7 +336,7 @@ definition {
 		task ("Then I can see items in desc sort order in response") {
 			AssertTextEquals.assertPartialText(
 				locator1 = "OpenAPI#RESPONSE_BODY",
-				method = "getTestEndpointPage",
+				method = "getTestendpointPage",
 				value1 = "\"items\": [     {       \"entryName\": \"Tom\"     },     {       \"entryName\": \"Test\"     },     {       \"entryName\": \"Able\"     }   ]");
 		}
 	}
@@ -348,8 +348,8 @@ definition {
 		task ("Given an published API application with singleElement endpoint") {
 			ApplicationAPI.createAPIApplication(
 				baseURL = "my-app",
-				endpointName = "testEndpoint",
-				endpointPath = "/testEndpoint/{id}",
+				endpointName = "testendpoint",
+				endpointPath = "/testendpoint/{id}",
 				pathParameter = "ID",
 				relatedEndpoint = "true",
 				retrieveType = "singleElement",
@@ -361,19 +361,19 @@ definition {
 			APIExplorer.navigateToOpenAPI(customObjectPlural = "my-app");
 
 			APIExplorer.expandAPIMethod(
-				method = "getTestEndpointId",
+				method = "getTestendpointId",
 				service = "default");
 		}
 
 		task ("Then filter and sort parameters are not present") {
 			AssertElementNotPresent(
 				locator1 = "OpenAPI#PARAMETER_UNDER_METHOD",
-				method = "getTestEndpointId",
+				method = "getTestendpointId",
 				parameter = "filter");
 
 			AssertElementNotPresent(
 				locator1 = "OpenAPI#PARAMETER_UNDER_METHOD",
-				method = "getTestEndpointId",
+				method = "getTestendpointId",
 				parameter = "sort");
 		}
 	}
@@ -385,8 +385,8 @@ definition {
 		task ("Given an published API application with company scoped endpoint") {
 			ApplicationAPI.createAPIApplication(
 				baseURL = "my-app",
-				endpointName = "testEndpoint",
-				endpointPath = "/testEndpoint",
+				endpointName = "testendpoint",
+				endpointPath = "/testendpoint",
 				relatedEndpoint = "true",
 				status = "published",
 				title = "My-app");
@@ -396,7 +396,7 @@ definition {
 			APIExplorer.navigateToOpenAPI(customObjectPlural = "my-app");
 
 			APIExplorer.expandAPIMethod(
-				method = "getTestEndpointPage",
+				method = "getTestendpointPage",
 				service = "default");
 		}
 
@@ -420,8 +420,8 @@ definition {
 		task ("Given an published API application with site scoped endpoint") {
 			ApplicationAPI.createAPIApplication(
 				baseURL = "my-app",
-				endpointName = "testEndpoint",
-				endpointPath = "/testEndpoint",
+				endpointName = "testendpoint",
+				endpointPath = "/testendpoint",
 				relatedEndpoint = "true",
 				scopeKey = "group",
 				status = "published",
@@ -432,7 +432,7 @@ definition {
 			APIExplorer.navigateToOpenAPI(customObjectPlural = "my-app");
 
 			APIExplorer.expandAPIMethod(
-				method = "getScopeScopeKeyTestEndpointPage",
+				method = "getScopeScopeKeyTestendpointPage",
 				service = "default");
 		}
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[APIRest]APIGenerator/GenerateOpenAPIFromAPIApplicationDefinition.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[APIRest]APIGenerator/GenerateOpenAPIFromAPIApplicationDefinition.testcase
@@ -32,8 +32,8 @@ definition {
 		task ("Given APIApplication ‘my-app’ with APIEndpoints with related APISchemas created") {
 			var response = ApplicationAPI.createAPIApplication(
 				baseURL = "my-app",
-				endpointName = "testEndpoint",
-				endpointPath = "/testEndpoint",
+				endpointName = "testendpoint",
+				endpointPath = "/testendpoint",
 				mainObjectDefinitionErc = "L_API_APPLICATION",
 				relatedEndpoint = "true",
 				relatedSchema = "true",
@@ -68,9 +68,9 @@ definition {
 		task ("Then I am redirected to the OpenApi page with endpoints and schemas details") {
 			AssertTextEquals.assertPartialText(
 				locator1 = "OpenAPI#API_METHOD",
-				method = "getTestEndpointPage",
+				method = "getTestendpointPage",
 				service = "testSchema",
-				value1 = "/testEndpoint");
+				value1 = "/testendpoint");
 
 			AssertElementPresent(
 				locator1 = "OpenAPI#SCHEMA_COLLAPSED",
@@ -91,8 +91,8 @@ definition {
 		task ("Given APIApplication ‘my-app’ of status ‘published’ with APIEndpoints with related APISchemas created") {
 			var response = ApplicationAPI.createAPIApplication(
 				baseURL = "my-app",
-				endpointName = "testEndpoint",
-				endpointPath = "/testEndpoint",
+				endpointName = "testendpoint",
+				endpointPath = "/testendpoint",
 				mainObjectDefinitionErc = "L_API_APPLICATION",
 				relatedEndpoint = "true",
 				relatedSchema = "true",
@@ -128,8 +128,8 @@ definition {
 		task ("When APIApplication ‘my-app’ of status ‘unpublished’ with APIEndpoints with related APISchemas created") {
 			var response = ApplicationAPI.createAPIApplication(
 				baseURL = "my-app",
-				endpointName = "testEndpoint",
-				endpointPath = "/testEndpoint",
+				endpointName = "testendpoint",
+				endpointPath = "/testendpoint",
 				mainObjectDefinitionErc = "L_API_APPLICATION",
 				relatedEndpoint = "true",
 				relatedSchema = "true",
@@ -167,8 +167,8 @@ definition {
 		task ("Given APIApplication ‘my-app’ with APIEndpoints with related APISchemas created") {
 			var response = ApplicationAPI.createAPIApplication(
 				baseURL = "my-app",
-				endpointName = "testEndpoint",
-				endpointPath = "/testEndpoint",
+				endpointName = "testendpoint",
+				endpointPath = "/testendpoint",
 				mainObjectDefinitionErc = "L_API_APPLICATION",
 				relatedEndpoint = "true",
 				relatedSchema = "true",

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[APIRest]APIGenerator/GeneratePathStructureForEndpoints.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[APIRest]APIGenerator/GeneratePathStructureForEndpoints.testcase
@@ -105,8 +105,8 @@ definition {
 
 			APIBuilderUI.createAPIEndpoint(
 				applicationId = ${applicationId},
-				name = "testEndpoint",
-				path = "/testEndpoint");
+				name = "testendpoint",
+				path = "/testendpoint");
 		}
 
 		task ("Then I can see endpoint is created with correct path") {
@@ -117,7 +117,7 @@ definition {
 				title = "App-test");
 
 			AssertElementPresent(
-				key_name = "/testEndpoint/",
+				key_name = "/testendpoint/",
 				locator1 = "ObjectAdmin#TABLE_LIST_TITLE");
 		}
 	}
@@ -174,8 +174,8 @@ definition {
 
 			APIBuilderUI.createAPIEndpoint(
 				applicationId = ${applicationId},
-				name = "testEndpoint",
-				path = "testEndpoint");
+				name = "testendpoint",
+				path = "testendpoint");
 		}
 
 		task ("Then I can see error message") {
@@ -188,7 +188,7 @@ definition {
 				title = "App-test");
 
 			AssertElementNotPresent(
-				key_name = "/testEndpoint/",
+				key_name = "/testendpoint/",
 				locator1 = "ObjectAdmin#TABLE_LIST_TITLE");
 		}
 	}
@@ -202,8 +202,8 @@ definition {
 		task ("Given with postAPIApplication including apiApplicationToAPIEndpoints and path to create an API application with its endpoint") {
 			ApplicationAPI.createAPIApplication(
 				baseURL = "app-test",
-				endpointName = "testEndpoint",
-				endpointPath = "/testEndpoint",
+				endpointName = "testendpoint",
+				endpointPath = "/testendpoint",
 				relatedEndpoint = "true",
 				status = "unpublished",
 				title = "App-test");
@@ -217,7 +217,7 @@ definition {
 
 		task ("Then I can see correct path") {
 			AssertElementPresent(
-				key_name = "/testEndpoint/",
+				key_name = "/testendpoint/",
 				locator1 = "ObjectAdmin#TABLE_LIST_TITLE");
 		}
 	}
@@ -231,8 +231,8 @@ definition {
 		task ("Given with postAPIApplication including apiApplicationToAPIEndpoints and path to create an published API application with its endpoint") {
 			ApplicationAPI.createAPIApplication(
 				baseURL = "app-test",
-				endpointName = "testEndpoint",
-				endpointPath = "/testEndpoint",
+				endpointName = "testendpoint",
+				endpointPath = "/testendpoint",
 				relatedEndpoint = "true",
 				status = "published",
 				title = "App-test");
@@ -245,9 +245,9 @@ definition {
 		task ("Then I can see '/{path}' is present under get{Endpoint}Page") {
 			AssertTextEquals.assertPartialText(
 				locator1 = "OpenAPI#API_METHOD",
-				method = "getTestEndpointPage",
+				method = "getTestendpointPage",
 				service = "default",
-				value1 = "/testEndpoint");
+				value1 = "/testendpoint");
 		}
 	}
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[APIRest]APIGenerator/ProcedureForTriggerAPIGenerator.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[APIRest]APIGenerator/ProcedureForTriggerAPIGenerator.testcase
@@ -30,8 +30,8 @@ definition {
 		task ("Given api-application with GET endpoint is published") {
 			ApplicationAPI.createAPIApplication(
 				baseURL = "app-test",
-				endpointName = "testEndpoint",
-				endpointPath = "/testEndpoint",
+				endpointName = "testendpoint",
+				endpointPath = "/testendpoint",
 				relatedEndpoint = "true",
 				status = "published",
 				title = "App-test");
@@ -57,7 +57,7 @@ definition {
 
 			WaitForElementPresent(
 				locator1 = "OpenAPI#API_METHOD",
-				method = "getTestEndpointPage",
+				method = "getTestendpointPage",
 				service = "default");
 		}
 	}

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[APIRest]APIGenerator/PublishARESTAPIApplication.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[APIRest]APIGenerator/PublishARESTAPIApplication.testcase
@@ -46,8 +46,8 @@ definition {
 
 			EndpointAPI.createAPIEndpoint(
 				externalReferenceCode = "App-test",
-				name = "AppTest",
-				path = "/AppTest",
+				name = "apptest",
+				path = "/apptest",
 				responseSchemaId = ${schemaId});
 		}
 
@@ -66,7 +66,7 @@ definition {
 
 			WaitForElementPresent(
 				locator1 = "OpenAPI#API_METHOD",
-				method = "getAppTestPage",
+				method = "getApptestPage",
 				service = "AppTest");
 		}
 	}
@@ -78,8 +78,8 @@ definition {
 		task ("And Given an API endpoint 'AppTest' related to an Application by post request postAPIEndpoint") {
 			EndpointAPI.createAPIEndpoint(
 				externalReferenceCode = "App-test",
-				name = "AppTest",
-				path = "/AppTest");
+				name = "apptest",
+				path = "/apptest");
 		}
 
 		task ("When I can navigate to App-test page in API Explorer") {
@@ -91,7 +91,7 @@ definition {
 
 			WaitForElementPresent(
 				locator1 = "OpenAPI#API_METHOD",
-				method = "getAppTestPage",
+				method = "getApptestPage",
 				service = "default");
 		}
 	}

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationEndpoints/AllowUsersToDefineEndpointsForObjectsWithSiteScope.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationEndpoints/AllowUsersToDefineEndpointsForObjectsWithSiteScope.testcase
@@ -30,8 +30,8 @@ definition {
 		task ("Given with postAPIApplication to create a published api Application with site scope endpoint with related schema") {
 			var response = ApplicationAPI.createAPIApplication(
 				baseURL = "my-app",
-				endpointName = "testEndpoint",
-				endpointPath = "/testEndpoint",
+				endpointName = "testendpoint",
+				endpointPath = "/testendpoint",
 				mainObjectDefinitionErc = "L_API_APPLICATION",
 				relatedEndpoint = "true",
 				relatedSchema = "true",
@@ -60,7 +60,7 @@ definition {
 				site = "true");
 
 			APIExplorer.executeAPIMethod(
-				method = "getScopeScopeKeyTestEndpointPage",
+				method = "getScopeScopeKeyTestendpointPage",
 				parameter = "scopeKey",
 				service = "testSchema",
 				value = ${siteId});
@@ -69,7 +69,7 @@ definition {
 		task ("Then I can get correct 200 response code") {
 			AssertTextEquals(
 				locator1 = "OpenAPI#RESPONSE_CODE",
-				method = "getScopeScopeKeyTestEndpointPage",
+				method = "getScopeScopeKeyTestendpointPage",
 				value1 = 200);
 		}
 	}
@@ -81,8 +81,8 @@ definition {
 		task ("Given with postAPIApplication to create an unpublished api Application with site scope endpoint") {
 			ApplicationAPI.createAPIApplication(
 				baseURL = "my-app",
-				endpointName = "testEndpoint",
-				endpointPath = "/testEndpoint",
+				endpointName = "testendpoint",
+				endpointPath = "/testendpoint",
 				relatedEndpoint = "true",
 				scopeKey = "group",
 				status = "unpublished",
@@ -107,8 +107,8 @@ definition {
 		task ("Given with postAPIApplication to create a published api Application with site scope endpoint and company scope endpoint") {
 			var response = ApplicationAPI.createAPIApplication(
 				baseURL = "my-app",
-				endpointName = "testEndpoint",
-				endpointPath = "/testEndpoint",
+				endpointName = "testendpoint",
+				endpointPath = "/testendpoint",
 				relatedEndpoint = "true",
 				scopeKey = "group",
 				status = "published",
@@ -118,8 +118,8 @@ definition {
 
 			EndpointAPI.createAPIEndpoint(
 				externalReferenceCode = "My-app",
-				name = "myEndpoint",
-				path = "/myEndpoint");
+				name = "myendpoint",
+				path = "/myendpoint");
 		}
 
 		task ("When I navigate to /o/c/{apiApplication}") {
@@ -129,17 +129,17 @@ definition {
 		task ("Then getScopes{siteScopeEndpointPath}Page is present under default") {
 			AssertTextEquals.assertPartialText(
 				locator1 = "OpenAPI#API_METHOD",
-				method = "getScopeScopeKeyTestEndpointPage",
+				method = "getScopeScopeKeyTestendpointPage",
 				service = "default",
-				value1 = "/testEndpoint");
+				value1 = "/testendpoint");
 		}
 
 		task ("And Then get{companyScopeEndpointPath}Page is present under default") {
 			AssertTextEquals.assertPartialText(
 				locator1 = "OpenAPI#API_METHOD",
-				method = "getMyEndpointPage",
+				method = "getMyendpointPage",
 				service = "default",
-				value1 = "/myEndpoint");
+				value1 = "/myendpoint");
 		}
 	}
 
@@ -150,8 +150,8 @@ definition {
 		task ("Given created an published api application with site scope endpoint and company scope endpoint with related request and response schemas") {
 			var responseFromApplication = ApplicationAPI.createAPIApplication(
 				baseURL = "my-app",
-				endpointName = "testEndpoint",
-				endpointPath = "/testEndpoint",
+				endpointName = "testendpoint",
+				endpointPath = "/testendpoint",
 				mainObjectDefinitionErc = "L_API_APPLICATION",
 				relatedEndpoint = "true",
 				relatedSchema = "true",
@@ -173,8 +173,8 @@ definition {
 
 			var responseFromEndpoint = EndpointAPI.createAPIEndpoint(
 				externalReferenceCode = "My-app",
-				name = "myEndpoint",
-				path = "/myEndpoint");
+				name = "myendpoint",
+				path = "/myendpoint");
 
 			var endpointId2 = JSONPathUtil.getIdValue(response = ${responseFromEndpoint});
 
@@ -194,17 +194,17 @@ definition {
 		task ("Then getScopeScopeKey{siteScopeEndpointPath}Page is present under {schemaName}") {
 			AssertTextEquals.assertPartialText(
 				locator1 = "OpenAPI#API_METHOD",
-				method = "getScopeScopeKeyTestEndpointPage",
+				method = "getScopeScopeKeyTestendpointPage",
 				service = "testSchema",
-				value1 = "/testEndpoint");
+				value1 = "/testendpoint");
 		}
 
 		task ("And Then get{companyScopeEndpointPath}Page is present under {schemaName}") {
 			AssertTextEquals.assertPartialText(
 				locator1 = "OpenAPI#API_METHOD",
-				method = "getMyEndpointPage",
+				method = "getMyendpointPage",
 				service = "testSchema",
-				value1 = "/myEndpoint");
+				value1 = "/myendpoint");
 		}
 	}
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationEndpoints/DeleteAPIApplicationEndPoint.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationEndpoints/DeleteAPIApplicationEndPoint.testcase
@@ -31,8 +31,8 @@ definition {
 		task ("Given published API Application with Endpoint created") {
 			ApplicationAPI.createAPIApplication(
 				baseURL = "my-app",
-				endpointName = "testEndpoint",
-				endpointPath = "/testEndpoint",
+				endpointName = "testendpoint",
+				endpointPath = "/testendpoint",
 				relatedEndpoint = "true",
 				status = "published",
 				title = "My-app");
@@ -41,7 +41,7 @@ definition {
 		task ("And Given delete API Endpoint") {
 			APIBuilderUI.deleteAPIEndpoint(
 				applicationTitle = "My-app",
-				endpointPath = "/testEndpoint");
+				endpointPath = "/testendpoint");
 		}
 
 		task ("When I click cancel button") {
@@ -50,7 +50,7 @@ definition {
 
 		task ("Then I can see the API Endpoint in the UI") {
 			AssertElementPresent(
-				key_name = "/testEndpoint",
+				key_name = "/testendpoint",
 				locator1 = "ObjectAdmin#TABLE_LIST_TITLE");
 		}
 	}
@@ -63,8 +63,8 @@ definition {
 		task ("Given published API Application with Endpoint created") {
 			ApplicationAPI.createAPIApplication(
 				baseURL = "my-app",
-				endpointName = "testEndpoint",
-				endpointPath = "/testEndpoint",
+				endpointName = "testendpoint",
+				endpointPath = "/testendpoint",
 				relatedEndpoint = "true",
 				status = "published",
 				title = "My-app");
@@ -73,7 +73,7 @@ definition {
 		task ("And Given goto dropdown menu and click delete") {
 			APIBuilderUI.deleteAPIEndpoint(
 				applicationTitle = "My-app",
-				endpointPath = "/testEndpoint");
+				endpointPath = "/testendpoint");
 		}
 
 		task ("When I click delete button") {
@@ -84,7 +84,7 @@ definition {
 			Alert.viewSuccessMessageText(successMessage = "The endpoint was deleted successfully.");
 
 			AssertElementNotPresent(
-				key_name = "/testEndpoint",
+				key_name = "/testendpoint",
 				locator1 = "ObjectAdmin#TABLE_LIST_TITLE");
 		}
 	}
@@ -98,8 +98,8 @@ definition {
 		task ("Given published API Application with Endpoint created") {
 			ApplicationAPI.createAPIApplication(
 				baseURL = "my-app",
-				endpointName = "testEndpoint",
-				endpointPath = "/testEndpoint",
+				endpointName = "testendpoint",
+				endpointPath = "/testendpoint",
 				relatedEndpoint = "true",
 				status = "published",
 				title = "My-app");
@@ -109,7 +109,7 @@ definition {
 			APIBuilderUI.deleteAPIEndpoint(
 				applicationTitle = "My-app",
 				confirmDeletion = "true",
-				endpointPath = "testEndpoint");
+				endpointPath = "testendpoint");
 		}
 
 		task ("Then API Endpoint is not visible in the created API Application in API Explorer") {
@@ -117,7 +117,7 @@ definition {
 
 			AssertElementNotPresent(
 				locator1 = "OpenAPI#API_METHOD",
-				method = "getTestEndpointPage",
+				method = "getTestendpointPage",
 				service = "default");
 		}
 	}
@@ -131,8 +131,8 @@ definition {
 		task ("Given published API Application with group scoped Endpoint with related schema created") {
 			ApplicationAPI.createAPIApplication(
 				baseURL = "my-app",
-				endpointName = "testEndpoint",
-				endpointPath = "/testEndpoint",
+				endpointName = "testendpoint",
+				endpointPath = "/testendpoint",
 				mainObjectDefinitionErc = "L_API_APPLICATION",
 				relatedEndpoint = "true",
 				relatedSchema = "true",
@@ -146,7 +146,7 @@ definition {
 			APIBuilderUI.deleteAPIEndpoint(
 				applicationTitle = "My-app",
 				confirmDeletion = "true",
-				endpointPath = "/testEndpoint");
+				endpointPath = "/testendpoint");
 		}
 
 		task ("When navigate to API Explorer's created API Application") {
@@ -156,7 +156,7 @@ definition {
 		task ("Then API Endpoint is not visible under {schema} in the created API Application in API Explorer") {
 			AssertElementNotPresent(
 				locator1 = "OpenAPI#API_METHOD",
-				method = "getScopeScopeKeyTestEndpointPage",
+				method = "getScopeScopeKeyTestendpointPage",
 				service = "testSchema");
 		}
 	}
@@ -170,8 +170,8 @@ definition {
 		task ("Given published API Application with Endpoint created") {
 			ApplicationAPI.createAPIApplication(
 				baseURL = "my-app",
-				endpointName = "testEndpoint",
-				endpointPath = "/testEndpoint",
+				endpointName = "testendpoint",
+				endpointPath = "/testendpoint",
 				relatedEndpoint = "true",
 				status = "published",
 				title = "My-app");
@@ -180,7 +180,7 @@ definition {
 		task ("When delete API Endpoint") {
 			APIBuilderUI.deleteAPIEndpoint(
 				applicationTitle = "My-app",
-				endpointPath = "/testEndpoint");
+				endpointPath = "/testendpoint");
 		}
 
 		task ("Then I can see the Delete API Endpoint dialog with warning message") {

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationEndpoints/ListAPIApplicationEndpoints.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationEndpoints/ListAPIApplicationEndpoints.testcase
@@ -60,8 +60,8 @@ definition {
 		task ("And Given I create an endpoint associate to the API application") {
 			EndpointAPI.createAPIEndpoint(
 				externalReferenceCode = "My-app",
-				name = "myEndpoint",
-				path = "/myEndpoint");
+				name = "myendpoint",
+				path = "/myendpoint");
 		}
 
 		task ("When I click over the path of the endpoint") {
@@ -71,12 +71,12 @@ definition {
 
 			Click(
 				locator1 = "Button#BUTTON_WITH_VALUE",
-				value = "/myEndpoint/");
+				value = "/myendpoint/");
 		}
 
 		task ("Then it navigates to another page") {
 			AssertElementPresent(
-				key_breadcrumbName = "GET /myEndpoint",
+				key_breadcrumbName = "GET /myendpoint",
 				locator1 = "Breadcrumb#BREADCRUMB_ENTRY_LINK");
 		}
 	}
@@ -90,8 +90,8 @@ definition {
 		task ("And Given I create an endpoint associate to the API application") {
 			EndpointAPI.createAPIEndpoint(
 				externalReferenceCode = "My-app",
-				name = "myEndpoint",
-				path = "/myEndpoint");
+				name = "myendpoint",
+				path = "/myendpoint");
 		}
 
 		task ("When I click Copy URL in Actions icon") {
@@ -115,7 +115,7 @@ definition {
 
 			AssertTextEquals(
 				locator1 = "TextInput#SEARCH",
-				value1 = "${portalURL}/o/c/my-app/myEndpoint");
+				value1 = "${portalURL}/o/c/my-app/myendpoint");
 		}
 	}
 
@@ -128,8 +128,8 @@ definition {
 		task ("And Given I create an endpoint associate to the API application") {
 			EndpointAPI.createAPIEndpoint(
 				externalReferenceCode = "My-app",
-				name = "myEndpoint",
-				path = "/myEndpoint");
+				name = "myendpoint",
+				path = "/myendpoint");
 		}
 
 		task ("When I filter endpoints with Last updated from ${schema_creation_date} to ${schema_creation_date}") {
@@ -146,7 +146,7 @@ definition {
 
 		task ("Then I can see the endpoint is listed") {
 			AssertElementPresent(
-				key_name = "/myEndpoint/",
+				key_name = "/myendpoint/",
 				locator1 = "ObjectAdmin#TABLE_LIST_TITLE");
 		}
 	}
@@ -160,8 +160,8 @@ definition {
 		task ("And Given I create an endpoint associate to the API application") {
 			EndpointAPI.createAPIEndpoint(
 				externalReferenceCode = "My-app",
-				name = "myEndpoint",
-				path = "/myEndpoint");
+				name = "myendpoint",
+				path = "/myendpoint");
 		}
 
 		task ("When I filter endpoints with Last updated from ${schema_creation_date} - 1 day to ${schema_creation_date} - 1 day") {
@@ -179,7 +179,7 @@ definition {
 
 		task ("Then I can see No API Endpoint Found") {
 			AssertElementNotPresent(
-				key_name = "/myEndpoint/",
+				key_name = "/myendpoint/",
 				locator1 = "ObjectAdmin#TABLE_LIST_TITLE");
 		}
 	}
@@ -193,8 +193,8 @@ definition {
 		task ("And Given with postEndpointAPI to create an endpoint associate to the API application") {
 			EndpointAPI.createAPIEndpoint(
 				externalReferenceCode = "My-app",
-				name = "myEndpoint",
-				path = "/myEndpoint");
+				name = "myendpoint",
+				path = "/myendpoint");
 		}
 
 		task ("When I navigate to Endpoints in Edit API Application") {
@@ -205,7 +205,7 @@ definition {
 
 		task ("Then the created endpoint is listed") {
 			AssertElementPresent(
-				key_name = "/myEndpoint/",
+				key_name = "/myendpoint/",
 				locator1 = "ObjectAdmin#TABLE_LIST_TITLE");
 		}
 
@@ -223,9 +223,9 @@ definition {
 		task ("And Given with postEndpointAPI to create two endpoints associate to the API application") {
 			EndpointAPI.createNAPIEndpoints(
 				externalReferenceCode = "My-app",
-				name = "myEndpoint",
+				name = "myendpoint",
 				numberOfEndpoints = 2,
-				path = "/myEndpoint");
+				path = "/myendpoint");
 		}
 
 		task ("And Given I navigate to Endpoints in Edit API Application") {
@@ -241,7 +241,7 @@ definition {
 		}
 
 		task ("Then the endpoints are ordered") {
-			APIBuilderUI.viewItemsInOrder(itemList = "/myEndpoint1/,/myEndpoint2/");
+			APIBuilderUI.viewItemsInOrder(itemList = "/myendpoint1/,/myendpoint2/");
 		}
 	}
 
@@ -254,9 +254,9 @@ definition {
 		task ("And Given postAPIEndpoint to create 11 endpoints associate to the API application") {
 			EndpointAPI.createNAPIEndpoints(
 				externalReferenceCode = "My-app",
-				name = "myEndpoint",
+				name = "myendpoint",
 				numberOfEndpoints = 11,
-				path = "/myEndpoint");
+				path = "/myendpoint");
 		}
 
 		task ("And Given I navigate to Endpoints in Edit API Application") {
@@ -277,7 +277,7 @@ definition {
 
 		task ("Then the 11th endpoint is present with Showing 11 to 11 of 11 entries message") {
 			AssertElementPresent(
-				key_name = "/myEndpoint11/",
+				key_name = "/myendpoint11/",
 				locator1 = "ObjectAdmin#TABLE_LIST_TITLE");
 
 			Pagination.viewResults(results = "Showing 11 to 11 of 11 entries.");
@@ -293,8 +293,8 @@ definition {
 		task ("And Given I create an edpoint associate to the API application") {
 			EndpointAPI.createAPIEndpoint(
 				externalReferenceCode = "My-app",
-				name = "myEndpoint",
-				path = "/myEndpoint");
+				name = "myendpoint",
+				path = "/myendpoint");
 		}
 
 		task ("When I search endpoints with existing name") {
@@ -302,12 +302,12 @@ definition {
 				entity = "Endpoints",
 				title = "My-app");
 
-			APIBuilderUI.searchItem(value = "myEndpoint");
+			APIBuilderUI.searchItem(value = "myendpoint");
 		}
 
 		task ("Then I can see the endpoint is listed") {
 			AssertElementPresent(
-				key_name = "/myEndpoint/",
+				key_name = "/myendpoint/",
 				locator1 = "ObjectAdmin#TABLE_LIST_TITLE");
 		}
 	}
@@ -321,8 +321,8 @@ definition {
 		task ("When I create an endpoint associate to the API application") {
 			EndpointAPI.createAPIEndpoint(
 				externalReferenceCode = "My-app",
-				name = "myEndpoint",
-				path = "/myEndpoint");
+				name = "myendpoint",
+				path = "/myendpoint");
 		}
 
 		task ("Then Method, Path, Description and Last updated are visible") {

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]DefineAPISchemasWithinAnAPIGroup/DeleteAPIApplicationSchema.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]DefineAPISchemasWithinAnAPIGroup/DeleteAPIApplicationSchema.testcase
@@ -86,8 +86,8 @@ definition {
 		task ("And Given create an API Endpoint in the Application") {
 			EndpointAPI.createAPIEndpoint(
 				externalReferenceCode = "My-app",
-				name = "myEndpoint",
-				path = "/myEndpoint");
+				name = "myendpoint",
+				path = "/myendpoint");
 		}
 
 		task ("When I delete the API Schema") {
@@ -102,9 +102,9 @@ definition {
 
 			AssertTextEquals.assertPartialText(
 				locator1 = "OpenAPI#API_METHOD",
-				method = "getMyEndpointPage",
+				method = "getMyendpointPage",
 				service = "default",
-				value1 = "/myEndpoint");
+				value1 = "/myendpoint");
 
 			AssertElementNotPresent(
 				locator1 = "OpenAPI#SCHEMA_COLLAPSED",

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/instance/lifecycle/test/APIApplicationPublisherPortalInstanceLifecycleListenerTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/instance/lifecycle/test/APIApplicationPublisherPortalInstanceLifecycleListenerTest.java
@@ -94,6 +94,9 @@ public class APIApplicationPublisherPortalInstanceLifecycleListenerTest
 
 		String apiEndpointExternalReferenceCode = RandomTestUtil.randomString();
 		String apiSchemaExternalReferenceCode = RandomTestUtil.randomString();
+		String path =
+			StringPool.FORWARD_SLASH +
+				StringUtil.toLowerCase(RandomTestUtil.randomString());
 
 		HTTPTestUtil.invokeToJSONObject(
 			JSONUtil.put(
@@ -109,8 +112,7 @@ public class APIApplicationPublisherPortalInstanceLifecycleListenerTest
 					).put(
 						"name", "name"
 					).put(
-						"path",
-						StringPool.FORWARD_SLASH + RandomTestUtil.randomString()
+						"path", path
 					).put(
 						"retrieveType",
 						APIApplication.Endpoint.RetrieveType.COLLECTION.

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APIEndpointRelevantObjectEntryModelListenerTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APIEndpointRelevantObjectEntryModelListenerTest.java
@@ -66,7 +66,8 @@ public class APIEndpointRelevantObjectEntryModelListenerTest
 					"name", RandomTestUtil.randomString()
 				).put(
 					"path",
-					StringPool.FORWARD_SLASH + RandomTestUtil.randomString()
+					StringPool.FORWARD_SLASH +
+						StringUtil.toLowerCase(RandomTestUtil.randomString())
 				).put(
 					"retrieveType",
 					APIApplication.Endpoint.RetrieveType.COLLECTION.getValue()
@@ -91,7 +92,8 @@ public class APIEndpointRelevantObjectEntryModelListenerTest
 					"name", RandomTestUtil.randomString()
 				).put(
 					"path",
-					StringPool.FORWARD_SLASH + RandomTestUtil.randomString()
+					StringPool.FORWARD_SLASH +
+						StringUtil.toLowerCase(RandomTestUtil.randomString())
 				).put(
 					"r_apiApplicationToAPIEndpoints_c_apiApplicationId",
 					RandomTestUtil.randomLong()
@@ -119,7 +121,8 @@ public class APIEndpointRelevantObjectEntryModelListenerTest
 					"name", RandomTestUtil.randomString()
 				).put(
 					"path",
-					StringPool.FORWARD_SLASH + RandomTestUtil.randomString()
+					StringPool.FORWARD_SLASH +
+						StringUtil.toLowerCase(RandomTestUtil.randomString())
 				).put(
 					"r_apiApplicationToAPIEndpoints_c_apiApplicationId",
 					TestPropsValues.getUserId()
@@ -156,7 +159,8 @@ public class APIEndpointRelevantObjectEntryModelListenerTest
 					"name", RandomTestUtil.randomString()
 				).put(
 					"path",
-					StringPool.FORWARD_SLASH + RandomTestUtil.randomString()
+					StringPool.FORWARD_SLASH +
+						StringUtil.toLowerCase(RandomTestUtil.randomString())
 				).put(
 					"r_apiApplicationToAPIEndpoints_c_apiApplicationId",
 					apiApplicationJSONObject1.getLong("id")
@@ -191,8 +195,10 @@ public class APIEndpointRelevantObjectEntryModelListenerTest
 				).put(
 					"path",
 					StringBundler.concat(
-						StringPool.FORWARD_SLASH, RandomTestUtil.randomString(),
-						StringPool.FORWARD_SLASH, RandomTestUtil.randomString(),
+						StringPool.FORWARD_SLASH,
+						StringUtil.toLowerCase(RandomTestUtil.randomString()),
+						StringPool.FORWARD_SLASH,
+						StringUtil.toLowerCase(RandomTestUtil.randomString()),
 						StringPool.COMMA)
 				).put(
 					"r_apiApplicationToAPIEndpoints_c_apiApplicationId",
@@ -221,7 +227,8 @@ public class APIEndpointRelevantObjectEntryModelListenerTest
 				).put(
 					"path",
 					StringBundler.concat(
-						StringPool.FORWARD_SLASH, RandomTestUtil.randomString(),
+						StringPool.FORWARD_SLASH,
+						StringUtil.toLowerCase(RandomTestUtil.randomString()),
 						StringPool.FORWARD_SLASH, StringPool.OPEN_CURLY_BRACE)
 				).put(
 					"pathParameter", HeadlessBuilderConstants.PATH_PARAMETER_ERC
@@ -267,7 +274,8 @@ public class APIEndpointRelevantObjectEntryModelListenerTest
 				).put(
 					"path",
 					StringBundler.concat(
-						StringPool.FORWARD_SLASH, RandomTestUtil.randomString(),
+						StringPool.FORWARD_SLASH,
+						StringUtil.toLowerCase(RandomTestUtil.randomString()),
 						StringPool.FORWARD_SLASH, StringPool.OPEN_CURLY_BRACE,
 						RandomTestUtil.randomString(),
 						StringPool.CLOSE_CURLY_BRACE)
@@ -304,8 +312,8 @@ public class APIEndpointRelevantObjectEntryModelListenerTest
 				).put(
 					"path",
 					StringBundler.concat(
-						RandomTestUtil.randomString(), StringPool.FORWARD_SLASH,
-						StringPool.COMMA)
+						StringUtil.toLowerCase(RandomTestUtil.randomString()),
+						StringPool.FORWARD_SLASH, StringPool.COMMA)
 				).put(
 					"r_apiApplicationToAPIEndpoints_c_apiApplicationId",
 					apiApplicationJSONObject1.getLong("id")
@@ -332,7 +340,8 @@ public class APIEndpointRelevantObjectEntryModelListenerTest
 				).put(
 					"path",
 					StringBundler.concat(
-						StringPool.FORWARD_SLASH, RandomTestUtil.randomString(),
+						StringPool.FORWARD_SLASH,
+						StringUtil.toLowerCase(RandomTestUtil.randomString()),
 						StringPool.FORWARD_SLASH, StringPool.OPEN_CURLY_BRACE,
 						RandomTestUtil.randomString(),
 						StringPool.CLOSE_CURLY_BRACE)
@@ -372,7 +381,8 @@ public class APIEndpointRelevantObjectEntryModelListenerTest
 					"name", RandomTestUtil.randomString()
 				).put(
 					"path",
-					StringPool.FORWARD_SLASH + RandomTestUtil.randomString()
+					StringPool.FORWARD_SLASH +
+						StringUtil.toLowerCase(RandomTestUtil.randomString())
 				).put(
 					"r_apiApplicationToAPIEndpoints_c_apiApplicationId",
 					apiApplicationJSONObject1.getLong("id")
@@ -406,7 +416,8 @@ public class APIEndpointRelevantObjectEntryModelListenerTest
 				).put(
 					"path",
 					StringBundler.concat(
-						StringPool.FORWARD_SLASH, RandomTestUtil.randomString(),
+						StringPool.FORWARD_SLASH,
+						StringUtil.toLowerCase(RandomTestUtil.randomString()),
 						StringPool.FORWARD_SLASH, StringPool.OPEN_CURLY_BRACE,
 						RandomTestUtil.randomString(),
 						StringPool.CLOSE_CURLY_BRACE)
@@ -432,7 +443,9 @@ public class APIEndpointRelevantObjectEntryModelListenerTest
 			).toString(),
 			JSONCompareMode.LENIENT);
 
-		String path = StringPool.FORWARD_SLASH + RandomTestUtil.randomString();
+		String path =
+			StringPool.FORWARD_SLASH +
+				StringUtil.toLowerCase(RandomTestUtil.randomString());
 
 		JSONObject apiEndpointJSONObject = HTTPTestUtil.invokeToJSONObject(
 			JSONUtil.put(
@@ -542,7 +555,8 @@ public class APIEndpointRelevantObjectEntryModelListenerTest
 					"name", RandomTestUtil.randomString()
 				).put(
 					"path",
-					StringPool.FORWARD_SLASH + RandomTestUtil.randomString()
+					StringPool.FORWARD_SLASH +
+						StringUtil.toLowerCase(RandomTestUtil.randomString())
 				).put(
 					"r_apiApplicationToAPIEndpoints_c_apiApplicationId",
 					apiApplicationJSONObject1.getLong("id")

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APIEndpointRelevantObjectEntryModelListenerTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APIEndpointRelevantObjectEntryModelListenerTest.java
@@ -246,6 +246,41 @@ public class APIEndpointRelevantObjectEntryModelListenerTest
 			).toString(),
 			JSONCompareMode.STRICT);
 
+		JSONAssert.assertEquals(
+			JSONUtil.put(
+				"status", "BAD_REQUEST"
+			).put(
+				"title", "Path must contain only lower case characters."
+			).toString(),
+			HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					"httpMethod", "get"
+				).put(
+					"name", RandomTestUtil.randomString()
+				).put(
+					"path",
+					StringBundler.concat(
+						StringPool.FORWARD_SLASH,
+						StringUtil.toUpperCase(RandomTestUtil.randomString()),
+						StringPool.FORWARD_SLASH, StringPool.OPEN_CURLY_BRACE,
+						RandomTestUtil.randomString(),
+						StringPool.CLOSE_CURLY_BRACE)
+				).put(
+					"pathParameter", HeadlessBuilderConstants.PATH_PARAMETER_ERC
+				).put(
+					"r_apiApplicationToAPIEndpoints_c_apiApplicationId",
+					apiApplicationJSONObject1.getLong("id")
+				).put(
+					"retrieveType",
+					APIApplication.Endpoint.RetrieveType.SINGLE_ELEMENT.
+						getValue()
+				).put(
+					"scope", APIApplication.Endpoint.Scope.COMPANY.getValue()
+				).toString(),
+				"headless-builder/endpoints", Http.Method.POST
+			).toString(),
+			JSONCompareMode.STRICT);
+
 		JSONObject apiSchemaJSONObject1 = HTTPTestUtil.invokeToJSONObject(
 			JSONUtil.put(
 				"mainObjectDefinitionERC",

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APIFilterRelevantObjectEntryModelListenerTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APIFilterRelevantObjectEntryModelListenerTest.java
@@ -338,7 +338,8 @@ public class APIFilterRelevantObjectEntryModelListenerTest
 	}
 
 	private static final String _API_APPLICATION_PATH =
-		StringPool.SLASH + RandomTestUtil.randomString();
+		StringPool.SLASH +
+			StringUtil.toLowerCase(RandomTestUtil.randomString());
 
 	private static final String _API_ENDPOINT_ERC =
 		RandomTestUtil.randomString();

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APISortRelevantObjectEntryModelListenerTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APISortRelevantObjectEntryModelListenerTest.java
@@ -132,6 +132,9 @@ public class APISortRelevantObjectEntryModelListenerTest extends BaseTestCase {
 		throws Exception {
 
 		String apiSchemaExternalReferenceCode = RandomTestUtil.randomString();
+		String path =
+			StringPool.SLASH +
+				StringUtil.toLowerCase(RandomTestUtil.randomString());
 
 		HTTPTestUtil.invokeToHttpCode(
 			JSONUtil.put(
@@ -146,7 +149,7 @@ public class APISortRelevantObjectEntryModelListenerTest extends BaseTestCase {
 					).put(
 						"name", "name"
 					).put(
-						"path", StringPool.SLASH + RandomTestUtil.randomString()
+						"path", path
 					).put(
 						"retrieveType", "collection"
 					).put(

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
@@ -1969,10 +1969,12 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 		RandomTestUtil.randomString();
 
 	private static final String _API_APPLICATION_PATH_1 =
-		StringPool.SLASH + RandomTestUtil.randomString();
+		StringPool.SLASH +
+			StringUtil.toLowerCase(RandomTestUtil.randomString());
 
 	private static final String _API_APPLICATION_PATH_2 =
-		StringPool.SLASH + RandomTestUtil.randomString();
+		StringPool.SLASH +
+			StringUtil.toLowerCase(RandomTestUtil.randomString());
 
 	private static final String _API_ENDPOINT_ERC_1 =
 		RandomTestUtil.randomString();


### PR DESCRIPTION
**What is new?**
- Include validation to not allow users to set API Endpoint's path in upper case. This validation is going to be applied for singleElement and collection ones.
- Test case

**How to reproduce it?**
- Execute this curl:

```json

curl -X 'POST' \
  'http://localhost:8080/o/headless-builder/applications/' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -u 'test@liferay.com:test' \
  -d '{
  "applicationStatus": "published",
  "baseURL": "app1",
  "title": "app1",
  "apiApplicationToAPIEndpoints": [
    {
      "httpMethod": "get",
      "name": "myep",
      "path": "/myEP",
      "pathParameter": "Collection"
    }
  ]
}'
```

**JIRA Related Ticket**
https://liferay.atlassian.net/browse/LPS-199071