### PR TITLE
LPS-199231 Added new autogenerated method that returns an atribute by it's name + usage for declaring the model attributes in API Builder

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-impl/build.gradle
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/build.gradle
@@ -19,7 +19,6 @@ dependencies {
 	compileOnly project(":apps:static:osgi:osgi-util")
 	compileOnly project(":core:osgi-service-tracker-collections")
 	compileOnly project(":core:petra:petra-function")
-	compileOnly project(":core:petra:petra-reflect")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/helper/EndpointHelper.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/helper/EndpointHelper.java
@@ -9,7 +9,6 @@ import com.liferay.headless.builder.application.APIApplication;
 import com.liferay.headless.builder.constants.HeadlessBuilderConstants;
 import com.liferay.object.exception.NoSuchObjectEntryException;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
-import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -17,8 +16,6 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
-
-import java.lang.reflect.Field;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -141,25 +138,11 @@ public class EndpointHelper {
 	}
 
 	private Object _getRelatedObjectValue(
-			ObjectEntry objectEntry, APIApplication.Property property,
-			List<String> relationshipsNames)
-		throws Exception {
+		ObjectEntry objectEntry, APIApplication.Property property,
+		List<String> relationshipsNames) {
 
 		if (relationshipsNames.isEmpty()) {
-			Map<String, Object> objectEntryProperties =
-				objectEntry.getProperties();
-
-			Object object = objectEntryProperties.get(
-				property.getSourceFieldName());
-
-			if (object == null) {
-				Field declaredField = ReflectionUtil.getDeclaredField(
-					ObjectEntry.class, property.getSourceFieldName());
-
-				return declaredField.get(objectEntry);
-			}
-
-			return object;
+			return objectEntry.getValue(property.getSourceFieldName());
 		}
 
 		List<Object> values = new ArrayList<>();

--- a/modules/apps/object/object-rest-api/bnd.bnd
+++ b/modules/apps/object/object-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object REST API
 Bundle-SymbolicName: com.liferay.object.rest.api
-Bundle-Version: 19.1.3
+Bundle-Version: 19.2.0
 Export-Package:\
 	com.liferay.object.rest.dto.v1_0,\
 	com.liferay.object.rest.dto.v1_0.util,\

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/ObjectEntry.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/ObjectEntry.java
@@ -459,6 +459,50 @@ public class ObjectEntry implements Serializable {
 		return Objects.equals(toString(), objectEntry.toString());
 	}
 
+	public Object getValue(String propertyName) {
+		if (Objects.equals(propertyName, "actions")) {
+			return actions;
+		}
+		else if (Objects.equals(propertyName, "auditEvents")) {
+			return auditEvents;
+		}
+		else if (Objects.equals(propertyName, "creator")) {
+			return creator;
+		}
+		else if (Objects.equals(propertyName, "dateCreated")) {
+			return dateCreated;
+		}
+		else if (Objects.equals(propertyName, "dateModified")) {
+			return dateModified;
+		}
+		else if (Objects.equals(propertyName, "externalReferenceCode")) {
+			return externalReferenceCode;
+		}
+		else if (Objects.equals(propertyName, "id")) {
+			return id;
+		}
+		else if (Objects.equals(propertyName, "keywords")) {
+			return keywords;
+		}
+		else if (Objects.equals(propertyName, "scopeKey")) {
+			return scopeKey;
+		}
+		else if (Objects.equals(propertyName, "status")) {
+			return status;
+		}
+		else if (Objects.equals(propertyName, "taxonomyCategoryBriefs")) {
+			return taxonomyCategoryBriefs;
+		}
+		else if (Objects.equals(propertyName, "taxonomyCategoryIds")) {
+			return taxonomyCategoryIds;
+		}
+		else if (properties.containsKey(propertyName)) {
+			return properties.get(propertyName);
+		}
+
+		return null;
+	}
+
 	@Override
 	public int hashCode() {
 		String string = toString();

--- a/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/dto/v1_0/packageinfo
+++ b/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.6.2
+version 1.7.0

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/dto.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/dto.ftl
@@ -129,6 +129,7 @@ public class ${schemaName} <#if dtoParentClassName?has_content>extends ${dtoPare
 
 	<#assign
 		enumSchemas = freeMarkerTool.getDTOEnumSchemas(openAPIYAML, schema)
+		jsonMapPropertyNames = []
 		properties = freeMarkerTool.getDTOProperties(configYAML, openAPIYAML, schema)
 	/>
 
@@ -149,6 +150,7 @@ public class ${schemaName} <#if dtoParentClassName?has_content>extends ${dtoPare
 
 		<#if propertySchema.jsonMap>
 			@JsonAnyGetter
+			<#assign jsonMapPropertyNames = jsonMapPropertyNames + [propertyName] />
 		</#if>
 
 		<#if propertySchema.maxLength??>
@@ -280,6 +282,34 @@ public class ${schemaName} <#if dtoParentClassName?has_content>extends ${dtoPare
 
 		return Objects.equals(toString(), ${schemaVarName}.toString());
 	}
+
+	<#if jsonMapPropertyNames?has_content>
+		public Object getValue(String propertyName) {
+
+		<#list properties?keys as propertyName>
+			<#if jsonMapPropertyNames?seq_contains(propertyName)>
+				<#continue>
+			</#if>
+
+			if (Objects.equals(propertyName, "${propertyName}")) {
+					return ${propertyName};
+			}
+			else
+		</#list>
+
+		<#list jsonMapPropertyNames as propertyName>
+			if (${propertyName}.containsKey(propertyName)) {
+				return ${propertyName}.get(propertyName);
+			}
+
+			<#sep>
+				else
+			</#sep>
+		</#list>
+
+			return null;
+		}
+	</#if>
 
 	@Override
 	public int hashCode() {

--- a/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/dependencies/expected/sample-api/src/main/java/com/example/sample/dto/v1_0_0/TestJsonMapAttribute.java
+++ b/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/dependencies/expected/sample-api/src/main/java/com/example/sample/dto/v1_0_0/TestJsonMapAttribute.java
@@ -1,0 +1,367 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.example.sample.dto.v1_0_0;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.io.Serializable;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import javax.annotation.Generated;
+
+import javax.validation.Valid;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * @author John Doe
+ * @generated
+ */
+@Generated("")
+@GraphQLName(
+	description = "Test Component to test the generation of getValue method on DTOs when one or multiple JSON Maps are present.",
+	value = "TestJsonMapAttribute"
+)
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "TestJsonMapAttribute")
+public class TestJsonMapAttribute implements Serializable {
+
+	public static TestJsonMapAttribute toDTO(String json) {
+		return ObjectMapperUtil.readValue(TestJsonMapAttribute.class, json);
+	}
+
+	public static TestJsonMapAttribute unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(
+			TestJsonMapAttribute.class, json);
+	}
+
+	@Schema
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	@JsonIgnore
+	public void setDescription(
+		UnsafeSupplier<String, Exception> descriptionUnsafeSupplier) {
+
+		try {
+			description = descriptionUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String description;
+
+	@Schema
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	@JsonIgnore
+	public void setName(UnsafeSupplier<String, Exception> nameUnsafeSupplier) {
+		try {
+			name = nameUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String name;
+
+	@JsonAnyGetter
+	@Schema
+	@Valid
+	public Map<String, Object> getProperties1() {
+		return properties1;
+	}
+
+	public void setProperties1(Map<String, Object> properties1) {
+		this.properties1 = properties1;
+	}
+
+	@JsonIgnore
+	public void setProperties1(
+		UnsafeSupplier<Map<String, Object>, Exception>
+			properties1UnsafeSupplier) {
+
+		try {
+			properties1 = properties1UnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonAnySetter
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Map<String, Object> properties1 = new HashMap<>();
+
+	@JsonAnyGetter
+	@Schema
+	@Valid
+	public Map<String, Object> getProperties2() {
+		return properties2;
+	}
+
+	public void setProperties2(Map<String, Object> properties2) {
+		this.properties2 = properties2;
+	}
+
+	@JsonIgnore
+	public void setProperties2(
+		UnsafeSupplier<Map<String, Object>, Exception>
+			properties2UnsafeSupplier) {
+
+		try {
+			properties2 = properties2UnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonAnySetter
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Map<String, Object> properties2 = new HashMap<>();
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof TestJsonMapAttribute)) {
+			return false;
+		}
+
+		TestJsonMapAttribute testJsonMapAttribute =
+			(TestJsonMapAttribute)object;
+
+		return Objects.equals(toString(), testJsonMapAttribute.toString());
+	}
+
+	public Object getValue(String propertyName) {
+		if (Objects.equals(propertyName, "description")) {
+			return description;
+		}
+		else if (Objects.equals(propertyName, "name")) {
+			return name;
+		}
+		else if (properties1.containsKey(propertyName)) {
+			return properties1.get(propertyName);
+		}
+		else if (properties2.containsKey(propertyName)) {
+			return properties2.get(propertyName);
+		}
+
+		return null;
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		if (description != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"description\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(description));
+
+			sb.append("\"");
+		}
+
+		if (name != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"name\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(name));
+
+			sb.append("\"");
+		}
+
+		if (properties1 != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"properties1\": ");
+
+			sb.append(_toJSON(properties1));
+		}
+
+		if (properties2 != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"properties2\": ");
+
+			sb.append(_toJSON(properties2));
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@Schema(
+		accessMode = Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.example.sample.dto.v1_0_0.TestJsonMapAttribute",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+	private Map<String, Serializable> _extendedProperties;
+
+}

--- a/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/dependencies/rest-openapi.yaml
+++ b/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/dependencies/rest-openapi.yaml
@@ -62,6 +62,27 @@ components:
                         name: xmlProperty
                 property-with-hyphens:
                     type: string
+        TestJsonMapAttribute:
+            description:
+                Test Component to test the generation of getValue method on DTOs when one or multiple JSON Maps are
+                present.
+            properties:
+                description:
+                    type: string
+                name:
+                    type: string
+                properties1:
+                    additionalProperties:
+                        type: object
+                    type: object
+                    x-json-map: true
+                properties2:
+                    additionalProperties:
+                        type: object
+                    type: object
+                    x-json-map: true
+            title: TestJsonMap
+            type: object
         TestNestedArrayItems:
             description:
                 Test Component to test the REST Builder support for nested array items


### PR DESCRIPTION
**What's new?:**
- Created new autogenerated method called "getValue" in the DTOs which returns a specific atribute by it's name. It takes into account both model attributes and the "properties" defined by a json-map.
- Executed buildREST in all the portal.

**What's changed?:**
- Swapped the previous reflection usage with the new "getValue" method.

See the following **Jira ticket**: [LPS-198749](https://liferay.atlassian.net/browse/LPS-198749)