### PR TITLE
LRQA-83919 Add wait for loading api builder objects

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/APIBuilderUI.macro
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/APIBuilderUI.macro
@@ -238,6 +238,8 @@ definition {
 
 		ObjectAdmin.openObjectAdmin();
 
+		WaitForPageLoad();
+
 		ObjectPortlet.selectCustomObject(label = ${objectDefinition});
 
 		CreateObject.selectPanelCategoryKey(panelCategoryKey = "Control Panel > Object");


### PR DESCRIPTION
Background:

- Sometimes our api builder test will fail because of it hasn't finish loading all objects in object admin page. Add waitfor to avoid this kind of failures

JIra Ticket
- https://liferay.atlassian.net/browse/LRQA-83919