### PR TITLE
LPS-200125 Return the base64 encoded data of an Objects attachments field if it is required as nested field

### DIFF
--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/FileEntry.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/FileEntry.java
@@ -49,6 +49,38 @@ public class FileEntry implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(FileEntry.class, json);
 	}
 
+	@Schema(
+		description = "optional field with the content of the document in Base64, can be embedded with nestedFields (the format of the nested field must be `<attachment field name>.fieldBase64`)"
+	)
+	public String getFileBase64() {
+		return fileBase64;
+	}
+
+	public void setFileBase64(String fileBase64) {
+		this.fileBase64 = fileBase64;
+	}
+
+	@JsonIgnore
+	public void setFileBase64(
+		UnsafeSupplier<String, Exception> fileBase64UnsafeSupplier) {
+
+		try {
+			fileBase64 = fileBase64UnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(
+		description = "optional field with the content of the document in Base64, can be embedded with nestedFields (the format of the nested field must be `<attachment field name>.fieldBase64`)"
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String fileBase64;
+
 	@Schema
 	public Long getId() {
 		return id;
@@ -154,6 +186,20 @@ public class FileEntry implements Serializable {
 		StringBundler sb = new StringBundler();
 
 		sb.append("{");
+
+		if (fileBase64 != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"fileBase64\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(fileBase64));
+
+			sb.append("\"");
+		}
 
 		if (id != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/object/object-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-rest-impl/rest-openapi.yaml
@@ -28,6 +28,12 @@ components:
                     type: object
         FileEntry:
             properties:
+                fileBase64:
+                    # @review
+                    description:
+                        optional field with the content of the document in Base64, can be embedded with nestedFields
+                    readOnly: true
+                    type: string
                 id:
                     format: int64
                     type: integer

--- a/modules/apps/object/object-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-rest-impl/rest-openapi.yaml
@@ -32,6 +32,7 @@ components:
                     # @review
                     description:
                         optional field with the content of the document in Base64, can be embedded with nestedFields
+                        (the format of the nested field must be `<attachment field name>.fieldBase64`)
                     readOnly: true
                     type: string
                 id:

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -60,6 +60,8 @@ import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.Base64;
+import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
@@ -660,6 +662,12 @@ public class ObjectEntryDTOConverter
 					_dLFileEntryLocalService.fetchDLFileEntry(fileEntryId);
 
 				if (dlFileEntry != null) {
+					fileEntry.setFileBase64(
+						(String)NestedFieldsSupplier.supply(
+							objectFieldName + ".fileBase64",
+							fieldName -> Base64.encode(
+								_file.getBytes(
+									dlFileEntry.getContentStream()))));
 					fileEntry.setId(dlFileEntry.getFileEntryId());
 					fileEntry.setLink(
 						LinkUtil.toLink(
@@ -799,6 +807,9 @@ public class ObjectEntryDTOConverter
 
 	@Reference
 	private ExtensionProviderRegistry _extensionProviderRegistry;
+
+	@Reference
+	private File _file;
 
 	@Reference
 	private GroupLocalService _groupLocalService;

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -119,7 +119,67 @@ public class ObjectEntryDTOConverter
 			com.liferay.object.model.ObjectEntry objectEntry)
 		throws Exception {
 
-		return _toDTO(dtoConverterContext, objectEntry);
+		ObjectDefinition objectDefinition = _getObjectDefinition(
+			dtoConverterContext, objectEntry);
+
+		return new ObjectEntry() {
+			{
+				actions = dtoConverterContext.getActions();
+				auditEvents = _toAuditEvents(
+					dtoConverterContext, objectDefinition, objectEntry);
+				creator = CreatorUtil.toCreator(
+					_portal, dtoConverterContext.getUriInfo(),
+					_userLocalService.fetchUser(objectEntry.getUserId()));
+				dateCreated = objectEntry.getCreateDate();
+				dateModified = objectEntry.getModifiedDate();
+				externalReferenceCode = objectEntry.getExternalReferenceCode();
+				id = objectEntry.getObjectEntryId();
+				properties = _toProperties(
+					dtoConverterContext, objectDefinition, objectEntry);
+				scopeKey = _getScopeKey(objectDefinition, objectEntry);
+				status = new Status() {
+					{
+						code = objectEntry.getStatus();
+						label = WorkflowConstants.getStatusLabel(
+							objectEntry.getStatus());
+						label_i18n = _language.get(
+							LanguageResources.getResourceBundle(
+								dtoConverterContext.getLocale()),
+							WorkflowConstants.getStatusLabel(
+								objectEntry.getStatus()));
+					}
+				};
+
+				setKeywords(
+					() -> {
+						if (!objectDefinition.isEnableCategorization()) {
+							return null;
+						}
+
+						return ListUtil.toArray(
+							_assetTagLocalService.getTags(
+								objectDefinition.getClassName(),
+								objectEntry.getObjectEntryId()),
+							AssetTag.NAME_ACCESSOR);
+					});
+				setTaxonomyCategoryBriefs(
+					() -> {
+						if (!objectDefinition.isEnableCategorization()) {
+							return null;
+						}
+
+						return TransformUtil.transformToArray(
+							_assetCategoryLocalService.getCategories(
+								objectDefinition.getClassName(),
+								objectEntry.getObjectEntryId()),
+							assetCategory ->
+								TaxonomyCategoryBriefUtil.
+									toTaxonomyCategoryBrief(
+										assetCategory, dtoConverterContext),
+							TaxonomyCategoryBrief.class);
+					});
+			}
+		};
 	}
 
 	private void _addManyToOneObjectRelationshipNames(
@@ -390,7 +450,7 @@ public class ObjectEntryDTOConverter
 						com.liferay.object.model.ObjectEntry objectEntry =
 							(com.liferay.object.model.ObjectEntry)relatedModel;
 
-						return _toDTO(
+						return toDTO(
 							_getDTOConverterContext(
 								dtoConverterContext,
 								objectEntry.getObjectEntryId()),
@@ -516,74 +576,6 @@ public class ObjectEntryDTOConverter
 				}
 			},
 			AuditFieldChange.class);
-	}
-
-	private ObjectEntry _toDTO(
-			DTOConverterContext dtoConverterContext,
-			com.liferay.object.model.ObjectEntry objectEntry)
-		throws Exception {
-
-		ObjectDefinition objectDefinition = _getObjectDefinition(
-			dtoConverterContext, objectEntry);
-
-		return new ObjectEntry() {
-			{
-				actions = dtoConverterContext.getActions();
-				auditEvents = _toAuditEvents(
-					dtoConverterContext, objectDefinition, objectEntry);
-				creator = CreatorUtil.toCreator(
-					_portal, dtoConverterContext.getUriInfo(),
-					_userLocalService.fetchUser(objectEntry.getUserId()));
-				dateCreated = objectEntry.getCreateDate();
-				dateModified = objectEntry.getModifiedDate();
-				externalReferenceCode = objectEntry.getExternalReferenceCode();
-				id = objectEntry.getObjectEntryId();
-				properties = _toProperties(
-					dtoConverterContext, objectDefinition, objectEntry);
-				scopeKey = _getScopeKey(objectDefinition, objectEntry);
-				status = new Status() {
-					{
-						code = objectEntry.getStatus();
-						label = WorkflowConstants.getStatusLabel(
-							objectEntry.getStatus());
-						label_i18n = _language.get(
-							LanguageResources.getResourceBundle(
-								dtoConverterContext.getLocale()),
-							WorkflowConstants.getStatusLabel(
-								objectEntry.getStatus()));
-					}
-				};
-
-				setKeywords(
-					() -> {
-						if (!objectDefinition.isEnableCategorization()) {
-							return null;
-						}
-
-						return ListUtil.toArray(
-							_assetTagLocalService.getTags(
-								objectDefinition.getClassName(),
-								objectEntry.getObjectEntryId()),
-							AssetTag.NAME_ACCESSOR);
-					});
-				setTaxonomyCategoryBriefs(
-					() -> {
-						if (!objectDefinition.isEnableCategorization()) {
-							return null;
-						}
-
-						return TransformUtil.transformToArray(
-							_assetCategoryLocalService.getCategories(
-								objectDefinition.getClassName(),
-								objectEntry.getObjectEntryId()),
-							assetCategory ->
-								TaxonomyCategoryBriefUtil.
-									toTaxonomyCategoryBrief(
-										assetCategory, dtoConverterContext),
-							TaxonomyCategoryBrief.class);
-					});
-			}
-		};
 	}
 
 	private ExtendedEntity _toExtendedEntity(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -180,7 +180,8 @@ public class ObjectEntryResourceTest {
 		_objectDefinition1 = ObjectDefinitionTestUtil.publishObjectDefinition(
 			Arrays.asList(
 				ObjectFieldUtil.createObjectField(
-					"Text", "String", true, true, null,
+					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+					ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
 					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME_1, false),
 				ObjectFieldUtil.createObjectField(
 					ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT,
@@ -221,7 +222,8 @@ public class ObjectEntryResourceTest {
 		_objectDefinition2 = ObjectDefinitionTestUtil.publishObjectDefinition(
 			Arrays.asList(
 				ObjectFieldUtil.createObjectField(
-					"Text", "String", true, true, null,
+					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+					ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
 					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME_2, false),
 				ObjectFieldUtil.createObjectField(
 					_listTypeDefinition.getListTypeDefinitionId(),
@@ -236,7 +238,8 @@ public class ObjectEntryResourceTest {
 		_objectDefinition3 = ObjectDefinitionTestUtil.publishObjectDefinition(
 			Arrays.asList(
 				ObjectFieldUtil.createObjectField(
-					"Text", "String", true, true, null,
+					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+					ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
 					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME_3, false),
 				ObjectFieldUtil.createObjectField(
 					_listTypeDefinition.getListTypeDefinitionId(),
@@ -251,7 +254,8 @@ public class ObjectEntryResourceTest {
 		_objectDefinition4 = ObjectDefinitionTestUtil.publishObjectDefinition(
 			Arrays.asList(
 				ObjectFieldUtil.createObjectField(
-					"Text", "String", true, true, null,
+					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+					ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
 					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME_4, false),
 				ObjectFieldUtil.createObjectField(
 					_listTypeDefinition.getListTypeDefinitionId(),
@@ -267,7 +271,8 @@ public class ObjectEntryResourceTest {
 			ObjectDefinitionTestUtil.publishObjectDefinition(
 				Collections.singletonList(
 					ObjectFieldUtil.createObjectField(
-						"Text", "String", true, true, null,
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
 						RandomTestUtil.randomString(), _OBJECT_FIELD_NAME_1,
 						false)),
 				ObjectDefinitionConstants.SCOPE_SITE);
@@ -3883,19 +3888,20 @@ public class ObjectEntryResourceTest {
 						Arrays.asList(
 							new ObjectFieldSettingBuilder(
 							).name(
-								"acceptedFileExtensions"
+								ObjectFieldSettingConstants.
+									NAME_ACCEPTED_FILE_EXTENSIONS
 							).value(
 								"txt"
 							).build(),
 							new ObjectFieldSettingBuilder(
 							).name(
-								"fileSource"
+								ObjectFieldSettingConstants.NAME_FILE_SOURCE
 							).value(
-								"userComputer"
+								ObjectFieldSettingConstants.VALUE_USER_COMPUTER
 							).build(),
 							new ObjectFieldSettingBuilder(
 							).name(
-								"maximumFileSize"
+								ObjectFieldSettingConstants.NAME_MAX_FILE_SIZE
 							).value(
 								"100"
 							).build()),

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -25,6 +25,7 @@ import com.liferay.object.constants.ObjectActionKeys;
 import com.liferay.object.constants.ObjectActionTriggerConstants;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.constants.ObjectFieldSettingConstants;
 import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.field.setting.builder.ObjectFieldSettingBuilder;
 import com.liferay.object.field.util.ObjectFieldUtil;
@@ -42,6 +43,7 @@ import com.liferay.object.rest.test.util.UserAccountTestUtil;
 import com.liferay.object.service.ObjectActionLocalService;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectFieldSettingLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.system.SystemObjectDefinitionManager;
 import com.liferay.object.system.SystemObjectDefinitionManagerRegistry;
@@ -75,6 +77,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -179,6 +182,32 @@ public class ObjectEntryResourceTest {
 				ObjectFieldUtil.createObjectField(
 					"Text", "String", true, true, null,
 					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME_1, false),
+				ObjectFieldUtil.createObjectField(
+					ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT,
+					ObjectFieldConstants.DB_TYPE_LONG, true, false, null,
+					_OBJECT_FIELD_NAME_ATTACHMENT,
+					_OBJECT_FIELD_NAME_ATTACHMENT,
+					Arrays.asList(
+						new ObjectFieldSettingBuilder(
+						).name(
+							ObjectFieldSettingConstants.
+								NAME_ACCEPTED_FILE_EXTENSIONS
+						).value(
+							"txt"
+						).build(),
+						new ObjectFieldSettingBuilder(
+						).name(
+							ObjectFieldSettingConstants.NAME_FILE_SOURCE
+						).value(
+							ObjectFieldSettingConstants.VALUE_USER_COMPUTER
+						).build(),
+						new ObjectFieldSettingBuilder(
+						).name(
+							ObjectFieldSettingConstants.NAME_MAX_FILE_SIZE
+						).value(
+							"100"
+						).build()),
+					false),
 				ObjectFieldUtil.createObjectField(
 					_listTypeDefinition.getListTypeDefinitionId(),
 					ObjectFieldConstants.BUSINESS_TYPE_MULTISELECT_PICKLIST,
@@ -3731,6 +3760,78 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
+	public void testGetObjectEntryWithAttachmentField() throws Exception {
+		String content = RandomTestUtil.randomString();
+
+		FileEntry fileEntry = _addTempFileEntry(
+			content, _objectDefinition1, RandomTestUtil.randomString());
+
+		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				_OBJECT_FIELD_NAME_1, "value1"
+			).put(
+				_OBJECT_FIELD_NAME_ATTACHMENT, fileEntry.getFileEntryId()
+			).toString(),
+			_objectDefinition1.getRESTContextPath(), Http.Method.POST);
+
+		JSONObject attachmentJSONObject = jsonObject.getJSONObject(
+			_OBJECT_FIELD_NAME_ATTACHMENT);
+
+		Assert.assertNull(attachmentJSONObject.get("fileBase64"));
+
+		content = RandomTestUtil.randomString();
+
+		fileEntry = _addTempFileEntry(
+			content, _objectDefinition1, RandomTestUtil.randomString());
+
+		jsonObject = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				_OBJECT_FIELD_NAME_1, "value2"
+			).put(
+				_OBJECT_FIELD_NAME_ATTACHMENT, fileEntry.getFileEntryId()
+			).toString(),
+			StringBundler.concat(
+				_objectDefinition1.getRESTContextPath(), "?nestedFields=",
+				_OBJECT_FIELD_NAME_ATTACHMENT, ".fileBase64"),
+			Http.Method.POST);
+
+		attachmentJSONObject = jsonObject.getJSONObject(
+			_OBJECT_FIELD_NAME_ATTACHMENT);
+
+		Assert.assertEquals(
+			Base64.encode(content.getBytes()),
+			attachmentJSONObject.getString("fileBase64"));
+
+		jsonObject = HTTPTestUtil.invokeToJSONObject(
+			null,
+			_objectDefinition1.getRESTContextPath() +
+				"/by-external-reference-code/" +
+					jsonObject.getString("externalReferenceCode"),
+			Http.Method.GET);
+
+		attachmentJSONObject = jsonObject.getJSONObject(
+			_OBJECT_FIELD_NAME_ATTACHMENT);
+
+		Assert.assertNull(attachmentJSONObject.get("fileBase64"));
+
+		jsonObject = HTTPTestUtil.invokeToJSONObject(
+			null,
+			StringBundler.concat(
+				_objectDefinition1.getRESTContextPath(),
+				"/by-external-reference-code/",
+				jsonObject.getString("externalReferenceCode"), "?nestedFields=",
+				_OBJECT_FIELD_NAME_ATTACHMENT, ".fileBase64"),
+			Http.Method.GET);
+
+		attachmentJSONObject = jsonObject.getJSONObject(
+			_OBJECT_FIELD_NAME_ATTACHMENT);
+
+		Assert.assertEquals(
+			Base64.encode(content.getBytes()),
+			attachmentJSONObject.getString("fileBase64"));
+	}
+
+	@Test
 	public void testGetObjectEntryWithAuditEvents() throws Exception {
 		ListTypeDefinition listTypeDefinition =
 			_listTypeDefinitionLocalService.addListTypeDefinition(
@@ -3840,7 +3941,8 @@ public class ObjectEntryResourceTest {
 						"upload",
 						() -> {
 							FileEntry fileEntry = _addTempFileEntry(
-								objectDefinition, "Old Testament");
+								RandomTestUtil.randomString(), objectDefinition,
+								"Old Testament");
 
 							return fileEntry.getFileEntryId();
 						}
@@ -3863,7 +3965,8 @@ public class ObjectEntryResourceTest {
 					"upload",
 					() -> {
 						FileEntry fileEntry = _addTempFileEntry(
-							objectDefinition, "New Testament");
+							RandomTestUtil.randomString(), objectDefinition,
+							"New Testament");
 
 						return fileEntry.getFileEntryId();
 					}
@@ -5413,14 +5516,14 @@ public class ObjectEntryResourceTest {
 	}
 
 	private FileEntry _addTempFileEntry(
-			ObjectDefinition objectDefinition, String title)
+			String content, ObjectDefinition objectDefinition, String title)
 		throws Exception {
 
 		return TempFileEntryUtil.addTempFileEntry(
 			TestPropsValues.getGroupId(), TestPropsValues.getUserId(),
 			objectDefinition.getPortletId(),
 			TempFileEntryUtil.getTempFileName(title + ".txt"),
-			FileUtil.createTempFile(RandomTestUtil.randomBytes()),
+			FileUtil.createTempFile(content.getBytes()),
 			ContentTypes.TEXT_PLAIN);
 	}
 
@@ -6127,6 +6230,9 @@ public class ObjectEntryResourceTest {
 	private static final String _OBJECT_FIELD_NAME_4 =
 		"x" + RandomTestUtil.randomString();
 
+	private static final String _OBJECT_FIELD_NAME_ATTACHMENT =
+		"x" + RandomTestUtil.randomString();
+
 	private static final String _OBJECT_FIELD_NAME_MULTISELECT_PICKLIST =
 		"x" + RandomTestUtil.randomString();
 
@@ -6173,6 +6279,9 @@ public class ObjectEntryResourceTest {
 
 	@Inject
 	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject
+	private ObjectFieldSettingLocalService _objectFieldSettingLocalService;
 
 	private ObjectRelationship _objectRelationship1;
 	private ObjectRelationship _objectRelationship2;


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPS-200125

---

The purpose of this PR is to return the base64 encoded data of an attachment field of a given Object Entry in the `GET` endpoints. For that, the user has to require the field by using the query parameter `nestedFields`.

Given an attachmenf field called `myAttachmentField`, the format of the field in the Object Entry REST API is the following one:

```
"myAttachmentField": {
  "id": 1234,
  "link": {
    "href": "/documents/20113/0/ticket_16.10.2023.jpg/....",
    "label": "image.jpg"
  },
  "name": "image.jpg",
}
```
For the new base64 encoded content, we have created the field `fileBase64` inside the `FileEntry` schema:

```
"myAttachmentField": {
  "fileBase64": "<base64 content>",
  "id": 1234,
  "link": {
    "href": "/documents/20113/0/ticket_16.10.2023.jpg/....",
    "label": "image.jpg"
  },
  "name": "image.jpg"
}
```

In order to get the new `fileBase64` subfield, the format of the nested field is:

`nestedFields=<name_of_the_field>.fileBase64`, in this case `nestedFields=myAttachmentField.fileBase64`

