### PR TITLE
LPS-200173 Fix regex as we need to allow 1 only alphanumeric character as minimum, not 2

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIEndpointRelevantObjectEntryModelListener.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIEndpointRelevantObjectEntryModelListener.java
@@ -352,9 +352,9 @@ public class APIEndpointRelevantObjectEntryModelListener
 	private static final Pattern _curlyBracePattern = Pattern.compile(
 		"^\\{[a-zA-Z0-9]+\\}$");
 	private static final Pattern _pathPattern = Pattern.compile(
-		"/[a-z0-9][a-z0-9-/]{1,253}");
+		"/[a-z0-9][a-z0-9-/]{0,253}");
 	private static final Pattern _singleElementPathPattern = Pattern.compile(
-		"/[a-zA-Z0-9][a-zA-Z0-9-/-{\\-}]{1,253}");
+		"/[a-zA-Z0-9][a-zA-Z0-9-/-{\\-}]{0,253}");
 
 	@Reference(
 		target = "(filter.factory.key=" + ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT + ")"


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPS-200173

----

The purpose of this PR is to fix the related ticket. The problem is the regular expression was accepting a minimum of 2 alphanumeric characters (apart from the initial `/`), making the process fail if the path just contains 1