### PR TITLE
LPS-200502: Not possible to get Objects OpenAPI in Yaml format

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/openapi/v1_0/ObjectEntryOpenAPIResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/openapi/v1_0/ObjectEntryOpenAPIResourceImpl.java
@@ -9,7 +9,6 @@ import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.constants.ObjectFieldSettingConstants;
 import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.field.setting.util.ObjectFieldSettingUtil;
-import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectRelationship;
@@ -28,7 +27,6 @@ import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.system.SystemObjectDefinitionManagerRegistry;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.TreeMapBuilder;
 import com.liferay.portal.vulcan.batch.engine.Field;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
@@ -49,7 +47,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -265,24 +262,23 @@ public class ObjectEntryOpenAPIResourceImpl
 			boolean addRelatedSchemas, String type, UriInfo uriInfo)
 		throws Exception {
 
-		return _setReadOnly(
-			_openAPIResource.getOpenAPI(
-				new ObjectEntryOpenAPIContributor(
-					addRelatedSchemas, _bundleContext, _dtoConverterRegistry,
-					_objectActionLocalService, _objectDefinition,
-					_objectDefinitionLocalService, this,
-					_objectEntryOpenAPIResourceProvider,
-					_objectRelationshipLocalService, _openAPIResource,
-					_systemObjectDefinitionManagerRegistry),
-				_getOpenAPISchemaFilter(_objectDefinition),
-				new HashSet<Class<?>>() {
-					{
-						add(ObjectEntryRelatedObjectsResourceImpl.class);
-						add(ObjectEntryResourceImpl.class);
-						add(OpenAPIResourceImpl.class);
-					}
-				},
-				type, uriInfo));
+		return _openAPIResource.getOpenAPI(
+			new ObjectEntryOpenAPIContributor(
+				addRelatedSchemas, _bundleContext, _dtoConverterRegistry,
+				_objectActionLocalService, _objectDefinition,
+				_objectDefinitionLocalService, this,
+				_objectEntryOpenAPIResourceProvider, _objectFieldLocalService,
+				_objectRelationshipLocalService, _openAPIResource,
+				_systemObjectDefinitionManagerRegistry),
+			_getOpenAPISchemaFilter(_objectDefinition),
+			new HashSet<Class<?>>() {
+				{
+					add(ObjectEntryRelatedObjectsResourceImpl.class);
+					add(ObjectEntryResourceImpl.class);
+					add(OpenAPIResourceImpl.class);
+				}
+			},
+			type, uriInfo);
 	}
 
 	private OpenAPISchemaFilter _getOpenAPISchemaFilter(
@@ -408,52 +404,6 @@ public class ObjectEntryOpenAPIResourceImpl
 		return requiredPropertySchemaNames;
 	}
 
-	private Response _setReadOnly(Response response) {
-		Map<String, ObjectField> objectFields =
-			ObjectFieldUtil.toObjectFieldsMap(
-				_objectFieldLocalService.getObjectFields(
-					_objectDefinition.getObjectDefinitionId()));
-
-		Schema schema = _getObjectDefinitionSchema(
-			(OpenAPI)response.getEntity());
-
-		Map<String, Schema> properties = schema.getProperties();
-
-		for (Map.Entry<String, Schema> entry : properties.entrySet()) {
-			String key = entry.getKey();
-
-			schema = entry.getValue();
-
-			if (_readOnlyFieldNames.contains(key)) {
-				schema.readOnly(true);
-
-				continue;
-			}
-
-			ObjectField objectField = objectFields.get(key);
-
-			if (objectField == null) {
-				continue;
-			}
-
-			if (Objects.equals(
-					objectField.getReadOnly(),
-					ObjectFieldConstants.READ_ONLY_CONDITIONAL) ||
-				Objects.equals(
-					objectField.getReadOnly(),
-					ObjectFieldConstants.READ_ONLY_FALSE)) {
-
-				schema.readOnly(false);
-
-				continue;
-			}
-
-			schema.readOnly(true);
-		}
-
-		return response;
-	}
-
 	private final BundleContext _bundleContext;
 	private final DTOConverterRegistry _dtoConverterRegistry;
 	private final Map<String, String> _fieldNameMappings = HashMapBuilder.put(
@@ -470,8 +420,6 @@ public class ObjectEntryOpenAPIResourceImpl
 	private final ObjectRelationshipLocalService
 		_objectRelationshipLocalService;
 	private final OpenAPIResource _openAPIResource;
-	private final Set<String> _readOnlyFieldNames = SetUtil.fromArray(
-		"dateCreated", "dateModified", "id");
 	private final SystemObjectDefinitionManagerRegistry
 		_systemObjectDefinitionManagerRegistry;
 

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/openapi/contributor/ObjectEntryOpenAPIContributor.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/openapi/contributor/ObjectEntryOpenAPIContributor.java
@@ -6,9 +6,12 @@
 package com.liferay.object.rest.internal.vulcan.openapi.contributor;
 
 import com.liferay.object.constants.ObjectActionTriggerConstants;
+import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.constants.ObjectRelationshipConstants;
+import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectAction;
 import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.relationship.util.ObjectRelationshipUtil;
 import com.liferay.object.rest.internal.vulcan.openapi.contributor.util.OpenAPIContributorUtil;
@@ -16,6 +19,7 @@ import com.liferay.object.rest.openapi.v1_0.ObjectEntryOpenAPIResource;
 import com.liferay.object.rest.openapi.v1_0.ObjectEntryOpenAPIResourceProvider;
 import com.liferay.object.service.ObjectActionLocalService;
 import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.system.SystemObjectDefinitionManagerRegistry;
 import com.liferay.petra.string.StringBundler;
@@ -23,6 +27,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 import com.liferay.portal.vulcan.openapi.OpenAPIContext;
@@ -49,6 +54,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import org.osgi.framework.BundleContext;
 
@@ -65,6 +71,7 @@ public class ObjectEntryOpenAPIContributor extends BaseOpenAPIContributor {
 		ObjectDefinitionLocalService objectDefinitionLocalService,
 		ObjectEntryOpenAPIResource objectEntryOpenAPIResource,
 		ObjectEntryOpenAPIResourceProvider objectEntryOpenAPIResourceProvider,
+		ObjectFieldLocalService objectFieldLocalService,
 		ObjectRelationshipLocalService objectRelationshipLocalService,
 		OpenAPIResource openAPIResource,
 		SystemObjectDefinitionManagerRegistry
@@ -78,6 +85,7 @@ public class ObjectEntryOpenAPIContributor extends BaseOpenAPIContributor {
 		_objectEntryOpenAPIResource = objectEntryOpenAPIResource;
 		_objectEntryOpenAPIResourceProvider =
 			objectEntryOpenAPIResourceProvider;
+		_objectFieldLocalService = objectFieldLocalService;
 		_objectRelationshipLocalService = objectRelationshipLocalService;
 		_openAPIResource = openAPIResource;
 
@@ -208,6 +216,8 @@ public class ObjectEntryOpenAPIContributor extends BaseOpenAPIContributor {
 				_getIndividualActionSchemas(
 					openAPIContext, openAPI.getPaths()));
 		}
+
+		_setReadOnlyProperties(openAPI);
 	}
 
 	private void _addObjectActionPathItem(
@@ -504,6 +514,14 @@ public class ObjectEntryOpenAPIContributor extends BaseOpenAPIContributor {
 		return individualActionSchemas;
 	}
 
+	private Schema _getObjectDefinitionSchema(OpenAPI openAPI) {
+		Components components = openAPI.getComponents();
+
+		Map<String, Schema> schemas = components.getSchemas();
+
+		return schemas.get(_objectDefinition.getShortName());
+	}
+
 	private ApiResponses _getObjectRelationshipApiResponses(
 		Operation operation, String schemaName) {
 
@@ -771,6 +789,49 @@ public class ObjectEntryOpenAPIContributor extends BaseOpenAPIContributor {
 		}
 	}
 
+	private void _setReadOnlyProperties(OpenAPI openAPI) {
+		Map<String, ObjectField> objectFields =
+			ObjectFieldUtil.toObjectFieldsMap(
+				_objectFieldLocalService.getObjectFields(
+					_objectDefinition.getObjectDefinitionId()));
+
+		Schema schema = _getObjectDefinitionSchema(openAPI);
+
+		Map<String, Schema> properties = schema.getProperties();
+
+		for (Map.Entry<String, Schema> entry : properties.entrySet()) {
+			String key = entry.getKey();
+
+			schema = entry.getValue();
+
+			if (_readOnlyFieldNames.contains(key)) {
+				schema.readOnly(true);
+
+				continue;
+			}
+
+			ObjectField objectField = objectFields.get(key);
+
+			if (objectField == null) {
+				continue;
+			}
+
+			if (Objects.equals(
+					objectField.getReadOnly(),
+					ObjectFieldConstants.READ_ONLY_CONDITIONAL) ||
+				Objects.equals(
+					objectField.getReadOnly(),
+					ObjectFieldConstants.READ_ONLY_FALSE)) {
+
+				schema.readOnly(false);
+
+				continue;
+			}
+
+			schema.readOnly(true);
+		}
+	}
+
 	private void _setSchemaDescription(
 		ObjectRelationship objectRelationship, OpenAPI openAPI,
 		String relatedSchemaName) {
@@ -799,8 +860,11 @@ public class ObjectEntryOpenAPIContributor extends BaseOpenAPIContributor {
 	private final ObjectEntryOpenAPIResource _objectEntryOpenAPIResource;
 	private final ObjectEntryOpenAPIResourceProvider
 		_objectEntryOpenAPIResourceProvider;
+	private final ObjectFieldLocalService _objectFieldLocalService;
 	private final ObjectRelationshipLocalService
 		_objectRelationshipLocalService;
 	private final OpenAPIResource _openAPIResource;
+	private final Set<String> _readOnlyFieldNames = SetUtil.fromArray(
+		"dateCreated", "dateModified", "id");
 
 }

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/openapi/contributor/ObjectEntryOpenAPIContributor.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/openapi/contributor/ObjectEntryOpenAPIContributor.java
@@ -103,9 +103,7 @@ public class ObjectEntryOpenAPIContributor extends BaseOpenAPIContributor {
 		Map<ObjectRelationship, ObjectDefinition> relatedObjectDefinitionsMap =
 			_getRelatedObjectDefinitionsMap();
 
-		Components components = openAPI.getComponents();
-
-		Map<String, Schema> schemas = components.getSchemas();
+		Map<String, Schema> schemas = _getSchemas(openAPI);
 
 		Schema objectDefinitionSchema = schemas.get(
 			_objectDefinition.getShortName());
@@ -217,7 +215,7 @@ public class ObjectEntryOpenAPIContributor extends BaseOpenAPIContributor {
 					openAPIContext, openAPI.getPaths()));
 		}
 
-		_setReadOnlyProperties(openAPI);
+		_setReadOnlyProperties(schemas);
 	}
 
 	private void _addObjectActionPathItem(
@@ -514,14 +512,6 @@ public class ObjectEntryOpenAPIContributor extends BaseOpenAPIContributor {
 		return individualActionSchemas;
 	}
 
-	private Schema _getObjectDefinitionSchema(OpenAPI openAPI) {
-		Components components = openAPI.getComponents();
-
-		Map<String, Schema> schemas = components.getSchemas();
-
-		return schemas.get(_objectDefinition.getShortName());
-	}
-
 	private ApiResponses _getObjectRelationshipApiResponses(
 		Operation operation, String schemaName) {
 
@@ -701,6 +691,12 @@ public class ObjectEntryOpenAPIContributor extends BaseOpenAPIContributor {
 		return objectSchema;
 	}
 
+	private Map<String, Schema> _getSchemas(OpenAPI openAPI) {
+		Components components = openAPI.getComponents();
+
+		return components.getSchemas();
+	}
+
 	private void _setCollectionActionSchemas(
 		Map<String, Schema> actionSchemas, OpenAPIContext openAPIContext,
 		Map<PathItem.HttpMethod, Operation> operations, String pathName) {
@@ -789,23 +785,24 @@ public class ObjectEntryOpenAPIContributor extends BaseOpenAPIContributor {
 		}
 	}
 
-	private void _setReadOnlyProperties(OpenAPI openAPI) {
+	private void _setReadOnlyProperties(Map<String, Schema> schemas) {
 		Map<String, ObjectField> objectFields =
 			ObjectFieldUtil.toObjectFieldsMap(
 				_objectFieldLocalService.getObjectFields(
 					_objectDefinition.getObjectDefinitionId()));
 
-		Schema schema = _getObjectDefinitionSchema(openAPI);
+		Schema objectDefinitionSchema = schemas.get(
+			_objectDefinition.getShortName());
 
-		Map<String, Schema> properties = schema.getProperties();
+		Map<String, Schema> properties = objectDefinitionSchema.getProperties();
 
 		for (Map.Entry<String, Schema> entry : properties.entrySet()) {
 			String key = entry.getKey();
 
-			schema = entry.getValue();
+			objectDefinitionSchema = entry.getValue();
 
 			if (_readOnlyFieldNames.contains(key)) {
-				schema.readOnly(true);
+				objectDefinitionSchema.readOnly(true);
 
 				continue;
 			}
@@ -823,12 +820,12 @@ public class ObjectEntryOpenAPIContributor extends BaseOpenAPIContributor {
 					objectField.getReadOnly(),
 					ObjectFieldConstants.READ_ONLY_FALSE)) {
 
-				schema.readOnly(false);
+				objectDefinitionSchema.readOnly(false);
 
 				continue;
 			}
 
-			schema.readOnly(true);
+			objectDefinitionSchema.readOnly(true);
 		}
 	}
 
@@ -842,9 +839,7 @@ public class ObjectEntryOpenAPIContributor extends BaseOpenAPIContributor {
 			(objectRelationship.getObjectDefinitionId2() ==
 				_objectDefinition.getObjectDefinitionId())) {
 
-			Components components = openAPI.getComponents();
-
-			Map<String, Schema> schemas = components.getSchemas();
+			Map<String, Schema> schemas = _getSchemas(openAPI);
 
 			Schema schema = schemas.get(relatedSchemaName);
 

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/openapi/contributor/ObjectEntryOpenAPIContributor.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/openapi/contributor/ObjectEntryOpenAPIContributor.java
@@ -860,6 +860,6 @@ public class ObjectEntryOpenAPIContributor extends BaseOpenAPIContributor {
 		_objectRelationshipLocalService;
 	private final OpenAPIResource _openAPIResource;
 	private final Set<String> _readOnlyFieldNames = SetUtil.fromArray(
-		"dateCreated", "dateModified", "id");
+		"dateCreated", "dateModified");
 
 }

--- a/modules/apps/object/object-rest-test/bnd.bnd
+++ b/modules/apps/object/object-rest-test/bnd.bnd
@@ -1,6 +1,13 @@
 Bundle-Name: Liferay Object REST Test
 Bundle-SymbolicName: com.liferay.object.rest.test
 Bundle-Version: 1.0.0
+Import-Package: !com.fasterxml.jackson.dataformat.yaml.*
+\
+	!org.yaml.snakeyaml.*,\
+\
+	*
 -includeresource:\
 	com.liferay.headless.admin.taxonomy.client.jar=com.liferay.headless.admin.taxonomy.client-*.jar;lib:=true,\
-	@jsonassert-[0-9.]*.jar
+	@jackson-dataformat-yaml-[0-9.]*.jar,\
+	@jsonassert-[0-9.]*.jar,\
+	@snakeyaml-[0-9.]*.jar

--- a/modules/apps/object/object-rest-test/build.gradle
+++ b/modules/apps/object/object-rest-test/build.gradle
@@ -2,9 +2,12 @@ dependencies {
 	testCompileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	testCompileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 
+	testIntegrationImplementation group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.13.4.2"
+	testIntegrationImplementation group: "com.fasterxml.jackson.dataformat", name: "jackson-dataformat-yaml", version: "2.14.2"
 	testIntegrationImplementation group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"
 	testIntegrationImplementation group: "org.apache.cxf", name: "cxf-core", version: "3.4.10"
 	testIntegrationImplementation group: "org.skyscreamer", name: "jsonassert", version: "1.2.3"
+	testIntegrationImplementation group: "org.yaml", name: "snakeyaml", version: "2.0"
 	testIntegrationImplementation project(":apps:account:account-api")
 	testIntegrationImplementation project(":apps:document-library:document-library-api")
 	testIntegrationImplementation project(":apps:headless:headless-admin-taxonomy:headless-admin-taxonomy-client")

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/OpenAPIResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/OpenAPIResourceTest.java
@@ -5,6 +5,9 @@
 
 package com.liferay.object.rest.internal.resource.v1_0.test;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.object.constants.ObjectActionExecutorConstants;
 import com.liferay.object.constants.ObjectActionTriggerConstants;
@@ -21,6 +24,7 @@ import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.User;
@@ -218,6 +222,39 @@ public class OpenAPIResourceTest {
 				_objectDefinitionLocalService.updateObjectDefinition(
 					_objectDefinition1);
 		}
+	}
+
+	private void _assertJSONObjectOpenAPI(
+		JSONObject openAPIJSONObject, ObjectDefinition objectDefinition1,
+		ObjectDefinition objectDefinition2) {
+
+		Assert.assertNotNull(openAPIJSONObject.getString("openapi"));
+		Assert.assertNull(
+			openAPIJSONObject.getJSONArray(
+				objectDefinition2.getRESTContextPath()));
+
+		JSONObject schemasJSONObject = openAPIJSONObject.getJSONObject(
+			"components"
+		).getJSONObject(
+			"schemas"
+		);
+
+		Assert.assertNotNull(
+			schemasJSONObject.getJSONObject("TaxonomyCategoryBrief"));
+
+		JSONObject propertiesJSONObject = schemasJSONObject.getJSONObject(
+			objectDefinition1.getShortName()
+		).getJSONObject(
+			"properties"
+		);
+
+		Assert.assertNull(propertiesJSONObject.getJSONObject("createDate"));
+		Assert.assertNotNull(propertiesJSONObject.getJSONObject("keywords"));
+		Assert.assertNull(propertiesJSONObject.getJSONObject("modifiedDate"));
+		Assert.assertNotNull(
+			propertiesJSONObject.getJSONObject("taxonomyCategoryBriefs"));
+		Assert.assertNotNull(
+			propertiesJSONObject.getJSONObject("taxonomyCategoryIds"));
 	}
 
 	private void _assertObjectRelationshipEndpoints(
@@ -431,10 +468,10 @@ public class OpenAPIResourceTest {
 			ObjectDefinition objectDefinition2)
 		throws Exception {
 
-		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+		JSONObject openAPIJSONObject = HTTPTestUtil.invokeToJSONObject(
 			null, "/openapi", Http.Method.GET);
 
-		JSONArray jsonArray = jsonObject.getJSONArray(
+		JSONArray jsonArray = openAPIJSONObject.getJSONArray(
 			objectDefinition1.getRESTContextPath());
 
 		Assert.assertEquals(1, jsonArray.length());
@@ -443,42 +480,37 @@ public class OpenAPIResourceTest {
 				"/openapi.yaml",
 			jsonArray.get(0));
 
-		jsonObject = HTTPTestUtil.invokeToJSONObject(
+		openAPIJSONObject = HTTPTestUtil.invokeToJSONObject(
 			null, objectDefinition1.getRESTContextPath() + "/openapi.json",
 			Http.Method.GET);
 
-		Assert.assertNotNull(jsonObject.getString("openapi"));
-		Assert.assertNull(
-			jsonObject.getJSONArray(objectDefinition2.getRESTContextPath()));
+		_assertJSONObjectOpenAPI(
+			openAPIJSONObject, objectDefinition1, objectDefinition2);
 
-		JSONObject schemasJSONObject = jsonObject.getJSONObject(
-			"components"
-		).getJSONObject(
-			"schemas"
-		);
-
-		Assert.assertNotNull(
-			schemasJSONObject.getJSONObject("TaxonomyCategoryBrief"));
-
-		JSONObject propertiesJSONObject = schemasJSONObject.getJSONObject(
-			objectDefinition1.getShortName()
-		).getJSONObject(
-			"properties"
-		);
-
-		Assert.assertNull(propertiesJSONObject.getJSONObject("createDate"));
-		Assert.assertNotNull(propertiesJSONObject.getJSONObject("keywords"));
-		Assert.assertNull(propertiesJSONObject.getJSONObject("modifiedDate"));
-		Assert.assertNotNull(
-			propertiesJSONObject.getJSONObject("taxonomyCategoryBriefs"));
-		Assert.assertNotNull(
-			propertiesJSONObject.getJSONObject("taxonomyCategoryIds"));
-
-		jsonObject = HTTPTestUtil.invokeToJSONObject(
+		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
 			null, objectDefinition2.getRESTContextPath() + "/openapi.json",
 			Http.Method.GET);
 
 		Assert.assertEquals("NOT_FOUND", jsonObject.getString("status"));
+
+		String openAPIYAMLString = HTTPTestUtil.invokeToString(
+			null, objectDefinition1.getRESTContextPath() + "/openapi.yaml",
+			Http.Method.GET);
+
+		_assertJSONObjectOpenAPI(
+			_toJSONObject(openAPIYAMLString), objectDefinition1,
+			objectDefinition2);
+	}
+
+	private JSONObject _toJSONObject(String yamlString) throws Exception {
+		ObjectMapper yamlObjectMapper = new ObjectMapper(new YAMLFactory());
+
+		Object object = yamlObjectMapper.readValue(yamlString, Object.class);
+
+		ObjectMapper objectMapper = new ObjectMapper();
+
+		return JSONFactoryUtil.createJSONObject(
+			objectMapper.writeValueAsString(object));
 	}
 
 	private static final String _OBJECT_FIELD_NAME =

--- a/portal-test/bnd.bnd
+++ b/portal-test/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 23.0.2
+Bundle-Version: 23.1.0
 Export-Package:\
 	com.liferay.portal.kernel.dao.db.test,\
 	com.liferay.portal.kernel.test,\

--- a/portal-test/src/com/liferay/portal/kernel/test/util/HTTPTestUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/HTTPTestUtil.java
@@ -44,9 +44,17 @@ public class HTTPTestUtil {
 			String body, String endpoint, Http.Method httpMethod)
 		throws Exception {
 
+		return JSONFactoryUtil.createJSONObject(
+			invokeToString(body, endpoint, httpMethod));
+	}
+
+	public static String invokeToString(
+			String body, String endpoint, Http.Method httpMethod)
+		throws Exception {
+
 		Http.Options options = _getHttpOptions(body, endpoint, httpMethod);
 
-		return JSONFactoryUtil.createJSONObject(HttpUtil.URLtoString(options));
+		return HttpUtil.URLtoString(options);
 	}
 
 	public static class HTTPTestUtilCustomizer {

--- a/portal-test/src/com/liferay/portal/kernel/test/util/packageinfo
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 7.0.0
+version 7.1.0


### PR DESCRIPTION
## Motivation
This PR fixes the functionality to get the Object Entries OpenAPI in Yaml format. This PR starts from this [commit](https://github.com/liferay-headless/liferay-portal/pull/1634/commits/8e303fd0c7bf7f24edcf099dbe0805c1479a3f88)

**What is new?**
- Add `_setReadOnlyProperties` in `ObjectEntryOpenAPIContributor` instead of `ObjectEntryOpenAPIResourceImpl`.
- Refactor `ObjectEntryOpenAPIContributor`.
- Add new method in `HttpTestUtil` to get response in String format.
- Add test case for checking this is not going to happen.

**How to test this?**

1. Create a Custom Object Definition (Student)with a Custom Field (name).
2. Publish that Custom Object Definition.
3. Go to API Explorer and execute OpenAPI endpoint with path parameter as yaml.

**JIRA Related Ticket**
https://liferay.atlassian.net/browse/LPS-200502
