### PR TITLE
Lps 200318 Add tests for define api endpoint filters in api builder

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/APIApplicationEndpoint.macro
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/APIApplicationEndpoint.macro
@@ -19,6 +19,10 @@ definition {
 
 		var api = "${baseURL}${path}";
 
+		if (isSet(filter)) {
+			var api = StringUtil.add(${api}, "?filter=${filter}", "");
+		}
+
 		var curl = '''
 			${portalURL}/o/c/${api} \
 				-u test@liferay.com:test \
@@ -29,11 +33,27 @@ definition {
 	}
 
 	@summary = "Default summary"
-	macro getEndpoint(path = null, baseURL = null, portalURL = null) {
+	macro assertCorrectItemInResponse(baseURL = null, expectedValue = null, jsonObject = null, path = null) {
+		Variables.assertDefined(parameterList = "${baseURL},${path},${jsonObject},${expectedValue}");
+
+		var response = APIApplicationEndpoint.getEndpoint(
+			baseURL = ${baseURL},
+			path = ${path});
+
+		var actualValue = JSONUtil.getWithJSONPath(${response}, "$.items..${jsonObject}");
+
+		TestUtils.assertEquals(
+			actual = ${actualValue},
+			expected = ${expectedValue});
+	}
+
+	@summary = "Default summary"
+	macro getEndpoint(baseURL = null, filter = null, path = null, portalURL = null) {
 		Variables.assertDefined(parameterList = "${baseURL},${path}");
 
 		var curl = APIApplicationEndpoint._curlAPIEndpoint(
 			baseURL = ${baseURL},
+			filter = ${filter},
 			path = ${path},
 			portalURL = ${portalURL});
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/APIBuilderUI.macro
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/APIBuilderUI.macro
@@ -62,7 +62,7 @@ definition {
 	}
 
 	@summary = "Default summary"
-	macro addAndPublishSchemaProperties(relatedPlaceHolderName = null, fieldName = null, relatedPropertyName = null, relatedFieldName = null, propertyName = null, placeHolderName = null, name = null, relatedObjectName = null, title = null, entity = null) {
+	macro addAndPublishSchemaProperties(fieldName = null, relatedPropertyName = null, relatedFieldName = null, propertyName = null, name = null, relatedObjectName = null, title = null, entity = null) {
 		Variables.assertDefined(parameterList = "${name},${entity},${title}");
 
 		APIBuilderUI.goToEditRelatedEntryInEditApplication(
@@ -76,20 +76,9 @@ definition {
 			locator1 = "APIBuilder#PROPERTY_CONTAINER");
 
 		if (isSet(propertyName)) {
-			MouseOver(
-				key_commentValue = ${fieldName},
-				locator1 = "PublicationsChanges#COMMENT_VALUE");
-
-			Click(
-				key_text = "pencil",
-				locator1 = "Icon#ANY");
-
-			Type(
-				key_placeHolder = "Enter name",
-				locator1 = "TextInput#ANY_PLACEHOLDER",
-				value1 = ${propertyName});
-
-			Click(locator1 = "Button#UPDATE");
+			APIBuilderUI.editSchemaProperty(
+				fieldName = ${fieldName},
+				propertyName = ${propertyName});
 		}
 
 		if (IsElementPresent(locator1 = "APIBuilder#VIEW_RELATED_OBJECTS")) {
@@ -104,20 +93,9 @@ definition {
 				locator1 = "APIBuilder#PROPERTY_CONTAINER");
 
 			if (isSet(relatedPropertyName)) {
-				MouseOver(
-					key_commentValue = ${relatedFieldName},
-					locator1 = "PublicationsChanges#COMMENT_VALUE");
-
-				Click(
-					key_text = "pencil",
-					locator1 = "Icon#ANY");
-
-				Type(
-					key_placeHolder = "Enter name",
-					locator1 = "TextInput#ANY_PLACEHOLDER",
-					value1 = ${relatedPropertyName});
-
-				Click(locator1 = "Button#UPDATE");
+				APIBuilderUI.editSchemaProperty(
+					fieldName = ${relatedFieldName},
+					propertyName = ${relatedPropertyName});
 			}
 		}
 
@@ -312,6 +290,26 @@ definition {
 		if (isSet(confirmDeletion)) {
 			Click(locator1 = "APIBuilder#MODAL_DELETE_BUTTON");
 		}
+	}
+
+	@summary = "Default summary"
+	macro editSchemaProperty(fieldName = null, propertyName = null) {
+		Variables.assertDefined(parameterList = "${fieldName},${propertyName}");
+
+		MouseOver(
+			key_commentValue = ${fieldName},
+			locator1 = "PublicationsChanges#COMMENT_VALUE");
+
+		Click(
+			key_text = "pencil",
+			locator1 = "Icon#ANY");
+
+		Type(
+			key_placeHolder = "Enter name",
+			locator1 = "TextInput#ANY_PLACEHOLDER",
+			value1 = ${propertyName});
+
+		Click(locator1 = "Button#UPDATE");
 	}
 
 	@summary = "Default summary"

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/APIBuilderUI.macro
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/APIBuilderUI.macro
@@ -1,8 +1,8 @@
 definition {
 
 	@summary = "Default summary"
-	macro addAndPublishFiltersAndSortingInEndpointConfiguration(name = null,entity = null,fieldName = null,title = null,unpublish = null) {
-		Variables.assertDefined(parameterList = "${name},${entity},${fieldName},${title},${editValue}");
+	macro addAndPublishEndpointConfiguration(fieldName = null, name = null, editValue = null, title = null, schemaName = null, entity = null) {
+		Variables.assertDefined(parameterList = "${name},${entity},${title}");
 
 		APIBuilderUI.goToEditRelatedEntryInEditApplication(
 			entity = ${entity},
@@ -10,10 +10,116 @@ definition {
 			tabEntity = "Configuration",
 			title = ${title});
 
-		Type(
-			fieldName = ${fieldName},
-			locator1 = "APIBuilder#ODATA_TEXTAREA",
-			value1 = ${editValue});
+		if (isSet(schemaName)) {
+			Click(
+				key_value = "Select a Schema",
+				locator1 = "APIBuilder#DROPDOWN_TOGGLE");
+
+			Click(
+				key_optionName = ${schemaName},
+				locator1 = "ObjectAdmin#LAYOUT_ADD_FIELD_OPTION");
+		}
+
+		if (isSet(fieldName)) {
+			Type(
+				fieldName = ${fieldName},
+				locator1 = "APIBuilder#ODATA_TEXTAREA",
+				value1 = ${editValue});
+		}
+
+		Click(locator1 = "APIBuilder#PUBLISH_BUTTON");
+
+		Alert.viewSuccessMessage();
+	}
+
+	@summary = "Default summary"
+	macro addAndPublishEndpointInfo(endpointPath = null, name = null, description = null, title = null, entity = null) {
+		Variables.assertDefined(parameterList = "${name},${entity},${title}");
+
+		APIBuilderUI.goToEditRelatedEntryInEditApplication(
+			entity = ${entity},
+			name = ${name},
+			tabEntity = "Info",
+			title = ${title});
+
+		if (isSet(description)) {
+			Type(
+				key_value = "endpoint",
+				locator1 = "APIBuilder#DESCRIPTION",
+				value1 = ${description});
+		}
+
+		if (isSet(endpointPath)) {
+			Type(
+				key_placeHolder = "Enter Path",
+				locator1 = "TextInput#ANY_PLACEHOLDER",
+				value1 = ${endpointPath});
+		}
+
+		Click(locator1 = "APIBuilder#PUBLISH_BUTTON");
+
+		Alert.viewSuccessMessage();
+	}
+
+	@summary = "Default summary"
+	macro addAndPublishSchemaProperties(relatedPlaceHolderName = null, fieldName = null, relatedPropertyName = null, relatedFieldName = null, propertyName = null, placeHolderName = null, name = null, relatedObjectName = null, title = null, entity = null) {
+		Variables.assertDefined(parameterList = "${name},${entity},${title}");
+
+		APIBuilderUI.goToEditRelatedEntryInEditApplication(
+			entity = ${entity},
+			name = ${name},
+			tabEntity = "Properties",
+			title = ${title});
+
+		Click(
+			key_text = ${fieldName},
+			locator1 = "APIBuilder#PROPERTY_CONTAINER");
+
+		if (isSet(propertyName)) {
+			MouseOver(
+				key_commentValue = ${fieldName},
+				locator1 = "PublicationsChanges#COMMENT_VALUE");
+
+			Click(
+				key_text = "pencil",
+				locator1 = "Icon#ANY");
+
+			Type(
+				key_placeHolder = "Enter name",
+				locator1 = "TextInput#ANY_PLACEHOLDER",
+				value1 = ${propertyName});
+
+			Click(locator1 = "Button#UPDATE");
+		}
+
+		if (IsElementPresent(locator1 = "APIBuilder#VIEW_RELATED_OBJECTS")) {
+			Click(locator1 = "APIBuilder#VIEW_RELATED_OBJECTS");
+
+			Click(
+				key_componentName = ${relatedObjectName},
+				locator1 = "Panel#PANEL_TITLE");
+
+			Click(
+				key_text = ${relatedFieldName},
+				locator1 = "APIBuilder#PROPERTY_CONTAINER");
+
+			if (isSet(relatedPropertyName)) {
+				MouseOver(
+					key_commentValue = ${relatedFieldName},
+					locator1 = "PublicationsChanges#COMMENT_VALUE");
+
+				Click(
+					key_text = "pencil",
+					locator1 = "Icon#ANY");
+
+				Type(
+					key_placeHolder = "Enter name",
+					locator1 = "TextInput#ANY_PLACEHOLDER",
+					value1 = ${relatedPropertyName});
+
+				Click(locator1 = "Button#UPDATE");
+			}
+		}
 
 		Click(locator1 = "APIBuilder#PUBLISH_BUTTON");
 
@@ -84,6 +190,7 @@ definition {
 
 		if (isSet(description)) {
 			Type(
+				key_value = "API",
 				locator1 = "APIBuilder#DESCRIPTION",
 				value1 = ${description});
 		}
@@ -106,7 +213,7 @@ definition {
 		if (isSet(scope)) {
 			Click(
 				key_value = "Select Scope",
-				locator1 = "APIBuilder#ENDPOINT_DROPDOWN");
+				locator1 = "APIBuilder#DROPDOWN_TOGGLE");
 
 			Click(
 				key_optionName = ${scope},
@@ -272,8 +379,10 @@ definition {
 			title = ${title});
 
 		Click(
-			locator1 = "Button#BUTTON_WITH_VALUE",
-			value = "/${name}/");
+			key_title = ${name},
+			locator1 = "APIBuilder#DROPDOWN_MENU");
+
+		Click(locator1 = "APIBuilder#EDIT_BUTTON");
 
 		Click(
 			locator1 = "Button#BUTTON_WITH_VALUE",

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/PropertyAPI.macro
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/PropertyAPI.macro
@@ -29,9 +29,15 @@ definition {
 		Variables.assertDefined(parameterList = "${objectFieldERC},${name},${schemaERC}");
 
 		var curl = PropertyAPI._curlAPIProperty(virtualHost = ${virtualHost});
+
+		if (!(isSet(relationshipName))) {
+			var relationshipName = "";
+		}
+
 		var body = '''
 			"name": "${name}",
 			"objectFieldERC": "${objectFieldERC}",
+			"objectRelationshipNames": "${relationshipName}",
 			"r_apiSchemaToAPIProperties_c_apiSchemaERC": "${schemaERC}"
 		''';
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/paths/APIBuilder.path
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/paths/APIBuilder.path
@@ -67,7 +67,7 @@
 </tr>
 <tr>
 	<td>DESCRIPTION</td>
-	<td>//textarea[(@placeholder='Add a short description that describes this API.')]</td>
+	<td>//textarea[(@placeholder='Add a short description that describes this ${key_value}.')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -86,6 +86,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>DROPDOWN_TOGGLE</td>
+	<td>//button[@aria-controls='selectDropdown' and contains(.,'${key_value}')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>DROPDOWN_MENU</td>
 	<td>//div[contains(@class,'table-list-title') and contains(.,'${key_title}')]/../..//button[contains(.,'Action')]</td>
 	<td></td>
@@ -93,16 +98,6 @@
 <tr>
 	<td>EDIT_BUTTON</td>
 	<td>//div[@class='dropdown-menu show']//button[contains(text(),'Edit')]</td>
-	<td></td>
-</tr>
-<tr>
-	<td>ENDPOINT_DROPDOWN</td>
-	<td>//button[@aria-controls='selectDropdown' and contains(.,'${key_value}')]</td>
-	<td></td>
-</tr>
-<tr>
-	<td>ENTER_NAME</td>
-	<td>//input[(@placeholder='Enter name.')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -133,6 +128,11 @@
 <tr>
 	<td>ODATA_TEXTAREA</td>
 	<td>//textarea[@placeholder='Add a ${fieldName} using OData.']</td>
+	<td></td>
+</tr>
+<tr>
+	<td>PROPERTY_CONTAINER</td>
+	<td>//button[(@class='property-container btn btn-unstyled') and contains(.,'${key_text}')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -183,6 +183,11 @@
 <tr>
 	<td>URL_PROMPT_MESSAGE_IN_CREATE_APPLICATION_DIALOG</td>
 	<td>//span[contains(text(),'The URL can be modified.')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>VIEW_RELATED_OBJECTS</td>
+	<td>//button[(@class='view-related-objects btn btn-secondary') and contains(.,'View Related Objects')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationEndpoints/CreateAnAPIApplicationEndpoint.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationEndpoints/CreateAnAPIApplicationEndpoint.testcase
@@ -49,7 +49,7 @@ definition {
 
 			AssertElementPresent(
 				key_value = "Company",
-				locator1 = "APIBuilder#ENDPOINT_DROPDOWN");
+				locator1 = "APIBuilder#DROPDOWN_TOGGLE");
 
 			AssertTextEquals(
 				key_fieldLabel = "Path",
@@ -84,7 +84,7 @@ definition {
 
 			AssertElementPresent(
 				key_value = "Site",
-				locator1 = "APIBuilder#ENDPOINT_DROPDOWN");
+				locator1 = "APIBuilder#DROPDOWN_TOGGLE");
 
 			AssertTextEquals(
 				key_fieldLabel = "Path",
@@ -112,7 +112,7 @@ definition {
 
 			Click(
 				key_value = "Select Scope",
-				locator1 = "APIBuilder#ENDPOINT_DROPDOWN");
+				locator1 = "APIBuilder#DROPDOWN_TOGGLE");
 		}
 
 		task ("Then scope option is present for both site and company") {

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationEndpoints/EditAPIApplicationEndPoint.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationEndpoints/EditAPIApplicationEndPoint.testcase
@@ -11,6 +11,16 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		task ("Given API Application with endpoint of scope 'Company' created") {
+			ApplicationAPI.createAPIApplication(
+				baseURL = "my-app",
+				endpointName = "testendpoint",
+				endpointPath = "/testendpoint",
+				relatedEndpoint = "true",
+				status = "published",
+				title = "My-app");
+		}
 	}
 
 	tearDown {
@@ -28,16 +38,6 @@ definition {
 	@priority = 4
 	test CannotModifyMethodOfCretaedEndpoint {
 		property portal.acceptance = "true";
-
-		task ("Given API Application with endpoint created") {
-			ApplicationAPI.createAPIApplication(
-				baseURL = "my-app",
-				endpointName = "testendpoint",
-				endpointPath = "/testendpoint",
-				relatedEndpoint = "true",
-				status = "published",
-				title = "My-app");
-		}
 
 		task ("When when going to Edit endpoint") {
 			APIBuilderUI.goToEditRelatedEntryInEditApplication(
@@ -57,16 +57,6 @@ definition {
 	@priority = 4
 	test CanRelateEndpointWithSchema {
 		property portal.acceptance = "true";
-
-		task ("Given API Application with endpoint created") {
-			ApplicationAPI.createAPIApplication(
-				baseURL = "my-app",
-				endpointName = "testendpoint",
-				endpointPath = "/testendpoint",
-				relatedEndpoint = "true",
-				status = "published",
-				title = "My-app");
-		}
 
 		task ("And Given API Schema in API Application") {
 			SchemaAPI.createAPISchema(
@@ -138,16 +128,6 @@ definition {
 				relationshipName = "universityStudents");
 		}
 
-		task ("And Given API Application with endpoint of scope 'Company' created") {
-			ApplicationAPI.createAPIApplication(
-				baseURL = "my-app",
-				endpointName = "testendpoint",
-				endpointPath = "/testendpoint",
-				relatedEndpoint = "true",
-				status = "published",
-				title = "My-app");
-		}
-
 		task ("And Given Schema with properties: 'name' of university, 'name' of Student, ERC of university, ERC of student") {
 			SchemaAPI.createAPISchema(
 				externalReferenceCode = "My-app",
@@ -194,16 +174,10 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given API Application with two endpoints created") {
-			ApplicationAPI.createAPIApplication(
-				baseURL = "my-app",
-				status = "published",
-				title = "My-app");
-
-			EndpointAPI.createNAPIEndpoints(
+			EndpointAPI.createAPIEndpoint(
 				externalReferenceCode = "My-app",
-				name = "testendpoint",
-				numberOfEndpoints = 2,
-				path = "/testendpoint");
+				name = "testendpoint1",
+				path = "/testendpoint1");
 		}
 
 		task ("And Given one API Schema in API Application") {
@@ -216,7 +190,7 @@ definition {
 		task ("And Given modifying endpoint1 with API Schema") {
 			APIBuilderUI.addAndPublishEndpointConfiguration(
 				entity = "Endpoints",
-				name = "testendpoint1",
+				name = "testendpoint",
 				schemaName = "testSchema",
 				title = "My-app");
 		}
@@ -224,7 +198,7 @@ definition {
 		task ("When modifying endpoint2 wit the same API Schema") {
 			APIBuilderUI.addAndPublishEndpointConfiguration(
 				entity = "Endpoints",
-				name = "testendpoint2",
+				name = "testendpoint1",
 				schemaName = "testSchema",
 				title = "My-app");
 		}
@@ -245,16 +219,6 @@ definition {
 	@priority = 4
 	test CanUpdateEndpoint {
 		property portal.acceptance = "true";
-
-		task ("Given API Application with endpoint created") {
-			ApplicationAPI.createAPIApplication(
-				baseURL = "my-app",
-				endpointName = "testendpoint",
-				endpointPath = "/testendpoint",
-				relatedEndpoint = "true",
-				status = "published",
-				title = "My-app");
-		}
 
 		task ("When editing Path and Description of an endpoint") {
 			APIBuilderUI.addAndPublishEndpointInfo(

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationEndpoints/EditAPIApplicationEndPoint.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationEndpoints/EditAPIApplicationEndPoint.testcase
@@ -1,0 +1,281 @@
+@component-name = "portal-headless"
+definition {
+
+	property custom.properties = "feature.flag.LPS-178642=true";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Object";
+	property testray.main.component.name = "Headless Builder";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+	}
+
+	tearDown {
+		ApplicationAPI.deleteAllAPIApplication();
+
+		JSONObject.deleteAllCustomObjects();
+
+		var testLiferayVirtualInstance = PropsUtil.get("test.liferay.virtual.instance");
+
+		if (${testLiferayVirtualInstance} == "true") {
+			PortalInstances.tearDownCP();
+		}
+	}
+
+	@priority = 4
+	test CannotModifyMethodOfCretaedEndpoint {
+		property portal.acceptance = "true";
+
+		task ("Given API Application with endpoint created") {
+			ApplicationAPI.createAPIApplication(
+				baseURL = "my-app",
+				endpointName = "testendpoint",
+				endpointPath = "/testendpoint",
+				relatedEndpoint = "true",
+				status = "published",
+				title = "My-app");
+		}
+
+		task ("When when going to Edit endpoint") {
+			APIBuilderUI.goToEditRelatedEntryInEditApplication(
+				entity = "Endpoints",
+				name = "testendpoint",
+				tabEntity = "Info",
+				title = "My-app");
+		}
+
+		task ("Then method cannot be modified") {
+			AssertTextEquals(
+				locator1 = "Button#DISABLED_BUTTON",
+				value1 = "GET");
+		}
+	}
+
+	@priority = 4
+	test CanRelateEndpointWithSchema {
+		property portal.acceptance = "true";
+
+		task ("Given API Application with endpoint created") {
+			ApplicationAPI.createAPIApplication(
+				baseURL = "my-app",
+				endpointName = "testendpoint",
+				endpointPath = "/testendpoint",
+				relatedEndpoint = "true",
+				status = "published",
+				title = "My-app");
+		}
+
+		task ("And Given API Schema in API Application") {
+			SchemaAPI.createAPISchema(
+				externalReferenceCode = "My-app",
+				mainObjectDefinitionERC = "L_API_APPLICATION",
+				name = "testSchema");
+		}
+
+		task ("When editing the Endpoint") {
+			APIBuilderUI.addAndPublishEndpointConfiguration(
+				entity = "Endpoints",
+				name = "testendpoint",
+				schemaName = "testSchema",
+				title = "My-app");
+		}
+
+		task ("Then I can set API Schema in Response Body Schema") {
+			AssertElementPresent(
+				key_optionName = "testSchema",
+				locator1 = "ObjectAdmin#LAYOUT_ADD_FIELD_OPTION");
+		}
+	}
+
+	@priority = 4
+	test CanRelateSchemaOfRelatedObjectsWithEndpoint {
+		property portal.acceptance = "true";
+
+		task ("Given Student, University objects of scope 'Company' created with text field 'name'") {
+			ObjectDefinitionAPI.createAndPublishObjectDefinition(
+				en_US_label = "student",
+				en_US_plural_label = "students",
+				name = "Student",
+				objectDefinitionExternalReferenceCode = "student",
+				requiredStringFieldName = "name",
+				requiredStringFieldNameExternalReferenceCode = "studentName");
+
+			ObjectDefinitionAPI.createAndPublishObjectDefinition(
+				en_US_label = "university",
+				en_US_plural_label = "universities",
+				name = "University",
+				objectDefinitionExternalReferenceCode = "university",
+				requiredStringFieldName = "name",
+				requiredStringFieldNameExternalReferenceCode = "universityName");
+		}
+
+		task ("And Given universityStudents one-to-many relationship created") {
+			ObjectDefinitionAPI.createRelationshipWithObjectDefinitionNames(
+				childObjectName = "Student",
+				deletionType = "cascade",
+				name = "universityStudents",
+				parentObjectName = "University",
+				type = "oneToMany");
+		}
+
+		task ("And Given university entry related to student entry") {
+			ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "universities",
+				name = "Oxford");
+
+			ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "students",
+				name = "Pearl");
+
+			ObjectDefinitionAPI.relateObjectEntriesByName(
+				child_plural_label = "students",
+				childEntryName = "Pearl",
+				parent_plural_label = "universities",
+				parentEntryName = "Oxford",
+				relationshipName = "universityStudents");
+		}
+
+		task ("And Given API Application with endpoint of scope 'Company' created") {
+			ApplicationAPI.createAPIApplication(
+				baseURL = "my-app",
+				endpointName = "testendpoint",
+				endpointPath = "/testendpoint",
+				relatedEndpoint = "true",
+				status = "published",
+				title = "My-app");
+		}
+
+		task ("And Given Schema with properties: 'name' of university, 'name' of Student, ERC of university, ERC of student") {
+			SchemaAPI.createAPISchema(
+				externalReferenceCode = "My-app",
+				mainObjectDefinitionERC = "university",
+				name = "testSchema");
+
+			APIBuilderUI.addAndPublishSchemaProperties(
+				entity = "Schemas",
+				fieldName = "name",
+				name = "testSchema",
+				propertyName = "universityName",
+				relatedFieldName = "name",
+				relatedObjectName = "student",
+				relatedPropertyName = "studentName",
+				title = "My-app");
+		}
+
+		task ("And Given Schema related to the endpoint") {
+			APIBuilderUI.addAndPublishEndpointConfiguration(
+				entity = "Endpoints",
+				name = "testendpoint",
+				schemaName = "testSchema",
+				title = "My-app");
+		}
+
+		task ("When executing the endpoint") {
+			APIExplorer.navigateToOpenAPI(customObjectPlural = "my-app");
+
+			APIExplorer.executeAPIMethod(
+				method = "getTestendpointPage",
+				service = "testSchema");
+		}
+
+		task ("Then all fields are correctly returned") {
+			AssertTextEquals.assertPartialText(
+				locator1 = "OpenAPI#RESPONSE_BODY",
+				method = "getTestendpointPage",
+				value1 = "\"items\": [     {       \"universityName\": \"Oxford\",       \"studentName\": [         \"Pearl\"       ]     }   ]");
+		}
+	}
+
+	@priority = 4
+	test CanRelateSchemaWithManyEndpoints {
+		property portal.acceptance = "true";
+
+		task ("Given API Application with two endpoints created") {
+			ApplicationAPI.createAPIApplication(
+				baseURL = "my-app",
+				status = "published",
+				title = "My-app");
+
+			EndpointAPI.createNAPIEndpoints(
+				externalReferenceCode = "My-app",
+				name = "testendpoint",
+				numberOfEndpoints = 2,
+				path = "/testendpoint");
+		}
+
+		task ("And Given one API Schema in API Application") {
+			SchemaAPI.createAPISchema(
+				externalReferenceCode = "My-app",
+				mainObjectDefinitionERC = "L_API_APPLICATION",
+				name = "testSchema");
+		}
+
+		task ("And Given modifying endpoint1 with API Schema") {
+			APIBuilderUI.addAndPublishEndpointConfiguration(
+				entity = "Endpoints",
+				name = "testendpoint1",
+				schemaName = "testSchema",
+				title = "My-app");
+		}
+
+		task ("When modifying endpoint2 wit the same API Schema") {
+			APIBuilderUI.addAndPublishEndpointConfiguration(
+				entity = "Endpoints",
+				name = "testendpoint2",
+				schemaName = "testSchema",
+				title = "My-app");
+		}
+
+		task ("Then both endpoints work with the same schema") {
+			var response = EndpointAPI.getAPIEndpoints();
+
+			var actualValue = JSONPathUtil.getProperty(
+				property = "$.items..r_responseAPISchemaToAPIEndpoints_c_apiSchemaERC",
+				response = ${response});
+
+			TestUtils.assertEquals(
+				actual = ${actualValue},
+				expected = "testSchema,testSchema");
+		}
+	}
+
+	@priority = 4
+	test CanUpdateEndpoint {
+		property portal.acceptance = "true";
+
+		task ("Given API Application with endpoint created") {
+			ApplicationAPI.createAPIApplication(
+				baseURL = "my-app",
+				endpointName = "testendpoint",
+				endpointPath = "/testendpoint",
+				relatedEndpoint = "true",
+				status = "published",
+				title = "My-app");
+		}
+
+		task ("When editing Path and Description of an endpoint") {
+			APIBuilderUI.addAndPublishEndpointInfo(
+				description = "This is an updated endpoint",
+				endpointPath = "updatedendpoint",
+				entity = "Endpoints",
+				name = "testendpoint",
+				title = "My-app");
+		}
+
+		task ("Then the endpoint values are updated") {
+			AssertTextEquals(
+				key_value = "endpoint",
+				locator1 = "APIBuilder#DESCRIPTION",
+				value1 = "This is an updated endpoint");
+
+			AssertTextEquals(
+				key_placeHolder = "Enter Path",
+				locator1 = "TextInput#ANY_PLACEHOLDER",
+				value1 = "updatedendpoint");
+		}
+	}
+
+}

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationsInTheAPIBuilder/CreateAPIApplication.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationsInTheAPIBuilder/CreateAPIApplication.testcase
@@ -310,7 +310,9 @@ definition {
 
 			AssertElementPresent(locator1 = "APIBuilder#AUTOMATED_URL");
 
-			AssertElementPresent(locator1 = "APIBuilder#DESCRIPTION");
+			AssertElementPresent(
+				key_value = "API",
+				locator1 = "APIBuilder#DESCRIPTION");
 		}
 
 		task ("And Then I can see example url /o/ and note about url can be modified") {

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationsInTheAPIBuilder/EditAPIApplication.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationsInTheAPIBuilder/EditAPIApplication.testcase
@@ -48,7 +48,9 @@ definition {
 				locator1 = "APIBuilder#AUTOMATED_URL",
 				value1 = "app-test");
 
-			AssertElementPresent(locator1 = "APIBuilder#DESCRIPTION");
+			AssertElementPresent(
+				key_value = "API",
+				locator1 = "APIBuilder#DESCRIPTION");
 		}
 	}
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefinePrefiltersAndSorts/AllowUsersToDefinePrefilters.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefinePrefiltersAndSorts/AllowUsersToDefinePrefilters.testcase
@@ -52,23 +52,23 @@ definition {
 			CustomObjectAPI.createObjectRelatedToAnotherObject(
 				en_US_plural_label = "subjects",
 				name = "abc",
-				relatedObject = "student",
 				relatedObjectErc = "abc",
-				relationship = "studentSubjects");
+				relatedObjectName = "student",
+				relationshipName = "studentSubjects");
 
 			CustomObjectAPI.createObjectRelatedToAnotherObject(
 				en_US_plural_label = "subjects",
 				name = "zzzz",
-				relatedObject = "student",
 				relatedObjectErc = "bbbabc",
-				relationship = "studentSubjects");
+				relatedObjectName = "student",
+				relationshipName = "studentSubjects");
 
 			CustomObjectAPI.createObjectRelatedToAnotherObject(
 				en_US_plural_label = "subjects",
 				name = "bbbabc",
-				relatedObject = "student",
 				relatedObjectErc = "zzzz",
-				relationship = "studentSubjects");
+				relatedObjectName = "student",
+				relationshipName = "studentSubjects");
 		}
 
 		task ("And Given apiApplication with an endpoint of scope Company created and published") {
@@ -121,7 +121,7 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("And Given setting the Filters to 'contains(name,'abc')'") {
-			APIBuilderUI.addAndPublishFiltersAndSortingInEndpointConfiguration(
+			APIBuilderUI.addAndPublishEndpointConfiguration(
 				editValue = "contains(name,'abc')",
 				entity = "Endpoints",
 				fieldName = "filter",
@@ -154,7 +154,7 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("And Given setting the Filters to 'contains(studentSubjects/name,'abc')'") {
-			APIBuilderUI.addAndPublishFiltersAndSortingInEndpointConfiguration(
+			APIBuilderUI.addAndPublishEndpointConfiguration(
 				editValue = "contains(studentSubjects/name,'abc')",
 				entity = "Endpoints",
 				fieldName = "filter",
@@ -171,7 +171,7 @@ definition {
 		}
 
 		task ("When I empty the Filter box in endpoint configuration") {
-			APIBuilderUI.addAndPublishFiltersAndSortingInEndpointConfiguration(
+			APIBuilderUI.addAndPublishEndpointConfiguration(
 				editValue = "",
 				entity = "Endpoints",
 				fieldName = "filter",
@@ -212,7 +212,7 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("And Given setting the Filters to 'contains(studentSubjects/name,'abc') and name eq 'zzzz'") {
-			APIBuilderUI.addAndPublishFiltersAndSortingInEndpointConfiguration(
+			APIBuilderUI.addAndPublishEndpointConfiguration(
 				editValue = "contains(studentSubjects/name,'abc') and name eq 'zzzz'",
 				entity = "Endpoints",
 				fieldName = "filter",
@@ -229,7 +229,7 @@ definition {
 		}
 
 		task ("When I empty the Filters") {
-			APIBuilderUI.addAndPublishFiltersAndSortingInEndpointConfiguration(
+			APIBuilderUI.addAndPublishEndpointConfiguration(
 				editValue = "",
 				entity = "Endpoints",
 				fieldName = "filter",
@@ -262,7 +262,7 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("When setting the Filters to 'externalReferenceCode eq 'abc''") {
-			APIBuilderUI.addAndPublishFiltersAndSortingInEndpointConfiguration(
+			APIBuilderUI.addAndPublishEndpointConfiguration(
 				editValue = "externalReferenceCode eq 'abc'",
 				entity = "Endpoints",
 				fieldName = "filter",
@@ -284,7 +284,7 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("When setting the Filters to 'contains(name,'abc')'") {
-			APIBuilderUI.addAndPublishFiltersAndSortingInEndpointConfiguration(
+			APIBuilderUI.addAndPublishEndpointConfiguration(
 				editValue = "contains(name,'abc')",
 				entity = "Endpoints",
 				fieldName = "filter",
@@ -306,7 +306,7 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("When setting the Filters to 'contains(studentSubjects/name,'abc')'") {
-			APIBuilderUI.addAndPublishFiltersAndSortingInEndpointConfiguration(
+			APIBuilderUI.addAndPublishEndpointConfiguration(
 				editValue = "contains(studentSubjects/name,'abc')",
 				entity = "Endpoints",
 				fieldName = "filter",

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefinePrefiltersAndSorts/AllowUsersToDefinePrefilters.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefinePrefiltersAndSorts/AllowUsersToDefinePrefilters.testcase
@@ -1,0 +1,326 @@
+@component-name = "portal-headless"
+definition {
+
+	property custom.properties = "feature.flag.LPS-178642=true";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Object";
+	property testray.main.component.name = "Headless Builder";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+
+		task ("Given objects definitons Student, Subject with field name created") {
+			ObjectDefinitionAPI.createAndPublishObjectDefinition(
+				en_US_label = "student",
+				en_US_plural_label = "students",
+				name = "Student",
+				objectDefinitionExternalReferenceCode = "studentErc",
+				requiredStringFieldName = "name",
+				requiredStringFieldNameExternalReferenceCode = "studentNameErc");
+
+			ObjectDefinitionAPI.createAndPublishObjectDefinition(
+				en_US_label = "subject",
+				en_US_plural_label = "subjects",
+				name = "Subject",
+				objectDefinitionExternalReferenceCode = "subjectErc",
+				requiredStringFieldName = "name",
+				requiredStringFieldNameExternalReferenceCode = "subjectNameErc");
+		}
+
+		task ("And Given one-to-many relationship studentSubjects created") {
+			ObjectDefinitionAPI.createRelationshipWithObjectDefinitionNames(
+				childObjectName = "Subject",
+				deletionType = "cascade",
+				name = "studentSubjects",
+				parentObjectName = "Student",
+				type = "oneToMany");
+		}
+
+		task ("And Given Student entries 'aabc', 'abc', 'bbbabc','zzzz' with externalReferenceCode 'aabc', 'abc', 'bbbabc', 'zzzz' created") {
+			for (var name : list "aabc,abc,bbbabc,zzzz") {
+				ObjectDefinitionAPI.createObjectEntryWithName(
+					en_US_plural_label = "students",
+					externalReferenceCode = ${name},
+					name = ${name});
+			}
+		}
+
+		task ("And Given Subject entries 'abc', 'zzzz', 'bbbabc' created and related to students 'abc', 'bbbabc', 'zzzz'") {
+			CustomObjectAPI.createObjectRelatedToAnotherObject(
+				en_US_plural_label = "subjects",
+				name = "abc",
+				relatedObject = "student",
+				relatedObjectErc = "abc",
+				relationship = "studentSubjects");
+
+			CustomObjectAPI.createObjectRelatedToAnotherObject(
+				en_US_plural_label = "subjects",
+				name = "zzzz",
+				relatedObject = "student",
+				relatedObjectErc = "bbbabc",
+				relationship = "studentSubjects");
+
+			CustomObjectAPI.createObjectRelatedToAnotherObject(
+				en_US_plural_label = "subjects",
+				name = "bbbabc",
+				relatedObject = "student",
+				relatedObjectErc = "zzzz",
+				relationship = "studentSubjects");
+		}
+
+		task ("And Given apiApplication with an endpoint of scope Company created and published") {
+			ApplicationAPI.createAPIApplication(
+				baseURL = "my-app",
+				endpointName = "testEndpoint",
+				endpointPath = "/testendpoint",
+				relatedEndpoint = "true",
+				status = "published",
+				title = "My-app");
+		}
+
+		task ("And Given a schema based on Student object definition with student name, subject name as schema properties student_name, subject_name") {
+			SchemaAPI.createAPISchema(
+				externalReferenceCode = "My-app",
+				mainObjectDefinitionERC = "studentErc",
+				name = "testSchema");
+
+			SchemaAPI.relateResponseSchemaToEndpointByErc(
+				endpointErc = "testEndpoint",
+				responseSchemaErc = "testSchema");
+
+			PropertyAPI.createAPIProperty(
+				name = "student_name",
+				objectFieldERC = "studentNameErc",
+				schemaERC = "testSchema");
+
+			PropertyAPI.createAPIProperty(
+				name = "subject_name",
+				objectFieldERC = "subjectNameErc",
+				relationshipName = "studentSubjects",
+				schemaERC = "testSchema");
+		}
+	}
+
+	tearDown {
+		ApplicationAPI.deleteAllAPIApplication();
+
+		JSONObject.deleteAllCustomObjects();
+
+		var testLiferayVirtualInstance = PropsUtil.get("test.liferay.virtual.instance");
+
+		if (${testLiferayVirtualInstance} == "true") {
+			PortalInstances.tearDownCP();
+		}
+	}
+
+	@priority = 4
+	test CanApplyPrefilterAndFilter {
+		property portal.acceptance = "true";
+
+		task ("And Given setting the Filters to 'contains(name,'abc')'") {
+			APIBuilderUI.addAndPublishFiltersAndSortingInEndpointConfiguration(
+				editValue = "contains(name,'abc')",
+				entity = "Endpoints",
+				fieldName = "filter",
+				name = "testendpoint",
+				title = "My-app");
+		}
+
+		task ("When I call endpoint with '?filter=contains(subject_name,'z')' in API Explorer") {
+			APIExplorer.navigateToOpenAPI(
+				api = "c",
+				version = "my-app");
+
+			APIExplorer.executeAPIMethod(
+				method = "getTestendpointPage",
+				parameter = "filter",
+				service = "testSchema",
+				value = "contains(subject_name,'z')");
+		}
+
+		task ("Then endpoint returns student 'bbbabc'") {
+			AssertTextEquals.assertPartialText(
+				locator1 = "OpenAPI#RESPONSE_BODY",
+				method = "getTestendpointPage",
+				value1 = "\"items\": [     {       \"student_name\": \"bbbabc\",       \"subject_name\"");
+		}
+	}
+
+	@priority = 4
+	test CanResetPrefiltering {
+		property portal.acceptance = "true";
+
+		task ("And Given setting the Filters to 'contains(studentSubjects/name,'abc')'") {
+			APIBuilderUI.addAndPublishFiltersAndSortingInEndpointConfiguration(
+				editValue = "contains(studentSubjects/name,'abc')",
+				entity = "Endpoints",
+				fieldName = "filter",
+				name = "testendpoint",
+				title = "My-app");
+		}
+
+		task ("And Given endpoint returning students 'abc', 'zzzz'") {
+			APIApplicationEndpoint.assertCorrectItemInResponse(
+				baseURL = "my-app",
+				expectedValue = "abc,zzzz",
+				jsonObject = "student_name",
+				path = "/testendpoint");
+		}
+
+		task ("When I empty the Filter box in endpoint configuration") {
+			APIBuilderUI.addAndPublishFiltersAndSortingInEndpointConfiguration(
+				editValue = "",
+				entity = "Endpoints",
+				fieldName = "filter",
+				name = "testendpoint",
+				title = "My-app");
+		}
+
+		task ("Then Student entries 'aabc', 'abc', 'bbbabc', 'zzzz' are listed in the endpoint response") {
+			APIApplicationEndpoint.assertCorrectItemInResponse(
+				baseURL = "my-app",
+				expectedValue = "aabc,abc,bbbabc,zzzz",
+				jsonObject = "student_name",
+				path = "/testendpoint");
+		}
+	}
+
+	@priority = 5
+	test FiltersIsPresentInEndpointConfiguration {
+		property portal.acceptance = "true";
+
+		task ("When navigating to the endpoint Configuration tab") {
+			APIBuilderUI.goToEditRelatedEntryInEditApplication(
+				entity = "Endpoints",
+				name = "testendpoint",
+				tabEntity = "Configuration",
+				title = "My-app");
+		}
+
+		task ("Then Filters box to Add a filter using OData is present") {
+			WaitForElementPresent(
+				fieldName = "filter",
+				locator1 = "APIBuilder#ODATA_TEXTAREA");
+		}
+	}
+
+	@priority = 5
+	test PrefilterAndFilterReturnTheSameData {
+		property portal.acceptance = "true";
+
+		task ("And Given setting the Filters to 'contains(studentSubjects/name,'abc') and name eq 'zzzz'") {
+			APIBuilderUI.addAndPublishFiltersAndSortingInEndpointConfiguration(
+				editValue = "contains(studentSubjects/name,'abc') and name eq 'zzzz'",
+				entity = "Endpoints",
+				fieldName = "filter",
+				name = "testendpoint",
+				title = "My-app");
+		}
+
+		task ("And Given endpoint returning student 'zzzz'") {
+			APIApplicationEndpoint.assertCorrectItemInResponse(
+				baseURL = "my-app",
+				expectedValue = "zzzz",
+				jsonObject = "student_name",
+				path = "/testendpoint");
+		}
+
+		task ("When I empty the Filters") {
+			APIBuilderUI.addAndPublishFiltersAndSortingInEndpointConfiguration(
+				editValue = "",
+				entity = "Endpoints",
+				fieldName = "filter",
+				name = "testendpoint",
+				title = "My-app");
+		}
+
+		task ("And When I call endpoint with '?filter=contains(subject_name,'abc') and student_name eq 'zzzz'' in API Explorer") {
+			APIExplorer.navigateToOpenAPI(
+				api = "c",
+				version = "my-app");
+
+			APIExplorer.executeAPIMethod(
+				method = "getTestendpointPage",
+				parameter = "filter",
+				service = "testSchema",
+				value = "contains(subject_name,'abc') and student_name eq 'zzzz'");
+		}
+
+		task ("Then endpoint returns student 'zzzz'") {
+			AssertTextEquals.assertPartialText(
+				locator1 = "OpenAPI#RESPONSE_BODY",
+				method = "getTestendpointPage",
+				value1 = "\"items\": [     {       \"student_name\": \"zzzz\",       \"subject_name\"");
+		}
+	}
+
+	@priority = 4
+	test PrefilteringWorksWithMainObjectFieldsThatAreNotPartOfSchemaProperties {
+		property portal.acceptance = "true";
+
+		task ("When setting the Filters to 'externalReferenceCode eq 'abc''") {
+			APIBuilderUI.addAndPublishFiltersAndSortingInEndpointConfiguration(
+				editValue = "externalReferenceCode eq 'abc'",
+				entity = "Endpoints",
+				fieldName = "filter",
+				name = "testendpoint",
+				title = "My-app");
+		}
+
+		task ("Then endpoint returns student 'abc'") {
+			APIApplicationEndpoint.assertCorrectItemInResponse(
+				baseURL = "my-app",
+				expectedValue = "abc",
+				jsonObject = "student_name",
+				path = "/testendpoint");
+		}
+	}
+
+	@priority = 4
+	test PrefilteringWorksWithSchemaPropertiesMadeOfMainObjectFields {
+		property portal.acceptance = "true";
+
+		task ("When setting the Filters to 'contains(name,'abc')'") {
+			APIBuilderUI.addAndPublishFiltersAndSortingInEndpointConfiguration(
+				editValue = "contains(name,'abc')",
+				entity = "Endpoints",
+				fieldName = "filter",
+				name = "testendpoint",
+				title = "My-app");
+		}
+
+		task ("Then students 'aabc', 'abc', 'bbbabc' are listed in the endpoint response") {
+			APIApplicationEndpoint.assertCorrectItemInResponse(
+				baseURL = "my-app",
+				expectedValue = "aabc,abc,bbbabc",
+				jsonObject = "student_name",
+				path = "/testendpoint");
+		}
+	}
+
+	@priority = 4
+	test PrefilteringWorksWithSchemaPropertiesMadeOfObjectFieldsRelatedWithOneToManyRelationship {
+		property portal.acceptance = "true";
+
+		task ("When setting the Filters to 'contains(studentSubjects/name,'abc')'") {
+			APIBuilderUI.addAndPublishFiltersAndSortingInEndpointConfiguration(
+				editValue = "contains(studentSubjects/name,'abc')",
+				entity = "Endpoints",
+				fieldName = "filter",
+				name = "testendpoint",
+				title = "My-app");
+		}
+
+		task ("Then students 'abc', 'zzzz' are listed in the endpoint response") {
+			APIApplicationEndpoint.assertCorrectItemInResponse(
+				baseURL = "my-app",
+				expectedValue = "abc,zzzz",
+				jsonObject = "student_name",
+				path = "/testendpoint");
+		}
+	}
+
+}

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefinePrefiltersAndSorts/AllowUsersToDefineSorts.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefinePrefiltersAndSorts/AllowUsersToDefineSorts.testcase
@@ -80,7 +80,7 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("And Given setting the Sorting to 'age:asc'") {
-			APIBuilderUI.addAndPublishFiltersAndSortingInEndpointConfiguration(
+			APIBuilderUI.addAndPublishEndpointConfiguration(
 				editValue = "age:asc",
 				entity = "Endpoints",
 				fieldName = "sort",
@@ -111,7 +111,7 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("And Given setting the Sorting to 'age:desc'") {
-			APIBuilderUI.addAndPublishFiltersAndSortingInEndpointConfiguration(
+			APIBuilderUI.addAndPublishEndpointConfiguration(
 				editValue = "age:desc",
 				entity = "Endpoints",
 				fieldName = "sort",
@@ -132,7 +132,7 @@ definition {
 		}
 
 		task ("When I empty the Sorting box in endpoint configuration") {
-			APIBuilderUI.addAndPublishFiltersAndSortingInEndpointConfiguration(
+			APIBuilderUI.addAndPublishEndpointConfiguration(
 				editValue = "",
 				entity = "Endpoints",
 				fieldName = "sort",
@@ -158,7 +158,7 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("And Given setting the Sorting to 'age:asc'") {
-			APIBuilderUI.addAndPublishFiltersAndSortingInEndpointConfiguration(
+			APIBuilderUI.addAndPublishEndpointConfiguration(
 				editValue = "age:asc",
 				entity = "Endpoints",
 				fieldName = "sort",
@@ -179,7 +179,7 @@ definition {
 		}
 
 		task ("When I empty the Sorting") {
-			APIBuilderUI.addAndPublishFiltersAndSortingInEndpointConfiguration(
+			APIBuilderUI.addAndPublishEndpointConfiguration(
 				editValue = "",
 				entity = "Endpoints",
 				fieldName = "sort",
@@ -229,7 +229,7 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("When setting the Sorting to 'dateCreated:asc'") {
-			APIBuilderUI.addAndPublishFiltersAndSortingInEndpointConfiguration(
+			APIBuilderUI.addAndPublishEndpointConfiguration(
 				editValue = "dateCreated:asc",
 				entity = "Endpoints",
 				fieldName = "sort",
@@ -255,7 +255,7 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("When setting the Sorting to 'age:asc'") {
-			APIBuilderUI.addAndPublishFiltersAndSortingInEndpointConfiguration(
+			APIBuilderUI.addAndPublishEndpointConfiguration(
 				editValue = "age:asc",
 				entity = "Endpoints",
 				fieldName = "sort",

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]DefineAPISchemasWithinAnAPIGroup/CreateAPIApplicationSchema.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]DefineAPISchemasWithinAnAPIGroup/CreateAPIApplicationSchema.testcase
@@ -146,7 +146,8 @@ definition {
 
 		task ("Then I can see details info of the created schema") {
 			AssertTextEquals(
-				locator1 = "APIBuilder#ENTER_NAME",
+				key_placeHolder = "Enter name",
+				locator1 = "TextInput#ANY_PLACEHOLDER",
 				value1 = "testSchema");
 
 			AssertTextEquals(

--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/CustomObjectAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/CustomObjectAPI.macro
@@ -254,8 +254,8 @@ definition {
 	}
 
 	@summary = "Default summary"
-	macro createObjectRelatedToAnotherObject(en_US_plural_label = null, name = null, relatedObject = null, relatedObjectErc=null, relationship=null) {
-		Variables.assertDefined(parameterList = "${en_US_plural_label},${name},${relationship},${relatedObject},${relatedObjectErc}");
+	macro createObjectRelatedToAnotherObject(en_US_plural_label = null, name = null, relatedObject = null, relatedObjectErc=null, relationshipName=null) {
+		Variables.assertDefined(parameterList = "${en_US_plural_label},${name},${relationshipName},${relatedObjectName},${relatedObjectErc}");
 
 		var portalURL = JSONCompany.getPortalURL();
 
@@ -265,7 +265,7 @@ definition {
 				-H Content-Type: application/json \
 				-d {
 					"name": "${name}",
-					"r_${relationship}_c_${relatedObject}ERC": "${relatedObjectErc}"
+					"r_${relationshipName}_c_${relatedObjectName}ERC": "${relatedObjectErc}"
 				}
 		''';
 

--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/CustomObjectAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/CustomObjectAPI.macro
@@ -254,6 +254,27 @@ definition {
 	}
 
 	@summary = "Default summary"
+	macro createObjectRelatedToAnotherObject(en_US_plural_label = null, name = null, relatedObject = null, relatedObjectErc=null, relationship=null) {
+		Variables.assertDefined(parameterList = "${en_US_plural_label},${name},${relationship},${relatedObject},${relatedObjectErc}");
+
+		var portalURL = JSONCompany.getPortalURL();
+
+		var curl = '''
+			${portalURL}/o/c/${en_US_plural_label} \
+				-u test@liferay.com:test \
+				-H Content-Type: application/json \
+				-d {
+					"name": "${name}",
+					"r_${relationship}_c_${relatedObject}ERC": "${relatedObjectErc}"
+				}
+		''';
+
+		var objectId = JSONCurlUtil.post(${curl}, "$.id");
+
+		return ${objectId};
+	}
+
+	@summary = "Default summary"
 	macro createStudentRelatedToAccount(accountId = null, name = null) {
 		Variables.assertDefined(parameterList = "${name},${accountId}");
 

--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectDefinitionAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectDefinitionAPI.macro
@@ -65,11 +65,12 @@ definition {
 	}
 
 	@summary = "Default summary"
-	macro _createObjectEntryWithName(keywords = null, taxonomyCategoryIds = null, name = null, virtualHost = null, en_US_plural_label = null, token = null) {
+	macro _createObjectEntryWithName(externalReferenceCode = null, keywords = null,taxonomyCategoryIds = null,name = null,virtualHost = null,en_US_plural_label = null,token = null) {
 		Variables.assertDefined(parameterList = ${name});
 
 		var response = CustomObjectAPI.createObjectEntryWithFields(
 			en_US_plural_label = ${en_US_plural_label},
+			externalReferenceCode = ${externalReferenceCode},
 			fieldName = "name",
 			fieldValue = ${name},
 			keywords = ${keywords},
@@ -826,9 +827,10 @@ definition {
 	}
 
 	@summary = "Default summary"
-	macro createObjectEntryWithName(keywords = null, taxonomyCategoryIds = null, name = null, secondFieldValue = null, virtualHost = null, en_US_plural_label = null, token = null) {
+	macro createObjectEntryWithName(externalReferenceCode = null, keywords = null,taxonomyCategoryIds = null,name = null,secondFieldValue = null,virtualHost = null,en_US_plural_label = null,token = null) {
 		var objectId = ObjectDefinitionAPI._createObjectEntryWithName(
 			en_US_plural_label = ${en_US_plural_label},
+			externalReferenceCode = ${externalReferenceCode},
 			keywords = ${keywords},
 			name = ${name},
 			secondFieldValue = ${secondFieldValue},


### PR DESCRIPTION
Background:
- Add tests to define prefilter

Test Plan
- background: Given objects definitons Student, Subject with field name created
And Given one-to-many relationship studentSubjects created
And Given Student entries 'aabc', 'abc', 'bbbabc','zzzz'  with externalReferenceCode 'aabc', 'abc', 'bbbabc', 'zzzz' created
And Given Subject entries 'abc', 'zzzz', 'bbbabc' created and related to students 'abc', 'bbbabc', 'zzzz'
Given ApiApplication with an endpoint of scope Company created and published
And Given a schema based on Student object definition with student name, subject name as schema properties student_name, subject_name
- When navigating to the endpoint Configuration tab
Filters box to Add a filter using OData is present
- When setting the Filters to 'contains(name,'abc')'
Then students 'aabc', 'abc', 'bbbabc' are listed in the endpoint response
- When setting the Filters to 'contains(studentSubjects/name,'abc')'
Then students 'abc', 'zzzz' are listed in the endpoint response
- And Given setting the Filters to 'contains(studentSubjects/name,'abc')'
And Given endpoint returning students 'abc', 'zzzz'
When I empty the Filter box in endpoint configuration
Then Student entries 'aabc', 'abc', 'bbbabc', 'zzzz' are listed in the endpoint response
- And Given setting the Filters to 'contains(studentSubjects/name,'abc') and name eq 'zzzz''
And Given endpoint returning student 'zzzz'
When I empty the Filters
And When I call endpoint with '?filter=contains(subject_name,'abc') and student_name eq 'zzzz'' in API Explorer
Then endpoint returns student 'zzzz'
- And Given setting the Filters to 'contains(name,'abc')'
When I call endpoint with '?filter=contains(subject_name,'z')' in API Explorer
Then endpoint returns student 'bbbabc'
- When setting the Filters to 'externalReferenceCode eq 'abc''
Then endpoint returns student 'abc'

Jira Ticket:
- https://liferay.atlassian.net/browse/LPS-200318