### PR TITLE
LPS-201360 Add and update tests on api application in other instance

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
@@ -227,15 +227,13 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 						"/c/" + _BASE_URL_1
 					));
 
-				String externalReferenceCode = RandomTestUtil.randomString();
-
 				assertSuccessfulHttpCode(
 					JSONUtil.put(
 						"applicationStatus", "published"
 					).put(
 						"baseURL", _BASE_URL_1
 					).put(
-						"externalReferenceCode", externalReferenceCode
+						"externalReferenceCode", _API_APPLICATION_ERC_1
 					).put(
 						"title", "test-app"
 					).toString(),
@@ -248,10 +246,19 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 						"/c/" + _BASE_URL_1
 					));
 
+				JSONAssert.assertEquals(
+					JSONUtil.put(
+						"totalCount", 1
+					).toString(),
+					HTTPTestUtil.invokeToJSONObject(
+						null, "headless-builder/applications", Http.Method.GET
+					).toString(),
+					JSONCompareMode.LENIENT);
+
 				assertSuccessfulHttpCode(
 					null,
 					"headless-builder/applications/by-external-reference-code" +
-						"/" + externalReferenceCode,
+						"/" + _API_APPLICATION_ERC_1,
 					Http.Method.DELETE);
 
 				Assert.assertFalse(
@@ -262,6 +269,12 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 					));
 			}
 		);
+
+		assertSuccessfulHttpCode(
+			null,
+			"headless-builder/applications/by-external-reference-code/" +
+				_API_APPLICATION_ERC_1,
+			Http.Method.GET);
 	}
 
 	@Test


### PR DESCRIPTION
Background:
- Add tests `CannotGetAPIApplicationOfOtherInstance` and `CanGetAPIWithSameErcApplicationDeletedOnAnotherInstance` into integration layer

Jira Ticket
- https://liferay.atlassian.net/browse/LPS-201360

Test Plan
- CanGetAPIWithSameErcApplicationDeletedOnAnotherInstance
    - Given an published API application with endpoint and schema created in default instanceAnd Given a virtual instance is created
    - And Given another published API Application on virtual instance with same erc as the one on default instance
    - When with deleteByExternalReferenceCode and externalReferenceCode to delete the application on default instancet
    - Then the application on default instance is deletedAnd Then the application rest api on virtual instance still works
- CannotGetAPIApplicationOfOtherInstance
    - Given an published API application with endpoint and schema created in default instanceAnd Given a virtual instance is created
    - And Given an published API application created in virtual instance
    - When request getAPIApplicationsPage in virtual instance
    - Then only the API in virtual instance is returned