### PR TITLE
LRQA-84217 

### DIFF
--- a/modules/apps/object/object-rest-test-util/src/main/java/com/liferay/object/rest/test/util/UserAccountTestUtil.java
+++ b/modules/apps/object/object-rest-test-util/src/main/java/com/liferay/object/rest/test/util/UserAccountTestUtil.java
@@ -86,6 +86,8 @@ public class UserAccountTestUtil {
 
 		UserAccount userAccount = randomUserAccount();
 
+		userAccount.setStatus(UserAccount.Status.ACTIVE);
+
 		JaxRsApplicationDescriptor jaxRsApplicationDescriptor =
 			systemObjectDefinitionManager.getJaxRsApplicationDescriptor();
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-84217
@4lejandrito @sergiojimcos 
The test was failing because there was an invalid "null" value sent as Status of the entry. However in testPutSystemObjectEntryWithNestedCustomObjectEntriesByExternalReferenceCode we use the same UserAccount object (without the status field being set), and the test pases OK. So, I'm wondering what is the difference and whether I'm masking an eventual bug rn 😅 