### PR TITLE
LPS-201612 Fix BatchEngineBrokerTest.testImportObjectDefinition to add objectRelationship erc

### DIFF
--- a/modules/apps/batch-planner/batch-planner-test/src/testIntegration/resources/com/liferay/batch/planner/batch/engine/broker/test/dependencies/object_definition_import.json
+++ b/modules/apps/batch-planner/batch-planner-test/src/testIntegration/resources/com/liferay/batch/planner/batch/engine/broker/test/dependencies/object_definition_import.json
@@ -499,6 +499,7 @@
 			{
 				"deletionType": "prevent",
 				"edge": false,
+				"externalReferenceCode": "TEST-OBJECT-RELATIONSHIP",
 				"id": 35639,
 				"label": {
 					"en_US": "relationship"


### PR DESCRIPTION
Background:
- Our existing test is failed because of [LPS-201121](https://liferay.atlassian.net/browse/LPS-201121) add objectRelationship erc

Test Plan
- Test fix for integration test BatchEngineBrokerTest.testImportObjectDefinition

Jira ticket
- https://liferay.atlassian.net/browse/LPS-201612