### PR TITLE
LPS-200562 | Add a testcase to support export object entries at site level

### DIFF
--- a/modules/apps/batch-planner/batch-planner-test/src/testFunctional/macros/ImportExport.macro
+++ b/modules/apps/batch-planner/batch-planner-test/src/testFunctional/macros/ImportExport.macro
@@ -223,8 +223,16 @@ definition {
 	}
 
 	@summary = "Default summary"
-	macro configureExport(containsHeaders = null, templateName = null, entityType = null, exportFields = null, exportFileFormat = null) {
-		ImportExport.selectEntity(entityType = ${entityType});
+	macro configureExport(containsHeaders = null, templateName = null, entityType = null, scope = null, exportFields = null, exportFileFormat = null) {
+		if (isSet(entityType)) {
+			ImportExport.selectEntity(entityType = ${entityType});
+		}
+
+		if (isSet(scope)) {
+			Select(
+				locator1 = "Select#SCOPE_CONFIGURATION",
+				value1 = ${scope});
+		}
 
 		Select(
 			key_selectFieldLabel = "Export File Format",
@@ -273,8 +281,7 @@ definition {
 
 		if (isSet(scope)) {
 			Select(
-				key_selectFieldLabel = "Scope",
-				locator1 = "ImportExport#SELECT",
+				locator1 = "Select#SCOPE_CONFIGURATION",
 				value1 = ${scope});
 		}
 

--- a/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/SupportExportObjectEntriesAtSiteLevel.testcase
+++ b/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/SupportExportObjectEntriesAtSiteLevel.testcase
@@ -1,0 +1,259 @@
+@component-name = "portal-batch-planner"
+definition {
+
+	property custom.properties = "feature.flag.COMMERCE-8087=true";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.main.component.name = "Import/Export";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+
+		task ("Given site scoped Student, Subject, and company scope University object definition with text field 'name' created") {
+			var studentId = ObjectDefinitionAPI.createAndPublishObjectDefinition(
+				en_US_label = "student",
+				en_US_plural_label = "students",
+				name = "Student",
+				requiredStringFieldName = "name",
+				scope = "site");
+
+			ObjectDefinitionAPI.createAndPublishObjectDefinition(
+				en_US_label = "subject",
+				en_US_plural_label = "subjects",
+				name = "Subject",
+				requiredStringFieldName = "name",
+				scope = "site");
+
+			ObjectDefinitionAPI.createAndPublishObjectDefinition(
+				en_US_label = "university",
+				en_US_plural_label = "universities",
+				name = "University",
+				requiredStringFieldName = "name");
+		}
+
+		task ("And Given many-to-many studentsSubjects relationship created") {
+			ObjectDefinitionAPI.createRelationshipWithObjectDefinitionNames(
+				childObjectName = "Subject",
+				deletionType = "cascade",
+				name = "studentsSubjects",
+				parentObjectName = "Student",
+				type = "manyToMany");
+		}
+
+		task ("And Given one-to-many studentAccounts relationship created") {
+			var accountId = ObjectDefinitionAPI.getObjectDefinitionIdByName(name = "AccountEntry");
+
+			ObjectDefinitionAPI.createRelationship(
+				deletionType = "cascade",
+				en_US_label = "StudentAccounts",
+				name = "studentAccounts",
+				objectDefinitionId1 = ${studentId},
+				objectDefinitionId2 = ${accountId},
+				type = "oneToMany");
+		}
+
+		task ("And Given object entries of Student, Subject, Account created with related entries") {
+			var accountEntryId = AccountAPI.createAccount(name = "accountForStudent");
+			var studentEntryId = ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "students",
+				name = "Able",
+				scopeKey = "true");
+			var subjectEntryId = ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "subjects",
+				name = "English",
+				scopeKey = "true");
+
+			ObjectDefinitionAPI.relateObjectEntries(
+				en_US_plural_label = "students",
+				objectEntry1 = ${studentEntryId},
+				objectEntry2 = ${accountEntryId},
+				relationshipName = "studentAccounts");
+
+			ObjectDefinitionAPI.relateObjectEntries(
+				en_US_plural_label = "students",
+				objectEntry1 = ${studentEntryId},
+				objectEntry2 = ${subjectEntryId},
+				relationshipName = "studentsSubjects");
+		}
+
+		task ("And Given navigate to export in Data Migration Center") {
+			ImportExport.openImportExportAdmin();
+
+			ImportExport.gotoExport();
+		}
+	}
+
+	tearDown {
+		var testLiferayVirtualInstance = PropsUtil.get("test.liferay.virtual.instance");
+
+		ObjectAdmin.deleteAllCustomObjectsViaAPI();
+
+		BatchPlanner.batchPlannerTearDown();
+
+		AccountAPI.tearDownAllAccounts();
+
+		if (${testLiferayVirtualInstance} == "true") {
+			PortalInstances.tearDownCP();
+		}
+	}
+
+	@priority = 5
+	test CanDownloadFileWithAllFieldsSelected {
+		property portal.acceptance = "true";
+
+		task ("And Given 'C_Student (v1_0 - Liferay Object REST)' as Entity Type in Data Migration Center --> Export File") {
+			ImportExport.selectEntity(entityType = "C_Student (v1_0 - Liferay Object REST)");
+		}
+
+		task ("When exporting file in JSON format with all fields selected") {
+			var scope = TestCase.getSiteName();
+
+			ImportExport.configureExport(
+				exportFileFormat = "JSON",
+				scope = ${scope});
+
+			Button.click(button = "Export");
+
+			WaitForElementPresent(locator1 = "ImportExport#EXECUTION_SUCCESS");
+		}
+
+		task ("Then all fields values available in the downloaded file") {
+			ImportExport.unzipDownloadedExportFile();
+
+			var response = ObjectDefinitionAPI.getObjectEntries(
+				en_US_plural_label = "students",
+				scopeKey = "true");
+			var totalFieldsList = "creator,dateCreated,dateModified,externalReferenceCode,id,keywords,name,scopeKey,status";
+
+			for (var fieldName : list ${totalFieldsList}) {
+				var expectedValue = JSONPathUtil.getProperty(
+					property = "$.items..[0]${fieldName}",
+					response = ${response});
+
+				BatchEngine.assertExportedFileContainsCorrectObject(
+					expectedValue = ${expectedValue},
+					fileName = "export.json",
+					jsonObject = "$..[0]${fieldName}");
+			}
+
+			BatchEngine.assertExportedFileContainsCorrectObject(
+				expectedValue = "DELETE,GET,GET,PUT,PATCH",
+				fileName = "export.json",
+				jsonObject = "$..actions..method");
+		}
+	}
+
+	@priority = 4
+	test CanExportSpecificFieldsWithJSONTConfigurationNode {
+		property portal.acceptance = "true";
+
+		task ("And Given 'C_Student (v1_0 - Liferay Object REST)' as Entity Type and current site as Scope in Data Migration Center --> Export File") {
+			var scope = TestCase.getSiteName();
+
+			ImportExport.configureExport(
+				entityType = "C_Student (v1_0 - Liferay Object REST)",
+				exportFileFormat = "JSONT",
+				scope = ${scope});
+		}
+
+		task ("When exporting file in JSONT format with field 'name' selected") {
+			ImportExport.mapExport(exportFields = "name");
+
+			Button.click(button = "Export");
+
+			WaitForElementPresent(locator1 = "ImportExport#EXECUTION_SUCCESS");
+		}
+
+		task ("Then 'name' value for created entry, actions node, configuration node available in the dowloaded file") {
+			ImportExport.unzipDownloadedExportFile();
+
+			BatchEngine.assertExportedFileContainsCorrectObject(
+				expectedValue = "Able",
+				fileName = "export.batch-engine-data.json",
+				jsonObject = "$.items..name");
+
+			BatchEngine.assertExportedFileContainsCorrectObject(
+				expectedValue = "POST,DELETE,PUT",
+				fileName = "export.batch-engine-data.json",
+				jsonObject = "$.actions..method");
+
+			BatchEngine.assertExportedFileContainsCorrectObject(
+				expectedValue = "com.liferay.object.rest.dto.v1_0.ObjectEntry",
+				fileName = "export.batch-engine-data.json",
+				jsonObject = "$.configuration.className");
+		}
+	}
+
+	@priority = 4
+	test CannotSeeScopeSelectorForObjectDefinitionsScopedByCompany {
+		property portal.acceptance = "true";
+
+		task ("When 'C_University (v1_0 - Liferay Object REST)' as Entity Type in Data Migration Center --> Export File") {
+			ImportExport.selectEntity(entityType = "C_University (v1_0 - Liferay Object REST)");
+		}
+
+		task ("Then 'Scope' selector is not present") {
+			AssertElementNotPresent(locator1 = "Select#SCOPE_CONFIGURATION");
+		}
+	}
+
+	@priority = 5
+	test CanSeeCreatedSiteInScopeSelector {
+		property portal.acceptance = "true";
+
+		task ("And Given a new site named test") {
+			HeadlessSite.addSite(siteName = "test");
+		}
+
+		task ("And Given 'C_Student (v1_0 - Liferay Object REST)' as Entity Type and default site as scope in Data Migration Center --> Export File") {
+			ImportExport.selectEntity(entityType = "C_Student (v1_0 - Liferay Object REST)");
+		}
+
+		task ("When click the scope selector") {
+			Click(locator1 = "Select#SCOPE_CONFIGURATION");
+		}
+
+		task ("Then test site present in the dropdown list") {
+			AssertElementPresent(
+				key_scopeName = "test",
+				locator1 = "Select#SCOPE_SELECTED");
+		}
+	}
+
+	@priority = 4
+	test CanSelectAllExistingFields {
+		property portal.acceptance = "true";
+
+		task ("When selecting 'C_Student (v1_0 - Liferay Object REST)' as Entity Type in Data Migration Center --> Export File") {
+			ImportExport.selectEntity(entityType = "C_Student (v1_0 - Liferay Object REST)");
+		}
+
+		task ("Then the list of fields to select contains all the fields available with GET request") {
+			var fieldList = "name,actions,creator,dateCreated,dateModified,externalReferenceCode,id,keywords,scopeKey,status";
+
+			ImportExport.mapExport(exportFields = ${fieldList});
+		}
+	}
+
+	@priority = 4
+	test CanSelectGlobalSiteAsScope {
+		property portal.acceptance = "true";
+
+		task ("When 'C_Student (v1_0 - Liferay Object REST)' as Entity Type in Data Migration Center --> Export File") {
+			ImportExport.selectEntity(entityType = "C_Student (v1_0 - Liferay Object REST)");
+		}
+
+		task ("Then Global site available as scope") {
+			ImportExport.configureExport(
+				exportFileFormat = "JSON",
+				scope = "Global");
+
+			Button.click(button = "Export");
+
+			WaitForElementPresent(locator1 = "ImportExport#EXECUTION_SUCCESS");
+		}
+	}
+
+}

--- a/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectDefinitionAPI.macro
+++ b/modules/apps/object/object-rest-test/src/testFunctional/macros/ObjectDefinitionAPI.macro
@@ -65,7 +65,7 @@ definition {
 	}
 
 	@summary = "Default summary"
-	macro _createObjectEntryWithName(externalReferenceCode = null, keywords = null,taxonomyCategoryIds = null,name = null,virtualHost = null,en_US_plural_label = null,token = null) {
+	macro _createObjectEntryWithName(keywords = null, taxonomyCategoryIds = null, name = null, scopeKey = null, virtualHost = null, en_US_plural_label = null, externalReferenceCode = null, token = null) {
 		Variables.assertDefined(parameterList = ${name});
 
 		var response = CustomObjectAPI.createObjectEntryWithFields(
@@ -74,6 +74,7 @@ definition {
 			fieldName = "name",
 			fieldValue = ${name},
 			keywords = ${keywords},
+			scopeKey = ${scopeKey},
 			taxonomyCategoryIds = ${taxonomyCategoryIds},
 			token = ${token},
 			virtualHost = ${virtualHost});
@@ -827,12 +828,13 @@ definition {
 	}
 
 	@summary = "Default summary"
-	macro createObjectEntryWithName(externalReferenceCode = null, keywords = null,taxonomyCategoryIds = null,name = null,secondFieldValue = null,virtualHost = null,en_US_plural_label = null,token = null) {
+	macro createObjectEntryWithName(keywords = null, taxonomyCategoryIds = null, name = null, scopeKey = null, secondFieldValue = null, virtualHost = null, en_US_plural_label = null, externalReferenceCode = null, token = null) {
 		var objectId = ObjectDefinitionAPI._createObjectEntryWithName(
 			en_US_plural_label = ${en_US_plural_label},
 			externalReferenceCode = ${externalReferenceCode},
 			keywords = ${keywords},
 			name = ${name},
+			scopeKey = ${scopeKey},
 			secondFieldValue = ${secondFieldValue},
 			taxonomyCategoryIds = ${taxonomyCategoryIds},
 			token = ${token},
@@ -1033,6 +1035,20 @@ definition {
 		if (isSet(parameter)) {
 			var curl = '''
 				${portalURL}/o/c/${en_US_plural_label_lowercase}?${parameter} \
+					-u test@liferay.com:test
+			''';
+		}
+		else if (isSet(scopeKey)) {
+			if (!(isSet(groupName))) {
+				var groupName = "Guest";
+			}
+
+			var scopeKey = JSONGroupAPI._getSiteIdByGroupKeyNoSelenium(
+				groupName = ${groupName},
+				token = ${token});
+
+			var curl = '''
+				${portalURL}/o/c/${en_US_plural_label_lowercase}/scopes/${scopeKey} \
 					-u test@liferay.com:test
 			''';
 		}


### PR DESCRIPTION
Background:
Add a testcase to support export object entries at site level

Test Plan
CanSelectAllExistingFields
When selecting 'C_Student (v1_0 - Liferay Object REST)' as Entity Type in Data Migration Center --> Export File
Then the list of fields to select contains all the fields available with GET request

CanDownloadFileWithAllFieldsSelected
And Given 'C_Student (v1_0 - Liferay Object REST)' as Entity Type  and current site as Scope in Data Migration Center --> Export File
When exporting file in JSON format with all fields selected
Then all fields values available in the downloaded file

CanSeeCreatedSiteInScopeSelector
And Given a new site named test
And Given 'C_Student (v1_0 - Liferay Object REST)' as Entity Type and default site as scope in Data Migration Center --> Export File
When click the scope selector
Then test site present in the dropdown list

CanSelectGlobalSiteAsScope
When 'C_Student (v1_0 - Liferay Object REST)' as Entity Type in Data Migration Center --> Export File
Then and Global site available as scope

CanExportSpecificFieldsWithJSONTConfigurationNode
And Given 'C_Student (v1_0 - Liferay Object REST)' as Entity Type and current site as Scope in Data Migration Center --> Export File
When exporting file in JSONT format with field 'name' selected
Then 'name' value for created entry, actions node, configuration node available in the dowloaded file

CannotSeeScopeSelectorForObjectDefinitionsScopedByCompany
Given company scoped University object definition with text field 'name' created
When 'C_University (v1_0 - Liferay Object REST)' as Entity Type in Data Migration Center --> Export File
Then 'Scope' selector is not present

Jira ticket:
https://liferay.atlassian.net/browse/LPS-200562