### PR TITLE
LPS-201627 Use the internal name of the EntityField instead of its name for CollectionEntityField

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
@@ -6,6 +6,10 @@
 package com.liferay.headless.delivery.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.kernel.service.AssetCategoryLocalService;
+import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.blogs.model.BlogsEntry;
 import com.liferay.blogs.test.util.BlogsTestUtil;
 import com.liferay.document.library.kernel.model.DLFileEntry;
@@ -52,6 +56,7 @@ import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserGroupRoleLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
@@ -319,6 +324,77 @@ public class StructuredContentResourceTest
 		_testGetSiteStructuredContentsPageByDefaultPriority();
 		_testGetSiteStructuredContentsPageByGivenPriority();
 		_testGetSiteStructuredContentsPageOrderedByDescendingPriority();
+	}
+
+	@Override
+	@Test
+	public void testGetSiteStructuredContentsPageWithSortInteger()
+		throws Exception {
+
+		super.testGetSiteStructuredContentsPageWithSortInteger();
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(testGroup.getGroupId());
+
+		AssetVocabulary assetVocabulary =
+			_assetVocabularyLocalService.addVocabulary(
+				TestPropsValues.getUserId(), testGroup.getGroupId(),
+				RandomTestUtil.randomString(), serviceContext);
+
+		AssetCategory assetCategory1 = _assetCategoryLocalService.addCategory(
+			TestPropsValues.getUserId(), testGroup.getGroupId(),
+			RandomTestUtil.randomString(), assetVocabulary.getVocabularyId(),
+			serviceContext);
+
+		AssetCategory assetCategory2 = _assetCategoryLocalService.addCategory(
+			TestPropsValues.getUserId(), testGroup.getGroupId(),
+			RandomTestUtil.randomString(), assetVocabulary.getVocabularyId(),
+			serviceContext);
+
+		Assert.assertTrue(
+			assetCategory1.getCategoryId() < assetCategory2.getCategoryId());
+
+		StructuredContent structuredContent1 = randomStructuredContent();
+
+		structuredContent1.setTaxonomyCategoryIds(
+			new Long[] {assetCategory2.getCategoryId()});
+
+		StructuredContent structuredContent2 = randomStructuredContent();
+
+		structuredContent2.setTaxonomyCategoryIds(
+			new Long[] {assetCategory1.getCategoryId()});
+
+		structuredContent1 =
+			testGetSiteStructuredContentsPage_addStructuredContent(
+				testGroup.getGroupId(), structuredContent1);
+
+		structuredContent2 =
+			testGetSiteStructuredContentsPage_addStructuredContent(
+				testGroup.getGroupId(), structuredContent2);
+
+		Page<StructuredContent> page =
+			structuredContentResource.getSiteStructuredContentsPage(
+				testGroup.getGroupId(), null, null, null,
+				String.format(
+					"taxonomyCategoryIds/any(k:k in (%d,%d))",
+					assetCategory1.getCategoryId(),
+					assetCategory2.getCategoryId()),
+				null, "taxonomyCategoryIds:asc");
+
+		assertEquals(
+			Arrays.asList(structuredContent2, structuredContent1),
+			(List<StructuredContent>)page.getItems());
+
+		page = structuredContentResource.getSiteStructuredContentsPage(
+			testGroup.getGroupId(), null, null, null,
+			String.format(
+				"taxonomyCategoryIds/any(k:k in (%d,%d))",
+				assetCategory1.getCategoryId(), assetCategory2.getCategoryId()),
+			null, "taxonomyCategoryIds:desc");
+
+		assertEquals(
+			Arrays.asList(structuredContent1, structuredContent2),
+			(List<StructuredContent>)page.getItems());
 	}
 
 	@Override
@@ -1699,6 +1775,12 @@ public class StructuredContentResourceTest
 
 	@Inject(filter = "ddm.form.deserializer.type=json")
 	private static DDMFormDeserializer _jsonDDMFormDeserializer;
+
+	@Inject
+	private AssetCategoryLocalService _assetCategoryLocalService;
+
+	@Inject
+	private AssetVocabularyLocalService _assetVocabularyLocalService;
 
 	private BlogsEntry _blogsEntry;
 	private DDMStructure _complexDDMStructure;

--- a/modules/apps/portal-odata/portal-odata-api/src/main/java/com/liferay/portal/odata/entity/CollectionEntityField.java
+++ b/modules/apps/portal-odata/portal-odata-api/src/main/java/com/liferay/portal/odata/entity/CollectionEntityField.java
@@ -22,7 +22,7 @@ public class CollectionEntityField extends EntityField {
 	public CollectionEntityField(EntityField entityField) {
 		super(
 			entityField.getName(), Type.COLLECTION,
-			locale -> entityField.getName(), locale -> entityField.getName(),
+			entityField::getSortableName, entityField::getFilterableName,
 			String::valueOf);
 
 		_entityField = entityField;


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPS-201627

---

The purpose of this ticket is to fix the usage of the Collection field for sorting purposes. Previously, the field used is the one given by the `getName` method (that is the field of the REST API). However, we need to use the internal one given by the methods `getSortableName` and `getFilterableName`.

For example, for the Headless Delivery REST API, when using the `taxonomyCategoryIds` field in the sort:

```shell
curl -X GET \
      -u test@liferay.com:test \
      http://localhost:8080/o/headless-delivery/v1.0/sites/20119/structured-contents?sort=taxonomyCategoryIds
```

Being the document in ElasticSearch:

```json
          "assetCategoryIds" : [
            "102506",
            "102509"
          ],
```

See the fragment of the query in ElasticSearch

**Before the PR:**

```json
  "sort": [
    {
      "taxonomyCategoryIds": {
        "order": "asc",
        "unmapped_type": "keyword"
      }
    },
```

**After the PR:**

```json
  "sort": [
    {
      "assetCategoryIds": {
        "order": "asc",
        "unmapped_type": "keyword"
      }
    },
```
