### PR TITLE
LPS-201868 Test fix for HeadlessBuilderOpenAPIResourceTest to remove readOnly property for fileBase64

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/resources/com/liferay/headless/builder/resource/test/dependencies/expected_openapi.json
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/resources/com/liferay/headless/builder/resource/test/dependencies/expected_openapi.json
@@ -31,7 +31,6 @@
 				"properties": {
 					"fileBase64": {
 						"description": "optional field with the content of the document in Base64, can be embedded with nestedFields (the format of the nested field must be `<attachment field name>.fileBase64`)",
-						"readOnly": true,
 						"type": "string"
 					},
 					"id": {


### PR DESCRIPTION
Background:
- Test fix for HeadlessBuilderOpenAPIResourceTest since readyOnly property is removed in LPS-200329

Jira Ticket
- https://liferay.atlassian.net/browse/LPS-201864