### PR TITLE
LPS-202102 Throw an IllegalArgumentException if the base64 encoding sent via REST API is invalid

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -1009,6 +1009,16 @@ public class DefaultObjectEntryManagerImpl
 		}
 	}
 
+	private byte[] _decode(String base64) {
+		try {
+			return Base64.decode(base64);
+		}
+		catch (Exception exception) {
+			throw new IllegalArgumentException(
+				"Error decoding base64 content", exception);
+		}
+	}
+
 	private void _disassociateRelatedModels(
 			ObjectDefinition objectDefinition,
 			ObjectRelationship objectRelationship, long primaryKey1,
@@ -1437,8 +1447,8 @@ public class DefaultObjectEntryManagerImpl
 
 		com.liferay.portal.kernel.repository.model.FileEntry
 			serviceBuilderFileEntry = _attachmentManager.addFileEntry(
-				objectField.getCompanyId(),
-				Base64.decode(fileEntry.getFileBase64()), fileEntry.getName(),
+				objectField.getCompanyId(), _decode(fileEntry.getFileBase64()),
+				fileEntry.getName(),
 				getGroupId(objectDefinition, scopeKey, true),
 				objectField.getObjectFieldId(), serviceContext);
 


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPS-202102

---

The purpose of this PR is to throw an exception that is mapped into a Bad Request error code in the REST API. For that, all the exception thrown is caught when decoding the base64 encoding and if any error happened, an IllegalArgumentException is thrown.

How to reproduce it:

Follow the steps of the ticket

NOTE: A test will be added in a followed-up PR 