### PR TITLE
LPS-202416 Modified endpoint matcher for allowing the new POST structure

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/application/endpoint/EndpointMatcher.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/application/endpoint/EndpointMatcher.java
@@ -7,6 +7,7 @@ package com.liferay.headless.builder.internal.application.endpoint;
 
 import com.liferay.headless.builder.application.APIApplication;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.Validator;
 
 import java.util.HashMap;
 import java.util.List;
@@ -27,7 +28,8 @@ public class EndpointMatcher {
 		for (APIApplication.Endpoint endpoint : endpoints) {
 			if (Objects.equals(
 					endpoint.getRetrieveType(),
-					APIApplication.Endpoint.RetrieveType.SINGLE_ELEMENT)) {
+					APIApplication.Endpoint.RetrieveType.SINGLE_ELEMENT) &&
+				Validator.isNotNull(endpoint.getPathParameter())) {
 
 				Pattern pattern = Pattern.compile(
 					_getSingleElementRegex(endpoint));


### PR DESCRIPTION
**What's changed?:**
- Now, when establishing the predicates of the Endpoint Matcher, the path parameter is taken into account so that POST API Endpoints (which are Single Element but can't contain path parameters) get interpreted properly.

See the following **Jira ticket**: [LPS-202416](https://liferay.atlassian.net/browse/LPS-202416)