### PR TITLE
LPS-196412- API Builder relationship fields should be system

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/resources/com/liferay/headless/builder/internal/batch/headless-builder.batch-engine-data.json
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/resources/com/liferay/headless/builder/internal/batch/headless-builder.batch-engine-data.json
@@ -328,6 +328,7 @@
 					"parameterObjectFieldId": 0,
 					"parameterObjectFieldName": "",
 					"reverse": false,
+					"system": true,
 					"type": "oneToMany"
 				},
 				{
@@ -342,6 +343,7 @@
 					"parameterObjectFieldId": 0,
 					"parameterObjectFieldName": "",
 					"reverse": false,
+					"system": true,
 					"type": "oneToMany"
 				}
 			],
@@ -441,6 +443,7 @@
 					"parameterObjectFieldId": 0,
 					"parameterObjectFieldName": "",
 					"reverse": false,
+					"system": true,
 					"type": "manyToMany"
 				}
 			],
@@ -524,6 +527,7 @@
 					"parameterObjectFieldId": 0,
 					"parameterObjectFieldName": "",
 					"reverse": false,
+					"system": true,
 					"type": "oneToMany"
 				},
 				{
@@ -538,6 +542,7 @@
 					"parameterObjectFieldId": 0,
 					"parameterObjectFieldName": "",
 					"reverse": false,
+					"system": true,
 					"type": "oneToMany"
 				},
 				{
@@ -552,6 +557,7 @@
 					"parameterObjectFieldId": 0,
 					"parameterObjectFieldName": "",
 					"reverse": false,
+					"system": true,
 					"type": "oneToMany"
 				}
 			],
@@ -708,6 +714,7 @@
 					"parameterObjectFieldId": 0,
 					"parameterObjectFieldName": "",
 					"reverse": false,
+					"system": true,
 					"type": "oneToMany"
 				},
 				{
@@ -722,6 +729,7 @@
 					"parameterObjectFieldId": 0,
 					"parameterObjectFieldName": "",
 					"reverse": false,
+					"system": true,
 					"type": "oneToMany"
 				}
 			],

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -1718,8 +1718,7 @@ public class ObjectEntryLocalServiceImpl
 		long objectDefinitionId, Map<String, Serializable> values) {
 
 		for (ObjectField objectField :
-				_objectFieldLocalService.getObjectFields(
-					objectDefinitionId, false)) {
+				_objectFieldLocalService.getObjectFields(objectDefinitionId)) {
 
 			if (!Objects.equals(
 					objectField.getRelationshipType(),


### PR DESCRIPTION
Hi @G-Sa, this PR contains the changes in order to set ObjectRelationship field names to system. The commit added, retrieves all the object fields that could be system or custom.

**What is new?**
- Changes in ObjectEntryLocalService to retrieve all the object fields
- Set ObjectRelationships to system.

**Related JIRA Ticket**
[LPS-196412](https://liferay.atlassian.net/browse/LPS-196412)