### PR TITLE
LPS-202537 Making graphql namespace configurable

### DIFF
--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=Grant type "{0}" is unsupported
 granted=Granted
 graph-url=Graph URL
 graphql-api=GraphQL API
+graphql-namespace=GraphQL Namespace
 gray-100=Gray 100
 gray-200=Gray 200
 gray-300=Gray 300

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=نوع المنحة "{0}" غي�
 granted=ممنوح
 graph-url=رابط الرسم البياني
 graphql-api=GraphQL API
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=رمادي 100
 gray-200=رمادي 200
 gray-300=رمادي 300

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=Grant type "{0}" is unsupported
 granted=Предоставя (Automatic Translation)
 graph-url=URL адрес на графиката (Automatic Translation)
 graphql-api=ГрафQL API (Automatic Translation)
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Сив 100 (Automatic Translation)
 gray-200=Сив 200 (Automatic Translation)
 gray-300=Сив 300 (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=Aquest tipus de client no admet
 granted=Concedit
 graph-url=URL del gràfic
 graphql-api=API de GraphQL
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Gris 100
 gray-200=Gris 200
 gray-300=Gris 300

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=Grant type "{0}" is unsupported
 granted=Granted (Automatic Copy)
 graph-url=Facebook Graph URL
 graphql-api=GraphQL API (Automatic Copy)
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Gray 100 (Automatic Copy)
 gray-200=Gray 200 (Automatic Copy)
 gray-300=Gray 300 (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=Grant type "{0}" is unsupported
 granted=Givet (Automatic Translation)
 graph-url=Graph URL (Automatic Copy)
 graphql-api=GraphQL API (Automatic Translation)
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Grå 100 (Automatic Translation)
 gray-200=Grå 200 (Automatic Translation)
 gray-300=Grå 300 (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=Genehmigungstyp "{0}" wird für
 granted=Gewährt
 graph-url=Graph-URL
 graphql-api=GraphQL API
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Grau 100
 gray-200=Grau 200
 gray-300=Grau 300

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=Grant type "{0}" is unsupported
 granted=Χορηγείται (Automatic Translation)
 graph-url=URL γραφήματος
 graphql-api=API γραφημάτων (Automatic Translation)
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Γκρι 100 (Automatic Translation)
 gray-200=Γκρι 200 (Automatic Translation)
 gray-300=Γκρι 300 (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=Grant type "{0}" is unsupported
 granted=Granted
 graph-url=Graph URL
 graphql-api=GraphQL API
+graphql-namespace=GraphQL Namespace
 gray-100=Gray 100
 gray-200=Gray 200
 gray-300=Gray 300

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=Grant type "{0}" is unsupported
 granted=Granted (Automatic Copy)
 graph-url=Graph URL (Automatic Copy)
 graphql-api=GraphQL API (Automatic Copy)
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Grey 100
 gray-200=Grey 200
 gray-300=Grey 300

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=Grant type "{0}" is unsupported
 granted=Granted (Automatic Copy)
 graph-url=Graph URL (Automatic Copy)
 graphql-api=GraphQL API (Automatic Copy)
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Grey 100
 gray-200=Grey 200
 gray-300=Grey 300

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=El tipo de concesión "{0}" no 
 granted=Concedido
 graph-url=URL de Graph
 graphql-api=API de GraphQL
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Gris 100
 gray-200=Gris 200
 gray-300=Gris 300

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=El tipo de concesión "{0}" no 
 granted=Concedido
 graph-url=URL de Graph
 graphql-api=API de GraphQL
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Gris 100
 gray-200=Gris 200
 gray-300=Gris 300

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=El tipo de concesión "{0}" no 
 granted=Concedido
 graph-url=URL de Graph
 graphql-api=API de GraphQL
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Gris 100
 gray-200=Gris 200
 gray-300=Gris 300

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=El tipo de concesión "{0}" no 
 granted=Concedido
 graph-url=URL de Graph
 graphql-api=API de GraphQL
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Gris 100
 gray-200=Gris 200
 gray-300=Gris 300

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=Grant type "{0}" is unsupported
 granted=Antud (Automatic Translation)
 graph-url=Graafiku URL (Automatic Translation)
 graphql-api=GraphQL API (Automatic Translation)
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Hall 100 (Automatic Translation)
 gray-200=Hall 200 (Automatic Translation)
 gray-300=Hall 300 (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=Grant type "{0}" is unsupported
 granted=Granted (Automatic Copy)
 graph-url=URL grafikoa
 graphql-api=GraphQL API (Automatic Copy)
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Gray 100 (Automatic Copy)
 gray-200=Gray 200 (Automatic Copy)
 gray-300=Gray 300 (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=Grant type "{0}" is unsupported
 granted=اعطا (Automatic Translation)
 graph-url=آدرس گراف
 graphql-api=GraphQL API (Automatic Translation)
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=خاکستری ۱۰۰ (Automatic Translation)
 gray-200=خاکستری ۲۰۰ (Automatic Translation)
 gray-300=خاکستری ۳۰۰ (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=Myöntämistyyppiä "{0}" ei tu
 granted=Myönnetty
 graph-url=Grafiikan URL
 graphql-api=GraphQL API
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Harmaa 100
 gray-200=Harmaa 200
 gray-300=Harmaa 300

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=Le type d'autorisation «{0}» 
 granted=Accordé
 graph-url=URL de graphique
 graphql-api=API GraphQL
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Gris 100
 gray-200=Gris 200
 gray-300=Gris 300

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=Le type d'autorisation «{0}» 
 granted=Accordé
 graph-url=URL de graphique
 graphql-api=API GraphQL
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Gris 100
 gray-200=Gris 200
 gray-300=Gris 300

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=Grant type "{0}" is unsupported
 granted=Concedido
 graph-url=URL do gráfico
 graphql-api=API de GraphQL
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Gris 100
 gray-200=Gris 200
 gray-300=Gris 300

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=Grant type "{0}" is unsupported
 granted=दी (Automatic Translation)
 graph-url=ग्राफ यूआरएल (Automatic Translation)
 graphql-api=ग्राफक्यूएल एपीआई (Automatic Translation)
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=ग्रे 100 (Automatic Translation)
 gray-200=ग्रे 200 (Automatic Translation)
 gray-300=ग्रे 300 (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=Grant type "{0}" is unsupported
 granted=Granted (Automatic Copy)
 graph-url=Grafikon URL
 graphql-api=GraphQL API (Automatic Copy)
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Gray 100 (Automatic Copy)
 gray-200=Gray 200 (Automatic Copy)
 gray-300=Gray 300 (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=A "{0}" engedélyezési típus 
 granted=Odaítélve
 graph-url=Grafika URL
 graphql-api=GraphQL API
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Szürke 100
 gray-200=Szürke 200
 gray-300=Szürke 300

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=Grant type "{0}" is unsupported
 granted=Diberikan (Automatic Translation)
 graph-url=Grafil URL
 graphql-api=GraphQL API (Automatic Translation)
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Abu-abu 100 (Automatic Translation)
 gray-200=Abu-abu 200 (Automatic Translation)
 gray-300=Abu-abu 300 (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
@@ -7926,6 +7926,7 @@ grant-type-x-is-unsupported-for-this-client-type=Grant type "{0}" is unsupported
 granted=accordato (Automatic Translation)
 graph-url=URL Grafico
 graphql-api=GraphQL API (Automatic Translation)
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Grigio 100 (Automatic Translation)
 gray-200=Grigio 200 (Automatic Translation)
 gray-300=Grigio 300 (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=מעניק סוג "{0}" אינ�
 granted=הוענק (Automatic Translation)
 graph-url=כתובת URL של גרף
 graphql-api=GraphQL API (Automatic Translation)
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=אפור 100 (Automatic Translation)
 gray-200=אפור 200 (Automatic Translation)
 gray-300=אפור 300 (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=このクライアント種別�
 granted=許可されました
 graph-url=グラフURL
 graphql-api=GraphQL API
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=グレー100
 gray-200=グレー200
 gray-300=グレー300

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=Grant type "{0}" is unsupported
 granted=Granted (Automatic Copy)
 graph-url=Graph URL (Automatic Copy)
 graphql-api=GraphQL API (Automatic Copy)
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Gray 100 (Automatic Copy)
 gray-200=Gray 200 (Automatic Copy)
 gray-300=Gray 300 (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=Grant type "{0}" is unsupported
 granted=Granted
 graph-url=Graph URL
 graphql-api=GraphQL API
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Gray 100
 gray-200=Gray 200
 gray-300=Gray 300

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=허가 유형 "{0}"은(는) 이
 granted=승인됨
 graph-url=그래프 URL
 graphql-api=GraphQL API
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Gray 100
 gray-200=Gray 200
 gray-300=Gray 300

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=Grant type "{0}" is unsupported
 granted=Granted (Automatic Copy)
 graph-url=ກຣາຟ URL
 graphql-api=GraphQL API (Automatic Copy)
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Gray 100 (Automatic Copy)
 gray-200=Gray 200 (Automatic Copy)
 gray-300=Gray 300 (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=Grant type "{0}" is unsupported
 granted=Suteikta (Automatic Translation)
 graph-url=Diagramos URL (Automatic Translation)
 graphql-api=GraphQL API (Automatic Translation)
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Pilkasis 100 (Automatic Translation)
 gray-200=Pilkasis 200 (Automatic Translation)
 gray-300=Pilkasis 300 (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=Grant type "{0}" is unsupported
 granted=Diberikan (Automatic Translation)
 graph-url=URL Graf (Automatic Translation)
 graphql-api=API GrafQL (Automatic Translation)
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Kelabu 100 (Automatic Translation)
 gray-200=Kelabu 200 (Automatic Translation)
 gray-300=Kelabu 300 (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=Tilgangtype "{0}" støttes ikke
 granted=Gitt (Automatic Translation)
 graph-url=Graf URL
 graphql-api=API-api for grafkL (Automatic Translation)
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Grå 100 (Automatic Translation)
 gray-200=Grå 200 (Automatic Translation)
 gray-300=Grå 300 (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=Toewijzingstype "{0}" wordt nie
 granted=Toegekend
 graph-url=Grafiek-URL
 graphql-api=GraphQL-API
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Grijs 100
 gray-200=Grijs 200
 gray-300=Grijs 300

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=Grant type "{0}" is unsupported
 granted=Granted (Automatic Copy)
 graph-url=Grafiek URL
 graphql-api=GraphQL API (Automatic Copy)
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Gray 100 (Automatic Copy)
 gray-200=Gray 200 (Automatic Copy)
 gray-300=Gray 300 (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=Grant type "{0}" is unsupported
 granted=Przyznane (Automatic Translation)
 graph-url=URL wykresu
 graphql-api=GraphQL API (Automatic Translation)
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Szary 100 (Automatic Translation)
 gray-200=Szary 200 (Automatic Translation)
 gray-300=Szary 300 (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=O tipo de concessão "{0}" não
 granted=Concedido
 graph-url=URL do gráfico
 graphql-api=GraphQL API
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Cinza 100
 gray-200=Cinza 200
 gray-300=Cinza 300

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=Grant type "{0}" is unsupported
 granted=concedido (Automatic Translation)
 graph-url=URL do gráfico
 graphql-api=GraphQL API (Automatic Translation)
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Cinza 100 (Automatic Translation)
 gray-200=Cinza 200 (Automatic Translation)
 gray-300=Cinza 300 (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=Grant type "{0}" is unsupported
 granted=acordat (Automatic Translation)
 graph-url=Grafic URL
 graphql-api=GraphQL API (Automatic Translation)
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Gri 100 (Automatic Translation)
 gray-200=Gri 200 (Automatic Translation)
 gray-300=Gri 300 (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=Grant type "{0}" is unsupported
 granted=хорошо (Automatic Translation)
 graph-url=URL графа
 graphql-api=График-L API (Automatic Translation)
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Серый 100 (Automatic Translation)
 gray-200=Серый 200 (Automatic Translation)
 gray-300=Серый 300 (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=Grant type "{0}" is unsupported
 granted=pripusťme (Automatic Translation)
 graph-url=URL grafu
 graphql-api=GraphQL API (Automatic Translation)
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Sivá 100 (Automatic Translation)
 gray-200=Sivá 200 (Automatic Translation)
 gray-300=Sivá 300 (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=Grant type "{0}" is unsupported
 granted=Odobrena (Automatic Translation)
 graph-url=URL grafikona (Automatic Translation)
 graphql-api=GraphQL API (Automatic Translation)
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Siva 100 (Automatic Translation)
 gray-200=Siva 200 (Automatic Translation)
 gray-300=Siva 300 (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=Grant type "{0}" is unsupported
 granted=Granted (Automatic Copy)
 graph-url=Графикон УРЛ
 graphql-api=GraphQL API (Automatic Copy)
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Gray 100 (Automatic Copy)
 gray-200=Gray 200 (Automatic Copy)
 gray-300=Gray 300 (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=Grant type "{0}" is unsupported
 granted=Granted (Automatic Copy)
 graph-url=Grafikon URL
 graphql-api=GraphQL API (Automatic Copy)
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Gray 100 (Automatic Copy)
 gray-200=Gray 200 (Automatic Copy)
 gray-300=Gray 300 (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=Det går inte att bevilja typen
 granted=Beviljad
 graph-url=Graf URL
 graphql-api=GraphQL-API
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Grå 100
 gray-200=Grå 200
 gray-300=Grå 300

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type="{0}" Grant type-க்கு �
 granted=Granted (Automatic Copy)
 graph-url=வரைபடத்தின் லிங்க்
 graphql-api=GraphQL API (Automatic Copy)
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Gray 100 (Automatic Copy)
 gray-200=Gray 200 (Automatic Copy)
 gray-300=Gray 300 (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=ไม่รองรับป�
 granted=ยินยอม
 graph-url=URL ของกราฟ
 graphql-api=กราฟ QL API
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Gray 100
 gray-200=Gray 200
 gray-300=Gray 300

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=Grant type "{0}" is unsupported
 granted=Verilen (Automatic Translation)
 graph-url=Grafik URL'si (Automatic Translation)
 graphql-api=GraphQL API (Automatic Translation)
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Gri 100 (Automatic Translation)
 gray-200=Gri 200 (Automatic Translation)
 gray-300=Gri 300 (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=Grant type "{0}" is unsupported
 granted=Надано (Automatic Translation)
 graph-url=URL-адреса графіка (Automatic Translation)
 graphql-api=GraphQL API (Automatic Translation)
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Сірий 100 (Automatic Translation)
 gray-200=Сірий 200 (Automatic Translation)
 gray-300=Сірий 300 (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=Grant type "{0}" is unsupported
 granted=Cấp (Automatic Translation)
 graph-url=URL đồ thị
 graphql-api=GraphQL API (Automatic Translation)
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=Màu xám 100 (Automatic Translation)
 gray-200=Màu xám 200 (Automatic Translation)
 gray-300=Màu xám 300 (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=此客户端类型不支持授�
 granted=已授予
 graph-url=图表 URL
 graphql-api=GraphQL API
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=灰度 100
 gray-200=灰度 200
 gray-300=灰度 300

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
@@ -7927,6 +7927,7 @@ grant-type-x-is-unsupported-for-this-client-type=此客戶端類型不支持授�
 granted=已授權
 graph-url=圖表網址
 graphql-api=GraphQL API
+graphql-namespace=GraphQL Namespace (Automatic Copy)
 gray-100=灰度 100
 gray-200=灰度 200
 gray-300=灰度 300

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/bnd.bnd
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/bnd.bnd
@@ -23,4 +23,8 @@ Import-Package:\
 	!org.jsoup.*,\
 	\
 	*
+Require-Capability:\
+	osgi.extender;\
+		filter := "(&(osgi.extender=osgi.configurator)(version>=1.0)(!(version>=2.0)))"
 -fixupmessages: "^Classes found in the wrong directory: \\\\{META-INF/versions/9/";is:=warning
+-includeresource: OSGI-INF/configurator=configurator

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/configurator/configurations.json
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/configurator/configurations.json
@@ -1,0 +1,18 @@
+{
+	"com.liferay.portal.vulcan.internal.configuration.VulcanConfiguration~analytics-settings": {
+		"graphQLNamespace": "analytics_settings_v1_0",
+		"path": "/analytics-settings-rest-graphql/v1_0"
+	},
+	"com.liferay.portal.vulcan.internal.configuration.VulcanConfiguration~commerce-admin-account": {
+		"graphQLNamespace": "commerce_admin_account_v1_0",
+		"path": "/headless-commerce-admin-account-graphql/v1_0"
+	},
+	"com.liferay.portal.vulcan.internal.configuration.VulcanConfiguration~commerce-admin-channel": {
+		"graphQLNamespace": "commerce_admin_channel_v1_0",
+		"path": "/headless-commerce-admin-channel-graphql/v1_0"
+	},
+	"com.liferay.portal.vulcan.internal.configuration.VulcanConfiguration~commerce-admin-pricing": {
+		"graphQLNamespace": "commerce_admin_pricing_v1_0",
+		"path": "/headless-commerce-admin-pricing-graphql/v1_0"
+	}
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/configuration/VulcanConfiguration.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/configuration/VulcanConfiguration.java
@@ -36,4 +36,7 @@ public interface VulcanConfiguration {
 	@Meta.AD(name = "excluded-operation-ids", required = false)
 	public String excludedOperationIds();
 
+	@Meta.AD(name = "graphql-namespace", required = false)
+	public String graphQLNamespace();
+
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/configuration/util/ConfigurationUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/configuration/util/ConfigurationUtil.java
@@ -10,8 +10,12 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.vulcan.graphql.servlet.ServletData;
 import com.liferay.portal.vulcan.internal.configuration.VulcanCompanyConfiguration;
 import com.liferay.portal.vulcan.internal.configuration.VulcanConfiguration;
+
+import graphql.annotations.processor.util.NamingKit;
 
 import java.util.Dictionary;
 import java.util.HashSet;
@@ -53,6 +57,44 @@ public class ConfigurationUtil {
 		}
 
 		return new HashSet<>();
+	}
+
+	public static String getGraphQLNamespace(
+		ConfigurationAdmin configurationAdmin, ServletData servletData) {
+
+		if (servletData == null) {
+			return null;
+		}
+
+		try {
+			Configuration[] configurations =
+				configurationAdmin.listConfigurations(
+					String.format(
+						"(&(path=%s)(service.factoryPid=%s))",
+						servletData.getPath(),
+						VulcanConfiguration.class.getName()));
+
+			if (configurations != null) {
+				for (Configuration configuration : configurations) {
+					Dictionary<String, Object> properties =
+						configuration.getProperties();
+
+					String graphQLNamespace = GetterUtil.getString(
+						properties.get("graphQLNamespace"));
+
+					if (Validator.isNotNull(graphQLNamespace)) {
+						return NamingKit.toGraphqlName(graphQLNamespace);
+					}
+				}
+			}
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+		}
+
+		return servletData.getGraphQLNamespace();
 	}
 
 	private static Set<String> _getExcludedOperationIds(

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -816,7 +816,10 @@ public class GraphQLServletExtender {
 		Map<String, TreeSet<Method>> methods = new HashMap<>();
 
 		for (ServletData servletData : servletDatas) {
-			if (servletData.getGraphQLNamespace() != null) {
+			String graphQLNamespace = ConfigurationUtil.getGraphQLNamespace(
+				_configurationAdmin, servletData);
+
+			if (graphQLNamespace != null) {
 				continue;
 			}
 
@@ -1614,7 +1617,8 @@ public class GraphQLServletExtender {
 		List<ServletData> servletDatas) {
 
 		for (ServletData servletData : servletDatas) {
-			String graphQLNamespace = servletData.getGraphQLNamespace();
+			String graphQLNamespace = ConfigurationUtil.getGraphQLNamespace(
+				_configurationAdmin, servletData);
 
 			if (graphQLNamespace == null) {
 				continue;
@@ -1666,7 +1670,8 @@ public class GraphQLServletExtender {
 							graphQLNamespace, method.getName()),
 						new LiferayMethodDataFetcher(
 							new ServletDataRequestContext(
-								_companyId, method, mutation, servletData),
+								_companyId, _configurationAdmin, method,
+								mutation, servletData),
 							_graphQLRequestContextValidators,
 							_liferayMethodDataFetchingProcessor, method)
 					).build());
@@ -2522,7 +2527,8 @@ public class GraphQLServletExtender {
 			graphQLFieldDefinitionBuilder.dataFetcher(
 				new LiferayMethodDataFetcher(
 					new ServletDataRequestContext(
-						_companyId, method, !canonicalName.contains("Query"),
+						_companyId, _configurationAdmin, method,
+						!canonicalName.contains("Query"),
 						_servletDataMap.get(method)),
 					_graphQLRequestContextValidators,
 					_liferayMethodDataFetchingProcessor, method));

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -15,6 +15,7 @@ import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapListener;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
@@ -166,6 +167,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.Dictionary;
 import java.util.HashMap;
@@ -174,6 +176,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.Stack;
+import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
@@ -810,7 +813,7 @@ public class GraphQLServletExtender {
 		ProcessingElementsContainer processingElementsContainer,
 		List<ServletData> servletDatas) {
 
-		Map<String, Method> methods = new HashMap<>();
+		Map<String, TreeSet<Method>> methods = new HashMap<>();
 
 		for (ServletData servletData : servletDatas) {
 			if (servletData.getGraphQLNamespace() != null) {
@@ -832,28 +835,71 @@ public class GraphQLServletExtender {
 
 				_servletDataMap.put(method, servletData);
 
-				methods.compute(
+				Comparator<ServletData> comparator = Comparator.comparing(
+					ServletData::getApplicationName);
+
+				TreeSet<Method> methodTreeSet = methods.computeIfAbsent(
 					method.getName(),
-					(key, value) -> {
-						if ((value == null) ||
-							((value != null) &&
-							 (_getVersion(value) < _getVersion(method)))) {
+					key -> new TreeSet<>(
+						(a, b) -> {
+							int value = comparator.compare(
+								_servletDataMap.get(a), _servletDataMap.get(b));
 
-							return method;
-						}
+							if (value == 0) {
+								return _getVersion(b) - _getVersion(a);
+							}
 
-						return value;
-					});
+							return value;
+						}));
+
+				methodTreeSet.add(method);
 			}
 		}
 
-		for (Method method : methods.values()) {
-			Class<?> clazz = method.getDeclaringClass();
+		for (TreeSet<Method> methodTreeSet : methods.values()) {
+			for (Method method : methodTreeSet) {
+				Class<?> clazz = method.getDeclaringClass();
 
-			graphQLObjectTypeBuilder.field(
-				_graphQLFieldRetriever.getField(
-					clazz.getSimpleName(), method,
-					processingElementsContainer));
+				GraphQLFieldDefinition field = _graphQLFieldRetriever.getField(
+					clazz.getSimpleName(), method, processingElementsContainer);
+
+				Method firstMethod = methodTreeSet.first();
+
+				if (method == firstMethod) {
+					graphQLObjectTypeBuilder.field(field);
+				}
+				else {
+					ServletData firstServletData = _servletDataMap.get(
+						firstMethod);
+
+					ServletData servletData = _servletDataMap.get(method);
+
+					String fieldName = servletData.getPath();
+
+					fieldName = fieldName.substring(1);
+					fieldName = fieldName.replaceAll(
+						"[/-]", StringPool.UNDERLINE);
+					fieldName = NamingKit.toGraphqlName(
+						fieldName + "_" + field.getName());
+
+					_log.error(
+						StringBundler.concat(
+							"Error when trying to register the GraphQL field ",
+							"\"", field.getName(), "\" from the application \"",
+							servletData.getPath(),
+							"\". There is already a field with the same name ",
+							"coming from the application \"",
+							firstServletData.getPath(),
+							"\". It will be renamed to \"", fieldName, "\"."));
+
+					graphQLObjectTypeBuilder.field(
+						GraphQLFieldDefinition.newFieldDefinition(
+							field
+						).name(
+							fieldName
+						));
+				}
+			}
 		}
 	}
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/validation/ServletDataRequestContext.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/validation/ServletDataRequestContext.java
@@ -10,10 +10,13 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLTypeExtension;
 import com.liferay.portal.vulcan.graphql.servlet.ServletData;
 import com.liferay.portal.vulcan.graphql.validation.GraphQLRequestContext;
+import com.liferay.portal.vulcan.internal.configuration.util.ConfigurationUtil;
 
 import java.lang.reflect.Method;
 
 import java.util.Objects;
+
+import org.osgi.service.cm.ConfigurationAdmin;
 
 /**
  * @author Carlos Correa
@@ -21,13 +24,14 @@ import java.util.Objects;
 public class ServletDataRequestContext implements GraphQLRequestContext {
 
 	public ServletDataRequestContext(
-		long companyId, Method method, boolean mutation,
-		ServletData servletData) {
+		long companyId, ConfigurationAdmin configurationAdmin, Method method,
+		boolean mutation, ServletData servletData) {
 
 		_companyId = companyId;
+		_configurationAdmin = configurationAdmin;
 		_servletData = servletData;
 
-		_namespace = _getNamespace(servletData);
+		_namespace = _getNamespace(configurationAdmin, servletData);
 		_resourceClass = _getResourceClass(method, mutation, servletData);
 		_resourceMethod = _getResourceMethod(method, mutation, servletData);
 	}
@@ -81,15 +85,17 @@ public class ServletDataRequestContext implements GraphQLRequestContext {
 		return value.getSimpleName() + "." + method.getName();
 	}
 
-	private String _getNamespace(ServletData servletData) {
-		if ((servletData == null) ||
-			(servletData.getGraphQLNamespace() == null)) {
+	private String _getNamespace(
+		ConfigurationAdmin configurationAdmin, ServletData servletData) {
 
+		String graphQLNamespace = ConfigurationUtil.getGraphQLNamespace(
+			configurationAdmin, servletData);
+
+		if (graphQLNamespace == null) {
 			return null;
 		}
 
-		return StringUtil.upperCaseFirstLetter(
-			servletData.getGraphQLNamespace());
+		return StringUtil.upperCaseFirstLetter(graphQLNamespace);
 	}
 
 	private Class<?> _getResourceClass(
@@ -140,6 +146,7 @@ public class ServletDataRequestContext implements GraphQLRequestContext {
 	}
 
 	private final long _companyId;
+	private final ConfigurationAdmin _configurationAdmin;
 	private final String _namespace;
 	private final Class<?> _resourceClass;
 	private final Method _resourceMethod;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-202537.

With this PR admins can set custom graphql namespaces. This will help solve the existing clashes when different apps have the same operationIds. 

These are the current clashes in master:

```
Liferay_Analytyics_Settings_REST_channels
Liferay_Analytyics_Settings_REST_createChannel
Liferay_Analytyics_Settings_REST_patchChannel
Liferay_Headless_Commerce_Admin_Account_account
Liferay_Headless_Commerce_Admin_Account_accountByExternalReferenceCode
Liferay_Headless_Commerce_Admin_Account_accountGroup
Liferay_Headless_Commerce_Admin_Account_accountGroupByExternalReferenceCode
Liferay_Headless_Commerce_Admin_Account_accountGroups
Liferay_Headless_Commerce_Admin_Account_createAccount
Liferay_Headless_Commerce_Admin_Account_createAccountBatch
Liferay_Headless_Commerce_Admin_Account_createAccountGroup
Liferay_Headless_Commerce_Admin_Account_createAccountsPageExportBatch
Liferay_Headless_Commerce_Admin_Account_deleteAccount
Liferay_Headless_Commerce_Admin_Account_deleteAccountBatch
Liferay_Headless_Commerce_Admin_Account_deleteAccountByExternalReferenceCode
Liferay_Headless_Commerce_Admin_Account_deleteAccountGroup
Liferay_Headless_Commerce_Admin_Account_deleteAccountGroupByExternalReferenceCode
Liferay_Headless_Commerce_Admin_Account_patchAccount
Liferay_Headless_Commerce_Admin_Account_patchAccountByExternalReferenceCode
Liferay_Headless_Commerce_Admin_Account_patchAccountGroup
Liferay_Headless_Commerce_Admin_Account_patchAccountGroupByExternalReferenceCode
Liferay_Headless_Commerce_Admin_Site_Setting_taxCategory
Liferay_Headless_Commerce_Delivery_Catalog_channels
Liferay_Headless_Commerce_Delivery_Catalog_createChannelsPageExportBatch
```
**How to test**

1. Set a custom namespace for a given api (via UI or config file):

![Screenshot from 2023-11-24 10-46-46](https://github.com/liferay-headless/liferay-portal/assets/1937354/e28946b4-d35d-4968-8c64-5ab4cd54fb02)

```properties
# com.liferay.portal.vulcan.internal.configuration.VulcanConfiguration.config
excludedOperationIds=""
graphQLEnabled=B"true"
graphQLNamespace="commerce_admin_account_v1_0"
path="/headless-commerce-admin-account-graphql/v1_0"
restEnabled=B"true"
```
2. Redeploy `portal-vulcan-impl`.
3. Check the api is under a graphql namespace via o/api. Now we can for example run this query:
```graphql
{
  accounts {
    page
  }
  commerce_admin_account_v1_0 {
    accounts {
      page
    }
  }
}
```
And get results for previously clashing apis.

**To do:**
 - [x] Provide out of the box default configurations to solve existing clashes.
 - [x] Add an error log when a clash is identified.
 - [ ] Rebuild GraphQL servlets on config change.
 - [ ] Write integrations tests.
 - [ ] Delete https://github.com/liferay-headless/liferay-portal/pull/1697/commits/da57dbf7d1ad59948287199955544752d27ceec9?
