### PR TITLE
LPS-140570 Publish link for staging includes unwanted parameters

### DIFF
--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/menu/staging_actions.jspf
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/menu/staging_actions.jspf
@@ -74,9 +74,7 @@
 				<portlet:param name="localPublishing" value="<%= String.valueOf(localPublishing) %>" />
 				<portlet:param name="privateLayout" value="<%= String.valueOf(privateLayout) %>" />
 				<portlet:param name="quickPublish" value="<%= Boolean.TRUE.toString() %>" />
-				<portlet:param name="remoteAddress" value='<%= liveGroupTypeSettingsUnicodeProperties.getProperty("remoteAddress") %>' />
 				<portlet:param name="remotePathContext" value='<%= liveGroupTypeSettingsUnicodeProperties.getProperty("remotePathContext") %>' />
-				<portlet:param name="remotePort" value='<%= liveGroupTypeSettingsUnicodeProperties.getProperty("remotePort") %>' />
 				<portlet:param name="remoteGroupId" value='<%= liveGroupTypeSettingsUnicodeProperties.getProperty("remoteGroupId") %>' />
 				<portlet:param name="secureConnection" value='<%= liveGroupTypeSettingsUnicodeProperties.getProperty("secureConnection") %>' />
 				<portlet:param name="sourceGroupId" value="<%= String.valueOf(stagingGroupId) %>" />
@@ -93,9 +91,7 @@
 				<portlet:param name="localPublishing" value="<%= String.valueOf(localPublishing) %>" />
 				<portlet:param name="privateLayout" value="<%= String.valueOf(privateLayout) %>" />
 				<portlet:param name="quickPublish" value="<%= Boolean.TRUE.toString() %>" />
-				<portlet:param name="remoteAddress" value='<%= liveGroupTypeSettingsUnicodeProperties.getProperty("remoteAddress") %>' />
 				<portlet:param name="remotePathContext" value='<%= liveGroupTypeSettingsUnicodeProperties.getProperty("remotePathContext") %>' />
-				<portlet:param name="remotePort" value='<%= liveGroupTypeSettingsUnicodeProperties.getProperty("remotePort") %>' />
 				<portlet:param name="remoteGroupId" value='<%= liveGroupTypeSettingsUnicodeProperties.getProperty("remoteGroupId") %>' />
 				<portlet:param name="secureConnection" value='<%= liveGroupTypeSettingsUnicodeProperties.getProperty("secureConnection") %>' />
 				<portlet:param name="sourceGroupId" value="<%= String.valueOf(stagingGroupId) %>" />

--- a/portal-kernel/src/com/liferay/exportimport/kernel/configuration/ExportImportConfigurationFactory.java
+++ b/portal-kernel/src/com/liferay/exportimport/kernel/configuration/ExportImportConfigurationFactory.java
@@ -17,7 +17,6 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
-import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.io.Serializable;
@@ -94,27 +93,17 @@ public class ExportImportConfigurationFactory {
 		long sourceGroupId = ParamUtil.getLong(portletRequest, "sourceGroupId");
 		boolean privateLayout = ParamUtil.getBoolean(
 			portletRequest, "privateLayout");
-		String remoteAddress = ParamUtil.getString(
-			portletRequest, "remoteAddress");
-		int remotePort = ParamUtil.getInteger(portletRequest, "remotePort");
 		String remotePathContext = ParamUtil.getString(
 			portletRequest, "remotePathContext");
 		boolean secureConnection = ParamUtil.getBoolean(
 			portletRequest, "secureConnection");
 		long remoteGroupId = ParamUtil.getLong(portletRequest, "remoteGroupId");
 
-		if (Validator.isNull(remoteAddress) || (remotePort == 0)) {
-			Group group = GroupLocalServiceUtil.getGroup(sourceGroupId);
+		Group group = GroupLocalServiceUtil.getGroup(sourceGroupId);
 
-			if (Validator.isNull(remoteAddress)) {
-				remoteAddress = group.getTypeSettingsProperty("remoteAddress");
-			}
-
-			if (remotePort == 0) {
-				remotePort = GetterUtil.getInteger(
-					group.getTypeSettingsProperty("remotePort"));
-			}
-		}
+		String remoteAddress = group.getTypeSettingsProperty("remoteAddress");
+		int remotePort = GetterUtil.getInteger(
+			group.getTypeSettingsProperty("remotePort"));
 
 		return buildDefaultRemotePublishingExportImportConfiguration(
 			themeDisplay.getUser(), sourceGroupId, privateLayout, remoteAddress,

--- a/portal-kernel/src/com/liferay/exportimport/kernel/configuration/ExportImportConfigurationFactory.java
+++ b/portal-kernel/src/com/liferay/exportimport/kernel/configuration/ExportImportConfigurationFactory.java
@@ -10,10 +10,14 @@ import com.liferay.exportimport.kernel.lar.ExportImportHelperUtil;
 import com.liferay.exportimport.kernel.model.ExportImportConfiguration;
 import com.liferay.exportimport.kernel.service.ExportImportConfigurationLocalServiceUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.io.Serializable;
@@ -98,6 +102,19 @@ public class ExportImportConfigurationFactory {
 		boolean secureConnection = ParamUtil.getBoolean(
 			portletRequest, "secureConnection");
 		long remoteGroupId = ParamUtil.getLong(portletRequest, "remoteGroupId");
+
+		if (Validator.isNull(remoteAddress) || (remotePort == 0)) {
+			Group group = GroupLocalServiceUtil.getGroup(sourceGroupId);
+
+			if (Validator.isNull(remoteAddress)) {
+				remoteAddress = group.getTypeSettingsProperty("remoteAddress");
+			}
+
+			if (remotePort == 0) {
+				remotePort = GetterUtil.getInteger(
+					group.getTypeSettingsProperty("remotePort"));
+			}
+		}
 
 		return buildDefaultRemotePublishingExportImportConfiguration(
 			themeDisplay.getUser(), sourceGroupId, privateLayout, remoteAddress,


### PR DESCRIPTION
[LPS-140570](https://liferay.atlassian.net/browse/LPS-140570)

When using remote staging and simple publish, don't use the `remoteAddress` and `remotePort` parameters from the link, but load them from the remote staging site's settings.