### PR TITLE
LPS-203194 Remove no longer needed test CannotDisplayIncludeHeaderWithExportBlogPostingJOSNLFormat

### DIFF
--- a/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/HideOptionsForEntitiesInImportAndExport.testcase
+++ b/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/HideOptionsForEntitiesInImportAndExport.testcase
@@ -176,26 +176,6 @@ definition {
 	}
 
 	@priority = 4
-	test CanDisplayIncludeHeadersWithExportObjectDefinitionCSVFormat {
-		property custom.properties = "feature.flag.LPS-173135=true";
-		property portal.acceptance = "true";
-
-		task ("When I select CSV format to export ObjectDefinition") {
-			ImportExport.gotoExport();
-
-			ImportExport.configureExport(
-				entityType = "ObjectDefinition (v1_0 - Liferay Object Admin REST)",
-				exportFileFormat = "CSV");
-		}
-
-		task ("Then the Include Headers is checked") {
-			AssertChecked.assertCheckedNotVisible(
-				checkboxName = "Include Headers",
-				locator1 = "Checkbox#ANY_CHECKBOX");
-		}
-	}
-
-	@priority = 4
 	test CannotDisplayIncludeHeaderWithExportBlogPostingJOSNLFormat {
 		property portal.acceptance = "true";
 


### PR DESCRIPTION
Background
- remove no longer needed test CannotDisplayIncludeHeaderWithExportBlogPostingJOSNLFormat since the Include Header option is hided in https://liferay.atlassian.net/browse/LPS-186637
