### PR TITLE
LPS-203205 Update import/export objectDefinition in json instead of csv format

### DIFF
--- a/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/ImportExport.testcase
+++ b/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/ImportExport.testcase
@@ -382,7 +382,6 @@ definition {
 	@description = "Verify users can filter Import/Export executions by Action."
 	@priority = 3
 	test CanFilterExecutionsByAction {
-		property custom.properties = "feature.flag.LPS-173135=true";
 		property portal.acceptance = "true";
 
 		task ("Given Object Definition import and export") {
@@ -656,7 +655,6 @@ definition {
 	@description = "Verify users can order Import/Export executions by Create Date."
 	@priority = 3
 	test CanOrderExecutionsByCreateDate {
-		property custom.properties = "feature.flag.LPS-173135=true";
 		property portal.acceptance = "true";
 
 		task ("Given Object Definition import and export") {
@@ -942,7 +940,6 @@ definition {
 	@description = "Verify users can search Import/Exports templates by name and action."
 	@priority = 3
 	test CanSearchTemplates {
-		property custom.properties = "feature.flag.LPS-173135=true";
 		property portal.acceptance = "true";
 
 		task ("Given object definition import and export templates") {
@@ -1079,7 +1076,6 @@ definition {
 	@description = "Verify users receive a notification when an export is triggered."
 	@priority = 3
 	test CanViewExportNotifications {
-		property custom.properties = "feature.flag.LPS-173135=true";
 		property portal.acceptance = "true";
 
 		task ("Given a failed export") {


### PR DESCRIPTION
Background
- objectDefinition entity type is removed in export wizard when selecting csv format

Test plan
- update tests on export objectDefinition from csv format to json format