### PR TITLE
LPS-202537 Ignoring duplicated fields (2nd and following alphabetically sorted by REST app name)

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -875,7 +875,7 @@ public class GraphQLServletExtender {
 			Class<?> clazz = object.getClass();
 
 			for (Method method : clazz.getMethods()) {
-				if (!_isMethodEnabled(method, servletData.getPath())) {
+				if (!_isMethodEnabled(method, servletData)) {
 					continue;
 				}
 
@@ -887,7 +887,7 @@ public class GraphQLServletExtender {
 						key -> new TreeMap<>(Comparator.naturalOrder()));
 
 				TreeSet<Method> methodTreeSet = methodSortedMap.computeIfAbsent(
-					servletData.getApplicationName(),
+					_getPath(servletData),
 					key -> new TreeSet<>(
 						Comparator.comparing(
 							this::_getVersion
@@ -900,15 +900,15 @@ public class GraphQLServletExtender {
 		for (SortedMap<String, TreeSet<Method>> methodSortedMap :
 				methods.values()) {
 
-			String firstApplicationName = methodSortedMap.firstKey();
+			String firstPath = methodSortedMap.firstKey();
 
 			for (Map.Entry<String, TreeSet<Method>> entry :
 					methodSortedMap.entrySet()) {
 
-				String applicationName = entry.getKey();
+				String path = entry.getKey();
 				TreeSet<Method> methodTreeSet = entry.getValue();
 
-				if (StringUtil.equals(applicationName, firstApplicationName)) {
+				if (StringUtil.equals(firstPath, path)) {
 					Method firstMethod = methodTreeSet.first();
 
 					for (Method method : methodTreeSet) {
@@ -927,9 +927,8 @@ public class GraphQLServletExtender {
 								StringBundler.concat(
 									"There is already a field called \"",
 									field.getName(),
-									"\" in the same application \"",
-									applicationName,
-									"\". The field of the version \"",
+									"\" in the same application with path \"",
+									path, "\". The field of the version \"",
 									_getVersion(method), "\" will be ignored"));
 						}
 					}
@@ -942,9 +941,9 @@ public class GraphQLServletExtender {
 						StringBundler.concat(
 							"There is already a field called \"",
 							methodNameBuilder.build(),
-							"\" in the application \"", firstApplicationName,
-							"\". The field of the application \"",
-							applicationName, "\" will be ignored."));
+							"\" in the application with the path \"", firstPath,
+							"\". The field of the application with the path \"",
+							path, "\" will be ignored."));
 				}
 			}
 		}
@@ -1002,7 +1001,7 @@ public class GraphQLServletExtender {
 			List<ServletData> servletDatas = new ArrayList<>();
 
 			for (ServletData servletData : _servletDataServiceTrackerList) {
-				if (_isGraphQLEnabled(servletData.getPath())) {
+				if (_isGraphQLEnabled(servletData)) {
 					servletDatas.add(servletData);
 				}
 
@@ -1239,6 +1238,12 @@ public class GraphQLServletExtender {
 		return graphQLObjectTypeBuilder.build();
 	}
 
+	private String _getPath(ServletData servletData) {
+		String path = servletData.getPath();
+
+		return path.substring(0, path.indexOf("-graphql"));
+	}
+
 	private QueryDepthLimitInstrumentation _getQueryDepthLimitInstrumentation(
 		long companyId) {
 
@@ -1267,13 +1272,13 @@ public class GraphQLServletExtender {
 		return GetterUtil.getInteger(version.replaceAll("\\D", ""), 1);
 	}
 
-	private boolean _isGraphQLEnabled(String path) throws Exception {
-		path = path.substring(0, path.indexOf("-graphql"));
+	private boolean _isGraphQLEnabled(ServletData servletData)
+		throws Exception {
 
 		String filterString = String.format(
 			"(&(path=%s)(|(service.factoryPid=%s)" +
 				"(&(service.factoryPid=%s)(%s=%d))))",
-			path, VulcanConfiguration.class.getName(),
+			_getPath(servletData), VulcanConfiguration.class.getName(),
 			VulcanCompanyConfiguration.class.getName(),
 			ExtendedObjectClassDefinition.Scope.COMPANY.getPropertyKey(),
 			_companyId);
@@ -1291,12 +1296,10 @@ public class GraphQLServletExtender {
 		return true;
 	}
 
-	private boolean _isMethodEnabled(Method method, String path) {
-		path = path.substring(0, path.indexOf("-graphql"));
-
+	private boolean _isMethodEnabled(Method method, ServletData servletData) {
 		Set<String> excludedOperationIds =
 			ConfigurationUtil.getExcludedOperationIds(
-				_companyId, _configurationAdmin, path);
+				_companyId, _configurationAdmin, _getPath(servletData));
 
 		if (excludedOperationIds.contains(method.getName())) {
 			return false;
@@ -1674,7 +1677,7 @@ public class GraphQLServletExtender {
 			List<Method> methods = TransformUtil.transformToList(
 				clazz.getMethods(),
 				method -> {
-					if (_isMethodEnabled(method, servletData.getPath())) {
+					if (_isMethodEnabled(method, servletData)) {
 						return method;
 					}
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -17,6 +17,7 @@ import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapListener;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
@@ -182,6 +183,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.Dictionary;
 import java.util.HashMap;
@@ -189,7 +191,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedMap;
 import java.util.Stack;
+import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
@@ -852,7 +857,8 @@ public class GraphQLServletExtender {
 		ProcessingElementsContainer processingElementsContainer,
 		List<ServletData> servletDatas) {
 
-		Map<String, Method> methods = new HashMap<>();
+		Map<String, SortedMap<String, TreeSet<Method>>> methods =
+			new HashMap<>();
 
 		for (ServletData servletData : servletDatas) {
 			if (servletData.getGraphQLNamespace() != null) {
@@ -874,28 +880,72 @@ public class GraphQLServletExtender {
 
 				_servletDataMap.put(method, servletData);
 
-				methods.compute(
-					method.getName(),
-					(key, value) -> {
-						if ((value == null) ||
-							((value != null) &&
-							 (_getVersion(value) < _getVersion(method)))) {
+				SortedMap<String, TreeSet<Method>> methodSortedMap =
+					methods.computeIfAbsent(
+						method.getName(),
+						key -> new TreeMap<>(Comparator.naturalOrder()));
 
-							return method;
-						}
+				TreeSet<Method> methodTreeSet = methodSortedMap.computeIfAbsent(
+					servletData.getApplicationName(),
+					key -> new TreeSet<>(
+						Comparator.comparing(
+							this::_getVersion
+						).reversed()));
 
-						return value;
-					});
+				methodTreeSet.add(method);
 			}
 		}
 
-		for (Method method : methods.values()) {
-			Class<?> clazz = method.getDeclaringClass();
+		for (SortedMap<String, TreeSet<Method>> methodSortedMap :
+				methods.values()) {
 
-			graphQLObjectTypeBuilder.field(
-				_graphQLFieldRetriever.getField(
-					clazz.getSimpleName(), method,
-					processingElementsContainer));
+			String firstApplicationName = methodSortedMap.firstKey();
+
+			for (Map.Entry<String, TreeSet<Method>> entry :
+					methodSortedMap.entrySet()) {
+
+				String applicationName = entry.getKey();
+				TreeSet<Method> methodTreeSet = entry.getValue();
+
+				if (StringUtil.equals(applicationName, firstApplicationName)) {
+					Method firstMethod = methodTreeSet.first();
+
+					for (Method method : methodTreeSet) {
+						Class<?> clazz = method.getDeclaringClass();
+
+						GraphQLFieldDefinition field =
+							_graphQLFieldRetriever.getField(
+								clazz.getSimpleName(), method,
+								processingElementsContainer);
+
+						if (firstMethod == method) {
+							graphQLObjectTypeBuilder.field(field);
+						}
+						else if (_log.isDebugEnabled()) {
+							_log.debug(
+								StringBundler.concat(
+									"There is already a field called \"",
+									field.getName(),
+									"\" in the same application \"",
+									applicationName,
+									"\". The field of the version \"",
+									_getVersion(method), "\" will be ignored"));
+						}
+					}
+				}
+				else if (_log.isDebugEnabled()) {
+					MethodNameBuilder methodNameBuilder = new MethodNameBuilder(
+						methodTreeSet.first());
+
+					_log.debug(
+						StringBundler.concat(
+							"There is already a field called \"",
+							methodNameBuilder.build(),
+							"\" in the application \"", firstApplicationName,
+							"\". The field of the application \"",
+							applicationName, "\" will be ignored."));
+				}
+			}
 		}
 	}
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -39,6 +39,7 @@ import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TextFormatter;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
@@ -1263,7 +1264,13 @@ public class GraphQLServletExtender {
 
 		String version = packageNames[packageNames.length - 1];
 
-		return Integer.valueOf(version.replaceAll("\\D", ""));
+		String versionString = version.replaceAll("\\D", "");
+
+		if (Validator.isNull(versionString)) {
+			return 1;
+		}
+
+		return Integer.valueOf(versionString);
 	}
 
 	private boolean _isGraphQLEnabled(String path) throws Exception {

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -39,7 +40,6 @@ import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TextFormatter;
-import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
@@ -1264,13 +1264,7 @@ public class GraphQLServletExtender {
 
 		String version = packageNames[packageNames.length - 1];
 
-		String versionString = version.replaceAll("\\D", "");
-
-		if (Validator.isNull(versionString)) {
-			return 1;
-		}
-
-		return Integer.valueOf(versionString);
+		return GetterUtil.getInteger(version.replaceAll("\\D", ""), 1);
 	}
 
 	private boolean _isGraphQLEnabled(String path) throws Exception {

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/BaseGraphQLServlet.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/BaseGraphQLServlet.java
@@ -172,6 +172,11 @@ public class BaseGraphQLServlet {
 		}
 
 		@Override
+		public String getApplicationName() {
+			return "test";
+		}
+
+		@Override
 		public Object getMutation() {
 			return _testMutation;
 		}


### PR DESCRIPTION
Related issue: https://liferay.atlassian.net/browse/LPS-202537

---

The purpose of this PR is to avoid registering more than one GraphQL field with the same name. For those cases where it is detected, a log trace will be printed and the second and following fields with the same name alphabetically sorted will be ignored.

However, the underlaying issue is still present (duplicated operation ids in the root namespace) but we still need to decide how to fix that causing the minimum breaking changes. We will probably generate uniques namespaces and we will leave the problem as it is, and then, we will provide a new way to access the endpoints by identifying by a unique namespace.