### PR TITLE
[TS] LPS-202900 

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exportimport/data/handler/StagedLayoutSetStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exportimport/data/handler/StagedLayoutSetStagedModelDataHandler.java
@@ -791,9 +791,13 @@ public class StagedLayoutSetStagedModelDataHandler
 						portletDataContext, stagedLayoutSet,
 						layoutSet.getCss());
 
-			layoutSet.setCss(css);
+			if (!css.isEmpty() ||
+				!MergeLayoutPrototypesThreadLocal.isInProgress()) {
 
-			_themeImporter.importTheme(portletDataContext, layoutSet);
+				layoutSet.setCss(css);
+
+				_themeImporter.importTheme(portletDataContext, layoutSet);
+			}
 		}
 		catch (Exception exception) {
 			if (_log.isWarnEnabled()) {


### PR DESCRIPTION
### Steps to reproduce:
1. Create a site template MY_SITE_TPL.
2. Create a TEST site using that template.
3. Add any Design setting to Site Pages (Site Builder → Pages → Three Dots → Configuration).
- For example any string in Custom CSS: “test”.
4. Close this settings section.
5. In MY_SITE_TPL, add any change related to pages, for example add a new Display Page Template.
6. Check TEST’s page design settings. 

_Expected result:_ Custom CSS remains.
_Observed result:_ Custom CSS is now empty

### Results of investigation:
This flow is started by a background task. –[ LayoutSetPrototypeMergeBackgroundTaskExecutor](https://github.com/liferay/liferay-portal-ee/blob/master/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/background/task/LayoutSetPrototypeMergeBackgroundTaskExecutor.java#L68) class will be called whenever the page is loaded after a layout change. After that, the method [doImportStagedModel from StagedLayoutSetStagedModelDataHandler](https://github.com/liferay/liferay-portal-ee/blob/master/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exportimport/data/handler/StagedLayoutSetStagedModelDataHandler.java#L177) class will be called and within it there is the [_importTheme](https://github.com/liferay/liferay-portal-ee/blob/master/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exportimport/data/handler/StagedLayoutSetStagedModelDataHandler.java#L794) method -- It is where the css is overwritten:

But the main problem with this merge is that the display page’s layout set will never have the css populated as it is stated that the custom css is disabled because it is using the inherited theme:
![template-design-configuration](https://github.com/liferay-headless/liferay-portal/assets/37600472/34ecf4f6-64fe-439f-943a-b6575ecc87f8)

