### PR TITLE
LPS-166581 Error when validating partial DL URL in web content template

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/DLReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/DLReferencesExportImportContentProcessor.java
@@ -164,24 +164,34 @@ public class DLReferencesExportImportContentProcessor
 					pathArray[2],
 					FriendlyURLResolverConstants.URL_SEPARATOR_Y_FILE_ENTRY)) {
 
-				map.put(
-					"friendlyURL",
-					new String[] {
-						StringUtils.substringBefore(
-							HttpComponentsUtil.decodeURL(pathArray[4]),
-							StringPool.POUND)
-					});
-				map.put("groupName", new String[] {pathArray[3]});
+				if (pathArray.length >= 5) {
+					map.put(
+						"friendlyURL",
+						new String[] {
+							StringUtils.substringBefore(
+								HttpComponentsUtil.decodeURL(pathArray[4]),
+								StringPool.POUND)
+						});
+				}
+
+				if (pathArray.length >= 4) {
+					map.put("groupName", new String[] {pathArray[3]});
+				}
 			}
 			else if (Objects.equals(pathArray[2], "portlet_file_entry")) {
-				map.put("groupId", new String[] {pathArray[3]});
-				map.put(
-					"title",
-					new String[] {
-						StringUtils.substringBefore(
-							HttpComponentsUtil.decodeURL(pathArray[4]),
-							StringPool.POUND)
-					});
+				if (pathArray.length >= 4) {
+					map.put("groupId", new String[] {pathArray[3]});
+				}
+
+				if (pathArray.length >= 5) {
+					map.put(
+						"title",
+						new String[] {
+							StringUtils.substringBefore(
+								HttpComponentsUtil.decodeURL(pathArray[4]),
+								StringPool.POUND)
+						});
+				}
 			}
 			else {
 				map.put("groupId", new String[] {pathArray[2]});

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/DefaultExportImportContentProcessorTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/DefaultExportImportContentProcessorTest.java
@@ -336,20 +336,6 @@ public class DefaultExportImportContentProcessorTest {
 	public void testExportDLReferencesInvalidReference() throws Exception {
 		_portletDataContextExport.setZipWriter(new TestReaderWriter());
 
-		_exportImportContentProcessor.replaceExportContentReferences(
-			_portletDataContextExport, _referrerStagedModel,
-			StringBundler.concat(
-				"{{/documents/}}", StringPool.NEW_LINE, "[[/documents/]]",
-				StringPool.NEW_LINE, "<a href=/documents/>Link</a>",
-				StringPool.NEW_LINE, "<a href=\"/documents/\">Link</a>",
-				StringPool.NEW_LINE, "<a href='/documents/'>Link</a>"),
-			true, true);
-	}
-
-	@Test
-	public void testExportInvalidDLReferencesFriendlyURL() throws Exception {
-		_portletDataContextExport.setZipWriter(new TestReaderWriter());
-
 		_fileEntry = DLAppLocalServiceUtil.updateFileEntry(
 			TestPropsValues.getUserId(), _fileEntry.getFileEntryId(),
 			RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN,

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/DefaultExportImportContentProcessorTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/DefaultExportImportContentProcessorTest.java
@@ -347,6 +347,35 @@ public class DefaultExportImportContentProcessorTest {
 	}
 
 	@Test
+	public void testExportInvalidDLReferencesFriendlyURL() throws Exception {
+		_portletDataContextExport.setZipWriter(new TestReaderWriter());
+
+		_fileEntry = DLAppLocalServiceUtil.updateFileEntry(
+			TestPropsValues.getUserId(), _fileEntry.getFileEntryId(),
+			RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN,
+			_fileEntry.getTitle(), _fileEntry.getTitle(), StringPool.BLANK,
+			StringPool.BLANK, DLVersionNumberIncrease.AUTOMATIC,
+			TestDataConstants.TEST_BYTE_ARRAY, null, null,
+			ServiceContextTestUtil.getServiceContext(
+				_stagingGroup.getGroupId(), TestPropsValues.getUserId()));
+
+		String content = _replaceParameters(
+			_getContent("invalid_dl_references.txt"), _fileEntry);
+
+		List<String> urls = _getURLs(content);
+
+		content = _exportImportContentProcessor.replaceExportContentReferences(
+			_portletDataContextExport, _referrerStagedModel, content, true,
+			true);
+
+		for (String url : urls) {
+			Assert.assertTrue(
+				url + " must be unchanged in :" + content,
+				content.contains(url));
+		}
+	}
+
+	@Test
 	public void testExportLayoutReferencesWithContext() throws Exception {
 		PortalImpl portalImpl = new PortalImpl() {
 

--- a/modules/apps/export-import/export-import-test/src/testIntegration/resources/com/liferay/exportimport/internal/content/processor/test/dependencies/invalid_dl_references.txt
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/resources/com/liferay/exportimport/internal/content/processor/test/dependencies/invalid_dl_references.txt
@@ -1,39 +1,49 @@
 CREOLE image reference:
 
+{{/documents/}}
 {{/documents/d/[$GROUP_NAME$]/}}
 
 CREOLE link with text:
 
+[[/documents/|Link]]
 [[/documents/d/[$GROUP_NAME$]/|Link]]
 
 CREOLE link without text:
 
+[[/documents/]]
 [[/documents/d/[$GROUP_NAME$]/]]
 
 HTML references with no quotes:
 
+<a href=/documents/>Link</a>
 <a href=/documents/d/[$GROUP_NAME$]/>Link</a>
 
 # HTML references with no quotes but space:
 
+<a href=/documents/ style=mustkeep>Link</a>
 <a href=/documents/d/[$GROUP_NAME$]/ style=mustkeep>Link</a>
 
 HTML references with double quotes:
 
+<a href="/documents/">Link</a>
 <a href="/documents/d/[$GROUP_NAME$]/">Link</a>
 
 HTML references with single quotes:
 
+<a href='/documents/'>Link</a>
 <a href='/documents/d/[$GROUP_NAME$]/'>Link</a>
 
 JSON configuration of image fragment entry:
 
+{"com.liferay.fragment.entry.processor.editable.EditableFragmentEntryProcessor": {"image-square": {"defaultValue": "", "config": {"alt": {"en_US": ""}, "imageConfiguration":{}}, "en_US": {"classNameId": 99999, "classPK": "99999", "fileEntryId": "99999", "title": "file1821253941895", "url": "/documents/"}}}, "com.liferay.fragment.entry.processor.freemarker.FreeMarkerFragmentEntryProcessor": {"imageSize": "w-100"}}
 {"com.liferay.fragment.entry.processor.editable.EditableFragmentEntryProcessor": {"image-square": {"defaultValue": "", "config": {"alt": {"en_US": ""}, "imageConfiguration":{}}, "en_US": {"classNameId": 99999, "classPK": "99999", "fileEntryId": "99999", "title": "file1821253941895", "url": "/documents/d/[$GROUP_NAME$]/"}}}, "com.liferay.fragment.entry.processor.freemarker.FreeMarkerFragmentEntryProcessor": {"imageSize": "w-100"}}
 
 Nonlegacy HTML reference with escaped double quotes:
 
+<a href=\"/documents/\">Link</a>
 <a href=\"/documents/d/[$GROUP_NAME$]/\">Link</a>
 
 Nonlegacy HTML reference with escaped single quotes:
 
+<a href=\'/documents/\'>Link</a>
 <a href=\'/documents/d/[$GROUP_NAME$]/\'>Link</a>

--- a/modules/apps/export-import/export-import-test/src/testIntegration/resources/com/liferay/exportimport/internal/content/processor/test/dependencies/invalid_dl_references.txt
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/resources/com/liferay/exportimport/internal/content/processor/test/dependencies/invalid_dl_references.txt
@@ -1,0 +1,39 @@
+CREOLE image reference:
+
+{{/documents/d/[$GROUP_NAME$]/}}
+
+CREOLE link with text:
+
+[[/documents/d/[$GROUP_NAME$]/|Link]]
+
+CREOLE link without text:
+
+[[/documents/d/[$GROUP_NAME$]/]]
+
+HTML references with no quotes:
+
+<a href=/documents/d/[$GROUP_NAME$]/>Link</a>
+
+# HTML references with no quotes but space:
+
+<a href=/documents/d/[$GROUP_NAME$]/ style=mustkeep>Link</a>
+
+HTML references with double quotes:
+
+<a href="/documents/d/[$GROUP_NAME$]/">Link</a>
+
+HTML references with single quotes:
+
+<a href='/documents/d/[$GROUP_NAME$]/'>Link</a>
+
+JSON configuration of image fragment entry:
+
+{"com.liferay.fragment.entry.processor.editable.EditableFragmentEntryProcessor": {"image-square": {"defaultValue": "", "config": {"alt": {"en_US": ""}, "imageConfiguration":{}}, "en_US": {"classNameId": 99999, "classPK": "99999", "fileEntryId": "99999", "title": "file1821253941895", "url": "/documents/d/[$GROUP_NAME$]/"}}}, "com.liferay.fragment.entry.processor.freemarker.FreeMarkerFragmentEntryProcessor": {"imageSize": "w-100"}}
+
+Nonlegacy HTML reference with escaped double quotes:
+
+<a href=\"/documents/d/[$GROUP_NAME$]/\">Link</a>
+
+Nonlegacy HTML reference with escaped single quotes:
+
+<a href=\'/documents/d/[$GROUP_NAME$]/\'>Link</a>


### PR DESCRIPTION
[LPS-166581](https://liferay.atlassian.net/browse/LPS-166581)

https://github.com/liferay-headless/liferay-portal/commit/fa26c4957af5fc72f06ad60eaf5e3c9cff404cea seemed to be the best solution, so we can still extract all available data from the path part of the URL.