### PR TITLE
LPS-204388: Delete previous Job Scheduler when it is updated

### DIFF
--- a/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/service/impl/DispatchTriggerLocalServiceImpl.java
+++ b/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/service/impl/DispatchTriggerLocalServiceImpl.java
@@ -282,10 +282,6 @@ public class DispatchTriggerLocalServiceImpl
 		DispatchTrigger dispatchTrigger =
 			dispatchTriggerPersistence.fetchByPrimaryKey(dispatchTriggerId);
 
-		DispatchTaskClusterMode oldDispatchTaskClusterMode =
-			DispatchTaskClusterMode.valueOf(
-				dispatchTrigger.getDispatchTaskClusterMode());
-
 		if ((dispatchTaskClusterMode == DispatchTaskClusterMode.ALL_NODES) &&
 			_dispatchTaskExecutorRegistry.isClusterModeSingle(
 				dispatchTrigger.getDispatchTaskExecutorType())) {
@@ -308,6 +304,10 @@ public class DispatchTriggerLocalServiceImpl
 						endDateMinute, DispatchTriggerEndDateException.class),
 					timeZoneId));
 		}
+
+		DispatchTaskClusterMode oldDispatchTaskClusterMode =
+			DispatchTaskClusterMode.valueOf(
+				dispatchTrigger.getDispatchTaskClusterMode());
 
 		dispatchTrigger.setDispatchTaskClusterMode(
 			dispatchTaskClusterMode.getMode());

--- a/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/service/impl/DispatchTriggerLocalServiceImpl.java
+++ b/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/service/impl/DispatchTriggerLocalServiceImpl.java
@@ -282,6 +282,10 @@ public class DispatchTriggerLocalServiceImpl
 		DispatchTrigger dispatchTrigger =
 			dispatchTriggerPersistence.fetchByPrimaryKey(dispatchTriggerId);
 
+		DispatchTaskClusterMode oldDispatchTaskClusterMode =
+			DispatchTaskClusterMode.valueOf(
+				dispatchTrigger.getDispatchTaskClusterMode());
+
 		if ((dispatchTaskClusterMode == DispatchTaskClusterMode.ALL_NODES) &&
 			_dispatchTaskExecutorRegistry.isClusterModeSingle(
 				dispatchTrigger.getDispatchTaskExecutorType())) {
@@ -319,7 +323,7 @@ public class DispatchTriggerLocalServiceImpl
 		dispatchTrigger = dispatchTriggerPersistence.update(dispatchTrigger);
 
 		_dispatchTriggerHelper.deleteSchedulerJob(
-			dispatchTriggerId, dispatchTaskClusterMode.getStorageType());
+			dispatchTriggerId, oldDispatchTaskClusterMode.getStorageType());
 
 		if (active) {
 			_dispatchTriggerHelper.addSchedulerJob(

--- a/modules/apps/dispatch/dispatch-test/src/testIntegration/java/com/liferay/dispatch/service/test/DispatchTriggerLocalServiceTest.java
+++ b/modules/apps/dispatch/dispatch-test/src/testIntegration/java/com/liferay/dispatch/service/test/DispatchTriggerLocalServiceTest.java
@@ -273,12 +273,8 @@ public class DispatchTriggerLocalServiceTest {
 
 			Assert.assertNull(
 				_schedulerEngineHelper.getScheduledJob(
-					String.format(
-						"DISPATCH_JOB_%07d",
-						dispatchTrigger.getDispatchTriggerId()),
-					String.format(
-						"DISPATCH_GROUP_%07d",
-						dispatchTrigger.getDispatchTriggerId()),
+					_getJobName(dispatchTrigger.getDispatchTriggerId()),
+					_getGroupName(dispatchTrigger.getDispatchTriggerId()),
 					dispatchTaskClusterMode.getStorageType()));
 		}
 	}

--- a/modules/apps/dispatch/dispatch-test/src/testIntegration/java/com/liferay/dispatch/service/test/DispatchTriggerLocalServiceTest.java
+++ b/modules/apps/dispatch/dispatch-test/src/testIntegration/java/com/liferay/dispatch/service/test/DispatchTriggerLocalServiceTest.java
@@ -355,6 +355,71 @@ public class DispatchTriggerLocalServiceTest {
 			dispatchTrigger1.getName(), dispatchTrigger2.getName());
 	}
 
+	@Test
+	public void testUpdateDispatchTriggerWithDifferentDispatchTaskClusterMode()
+		throws Exception {
+
+		DispatchTrigger dispatchTrigger = _addDispatchTrigger(
+			DispatchTriggerTestUtil.randomDispatchTrigger(
+				UserTestUtil.addUser(), _getRandomDispatchExecutorType(), 1));
+
+		dispatchTrigger = _dispatchTriggerLocalService.updateDispatchTrigger(
+			dispatchTrigger.getDispatchTriggerId(), true,
+			CronExpressionUtil.getCronExpression(),
+			DispatchTaskClusterMode.valueOf(
+				dispatchTrigger.getDispatchTaskClusterMode()),
+			CronExpressionUtil.getMonth() + 1, 20, CronExpressionUtil.getYear(),
+			23, 59, false, true, CronExpressionUtil.getMonth() - 1, 1,
+			CronExpressionUtil.getYear(), 0, 0, "UTC");
+
+		DispatchTaskClusterMode dispatchTaskClusterMode =
+			DispatchTaskClusterMode.valueOf(
+				dispatchTrigger.getDispatchTaskClusterMode());
+
+		try {
+			DispatchTrigger updateDispatchTrigger =
+				_dispatchTriggerLocalService.updateDispatchTrigger(
+					dispatchTrigger.getDispatchTriggerId(), true,
+					CronExpressionUtil.getCronExpression(),
+					DispatchTaskClusterMode.SINGLE_NODE_MEMORY_CLUSTERED,
+					CronExpressionUtil.getMonth() + 1, 20,
+					CronExpressionUtil.getYear(), 23, 59, false, true,
+					CronExpressionUtil.getMonth() - 1, 1,
+					CronExpressionUtil.getYear(), 0, 0, "UTC");
+
+			DispatchTaskClusterMode updateDispatchTaskClusterMode =
+				DispatchTaskClusterMode.valueOf(
+					updateDispatchTrigger.getDispatchTaskClusterMode());
+
+			Assert.assertEquals(
+				DispatchTaskClusterMode.SINGLE_NODE_MEMORY_CLUSTERED,
+				updateDispatchTaskClusterMode);
+
+			Assert.assertNull(
+				_schedulerEngineHelper.getScheduledJob(
+					_getJobName(dispatchTrigger.getDispatchTriggerId()),
+					_getGroupName(dispatchTrigger.getDispatchTriggerId()),
+					dispatchTaskClusterMode.getStorageType()));
+
+			Assert.assertNotNull(
+				_schedulerEngineHelper.getScheduledJob(
+					_getJobName(updateDispatchTrigger.getDispatchTriggerId()),
+					_getGroupName(updateDispatchTrigger.getDispatchTriggerId()),
+					updateDispatchTaskClusterMode.getStorageType()));
+		}
+		catch (Exception exception) {
+			if (!(exception instanceof DispatchTriggerSchedulerException)) {
+				throw exception;
+			}
+
+			Assert.assertNull(
+				_schedulerEngineHelper.getScheduledJob(
+					_getJobName(dispatchTrigger.getDispatchTriggerId()),
+					_getGroupName(dispatchTrigger.getDispatchTriggerId()),
+					dispatchTaskClusterMode.getStorageType()));
+		}
+	}
+
 	private DispatchTrigger _addDispatchTrigger(DispatchTrigger dispatchTrigger)
 		throws Exception {
 
@@ -434,6 +499,14 @@ public class DispatchTriggerLocalServiceTest {
 			(key, value) -> Assert.assertEquals(
 				expectedDispatchTaskSettingsUnicodeProperties.getProperty(key),
 				value));
+	}
+
+	private String _getGroupName(long dispatchTriggerId) {
+		return String.format("DISPATCH_GROUP_%07d", dispatchTriggerId);
+	}
+
+	private String _getJobName(long dispatchTriggerId) {
+		return String.format("DISPATCH_JOB_%07d", dispatchTriggerId);
 	}
 
 	private String _getRandomDispatchExecutorType() {

--- a/modules/apps/dispatch/dispatch-test/src/testIntegration/java/com/liferay/dispatch/service/test/DispatchTriggerLocalServiceTest.java
+++ b/modules/apps/dispatch/dispatch-test/src/testIntegration/java/com/liferay/dispatch/service/test/DispatchTriggerLocalServiceTest.java
@@ -372,48 +372,35 @@ public class DispatchTriggerLocalServiceTest {
 			DispatchTaskClusterMode.valueOf(
 				dispatchTrigger.getDispatchTaskClusterMode());
 
-		try {
-			DispatchTrigger updateDispatchTrigger =
-				_dispatchTriggerLocalService.updateDispatchTrigger(
-					dispatchTrigger.getDispatchTriggerId(), true,
-					CronExpressionUtil.getCronExpression(),
-					DispatchTaskClusterMode.SINGLE_NODE_MEMORY_CLUSTERED,
-					CronExpressionUtil.getMonth() + 1, 20,
-					CronExpressionUtil.getYear(), 23, 59, false, true,
-					CronExpressionUtil.getMonth() - 1, 1,
-					CronExpressionUtil.getYear(), 0, 0, "UTC");
-
-			DispatchTaskClusterMode updateDispatchTaskClusterMode =
-				DispatchTaskClusterMode.valueOf(
-					updateDispatchTrigger.getDispatchTaskClusterMode());
-
-			Assert.assertEquals(
+		DispatchTrigger updateDispatchTrigger =
+			_dispatchTriggerLocalService.updateDispatchTrigger(
+				dispatchTrigger.getDispatchTriggerId(), true,
+				CronExpressionUtil.getCronExpression(),
 				DispatchTaskClusterMode.SINGLE_NODE_MEMORY_CLUSTERED,
-				updateDispatchTaskClusterMode);
+				CronExpressionUtil.getMonth() + 1, 20,
+				CronExpressionUtil.getYear(), 23, 59, false, true,
+				CronExpressionUtil.getMonth() - 1, 1,
+				CronExpressionUtil.getYear(), 0, 0, "UTC");
 
-			Assert.assertNull(
-				_schedulerEngineHelper.getScheduledJob(
-					_getJobName(dispatchTrigger.getDispatchTriggerId()),
-					_getGroupName(dispatchTrigger.getDispatchTriggerId()),
-					dispatchTaskClusterMode.getStorageType()));
+		DispatchTaskClusterMode updateDispatchTaskClusterMode =
+			DispatchTaskClusterMode.valueOf(
+				updateDispatchTrigger.getDispatchTaskClusterMode());
 
-			Assert.assertNotNull(
-				_schedulerEngineHelper.getScheduledJob(
-					_getJobName(updateDispatchTrigger.getDispatchTriggerId()),
-					_getGroupName(updateDispatchTrigger.getDispatchTriggerId()),
-					updateDispatchTaskClusterMode.getStorageType()));
-		}
-		catch (Exception exception) {
-			if (!(exception instanceof DispatchTriggerSchedulerException)) {
-				throw exception;
-			}
+		Assert.assertEquals(
+			DispatchTaskClusterMode.SINGLE_NODE_MEMORY_CLUSTERED,
+			updateDispatchTaskClusterMode);
 
-			Assert.assertNull(
-				_schedulerEngineHelper.getScheduledJob(
-					_getJobName(dispatchTrigger.getDispatchTriggerId()),
-					_getGroupName(dispatchTrigger.getDispatchTriggerId()),
-					dispatchTaskClusterMode.getStorageType()));
-		}
+		Assert.assertNull(
+			_schedulerEngineHelper.getScheduledJob(
+				_getJobName(dispatchTrigger.getDispatchTriggerId()),
+				_getGroupName(dispatchTrigger.getDispatchTriggerId()),
+				dispatchTaskClusterMode.getStorageType()));
+
+		Assert.assertNotNull(
+			_schedulerEngineHelper.getScheduledJob(
+				_getJobName(updateDispatchTrigger.getDispatchTriggerId()),
+				_getGroupName(updateDispatchTrigger.getDispatchTriggerId()),
+				updateDispatchTaskClusterMode.getStorageType()));
 	}
 
 	private DispatchTrigger _addDispatchTrigger(DispatchTrigger dispatchTrigger)


### PR DESCRIPTION
## Motivation
The idea of this PR is to delete the previous `dispatchTaskClusterMode`'s Job Scheduler created and set the new one. Before it always add new ones instead of delete the previous one.

**What is new?**
- Recover previous 	`dispatchTaskClusterMode` in order to delete the previous one and update the new one.
- Add test case to represent this use case

**JIRA Related Ticket**
https://liferay.atlassian.net/browse/LPS-204388