### PR TITLE
LPS-203455: POST API Endpoint without request schema should not be shown in OpenAPI

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/vulcan/openapi/contributor/APIApplicationOpenApiContributor.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/vulcan/openapi/contributor/APIApplicationOpenApiContributor.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.vulcan.openapi.OpenAPIContext;
 import com.liferay.portal.vulcan.openapi.contributor.OpenAPIContributor;
 import com.liferay.portal.vulcan.pagination.Page;
@@ -127,6 +128,12 @@ public class APIApplicationOpenApiContributor implements OpenAPIContributor {
 		Set<String> schemasSet = new HashSet<>();
 
 		for (APIApplication.Endpoint endpoint : apiApplication.getEndpoints()) {
+			if (Validator.isNull(endpoint.getRequestSchema()) &&
+				Objects.equals(Http.Method.POST, endpoint.getMethod())) {
+
+				continue;
+			}
+
 			paths.put(_formatPath(endpoint), _toOpenAPIPathItem(endpoint));
 
 			APIApplication.Schema responseSchema = endpoint.getResponseSchema();

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderOpenAPIResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderOpenAPIResourceTest.java
@@ -498,6 +498,26 @@ public class HeadlessBuilderOpenAPIResourceTest extends BaseTestCase {
 						"path", "/no-schema"
 					).put(
 						"scope", APIApplication.Endpoint.Scope.SITE.getValue()
+					),
+					JSONUtil.put(
+						"description",
+						"post endpoint no request schema description"
+					).put(
+						"externalReferenceCode",
+						_API_POST_COMPANY_SCOPED_NO_SCHEMA_ENDPOINT_ERC
+					).put(
+						"httpMethod", "post"
+					).put(
+						"name", "company scoped post no schema"
+					).put(
+						"path", "/no-schema"
+					).put(
+						"retrieveType",
+						APIApplication.Endpoint.RetrieveType.SINGLE_ELEMENT.
+							getValue()
+					).put(
+						"scope",
+						APIApplication.Endpoint.Scope.COMPANY.getValue()
 					))
 			).put(
 				"apiApplicationToAPISchemas",
@@ -803,6 +823,10 @@ public class HeadlessBuilderOpenAPIResourceTest extends BaseTestCase {
 
 	private static final String _API_ENDPOINT_ERC =
 		RandomTestUtil.randomString();
+
+	private static final String
+		_API_POST_COMPANY_SCOPED_NO_SCHEMA_ENDPOINT_ERC =
+			RandomTestUtil.randomString();
 
 	private static final String _API_SCHEMA_AGGREGATION_FIELD_ERC =
 		RandomTestUtil.randomString();


### PR DESCRIPTION
## Motivation
This PR fixes not to show POST API Endpoint without request Schema in the `OpenAPI`.

**What is new?**
- Change in `APIApplicationOpenApiContributor`
- Add test scenenario

**JIRA Related Ticket**
https://liferay.atlassian.net/browse/LPS-203455