### PR TITLE
LPS-203472 Use the encapsulated UploadServletRequest to create the MultipartBody object in MultipartBodyMessageBodyReader

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/message/body/MultipartBodyMessageBodyReader.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/message/body/MultipartBodyMessageBodyReader.java
@@ -170,15 +170,19 @@ public class MultipartBodyMessageBodyReader
 	private UploadServletRequest _getUploadServletRequest(
 		ServletRequest servletRequest) {
 
-		if (servletRequest instanceof UploadServletRequest) {
-			return (UploadServletRequest)servletRequest;
-		}
+		while (servletRequest instanceof ServletRequestWrapper) {
+			if (servletRequest instanceof UploadServletRequest) {
+				return (UploadServletRequest)servletRequest;
+			}
 
-		if (servletRequest instanceof ServletRequestWrapper) {
 			ServletRequestWrapper servletRequestWrapper =
 				(ServletRequestWrapper)servletRequest;
 
-			return _getUploadServletRequest(servletRequestWrapper.getRequest());
+			servletRequest = servletRequestWrapper.getRequest();
+		}
+
+		if (servletRequest instanceof UploadServletRequest) {
+			return (UploadServletRequest)servletRequest;
 		}
 
 		return null;

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/message/body/MultipartBodyMessageBodyReader.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/message/body/MultipartBodyMessageBodyReader.java
@@ -10,6 +10,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.liferay.document.library.kernel.util.DLValidatorUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.upload.FileItem;
+import com.liferay.portal.kernel.upload.UploadException;
+import com.liferay.portal.kernel.upload.UploadServletRequest;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.vulcan.internal.multipart.MultipartUtil;
 import com.liferay.portal.vulcan.multipart.BinaryFile;
 import com.liferay.portal.vulcan.multipart.MultipartBody;
@@ -24,6 +28,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletRequestWrapper;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.Part;
 
@@ -37,11 +43,9 @@ import javax.ws.rs.ext.MessageBodyReader;
 import javax.ws.rs.ext.Provider;
 import javax.ws.rs.ext.Providers;
 
-import org.apache.commons.fileupload.FileItem;
-import org.apache.commons.fileupload.FileUploadBase;
-import org.apache.commons.fileupload.disk.DiskFileItemFactory;
-import org.apache.commons.fileupload.servlet.ServletFileUpload;
 import org.apache.commons.fileupload.util.Streams;
+import org.apache.cxf.jaxrs.utils.JAXRSUtils;
+import org.apache.cxf.message.Message;
 
 /**
  * @author Alejandro Hernández
@@ -66,11 +70,35 @@ public class MultipartBodyMessageBodyReader
 		MediaType mediaType, MultivaluedMap<String, String> multivaluedMap,
 		InputStream inputStream) {
 
+		Message message = JAXRSUtils.getCurrentMessage();
+
+		UploadServletRequest uploadServletRequest = _getUploadServletRequest(
+			(HttpServletRequest)message.getContextualProperty("HTTP.REQUEST"));
+
+		if (uploadServletRequest == null) {
+			if (_log.isWarnEnabled()) {
+				_log.warn("No UploadServletRequest read from the message");
+			}
+
+			return null;
+		}
+
+		UploadException uploadException =
+			(UploadException)uploadServletRequest.getAttribute(
+				WebKeys.UPLOAD_EXCEPTION);
+
+		if (uploadException != null) {
+			throw new BadRequestException(
+				"Please enter a file with a valid file size no larger than " +
+					DLValidatorUtil.getMaxAllowableSize(0, null),
+				uploadException);
+		}
+
 		Map<String, BinaryFile> binaryFiles = new HashMap<>();
 		Map<String, String> values = new HashMap<>();
 
 		try {
-			Collection<Part> parts = _httpServletRequest.getParts();
+			Collection<Part> parts = uploadServletRequest.getParts();
 
 			if ((parts != null) && !parts.isEmpty()) {
 				for (Part part : parts) {
@@ -99,35 +127,31 @@ public class MultipartBodyMessageBodyReader
 
 		if (binaryFiles.isEmpty() && values.isEmpty()) {
 			try {
-				ServletFileUpload servletFileUpload = new ServletFileUpload(
-					new DiskFileItemFactory());
+				Map<String, FileItem[]> multipartParameterMap =
+					uploadServletRequest.getMultipartParameterMap();
 
-				List<FileItem> fileItems = servletFileUpload.parseRequest(
-					_httpServletRequest);
+				for (Map.Entry<String, FileItem[]> entry :
+						multipartParameterMap.entrySet()) {
 
-				for (FileItem fileItem : fileItems) {
-					String name = fileItem.getFieldName();
+					FileItem fileItem = entry.getValue()[0];
 
-					if (fileItem.isFormField()) {
-						values.put(
-							name, Streams.asString(fileItem.getInputStream()));
-					}
-					else {
-						binaryFiles.put(
-							name,
-							new BinaryFile(
-								fileItem.getContentType(), fileItem.getName(),
-								fileItem.getInputStream(), fileItem.getSize()));
-					}
+					binaryFiles.put(
+						entry.getKey(),
+						new BinaryFile(
+							fileItem.getContentType(), fileItem.getFileName(),
+							fileItem.getInputStream(), fileItem.getSize()));
 				}
-			}
-			catch (FileUploadBase.SizeLimitExceededException
-						sizeLimitExceededException) {
 
-				throw new BadRequestException(
-					"Please enter a file with a valid file size no larger " +
-						"than " + DLValidatorUtil.getMaxAllowableSize(0, null),
-					sizeLimitExceededException);
+				Map<String, List<String>> regularParameterMap =
+					uploadServletRequest.getRegularParameterMap();
+
+				for (Map.Entry<String, List<String>> entry :
+						regularParameterMap.entrySet()) {
+
+					List<String> parameterValues = entry.getValue();
+
+					values.put(entry.getKey(), parameterValues.get(0));
+				}
 			}
 			catch (Exception exception) {
 				throw new BadRequestException(
@@ -143,11 +167,25 @@ public class MultipartBodyMessageBodyReader
 			binaryFiles, contextResolver::getContext, values);
 	}
 
+	private UploadServletRequest _getUploadServletRequest(
+		ServletRequest servletRequest) {
+
+		if (servletRequest instanceof UploadServletRequest) {
+			return (UploadServletRequest)servletRequest;
+		}
+
+		if (servletRequest instanceof ServletRequestWrapper) {
+			ServletRequestWrapper servletRequestWrapper =
+				(ServletRequestWrapper)servletRequest;
+
+			return _getUploadServletRequest(servletRequestWrapper.getRequest());
+		}
+
+		return null;
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		MultipartBodyMessageBodyReader.class);
-
-	@Context
-	private HttpServletRequest _httpServletRequest;
 
 	@Context
 	private ObjectMapper _objectMapper;


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPS-203472

---

The purpose of this ticket is to modify the way the `MultipartBody` is being built. Before this PR, the `HttpServletRequest` injected by Apache CXF as a context parameter was the request that was being used to build the MultipartBody.

By analyzing the bug, we realised an `UploadServletRequest` was being generated [here](https://github.com/liferay/liferay-portal/blob/6ce0b9eb049e99a50285a324a3bd4afd76d340ab/modules/apps/portal/portal-upload-servlet-request-filter/src/main/java/com/liferay/portal/upload/servlet/request/filter/internal/UploadServletRequestFilter.java#L99). That means that request already contains the multiparts, so it is no longer needed to parse it again inside the ` `MultipartBodyMessageBodyReader` class.

For that, we have modified the `MultipartBodyMessageBodyReader` in order to get the multiparts from the previously created `UploadServletRequest` instead of using the `HttpServletRequest` injected by CXF.

cc/ @magjed4289 