### PR TITLE
LPS-205933 Use the attribute model name if sent

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PortletDataContextImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PortletDataContextImpl.java
@@ -1313,7 +1313,7 @@ public class PortletDataContextImpl implements PortletDataContext {
 			}
 		}
 
-		_importWorkflowDefinitionLink(newClassedModel);
+		_importWorkflowDefinitionLink(clazz, newClassedModel);
 
 		importLocks(
 			clazz, String.valueOf(primaryKeyObj),
@@ -2484,15 +2484,18 @@ public class PortletDataContextImpl implements PortletDataContext {
 		return StringBundler.concat(className, StringPool.POUND, classPK);
 	}
 
-	private void _importWorkflowDefinitionLink(ClassedModel classedModel)
+	private void _importWorkflowDefinitionLink(
+			Class<?> clazz, ClassedModel classedModel)
 		throws PortletDataException {
 
 		Element stagedGroupedWorkflowDefinitionLinkElements =
 			getImportDataGroupElement(
 				StagedGroupedWorkflowDefinitionLink.class);
 
+		String className = clazz.getName();
+
 		Map<Long, Long> primaryKeys = (Map<Long, Long>)getNewPrimaryKeysMap(
-			classedModel.getModelClass());
+			className);
 
 		for (Element stagedGroupedWorkflowDefinitionLinkElement :
 				stagedGroupedWorkflowDefinitionLinkElements.elements()) {
@@ -2503,8 +2506,6 @@ public class PortletDataContextImpl implements PortletDataContext {
 			long referrerClassPK = GetterUtil.getLong(
 				stagedGroupedWorkflowDefinitionLinkElement.attributeValue(
 					"referrer-class-pk"));
-
-			String className = classedModel.getModelClassName();
 
 			long newPrimaryKey = GetterUtil.getLong(
 				classedModel.getPrimaryKeyObj());


### PR DESCRIPTION
Steps to reproduce in https://liferay.atlassian.net/browse/LPS-205933

In this case the problem seems related with the current use of the method parameters in the export-import API:

In com.liferay.document.library.internal.exportimport.data.handler.FolderStagedModelDataHandler#doImportStagedModel we are doing this:

```
portletDataContext.importClassedModel(
			folder, importedFolder, DLFolder.class);
```

The third parameter in other cases (importLocks or importPermissions) is been used to set the right class name, but in the case of _importWorkflowDefinitionLink it is been extracted from the classed model.

I've changed this and use this className as when sent, and it fixes the issue.
