### PR TITLE
LPD-9964 New site/company scoped tests for POST API Endpoints

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/application/endpoint/EndpointMatcher.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/application/endpoint/EndpointMatcher.java
@@ -7,6 +7,7 @@ package com.liferay.headless.builder.internal.application.endpoint;
 
 import com.liferay.headless.builder.application.APIApplication;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.HashMap;
@@ -50,10 +51,12 @@ public class EndpointMatcher {
 	}
 
 	public APIApplication.Endpoint getEndpoint(
-		String path, APIApplication.Endpoint.Scope scope) {
+		Http.Method method, String path, APIApplication.Endpoint.Scope scope) {
 
 		for (APIApplication.Endpoint endpoint : _endpoints) {
-			if (scope != endpoint.getScope()) {
+			if ((method != endpoint.getMethod()) ||
+				(scope != endpoint.getScope())) {
+
 				continue;
 			}
 

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/resource/HeadlessBuilderResourceImpl.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/resource/HeadlessBuilderResourceImpl.java
@@ -11,6 +11,7 @@ import com.liferay.headless.builder.internal.application.endpoint.EndpointMatche
 import com.liferay.headless.builder.internal.helper.EndpointHelper;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Pagination;
@@ -151,7 +152,8 @@ public class HeadlessBuilderResourceImpl {
 				successUnsafeFunction)
 		throws Exception {
 
-		APIApplication.Endpoint endpoint = _getEndpoint(path, scope);
+		APIApplication.Endpoint endpoint = _getEndpoint(
+			Http.Method.GET, path, scope);
 
 		if (endpoint == null) {
 			return Response.status(
@@ -178,7 +180,7 @@ public class HeadlessBuilderResourceImpl {
 	}
 
 	private APIApplication.Endpoint _getEndpoint(
-		String path, APIApplication.Endpoint.Scope scope) {
+		Http.Method method, String path, APIApplication.Endpoint.Scope scope) {
 
 		EndpointMatcher endpointMatcher = _endpointMatcherFunction.apply(
 			_company.getCompanyId());
@@ -187,7 +189,7 @@ public class HeadlessBuilderResourceImpl {
 			return null;
 		}
 
-		return endpointMatcher.getEndpoint("/" + path, scope);
+		return endpointMatcher.getEndpoint(method, "/" + path, scope);
 	}
 
 	private <T> Response _post(
@@ -196,7 +198,8 @@ public class HeadlessBuilderResourceImpl {
 				successUnsafeFunction)
 		throws Exception {
 
-		APIApplication.Endpoint endpoint = _getEndpoint(path, scope);
+		APIApplication.Endpoint endpoint = _getEndpoint(
+			Http.Method.POST, path, scope);
 
 		if (endpoint == null) {
 			return Response.status(

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/test/java/com/liferay/headless/builder/internal/application/endpoint/EndpointMatcherTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/test/java/com/liferay/headless/builder/internal/application/endpoint/EndpointMatcherTest.java
@@ -53,6 +53,9 @@ public class EndpointMatcherTest {
 			endpoints.get(2),
 			endpointMatcher.getEndpoint(Http.Method.GET, "/path-name2", null));
 		Assert.assertEquals(
+			null,
+			endpointMatcher.getEndpoint(Http.Method.POST, "/path-name2", null));
+		Assert.assertEquals(
 			endpoints.get(3),
 			endpointMatcher.getEndpoint(Http.Method.GET, "/path/1234", null));
 	}

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/test/java/com/liferay/headless/builder/internal/application/endpoint/EndpointMatcherTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/test/java/com/liferay/headless/builder/internal/application/endpoint/EndpointMatcherTest.java
@@ -30,26 +30,35 @@ public class EndpointMatcherTest {
 	@Test
 	public void testGetEndpoint() {
 		List<APIApplication.Endpoint> endpoints = Arrays.asList(
-			_getEndpoint("/path-name", false),
-			_getEndpoint("/path-name2", false),
-			_getEndpoint("/path/{parameter}", true));
+			_getEndpoint(Http.Method.GET, "/path-name", false),
+			_getEndpoint(Http.Method.POST, "/path-name", false),
+			_getEndpoint(Http.Method.GET, "/path-name2", false),
+			_getEndpoint(Http.Method.GET, "/path/{parameter}", true));
 
 		EndpointMatcher endpointMatcher = new EndpointMatcher(endpoints);
 
-		Assert.assertNull(endpointMatcher.getEndpoint("/path", null));
+		Assert.assertNull(
+			endpointMatcher.getEndpoint(Http.Method.GET, "/path", null));
 		Assert.assertNull(
 			endpointMatcher.getEndpoint(
-				"/path-name", APIApplication.Endpoint.Scope.SITE));
+				Http.Method.GET, "/path-name",
+				APIApplication.Endpoint.Scope.SITE));
 		Assert.assertEquals(
-			endpoints.get(0), endpointMatcher.getEndpoint("/path-name", null));
+			endpoints.get(0),
+			endpointMatcher.getEndpoint(Http.Method.GET, "/path-name", null));
 		Assert.assertEquals(
-			endpoints.get(1), endpointMatcher.getEndpoint("/path-name2", null));
+			endpoints.get(1),
+			endpointMatcher.getEndpoint(Http.Method.POST, "/path-name", null));
 		Assert.assertEquals(
-			endpoints.get(2), endpointMatcher.getEndpoint("/path/1234", null));
+			endpoints.get(2),
+			endpointMatcher.getEndpoint(Http.Method.GET, "/path-name2", null));
+		Assert.assertEquals(
+			endpoints.get(3),
+			endpointMatcher.getEndpoint(Http.Method.GET, "/path/1234", null));
 	}
 
 	private APIApplication.Endpoint _getEndpoint(
-		String path, boolean singleElement) {
+		Http.Method method, String path, boolean singleElement) {
 
 		return new APIApplication.Endpoint() {
 
@@ -60,7 +69,7 @@ public class EndpointMatcherTest {
 
 			@Override
 			public Http.Method getMethod() {
-				return null;
+				return method;
 			}
 
 			@Override

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
@@ -2301,6 +2301,101 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 		Assert.assertEquals(textPropertyValue, values.get("textField"));
 	}
 
+	@Test
+	public void testPostWithSiteScopedEndpoint() throws Exception {
+		_addAPIApplicationWithPostEndpoint(
+			true, _siteScopedObjectDefinition1.getExternalReferenceCode(),
+			APIApplication.Endpoint.Scope.SITE);
+
+		Document document = _addRandomDocument();
+
+		String body = JSONUtil.put(
+			"attachmentProperty", document.getId()
+		).put(
+			"booleanProperty", RandomTestUtil.randomBoolean()
+		).put(
+			"dateProperty", _dateFormat.format(RandomTestUtil.nextDate())
+		).put(
+			"dateTimeProperty",
+			_dateTimeFormat.format(RandomTestUtil.nextDate())
+		).put(
+			"decimalProperty", RandomTestUtil.randomDouble()
+		).put(
+			"integerProperty", RandomTestUtil.randomInt()
+		).put(
+			"longIntegerProperty",
+			RandomTestUtil.randomLong(
+				ObjectFieldValidationConstants.BUSINESS_TYPE_LONG_VALUE_MIN,
+				ObjectFieldValidationConstants.BUSINESS_TYPE_LONG_VALUE_MAX)
+		).put(
+			"longTextProperty", RandomTestUtil.randomString()
+		).put(
+			"multiselectPicklistProperty",
+			TransformUtil.transform(
+				Arrays.asList(ListTypeValue.VALUE1, ListTypeValue.VALUE3),
+				ListTypeValue::name)
+		).put(
+			"picklistProperty", ListTypeValue.VALUE1.name()
+		).put(
+			"precisionDecimalProperty", 1.1
+		).put(
+			"richTextProperty", RandomTestUtil.randomString()
+		).put(
+			"textProperty", RandomTestUtil.randomString()
+		).toString();
+
+		String endpointPath = "c/" + _BASE_URL_1 + "/test";
+
+		Assert.assertEquals(
+			404,
+			HTTPTestUtil.invokeToHttpCode(
+				body, endpointPath, Http.Method.POST));
+
+		long groupId = TestPropsValues.getGroupId();
+
+		String scopedEndpointPath = StringBundler.concat(
+			"c/", _BASE_URL_1, "/scopes/", groupId, "/test");
+
+		Assert.assertEquals(
+			404,
+			HTTPTestUtil.invokeToHttpCode(
+				body, scopedEndpointPath, Http.Method.POST));
+
+		_publishAPIApplication(_API_APPLICATION_ERC_1);
+
+		Assert.assertEquals(
+			404,
+			HTTPTestUtil.invokeToHttpCode(
+				body, endpointPath, Http.Method.POST));
+
+		Assert.assertEquals(
+			200,
+			HTTPTestUtil.invokeToHttpCode(
+				body, scopedEndpointPath, Http.Method.POST));
+
+		List<ObjectEntry> objectEntries =
+			_objectEntryLocalService.getObjectEntries(
+				groupId, _siteScopedObjectDefinition1.getObjectDefinitionId(),
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+
+		Assert.assertEquals(objectEntries.toString(), 1, objectEntries.size());
+
+		scopedEndpointPath = StringBundler.concat(
+			"c/", _BASE_URL_1, "/scopes/", _group.getGroupId(), "/test");
+
+		Assert.assertEquals(
+			200,
+			HTTPTestUtil.invokeToHttpCode(
+				body, scopedEndpointPath, Http.Method.POST));
+
+		objectEntries = _objectEntryLocalService.getObjectEntries(
+			_group.getGroupId(),
+			_siteScopedObjectDefinition1.getObjectDefinitionId(),
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+
+		Assert.assertEquals(objectEntries.toString(), 1, objectEntries.size());
+	}
+
 	private void _addAggregationObjectField(
 			ObjectDefinition objectDefinition, String relationshipName)
 		throws Exception {

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
@@ -2008,7 +2008,8 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 	@Test
 	public void testPostWithAllFields() throws Exception {
 		_addAPIApplicationWithPostEndpoint(
-			true, _objectDefinition1.getExternalReferenceCode());
+			true, _objectDefinition1.getExternalReferenceCode(),
+			APIApplication.Endpoint.Scope.COMPANY);
 
 		_publishAPIApplication(_API_APPLICATION_ERC_1);
 
@@ -2270,7 +2271,8 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 	@Test
 	public void testPostWithoutResponseSchema() throws Exception {
 		_addAPIApplicationWithPostEndpoint(
-			false, _objectDefinition1.getExternalReferenceCode());
+			false, _objectDefinition1.getExternalReferenceCode(),
+			APIApplication.Endpoint.Scope.COMPANY);
 
 		_publishAPIApplication(_API_APPLICATION_ERC_1);
 
@@ -2475,7 +2477,8 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 
 	private void _addAPIApplicationWithPostEndpoint(
 			boolean addResponseSchema,
-			String objectDefinitionExternalReferenceCode)
+			String objectDefinitionExternalReferenceCode,
+			APIApplication.Endpoint.Scope scope)
 		throws Exception {
 
 		String apiSchemaExternalReferenceCode = RandomTestUtil.randomString();
@@ -2488,7 +2491,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 						_API_ENDPOINT_ERC_1, Http.Method.POST, "/test", null,
 						APIApplication.Endpoint.RetrieveType.SINGLE_ELEMENT.
 							getValue(),
-						APIApplication.Endpoint.Scope.COMPANY))
+						scope))
 			).put(
 				"apiApplicationToAPISchemas",
 				JSONUtil.put(

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
@@ -53,7 +53,10 @@ import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.test.constants.TestDataConstants;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DataGuard;
@@ -62,6 +65,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -184,27 +188,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 	}
 
 	@Test
-	public void testGetInDifferentCompany() throws Exception {
-		_addAPIApplication(
-			_API_APPLICATION_ERC_1, _API_ENDPOINT_ERC_1, _BASE_URL_1,
-			_objectDefinition1.getExternalReferenceCode(),
-			_objectRelationship1.getName(), _objectRelationship2.getName(),
-			_API_APPLICATION_PATH_1, null,
-			APIApplication.Endpoint.RetrieveType.COLLECTION.getValue(),
-			APIApplication.Endpoint.Scope.COMPANY);
-		_publishAPIApplication(_API_APPLICATION_ERC_1);
-
-		assertSuccessfulJSONObject(
-			null, "c/" + _BASE_URL_1 + _API_APPLICATION_PATH_1,
-			Http.Method.GET);
-
-		Assert.assertTrue(
-			HTTPTestUtil.invokeToJSONObject(
-				null, "openapi", Http.Method.GET
-			).has(
-				"/c/" + _BASE_URL_1
-			));
-
+	public void testDifferentCompany() throws Exception {
 		HTTPTestUtil.invokeToJSONObject(
 			JSONUtil.put(
 				"domain", "able.com"
@@ -216,73 +200,33 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			"headless-portal-instances/v1.0/portal-instances",
 			Http.Method.POST);
 
-		HTTPTestUtil.customize(
-		).withBaseURL(
-			"http://www.able.com:8080"
-		).withCredentials(
-			"test@able.com", "test"
-		).apply(
-			() -> {
-				Assert.assertEquals(
-					404,
-					HTTPTestUtil.invokeToHttpCode(
-						null, "c/" + _BASE_URL_1 + _API_APPLICATION_PATH_1,
-						Http.Method.GET));
-				Assert.assertFalse(
-					HTTPTestUtil.invokeToJSONObject(
-						null, "openapi", Http.Method.GET
-					).has(
-						"/c/" + _BASE_URL_1
-					));
+		Company company = CompanyLocalServiceUtil.getCompanyByVirtualHost(
+			"www.able.com");
 
-				assertSuccessfulJSONObject(
-					JSONUtil.put(
-						"applicationStatus", "published"
-					).put(
-						"baseURL", _BASE_URL_1
-					).put(
-						"externalReferenceCode", _API_APPLICATION_ERC_1
-					).put(
-						"title", "test-app"
-					).toString(),
-					"headless-builder/applications", Http.Method.POST);
+		User user = UserTestUtil.getAdminUser(company.getCompanyId());
 
-				Assert.assertTrue(
-					HTTPTestUtil.invokeToJSONObject(
-						null, "openapi", Http.Method.GET
-					).has(
-						"/c/" + _BASE_URL_1
-					));
+		long userId = user.getUserId();
 
-				JSONAssert.assertEquals(
-					JSONUtil.put(
-						"totalCount", 1
-					).toString(),
-					HTTPTestUtil.invokeToJSONObject(
-						null, "headless-builder/applications", Http.Method.GET
-					).toString(),
-					JSONCompareMode.LENIENT);
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				Collections.singletonList(
+					new TextObjectFieldBuilder(
+					).externalReferenceCode(
+						_API_SCHEMA_TEXT_FIELD_ERC
+					).labelMap(
+						LocalizedMapUtil.getLocalizedMap(
+							RandomTestUtil.randomString())
+					).name(
+						"textField"
+					).build()),
+				ObjectDefinitionConstants.SCOPE_COMPANY, userId);
 
-				assertSuccessfulJSONObject(
-					null,
-					"headless-builder/applications/by-external-reference-code" +
-						"/" + _API_APPLICATION_ERC_1,
-					Http.Method.DELETE);
+		String apiSchemaExternalReferenceCode = RandomTestUtil.randomString();
 
-				Assert.assertFalse(
-					HTTPTestUtil.invokeToJSONObject(
-						null, "openapi", Http.Method.GET
-					).has(
-						"/c/" + _BASE_URL_1
-					));
-			}
-		);
+		_testGetInDifferentCompany(
+			apiSchemaExternalReferenceCode, objectDefinition, userId);
 
-		assertSuccessfulJSONObject(
-			null,
-			"headless-builder/applications/by-external-reference-code/" +
-				_API_APPLICATION_ERC_1,
-			Http.Method.GET);
+		_testGetOpenAPIInDifferentCompany();
 	}
 
 	@Test
@@ -3124,6 +3068,194 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 		ObjectRelationshipTestUtil.relateObjectEntries(
 			objectEntry1.getObjectEntryId(), objectEntry2.getObjectEntryId(),
 			objectRelationship, TestPropsValues.getUserId());
+	}
+
+	private void _testGetInDifferentCompany(
+			String apiSchemaExternalReferenceCode,
+			ObjectDefinition objectDefinition, long userId)
+		throws Exception {
+
+		HTTPTestUtil.customize(
+		).withBaseURL(
+			"http://www.able.com:8080"
+		).withCredentials(
+			"test@able.com", "test"
+		).apply(
+			() -> {
+				assertSuccessfulJSONObject(
+					JSONUtil.put(
+						"apiApplicationToAPIEndpoints",
+						JSONUtil.putAll(
+							_createAPIEndpoint(
+								_API_ENDPOINT_ERC_1, Http.Method.GET,
+								_API_APPLICATION_PATH_1, null,
+								APIApplication.Endpoint.RetrieveType.COLLECTION.
+									getValue(),
+								APIApplication.Endpoint.Scope.COMPANY))
+					).put(
+						"apiApplicationToAPISchemas",
+						JSONUtil.put(
+							JSONUtil.put(
+								"apiSchemaToAPIProperties",
+								JSONUtil.putAll(
+									JSONUtil.put(
+										"description", "description"
+									).put(
+										"name", "textProperty"
+									).put(
+										"objectFieldERC",
+										_API_SCHEMA_TEXT_FIELD_ERC
+									))
+							).put(
+								"description", "description"
+							).put(
+								"externalReferenceCode",
+								apiSchemaExternalReferenceCode
+							).put(
+								"mainObjectDefinitionERC",
+								objectDefinition.getExternalReferenceCode()
+							).put(
+								"name", "name"
+							))
+					).put(
+						"applicationStatus", "published"
+					).put(
+						"baseURL", _BASE_URL_1
+					).put(
+						"externalReferenceCode", _API_APPLICATION_ERC_1
+					).put(
+						"title", RandomTestUtil.randomString()
+					).toString(),
+					"headless-builder/applications", Http.Method.POST);
+				assertSuccessfulJSONObject(
+					null,
+					StringBundler.concat(
+						"headless-builder/schemas/by-external-reference-code/",
+						apiSchemaExternalReferenceCode,
+						"/responseAPISchemaToAPIEndpoints/",
+						_API_ENDPOINT_ERC_1),
+					Http.Method.PUT);
+
+				String textFieldValue = RandomTestUtil.randomString();
+
+				ObjectEntryTestUtil.addObjectEntry(
+					objectDefinition, userId,
+					HashMapBuilder.<String, Serializable>put(
+						"textField", textFieldValue
+					).build());
+
+				String jsonObjectString = HTTPTestUtil.invokeToJSONObject(
+					null, "c/" + _BASE_URL_1 + _API_APPLICATION_PATH_1,
+					Http.Method.GET
+				).toString();
+
+				JSONAssert.assertEquals(
+					JSONUtil.put(
+						"items",
+						JSONUtil.putAll(
+							JSONUtil.put("textProperty", textFieldValue))
+					).put(
+						"lastPage", 1
+					).put(
+						"page", 1
+					).put(
+						"pageSize", 20
+					).put(
+						"totalCount", 1
+					).toString(),
+					jsonObjectString, JSONCompareMode.LENIENT);
+			}
+		);
+	}
+
+	private void _testGetOpenAPIInDifferentCompany() throws Exception {
+		_addAPIApplication(
+			_API_APPLICATION_ERC_2, _API_ENDPOINT_ERC_2, _BASE_URL_2,
+			_objectDefinition1.getExternalReferenceCode(),
+			_objectRelationship1.getName(), _objectRelationship2.getName(),
+			_API_APPLICATION_PATH_1, null,
+			APIApplication.Endpoint.RetrieveType.COLLECTION.getValue(),
+			APIApplication.Endpoint.Scope.COMPANY);
+		_publishAPIApplication(_API_APPLICATION_ERC_2);
+
+		assertSuccessfulJSONObject(
+			null, "c/" + _BASE_URL_2 + _API_APPLICATION_PATH_2,
+			Http.Method.GET);
+
+		Assert.assertTrue(
+			HTTPTestUtil.invokeToJSONObject(
+				null, "openapi", Http.Method.GET
+			).has(
+				"/c/" + _BASE_URL_2
+			));
+
+		HTTPTestUtil.customize(
+		).withBaseURL(
+			"http://www.able.com:8080"
+		).withCredentials(
+			"test@able.com", "test"
+		).apply(
+			() -> {
+				Assert.assertEquals(
+					404,
+					HTTPTestUtil.invokeToHttpCode(
+						null, "c/" + _BASE_URL_2 + _API_APPLICATION_PATH_2,
+						Http.Method.GET));
+				Assert.assertFalse(
+					HTTPTestUtil.invokeToJSONObject(
+						null, "openapi", Http.Method.GET
+					).has(
+						"/c/" + _BASE_URL_2
+					));
+
+				assertSuccessfulJSONObject(
+					JSONUtil.put(
+						"applicationStatus", "published"
+					).put(
+						"baseURL", _BASE_URL_2
+					).put(
+						"externalReferenceCode", _API_APPLICATION_ERC_2
+					).put(
+						"title", "test-app"
+					).toString(),
+					"headless-builder/applications", Http.Method.POST);
+
+				Assert.assertTrue(
+					HTTPTestUtil.invokeToJSONObject(
+						null, "openapi", Http.Method.GET
+					).has(
+						"/c/" + _BASE_URL_2
+					));
+
+				JSONAssert.assertEquals(
+					JSONUtil.put(
+						"totalCount", 2
+					).toString(),
+					HTTPTestUtil.invokeToJSONObject(
+						null, "headless-builder/applications", Http.Method.GET
+					).toString(),
+					JSONCompareMode.LENIENT);
+
+				assertSuccessfulJSONObject(
+					null,
+					"headless-builder/applications/by-external-reference-code" +
+						"/" + _API_APPLICATION_ERC_2,
+					Http.Method.DELETE);
+
+				Assert.assertFalse(
+					HTTPTestUtil.invokeToJSONObject(
+						null, "openapi", Http.Method.GET
+					).has(
+						"/c/" + _BASE_URL_2
+					));
+			}
+		);
+
+		assertSuccessfulJSONObject(
+			null,
+			"headless-builder/applications/by-external-reference-code/" +
+				_API_APPLICATION_ERC_1,
+			Http.Method.GET);
 	}
 
 	private static final String _API_APPLICATION_ERC_1 =

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
@@ -1942,15 +1942,11 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 					).build()),
 				ObjectDefinitionConstants.SCOPE_COMPANY, userId);
 
-		String apiSchemaExternalReferenceCode = RandomTestUtil.randomString();
-
-		_testGetInDifferentCompany(
-			apiSchemaExternalReferenceCode, objectDefinition, userId);
+		_testGetInDifferentCompany(objectDefinition, userId);
 
 		_testGetOpenAPIInDifferentCompany();
 
-		_testPostInDifferentCompany(
-			apiSchemaExternalReferenceCode, objectDefinition);
+		_testPostInDifferentCompany(objectDefinition);
 
 		List<ObjectEntry> objectEntries =
 			_objectEntryLocalService.getObjectEntries(
@@ -3084,9 +3080,10 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 	}
 
 	private void _testGetInDifferentCompany(
-			String apiSchemaExternalReferenceCode,
 			ObjectDefinition objectDefinition, long userId)
 		throws Exception {
+
+		String apiSchemaExternalReferenceCode = RandomTestUtil.randomString();
 
 		HTTPTestUtil.customize(
 		).withBaseURL(
@@ -3270,10 +3267,10 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			Http.Method.GET);
 	}
 
-	private void _testPostInDifferentCompany(
-			String apiSchemaExternalReferenceCode,
-			ObjectDefinition objectDefinition)
+	private void _testPostInDifferentCompany(ObjectDefinition objectDefinition)
 		throws Exception {
+
+		String apiSchemaExternalReferenceCode = RandomTestUtil.randomString();
 
 		HTTPTestUtil.customize(
 		).withBaseURL(

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
@@ -42,6 +42,7 @@ import com.liferay.object.rest.test.util.ObjectFieldTestUtil;
 import com.liferay.object.rest.test.util.ObjectRelationshipTestUtil;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectEntryLocalServiceUtil;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectFieldSettingLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
@@ -185,51 +186,6 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 		_addAggregationObjectField(
 			_siteScopedObjectDefinition2,
 			_siteScopedObjectRelationship2.getName());
-	}
-
-	@Test
-	public void testInDifferentCompany() throws Exception {
-		HTTPTestUtil.invokeToJSONObject(
-			JSONUtil.put(
-				"domain", "able.com"
-			).put(
-				"portalInstanceId", "able.com"
-			).put(
-				"virtualHost", "www.able.com"
-			).toString(),
-			"headless-portal-instances/v1.0/portal-instances",
-			Http.Method.POST);
-
-		Company company = CompanyLocalServiceUtil.getCompanyByVirtualHost(
-			"www.able.com");
-
-		User user = UserTestUtil.getAdminUser(company.getCompanyId());
-
-		long userId = user.getUserId();
-
-		ObjectDefinition objectDefinition =
-			ObjectDefinitionTestUtil.publishObjectDefinition(
-				Collections.singletonList(
-					new TextObjectFieldBuilder(
-					).externalReferenceCode(
-						_API_SCHEMA_TEXT_FIELD_ERC
-					).labelMap(
-						LocalizedMapUtil.getLocalizedMap(
-							RandomTestUtil.randomString())
-					).name(
-						"textField"
-					).build()),
-				ObjectDefinitionConstants.SCOPE_COMPANY, userId);
-
-		String apiSchemaExternalReferenceCode = RandomTestUtil.randomString();
-
-		_testGetInDifferentCompany(
-			apiSchemaExternalReferenceCode, objectDefinition, userId);
-
-		_testGetOpenAPIInDifferentCompany();
-
-		_testPostInDifferentCompany(
-			apiSchemaExternalReferenceCode, objectDefinition);
 	}
 
 	@Test
@@ -1953,6 +1909,60 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 	}
 
 	@Test
+	public void testInDifferentCompany() throws Exception {
+		HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				"domain", "able.com"
+			).put(
+				"portalInstanceId", "able.com"
+			).put(
+				"virtualHost", "www.able.com"
+			).toString(),
+			"headless-portal-instances/v1.0/portal-instances",
+			Http.Method.POST);
+
+		Company company = CompanyLocalServiceUtil.getCompanyByVirtualHost(
+			"www.able.com");
+
+		User user = UserTestUtil.getAdminUser(company.getCompanyId());
+
+		long userId = user.getUserId();
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				Collections.singletonList(
+					new TextObjectFieldBuilder(
+					).externalReferenceCode(
+						_API_SCHEMA_TEXT_FIELD_ERC
+					).labelMap(
+						LocalizedMapUtil.getLocalizedMap(
+							RandomTestUtil.randomString())
+					).name(
+						"textField"
+					).build()),
+				ObjectDefinitionConstants.SCOPE_COMPANY, userId);
+
+		String apiSchemaExternalReferenceCode = RandomTestUtil.randomString();
+
+		_testGetInDifferentCompany(
+			apiSchemaExternalReferenceCode, objectDefinition, userId);
+
+		_testGetOpenAPIInDifferentCompany();
+
+		_testPostInDifferentCompany(
+			apiSchemaExternalReferenceCode, objectDefinition);
+
+		List<ObjectEntry> objectEntries =
+			_objectEntryLocalService.getObjectEntries(
+				0, objectDefinition.getObjectDefinitionId(), QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS);
+
+		for (ObjectEntry objectEntry : objectEntries) {
+			ObjectEntryLocalServiceUtil.deleteObjectEntry(objectEntry);
+		}
+	}
+
+	@Test
 	public void testPostWithAllFields() throws Exception {
 		_addAPIApplicationWithPostEndpoint(
 			true, _objectDefinition1.getExternalReferenceCode(),
@@ -3320,6 +3330,12 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 
 				Assert.assertEquals(
 					objectEntries.toString(), 2, objectEntries.size());
+
+				assertSuccessfulJSONObject(
+					null,
+					"headless-builder/applications/by-external-reference-code" +
+						"/" + _API_APPLICATION_ERC_1,
+					Http.Method.DELETE);
 			}
 		);
 	}

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
@@ -3137,65 +3137,76 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 						"title", RandomTestUtil.randomString()
 					).toString(),
 					"headless-builder/applications", Http.Method.POST);
-				assertSuccessfulJSONObject(
-					null,
-					StringBundler.concat(
-						"headless-builder/schemas/by-external-reference-code/",
-						apiSchemaExternalReferenceCode,
-						"/responseAPISchemaToAPIEndpoints/",
-						_API_ENDPOINT_ERC_1),
-					Http.Method.PUT);
 
-				String textFieldValue = RandomTestUtil.randomString();
+				try {
+					assertSuccessfulJSONObject(
+						null,
+						StringBundler.concat(
+							"headless-builder/schemas/by-external-reference-",
+							"code/", apiSchemaExternalReferenceCode,
+							"/responseAPISchemaToAPIEndpoints/",
+							_API_ENDPOINT_ERC_1),
+						Http.Method.PUT);
 
-				ObjectEntryTestUtil.addObjectEntry(
-					objectDefinition, userId,
-					HashMapBuilder.<String, Serializable>put(
-						"textField", textFieldValue
-					).build());
+					String textFieldValue = RandomTestUtil.randomString();
 
-				JSONAssert.assertEquals(
-					JSONUtil.put(
-						"items",
-						JSONUtil.putAll(
-							JSONUtil.put("textProperty", textFieldValue))
-					).put(
-						"lastPage", 1
-					).put(
-						"page", 1
-					).put(
-						"pageSize", 20
-					).put(
-						"totalCount", 1
-					).toString(),
-					HTTPTestUtil.invokeToJSONObject(
-						null, "c/" + _BASE_URL_1 + _API_APPLICATION_PATH_1,
-						Http.Method.GET
-					).toString(),
-					JSONCompareMode.LENIENT);
+					ObjectEntryTestUtil.addObjectEntry(
+						objectDefinition, userId,
+						HashMapBuilder.<String, Serializable>put(
+							"textField", textFieldValue
+						).build());
+
+					JSONAssert.assertEquals(
+						JSONUtil.put(
+							"items",
+							JSONUtil.putAll(
+								JSONUtil.put("textProperty", textFieldValue))
+						).put(
+							"lastPage", 1
+						).put(
+							"page", 1
+						).put(
+							"pageSize", 20
+						).put(
+							"totalCount", 1
+						).toString(),
+						HTTPTestUtil.invokeToJSONObject(
+							null, "c/" + _BASE_URL_1 + _API_APPLICATION_PATH_1,
+							Http.Method.GET
+						).toString(),
+						JSONCompareMode.LENIENT);
+				}
+				finally {
+					assertSuccessfulJSONObject(
+						null,
+						StringBundler.concat(
+							"headless-builder/applications/by-external-",
+							"reference-code/", _API_APPLICATION_ERC_1),
+						Http.Method.DELETE);
+				}
 			}
 		);
 	}
 
 	private void _testGetOpenAPIInDifferentCompany() throws Exception {
 		_addAPIApplication(
-			_API_APPLICATION_ERC_2, _API_ENDPOINT_ERC_2, _BASE_URL_2,
+			_API_APPLICATION_ERC_1, _API_ENDPOINT_ERC_1, _BASE_URL_1,
 			_objectDefinition1.getExternalReferenceCode(),
 			_objectRelationship1.getName(), _objectRelationship2.getName(),
 			_API_APPLICATION_PATH_1, null,
 			APIApplication.Endpoint.RetrieveType.COLLECTION.getValue(),
 			APIApplication.Endpoint.Scope.COMPANY);
-		_publishAPIApplication(_API_APPLICATION_ERC_2);
+		_publishAPIApplication(_API_APPLICATION_ERC_1);
 
 		assertSuccessfulJSONObject(
-			null, "c/" + _BASE_URL_2 + _API_APPLICATION_PATH_2,
+			null, "c/" + _BASE_URL_1 + _API_APPLICATION_PATH_1,
 			Http.Method.GET);
 
 		Assert.assertTrue(
 			HTTPTestUtil.invokeToJSONObject(
 				null, "openapi", Http.Method.GET
 			).has(
-				"/c/" + _BASE_URL_2
+				"/c/" + _BASE_URL_1
 			));
 
 		HTTPTestUtil.customize(
@@ -3208,55 +3219,60 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 				Assert.assertEquals(
 					404,
 					HTTPTestUtil.invokeToHttpCode(
-						null, "c/" + _BASE_URL_2 + _API_APPLICATION_PATH_2,
+						null, "c/" + _BASE_URL_1 + _API_APPLICATION_PATH_1,
 						Http.Method.GET));
 				Assert.assertFalse(
 					HTTPTestUtil.invokeToJSONObject(
 						null, "openapi", Http.Method.GET
 					).has(
-						"/c/" + _BASE_URL_2
+						"/c/" + _BASE_URL_1
 					));
 
 				assertSuccessfulJSONObject(
 					JSONUtil.put(
 						"applicationStatus", "published"
 					).put(
-						"baseURL", _BASE_URL_2
+						"baseURL", _BASE_URL_1
 					).put(
-						"externalReferenceCode", _API_APPLICATION_ERC_2
+						"externalReferenceCode", _API_APPLICATION_ERC_1
 					).put(
 						"title", "test-app"
 					).toString(),
 					"headless-builder/applications", Http.Method.POST);
 
-				Assert.assertTrue(
-					HTTPTestUtil.invokeToJSONObject(
-						null, "openapi", Http.Method.GET
-					).has(
-						"/c/" + _BASE_URL_2
-					));
+				try {
+					Assert.assertTrue(
+						HTTPTestUtil.invokeToJSONObject(
+							null, "openapi", Http.Method.GET
+						).has(
+							"/c/" + _BASE_URL_1
+						));
 
-				JSONAssert.assertEquals(
-					JSONUtil.put(
-						"totalCount", 2
-					).toString(),
-					HTTPTestUtil.invokeToJSONObject(
-						null, "headless-builder/applications", Http.Method.GET
-					).toString(),
-					JSONCompareMode.LENIENT);
+					JSONAssert.assertEquals(
+						JSONUtil.put(
+							"totalCount", 1
+						).toString(),
+						HTTPTestUtil.invokeToJSONObject(
+							null, "headless-builder/applications",
+							Http.Method.GET
+						).toString(),
+						JSONCompareMode.LENIENT);
+				}
+				finally {
+					assertSuccessfulJSONObject(
+						null,
+						StringBundler.concat(
+							"headless-builder/applications/by-external-",
+							"reference-code/", _API_APPLICATION_ERC_1),
+						Http.Method.DELETE);
 
-				assertSuccessfulJSONObject(
-					null,
-					"headless-builder/applications/by-external-reference-code" +
-						"/" + _API_APPLICATION_ERC_2,
-					Http.Method.DELETE);
-
-				Assert.assertFalse(
-					HTTPTestUtil.invokeToJSONObject(
-						null, "openapi", Http.Method.GET
-					).has(
-						"/c/" + _BASE_URL_2
-					));
+					Assert.assertFalse(
+						HTTPTestUtil.invokeToJSONObject(
+							null, "openapi", Http.Method.GET
+						).has(
+							"/c/" + _BASE_URL_1
+						));
+				}
 			}
 		);
 
@@ -3280,59 +3296,97 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 		).apply(
 			() -> {
 				assertSuccessfulJSONObject(
-					_createAPIEndpoint(
-						_API_ENDPOINT_ERC_2, Http.Method.POST,
-						_API_APPLICATION_PATH_1, null,
-						APIApplication.Endpoint.RetrieveType.SINGLE_ELEMENT.
-							getValue(),
-						APIApplication.Endpoint.Scope.COMPANY
+					JSONUtil.put(
+						"apiApplicationToAPIEndpoints",
+						JSONUtil.putAll(
+							_createAPIEndpoint(
+								_API_ENDPOINT_ERC_1, Http.Method.POST,
+								_API_APPLICATION_PATH_1, null,
+								APIApplication.Endpoint.RetrieveType.
+									SINGLE_ELEMENT.getValue(),
+								APIApplication.Endpoint.Scope.COMPANY))
 					).put(
-						"r_apiApplicationToAPIEndpoints_c_apiApplicationERC",
-						_API_APPLICATION_ERC_1
+						"apiApplicationToAPISchemas",
+						JSONUtil.put(
+							JSONUtil.put(
+								"apiSchemaToAPIProperties",
+								JSONUtil.putAll(
+									JSONUtil.put(
+										"description", "description"
+									).put(
+										"name", "textProperty"
+									).put(
+										"objectFieldERC",
+										_API_SCHEMA_TEXT_FIELD_ERC
+									))
+							).put(
+								"description", "description"
+							).put(
+								"externalReferenceCode",
+								apiSchemaExternalReferenceCode
+							).put(
+								"mainObjectDefinitionERC",
+								objectDefinition.getExternalReferenceCode()
+							).put(
+								"name", "name"
+							))
+					).put(
+						"applicationStatus", "published"
+					).put(
+						"baseURL", _BASE_URL_1
+					).put(
+						"externalReferenceCode", _API_APPLICATION_ERC_1
+					).put(
+						"title", RandomTestUtil.randomString()
 					).toString(),
-					"headless-builder/endpoints", Http.Method.POST);
-				assertSuccessfulJSONObject(
-					null,
-					StringBundler.concat(
-						"headless-builder/schemas/by-external-reference-code/",
-						apiSchemaExternalReferenceCode,
-						"/requestAPISchemaToAPIEndpoints/",
-						_API_ENDPOINT_ERC_2),
-					Http.Method.PUT);
-				assertSuccessfulJSONObject(
-					null,
-					StringBundler.concat(
-						"headless-builder/schemas/by-external-reference-code/",
-						apiSchemaExternalReferenceCode,
-						"/responseAPISchemaToAPIEndpoints/",
-						_API_ENDPOINT_ERC_2),
-					Http.Method.PUT);
+					"headless-builder/applications", Http.Method.POST);
 
-				JSONObject jsonObject = JSONUtil.put(
-					"textProperty", RandomTestUtil.randomString());
+				try {
+					assertSuccessfulJSONObject(
+						null,
+						StringBundler.concat(
+							"headless-builder/schemas/by-external-reference-",
+							"code/", apiSchemaExternalReferenceCode,
+							"/responseAPISchemaToAPIEndpoints/",
+							_API_ENDPOINT_ERC_1),
+						Http.Method.PUT);
+					assertSuccessfulJSONObject(
+						null,
+						StringBundler.concat(
+							"headless-builder/schemas/by-external-reference-",
+							"code/", apiSchemaExternalReferenceCode,
+							"/requestAPISchemaToAPIEndpoints/",
+							_API_ENDPOINT_ERC_1),
+						Http.Method.PUT);
 
-				JSONAssert.assertEquals(
-					jsonObject.toString(),
-					HTTPTestUtil.invokeToJSONObject(
+					JSONObject jsonObject = JSONUtil.put(
+						"textProperty", RandomTestUtil.randomString());
+
+					JSONAssert.assertEquals(
 						jsonObject.toString(),
-						"c/" + _BASE_URL_1 + _API_APPLICATION_PATH_1,
-						Http.Method.POST
-					).toString(),
-					JSONCompareMode.LENIENT);
+						HTTPTestUtil.invokeToJSONObject(
+							jsonObject.toString(),
+							"c/" + _BASE_URL_1 + _API_APPLICATION_PATH_1,
+							Http.Method.POST
+						).toString(),
+						JSONCompareMode.LENIENT);
 
-				List<ObjectEntry> objectEntries =
-					_objectEntryLocalService.getObjectEntries(
-						0, objectDefinition.getObjectDefinitionId(),
-						QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+					List<ObjectEntry> objectEntries =
+						_objectEntryLocalService.getObjectEntries(
+							0, objectDefinition.getObjectDefinitionId(),
+							QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
-				Assert.assertEquals(
-					objectEntries.toString(), 2, objectEntries.size());
-
-				assertSuccessfulJSONObject(
-					null,
-					"headless-builder/applications/by-external-reference-code" +
-						"/" + _API_APPLICATION_ERC_1,
-					Http.Method.DELETE);
+					Assert.assertEquals(
+						objectEntries.toString(), 2, objectEntries.size());
+				}
+				finally {
+					assertSuccessfulJSONObject(
+						null,
+						StringBundler.concat(
+							"headless-builder/applications/by-external-",
+							"reference-code/", _API_APPLICATION_ERC_1),
+						Http.Method.DELETE);
+				}
 			}
 		);
 	}

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
@@ -3314,14 +3314,14 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 				JSONObject jsonObject = JSONUtil.put(
 					"textProperty", RandomTestUtil.randomString());
 
-				String str = HTTPTestUtil.invokeToJSONObject(
-					jsonObject.toString(),
-					"c/" + _BASE_URL_1 + _API_APPLICATION_PATH_1,
-					Http.Method.POST
-				).toString();
-
 				JSONAssert.assertEquals(
-					jsonObject.toString(), str, JSONCompareMode.LENIENT);
+					jsonObject.toString(),
+					HTTPTestUtil.invokeToJSONObject(
+						jsonObject.toString(),
+						"c/" + _BASE_URL_1 + _API_APPLICATION_PATH_1,
+						Http.Method.POST
+					).toString(),
+					JSONCompareMode.LENIENT);
 
 				List<ObjectEntry> objectEntries =
 					_objectEntryLocalService.getObjectEntries(

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
@@ -3147,11 +3147,6 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 						"textField", textFieldValue
 					).build());
 
-				String jsonObjectString = HTTPTestUtil.invokeToJSONObject(
-					null, "c/" + _BASE_URL_1 + _API_APPLICATION_PATH_1,
-					Http.Method.GET
-				).toString();
-
 				JSONAssert.assertEquals(
 					JSONUtil.put(
 						"items",
@@ -3166,7 +3161,11 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 					).put(
 						"totalCount", 1
 					).toString(),
-					jsonObjectString, JSONCompareMode.LENIENT);
+					HTTPTestUtil.invokeToJSONObject(
+						null, "c/" + _BASE_URL_1 + _API_APPLICATION_PATH_1,
+						Http.Method.GET
+					).toString(),
+					JSONCompareMode.LENIENT);
 			}
 		);
 	}

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
@@ -188,7 +188,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 	}
 
 	@Test
-	public void testDifferentCompany() throws Exception {
+	public void testInDifferentCompany() throws Exception {
 		HTTPTestUtil.invokeToJSONObject(
 			JSONUtil.put(
 				"domain", "able.com"

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
@@ -1947,15 +1947,6 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 		_testGetOpenAPIInDifferentCompany();
 
 		_testPostInDifferentCompany(objectDefinition);
-
-		List<ObjectEntry> objectEntries =
-			_objectEntryLocalService.getObjectEntries(
-				0, objectDefinition.getObjectDefinitionId(), QueryUtil.ALL_POS,
-				QueryUtil.ALL_POS);
-
-		for (ObjectEntry objectEntry : objectEntries) {
-			ObjectEntryLocalServiceUtil.deleteObjectEntry(objectEntry);
-		}
 	}
 
 	@Test
@@ -3183,6 +3174,16 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 							"headless-builder/applications/by-external-",
 							"reference-code/", _API_APPLICATION_ERC_1),
 						Http.Method.DELETE);
+
+					List<ObjectEntry> objectEntries =
+						_objectEntryLocalService.getObjectEntries(
+							0, objectDefinition.getObjectDefinitionId(),
+							QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+
+					for (ObjectEntry objectEntry : objectEntries) {
+						ObjectEntryLocalServiceUtil.deleteObjectEntry(
+							objectEntry);
+					}
 				}
 			}
 		);
@@ -3377,7 +3378,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 							QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
 					Assert.assertEquals(
-						objectEntries.toString(), 2, objectEntries.size());
+						objectEntries.toString(), 1, objectEntries.size());
 				}
 				finally {
 					assertSuccessfulJSONObject(
@@ -3386,6 +3387,16 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 							"headless-builder/applications/by-external-",
 							"reference-code/", _API_APPLICATION_ERC_1),
 						Http.Method.DELETE);
+
+					List<ObjectEntry> objectEntries =
+						_objectEntryLocalService.getObjectEntries(
+							0, objectDefinition.getObjectDefinitionId(),
+							QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+
+					for (ObjectEntry objectEntry : objectEntries) {
+						ObjectEntryLocalServiceUtil.deleteObjectEntry(
+							objectEntry);
+					}
 				}
 			}
 		);

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
@@ -227,6 +227,9 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			apiSchemaExternalReferenceCode, objectDefinition, userId);
 
 		_testGetOpenAPIInDifferentCompany();
+
+		_testPostInDifferentCompany(
+			apiSchemaExternalReferenceCode, objectDefinition);
 	}
 
 	@Test
@@ -3256,6 +3259,70 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			"headless-builder/applications/by-external-reference-code/" +
 				_API_APPLICATION_ERC_1,
 			Http.Method.GET);
+	}
+
+	private void _testPostInDifferentCompany(
+			String apiSchemaExternalReferenceCode,
+			ObjectDefinition objectDefinition)
+		throws Exception {
+
+		HTTPTestUtil.customize(
+		).withBaseURL(
+			"http://www.able.com:8080"
+		).withCredentials(
+			"test@able.com", "test"
+		).apply(
+			() -> {
+				assertSuccessfulJSONObject(
+					_createAPIEndpoint(
+						_API_ENDPOINT_ERC_2, Http.Method.POST,
+						_API_APPLICATION_PATH_1, null,
+						APIApplication.Endpoint.RetrieveType.SINGLE_ELEMENT.
+							getValue(),
+						APIApplication.Endpoint.Scope.COMPANY
+					).put(
+						"r_apiApplicationToAPIEndpoints_c_apiApplicationERC",
+						_API_APPLICATION_ERC_1
+					).toString(),
+					"headless-builder/endpoints", Http.Method.POST);
+				assertSuccessfulJSONObject(
+					null,
+					StringBundler.concat(
+						"headless-builder/schemas/by-external-reference-code/",
+						apiSchemaExternalReferenceCode,
+						"/requestAPISchemaToAPIEndpoints/",
+						_API_ENDPOINT_ERC_2),
+					Http.Method.PUT);
+				assertSuccessfulJSONObject(
+					null,
+					StringBundler.concat(
+						"headless-builder/schemas/by-external-reference-code/",
+						apiSchemaExternalReferenceCode,
+						"/responseAPISchemaToAPIEndpoints/",
+						_API_ENDPOINT_ERC_2),
+					Http.Method.PUT);
+
+				JSONObject jsonObject = JSONUtil.put(
+					"textProperty", RandomTestUtil.randomString());
+
+				String str = HTTPTestUtil.invokeToJSONObject(
+					jsonObject.toString(),
+					"c/" + _BASE_URL_1 + _API_APPLICATION_PATH_1,
+					Http.Method.POST
+				).toString();
+
+				JSONAssert.assertEquals(
+					jsonObject.toString(), str, JSONCompareMode.LENIENT);
+
+				List<ObjectEntry> objectEntries =
+					_objectEntryLocalService.getObjectEntries(
+						0, objectDefinition.getObjectDefinitionId(),
+						QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+
+				Assert.assertEquals(
+					objectEntries.toString(), 2, objectEntries.size());
+			}
+		);
 	}
 
 	private static final String _API_APPLICATION_ERC_1 =

--- a/modules/apps/object/object-rest-test-util/bnd.bnd
+++ b/modules/apps/object/object-rest-test-util/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Object REST Test Utilities
 Bundle-SymbolicName: com.liferay.object.rest.test.util
-Bundle-Version: 2.0.1
+Bundle-Version: 2.1.0
 Export-Package: com.liferay.object.rest.test.util

--- a/modules/apps/object/object-rest-test-util/src/main/java/com/liferay/object/rest/test/util/ObjectEntryTestUtil.java
+++ b/modules/apps/object/object-rest-test-util/src/main/java/com/liferay/object/rest/test/util/ObjectEntryTestUtil.java
@@ -25,7 +25,7 @@ import java.util.Map;
 public class ObjectEntryTestUtil {
 
 	public static ObjectEntry addObjectEntry(
-			long groupId, ObjectDefinition objectDefinition,
+			long groupId, ObjectDefinition objectDefinition, long userId,
 			Map<String, Serializable> values, String... keywords)
 		throws Exception {
 
@@ -37,8 +37,36 @@ public class ObjectEntryTestUtil {
 		}
 
 		return ObjectEntryLocalServiceUtil.addObjectEntry(
-			TestPropsValues.getUserId(), groupId,
-			objectDefinition.getObjectDefinitionId(), values, serviceContext);
+			userId, groupId, objectDefinition.getObjectDefinitionId(), values,
+			serviceContext);
+	}
+
+	public static ObjectEntry addObjectEntry(
+			long groupId, ObjectDefinition objectDefinition,
+			Map<String, Serializable> values, String... keywords)
+		throws Exception {
+
+		return addObjectEntry(
+			groupId, objectDefinition, TestPropsValues.getUserId(), values,
+			keywords);
+	}
+
+	public static ObjectEntry addObjectEntry(
+			ObjectDefinition objectDefinition, long userId,
+			Map<String, Serializable> values, String... keywords)
+		throws Exception {
+
+		long groupId = 0;
+
+		if (StringUtil.equals(
+				objectDefinition.getScope(),
+				ObjectDefinitionConstants.SCOPE_SITE)) {
+
+			groupId = TestPropsValues.getGroupId();
+		}
+
+		return addObjectEntry(
+			groupId, objectDefinition, userId, values, keywords);
 	}
 
 	public static ObjectEntry addObjectEntry(

--- a/modules/apps/object/object-rest-test-util/src/main/resources/com/liferay/object/rest/test/util/packageinfo
+++ b/modules/apps/object/object-rest-test-util/src/main/resources/com/liferay/object/rest/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0


### PR DESCRIPTION
**_Purpose of this PR:_** Adding tests that check if the behavior of POST endpoints in different companies/sites is the expected.

**What's new?:**
- Added new site/company scoped tests.

**What's changed?:**
- Now the GET endpoints functionality is also tested in a different company.
- The endpointMatcher now takes into account the HTTP method of the endpoint.
- Modified the endpointMatcher unit test so that it checks for the new behavior.

See the following **Jira ticket**: [LPD-9964](https://liferay.atlassian.net/browse/LPD-9964)

**NOTE:** The first commit of this PR is https://github.com/liferay-headless/liferay-portal/pull/1818/commits/bfa6fc6815b5fed5d0f813c9e7a80d6d93d4d4c4