### PR TITLE
LPS-206062 Check if transaction was already completed before we call commit/rollback

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/container/request/filter/TransactionContainerRequestFilter.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/container/request/filter/TransactionContainerRequestFilter.java
@@ -138,39 +138,36 @@ public class TransactionContainerRequestFilter
 		extends AbstractPhaseInterceptor implements MessageObserver {
 
 		public void commit() {
-			try {
-				_transactionExecutor.commit(
-					_transactionAttributeAdapter, _transactionStatusAdapter);
+			if (_transactionStatusAdapter.isCompleted()) {
+				return;
 			}
-			finally {
-				_complete = true;
-			}
+
+			_transactionExecutor.commit(
+				_transactionAttributeAdapter, _transactionStatusAdapter);
 		}
 
 		@Override
 		public void handleFault(Message message) {
-			if (!_complete) {
-				rollback("Rollback due to uncaught exception");
-			}
+			rollback("Rollback due to uncaught exception");
 		}
 
 		@Override
 		public void handleMessage(Message message) {
-			if (!_complete) {
-				rollback("Rollback due to uncaught exception");
-			}
+			rollback("Rollback due to uncaught exception");
 		}
 
 		@Override
 		public void onMessage(Message message) {
-			if (!_complete) {
-				rollback("Rollback due to uncaught exception");
-			}
+			rollback("Rollback due to uncaught exception");
 
 			_messageObserver.onMessage(message);
 		}
 
 		public void rollback(String message) {
+			if (_transactionStatusAdapter.isCompleted()) {
+				return;
+			}
+
 			Exception exception = new Exception(message);
 
 			try {
@@ -184,9 +181,6 @@ public class TransactionContainerRequestFilter
 						"Unable to roll back the transaction", throwable);
 				}
 			}
-			finally {
-				_complete = true;
-			}
 		}
 
 		private TransactionCleanUpMessageObserver(
@@ -199,7 +193,6 @@ public class TransactionContainerRequestFilter
 			_transactionStatusAdapter = transactionStatusAdapter;
 		}
 
-		private boolean _complete;
 		private final MessageObserver _messageObserver;
 		private final TransactionStatusAdapter _transactionStatusAdapter;
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-206062

## Testing notes

Because this started with an investigation into `testPostSystemObjectEntryWithInvalidNestedCustomObjectEntries`, I ran the appropriate integration test to confirm that the test now passed:

```bash
../gradlew -a :apps:object:object-rest-test:testIntegration --tests SystemObjectRelatedObjectEntriesTest
```

I also followed the steps in LPS-206062 to confirm that an exception was no longer printed to the logs and tested LPS-199370 to confirm that these changes did not introduce a regression related to that ticket.
