### PR TITLE
LPD-15853 Get the long value of the relationship field before checking if it is null

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -8100,9 +8100,23 @@ public class ObjectEntryResourceTest {
 					0
 				).put(
 					StringBundler.concat(
+						"r_", _objectRelationship1.getName(), "_",
+						StringUtil.replaceLast(
+							_objectDefinition2.getPKObjectFieldName(), "Id",
+							"ERC")),
+					""
+				).put(
+					StringBundler.concat(
 						"r_", _objectRelationship2.getName(), "_",
 						_objectDefinition2.getPKObjectFieldName()),
 					0
+				).put(
+					StringBundler.concat(
+						"r_", _objectRelationship2.getName(), "_",
+						StringUtil.replaceLast(
+							_objectDefinition2.getPKObjectFieldName(), "Id",
+							"ERC")),
+					""
 				).toString(),
 				jsonObject.toString(), JSONCompareMode.LENIENT);
 		}

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -5847,6 +5847,10 @@ public class ObjectEntryResourceTest {
 			_objectDefinition2, _objectDefinition1, TestPropsValues.getUserId(),
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
+		_objectRelationship2 = ObjectRelationshipTestUtil.addObjectRelationship(
+			_objectDefinition2, _objectDefinition1, TestPropsValues.getUserId(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
 		_testPutCustomObjectEntryUnlinkNestedCustomObjectEntries(true);
 
 		_objectRelationshipLocalService.deleteObjectRelationship(
@@ -8043,15 +8047,24 @@ public class ObjectEntryResourceTest {
 			objectEntryJSONObject.toString(),
 			_objectDefinition1.getRESTContextPath(), Http.Method.POST);
 
-		JSONObject newObjectEntryJSONObject = JSONUtil.put(
-			_objectRelationship1.getName(),
-			() -> {
-				if (manyToOne) {
-					return JSONFactoryUtil.createJSONObject();
-				}
+		JSONObject newObjectEntryJSONObject;
 
-				return JSONFactoryUtil.createJSONArray();
-			});
+		if (manyToOne) {
+			newObjectEntryJSONObject = JSONUtil.put(
+				_objectRelationship1.getName(),
+				JSONFactoryUtil.createJSONObject()
+			).put(
+				StringBundler.concat(
+					"r_", _objectRelationship2.getName(), "_",
+					_objectDefinition2.getPKObjectFieldName()),
+				0
+			);
+		}
+		else {
+			newObjectEntryJSONObject = JSONUtil.put(
+				_objectRelationship1.getName(),
+				JSONFactoryUtil.createJSONArray());
+		}
 
 		jsonObject = HTTPTestUtil.invokeToJSONObject(
 			newObjectEntryJSONObject.toString(),
@@ -8069,10 +8082,29 @@ public class ObjectEntryResourceTest {
 			));
 
 		if (manyToOne) {
-			JSONObject nestedObjectEntryJSONObject = jsonObject.getJSONObject(
+			JSONObject nestedObjectEntryJSONObject1 = jsonObject.getJSONObject(
 				_objectRelationship1.getName());
 
-			Assert.assertNull(nestedObjectEntryJSONObject);
+			Assert.assertNull(nestedObjectEntryJSONObject1);
+
+			JSONObject nestedObjectEntryJSONObject2 = jsonObject.getJSONObject(
+				_objectRelationship2.getName());
+
+			Assert.assertNull(nestedObjectEntryJSONObject2);
+
+			JSONAssert.assertEquals(
+				JSONUtil.put(
+					StringBundler.concat(
+						"r_", _objectRelationship1.getName(), "_",
+						_objectDefinition2.getPKObjectFieldName()),
+					0
+				).put(
+					StringBundler.concat(
+						"r_", _objectRelationship2.getName(), "_",
+						_objectDefinition2.getPKObjectFieldName()),
+					0
+				).toString(),
+				jsonObject.toString(), JSONCompareMode.LENIENT);
 		}
 		else {
 			JSONArray nestedObjectEntriesJSONArray = jsonObject.getJSONArray(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -8069,10 +8069,10 @@ public class ObjectEntryResourceTest {
 			));
 
 		if (manyToOne) {
-			JSONObject systemObjectEntryJSONObject = jsonObject.getJSONObject(
+			JSONObject nestedObjectEntryJSONObject = jsonObject.getJSONObject(
 				_objectRelationship1.getName());
 
-			Assert.assertNull(systemObjectEntryJSONObject);
+			Assert.assertNull(nestedObjectEntryJSONObject);
 		}
 		else {
 			JSONArray nestedObjectEntriesJSONArray = jsonObject.getJSONArray(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/business/type/RelationshipObjectFieldBusinessType.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/business/type/RelationshipObjectFieldBusinessType.java
@@ -93,7 +93,9 @@ public class RelationshipObjectFieldBusinessType
 
 			Object value = values.get(objectField.getName());
 
-			if (Validator.isNull(value)) {
+			Long longValue = GetterUtil.getLong(value);
+
+			if (Validator.isNull(longValue)) {
 				return value;
 			}
 
@@ -116,15 +118,14 @@ public class RelationshipObjectFieldBusinessType
 					systemObjectDefinitionManager.
 						getBaseModelByExternalReferenceCode(
 							systemObjectDefinitionManager.
-								getBaseModelExternalReferenceCode(
-									GetterUtil.getLong(value)),
+								getBaseModelExternalReferenceCode(longValue),
 							objectDefinition.getCompanyId());
 
 				return baseModel.getPrimaryKeyObj();
 			}
 
 			ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
-				GetterUtil.getLong(value));
+				longValue);
 
 			return objectEntry.getObjectEntryId();
 		}


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPD-15853

---

How to reproduce it: Check the related ticket.

The purpose of this ticket is to fix the current validation that is being done over the relationship field content.

In the related ticket example, given the curl:

```
curl -X 'POST'  \
     -u 'test@liferay.com:test' \
     'http://localhost:8080/o/c/students' \
     -H 'Content-type: application/json' \
     -d '{
         "studentName":"Carlos",
        "r_universityStudents_c_universityId": 0
     }'
```

The value `0` is being parsed as an `Integer`.

In order to validate the null value, the `Validator.isNull` method is used [here](https://github.com/liferay/liferay-portal/blob/ca882b90a970d51cc644e0eaf51cbb05f7411532/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/business/type/RelationshipObjectFieldBusinessType.java#L96). With the current implementation of the method, if the argument is an instance of the `Integer` class, then the isNull method return `false`, as it is not covered by any if clause. That triggers a following query over the ObjectEntry service with the id 0, that will throw an exception.

We have tried to update the implementation of the `isNull` value, but it would be a breaking change, as an integer 0 value is not being considered as null value, so the components that are using it should be updated too, that is why I think it is more safe to keep the current implementation of the `isNull` method.

With the code of this PR, we are parsing the current value as a Long, as it is the one that must be.