### PR TITLE
LPD-15900: Change ClayLabel displayType depending on the httpMethod name

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/FDS/fdsUtils/fdsRenderers.tsx
+++ b/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/FDS/fdsUtils/fdsRenderers.tsx
@@ -11,13 +11,27 @@ import React, {Dispatch, SetStateAction} from 'react';
 import StatusLabel from '../../StatusLabel';
 import {wrapStringInForwardSlashes} from '../../utils/string';
 
+export function getDisplayType(httpMethodName: string) {
+	if (httpMethodName === 'post') {
+		return 'success';
+	}
+	else {
+		return 'info';
+	}
+}
+
 export function itemMethodRenderer({
 	itemData,
 }: {
 	itemData: {httpMethod: {name: string}};
 }) {
-	return <ClayLabel displayType="info">{itemData.httpMethod.name}</ClayLabel>;
+	return (
+		<ClayLabel displayType={getDisplayType(itemData.httpMethod.name)}>
+			{itemData.httpMethod.name}
+		</ClayLabel>
+	);
 }
+
 export function itemPathRenderer({
 	fdsItem,
 	setMainEndpointNav,

--- a/modules/apps/headless/headless-builder/headless-builder-web/types/src/main/resources/META-INF/resources/js/components/FDS/fdsUtils/fdsRenderers.d.ts
+++ b/modules/apps/headless/headless-builder/headless-builder-web/types/src/main/resources/META-INF/resources/js/components/FDS/fdsUtils/fdsRenderers.d.ts
@@ -4,6 +4,9 @@
  */
 
 import {Dispatch, SetStateAction} from 'react';
+export declare function getDisplayType(
+	httpMethodName: string
+): 'success' | 'info';
 export declare function itemMethodRenderer({
 	itemData,
 }: {


### PR DESCRIPTION
**What's new?**
- Fix displayType depending on the `httpMethod` value of the API Endpoint

**Before the PR**
![Screenshot from 2024-01-30 16-34-51](https://github.com/liferay-headless/liferay-portal/assets/44723449/05df9775-d4bf-4f4e-8d32-fe6ec1f254be)


**After PR**
 
![Screenshot from 2024-01-30 16-34-18](https://github.com/liferay-headless/liferay-portal/assets/44723449/b27f2bde-2e64-40c3-91ae-8f2f3a128538)

**JIRA Related Ticket**
https://liferay.atlassian.net/browse/LPD-15900
