### PR TITLE
LPD-15236 Use a lowercase object definition name for the JAX-RS properties and update the usages of the getOSGiJaxRsName method

### DIFF
--- a/modules/apps/batch-engine/batch-engine-api/bnd.bnd
+++ b/modules/apps/batch-engine/batch-engine-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Batch Engine API
 Bundle-SymbolicName: com.liferay.batch.engine.api
-Bundle-Version: 23.3.3
+Bundle-Version: 24.0.0
 Export-Package:\
 	com.liferay.batch.engine,\
 	com.liferay.batch.engine.action,\

--- a/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/BatchEngineTaskItemDelegateRegistry.java
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/BatchEngineTaskItemDelegateRegistry.java
@@ -14,6 +14,6 @@ import org.osgi.annotation.versioning.ProviderType;
 public interface BatchEngineTaskItemDelegateRegistry {
 
 	public BatchEngineTaskItemDelegate<?> getBatchEngineTaskItemDelegate(
-		String itemClassName, String taskItemDelegateName);
+		long companyId, String itemClassName, String taskItemDelegateName);
 
 }

--- a/modules/apps/batch-engine/batch-engine-api/src/main/resources/com/liferay/batch/engine/packageinfo
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/resources/com/liferay/batch/engine/packageinfo
@@ -1,1 +1,1 @@
-version 7.0.0
+version 8.0.0

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineImportTaskExecutorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineImportTaskExecutorImpl.java
@@ -70,6 +70,7 @@ public class BatchEngineImportTaskExecutorImpl
 	public void execute(BatchEngineImportTask batchEngineImportTask) {
 		BatchEngineTaskItemDelegate<?> batchEngineTaskItemDelegate =
 			_batchEngineTaskItemDelegateRegistry.getBatchEngineTaskItemDelegate(
+				batchEngineImportTask.getCompanyId(),
 				batchEngineImportTask.getClassName(),
 				batchEngineImportTask.getTaskItemDelegateName());
 

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineTaskItemDelegateRegistryImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineTaskItemDelegateRegistryImpl.java
@@ -34,10 +34,22 @@ public class BatchEngineTaskItemDelegateRegistryImpl
 
 	@Override
 	public BatchEngineTaskItemDelegate<?> getBatchEngineTaskItemDelegate(
-		String itemClassName, String taskItemDelegateName) {
+		long companyId, String itemClassName, String taskItemDelegateName) {
 
-		return _serviceTrackerMap.getService(
-			_encodeKey(itemClassName, taskItemDelegateName));
+		String companyIdKey = _encodeKey(
+			companyId, itemClassName, taskItemDelegateName);
+
+		if (_serviceTrackerMap.containsKey(companyIdKey)) {
+			return _serviceTrackerMap.getService(companyIdKey);
+		}
+
+		String key = _encodeKey(null, itemClassName, taskItemDelegateName);
+
+		if (_serviceTrackerMap.containsKey(key)) {
+			return _serviceTrackerMap.getService(key);
+		}
+
+		return null;
 	}
 
 	@Activate
@@ -53,6 +65,7 @@ public class BatchEngineTaskItemDelegateRegistryImpl
 
 					emitter.emit(
 						_encodeKey(
+							(Long)serviceReference.getProperty("companyId"),
 							itemClass.getName(),
 							(String)serviceReference.getProperty(
 								"batch.engine.task.item.delegate.name")));
@@ -98,14 +111,20 @@ public class BatchEngineTaskItemDelegateRegistryImpl
 	}
 
 	private String _encodeKey(
-		String itemClassName, String taskItemDelegateName) {
+		Long companyId, String itemClassName, String taskItemDelegateName) {
 
 		if (Validator.isNull(taskItemDelegateName)) {
 			taskItemDelegateName = "DEFAULT";
 		}
 
+		if (Validator.isNull(companyId)) {
+			return StringBundler.concat(
+				itemClassName, StringPool.POUND, taskItemDelegateName);
+		}
+
 		return StringBundler.concat(
-			itemClassName, StringPool.POUND, taskItemDelegateName);
+			itemClassName, StringPool.POUND, taskItemDelegateName,
+			StringPool.POUND, companyId);
 	}
 
 	private Class<?> _getItemClass(

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/item/BatchEngineTaskItemDelegateExecutorFactory.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/item/BatchEngineTaskItemDelegateExecutorFactory.java
@@ -52,7 +52,7 @@ public class BatchEngineTaskItemDelegateExecutorFactory {
 
 		BatchEngineTaskItemDelegate<?> batchEngineTaskItemDelegate =
 			_batchEngineTaskItemDelegateRegistry.getBatchEngineTaskItemDelegate(
-				className, taskItemDelegateName);
+				company.getCompanyId(), className, taskItemDelegateName);
 
 		if (batchEngineTaskItemDelegate == null) {
 			throw new IllegalStateException(

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/service/impl/BatchEngineImportTaskLocalServiceImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/service/impl/BatchEngineImportTaskLocalServiceImpl.java
@@ -54,7 +54,7 @@ public class BatchEngineImportTaskLocalServiceImpl
 
 		BatchEngineTaskItemDelegate<?> batchEngineTaskItemDelegate =
 			_batchEngineTaskItemDelegateRegistry.getBatchEngineTaskItemDelegate(
-				className, taskItemDelegateName);
+				companyId, className, taskItemDelegateName);
 
 		return addBatchEngineImportTask(
 			externalReferenceCode, companyId, userId, batchSize, callbackURL,

--- a/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/StrategyResourceImpl.java
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/StrategyResourceImpl.java
@@ -37,6 +37,7 @@ public class StrategyResourceImpl extends BaseStrategyResourceImpl {
 
 		BatchEngineTaskItemDelegate<?> batchEngineTaskItemDelegate =
 			_batchEngineTaskItemDelegateRegistry.getBatchEngineTaskItemDelegate(
+				contextCompany.getCompanyId(),
 				TaskItemUtil.getInternalClassName(internalClassNameKey),
 				TaskItemUtil.getTaskItemDelegateName(internalClassNameKey));
 

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-test/bnd.bnd
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-test/bnd.bnd
@@ -3,4 +3,5 @@ Bundle-SymbolicName: com.liferay.headless.batch.engine.test
 Bundle-Version: 1.0.0
 -includeresource:\
 	com.liferay.headless.batch.engine.client.jar=com.liferay.headless.batch.engine.client-*.jar;lib:=true,\
-	META-INF/module-log4j.xml=src/testIntegration/resources/META-INF/module-log4j.xml
+	META-INF/module-log4j.xml=src/testIntegration/resources/META-INF/module-log4j.xml,\
+	@jsonassert-[0-9.]*.jar

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-test/build.gradle
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-test/build.gradle
@@ -1,11 +1,18 @@
 dependencies {
+	testCompileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
+	testCompileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+
 	testIntegrationImplementation group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.16.1"
 	testIntegrationImplementation group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.16.1"
 	testIntegrationImplementation group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.16.1"
 	testIntegrationImplementation group: "commons-lang", name: "commons-lang", version: "2.6"
 	testIntegrationImplementation group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"
+	testIntegrationImplementation group: "org.skyscreamer", name: "jsonassert", version: "1.2.3"
 	testIntegrationImplementation project(":apps:headless:headless-batch-engine:headless-batch-engine-api")
 	testIntegrationImplementation project(":apps:headless:headless-batch-engine:headless-batch-engine-client")
+	testIntegrationImplementation project(":apps:object:object-api")
+	testIntegrationImplementation project(":apps:object:object-test-util")
 	testIntegrationImplementation project(":apps:portal-vulcan:portal-vulcan-api")
+	testIntegrationImplementation project(":apps:static:osgi:osgi-util")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-test/src/testIntegration/java/com/liferay/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-test/src/testIntegration/java/com/liferay/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
@@ -249,6 +249,13 @@ public class ExportTaskResourceTest {
 		_assertExecuteStatusEquals(
 			ExportTask.ExecuteStatus.COMPLETED, exportTask2,
 			exportTaskResource);
+
+		ExportTask exportTask3 = exportTaskResource.postExportTask(
+			"com.liferay.object.rest.dto.v1_0.ObjectEntry", "json", null, null,
+			null, _objectDefinition1.getName());
+
+		_assertExecuteStatusEquals(
+			ExportTask.ExecuteStatus.FAILED, exportTask3, exportTaskResource);
 	}
 
 	private void _assertExecuteStatusEquals(

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-test/src/testIntegration/java/com/liferay/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-test/src/testIntegration/java/com/liferay/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
@@ -230,24 +230,9 @@ public class ExportTaskResourceTest {
 			"com.liferay.object.rest.dto.v1_0.ObjectEntry", "json", null, null,
 			null, _objectDefinition1.getName());
 
-		String externalReferenceCode1 = exportTask1.getExternalReferenceCode();
-
-		while (true) {
-			exportTask1 =
-				exportTaskResource.getExportTaskByExternalReferenceCode(
-					externalReferenceCode1);
-
-			if (Objects.equals(
-					exportTask1.getExecuteStatusAsString(), "COMPLETED")) {
-
-				break;
-			}
-			else if (Objects.equals(
-						exportTask1.getExecuteStatusAsString(), "FAILED")) {
-
-				throw new AssertionError(exportTask1.getErrorMessage());
-			}
-		}
+		_assertExecuteStatusEquals(
+			ExportTask.ExecuteStatus.COMPLETED, exportTask1,
+			exportTaskResource);
 
 		exportTaskResource = builder.authentication(
 			"test@able.com", "test"
@@ -261,22 +246,34 @@ public class ExportTaskResourceTest {
 			"com.liferay.object.rest.dto.v1_0.ObjectEntry", "json", null, null,
 			null, _objectDefinition2.getName());
 
-		String externalReferenceCode2 = exportTask2.getExternalReferenceCode();
+		_assertExecuteStatusEquals(
+			ExportTask.ExecuteStatus.COMPLETED, exportTask2,
+			exportTaskResource);
+	}
+
+	private void _assertExecuteStatusEquals(
+			ExportTask.ExecuteStatus expectedExecuteStatus,
+			ExportTask exportTask, ExportTaskResource exportTaskResource)
+		throws Exception {
+
+		String externalReferenceCode = exportTask.getExternalReferenceCode();
 
 		while (true) {
-			exportTask2 =
+			exportTask =
 				exportTaskResource.getExportTaskByExternalReferenceCode(
-					externalReferenceCode2);
+					externalReferenceCode);
 
-			if (Objects.equals(
-					exportTask2.getExecuteStatusAsString(), "COMPLETED")) {
+			ExportTask.ExecuteStatus executeStatus =
+				exportTask.getExecuteStatus();
+
+			if ((executeStatus == ExportTask.ExecuteStatus.COMPLETED) ||
+				(executeStatus == ExportTask.ExecuteStatus.FAILED)) {
+
+				if (expectedExecuteStatus != executeStatus) {
+					throw new AssertionError(exportTask.getErrorMessage());
+				}
 
 				break;
-			}
-			else if (Objects.equals(
-						exportTask2.getExecuteStatusAsString(), "FAILED")) {
-
-				throw new AssertionError(exportTask2.getErrorMessage());
 			}
 		}
 	}
@@ -295,22 +292,8 @@ public class ExportTaskResourceTest {
 
 		String externalReferenceCode = exportTask.getExternalReferenceCode();
 
-		while (true) {
-			exportTask =
-				exportTaskResource.getExportTaskByExternalReferenceCode(
-					externalReferenceCode);
-
-			if (Objects.equals(
-					exportTask.getExecuteStatusAsString(), "COMPLETED")) {
-
-				break;
-			}
-			else if (Objects.equals(
-						exportTask.getExecuteStatusAsString(), "FAILED")) {
-
-				throw new AssertionError(exportTask.getErrorMessage());
-			}
-		}
+		_assertExecuteStatusEquals(
+			ExportTask.ExecuteStatus.COMPLETED, exportTask, exportTaskResource);
 
 		String json = null;
 

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-test/src/testIntegration/java/com/liferay/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-test/src/testIntegration/java/com/liferay/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
@@ -11,17 +11,30 @@ import com.liferay.headless.batch.engine.client.dto.v1_0.ImportTask;
 import com.liferay.headless.batch.engine.client.http.HttpInvoker;
 import com.liferay.headless.batch.engine.client.resource.v1_0.ExportTaskResource;
 import com.liferay.headless.batch.engine.client.resource.v1_0.ImportTaskResource;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.field.util.ObjectFieldUtil;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.petra.io.unsync.UnsyncByteArrayInputStream;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringUtil;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.HTTPTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
@@ -32,6 +45,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -52,6 +66,9 @@ import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceReference;
 import org.osgi.util.tracker.ServiceTracker;
 import org.osgi.util.tracker.ServiceTrackerCustomizer;
+
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 
 /**
  * Modify the value of _testableClassNames to test specific class names.
@@ -139,6 +156,106 @@ public class ExportTaskResourceTest {
 	}
 
 	@Test
+	public void testExportCustomObjectEntryMultipleCompanies()
+		throws Exception {
+
+		String objectDefinitionName = RandomTestUtil.randomString() + "abc";
+
+		JSONObject jsonObject1 = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				"domain", "able.com"
+			).put(
+				"portalInstanceId", "able.com"
+			).put(
+				"virtualHost", "www.able.com"
+			).toString(),
+			"headless-portal-instances/v1.0/portal-instances",
+			Http.Method.POST);
+
+		_company = _companyLocalService.getCompany(
+			jsonObject1.getLong("companyId"));
+
+		_user = UserTestUtil.addUser(_company);
+
+		_objectDefinition1 = ObjectDefinitionTestUtil.publishObjectDefinition(
+			"A" + StringUtil.toLowerCase(objectDefinitionName),
+			Collections.singletonList(
+				ObjectFieldUtil.createObjectField(
+					"Text", "String", true, true, null,
+					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME, false)),
+			ObjectDefinitionConstants.SCOPE_COMPANY,
+			TestPropsValues.getUserId());
+
+		_objectDefinition2 = ObjectDefinitionTestUtil.publishObjectDefinition(
+			"A" + StringUtil.toUpperCase(objectDefinitionName),
+			Collections.singletonList(
+				ObjectFieldUtil.createObjectField(
+					"Text", "String", true, true, null,
+					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME, false)),
+			ObjectDefinitionConstants.SCOPE_COMPANY, _user.getUserId());
+
+		JSONObject jsonObject2 = HTTPTestUtil.invokeToJSONObject(
+			null, _exportTaskEndpoint() + _objectDefinition1.getName(),
+			Http.Method.POST);
+
+		JSONObject jsonObject3 = HTTPTestUtil.invokeToJSONObject(
+			null,
+			"headless-batch-engine/v1.0/export-task/" +
+				jsonObject2.getString("id"),
+			Http.Method.GET);
+
+		try {
+			JSONAssert.assertEquals(
+				JSONUtil.put(
+					"className", "com.liferay.object.rest.dto.v1_0.ObjectEntry"
+				).put(
+					"errorMessage", ""
+				).put(
+					"executeStatus", "COMPLETED"
+				).toString(),
+				jsonObject3.toString(), JSONCompareMode.LENIENT);
+		}
+		catch (AssertionError error) {
+			Assert.fail(jsonObject3.getString("errorMessage"));
+		}
+
+		HTTPTestUtil.customize(
+		).withBaseURL(
+			"http://www.able.com:8080"
+		).withCredentials(
+			"test@able.com", "test"
+		).apply(
+			() -> {
+				JSONObject jsonObject4 = HTTPTestUtil.invokeToJSONObject(
+					null, _exportTaskEndpoint() + _objectDefinition2.getName(),
+					Http.Method.POST);
+
+				JSONObject jsonObject5 = HTTPTestUtil.invokeToJSONObject(
+					null,
+					"headless-batch-engine/v1.0/export-task/" +
+						jsonObject4.getString("id"),
+					Http.Method.GET);
+
+				try {
+					JSONAssert.assertEquals(
+						JSONUtil.put(
+							"className",
+							"com.liferay.object.rest.dto.v1_0.ObjectEntry"
+						).put(
+							"errorMessage", ""
+						).put(
+							"executeStatus", "COMPLETED"
+						).toString(),
+						jsonObject5.toString(), JSONCompareMode.LENIENT);
+				}
+				catch (AssertionError error) {
+					Assert.fail(jsonObject5.getString("errorMessage"));
+				}
+			}
+		);
+	}
+
+	@Test
 	public void testPostExportTask() throws Exception {
 		Assert.assertFalse(_testableClassNames.isEmpty());
 
@@ -163,6 +280,12 @@ public class ExportTaskResourceTest {
 		if (sb.length() > 0) {
 			throw new AssertionError(sb.toString());
 		}
+	}
+
+	private String _exportTaskEndpoint() {
+		return "headless-batch-engine/v1.0/export-task" +
+			"/com.liferay.object.rest.dto.v1_0.ObjectEntry" +
+				"/json?fieldNames=id&taskItemDelegateName=";
 	}
 
 	private void _testPostExportTask(String className) throws Exception {
@@ -266,8 +389,17 @@ public class ExportTaskResourceTest {
 		}
 	}
 
+	private static final String _OBJECT_FIELD_NAME =
+		"x" + RandomTestUtil.randomString();
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		ExportTaskResourceTest.class);
+
+	@DeleteAfterTestRun
+	private static Company _company;
+
+	@Inject
+	private static CompanyLocalService _companyLocalService;
 
 	private static ServiceTracker<Object, String> _serviceTracker;
 
@@ -548,5 +680,14 @@ public class ExportTaskResourceTest {
 	private JSONFactory _jsonFactory;
 
 	private final List<LogCapture> _logCaptures = new ArrayList<>();
+
+	@DeleteAfterTestRun
+	private ObjectDefinition _objectDefinition1;
+
+	@DeleteAfterTestRun
+	private ObjectDefinition _objectDefinition2;
+
+	@DeleteAfterTestRun
+	private User _user;
 
 }

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-test/src/testIntegration/java/com/liferay/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-test/src/testIntegration/java/com/liferay/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
@@ -153,7 +153,34 @@ public class ExportTaskResourceTest {
 	}
 
 	@Test
-	public void testExportCustomObjectEntryMultipleCompanies()
+	public void testPostExportTask() throws Exception {
+		Assert.assertFalse(_testableClassNames.isEmpty());
+
+		StringBundler sb = new StringBundler();
+
+		for (String className : _testableClassNames) {
+			try {
+				if (_log.isInfoEnabled()) {
+					_log.info("Testing " + className);
+				}
+
+				_testPostExportTask(className);
+			}
+			catch (Throwable throwable) {
+				sb.append(className);
+				sb.append(": ");
+				sb.append(throwable.getMessage());
+				sb.append("\n");
+			}
+		}
+
+		if (sb.length() > 0) {
+			throw new AssertionError(sb.toString());
+		}
+	}
+
+	@Test
+	public void testPostExportTaskCustomObjectEntryMultipleCompanies()
 		throws Exception {
 
 		String objectDefinitionName = RandomTestUtil.randomString() + "abc";
@@ -251,33 +278,6 @@ public class ExportTaskResourceTest {
 
 				throw new AssertionError(exportTask2.getErrorMessage());
 			}
-		}
-	}
-
-	@Test
-	public void testPostExportTask() throws Exception {
-		Assert.assertFalse(_testableClassNames.isEmpty());
-
-		StringBundler sb = new StringBundler();
-
-		for (String className : _testableClassNames) {
-			try {
-				if (_log.isInfoEnabled()) {
-					_log.info("Testing " + className);
-				}
-
-				_testPostExportTask(className);
-			}
-			catch (Throwable throwable) {
-				sb.append(className);
-				sb.append(": ");
-				sb.append(throwable.getMessage());
-				sb.append("\n");
-			}
-		}
-
-		if (sb.length() > 0) {
-			throw new AssertionError(sb.toString());
 		}
 	}
 

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-test/src/testIntegration/java/com/liferay/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-test/src/testIntegration/java/com/liferay/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
@@ -67,9 +67,6 @@ import org.osgi.framework.ServiceReference;
 import org.osgi.util.tracker.ServiceTracker;
 import org.osgi.util.tracker.ServiceTrackerCustomizer;
 
-import org.skyscreamer.jsonassert.JSONAssert;
-import org.skyscreamer.jsonassert.JSONCompareMode;
-
 /**
  * Modify the value of _testableClassNames to test specific class names.
  *
@@ -194,65 +191,67 @@ public class ExportTaskResourceTest {
 					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME, false)),
 			ObjectDefinitionConstants.SCOPE_COMPANY, _user.getUserId());
 
-		JSONObject jsonObject2 = HTTPTestUtil.invokeToJSONObject(
-			null, _exportTaskEndpoint() + _objectDefinition1.getName(),
-			Http.Method.POST);
+		ExportTaskResource.Builder builder = ExportTaskResource.builder();
 
-		JSONObject jsonObject3 = HTTPTestUtil.invokeToJSONObject(
-			null,
-			"headless-batch-engine/v1.0/export-task/" +
-				jsonObject2.getString("id"),
-			Http.Method.GET);
+		ExportTaskResource exportTaskResource = builder.authentication(
+			"test@liferay.com", "test"
+		).header(
+			HttpHeaders.ACCEPT, ContentTypes.APPLICATION_JSON
+		).build();
 
-		try {
-			JSONAssert.assertEquals(
-				JSONUtil.put(
-					"className", "com.liferay.object.rest.dto.v1_0.ObjectEntry"
-				).put(
-					"errorMessage", ""
-				).put(
-					"executeStatus", "COMPLETED"
-				).toString(),
-				jsonObject3.toString(), JSONCompareMode.LENIENT);
-		}
-		catch (AssertionError error) {
-			Assert.fail(jsonObject3.getString("errorMessage"));
-		}
+		ExportTask exportTask1 = exportTaskResource.postExportTask(
+			"com.liferay.object.rest.dto.v1_0.ObjectEntry", "json", null, null,
+			null, _objectDefinition1.getName());
 
-		HTTPTestUtil.customize(
-		).withBaseURL(
-			"http://www.able.com:8080"
-		).withCredentials(
-			"test@able.com", "test"
-		).apply(
-			() -> {
-				JSONObject jsonObject4 = HTTPTestUtil.invokeToJSONObject(
-					null, _exportTaskEndpoint() + _objectDefinition2.getName(),
-					Http.Method.POST);
+		String externalReferenceCode1 = exportTask1.getExternalReferenceCode();
 
-				JSONObject jsonObject5 = HTTPTestUtil.invokeToJSONObject(
-					null,
-					"headless-batch-engine/v1.0/export-task/" +
-						jsonObject4.getString("id"),
-					Http.Method.GET);
+		while (true) {
+			exportTask1 =
+				exportTaskResource.getExportTaskByExternalReferenceCode(
+					externalReferenceCode1);
 
-				try {
-					JSONAssert.assertEquals(
-						JSONUtil.put(
-							"className",
-							"com.liferay.object.rest.dto.v1_0.ObjectEntry"
-						).put(
-							"errorMessage", ""
-						).put(
-							"executeStatus", "COMPLETED"
-						).toString(),
-						jsonObject5.toString(), JSONCompareMode.LENIENT);
-				}
-				catch (AssertionError error) {
-					Assert.fail(jsonObject5.getString("errorMessage"));
-				}
+			if (Objects.equals(
+					exportTask1.getExecuteStatusAsString(), "COMPLETED")) {
+
+				break;
 			}
-		);
+			else if (Objects.equals(
+						exportTask1.getExecuteStatusAsString(), "FAILED")) {
+
+				throw new AssertionError(exportTask1.getErrorMessage());
+			}
+		}
+
+		exportTaskResource = builder.authentication(
+			"test@able.com", "test"
+		).endpoint(
+			"www.able.com:8080", "http"
+		).header(
+			HttpHeaders.ACCEPT, ContentTypes.APPLICATION_JSON
+		).build();
+
+		ExportTask exportTask2 = exportTaskResource.postExportTask(
+			"com.liferay.object.rest.dto.v1_0.ObjectEntry", "json", null, null,
+			null, _objectDefinition2.getName());
+
+		String externalReferenceCode2 = exportTask2.getExternalReferenceCode();
+
+		while (true) {
+			exportTask2 =
+				exportTaskResource.getExportTaskByExternalReferenceCode(
+					externalReferenceCode2);
+
+			if (Objects.equals(
+					exportTask2.getExecuteStatusAsString(), "COMPLETED")) {
+
+				break;
+			}
+			else if (Objects.equals(
+						exportTask2.getExecuteStatusAsString(), "FAILED")) {
+
+				throw new AssertionError(exportTask2.getErrorMessage());
+			}
+		}
 	}
 
 	@Test
@@ -280,12 +279,6 @@ public class ExportTaskResourceTest {
 		if (sb.length() > 0) {
 			throw new AssertionError(sb.toString());
 		}
-	}
-
-	private String _exportTaskEndpoint() {
-		return "headless-batch-engine/v1.0/export-task" +
-			"/com.liferay.object.rest.dto.v1_0.ObjectEntry" +
-				"/json?fieldNames=id&taskItemDelegateName=";
 	}
 
 	private void _testPostExportTask(String className) throws Exception {

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -352,8 +352,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 								"openapi.resource", "true"
 							).put(
 								"openapi.resource.key",
-								objectDefinition.getOSGiJaxRsName(
-									"ObjectEntryOpenAPIResource")
+								objectDefinition.getName()
 							).put(
 								"openapi.resource.path",
 								objectDefinition.getRESTContextPath()

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -381,6 +381,10 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 
 							},
 							HashMapDictionaryBuilder.<String, Object>put(
+								"batch.engine.entity.class.name",
+								ObjectEntry.class.getName() + "#" +
+									osgiJaxRsName
+							).put(
 								"batch.engine.task.item.delegate", "true"
 							).put(
 								"batch.engine.task.item.delegate.name",
@@ -416,9 +420,6 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 
 		properties = HashMapDictionaryBuilder.<String, Object>put(
 			"api.version", "v1.0"
-		).put(
-			"batch.engine.entity.class.name",
-			ObjectEntry.class.getName() + "#" + osgiJaxRsName
 		).put(
 			"companyId", companyIds
 		).put(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -383,7 +383,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 							HashMapDictionaryBuilder.<String, Object>put(
 								"batch.engine.entity.class.name",
 								ObjectEntry.class.getName() + "#" +
-									osgiJaxRsName
+									objectDefinition.getName()
 							).put(
 								"batch.engine.task.item.delegate", "true"
 							).put(
@@ -398,7 +398,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 							).put(
 								"entity.class.name",
 								ObjectEntry.class.getName() + "#" +
-									osgiJaxRsName
+									objectDefinition.getName()
 							).build()),
 						_bundleContext.registerService(
 							ObjectRelationshipElementsParser.class,
@@ -424,7 +424,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 			"companyId", companyIds
 		).put(
 			"entity.class.name",
-			ObjectEntry.class.getName() + "#" + osgiJaxRsName
+			ObjectEntry.class.getName() + "#" + objectDefinition.getName()
 		).put(
 			"osgi.jaxrs.application.select",
 			"(osgi.jaxrs.name=" + osgiJaxRsName + ")"

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -359,6 +359,40 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 								objectDefinition.getRESTContextPath()
 							).build()),
 						_bundleContext.registerService(
+							ObjectEntryResource.class,
+							new PrototypeServiceFactory<ObjectEntryResource>() {
+
+								@Override
+								public ObjectEntryResource getService(
+									Bundle bundle,
+									ServiceRegistration<ObjectEntryResource>
+										serviceRegistration) {
+
+									return _createObjectEntryResourceImpl();
+								}
+
+								@Override
+								public void ungetService(
+									Bundle bundle,
+									ServiceRegistration<ObjectEntryResource>
+										serviceRegistration,
+									ObjectEntryResource objectEntryResource) {
+								}
+
+							},
+							HashMapDictionaryBuilder.<String, Object>put(
+								"batch.engine.task.item.delegate", "true"
+							).put(
+								"batch.engine.task.item.delegate.name",
+								objectDefinition.getName()
+							).put(
+								"batch.planner.export.enabled", "true"
+							).put(
+								"batch.planner.import.enabled", "true"
+							).put(
+								"companyId", objectDefinition.getCompanyId()
+							).build()),
+						_bundleContext.registerService(
 							ObjectRelationshipElementsParser.class,
 							new ObjectEntry1toMObjectRelationshipElementsParserImpl(
 								objectDefinition),
@@ -381,14 +415,6 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		).put(
 			"batch.engine.entity.class.name",
 			ObjectEntry.class.getName() + "#" + osgiJaxRsName
-		).put(
-			"batch.engine.task.item.delegate", "true"
-		).put(
-			"batch.engine.task.item.delegate.name", osgiJaxRsName
-		).put(
-			"batch.planner.export.enabled", "true"
-		).put(
-			"batch.planner.import.enabled", "true"
 		).put(
 			"companyId", companyIds
 		).put(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -419,7 +419,8 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 			"companyId", companyIds
 		).put(
 			"entity.class.name",
-			ObjectEntry.class.getName() + "#" + objectDefinition.getName()
+			ObjectEntry.class.getName() + "#" +
+				StringUtil.toLowerCase(objectDefinition.getName())
 		).put(
 			"osgi.jaxrs.application.select",
 			"(osgi.jaxrs.name=" + osgiJaxRsName + ")"
@@ -519,8 +520,13 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 							"api.version", "v1.0"
 						).put(
 							"entity.class.name",
-							ObjectEntry.class.getName() + "#" +
-								objectDefinition.getName()
+							() -> {
+								String lowerCaseName = StringUtil.toLowerCase(
+									objectDefinition.getName());
+
+								return ObjectEntry.class.getName() + "#" +
+									lowerCaseName;
+							}
 						).put(
 							"osgi.jaxrs.application.select",
 							"(osgi.jaxrs.name=" + osgiJaxRsName + ")"

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -394,10 +394,6 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 								"batch.planner.import.enabled", "true"
 							).put(
 								"companyId", objectDefinition.getCompanyId()
-							).put(
-								"entity.class.name",
-								ObjectEntry.class.getName() + "#" +
-									objectDefinition.getName()
 							).build()),
 						_bundleContext.registerService(
 							ObjectRelationshipElementsParser.class,

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -391,6 +391,10 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 								"batch.planner.import.enabled", "true"
 							).put(
 								"companyId", objectDefinition.getCompanyId()
+							).put(
+								"entity.class.name",
+								ObjectEntry.class.getName() + "#" +
+									osgiJaxRsName
 							).build()),
 						_bundleContext.registerService(
 							ObjectRelationshipElementsParser.class,

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/openapi/v1_0/ObjectEntryOpenAPIResourceProviderImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/openapi/v1_0/ObjectEntryOpenAPIResourceProviderImpl.java
@@ -28,8 +28,7 @@ public class ObjectEntryOpenAPIResourceProviderImpl
 		ObjectDefinition objectDefinition) {
 
 		return _scopedServiceTrackerMap.getService(
-			objectDefinition.getCompanyId(),
-			objectDefinition.getOSGiJaxRsName("ObjectEntryOpenAPIResource"));
+			objectDefinition.getCompanyId(), objectDefinition.getName());
 	}
 
 	@Activate

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
@@ -161,7 +161,7 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 		throws Exception {
 
 		vulcanBatchEngineImportTaskResource.setTaskItemDelegateName(
-			_objectDefinition.getOSGiJaxRsName());
+			_objectDefinition.getName());
 
 		return super.deleteObjectEntryBatch(callbackURL, object);
 	}
@@ -310,7 +310,7 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 		throws Exception {
 
 		vulcanBatchEngineExportTaskResource.setTaskItemDelegateName(
-			_objectDefinition.getOSGiJaxRsName());
+			_objectDefinition.getName());
 
 		return super.postObjectEntriesPageExportBatch(
 			search, filter, sorts, callbackURL, contentType, fieldNames);
@@ -334,7 +334,7 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 		throws Exception {
 
 		vulcanBatchEngineImportTaskResource.setTaskItemDelegateName(
-			_objectDefinition.getOSGiJaxRsName());
+			_objectDefinition.getName());
 
 		return super.postObjectEntryBatch(callbackURL, object);
 	}
@@ -436,7 +436,7 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 		throws Exception {
 
 		vulcanBatchEngineImportTaskResource.setTaskItemDelegateName(
-			_objectDefinition.getOSGiJaxRsName());
+			_objectDefinition.getName());
 
 		return super.putObjectEntryBatch(callbackURL, object);
 	}

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/odata/entity/v1_0/test/ObjectEntryEntityModelTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/odata/entity/v1_0/test/ObjectEntryEntityModelTest.java
@@ -287,7 +287,7 @@ public class ObjectEntryEntityModelTest {
 		ObjectEntryResource objectEntryResource = _serviceTrackerMap.getService(
 			StringBundler.concat(
 				ObjectEntry.class.getName(), StringPool.POUND,
-				objectDefinition.getOSGiJaxRsName()));
+				objectDefinition.getName()));
 
 		if (objectEntryResource instanceof EntityModelResource) {
 			Class<?> clazz = objectEntryResource.getClass();

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/odata/entity/v1_0/test/ObjectEntryEntityModelTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/odata/entity/v1_0/test/ObjectEntryEntityModelTest.java
@@ -287,7 +287,7 @@ public class ObjectEntryEntityModelTest {
 		ObjectEntryResource objectEntryResource = _serviceTrackerMap.getService(
 			StringBundler.concat(
 				ObjectEntry.class.getName(), StringPool.POUND,
-				objectDefinition.getName()));
+				StringUtil.toLowerCase(objectDefinition.getName())));
 
 		if (objectEntryResource instanceof EntityModelResource) {
 			Class<?> clazz = objectEntryResource.getClass();

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -6640,7 +6640,8 @@ public class ObjectEntryResourceTest {
 					StringBundler.concat(
 						com.liferay.object.rest.dto.v1_0.ObjectEntry.class.
 							getName(),
-						StringPool.POUND, objectDefinition.getName()));
+						StringPool.POUND,
+						StringUtil.toLowerCase(objectDefinition.getName())));
 
 			objectEntryResource.setContextAcceptLanguage(
 				new AcceptLanguage() {

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -6640,7 +6640,7 @@ public class ObjectEntryResourceTest {
 					StringBundler.concat(
 						com.liferay.object.rest.dto.v1_0.ObjectEntry.class.
 							getName(),
-						StringPool.POUND, objectDefinition.getOSGiJaxRsName()));
+						StringPool.POUND, objectDefinition.getName()));
 
 			objectEntryResource.setContextAcceptLanguage(
 				new AcceptLanguage() {

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/OpenAPIResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/OpenAPIResourceTest.java
@@ -12,6 +12,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.object.constants.ObjectActionExecutorConstants;
 import com.liferay.object.constants.ObjectActionTriggerConstants;
 import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectAction;
@@ -101,7 +102,8 @@ public class OpenAPIResourceTest {
 		_objectDefinition1 = ObjectDefinitionTestUtil.publishObjectDefinition(
 			Collections.singletonList(
 				ObjectFieldUtil.createObjectField(
-					"Text", "String", true, true, null,
+					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+					ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
 					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME, false)));
 	}
 
@@ -179,7 +181,8 @@ public class OpenAPIResourceTest {
 		_objectDefinition2 = ObjectDefinitionTestUtil.publishObjectDefinition(
 			Collections.singletonList(
 				ObjectFieldUtil.createObjectField(
-					"Text", "String", true, true, null,
+					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+					ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
 					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME, false)),
 			ObjectDefinitionConstants.SCOPE_COMPANY, _user.getUserId());
 
@@ -189,7 +192,8 @@ public class OpenAPIResourceTest {
 			ObjectDefinitionTestUtil.publishObjectDefinition(
 				Collections.singletonList(
 					ObjectFieldUtil.createObjectField(
-						"Text", "String", true, true, null,
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
 						RandomTestUtil.randomString(), _OBJECT_FIELD_NAME,
 						false)),
 				ObjectDefinitionConstants.SCOPE_SITE);
@@ -232,7 +236,8 @@ public class OpenAPIResourceTest {
 			"A" + StringUtil.toLowerCase(randomString),
 			Collections.singletonList(
 				ObjectFieldUtil.createObjectField(
-					"Text", "String", true, true, null,
+					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+					ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
 					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME, false)),
 			ObjectDefinitionConstants.SCOPE_COMPANY,
 			TestPropsValues.getUserId());
@@ -241,7 +246,8 @@ public class OpenAPIResourceTest {
 			"A" + StringUtil.toUpperCase(randomString),
 			Collections.singletonList(
 				ObjectFieldUtil.createObjectField(
-					"Text", "String", true, true, null,
+					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+					ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
 					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME, false)),
 			ObjectDefinitionConstants.SCOPE_COMPANY, _user.getUserId());
 
@@ -477,7 +483,8 @@ public class OpenAPIResourceTest {
 		_objectDefinition2 = ObjectDefinitionTestUtil.publishObjectDefinition(
 			Collections.singletonList(
 				ObjectFieldUtil.createObjectField(
-					"Text", "String", true, true, null,
+					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+					ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
 					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME, false)));
 
 		ObjectRelationship objectRelationship =
@@ -517,18 +524,20 @@ public class OpenAPIResourceTest {
 				ObjectDefinitionTestUtil.publishObjectDefinition(
 					Collections.singletonList(
 						ObjectFieldUtil.createObjectField(
-							"Text", "String", true, true, null,
-							RandomTestUtil.randomString(), _OBJECT_FIELD_NAME,
-							false)));
+							ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+							ObjectFieldConstants.DB_TYPE_STRING, true, true,
+							null, RandomTestUtil.randomString(),
+							_OBJECT_FIELD_NAME, false)));
 		}
 		else {
 			_objectDefinition2 =
 				ObjectDefinitionTestUtil.addCustomObjectDefinition(
 					Collections.singletonList(
 						ObjectFieldUtil.createObjectField(
-							"Text", "String", true, true, null,
-							RandomTestUtil.randomString(), _OBJECT_FIELD_NAME,
-							false)));
+							ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+							ObjectFieldConstants.DB_TYPE_STRING, true, true,
+							null, RandomTestUtil.randomString(),
+							_OBJECT_FIELD_NAME, false)));
 		}
 
 		ObjectRelationship objectRelationship =

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/OpenAPIResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/OpenAPIResourceTest.java
@@ -57,7 +57,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -259,7 +258,6 @@ public class OpenAPIResourceTest {
 		);
 	}
 
-	@Ignore
 	@Test
 	public void testGetOpenAPIWithCategorizationDisabled() throws Exception {
 		_objectDefinition1.setEnableCategorization(false);

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/OpenAPIResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/OpenAPIResourceTest.java
@@ -30,23 +30,16 @@ import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Company;
-import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
-import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
-import com.liferay.portal.kernel.test.randomizerbumpers.NumericStringRandomizerBumper;
-import com.liferay.portal.kernel.test.randomizerbumpers.UniqueStringRandomizerBumper;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.Http;
-import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.test.rule.FeatureFlags;
@@ -214,20 +207,6 @@ public class OpenAPIResourceTest {
 
 	@Test
 	public void testGetOpenAPIMultipleCompanies() throws Exception {
-		User user = UserTestUtil.getAdminUser(_company.getCompanyId());
-
-		Group group = GroupLocalServiceUtil.getGroup(
-			_company.getCompanyId(), GroupConstants.GUEST);
-
-		_user = UserTestUtil.addUser(
-			_company.getCompanyId(), user.getUserId(),
-			RandomTestUtil.randomString(
-				NumericStringRandomizerBumper.INSTANCE,
-				UniqueStringRandomizerBumper.INSTANCE),
-			LocaleUtil.getDefault(), RandomTestUtil.randomString(),
-			RandomTestUtil.randomString(), new long[] {group.getGroupId()},
-			ServiceContextTestUtil.getServiceContext());
-
 		String randomString = RandomTestUtil.randomString() + "abc";
 
 		_objectDefinition1 = ObjectDefinitionTestUtil.publishObjectDefinition(
@@ -239,6 +218,8 @@ public class OpenAPIResourceTest {
 					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME, false)),
 			ObjectDefinitionConstants.SCOPE_COMPANY,
 			TestPropsValues.getUserId());
+
+		_user = UserTestUtil.addUser(_company);
 
 		_objectDefinition2 = ObjectDefinitionTestUtil.publishObjectDefinition(
 			"A" + StringUtil.toUpperCase(randomString),

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/OpenAPIResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/OpenAPIResourceTest.java
@@ -40,7 +40,6 @@ import com.liferay.portal.kernel.test.randomizerbumpers.NumericStringRandomizerB
 import com.liferay.portal.kernel.test.randomizerbumpers.UniqueStringRandomizerBumper;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
-import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -83,7 +82,19 @@ public class OpenAPIResourceTest {
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {
-		_company = CompanyTestUtil.addCompany(true);
+		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				"domain", "able.com"
+			).put(
+				"portalInstanceId", "able.com"
+			).put(
+				"virtualHost", "www.able.com"
+			).toString(),
+			"headless-portal-instances/v1.0/portal-instances",
+			Http.Method.POST);
+
+		_company = _companyLocalService.getCompany(
+			jsonObject.getLong("companyId"));
 
 		_originalName = PrincipalThreadLocal.getName();
 
@@ -203,26 +214,13 @@ public class OpenAPIResourceTest {
 
 	@Test
 	public void testGetOpenAPIMultipleCompanies() throws Exception {
-		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
-			JSONUtil.put(
-				"domain", "able.com"
-			).put(
-				"portalInstanceId", "able.com"
-			).put(
-				"virtualHost", "www.able.com"
-			).toString(),
-			"headless-portal-instances/v1.0/portal-instances",
-			Http.Method.POST);
-
-		long companyId = (long)jsonObject.get("companyId");
-
-		User user = UserTestUtil.getAdminUser(companyId);
+		User user = UserTestUtil.getAdminUser(_company.getCompanyId());
 
 		Group group = GroupLocalServiceUtil.getGroup(
-			companyId, GroupConstants.GUEST);
+			_company.getCompanyId(), GroupConstants.GUEST);
 
 		_user = UserTestUtil.addUser(
-			companyId, user.getUserId(),
+			_company.getCompanyId(), user.getUserId(),
 			RandomTestUtil.randomString(
 				NumericStringRandomizerBumper.INSTANCE,
 				UniqueStringRandomizerBumper.INSTANCE),

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/OpenAPIResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/OpenAPIResourceTest.java
@@ -27,18 +27,26 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.test.randomizerbumpers.NumericStringRandomizerBumper;
+import com.liferay.portal.kernel.test.randomizerbumpers.UniqueStringRandomizerBumper;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.test.rule.FeatureFlags;
@@ -187,6 +195,83 @@ public class OpenAPIResourceTest {
 				ObjectDefinitionConstants.SCOPE_SITE);
 
 		_testGetOpenAPI(_siteScopedObjectDefinition, _objectDefinition2);
+	}
+
+	@Test
+	public void testGetOpenAPIMultipleCompanies() throws Exception {
+		String objectDefinitionName = RandomTestUtil.randomString() + "abc";
+
+		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				"domain", "able.com"
+			).put(
+				"portalInstanceId", "able.com"
+			).put(
+				"virtualHost", "www.able.com"
+			).toString(),
+			"headless-portal-instances/v1.0/portal-instances",
+			Http.Method.POST);
+
+		long companyId = (long)jsonObject.get("companyId");
+
+		User user = UserTestUtil.getAdminUser(companyId);
+
+		Group group = GroupLocalServiceUtil.getGroup(
+			companyId, GroupConstants.GUEST);
+
+		_user = UserTestUtil.addUser(
+			companyId, user.getUserId(),
+			RandomTestUtil.randomString(
+				NumericStringRandomizerBumper.INSTANCE,
+				UniqueStringRandomizerBumper.INSTANCE),
+			LocaleUtil.getDefault(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), new long[] {group.getGroupId()},
+			ServiceContextTestUtil.getServiceContext());
+
+		_objectDefinition1 = ObjectDefinitionTestUtil.publishObjectDefinition(
+			"A" + StringUtil.toLowerCase(objectDefinitionName),
+			Collections.singletonList(
+				ObjectFieldUtil.createObjectField(
+					"Text", "String", true, true, null,
+					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME, false)),
+			ObjectDefinitionConstants.SCOPE_COMPANY,
+			TestPropsValues.getUserId());
+
+		_objectDefinition2 = ObjectDefinitionTestUtil.publishObjectDefinition(
+			"A" + StringUtil.toUpperCase(objectDefinitionName),
+			Collections.singletonList(
+				ObjectFieldUtil.createObjectField(
+					"Text", "String", true, true, null,
+					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME, false)),
+			ObjectDefinitionConstants.SCOPE_COMPANY, _user.getUserId());
+
+		HTTPTestUtil.customize(
+		).withBaseURL(
+			"http://www.able.com:8080"
+		).withCredentials(
+			"test@able.com", "test"
+		).apply(
+			() -> {
+				Assert.assertEquals(
+					200,
+					HTTPTestUtil.invokeToHttpCode(
+						null, _objectDefinition2.getRESTContextPath(),
+						Http.Method.GET));
+
+				JSONObject openAPIJSONObject = HTTPTestUtil.invokeToJSONObject(
+					null, "/openapi", Http.Method.GET);
+
+				JSONArray jsonArray = openAPIJSONObject.getJSONArray(
+					_objectDefinition2.getRESTContextPath());
+
+				Assert.assertEquals(1, jsonArray.length());
+				Assert.assertEquals(
+					"http://www.able.com:8080/o" +
+						_objectDefinition2.getRESTContextPath() +
+							"/openapi.yaml",
+					jsonArray.get(0));
+			}
+		);
 	}
 
 	@Ignore

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/OpenAPIResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/OpenAPIResourceTest.java
@@ -199,8 +199,6 @@ public class OpenAPIResourceTest {
 
 	@Test
 	public void testGetOpenAPIMultipleCompanies() throws Exception {
-		String objectDefinitionName = RandomTestUtil.randomString() + "abc";
-
 		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
 			JSONUtil.put(
 				"domain", "able.com"
@@ -228,8 +226,10 @@ public class OpenAPIResourceTest {
 			RandomTestUtil.randomString(), new long[] {group.getGroupId()},
 			ServiceContextTestUtil.getServiceContext());
 
+		String randomString = RandomTestUtil.randomString() + "abc";
+
 		_objectDefinition1 = ObjectDefinitionTestUtil.publishObjectDefinition(
-			"A" + StringUtil.toLowerCase(objectDefinitionName),
+			"A" + StringUtil.toLowerCase(randomString),
 			Collections.singletonList(
 				ObjectFieldUtil.createObjectField(
 					"Text", "String", true, true, null,
@@ -238,7 +238,7 @@ public class OpenAPIResourceTest {
 			TestPropsValues.getUserId());
 
 		_objectDefinition2 = ObjectDefinitionTestUtil.publishObjectDefinition(
-			"A" + StringUtil.toUpperCase(objectDefinitionName),
+			"A" + StringUtil.toUpperCase(randomString),
 			Collections.singletonList(
 				ObjectFieldUtil.createObjectField(
 					"Text", "String", true, true, null,

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectDefinitionImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectDefinitionImpl.java
@@ -94,7 +94,7 @@ public class ObjectDefinitionImpl extends ObjectDefinitionBaseImpl {
 
 	@Override
 	public String getOSGiJaxRsName(String className) {
-		return getName() + className;
+		return StringUtil.toLowerCase(getName()) + className;
 	}
 
 	@Override

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectActionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectActionLocalServiceTest.java
@@ -2006,7 +2006,8 @@ public class ObjectActionLocalServiceTest {
 					StringBundler.concat(
 						com.liferay.object.rest.dto.v1_0.ObjectEntry.class.
 							getName(),
-						StringPool.POUND, _objectDefinition.getName()));
+						StringPool.POUND,
+						StringUtil.toLowerCase(_objectDefinition.getName())));
 
 			objectEntryResource.setContextAcceptLanguage(
 				new AcceptLanguage() {

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectActionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectActionLocalServiceTest.java
@@ -2006,8 +2006,7 @@ public class ObjectActionLocalServiceTest {
 					StringBundler.concat(
 						com.liferay.object.rest.dto.v1_0.ObjectEntry.class.
 							getName(),
-						StringPool.POUND,
-						_objectDefinition.getOSGiJaxRsName()));
+						StringPool.POUND, _objectDefinition.getName()));
 
 			objectEntryResource.setContextAcceptLanguage(
 				new AcceptLanguage() {

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/batch/engine/VulcanBatchEngineTaskItemDelegateRegistryImpl.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/batch/engine/VulcanBatchEngineTaskItemDelegateRegistryImpl.java
@@ -161,7 +161,7 @@ public class VulcanBatchEngineTaskItemDelegateRegistryImpl
 				serviceReference.getProperty("batch.planner.import.enabled"));
 			List<String> companyIdStrings = _companyIdStrings(serviceReference);
 			String entityClassName = (String)serviceReference.getProperty(
-				"entity.class.name");
+				"batch.engine.entity.class.name");
 			VulcanBatchEngineTaskItemDelegate<?>
 				vulcanBatchEngineTaskItemDelegate = _bundleContext.getService(
 					serviceReference);
@@ -236,7 +236,7 @@ public class VulcanBatchEngineTaskItemDelegateRegistryImpl
 			}
 
 			String entityClassName = (String)serviceReference.getProperty(
-				"entity.class.name");
+				"batch.engine.entity.class.name");
 
 			for (Map.Entry<Long, Map<String, Boolean>> entry :
 					_companyScopedBatchPlannerExportEnabledsMap.entrySet()) {
@@ -295,7 +295,7 @@ public class VulcanBatchEngineTaskItemDelegateRegistryImpl
 			List<String> companyIdStrings = _companyIdStrings(serviceReference);
 
 			String entityClassName = (String)serviceReference.getProperty(
-				"entity.class.name");
+				"batch.engine.entity.class.name");
 
 			if (companyIdStrings == null) {
 				_batchPlannerExportEnableds.remove(entityClassName);

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/batch/engine/VulcanBatchEngineTaskItemDelegateRegistryImpl.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/batch/engine/VulcanBatchEngineTaskItemDelegateRegistryImpl.java
@@ -9,6 +9,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegateRegistry;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -158,8 +159,7 @@ public class VulcanBatchEngineTaskItemDelegateRegistryImpl
 				serviceReference.getProperty("batch.planner.export.enabled"));
 			boolean batchPlannerImportEnabled = GetterUtil.getBoolean(
 				serviceReference.getProperty("batch.planner.import.enabled"));
-			List<String> companyIdStrings = (List)serviceReference.getProperty(
-				"companyId");
+			List<String> companyIdStrings = _companyIdStrings(serviceReference);
 			String entityClassName = (String)serviceReference.getProperty(
 				"entity.class.name");
 			VulcanBatchEngineTaskItemDelegate<?>
@@ -229,8 +229,7 @@ public class VulcanBatchEngineTaskItemDelegateRegistryImpl
 			VulcanBatchEngineTaskItemDelegate<?>
 				vulcanBatchEngineTaskItemDelegate) {
 
-			List<String> companyIdStrings = (List)serviceReference.getProperty(
-				"companyId");
+			List<String> companyIdStrings = _companyIdStrings(serviceReference);
 
 			if (companyIdStrings == null) {
 				return;
@@ -293,8 +292,8 @@ public class VulcanBatchEngineTaskItemDelegateRegistryImpl
 			VulcanBatchEngineTaskItemDelegate<?>
 				vulcanBatchEngineTaskItemDelegate) {
 
-			List<String> companyIdStrings = (List)serviceReference.getProperty(
-				"companyId");
+			List<String> companyIdStrings = _companyIdStrings(serviceReference);
+
 			String entityClassName = (String)serviceReference.getProperty(
 				"entity.class.name");
 
@@ -336,6 +335,21 @@ public class VulcanBatchEngineTaskItemDelegateRegistryImpl
 			BundleContext bundleContext) {
 
 			_bundleContext = bundleContext;
+		}
+
+		private List<String> _companyIdStrings(
+			ServiceReference<?> serviceReference) {
+
+			Object companyIdObject = serviceReference.getProperty("companyId");
+
+			if (companyIdObject == null) {
+				return null;
+			}
+			else if (companyIdObject instanceof List) {
+				return (List<String>)companyIdObject;
+			}
+
+			return Collections.singletonList(String.valueOf(companyIdObject));
 		}
 
 		private final BundleContext _bundleContext;

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/batch/engine/test/VulcanBatchEngineTaskItemDelegateRegistryTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/batch/engine/test/VulcanBatchEngineTaskItemDelegateRegistryTest.java
@@ -332,6 +332,9 @@ public class VulcanBatchEngineTaskItemDelegateRegistryTest {
 			VulcanBatchEngineTaskItemDelegate.class,
 			new TestVulcanBatchEngineTaskItemDelegate(),
 			HashMapDictionaryBuilder.<String, Object>put(
+				"batch.engine.entity.class.name",
+				TestVulcanBatchEngineTaskItemDelegate.class.getName()
+			).put(
 				"batch.engine.task.item.delegate", "true"
 			).put(
 				"batch.planner.export.enabled", String.valueOf(exportEnabled)
@@ -346,9 +349,6 @@ public class VulcanBatchEngineTaskItemDelegateRegistryTest {
 
 					return null;
 				}
-			).put(
-				"entity.class.name",
-				TestVulcanBatchEngineTaskItemDelegate.class.getName()
 			).build());
 	}
 


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPD-15236

See https://github.com/brianchandotcom/liferay-portal/pull/146979

---

The purpose of this ticket is to fix the bug of the related ticket. In order to reproduce the bug, please, see the related ticket.

In this PR, we have performed the following changes:

- The `ObjectDefinitionImpl.getOSGiJaxRsName` method has been updated to use the lowercase name instead of just the name. This has been done because, as two objects with similar names (for example `Test` and `test`) shares the same JAX-RS Application path (`/c/tests`), we need to set the JAX-RS related properties also considering the lowercase keys.
- As Batch Engine needs a taskItemDelegateName property to identify which object definition is importable/exportable, we have updated the `ObjectDefinitionDeployerImpl` class of the Objects REST API IMPL module to deploy one `VulcanBatchEngineTaskItemDelegate` implementation (that is: ObjectEntryResourceImpl) for each Object Definition, with the properties such as the companyId and the object definition name to avoid confussions with other objects with similar name in different companies.
- Update the usages of the `getOSGiJaxRsName` method to avoid using it if it is not JAX- RS related.
- Update the usages of the properties `entity.class.name` and `batch.engine.entity.class.name` to use them when it applies