### PR TITLE
LPD-17470: Set taskItemDelegateName as configuration property in JSONT external Type

### DIFF
--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineExportTaskExecutorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineExportTaskExecutorImpl.java
@@ -227,6 +227,8 @@ public class BatchEngineExportTaskExecutorImpl
 					batchEngineTaskContentType, unsyncByteArrayOutputStream)
 			).parameters(
 				parameters
+			).taskItemDelegateName(
+				batchEngineExportTask.getTaskItemDelegateName()
 			).userId(
 				batchEngineExportTask.getUserId()
 			).build();
@@ -261,10 +263,6 @@ public class BatchEngineExportTaskExecutorImpl
 		if (parameters == null) {
 			parameters = new HashMap<>();
 		}
-
-		parameters.computeIfAbsent(
-			"taskItemDelegateName",
-			key -> batchEngineExportTask.getTaskItemDelegateName());
 
 		return parameters;
 	}

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineImportTaskExecutorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineImportTaskExecutorImpl.java
@@ -242,10 +242,6 @@ public class BatchEngineImportTaskExecutorImpl
 			parameters = new HashMap<>();
 		}
 
-		parameters.computeIfAbsent(
-			"taskItemDelegateName",
-			key -> batchEngineImportTask.getTaskItemDelegateName());
-
 		return parameters;
 	}
 
@@ -296,6 +292,7 @@ public class BatchEngineImportTaskExecutorImpl
 						_companyLocalService.getCompany(
 							batchEngineImportTask.getCompanyId()),
 						parameters,
+						batchEngineImportTask.getTaskItemDelegateName(),
 						_userLocalService.getUser(
 							batchEngineImportTask.getUserId()));
 

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineImportTaskExecutorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineImportTaskExecutorImpl.java
@@ -292,7 +292,6 @@ public class BatchEngineImportTaskExecutorImpl
 						_companyLocalService.getCompany(
 							batchEngineImportTask.getCompanyId()),
 						parameters,
-						batchEngineImportTask.getTaskItemDelegateName(),
 						_userLocalService.getUser(
 							batchEngineImportTask.getUserId()));
 

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/item/BatchEngineTaskItemDelegateExecutor.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/item/BatchEngineTaskItemDelegateExecutor.java
@@ -15,7 +15,6 @@ import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
-import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -44,7 +43,7 @@ public class BatchEngineTaskItemDelegateExecutor {
 		BatchEngineTaskItemDelegate<?> batchEngineTaskItemDelegate,
 		Company company, ExpressionConvert<Filter> expressionConvert,
 		FilterParserProvider filterParserProvider,
-		Map<String, Serializable> parameters, String taskItemDelegateName,
+		Map<String, Serializable> parameters,
 		SortParserProvider sortParserProvider, User user) {
 
 		_batchEngineTaskItemDelegate =
@@ -52,11 +51,7 @@ public class BatchEngineTaskItemDelegateExecutor {
 		_company = company;
 		_expressionConvert = expressionConvert;
 		_filterParserProvider = filterParserProvider;
-		_parameters = HashMapBuilder.create(
-			parameters
-		).put(
-			"taskItemDelegateName", taskItemDelegateName
-		).build();
+		_parameters = parameters;
 		_sortParserProvider = sortParserProvider;
 		_user = user;
 	}

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/item/BatchEngineTaskItemDelegateExecutor.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/item/BatchEngineTaskItemDelegateExecutor.java
@@ -15,6 +15,7 @@ import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -43,7 +44,7 @@ public class BatchEngineTaskItemDelegateExecutor {
 		BatchEngineTaskItemDelegate<?> batchEngineTaskItemDelegate,
 		Company company, ExpressionConvert<Filter> expressionConvert,
 		FilterParserProvider filterParserProvider,
-		Map<String, Serializable> parameters,
+		Map<String, Serializable> parameters, String taskItemDelegateName,
 		SortParserProvider sortParserProvider, User user) {
 
 		_batchEngineTaskItemDelegate =
@@ -51,7 +52,11 @@ public class BatchEngineTaskItemDelegateExecutor {
 		_company = company;
 		_expressionConvert = expressionConvert;
 		_filterParserProvider = filterParserProvider;
-		_parameters = parameters;
+		_parameters = HashMapBuilder.create(
+			parameters
+		).put(
+			"taskItemDelegateName", taskItemDelegateName
+		).build();
 		_sortParserProvider = sortParserProvider;
 		_user = user;
 	}

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/item/BatchEngineTaskItemDelegateExecutorFactory.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/item/BatchEngineTaskItemDelegateExecutorFactory.java
@@ -38,13 +38,11 @@ public class BatchEngineTaskItemDelegateExecutorFactory {
 
 	public BatchEngineTaskItemDelegateExecutor create(
 		BatchEngineTaskItemDelegate<?> batchEngineTaskItemDelegate,
-		Company company, Map<String, Serializable> parameters,
-		String taskItemDelegateName, User user) {
+		Company company, Map<String, Serializable> parameters, User user) {
 
 		return new BatchEngineTaskItemDelegateExecutor(
 			batchEngineTaskItemDelegate, company, _expressionConvert,
-			_filterParserProvider, parameters, taskItemDelegateName,
-			_sortParserProvider, user);
+			_filterParserProvider, parameters, _sortParserProvider, user);
 	}
 
 	public BatchEngineTaskItemDelegateExecutor create(
@@ -62,9 +60,7 @@ public class BatchEngineTaskItemDelegateExecutorFactory {
 					className);
 		}
 
-		return create(
-			batchEngineTaskItemDelegate, company, parameters,
-			taskItemDelegateName, user);
+		return create(batchEngineTaskItemDelegate, company, parameters, user);
 	}
 
 	private final BatchEngineTaskItemDelegateRegistry

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/item/BatchEngineTaskItemDelegateExecutorFactory.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/item/BatchEngineTaskItemDelegateExecutorFactory.java
@@ -38,11 +38,13 @@ public class BatchEngineTaskItemDelegateExecutorFactory {
 
 	public BatchEngineTaskItemDelegateExecutor create(
 		BatchEngineTaskItemDelegate<?> batchEngineTaskItemDelegate,
-		Company company, Map<String, Serializable> parameters, User user) {
+		Company company, Map<String, Serializable> parameters,
+		String taskItemDelegateName, User user) {
 
 		return new BatchEngineTaskItemDelegateExecutor(
 			batchEngineTaskItemDelegate, company, _expressionConvert,
-			_filterParserProvider, parameters, _sortParserProvider, user);
+			_filterParserProvider, parameters, taskItemDelegateName,
+			_sortParserProvider, user);
 	}
 
 	public BatchEngineTaskItemDelegateExecutor create(
@@ -60,7 +62,9 @@ public class BatchEngineTaskItemDelegateExecutorFactory {
 					className);
 		}
 
-		return create(batchEngineTaskItemDelegate, company, parameters, user);
+		return create(
+			batchEngineTaskItemDelegate, company, parameters,
+			taskItemDelegateName, user);
 	}
 
 	private final BatchEngineTaskItemDelegateRegistry

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/writer/BatchEngineExportTaskItemWriterBuilder.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/writer/BatchEngineExportTaskItemWriterBuilder.java
@@ -77,6 +77,8 @@ public class BatchEngineExportTaskItemWriterBuilder {
 			_parameters.computeIfAbsent("updateStrategy", key -> "UPDATE");
 
 			batchEngineUnitConfiguration.setParameters(_parameters);
+			batchEngineUnitConfiguration.setTaskItemDelegateName(
+				_taskItemDelegateName);
 			batchEngineUnitConfiguration.setUserId(_userId);
 			batchEngineUnitConfiguration.setVersion("v1.0");
 
@@ -135,6 +137,14 @@ public class BatchEngineExportTaskItemWriterBuilder {
 		return this;
 	}
 
+	public BatchEngineExportTaskItemWriterBuilder taskItemDelegateName(
+		String taskItemDelegateName) {
+
+		_taskItemDelegateName = taskItemDelegateName;
+
+		return this;
+	}
+
 	public BatchEngineExportTaskItemWriterBuilder userId(long userId) {
 		_userId = userId;
 
@@ -148,6 +158,7 @@ public class BatchEngineExportTaskItemWriterBuilder {
 	private Class<?> _itemClass;
 	private OutputStream _outputStream;
 	private Map<String, Serializable> _parameters;
+	private String _taskItemDelegateName;
 	private long _userId;
 
 }

--- a/modules/apps/batch-engine/batch-engine-test/src/testFunctional/tests/dependencies/blogPostingJsonT/blogPostingJsonT.json
+++ b/modules/apps/batch-engine/batch-engine-test/src/testFunctional/tests/dependencies/blogPostingJsonT/blogPostingJsonT.json
@@ -14,9 +14,9 @@
 			"createStrategy": "INSERT",
 			"importStrategy": "ON_ERROR_FAIL",
 			"siteId": "20119",
-			"taskItemDelegateName": "DEFAULT",
 			"updateStrategy": "UPDATE"
 		},
+		"taskItemDelegateName": "DEFAULT",
 		"userId": 20123,
 		"version": "v1.0"
 	},

--- a/modules/apps/batch-planner/batch-planner-test/src/testIntegration/java/com/liferay/batch/planner/batch/engine/broker/test/BatchEngineBrokerTest.java
+++ b/modules/apps/batch-planner/batch-planner-test/src/testIntegration/java/com/liferay/batch/planner/batch/engine/broker/test/BatchEngineBrokerTest.java
@@ -303,10 +303,8 @@ public class BatchEngineBrokerTest {
 		Company company = _companyLocalService.getCompany(
 			TestPropsValues.getCompanyId());
 
-		Group globalGroup = company.getGroup();
-
 		_testExportSiteScopeObjectEntryJSONT(
-			globalGroup.getGroupId(), _OBJECT_ENTRY_ERC_2);
+			company.getGroupId(), _OBJECT_ENTRY_ERC_2);
 
 		// New group
 

--- a/modules/apps/batch-planner/batch-planner-test/src/testIntegration/java/com/liferay/batch/planner/batch/engine/broker/test/BatchEngineBrokerTest.java
+++ b/modules/apps/batch-planner/batch-planner-test/src/testIntegration/java/com/liferay/batch/planner/batch/engine/broker/test/BatchEngineBrokerTest.java
@@ -228,12 +228,52 @@ public class BatchEngineBrokerTest {
 	}
 
 	@Test
+	public void testExportCompanyScopeObjectEntryJSONT() throws Exception {
+		_objectDefinition1 = _publishObjectDefinition(
+			TestPropsValues.getCompanyId(), "TestObjectJSONT",
+			ObjectDefinitionConstants.SCOPE_COMPANY, TestPropsValues.getUser());
+
+		ObjectEntry objectEntry = _addObjectEntry(
+			TestPropsValues.getCompanyId(), RandomTestUtil.randomString(),
+			TestPropsValues.getGroupId(), _objectDefinition1,
+			TestPropsValues.getUserId());
+
+		_addObjectEntryInDifferentCompany("TestObjectJSONT");
+
+		_objectMapper.setFilterProvider(
+			new SimpleFilterProvider() {
+				{
+					addFilter(
+						"Liferay.Vulcan",
+						VulcanPropertyFilter.of(
+							new HashSet<>(_objectEntryExportFieldNames), null));
+				}
+			});
+
+		JsonNode jsonNode = _objectMapper.readTree(
+			_getExportFileString(
+				true, BatchPlannerPlanConstants.EXTERNAL_TYPE_JSONT,
+				_objectEntryExportFieldNames, null,
+				"com.liferay.object.rest.dto.v1_0.ObjectEntry",
+				"C_TestObjectJSONT"));
+
+		_assertEqualsExport(
+			_getExpectedJsonNode(
+				_objectDefinition1, objectEntry.getObjectEntryId()),
+			_objectEntryExportFieldNames,
+			_getFirstJsonNode(jsonNode.get("items")));
+
+		_assertJSONTConfiguration(
+			jsonNode.get("configuration"), _objectDefinition1.getName());
+	}
+
+	@Test
 	public void testExportObjectDefinitionCSV() throws Exception {
 		_setUpObjectDefinition("TestObjectCSV");
 
 		_assertEqualsExportCSV(
 			_getExportFileString(
-				BatchPlannerPlanConstants.EXTERNAL_TYPE_CSV,
+				false, BatchPlannerPlanConstants.EXTERNAL_TYPE_CSV,
 				_objectDefinitionExportCSVFieldNames, null,
 				"com.liferay.object.admin.rest.dto.v1_0.ObjectDefinition",
 				null),
@@ -244,6 +284,34 @@ public class BatchEngineBrokerTest {
 				_objectDefinition1.getModifiedDate()),
 			_objectDefinition1.getExternalReferenceCode(),
 			_objectDefinitionExportCSVFieldNames);
+	}
+
+	@Test
+	public void testExportSiteScopeObjectEntryJSONT() throws Exception {
+
+		// Default group
+
+		_objectDefinition1 = _publishObjectDefinition(
+			TestPropsValues.getCompanyId(), "TestObjectJSONT",
+			ObjectDefinitionConstants.SCOPE_SITE, TestPropsValues.getUser());
+
+		_testExportSiteScopeObjectEntryJSONT(
+			TestPropsValues.getGroupId(), _OBJECT_ENTRY_ERC_1);
+
+		// Global group
+
+		Company company = _companyLocalService.getCompany(
+			TestPropsValues.getCompanyId());
+
+		Group globalGroup = company.getGroup();
+
+		_testExportSiteScopeObjectEntryJSONT(
+			globalGroup.getGroupId(), _OBJECT_ENTRY_ERC_2);
+
+		// New group
+
+		_testExportSiteScopeObjectEntryJSONT(
+			_group.getGroupId(), _OBJECT_ENTRY_ERC_3);
 	}
 
 	@Test
@@ -274,7 +342,7 @@ public class BatchEngineBrokerTest {
 
 		_assertEqualsExportCSV(
 			_getExportFileString(
-				BatchPlannerPlanConstants.EXTERNAL_TYPE_CSV,
+				false, BatchPlannerPlanConstants.EXTERNAL_TYPE_CSV,
 				_objectEntryExportCSVFieldNames, null,
 				"com.liferay.object.rest.dto.v1_0.ObjectEntry",
 				"C_TestObjectCSV"),
@@ -329,7 +397,7 @@ public class BatchEngineBrokerTest {
 				_getFirstJsonNode(
 					_objectMapper.readTree(
 						_getExportFileString(
-							BatchPlannerPlanConstants.EXTERNAL_TYPE_JSON,
+							false, BatchPlannerPlanConstants.EXTERNAL_TYPE_JSON,
 							_objectEntryExportFieldNames, null,
 							"com.liferay.object.rest.dto.v1_0.ObjectEntry",
 							"C_TestObject"))));
@@ -381,7 +449,7 @@ public class BatchEngineBrokerTest {
 				_getFirstJsonNode(
 					_objectMapper.readTree(
 						_getExportFileString(
-							BatchPlannerPlanConstants.EXTERNAL_TYPE_JSON,
+							false, BatchPlannerPlanConstants.EXTERNAL_TYPE_JSON,
 							_objectDefinitionExportFieldNames, null,
 							"com.liferay.object.admin.rest.dto.v1_0." +
 								"ObjectDefinition",
@@ -657,6 +725,20 @@ public class BatchEngineBrokerTest {
 			found);
 	}
 
+	private void _assertJSONTConfiguration(
+		JsonNode jsonNode, String objectDefinitionName) {
+
+		JsonNode parametersJsonNode = jsonNode.get("parameters");
+
+		Assert.assertFalse(parametersJsonNode.has("taskItemDelegateName"));
+
+		Assert.assertEquals(
+			objectDefinitionName,
+			jsonNode.get(
+				"taskItemDelegateName"
+			).asText());
+	}
+
 	private File _createImportFile(
 			Date createDate, String externalReferenceCode, String fileName,
 			Long groupId, long id, Date modifiedDate)
@@ -798,6 +880,15 @@ public class BatchEngineBrokerTest {
 				_ENCLOSING_CHARACTER_VALUE);
 		}
 
+		if (Objects.equals(
+				externalType, BatchPlannerPlanConstants.EXTERNAL_TYPE_JSONT)) {
+
+			_batchPlannerPolicyLocalService.addBatchPlannerPolicy(
+				TestPropsValues.getUserId(),
+				batchPlannerPlan.getBatchPlannerPlanId(), "containsHeaders",
+				"true");
+		}
+
 		if (Validator.isNotNull(groupId)) {
 			_batchPlannerPolicyLocalService.addBatchPlannerPolicy(
 				TestPropsValues.getUserId(),
@@ -876,8 +967,9 @@ public class BatchEngineBrokerTest {
 	}
 
 	private String _getExportFileString(
-			String externalType, List<String> fieldNames, Long groupId,
-			String internalClassName, String taskItemDelegateName)
+			boolean containsHeaders, String externalType,
+			List<String> fieldNames, Long groupId, String internalClassName,
+			String taskItemDelegateName)
 		throws Exception {
 
 		BatchPlannerPlan batchPlannerPlan =
@@ -891,6 +983,13 @@ public class BatchEngineBrokerTest {
 				TestPropsValues.getUserId(),
 				batchPlannerPlan.getBatchPlannerPlanId(), fieldName, "String",
 				fieldName, "String", StringPool.BLANK);
+		}
+
+		if (containsHeaders) {
+			_batchPlannerPolicyLocalService.addBatchPlannerPolicy(
+				TestPropsValues.getUserId(),
+				batchPlannerPlan.getBatchPlannerPlanId(), "containsHeaders",
+				String.valueOf(Boolean.TRUE));
 		}
 
 		if (groupId != null) {
@@ -1307,6 +1406,41 @@ public class BatchEngineBrokerTest {
 			Arrays.asList(_createObjectViewSortColumn("createDate", "asc")));
 	}
 
+	private void _testExportSiteScopeObjectEntryJSONT(
+			long groupId, String objectEntryERC)
+		throws Exception {
+
+		ObjectEntry objectEntry = _addObjectEntry(
+			TestPropsValues.getCompanyId(), objectEntryERC, groupId,
+			_objectDefinition1, TestPropsValues.getUserId());
+
+		_objectMapper.setFilterProvider(
+			new SimpleFilterProvider() {
+				{
+					addFilter(
+						"Liferay.Vulcan",
+						VulcanPropertyFilter.of(
+							new HashSet<>(_objectEntryExportFieldNames), null));
+				}
+			});
+
+		JsonNode jsonNode = _objectMapper.readTree(
+			_getExportFileString(
+				true, BatchPlannerPlanConstants.EXTERNAL_TYPE_JSONT,
+				_objectEntryExportFieldNames, groupId,
+				"com.liferay.object.rest.dto.v1_0.ObjectEntry",
+				"C_TestObjectJSONT"));
+
+		_assertEqualsExport(
+			_getExpectedJsonNode(
+				_objectDefinition1, objectEntry.getObjectEntryId()),
+			_objectEntryExportFieldNames,
+			_getFirstJsonNode(jsonNode.get("items")));
+
+		_assertJSONTConfiguration(
+			jsonNode.get("configuration"), _objectDefinition1.getName());
+	}
+
 	private void _testImportExportSiteScopeObjectEntryCSV(
 			long groupId, String objectEntryERC)
 		throws Exception {
@@ -1331,7 +1465,7 @@ public class BatchEngineBrokerTest {
 
 		_assertEqualsExportCSV(
 			_getExportFileString(
-				BatchPlannerPlanConstants.EXTERNAL_TYPE_CSV,
+				false, BatchPlannerPlanConstants.EXTERNAL_TYPE_CSV,
 				_objectEntryExportCSVFieldNames, groupId,
 				"com.liferay.object.rest.dto.v1_0.ObjectEntry",
 				"C_TestObjectCSV"),
@@ -1383,7 +1517,7 @@ public class BatchEngineBrokerTest {
 				_getFirstJsonNode(
 					_objectMapper.readTree(
 						_getExportFileString(
-							BatchPlannerPlanConstants.EXTERNAL_TYPE_JSON,
+							false, BatchPlannerPlanConstants.EXTERNAL_TYPE_JSON,
 							_objectEntryExportFieldNames, groupId,
 							"com.liferay.object.rest.dto.v1_0.ObjectEntry",
 							"C_TestObject"))));

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/resource/v1_0/ExportTaskResourceImpl.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/resource/v1_0/ExportTaskResourceImpl.java
@@ -176,7 +176,7 @@ public class ExportTaskResourceImpl extends BaseExportTaskResourceImpl {
 	}
 
 	private static final Set<String> _ignoredParameters = new HashSet<>(
-		Arrays.asList("callbackURL", "fieldNames"));
+		Arrays.asList("callbackURL", "fieldNames", "taskItemDelegateName"));
 
 	@Reference
 	private BatchEngineExportTaskExecutor _batchEngineExportTaskExecutor;

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/resource/v1_0/ImportTaskResourceImpl.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/resource/v1_0/ImportTaskResourceImpl.java
@@ -559,7 +559,8 @@ public class ImportTaskResourceImpl extends BaseImportTaskResourceImpl {
 	}
 
 	private static final Set<String> _ignoredParameters = new HashSet<>(
-		Arrays.asList("callbackURL", "fieldNameMapping"));
+		Arrays.asList(
+			"callbackURL", "fieldNameMapping", "taskItemDelegateName"));
 
 	@Reference
 	private BatchEngineImportTaskErrorLocalService

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/resources/com/liferay/headless/builder/internal/batch/headless-builder.batch-engine-data.json
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/resources/com/liferay/headless/builder/internal/batch/headless-builder.batch-engine-data.json
@@ -7,9 +7,9 @@
 			"createStrategy": "UPSERT",
 			"featureFlag": "LPS-178642",
 			"importStrategy": "ON_ERROR_FAIL",
-			"taskItemDelegateName": "DEFAULT",
 			"updateStrategy": "UPDATE"
 		},
+		"taskItemDelegateName": "DEFAULT",
 		"userId": 0,
 		"version": "v1.0"
 	},

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -198,9 +198,11 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		_bundleContext = bundleContext;
 	}
 
-	private ObjectEntryResourceImpl _createObjectEntryResourceImpl() {
+	private ObjectEntryResourceImpl _createObjectEntryResourceImpl(
+		ObjectDefinition objectDefinition) {
+
 		return new ObjectEntryResourceImpl(
-			_dtoConverterRegistry, _entityModelProvider,
+			_dtoConverterRegistry, _entityModelProvider, objectDefinition,
 			_objectDefinitionLocalService, _objectEntryLocalService,
 			_objectEntryManagerRegistry, _objectFieldLocalService,
 			_objectRelationshipService, _objectScopeProviderRegistry,
@@ -367,7 +369,8 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 									ServiceRegistration<ObjectEntryResource>
 										serviceRegistration) {
 
-									return _createObjectEntryResourceImpl();
+									return _createObjectEntryResourceImpl(
+										objectDefinition);
 								}
 
 								@Override
@@ -448,7 +451,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 							ServiceRegistration<ObjectEntryResource>
 								serviceRegistration) {
 
-							return _createObjectEntryResourceImpl();
+							return _createObjectEntryResourceImpl(null);
 						}
 
 						@Override
@@ -540,7 +543,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 							_defaultPermissionCheckerFactory,
 							_expressionConvert, _filterParserProvider,
 							_groupLocalService, objectDefinition,
-							this::_createObjectEntryResourceImpl,
+							() -> _createObjectEntryResourceImpl(null),
 							_resourceActionLocalService,
 							_resourcePermissionLocalService, _roleLocalService,
 							_sortParserProvider, _userLocalService),

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
@@ -28,7 +28,6 @@ import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.vulcan.aggregation.Aggregation;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
@@ -41,7 +40,6 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.Map;
 
-import javax.ws.rs.NotFoundException;
 import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MultivaluedMap;
@@ -55,6 +53,7 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 	public ObjectEntryResourceImpl(
 		DTOConverterRegistry dtoConverterRegistry,
 		EntityModelProvider entityModelProvider,
+		ObjectDefinition objectDefinition,
 		ObjectDefinitionLocalService objectDefinitionLocalService,
 		ObjectEntryLocalService objectEntryLocalService,
 		ObjectEntryManagerRegistry objectEntryManagerRegistry,
@@ -66,6 +65,7 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 
 		_dtoConverterRegistry = dtoConverterRegistry;
 		_entityModelProvider = entityModelProvider;
+		_objectDefinition = objectDefinition;
 		_objectDefinitionLocalService = objectDefinitionLocalService;
 		_objectEntryLocalService = objectEntryLocalService;
 		_objectEntryManagerRegistry = objectEntryManagerRegistry;
@@ -81,8 +81,6 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 			Collection<ObjectEntry> objectEntries,
 			Map<String, Serializable> parameters)
 		throws Exception {
-
-		_loadObjectDefinition(parameters);
 
 		ObjectScopeProvider objectScopeProvider =
 			_objectScopeProviderRegistry.getObjectScopeProvider(
@@ -119,17 +117,6 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 		else {
 			super.create(objectEntries, parameters);
 		}
-	}
-
-	@Override
-	public void delete(
-			Collection<ObjectEntry> objectEntries,
-			Map<String, Serializable> parameters)
-		throws Exception {
-
-		_loadObjectDefinition(parameters);
-
-		super.delete(objectEntries, parameters);
 	}
 
 	@Override
@@ -495,8 +482,6 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		_loadObjectDefinition(parameters);
-
 		ObjectScopeProvider objectScopeProvider =
 			_objectScopeProviderRegistry.getObjectScopeProvider(
 				_objectDefinition.getScope());
@@ -515,17 +500,6 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 
 	public void setObjectDefinition(ObjectDefinition objectDefinition) {
 		_objectDefinition = objectDefinition;
-	}
-
-	@Override
-	public void update(
-			Collection<ObjectEntry> objectEntries,
-			Map<String, Serializable> parameters)
-		throws Exception {
-
-		_loadObjectDefinition(parameters);
-
-		super.update(objectEntries, parameters);
 	}
 
 	@Override
@@ -642,40 +616,6 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 		}
 
 		return null;
-	}
-
-	private void _loadObjectDefinition(Map<String, Serializable> parameters)
-		throws Exception {
-
-		String taskItemDelegateName = (String)parameters.get(
-			"taskItemDelegateName");
-
-		if (Validator.isNotNull(taskItemDelegateName)) {
-			_objectDefinition =
-				_objectDefinitionLocalService.fetchObjectDefinition(
-					contextCompany.getCompanyId(), taskItemDelegateName);
-
-			if (_objectDefinition != null) {
-				return;
-			}
-		}
-
-		String parameterValue = (String)parameters.get("objectDefinitionId");
-
-		if ((parameterValue != null) && (parameterValue.length() > 2)) {
-			String[] objectDefinitionIds = StringUtil.split(
-				parameterValue.substring(1, parameterValue.length() - 1), ",");
-
-			if (objectDefinitionIds.length > 0) {
-				_objectDefinition =
-					_objectDefinitionLocalService.getObjectDefinition(
-						GetterUtil.getLong(objectDefinitionIds[0]));
-
-				return;
-			}
-		}
-
-		throw new NotFoundException("Missing parameter \"objectDefinitionId\"");
 	}
 
 	private final DTOConverterRegistry _dtoConverterRegistry;

--- a/modules/apps/object/object-service/src/main/resources/com/liferay/object/internal/batch/bookmarks.batch-engine-data.json
+++ b/modules/apps/object/object-service/src/main/resources/com/liferay/object/internal/batch/bookmarks.batch-engine-data.json
@@ -7,9 +7,9 @@
 			"createStrategy": "UPSERT",
 			"featureFlag": "LPS-198183",
 			"importStrategy": "ON_ERROR_FAIL",
-			"taskItemDelegateName": "DEFAULT",
 			"updateStrategy": "UPDATE"
 		},
+		"taskItemDelegateName": "DEFAULT",
 		"userId": 0,
 		"version": "v1.0"
 	},

--- a/modules/sdk/gradle-plugins-workspace/src/gradleTest/clientExtensionTypeBatchBase64Encode/client-extension-batch/batch/C_FooModel/object-entry.batch-engine-data.json
+++ b/modules/sdk/gradle-plugins-workspace/src/gradleTest/clientExtensionTypeBatchBase64Encode/client-extension-batch/batch/C_FooModel/object-entry.batch-engine-data.json
@@ -24,7 +24,6 @@
 			"containsHeaders": "true",
 			"createStrategy": "UPSERT",
 			"onErrorFail": "false",
-			"taskItemDelegateName": "C_FooModel",
 			"updateStrategy": "UPDATE"
 		},
 		"taskItemDelegateName": "C_FooModel",

--- a/workspaces/liferay-clarity-workspace/client-extensions/liferay-clarity-batch/batch/workflow-definition.batch-engine-data.json
+++ b/workspaces/liferay-clarity-workspace/client-extensions/liferay-clarity-batch/batch/workflow-definition.batch-engine-data.json
@@ -5,9 +5,9 @@
 			"containsHeaders": "true",
 			"createStrategy": "INSERT",
 			"importStrategy": "ON_ERROR_FAIL",
-			"taskItemDelegateName": "DEFAULT",
 			"updateStrategy": "UPDATE"
-		}
+		},
+		"taskItemDelegateName": "DEFAULT"
 	},
 	"items": [
 		{

--- a/workspaces/liferay-jethr0-workspace/client-extensions/liferay-jethr0-batch-0/batch/list-type-definition.batch-engine-data.json
+++ b/workspaces/liferay-jethr0-workspace/client-extensions/liferay-jethr0-batch-0/batch/list-type-definition.batch-engine-data.json
@@ -6,9 +6,9 @@
 			"containsHeaders": "false",
 			"createStrategy": "INSERT",
 			"importStrategy": "ON_ERROR_FAIL",
-			"taskItemDelegateName": "DEFAULT",
 			"updateStrategy": "UPDATE"
-		}
+		},
+		"taskItemDelegateName": "DEFAULT"
 	},
 	"items": [
 		{

--- a/workspaces/liferay-jethr0-workspace/client-extensions/liferay-jethr0-batch-1/batch/object-definition.batch-engine-data.json
+++ b/workspaces/liferay-jethr0-workspace/client-extensions/liferay-jethr0-batch-1/batch/object-definition.batch-engine-data.json
@@ -6,9 +6,9 @@
 			"containsHeaders": "false",
 			"createStrategy": "INSERT",
 			"importStrategy": "ON_ERROR_FAIL",
-			"taskItemDelegateName": "DEFAULT",
 			"updateStrategy": "UPDATE"
-		}
+		},
+		"taskItemDelegateName": "DEFAULT"
 	},
 	"items": [
 		{

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-batch/batch/object-definition.batch-engine-data.json
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-batch/batch/object-definition.batch-engine-data.json
@@ -5,9 +5,9 @@
 			"containsHeaders": "true",
 			"createStrategy": "UPSERT",
 			"importStrategy": "ON_ERROR_FAIL",
-			"taskItemDelegateName": "DEFAULT",
 			"updateStrategy": "UPDATE"
-		}
+		},
+		"taskItemDelegateName": "DEFAULT"
 	},
 	"items": [
 		{

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-batch/batch/workflow-definition.batch-engine-data.json
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-batch/batch/workflow-definition.batch-engine-data.json
@@ -5,9 +5,9 @@
 			"containsHeaders": "true",
 			"createStrategy": "INSERT",
 			"importStrategy": "ON_ERROR_FAIL",
-			"taskItemDelegateName": "DEFAULT",
 			"updateStrategy": "UPDATE"
-		}
+		},
+		"taskItemDelegateName": "DEFAULT"
 	},
 	"items": [
 		{

--- a/workspaces/liferay-ticket-workspace/client-extensions/liferay-ticket-batch-list-type-definition/batch/list-type-definition.batch-engine-data.json
+++ b/workspaces/liferay-ticket-workspace/client-extensions/liferay-ticket-batch-list-type-definition/batch/list-type-definition.batch-engine-data.json
@@ -5,9 +5,9 @@
 			"containsHeaders": "true",
 			"createStrategy": "UPSERT",
 			"onErrorFail": "false",
-			"taskItemDelegateName": "DEFAULT",
 			"updateStrategy": "UPDATE"
-		}
+		},
+		"taskItemDelegateName": "DEFAULT"
 	},
 	"items": [
 		{

--- a/workspaces/liferay-ticket-workspace/client-extensions/liferay-ticket-batch-object-definition/batch/object-definition.batch-engine-data.json
+++ b/workspaces/liferay-ticket-workspace/client-extensions/liferay-ticket-batch-object-definition/batch/object-definition.batch-engine-data.json
@@ -5,9 +5,9 @@
 			"containsHeaders": "true",
 			"createStrategy": "UPSERT",
 			"onErrorFail": "false",
-			"taskItemDelegateName": "DEFAULT",
 			"updateStrategy": "UPDATE"
-		}
+		},
+		"taskItemDelegateName": "DEFAULT"
 	},
 	"items": [
 		{

--- a/workspaces/liferay-ticket-workspace/client-extensions/liferay-ticket-batch-object-entry/batch/C_J3Y7Ticket/object-entry.batch-engine-data.json
+++ b/workspaces/liferay-ticket-workspace/client-extensions/liferay-ticket-batch-object-entry/batch/C_J3Y7Ticket/object-entry.batch-engine-data.json
@@ -5,7 +5,6 @@
 			"containsHeaders": "true",
 			"createStrategy": "UPSERT",
 			"onErrorFail": "false",
-			"taskItemDelegateName": "C_J3Y7Ticket",
 			"updateStrategy": "UPDATE"
 		},
 		"taskItemDelegateName": "C_J3Y7Ticket"

--- a/workspaces/liferay-ticket-workspace/client-extensions/liferay-ticket-batch-object-relationship/batch/object-relationship.batch-engine-data.json
+++ b/workspaces/liferay-ticket-workspace/client-extensions/liferay-ticket-batch-object-relationship/batch/object-relationship.batch-engine-data.json
@@ -6,9 +6,9 @@
 			"createStrategy": "INSERT",
 			"externalReferenceCode": "L_USER",
 			"onErrorFail": "false",
-			"taskItemDelegateName": "DEFAULT",
 			"updateStrategy": "UPDATE"
-		}
+		},
+		"taskItemDelegateName": "DEFAULT"
 	},
 	"items": [
 		{

--- a/workspaces/liferay-tryitnow-workspace/client-extensions/liferay-tryitnow-batch-object-definition/batch/object-definition.batch-engine-data.json
+++ b/workspaces/liferay-tryitnow-workspace/client-extensions/liferay-tryitnow-batch-object-definition/batch/object-definition.batch-engine-data.json
@@ -5,9 +5,9 @@
 			"containsHeaders": "true",
 			"createStrategy": "UPSERT",
 			"onErrorFail": "false",
-			"taskItemDelegateName": "DEFAULT",
 			"updateStrategy": "UPDATE"
-		}
+		},
+		"taskItemDelegateName": "DEFAULT"
 	},
 	"items": [
 		{

--- a/workspaces/liferay-tryitnow-workspace/client-extensions/liferay-tryitnow-batch-object-entry/batch/C_M2H8ProgressTracker/object-entry.batch-engine-data.json
+++ b/workspaces/liferay-tryitnow-workspace/client-extensions/liferay-tryitnow-batch-object-entry/batch/C_M2H8ProgressTracker/object-entry.batch-engine-data.json
@@ -5,7 +5,6 @@
 			"containsHeaders": "true",
 			"createStrategy": "UPSERT",
 			"onErrorFail": "false",
-			"taskItemDelegateName": "C_M2H8ProgressTracker",
 			"updateStrategy": "UPDATE"
 		},
 		"taskItemDelegateName": "C_M2H8ProgressTracker"

--- a/workspaces/liferay-tryitnow-workspace/client-extensions/liferay-tryitnow-batch-user/batch/user.batch-engine-data.json
+++ b/workspaces/liferay-tryitnow-workspace/client-extensions/liferay-tryitnow-batch-user/batch/user.batch-engine-data.json
@@ -5,9 +5,9 @@
 			"containsHeaders": "true",
 			"createStrategy": "UPSERT",
 			"onErrorFail": "false",
-			"taskItemDelegateName": "DEFAULT",
 			"updateStrategy": "UPDATE"
-		}
+		},
+		"taskItemDelegateName": "DEFAULT"
 	},
 	"items": [
 		{


### PR DESCRIPTION
## Motivation
The idea of this PR is to update the JSONT external format when `taskItemDelegateName` is not null. Previously, this property was a `parameter` child, but right now it will a `configuration` child property. This will fix when an user wants to export a Object Definition or Object Entry JSONT and use it using the `BatchEngineUnit`.

**What is new**
- Remove setting `taskItemDelegateName` before calling the BatchEngineTaskExecutor and establish inside it.
- Update BatchEngineExportTaskItemWriterBuilder just to set the `taskItemDelegateName` as property in the build method.
- Update all data-engine.json files that is using in Liferay Portal.
- Add test case to Export Object Entries in JSONT format and assert the `configuration` structure.


**JIRA Related Ticket**
https://liferay.atlassian.net/browse/LPD-17470