### PR TITLE
LPD-17716 Remove DeleteAfterTestRun that duplicates actions of DataGuard

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
@@ -57,7 +57,6 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.constants.TestDataConstants;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DataGuard;
-import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -3209,13 +3208,8 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 	@Inject
 	private ListTypeDefinitionLocalService _listTypeDefinitionLocalService;
 
-	@DeleteAfterTestRun
 	private ObjectDefinition _objectDefinition1;
-
-	@DeleteAfterTestRun
 	private ObjectDefinition _objectDefinition2;
-
-	@DeleteAfterTestRun
 	private ObjectDefinition _objectDefinition3;
 
 	@Inject
@@ -3232,16 +3226,9 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 
 	private ObjectRelationship _objectRelationship1;
 	private ObjectRelationship _objectRelationship2;
-
-	@DeleteAfterTestRun
 	private ObjectDefinition _siteScopedObjectDefinition1;
-
-	@DeleteAfterTestRun
 	private ObjectDefinition _siteScopedObjectDefinition2;
-
-	@DeleteAfterTestRun
 	private ObjectDefinition _siteScopedObjectDefinition3;
-
 	private ObjectRelationship _siteScopedObjectRelationship1;
 	private ObjectRelationship _siteScopedObjectRelationship2;
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPD-17716

The purpose of this PR is to resolve issues with trying to remove an ObjectDefinition that is already deleted. 
DataGuard takes care of removing the data, so DeleteAfterTestRun is unnecessary and leads to issues when running tests:

`PortalLogAssertorTest#testScanXMLLog: null com.liferay.object.exception.NoSuchObjectDefinitionException: No ObjectDefinition exists with the primary key 73199  at com.liferay.object.service.persistence.impl.ObjectDefinitionPersistenceImpl.findByPrimaryKey(ObjectDefinitionPersistenceImpl.java:11878)  at com.liferay.object.service.persistence.impl.ObjectDefinitionPersistenceImpl.findByPrimaryKey(ObjectDefinitionPersistenceImpl.java:11896)  at com.liferay.object.service.impl.ObjectEntryLocalServiceImpl.getValues(ObjectEntryLocalServiceImpl.java:1090)  at sun.reflect.GeneratedMethodAccessor2577.invoke(Unknown Source)  at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)  at java.lang.reflect.Method.invoke(Method.java:498)  at com.liferay.portal.spring.aop.AopMethodInvocationImpl.proceed(AopMethodInvocationImpl.java:41)  at com.liferay.portal.spring.transaction.TransactionInterceptor.invoke(TransactionInterceptor.java:60)  at com.liferay.portal.spring.aop.AopMethodInvocationImpl.proceed(AopMe...`

DataGuard is enough and removes all the ObjectDefinitions from the DataBase leaving the instance clean.