### PR TITLE
LPD-15576 Additional commits to remove the unnecessary getBatchEngineImportTaskErrors() method

### DIFF
--- a/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/service/BatchEngineImportTaskService.java
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/service/BatchEngineImportTaskService.java
@@ -7,7 +7,6 @@ package com.liferay.batch.engine.service;
 
 import com.liferay.batch.engine.BatchEngineTaskItemDelegate;
 import com.liferay.batch.engine.model.BatchEngineImportTask;
-import com.liferay.batch.engine.model.BatchEngineImportTaskError;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.jsonwebservice.JSONWebService;
@@ -77,11 +76,6 @@ public interface BatchEngineImportTaskService extends BaseService {
 	public BatchEngineImportTask
 			getBatchEngineImportTaskByExternalReferenceCode(
 				String externalReferenceCode, long companyId)
-		throws PortalException;
-
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public List<BatchEngineImportTaskError> getBatchEngineImportTaskErrors(
-			long batchEngineImportTaskId)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/service/BatchEngineImportTaskServiceUtil.java
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/service/BatchEngineImportTaskServiceUtil.java
@@ -83,15 +83,6 @@ public class BatchEngineImportTaskServiceUtil {
 			externalReferenceCode, companyId);
 	}
 
-	public static List
-		<com.liferay.batch.engine.model.BatchEngineImportTaskError>
-				getBatchEngineImportTaskErrors(long batchEngineImportTaskId)
-			throws PortalException {
-
-		return getService().getBatchEngineImportTaskErrors(
-			batchEngineImportTaskId);
-	}
-
 	public static List<BatchEngineImportTask> getBatchEngineImportTasks(
 			long companyId, int start, int end)
 		throws PortalException {

--- a/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/service/BatchEngineImportTaskServiceWrapper.java
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/service/BatchEngineImportTaskServiceWrapper.java
@@ -88,16 +88,6 @@ public class BatchEngineImportTaskServiceWrapper
 	}
 
 	@Override
-	public java.util.List
-		<com.liferay.batch.engine.model.BatchEngineImportTaskError>
-				getBatchEngineImportTaskErrors(long batchEngineImportTaskId)
-			throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _batchEngineImportTaskService.getBatchEngineImportTaskErrors(
-			batchEngineImportTaskId);
-	}
-
-	@Override
 	public java.util.List<com.liferay.batch.engine.model.BatchEngineImportTask>
 			getBatchEngineImportTasks(long companyId, int start, int end)
 		throws com.liferay.portal.kernel.exception.PortalException {

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/service/http/BatchEngineImportTaskServiceHttp.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/service/http/BatchEngineImportTaskServiceHttp.java
@@ -237,51 +237,6 @@ public class BatchEngineImportTaskServiceHttp {
 	}
 
 	public static java.util.List
-		<com.liferay.batch.engine.model.BatchEngineImportTaskError>
-				getBatchEngineImportTaskErrors(
-					HttpPrincipal httpPrincipal, long batchEngineImportTaskId)
-			throws com.liferay.portal.kernel.exception.PortalException {
-
-		try {
-			MethodKey methodKey = new MethodKey(
-				BatchEngineImportTaskServiceUtil.class,
-				"getBatchEngineImportTaskErrors",
-				_getBatchEngineImportTaskErrorsParameterTypes4);
-
-			MethodHandler methodHandler = new MethodHandler(
-				methodKey, batchEngineImportTaskId);
-
-			Object returnObj = null;
-
-			try {
-				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
-			}
-			catch (Exception exception) {
-				if (exception instanceof
-						com.liferay.portal.kernel.exception.PortalException) {
-
-					throw (com.liferay.portal.kernel.exception.PortalException)
-						exception;
-				}
-
-				throw new com.liferay.portal.kernel.exception.SystemException(
-					exception);
-			}
-
-			return (java.util.List
-				<com.liferay.batch.engine.model.BatchEngineImportTaskError>)
-					returnObj;
-		}
-		catch (com.liferay.portal.kernel.exception.SystemException
-					systemException) {
-
-			_log.error(systemException, systemException);
-
-			throw systemException;
-		}
-	}
-
-	public static java.util.List
 		<com.liferay.batch.engine.model.BatchEngineImportTask>
 				getBatchEngineImportTasks(
 					HttpPrincipal httpPrincipal, long companyId, int start,
@@ -292,7 +247,7 @@ public class BatchEngineImportTaskServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				BatchEngineImportTaskServiceUtil.class,
 				"getBatchEngineImportTasks",
-				_getBatchEngineImportTasksParameterTypes5);
+				_getBatchEngineImportTasksParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, start, end);
@@ -341,7 +296,7 @@ public class BatchEngineImportTaskServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				BatchEngineImportTaskServiceUtil.class,
 				"getBatchEngineImportTasks",
-				_getBatchEngineImportTasksParameterTypes6);
+				_getBatchEngineImportTasksParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, start, end, orderByComparator);
@@ -384,7 +339,7 @@ public class BatchEngineImportTaskServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				BatchEngineImportTaskServiceUtil.class,
 				"getBatchEngineImportTasksCount",
-				_getBatchEngineImportTasksCountParameterTypes7);
+				_getBatchEngineImportTasksCountParameterTypes6);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId);
@@ -425,7 +380,7 @@ public class BatchEngineImportTaskServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				BatchEngineImportTaskServiceUtil.class,
 				"openContentInputStream",
-				_openContentInputStreamParameterTypes8);
+				_openContentInputStreamParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, batchEngineImportTaskId);
@@ -481,22 +436,18 @@ public class BatchEngineImportTaskServiceHttp {
 	private static final Class<?>[]
 		_getBatchEngineImportTaskByExternalReferenceCodeParameterTypes3 =
 			new Class[] {String.class, long.class};
-	private static final Class<?>[]
-		_getBatchEngineImportTaskErrorsParameterTypes4 = new Class[] {
-			long.class
-		};
-	private static final Class<?>[] _getBatchEngineImportTasksParameterTypes5 =
+	private static final Class<?>[] _getBatchEngineImportTasksParameterTypes4 =
 		new Class[] {long.class, int.class, int.class};
-	private static final Class<?>[] _getBatchEngineImportTasksParameterTypes6 =
+	private static final Class<?>[] _getBatchEngineImportTasksParameterTypes5 =
 		new Class[] {
 			long.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
 	private static final Class<?>[]
-		_getBatchEngineImportTasksCountParameterTypes7 = new Class[] {
+		_getBatchEngineImportTasksCountParameterTypes6 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _openContentInputStreamParameterTypes8 =
+	private static final Class<?>[] _openContentInputStreamParameterTypes7 =
 		new Class[] {long.class};
 
 }

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/service/impl/BatchEngineImportTaskServiceImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/service/impl/BatchEngineImportTaskServiceImpl.java
@@ -7,7 +7,6 @@ package com.liferay.batch.engine.service.impl;
 
 import com.liferay.batch.engine.BatchEngineTaskItemDelegate;
 import com.liferay.batch.engine.model.BatchEngineImportTask;
-import com.liferay.batch.engine.model.BatchEngineImportTaskError;
 import com.liferay.batch.engine.service.BatchEngineImportTaskErrorLocalService;
 import com.liferay.batch.engine.service.base.BatchEngineImportTaskServiceBaseImpl;
 import com.liferay.portal.aop.AopService;
@@ -108,19 +107,6 @@ public class BatchEngineImportTaskServiceImpl
 		_checkPermission(batchEngineImportTask);
 
 		return batchEngineImportTask;
-	}
-
-	@Override
-	public List<BatchEngineImportTaskError> getBatchEngineImportTaskErrors(
-			long batchEngineImportTaskId)
-		throws PortalException {
-
-		_checkPermission(
-			batchEngineImportTaskLocalService.getBatchEngineImportTask(
-				batchEngineImportTaskId));
-
-		return _batchEngineImportTaskErrorLocalService.
-			getBatchEngineImportTaskErrors(batchEngineImportTaskId);
 	}
 
 	@Override

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/resource/v1_0/ImportTaskResourceImpl.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/resource/v1_0/ImportTaskResourceImpl.java
@@ -355,9 +355,12 @@ public class ImportTaskResourceImpl extends BaseImportTaskResourceImpl {
 	private Response _getImportTaskFailedItemReport(long importTaskId)
 		throws Exception {
 
-		List<BatchEngineImportTaskError> batchEngineImportTaskErrors =
-			_batchEngineImportTaskService.getBatchEngineImportTaskErrors(
+		BatchEngineImportTask batchEngineImportTask =
+			_batchEngineImportTaskService.getBatchEngineImportTask(
 				importTaskId);
+
+		List<BatchEngineImportTaskError> batchEngineImportTaskErrors =
+			batchEngineImportTask.getBatchEngineImportTaskErrors();
 
 		StreamingOutput streamingOutput = outputStream -> {
 			try (CSVPrinter csvPrinter = new CSVPrinter(


### PR DESCRIPTION
Changes based on Brian's comment: https://github.com/brianchandotcom/liferay-portal/pull/147245#issuecomment-1952938206

We can query the list of errors this way: https://github.com/liferay-headless/liferay-portal/commit/63bea1b509ff2cc2bfc6c05d517d0e622eb6751e , see [example](https://github.com/liferay/liferay-portal/blob/7202f9fc4d80c3ee4a008b9d0d61f7764f80431e/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/resource/v1_0/ImportTaskResourceImpl.java#L530) in the same class. Also, `BatchEngineImportTaskErrorService` is not created yet and it would have to replicate the same permission checks, invoking `batchEngineImportTaskService.getBatchEngineImportTask(..)` anyways to check for the owner.

cc: @4lejandrito 