### PR TITLE
LPD-18477 Can't enable local staging due to StaleObjectStateException caused by a seemingly unrelated Publications change

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutSetLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutSetLocalServiceImpl.java
@@ -333,18 +333,28 @@ public class LayoutSetLocalServiceImpl extends LayoutSetLocalServiceBaseImpl {
 		LayoutSetBranch layoutSetBranch = _getLayoutSetBranch(layoutSet);
 
 		if (layoutSetBranch == null) {
-			layoutSet.setModifiedDate(new Date());
-
 			PortalUtil.updateImageId(
 				layoutSet, hasLogo, bytes, "logoId", 0, 0, 0);
+
+			long logoId = layoutSet.getLogoId();
+
+			layoutSet = layoutSetPersistence.findByG_P(groupId, privateLayout);
+
+			layoutSet.setModifiedDate(new Date());
+			layoutSet.setLogoId(logoId);
 
 			return layoutSetPersistence.update(layoutSet);
 		}
 
-		layoutSetBranch.setModifiedDate(new Date());
-
 		PortalUtil.updateImageId(
 			layoutSetBranch, hasLogo, bytes, "logoId", 0, 0, 0);
+
+		long logoId = layoutSetBranch.getLogoId();
+
+		layoutSetBranch = _getLayoutSetBranch(layoutSet);
+
+		layoutSetBranch.setModifiedDate(new Date());
+		layoutSetBranch.setLogoId(logoId);
 
 		_layoutSetBranchPersistence.update(layoutSetBranch);
 


### PR DESCRIPTION
Ticket: [LPD-18477](https://liferay.atlassian.net/browse/LPD-18477)

I've seen mixed examples of how we handle the `PortalUtil.updateImageId(..)` method call in the portal already, even in the same classes:
* Assumes the record is updated by it: https://github.com/liferay/liferay-portal/blob/093e096270c602bc1febf01600a2a01faac5ca84/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java#L532
* Assumes that it only sets the field value: https://github.com/liferay/liferay-portal/blob/093e096270c602bc1febf01600a2a01faac5ca84/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java#L1031-L1032

So I made changes to make sure we are always working with the latest LayoutSet or LayoutSetBranch and setting the correct values. It's still kind-of a workaround, and there might be better solutions for this problem.