### PR TITLE
LPD-19200 Remove Core Infra Unit test from headless test routine

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -4039,7 +4039,7 @@
         )
 
     #
-    # Commerce With Remote Elasticsearch 7
+    # Commerce with Remote Elasticsearch 7
     #
 
     search.engine[commerce-es7-remote]=remote-elasticsearch
@@ -4054,7 +4054,7 @@
         ${test.batch.run.property.query[functional-tomcat*-mysql*-jdk8][commerce-functional]}
 
     #
-    # Commerce With Remote Elasticsearch 8
+    # Commerce with Remote Elasticsearch 8
     #
 
     search.engine[commerce-es8-remote]=remote-elasticsearch
@@ -4070,7 +4070,7 @@
         ${test.batch.run.property.query[functional-tomcat*-mysql*-jdk8][commerce-functional]}
 
     #
-    # Commerce With Remote OpenSearch 2
+    # Commerce with Remote OpenSearch 2
     #
 
     search.engine[commerce-opensearch2]=opensearch2
@@ -4466,7 +4466,7 @@
         (testray.main.component.name ~ "Upgrades Content Management")
 
     #
-    # Content Management With Database Partition
+    # Content Management with Database Partition
     #
 
     database.partition.enabled[content-management-db-partition]=true
@@ -4493,7 +4493,7 @@
         )
 
     #
-    # Content Management With Liferay Experience Cloud Configurations
+    # Content Management with Liferay Experience Cloud Configurations
     #
 
     liferay.online.properties[content-management-lxc]=true
@@ -4592,7 +4592,7 @@
         )
 
     #
-    # Data Engine With Database Partition
+    # Data Engine with Database Partition
     #
 
     database.partition.enabled[data-engine-db-partition]=true
@@ -5412,7 +5412,7 @@
         (testray.main.component.name == "Forms")
 
     #
-    # Forms With Database Partition
+    # Forms with Database Partition
     #
 
     database.partition.enabled[forms-db-partition]=true
@@ -5757,29 +5757,11 @@
         **/src/testIntegration/**/staging/**/*Test.java,\
         **/staging/**/src/testIntegration/**/*Test.java
 
-    test.batch.class.names.includes[modules-unit-jdk8][headless]=\
-        **/batch-engine/**/src/test/**/*Test.java,\
-        **/batch-planner/**/src/test/**/*Test.java,\
-        **/dispatch/**/src/test/**/*Test.java,\
-        **/export-import/**/src/test/**/*Test.java,\
-        **/headless/headless-batch-engine/**/src/test/**/*Test.java,\
-        **/headless/headless-builder/**/src/test/**/*Test.java,\
-        **/headless/headless-discovery/**/src/test/**/*Test.java,\
-        **/object/object-rest-test/**/src/test/**/*Test.java,\
-        **/portal-security-ldap-impl/**/LDAPUserImporterImplTest.java,\
-        **/portal-tools-rest-builder/**/src/test/**/*Test.java,\
-        **/portal-vulcan/**/src/test/**/*Test.java,\
-        **/src/test/**/staging/**/*Test.java,\
-        **/staging/**/src/test/**/*Test.java
-
     test.batch.dist.app.servers[headless]=tomcat
 
     test.batch.names[headless]=\
         functional-tomcat90-mysql57-jdk8,\
-        js-unit-jdk8,\
-        modules-integration-mysql57-jdk8,\
-        modules-unit-jdk8,\
-        unit-jdk8
+        modules-integration-mysql57-jdk8
 
     test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][headless]=\
         (\
@@ -5818,17 +5800,6 @@
         **/object/object-rest-test/**/src/testIntegration/**/*Test.java,\
         **/portal-tools-rest-builder/**/src/testIntegration/**/*Test.java,\
         **/portal-vulcan/**/src/testIntegration/**/*Test.java
-
-    test.batch.class.names.includes[modules-unit-jdk8][headless-acceptance]=\
-        **/batch-engine/**/src/test/**/*Test.java,\
-        **/batch-planner/**/src/test/**/*Test.java,\
-        **/dispatch/**/src/test/**/*Test.java,\
-        **/headless/headless-batch-engine/**/src/test/**/*Test.java,\
-        **/headless/headless-builder/**/src/test/**/*Test.java,\
-        **/headless/headless-discovery/**/src/test/**/*Test.java,\
-        **/object/object-rest-test/**/src/test/**/*Test.java,\
-        **/portal-tools-rest-builder/**/src/test/**/*Test.java,\
-        **/portal-vulcan/**/src/test/**/*Test.java
 
     test.batch.dist.app.servers[headless-acceptance]=tomcat
 
@@ -6517,7 +6488,7 @@
         )
 
     #
-    # Object Integration Tests With Different Databases
+    # Object Integration Tests with Different Databases
     #
 
     test.batch.class.names.includes[object-db-integration]=\
@@ -6536,7 +6507,7 @@
         modules-integration-sqlserver2019-jdk8
 
     #
-    # Object With Database Partitioning
+    # Object with Database Partitioning
     #
 
     database.partition.enabled[object-db-partition]=true
@@ -6550,7 +6521,7 @@
         ${test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][object]}
 
     #
-    # Object With Different Application Server Environments
+    # Object with Different Application Server Environments
     #
 
     test.batch.dist.app.servers[object-as]=${test.batch.dist.app.servers}
@@ -6630,7 +6601,7 @@
         (testray.main.component.name == "Object")
 
     #
-    # Object With Different Database Environments
+    # Object with Different Database Environments
     #
 
     test.batch.class.names.includes[object-db]=${test.batch.class.names.includes[object]}
@@ -6720,7 +6691,7 @@
         (testray.main.component.name == "Upgrades Object")
 
     #
-    # Object With Liferay Experience Cloud Configurations
+    # Object with Liferay Experience Cloud Configurations
     #
 
     liferay.online.properties[object-lxc]=true
@@ -8357,7 +8328,7 @@
         (test.class.method.name == PublicationsUpgrade#ViewOutOfDatePublicationsArchive7310)
 
     #
-    # Publications With Database Partition
+    # Publications with Database Partition
     #
 
     database.partition.enabled[publications-db-partition]=true
@@ -8369,7 +8340,7 @@
         ${test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][publications]}
 
     #
-    # Publications With Different Application Server Environments
+    # Publications with Different Application Server Environments
     #
 
     test.batch.class.names.includes[publications-as]=${test.batch.class.names.includes[publications]}
@@ -8445,7 +8416,7 @@
         (testray.main.component.name == "Publications")
 
     #
-    # Publications With Different Database Environments
+    # Publications with Different Database Environments
     #
 
     test.batch.class.names.excludes[publications-db]=${test.batch.class.names.excludes.permanent}
@@ -8551,7 +8522,7 @@
         (testray.main.component.name == "Upgrades Publications")
 
     #
-    # Publications With Liferay Experience Cloud Configurations
+    # Publications with Liferay Experience Cloud Configurations
     #
 
     liferay.online.properties[publications-lxc]=true
@@ -8850,7 +8821,7 @@
         )
 
     #
-    # Search With Database Partitioning
+    # Search with Database Partitioning
     #
 
     database.partition.enabled[search-db-partition]=true
@@ -8867,7 +8838,7 @@
         ${test.batch.run.property.query[functional-tomcat90-mysql57-jdk11_open][search]}
 
     #
-    # Search With Different Application Server Environments
+    # Search with Different Application Server Environments
     #
 
     test.batch.dist.app.servers[search-as]=${test.batch.dist.app.servers}
@@ -8965,7 +8936,7 @@
         (test.class.method.name != SearchTuningES7#EnableAndDisableResultRankings)
 
     #
-    # Search With Different Database Environments
+    # Search with Different Database Environments
     #
 
     test.batch.class.names.excludes[search-db]=\
@@ -9046,7 +9017,7 @@
         )
 
     #
-    # Search With Elasticsearch 7
+    # Search with Elasticsearch 7
     #
 
     test.batch.class.names.excludes[search]=\
@@ -9140,7 +9111,7 @@
         test.class.method.name == Blueprints#ApplyBlueprintIDToSearchViaLLSO
 
     #
-    # Search With Liferay Experience Cloud Configurations
+    # Search with Liferay Experience Cloud Configurations
     #
 
     liferay.online.properties[search-lxc]=true
@@ -9154,7 +9125,7 @@
         (test.liferay.virtual.instance != false)
 
     #
-    # Search With Minimum Compatible Elasticsearch 7 Version
+    # Search with Minimum Compatible Elasticsearch 7 Version
     #
 
     search.engine[search-remote-minimum]=remote-elasticsearch
@@ -9174,7 +9145,7 @@
         ${test.batch.run.property.query[functional-upgrade-tomcat90-mysql57-jdk8][search]}
 
     #
-    # Search With Minimum Compatible Elasticsearch 8 Version
+    # Search with Minimum Compatible Elasticsearch 8 Version
     #
 
     search.engine[search-es8-remote-minimum]=remote-elasticsearch
@@ -9194,7 +9165,7 @@
         ${test.batch.run.property.query[functional-upgrade-tomcat90-mysql57-jdk8][search-es8-remote]}
 
     #
-    # Search With OpenSearch 2
+    # Search with OpenSearch 2
     #
 
     search.engine[search-opensearch2]=opensearch2
@@ -9224,7 +9195,7 @@
     test.batch.run.property.query[functional-upgrade-tomcat90-mysql57-jdk8][search-opensearch2]=${test.batch.run.property.query[functional-upgrade-tomcat90-mysql57-jdk8][search-remote]}
 
     #
-    # Search With OpenSearch 2 and Different Application Servers
+    # Search with OpenSearch 2 and Different Application Servers
     #
 
     search.engine[search-opensearch2-as]=opensearch2
@@ -9257,7 +9228,7 @@
         ${test.batch.run.property.query[functional-wildfly*][search-as]}
 
     #
-    # Search With OpenSearch 2 and Different Database Environments
+    # Search with OpenSearch 2 and Different Database Environments
     #
 
     search.engine[search-opensearch2-db]=opensearch2
@@ -9279,7 +9250,7 @@
     test.batch.run.property.query[functional-upgrade-tomcat90-sqlserver2017-jdk8][search-opensearch2-db]=${test.batch.run.property.query[functional-upgrade-tomcat90-sqlserver2017-jdk8][search-db]}
 
     #
-    # Search With Remote Elasticsearch 7
+    # Search with Remote Elasticsearch 7
     #
 
     search.engine[search-remote]=remote-elasticsearch
@@ -9311,7 +9282,7 @@
         ${test.batch.run.property.query[functional-upgrade-tomcat90-mysql57-jdk8][search]}
 
     #
-    # Search With Remote Elasticsearch 8
+    # Search with Remote Elasticsearch 8
     #
 
     search.engine[search-es8-remote]=remote-elasticsearch
@@ -9333,7 +9304,7 @@
         ${test.batch.run.property.query[functional-upgrade-tomcat90-mysql57-jdk8][search-remote]}
 
     #
-    # Search With Remote Elasticsearch 8 and Different Application Servers
+    # Search with Remote Elasticsearch 8 and Different Application Servers
     #
 
     search.engine[search-es8-as]=remote-elasticsearch
@@ -9370,7 +9341,7 @@
         ${test.batch.run.property.query[functional-wildfly*][search-as]}
 
     #
-    # Search With Remote Elasticsearch 8 and Different Database Environments
+    # Search with Remote Elasticsearch 8 and Different Database Environments
     #
 
     search.engine[search-es8-db]=remote-elasticsearch
@@ -9400,7 +9371,7 @@
         ${test.batch.run.property.query[functional-upgrade-tomcat90-sqlserver2017-jdk8][search-db]}
 
     #
-    # Search With Solr 8
+    # Search with Solr 8
     #
 
     search.engine[search-solr]=solr
@@ -9452,7 +9423,7 @@
         (test.class.method.name !~ SearchUpgrade#ViewSynonyms)
 
     #
-    # Search With Solr 8 and Different Application Servers
+    # Search with Solr 8 and Different Application Servers
     #
 
     search.engine[search-solr-as]=solr
@@ -9526,7 +9497,7 @@
         )
 
     #
-    # Search With Solr 8 and Different Database Environments
+    # Search with Solr 8 and Different Database Environments
     #
 
     search.engine[search-solr-db]=solr
@@ -10035,12 +10006,9 @@
     test.batch.names[headless-staging]=\
         central-requirements-jdk8,\
         functional-tomcat90-mysql57-jdk8,\
-        js-unit-jdk8,\
         modules-integration-mysql57-jdk8,\
         modules-semantic-versioning-jdk8,\
-        modules-unit-jdk8,\
-        semantic-versioning-jdk8,\
-        unit-jdk8
+        semantic-versioning-jdk8
 
     test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][headless-staging]=\
         (portal.upstream == true) AND \
@@ -10053,7 +10021,7 @@
         )
 
     #
-    # Staging With Custom Database
+    # Staging with Custom Database
     #
 
     custom.database.zip.url[headless-staging-custom-db]=http://test-1-1/userContent/${custom.database.name}.zip
@@ -10271,7 +10239,7 @@
         )
 
     #
-    # UM With Database Partition
+    # UM with Database Partition
     #
 
     database.partition.enabled[um-db-partition]=true
@@ -11173,7 +11141,7 @@
         (testray.main.component.name == "Workflow Metrics")
 
     #
-    # Workflow With Database Partition
+    # Workflow with Database Partition
     #
 
     database.partition.enabled[workflow-db-partition]=true
@@ -11185,7 +11153,7 @@
         ${test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][workflow]}
 
     #
-    # Workflow With OpenSearch 2
+    # Workflow with OpenSearch 2
     #
 
     search.engine[workflow-opensearch2]=opensearch2
@@ -11220,7 +11188,7 @@
         (testray.main.component.name == "Upgrades Workflow")
 
     #
-    # Workflow With Remote Elasticsearch 7
+    # Workflow with Remote Elasticsearch 7
     #
 
     search.engine[workflow-es7-remote]=remote-elasticsearch
@@ -11255,7 +11223,7 @@
         (testray.main.component.name == "Upgrades Workflow")
 
     #
-    # Workflow With Remote Elasticsearch 8
+    # Workflow with Remote Elasticsearch 8
     #
 
     search.engine[workflow-es8-remote]=remote-elasticsearch


### PR DESCRIPTION
https://issues.liferay.com/browse/LPD-19200

Motivation:
in our headless and staging routines there's a lot of unit tests that don't belong to the headless team. This PR's goal is to clean it up, so that the team member who is assigned to analyse the routines can focus on only headless-owned tests