### PR TITLE
LPD-19899 Add upgrade process to transform to lowercase the fields "applicationName" and "scopeAliases"  of the OAuth2ScopeGrant table when it refers to the Object's bundle

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-service/bnd.bnd
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay OAuth2 Provider Service
 Bundle-SymbolicName: com.liferay.oauth2.provider.service
 Bundle-Version: 4.0.82
-Liferay-Require-SchemaVersion: 4.2.5
+Liferay-Require-SchemaVersion: 4.2.6
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/upgrade/registry/OAuth2ServiceUpgradeStepRegistrator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/upgrade/registry/OAuth2ServiceUpgradeStepRegistrator.java
@@ -154,6 +154,22 @@ public class OAuth2ServiceUpgradeStepRegistrator
 				}
 
 			});
+
+		registry.register(
+			"4.2.5", "4.2.6",
+			new UpgradeProcess() {
+
+				@Override
+				protected void doUpgrade() throws Exception {
+					runSQL(
+						StringBundler.concat(
+							"update OAuth2ScopeGrant set applicationName = ",
+							"LOWER(applicationName), scopeAliases = ",
+							"LOWER(scopeAliases) where bundleSymbolicName = ",
+							"'com.liferay.object.rest.impl'"));
+				}
+
+			});
 	}
 
 	@Reference


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPD-19899

---

The purpose of this PR is to update the database rows of the table `OAuth2ScopeGrant` to transform to lowercase the fields `applicationName` and `scopeAliases`


