### PR TITLE
LPD-1988: Allow to disassociate Response Schema from an API Endpoint through the UI

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/EditAPIEndpoint.tsx
+++ b/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/EditAPIEndpoint.tsx
@@ -246,10 +246,8 @@ export default function EditAPIEndpoint({
 							r_requestAPISchemaToAPIEndpoints_c_apiSchemaId:
 								localUIData.r_requestAPISchemaToAPIEndpoints_c_apiSchemaId,
 						}),
-						...(localUIData.r_responseAPISchemaToAPIEndpoints_c_apiSchemaId && {
-							r_responseAPISchemaToAPIEndpoints_c_apiSchemaId:
-								localUIData.r_responseAPISchemaToAPIEndpoints_c_apiSchemaId,
-						}),
+						r_responseAPISchemaToAPIEndpoints_c_apiSchemaId:
+							localUIData.r_responseAPISchemaToAPIEndpoints_c_apiSchemaId,
 						retrieveType: localUIData.retrieveType,
 						scope: localUIData.scope,
 					},

--- a/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/EditEndpointConfiguration.tsx
+++ b/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/EditEndpointConfiguration.tsx
@@ -53,7 +53,13 @@ export default function EditEndpointConfiguration({
 				: [];
 
 			if (options.length) {
-				setSchemaOptions(options);
+				setSchemaOptions([
+					{
+						label: Liferay.Language.get('not-selected'),
+						value: '0',
+					},
+					...options,
+				]);
 			}
 		});
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -61,7 +67,10 @@ export default function EditEndpointConfiguration({
 
 	useEffect(() => {
 		if (schemaOptions.length) {
-			if (data.r_responseAPISchemaToAPIEndpoints_c_apiSchemaId) {
+			if (
+				data.r_responseAPISchemaToAPIEndpoints_c_apiSchemaId !==
+				undefined
+			) {
 				setSelectedResponseBodySchema(
 					schemaOptions.find(
 						(option) =>
@@ -70,7 +79,10 @@ export default function EditEndpointConfiguration({
 					)
 				);
 			}
-			if (data.r_requestAPISchemaToAPIEndpoints_c_apiSchemaId) {
+			if (
+				data.r_requestAPISchemaToAPIEndpoints_c_apiSchemaId !==
+				undefined
+			) {
 				setSelectedRequestBodySchema(
 					schemaOptions.find(
 						(option) =>

--- a/modules/test/playwright/tests/headless-builder-web/get.spec.ts
+++ b/modules/test/playwright/tests/headless-builder-web/get.spec.ts
@@ -17,6 +17,82 @@ export const test = mergeTests(
 	headlessDiscoveryPagesTest
 );
 
+test('can associate and disassociate schema', async ({
+	apiHelpers,
+	applicationPage,
+	headlessBuilderPage,
+	page,
+}) => {
+	const application = await apiHelpers.object.postObjectEntry(
+		{
+			apiApplicationToAPISchemas: [
+				{
+					description: 'API Application Schema',
+					externalReferenceCode: 'api-application-schema',
+					mainObjectDefinitionERC: 'L_API_APPLICATION',
+					name: 'API Application Schema',
+				},
+			],
+			applicationStatus: 'unpublished',
+			baseURL: 'basic-application',
+			description: 'Test API Application',
+			externalReferenceCode: 'basic-application',
+			title: 'Basic application',
+		},
+		'headless-builder/applications'
+	);
+
+	const endpoint = await apiHelpers.object.postObjectEntry(
+		{
+			description: 'Test API Endpoint',
+			externalReferenceCode: 'basic-endpoint',
+			httpMethod: 'get',
+			name: 'Basic API Endpoint',
+			path: '/endpoint/',
+			r_apiApplicationToAPIEndpoints_c_apiApplicationERC:
+				application.externalReferenceCode,
+			r_responseAPISchemaToAPIEndpoints_c_apiSchemaERC:
+				application.apiApplicationToAPISchemas[0].externalReferenceCode,
+			retrieveType: 'collection',
+			scope: 'company',
+		},
+		'headless-builder/endpoints'
+	);
+
+	await headlessBuilderPage.goto();
+	await headlessBuilderPage.goToEditApplication(application.title);
+	await applicationPage.goToEndpointsTab();
+	await applicationPage.goToEditEndpoint(endpoint.path);
+	await applicationPage.goToEndpointConfigurationTab();
+
+	await page.getByLabel('Response Body Schema').click();
+	await expect(
+		page.getByRole('menuitem', {name: 'Not Selected'})
+	).toBeVisible();
+
+	await page.getByRole('menuitem', {name: 'Not Selected'}).click();
+
+	await applicationPage.publishButton.click();
+
+	await page.waitForTimeout(1500);
+
+	await applicationPage.goToDetailsTab();
+	await applicationPage.goToEndpointsTab();
+	await applicationPage.goToEditEndpoint(endpoint.path);
+	await applicationPage.goToEndpointConfigurationTab();
+
+	const responseBodySchemaContent = await page
+		.getByLabel('Response Body Schema')
+		.textContent();
+
+	await expect(responseBodySchemaContent).toEqual('Select a Schema');
+
+	await apiHelpers.object.deleteObjectEntryByExternalReferenceCode(
+		'headless-builder/applications',
+		application.externalReferenceCode
+	);
+});
+
 test('can see available path parameter properties of a singleElement endpoint', async ({
 	applicationPage,
 	headlessBuilderPage,

--- a/modules/test/playwright/tests/headless-builder-web/post.spec.ts
+++ b/modules/test/playwright/tests/headless-builder-web/post.spec.ts
@@ -71,6 +71,43 @@ const studentSubjectsApplication = {
 	title: 'Student-Subject manager',
 };
 
+test('can create post endpoint and can not disassociate request api schema', async ({
+	apiHelpers,
+	applicationPage,
+	headlessBuilderPage,
+	page,
+}) => {
+	await apiHelpers.object.postObjectEntry(
+		application,
+		'headless-builder/applications'
+	);
+
+	await headlessBuilderPage.goto();
+	await headlessBuilderPage.goToEditApplication(application.title);
+
+	await applicationPage.createEndpoint('POST', 'Company', 'student');
+
+	await applicationPage.goToEndpointConfigurationTab();
+
+	await page.getByLabel('Response Body Schema').click();
+	await expect(
+		page.getByRole('menuitem', {name: 'Not Selected'})
+	).toBeVisible();
+
+	await page.getByRole('menuitem', {name: 'Not Selected'}).click();
+
+	await applicationPage.publishButton.click();
+
+	await expect(
+		page.getByText('Please select a request body schema.')
+	).toBeVisible();
+
+	await apiHelpers.object.deleteObjectEntryByExternalReferenceCode(
+		'headless-builder/applications',
+		application.externalReferenceCode
+	);
+});
+
 test('can create post endpoint and can not edit http method', async ({
 	apiHelpers,
 	applicationPage,
@@ -93,6 +130,11 @@ test('can create post endpoint and can not edit http method', async ({
 	);
 
 	await expect(isDisabled).toBeTruthy();
+
+	await apiHelpers.object.deleteObjectEntryByExternalReferenceCode(
+		'headless-builder/applications',
+		application.externalReferenceCode
+	);
 });
 
 test('can create post endpoint with different request and response schema', async ({


### PR DESCRIPTION
## Motivation
The idea of this PR is to allow users to disassociate Response Schemas in API Endpoints (GET or POST) operations. However, at the moment according to Product it is not possible Request Schemas, in a future that validations will be deleted, so the solution is ready for the future.

**What is new?**
- Define new `unSelectedOption` in schemas options
- Add test cases and correct a flaky test.

**JIRA Related Ticket**
https://liferay.atlassian.net/browse/LPD-1988