### PR TITLE
LPD-19684: Create LiberalPermissionChecker when Import Template is executed over Job Scheduler

### DIFF
--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/service/impl/BatchEngineImportTaskServiceImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/service/impl/BatchEngineImportTaskServiceImpl.java
@@ -6,14 +6,16 @@
 package com.liferay.batch.engine.service.impl;
 
 import com.liferay.batch.engine.BatchEngineTaskItemDelegate;
+import com.liferay.batch.engine.internal.security.permission.LiberalPermissionChecker;
 import com.liferay.batch.engine.model.BatchEngineImportTask;
-import com.liferay.batch.engine.service.BatchEngineImportTaskErrorLocalService;
 import com.liferay.batch.engine.service.base.BatchEngineImportTaskServiceBaseImpl;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.OrderByComparator;
 
 import java.io.InputStream;
@@ -49,7 +51,7 @@ public class BatchEngineImportTaskServiceImpl
 			String taskItemDelegateName)
 		throws PortalException {
 
-		_checkPermission(companyId);
+		_checkPermission(companyId, userId);
 
 		return batchEngineImportTaskLocalService.addBatchEngineImportTask(
 			externalReferenceCode, companyId, userId, batchSize, callbackURL,
@@ -68,7 +70,7 @@ public class BatchEngineImportTaskServiceImpl
 			BatchEngineTaskItemDelegate<?> batchEngineTaskItemDelegate)
 		throws PortalException {
 
-		_checkPermission(companyId);
+		_checkPermission(companyId, userId);
 
 		return batchEngineImportTaskLocalService.addBatchEngineImportTask(
 			externalReferenceCode, companyId, userId, batchSize, callbackURL,
@@ -178,6 +180,24 @@ public class BatchEngineImportTaskServiceImpl
 		}
 	}
 
+	private void _checkPermission(long companyId, long userId)
+		throws PortalException {
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if (permissionChecker == null) {
+			permissionChecker = new LiberalPermissionChecker(
+				_userLocalService.getUser(userId));
+		}
+
+		if ((companyId != permissionChecker.getCompanyId()) &&
+			!permissionChecker.isOmniadmin()) {
+
+			throw new PrincipalException();
+		}
+	}
+
 	private List<BatchEngineImportTask> _filterBatchEngineImportTasks(
 			List<BatchEngineImportTask> batchEngineImportTasks)
 		throws PrincipalException {
@@ -214,7 +234,6 @@ public class BatchEngineImportTaskServiceImpl
 	}
 
 	@Reference
-	private BatchEngineImportTaskErrorLocalService
-		_batchEngineImportTaskErrorLocalService;
+	private UserLocalService _userLocalService;
 
 }

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/service/impl/BatchEngineImportTaskServiceImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/service/impl/BatchEngineImportTaskServiceImpl.java
@@ -6,16 +6,14 @@
 package com.liferay.batch.engine.service.impl;
 
 import com.liferay.batch.engine.BatchEngineTaskItemDelegate;
-import com.liferay.batch.engine.internal.security.permission.LiberalPermissionChecker;
 import com.liferay.batch.engine.model.BatchEngineImportTask;
+import com.liferay.batch.engine.service.BatchEngineImportTaskErrorLocalService;
 import com.liferay.batch.engine.service.base.BatchEngineImportTaskServiceBaseImpl;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
-import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.OrderByComparator;
 
 import java.io.InputStream;
@@ -51,7 +49,7 @@ public class BatchEngineImportTaskServiceImpl
 			String taskItemDelegateName)
 		throws PortalException {
 
-		_checkPermission(companyId, userId);
+		_checkPermission(companyId);
 
 		return batchEngineImportTaskLocalService.addBatchEngineImportTask(
 			externalReferenceCode, companyId, userId, batchSize, callbackURL,
@@ -70,7 +68,7 @@ public class BatchEngineImportTaskServiceImpl
 			BatchEngineTaskItemDelegate<?> batchEngineTaskItemDelegate)
 		throws PortalException {
 
-		_checkPermission(companyId, userId);
+		_checkPermission(companyId);
 
 		return batchEngineImportTaskLocalService.addBatchEngineImportTask(
 			externalReferenceCode, companyId, userId, batchSize, callbackURL,
@@ -180,24 +178,6 @@ public class BatchEngineImportTaskServiceImpl
 		}
 	}
 
-	private void _checkPermission(long companyId, long userId)
-		throws PortalException {
-
-		PermissionChecker permissionChecker =
-			PermissionThreadLocal.getPermissionChecker();
-
-		if (permissionChecker == null) {
-			permissionChecker = new LiberalPermissionChecker(
-				_userLocalService.getUser(userId));
-		}
-
-		if ((companyId != permissionChecker.getCompanyId()) &&
-			!permissionChecker.isOmniadmin()) {
-
-			throw new PrincipalException();
-		}
-	}
-
 	private List<BatchEngineImportTask> _filterBatchEngineImportTasks(
 			List<BatchEngineImportTask> batchEngineImportTasks)
 		throws PrincipalException {
@@ -234,6 +214,7 @@ public class BatchEngineImportTaskServiceImpl
 	}
 
 	@Reference
-	private UserLocalService _userLocalService;
+	private BatchEngineImportTaskErrorLocalService
+		_batchEngineImportTaskErrorLocalService;
 
 }

--- a/modules/apps/batch-planner/batch-planner-service/src/main/java/com/liferay/batch/planner/internal/batch/engine/broker/BatchEngineBrokerImpl.java
+++ b/modules/apps/batch-planner/batch-planner-service/src/main/java/com/liferay/batch/planner/internal/batch/engine/broker/BatchEngineBrokerImpl.java
@@ -193,14 +193,17 @@ public class BatchEngineBrokerImpl implements BatchEngineBroker {
 	private void _submitImportTask(BatchPlannerPlan batchPlannerPlan)
 		throws Exception {
 
-		_importTaskResource.setContextCompany(
-			_companyLocalService.getCompany(batchPlannerPlan.getCompanyId()));
-		_importTaskResource.setContextUriInfo(
+		ImportTaskResource importTaskResource = _factory.create(
+		).uriInfo(
 			_getUriInfo(
 				batchPlannerPlan,
-				BatchPlannerPolicyConstants.importPlanPolicyNameTypes));
-		_importTaskResource.setContextUser(
-			_userLocalService.getUser(batchPlannerPlan.getUserId()));
+				BatchPlannerPolicyConstants.importPlanPolicyNameTypes)
+		).user(
+			_userLocalService.getUser(batchPlannerPlan.getUserId())
+		).build();
+
+		importTaskResource.setContextCompany(
+			_companyLocalService.getCompany(batchPlannerPlan.getCompanyId()));
 
 		File file = _getFile(batchPlannerPlan.getBatchPlannerPlanId());
 
@@ -218,7 +221,7 @@ public class BatchEngineBrokerImpl implements BatchEngineBroker {
 			if ((createStrategy == CreateStrategy.INSERT) ||
 				(createStrategy == CreateStrategy.UPSERT)) {
 
-				_importTaskResource.postImportTask(
+				importTaskResource.postImportTask(
 					batchPlannerPlan.getInternalClassName(), null,
 					createStrategy.name(),
 					String.valueOf(batchPlannerPlan.getBatchPlannerPlanId()),
@@ -241,7 +244,7 @@ public class BatchEngineBrokerImpl implements BatchEngineBroker {
 				return;
 			}
 
-			_importTaskResource.putImportTask(
+			importTaskResource.putImportTask(
 				batchPlannerPlan.getInternalClassName(), null,
 				String.valueOf(batchPlannerPlan.getBatchPlannerPlanId()),
 				_getImportErrorStrategy(batchPlannerPlan),
@@ -274,10 +277,10 @@ public class BatchEngineBrokerImpl implements BatchEngineBroker {
 	private ExportTaskResource _exportTaskResource;
 
 	@Reference
-	private com.liferay.portal.kernel.util.File _file;
+	private ImportTaskResource.Factory _factory;
 
 	@Reference
-	private ImportTaskResource _importTaskResource;
+	private com.liferay.portal.kernel.util.File _file;
 
 	@Reference
 	private UserLocalService _userLocalService;


### PR DESCRIPTION
**What is new?**
- Create LiberalPermissionchecker when Batch Planner Import task is executed using the Job Scheduler.

**Note:** This task doesn't need a test because it fixes this: [ImportExport#CanScheduleImport](https://testray.liferay.com/home/-/testray/case_results/2546468108?redirect=https%3A%2F%2Ftestray.liferay.com%2Fhome%2F-%2Ftestray%2Fcases%2F1705962837%2Fview%3Fcur%3D1%26delta%3D200%26testrayCaseId%3D1705962837%26orderByCol%3DcreateDate_sortable%26orderByType%3Ddesc)

**JIRA Related Ticket**
https://liferay.atlassian.net/browse/LPD-19684