### PR TITLE
LPD-20528: Return default response value locale when user locale is not registered in each Liferay instance

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/accept/language/AcceptLanguageImpl.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/accept/language/AcceptLanguageImpl.java
@@ -20,10 +20,12 @@ import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
 
+import javax.ws.rs.HttpMethod;
 import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.NotAcceptableException;
 import javax.ws.rs.NotFoundException;
@@ -81,7 +83,10 @@ public class AcceptLanguageImpl implements AcceptLanguage {
 					return null;
 				});
 
-			if (ListUtil.isEmpty(locales)) {
+			if (ListUtil.isEmpty(locales) &&
+				!Objects.equals(
+					_httpServletRequest.getMethod(), HttpMethod.GET)) {
+
 				throw new NotAcceptableException(
 					"No locales match the accepted languages: " +
 						acceptLanguage);

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/test/AcceptLanguageContextProviderTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/test/AcceptLanguageContextProviderTest.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -29,6 +30,7 @@ import com.liferay.portal.vulcan.internal.jaxrs.context.provider.test.util.MockM
 
 import java.util.Arrays;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Set;
 
 import javax.ws.rs.NotAcceptableException;
@@ -104,17 +106,22 @@ public class AcceptLanguageContextProviderTest {
 		User user = UserTestUtil.addUser(
 			_group.getGroupId(), LocaleUtil.BRAZIL);
 
-		_testCreateContext(LocaleUtil.BRAZIL, user);
+		_testCreateContext(Http.Method.GET, user, LocaleUtil.BRAZIL);
+
+		_testCreateContext(Http.Method.POST, user, LocaleUtil.BRAZIL);
 	}
 
 	@Test
 	public void testCreateContextWithGuestUser() throws Exception {
 		User user = _company.getGuestUser();
 
-		_testCreateContext(LocaleUtil.TAIWAN, user);
+		_testCreateContext(Http.Method.GET, user, LocaleUtil.TAIWAN);
+
+		_testCreateContext(Http.Method.POST, user, LocaleUtil.TAIWAN);
 	}
 
-	private void _testCreateContext(Locale userLocale, User user)
+	private void _testCreateContext(
+			Http.Method method, User user, Locale userLocale)
 		throws Exception {
 
 		// One locale
@@ -122,7 +129,7 @@ public class AcceptLanguageContextProviderTest {
 		_contextProvider.createContext(
 			new MockMessage(
 				new AcceptLanguageMockHttpServletRequest(
-					user, LocaleUtil.JAPAN)));
+					method, user, LocaleUtil.JAPAN)));
 
 		// One locale with variant
 
@@ -130,7 +137,8 @@ public class AcceptLanguageContextProviderTest {
 
 		AcceptLanguage acceptLanguage = _contextProvider.createContext(
 			new MockMessage(
-				new AcceptLanguageMockHttpServletRequest(user, caLocale)));
+				new AcceptLanguageMockHttpServletRequest(
+					method, user, caLocale)));
 
 		Assert.assertEquals(caLocale, acceptLanguage.getPreferredLocale());
 
@@ -138,7 +146,8 @@ public class AcceptLanguageContextProviderTest {
 
 		acceptLanguage = _contextProvider.createContext(
 			new MockMessage(
-				new AcceptLanguageMockHttpServletRequest(user, srLocale)));
+				new AcceptLanguageMockHttpServletRequest(
+					method, user, srLocale)));
 
 		Assert.assertEquals(srLocale, acceptLanguage.getPreferredLocale());
 
@@ -147,7 +156,7 @@ public class AcceptLanguageContextProviderTest {
 		acceptLanguage = _contextProvider.createContext(
 			new MockMessage(
 				new AcceptLanguageMockHttpServletRequest(
-					user, new Locale("pt", ""))));
+					method, user, new Locale("pt", ""))));
 
 		Assert.assertEquals(
 			LocaleUtil.BRAZIL, acceptLanguage.getPreferredLocale());
@@ -157,7 +166,8 @@ public class AcceptLanguageContextProviderTest {
 		acceptLanguage = _contextProvider.createContext(
 			new MockMessage(
 				new AcceptLanguageMockHttpServletRequest(
-					user, LocaleUtil.GERMAN, LocaleUtil.JAPAN, LocaleUtil.US)));
+					method, user, LocaleUtil.GERMAN, LocaleUtil.JAPAN,
+					LocaleUtil.US)));
 
 		Assert.assertEquals(
 			LocaleUtil.GERMAN, acceptLanguage.getPreferredLocale());
@@ -167,7 +177,8 @@ public class AcceptLanguageContextProviderTest {
 		Assert.assertEquals(userLocale, user.getLocale());
 
 		acceptLanguage = _contextProvider.createContext(
-			new MockMessage(new AcceptLanguageMockHttpServletRequest(user)));
+			new MockMessage(
+				new AcceptLanguageMockHttpServletRequest(method, user)));
 
 		Assert.assertEquals(
 			user.getLocale(), acceptLanguage.getPreferredLocale());
@@ -177,19 +188,26 @@ public class AcceptLanguageContextProviderTest {
 		acceptLanguage = _contextProvider.createContext(
 			new MockMessage(
 				new AcceptLanguageMockHttpServletRequest(
-					user, LocaleUtil.SPAIN)));
+					method, user, LocaleUtil.SPAIN)));
 
-		try {
-			Locale locale = acceptLanguage.getPreferredLocale();
-
-			Assert.fail("The locale  " + locale + " should not be available");
+		if (Objects.equals(method, Http.Method.GET)) {
+			Assert.assertEquals(
+				user.getLocale(), acceptLanguage.getPreferredLocale());
 		}
-		catch (Exception exception) {
-			Assert.assertEquals(
-				NotAcceptableException.class, exception.getClass());
-			Assert.assertEquals(
-				"No locales match the accepted languages: es-es",
-				exception.getMessage());
+		else {
+			try {
+				Locale locale = acceptLanguage.getPreferredLocale();
+
+				Assert.fail(
+					"The locale  " + locale + " should not be available");
+			}
+			catch (Exception exception) {
+				Assert.assertEquals(
+					NotAcceptableException.class, exception.getClass());
+				Assert.assertEquals(
+					"No locales match the accepted languages: es-es",
+					exception.getMessage());
+			}
 		}
 	}
 
@@ -210,7 +228,7 @@ public class AcceptLanguageContextProviderTest {
 		extends MockHttpServletRequest {
 
 		public AcceptLanguageMockHttpServletRequest(
-				User user, Locale... locales)
+				Http.Method method, User user, Locale... locales)
 			throws PortalException {
 
 			if (ArrayUtil.isNotEmpty(locales)) {
@@ -222,6 +240,8 @@ public class AcceptLanguageContextProviderTest {
 			}
 
 			addHeader("Host", _company.getVirtualHostname());
+
+			setMethod(method.toString());
 
 			if (!user.isGuestUser()) {
 				setAttribute(WebKeys.USER_ID, user.getUserId());

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/test/FilterContextProviderTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/test/FilterContextProviderTest.java
@@ -11,6 +11,7 @@ import com.liferay.portal.kernel.search.TermQuery;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.search.filter.QueryFilter;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.odata.filter.InvalidFilterException;
 import com.liferay.portal.test.rule.Inject;
@@ -19,6 +20,8 @@ import com.liferay.portal.vulcan.internal.jaxrs.context.provider.test.util.MockF
 import com.liferay.portal.vulcan.internal.jaxrs.context.provider.test.util.MockMessage;
 import com.liferay.portal.vulcan.internal.jaxrs.context.provider.test.util.MockResource;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
+
+import java.util.Locale;
 
 import javax.ws.rs.NotAcceptableException;
 import javax.ws.rs.core.Feature;
@@ -130,27 +133,49 @@ public class FilterContextProviderTest {
 				_mockResource));
 	}
 
-	@Test(expected = NotAcceptableException.class)
-	public void testCreateContextThrowsNotAcceptableException()
-		throws Exception {
+	@Test
+	public void testCreateContextWithDifferentLocale() throws Exception {
+		_testCreateContext(LocaleUtil.TAIWAN, Http.Method.GET);
 
+		_testCreateContext(LocaleUtil.TAIWAN, Http.Method.POST);
+	}
+
+	private void _testCreateContext(Locale locale, Http.Method method) {
 		MockHttpServletRequest mockHttpServletRequest =
 			new MockHttpServletRequest() {
 				{
 					addParameter("filter", "title eq 'example'");
 					addHeader(
 						HttpHeaders.ACCEPT_LANGUAGE,
-						LocaleUtil.toW3cLanguageId(LocaleUtil.TAIWAN));
+						LocaleUtil.toW3cLanguageId(locale));
 				}
 			};
 
+		mockHttpServletRequest.setMethod(method.toString());
+
 		Class<? extends MockResource> clazz = _mockResource.getClass();
 
-		_contextProvider.createContext(
-			new MockMessage(
-				mockHttpServletRequest,
-				clazz.getMethod(MockResource.METHOD_NAME, String.class),
-				_mockResource));
+		Filter filter = null;
+
+		try {
+			filter = _contextProvider.createContext(
+				new MockMessage(
+					mockHttpServletRequest,
+					clazz.getMethod(MockResource.METHOD_NAME, String.class),
+					_mockResource));
+
+			Assert.assertNotNull(filter);
+		}
+		catch (Exception exception) {
+			Assert.assertEquals(
+				NotAcceptableException.class, exception.getClass());
+			Assert.assertEquals(
+				"No locales match the accepted languages: " +
+					locale.toLanguageTag(),
+				exception.getMessage());
+
+			Assert.assertNull(filter);
+		}
 	}
 
 	private ContextProvider<Filter> _contextProvider;

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/test/FilterContextProviderTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/test/FilterContextProviderTest.java
@@ -10,8 +10,8 @@ import com.liferay.portal.kernel.search.QueryTerm;
 import com.liferay.portal.kernel.search.TermQuery;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.search.filter.QueryFilter;
+import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
-import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.odata.filter.InvalidFilterException;
 import com.liferay.portal.test.rule.Inject;
@@ -23,6 +23,7 @@ import com.liferay.portal.vulcan.resource.EntityModelResource;
 
 import java.util.Locale;
 
+import javax.ws.rs.HttpMethod;
 import javax.ws.rs.NotAcceptableException;
 import javax.ws.rs.core.Feature;
 import javax.ws.rs.core.HttpHeaders;
@@ -135,12 +136,8 @@ public class FilterContextProviderTest {
 
 	@Test
 	public void testCreateContextWithDifferentLocale() throws Exception {
-		_testCreateContext(LocaleUtil.TAIWAN, Http.Method.GET);
+		Locale locale = LocaleUtil.TAIWAN;
 
-		_testCreateContext(LocaleUtil.TAIWAN, Http.Method.POST);
-	}
-
-	private void _testCreateContext(Locale locale, Http.Method method) {
 		MockHttpServletRequest mockHttpServletRequest =
 			new MockHttpServletRequest() {
 				{
@@ -151,31 +148,42 @@ public class FilterContextProviderTest {
 				}
 			};
 
-		mockHttpServletRequest.setMethod(method.toString());
-
 		Class<? extends MockResource> clazz = _mockResource.getClass();
 
-		Filter filter = null;
+		// GET Method
 
-		try {
-			filter = _contextProvider.createContext(
+		mockHttpServletRequest.setMethod(HttpMethod.GET);
+
+		Filter filter = _contextProvider.createContext(
+			new MockMessage(
+				mockHttpServletRequest,
+				clazz.getMethod(MockResource.METHOD_NAME, String.class),
+				_mockResource));
+
+		Assert.assertTrue(filter instanceof QueryFilter);
+
+		QueryFilter queryFilter = (QueryFilter)filter;
+
+		TermQuery termQuery = (TermQuery)queryFilter.getQuery();
+
+		QueryTerm queryTerm = termQuery.getQueryTerm();
+
+		Assert.assertEquals("example", queryTerm.getValue());
+		Assert.assertEquals("internalTitle", queryTerm.getField());
+
+		// HTTP Method different from GET
+
+		mockHttpServletRequest.setMethod(HttpMethod.POST);
+
+		AssertUtils.assertFailure(
+			NotAcceptableException.class,
+			"No locales match the accepted languages: " +
+				locale.toLanguageTag(),
+			() -> _contextProvider.createContext(
 				new MockMessage(
 					mockHttpServletRequest,
 					clazz.getMethod(MockResource.METHOD_NAME, String.class),
-					_mockResource));
-
-			Assert.assertNotNull(filter);
-		}
-		catch (Exception exception) {
-			Assert.assertEquals(
-				NotAcceptableException.class, exception.getClass());
-			Assert.assertEquals(
-				"No locales match the accepted languages: " +
-					locale.toLanguageTag(),
-				exception.getMessage());
-
-			Assert.assertNull(filter);
-		}
+					_mockResource)));
 	}
 
 	private ContextProvider<Filter> _contextProvider;

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/test/SortContextProviderTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/test/SortContextProviderTest.java
@@ -8,6 +8,7 @@ package com.liferay.portal.vulcan.internal.jaxrs.context.provider.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.odata.sort.InvalidSortException;
 import com.liferay.portal.test.rule.Inject;
@@ -18,6 +19,7 @@ import com.liferay.portal.vulcan.internal.jaxrs.context.provider.test.util.MockR
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 
 import java.util.Arrays;
+import java.util.Locale;
 
 import javax.ws.rs.NotAcceptableException;
 import javax.ws.rs.core.Feature;
@@ -122,25 +124,49 @@ public class SortContextProviderTest {
 				_mockResource));
 	}
 
-	@Test(expected = NotAcceptableException.class)
-	public void testCreateContextThrowsNotAcceptable() throws Exception {
+	@Test
+	public void testCreateContextWithDifferentLocale() throws Exception {
+		_testCreateContext(LocaleUtil.TAIWAN, Http.Method.GET);
+
+		_testCreateContext(LocaleUtil.TAIWAN, Http.Method.POST);
+	}
+
+	private void _testCreateContext(Locale locale, Http.Method method) {
 		MockHttpServletRequest mockHttpServletRequest =
 			new MockHttpServletRequest() {
 				{
 					addHeader(
 						HttpHeaders.ACCEPT_LANGUAGE,
-						LocaleUtil.toW3cLanguageId(LocaleUtil.TAIWAN));
+						LocaleUtil.toW3cLanguageId(locale));
 					addParameter("sort", "title:desc");
 				}
 			};
 
+		mockHttpServletRequest.setMethod(method.toString());
+
 		Class<? extends MockResource> clazz = _mockResource.getClass();
 
-		_contextProvider.createContext(
-			new MockMessage(
-				mockHttpServletRequest,
-				clazz.getMethod(MockResource.METHOD_NAME, String.class),
-				_mockResource));
+		Sort[] sorts = null;
+
+		try {
+			sorts = _contextProvider.createContext(
+				new MockMessage(
+					mockHttpServletRequest,
+					clazz.getMethod(MockResource.METHOD_NAME, String.class),
+					_mockResource));
+
+			Assert.assertEquals(Arrays.toString(sorts), 1, sorts.length);
+		}
+		catch (Exception exception) {
+			Assert.assertEquals(
+				NotAcceptableException.class, exception.getClass());
+			Assert.assertEquals(
+				"No locales match the accepted languages: " +
+					locale.toLanguageTag(),
+				exception.getMessage());
+
+			Assert.assertNull(sorts);
+		}
 	}
 
 	private ContextProvider<Sort[]> _contextProvider;

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/test/SortContextProviderTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/test/SortContextProviderTest.java
@@ -7,8 +7,8 @@ package com.liferay.portal.vulcan.internal.jaxrs.context.provider.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
-import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.odata.sort.InvalidSortException;
 import com.liferay.portal.test.rule.Inject;
@@ -21,6 +21,7 @@ import com.liferay.portal.vulcan.resource.EntityModelResource;
 import java.util.Arrays;
 import java.util.Locale;
 
+import javax.ws.rs.HttpMethod;
 import javax.ws.rs.NotAcceptableException;
 import javax.ws.rs.core.Feature;
 import javax.ws.rs.core.HttpHeaders;
@@ -126,12 +127,8 @@ public class SortContextProviderTest {
 
 	@Test
 	public void testCreateContextWithDifferentLocale() throws Exception {
-		_testCreateContext(LocaleUtil.TAIWAN, Http.Method.GET);
+		Locale locale = LocaleUtil.TAIWAN;
 
-		_testCreateContext(LocaleUtil.TAIWAN, Http.Method.POST);
-	}
-
-	private void _testCreateContext(Locale locale, Http.Method method) {
 		MockHttpServletRequest mockHttpServletRequest =
 			new MockHttpServletRequest() {
 				{
@@ -142,31 +139,38 @@ public class SortContextProviderTest {
 				}
 			};
 
-		mockHttpServletRequest.setMethod(method.toString());
-
 		Class<? extends MockResource> clazz = _mockResource.getClass();
 
-		Sort[] sorts = null;
+		// GET Method
 
-		try {
-			sorts = _contextProvider.createContext(
+		mockHttpServletRequest.setMethod(HttpMethod.GET);
+
+		Sort[] sorts = _contextProvider.createContext(
+			new MockMessage(
+				mockHttpServletRequest,
+				clazz.getMethod(MockResource.METHOD_NAME, String.class),
+				_mockResource));
+
+		Assert.assertEquals(Arrays.toString(sorts), 1, sorts.length);
+
+		Sort sort = sorts[0];
+
+		Assert.assertEquals("internalTitle", sort.getFieldName());
+		Assert.assertTrue(sort.isReverse());
+
+		// HTTP Method different from GET
+
+		mockHttpServletRequest.setMethod(HttpMethod.POST);
+
+		AssertUtils.assertFailure(
+			NotAcceptableException.class,
+			"No locales match the accepted languages: " +
+				locale.toLanguageTag(),
+			() -> _contextProvider.createContext(
 				new MockMessage(
 					mockHttpServletRequest,
 					clazz.getMethod(MockResource.METHOD_NAME, String.class),
-					_mockResource));
-
-			Assert.assertEquals(Arrays.toString(sorts), 1, sorts.length);
-		}
-		catch (Exception exception) {
-			Assert.assertEquals(
-				NotAcceptableException.class, exception.getClass());
-			Assert.assertEquals(
-				"No locales match the accepted languages: " +
-					locale.toLanguageTag(),
-				exception.getMessage());
-
-			Assert.assertNull(sorts);
-		}
+					_mockResource)));
 	}
 
 	private ContextProvider<Sort[]> _contextProvider;


### PR DESCRIPTION
## Motivation
The idea of this PR is to return the default user locale when an user request a Liferay Headless API and the locate is not registered in the company. Before this PR, this will throw a `NotAcceptableException`. This only is going to be applied to GET requests.

**What is new?**
- Return the default user locale registered if the locale requested is not registered in the company.
- Update test case to assert that `NotAcceptableException` is not thrown.

**Steps to reproduce**
1. Execute this curl:

```curl
curl -X 'GET' 'http://localhost:8080/o/headless-admin-user/v1.0/roles' -H 'accept: application/json' -u test@liferay.com:test -H 'Accept-Language: vi-VN, vi;q=0.9'
```
**JIRA Related Ticket**
https://liferay.atlassian.net/browse/LPD-20528