### PR TITLE
LPD-20283 Fix test by generating the ERCs within the method

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -8094,18 +8094,15 @@ public class ObjectEntryResourceTest {
 
 		_testPatchPutCustomObjectEntryWithDuplicateExternalReferenceCode(
 			objectDefinition.getRESTContextPath(),
-			StringBundler.concat(
-				objectDefinition.getRESTContextPath(),
-				"/by-external-reference-code/", _ERC_VALUE_1),
+			objectDefinition.getRESTContextPath() +
+				"/by-external-reference-code/",
 			httpMethod);
+
+		String endpoint = _getEndpoint(
+			TestPropsValues.getGroupId(), siteScopedObjectDefinition);
+
 		_testPatchPutCustomObjectEntryWithDuplicateExternalReferenceCode(
-			_getEndpoint(
-				TestPropsValues.getGroupId(), siteScopedObjectDefinition),
-			StringBundler.concat(
-				_getEndpoint(
-					TestPropsValues.getGroupId(), siteScopedObjectDefinition),
-				"/by-external-reference-code/", _ERC_VALUE_1),
-			httpMethod);
+			endpoint, endpoint + "/by-external-reference-code/", httpMethod);
 	}
 
 	private void
@@ -8113,13 +8110,16 @@ public class ObjectEntryResourceTest {
 				String endpoint1, String endpoint2, Http.Method httpMethod)
 		throws Exception {
 
+		String externalReferenceCode1 = RandomTestUtil.randomString();
+		String externalReferenceCode2 = RandomTestUtil.randomString();
+
 		Assert.assertEquals(
 			200,
 			HTTPTestUtil.invokeToHttpCode(
 				JSONUtil.put(
 					_OBJECT_FIELD_NAME_1, RandomTestUtil.randomString()
 				).put(
-					"externalReferenceCode", _ERC_VALUE_1
+					"externalReferenceCode", externalReferenceCode1
 				).toString(),
 				endpoint1, Http.Method.POST));
 		Assert.assertEquals(
@@ -8128,7 +8128,7 @@ public class ObjectEntryResourceTest {
 				JSONUtil.put(
 					_OBJECT_FIELD_NAME_1, RandomTestUtil.randomString()
 				).put(
-					"externalReferenceCode", _ERC_VALUE_2
+					"externalReferenceCode", externalReferenceCode2
 				).toString(),
 				endpoint1, Http.Method.POST));
 
@@ -8136,9 +8136,9 @@ public class ObjectEntryResourceTest {
 			400,
 			HTTPTestUtil.invokeToHttpCode(
 				JSONUtil.put(
-					"externalReferenceCode", _ERC_VALUE_2
+					"externalReferenceCode", externalReferenceCode2
 				).toString(),
-				endpoint2, httpMethod));
+				endpoint2 + externalReferenceCode1, httpMethod));
 	}
 
 	private void _testPostCustomObjectEntryWithAttachmentField(


### PR DESCRIPTION
**What's changed?:**
- Now, the external reference code is generated within the method so that the new unique constraint between different object definition's entries isn't triggered.

See the following Jira Ticket: [LPD-20283](https://liferay.atlassian.net/browse/LPD-20283)