### PR TITLE
LPD-19990 Initial data is not propagated when we switch to a different site template using `LayoutSetLocalServiceUtil.updateLayoutSetPrototypeLinkEnabled()`

### DIFF
--- a/modules/test/playwright/fixtures/contentPagesTest.ts
+++ b/modules/test/playwright/fixtures/contentPagesTest.ts
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {test} from '@playwright/test';
+
+import {ContentPage} from '../pages/layout-admin-web/ContentPage';
+
+const contentPagesTest = test.extend<{
+	contentPage: ContentPage;
+}>({
+	contentPage: async ({page}, use) => {
+		await use(new ContentPage(page));
+	},
+});
+
+export {contentPagesTest};

--- a/modules/test/playwright/fixtures/productMenuPageTest.ts
+++ b/modules/test/playwright/fixtures/productMenuPageTest.ts
@@ -1,0 +1,20 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+// @ts-ignore
+
+import {test} from '@playwright/test';
+
+import {ProductMenuPage} from '../pages/product-navigation-control-menu-web/ProductMenuPage';
+
+const productMenuPageTest = test.extend<{
+	productMenuPage: ProductMenuPage;
+}>({
+	productMenuPage: async ({page}, use) => {
+		await use(new ProductMenuPage(page));
+	},
+});
+
+export {productMenuPageTest};

--- a/modules/test/playwright/fixtures/serverAdministrationPageTest.ts
+++ b/modules/test/playwright/fixtures/serverAdministrationPageTest.ts
@@ -1,0 +1,20 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+// @ts-ignore
+
+import {test} from '@playwright/test';
+
+import {ServerAdministrationPage} from '../pages/server-admin-web/ServerAdministrationPage';
+
+const serverAdministrationPageTest = test.extend<{
+	serverAdministrationPage: ServerAdministrationPage;
+}>({
+	serverAdministrationPage: async ({page}, use) => {
+		await use(new ServerAdministrationPage(page));
+	},
+});
+
+export {serverAdministrationPageTest};

--- a/modules/test/playwright/fixtures/sitesPageTest.ts
+++ b/modules/test/playwright/fixtures/sitesPageTest.ts
@@ -1,0 +1,20 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+// @ts-ignore
+
+import {test} from '@playwright/test';
+
+import {SitesPage} from '../pages/site-admin-web/SitesPage';
+
+const sitesPageTest = test.extend<{
+	sitesPage: SitesPage;
+}>({
+	sitesPage: async ({page}, use) => {
+		await use(new SitesPage(page));
+	},
+});
+
+export {sitesPageTest};

--- a/modules/test/playwright/fixtures/systemSettingsPageTest.ts
+++ b/modules/test/playwright/fixtures/systemSettingsPageTest.ts
@@ -1,0 +1,20 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+// @ts-ignore
+
+import {test} from '@playwright/test';
+
+import {SystemSettingsPage} from '../pages/configuration-admin-web/SystemSettingsPage';
+
+const systemSettingsPageTest = test.extend<{
+	systemSettingsPage: SystemSettingsPage;
+}>({
+	systemSettingsPage: async ({page}, use) => {
+		await use(new SystemSettingsPage(page));
+	},
+});
+
+export {systemSettingsPageTest};

--- a/modules/test/playwright/fixtures/uiElementsTest.ts
+++ b/modules/test/playwright/fixtures/uiElementsTest.ts
@@ -1,0 +1,20 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+// @ts-ignore
+
+import {test} from '@playwright/test';
+
+import {UIElementsPage} from '../pages/uielements/UIElementsPage';
+
+const uiElementsPageTest = test.extend<{
+	uiElementsPage: UIElementsPage;
+}>({
+	uiElementsPage: async ({page}, use) => {
+		await use(new UIElementsPage(page));
+	},
+});
+
+export {uiElementsPageTest};

--- a/modules/test/playwright/fixtures/webContentDisplayPageTest.ts
+++ b/modules/test/playwright/fixtures/webContentDisplayPageTest.ts
@@ -1,0 +1,20 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+// @ts-ignore
+
+import {test} from '@playwright/test';
+
+import {WebContentDisplayPage} from '../pages/journal-content-web/WebContentDisplayPage';
+
+const webContentDisplayPageTest = test.extend<{
+	webContentDisplayPage: WebContentDisplayPage;
+}>({
+	webContentDisplayPage: async ({page}, use) => {
+		await use(new WebContentDisplayPage(page));
+	},
+});
+
+export {webContentDisplayPageTest};

--- a/modules/test/playwright/helpers/ApiHelpers.ts
+++ b/modules/test/playwright/helpers/ApiHelpers.ts
@@ -30,6 +30,7 @@ import {JSONWebServicesDDMApiHelper} from './json-web-services/JSONWebServicesDD
 import {JSONWebServicesGroupApiHelper} from './json-web-services/JSONWebServicesGroupApiHelper';
 import {JSONWebServicesJournalApiHelper} from './json-web-services/JSONWebServicesJournalApiHelper';
 import {JSONWebServicesLayoutApiHelper} from './json-web-services/JSONWebServicesLayoutApiHelper';
+import {JSONWebServicesLayoutSetPrototypeApiHelper} from './json-web-services/JSONWebServicesLayoutSetPrototypeApiHelper';
 
 type TDataApiHelpersData = {
 	id: any;
@@ -57,6 +58,7 @@ export class ApiHelpers {
 	readonly jsonWebServicesGroup: JSONWebServicesGroupApiHelper;
 	readonly jsonWebServicesJournal: JSONWebServicesJournalApiHelper;
 	readonly jsonWebServicesLayout: JSONWebServicesLayoutApiHelper;
+	readonly jsonWebServicesLayoutSetPrototype: JSONWebServicesLayoutSetPrototypeApiHelper;
 	readonly listTypeAdmin: ListTypeAdminApiHelper;
 	readonly object: ObjectApiHelper;
 	readonly objectAdmin: ObjectAdminApiHelper;
@@ -94,6 +96,8 @@ export class ApiHelpers {
 		this.jsonWebServicesGroup = new JSONWebServicesGroupApiHelper(this);
 		this.jsonWebServicesJournal = new JSONWebServicesJournalApiHelper(this);
 		this.jsonWebServicesLayout = new JSONWebServicesLayoutApiHelper(this);
+		this.jsonWebServicesLayoutSetPrototype =
+			new JSONWebServicesLayoutSetPrototypeApiHelper(this);
 		this.listTypeAdmin = new ListTypeAdminApiHelper(this);
 		this.object = new ObjectApiHelper(this);
 		this.objectAdmin = new ObjectAdminApiHelper(this);

--- a/modules/test/playwright/helpers/HeadlessSiteApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessSiteApiHelper.ts
@@ -21,6 +21,16 @@ export class HeadlessSiteApiHelper {
 		);
 	}
 
+	async createSiteFromSiteTemplate(
+		name: string,
+		templateKey: number
+	): Promise<Site> {
+		return this.apiHelpers.post(
+			`${this.apiHelpers.baseUrl}${this.basePath}/sites`,
+			{name, templateKey, templateType: 'site-template'}
+		);
+	}
+
 	async deleteSite(siteId: string) {
 		return this.apiHelpers.delete(
 			`${this.apiHelpers.baseUrl}${this.basePath}/sites/${siteId}`

--- a/modules/test/playwright/helpers/json-web-services/JSONWebServicesLayoutSetPrototypeApiHelper.ts
+++ b/modules/test/playwright/helpers/json-web-services/JSONWebServicesLayoutSetPrototypeApiHelper.ts
@@ -1,0 +1,56 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {liferayConfig} from '../../liferay.config';
+import {ApiHelpers} from '../ApiHelpers';
+
+export type LayoutSetPrototype = {
+	layoutSetPrototypeId: number;
+	nameCurrentValue: string;
+	uuid: string;
+};
+
+export class JSONWebServicesLayoutSetPrototypeApiHelper {
+	readonly apiHelpers: ApiHelpers;
+	readonly basePath: string;
+	private layoutSetPrototypes: LayoutSetPrototype[];
+
+	constructor(apiHelpers: ApiHelpers) {
+		this.apiHelpers = apiHelpers;
+		this.basePath = '/api/jsonws/layoutsetprototype';
+		this.layoutSetPrototypes = [];
+	}
+
+	async deleteLayoutSetPrototypes(layoutSetPrototypeId: string) {
+		const urlSearchParams = new URLSearchParams();
+
+		urlSearchParams.append('layoutSetPrototypeId', layoutSetPrototypeId);
+
+		return this.apiHelpers.post(
+			`${liferayConfig.environment.baseUrl}${this.basePath}/delete-layout-set-prototype`,
+			urlSearchParams.toString(),
+			true,
+			await this.apiHelpers.getJSONWebServicesHeaders()
+		);
+	}
+
+	async getLayoutSetPrototypes(): Promise<LayoutSetPrototype[]> {
+		const urlSearchParams = new URLSearchParams();
+
+		const company =
+			await this.apiHelpers.jsonWebServicesCompany.getCompanyByWebId(
+				'liferay.com'
+			);
+
+		urlSearchParams.append('companyId', company.companyId);
+
+		return this.apiHelpers.post(
+			`${liferayConfig.environment.baseUrl}${this.basePath}/get-layout-set-prototypes`,
+			urlSearchParams.toString(),
+			true,
+			await this.apiHelpers.getJSONWebServicesHeaders()
+		);
+	}
+}

--- a/modules/test/playwright/pages/configuration-admin-web/SystemSettingsPage.ts
+++ b/modules/test/playwright/pages/configuration-admin-web/SystemSettingsPage.ts
@@ -1,0 +1,47 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+// @ts-ignore
+
+import {Locator, Page} from '@playwright/test';
+
+import {ApplicationsMenuPage} from '../product-navigation-applications-menu/ApplicationsMenuPage';
+import {UIElementsPage} from '../uielements/UIElementsPage';
+
+export class SystemSettingsPage {
+	private applicationsMenuPage;
+	readonly page: Page;
+	readonly disabledFeaturesSection: Locator;
+	readonly disablePrivatePagesOption: Locator;
+	readonly updateButton: Locator;
+	readonly releaseFeatureFlagsLink: Locator;
+	private uiElementsPage;
+
+	constructor(page: Page) {
+		this.page = page;
+		this.applicationsMenuPage = new ApplicationsMenuPage(page);
+		this.uiElementsPage = new UIElementsPage(page);
+
+		this.disabledFeaturesSection = page.getByLabel('Disabled Features', {
+			exact: true,
+		});
+		this.disablePrivatePagesOption = page.getByRole('option', {
+			name: 'Disable Private Pages',
+		});
+		this.releaseFeatureFlagsLink = page.getByRole('link', {
+			name: 'Release Feature Flags',
+		});
+		this.updateButton = page.getByRole('button', {name: 'Update'});
+	}
+
+	async disablePrivatePages() {
+		await this.applicationsMenuPage.goToSystemSettings();
+		await this.releaseFeatureFlagsLink.click();
+		await this.disabledFeaturesSection.click();
+		await this.disablePrivatePagesOption.click();
+		await this.updateButton.click();
+		await this.uiElementsPage.anySuccessAlert.waitFor({state: 'visible'});
+	}
+}

--- a/modules/test/playwright/pages/journal-content-web/WebContentDisplayPage.ts
+++ b/modules/test/playwright/pages/journal-content-web/WebContentDisplayPage.ts
@@ -1,0 +1,104 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {FrameLocator, Locator, Page} from '@playwright/test';
+
+import {UIElementsPage} from '../uielements/UIElementsPage';
+
+export class WebContentDisplayPage {
+	readonly page: Page;
+
+	readonly configurationOption: Locator;
+	readonly modalIFrame: FrameLocator;
+	readonly selectButton: Locator;
+	readonly selectWebContentButton: Locator;
+	readonly saveButton: Locator;
+	readonly webContentDisplay: Locator;
+	readonly webContentDisplayAddButton: Locator;
+	readonly webContentDisplayContent: Locator;
+	readonly webContentDisplayOptionsWidget: Locator;
+	readonly webContentDisplayWidget: Locator;
+	readonly webContentDisplayOptionsContent: Locator;
+	readonly uiElementsPage;
+
+	constructor(page: Page) {
+		this.configurationOption = page.getByRole('menuitem', {
+			exact: true,
+			name: 'Configuration',
+		});
+		this.modalIFrame = page.frameLocator('iframe[id="modalIframe"]');
+		this.page = page;
+		this.saveButton = this.modalIFrame.getByRole('button', {name: 'Save'});
+		this.selectButton = this.modalIFrame.getByRole('button', {
+			name: 'Select',
+		});
+		this.selectWebContentButton = this.modalIFrame
+			.frameLocator('iframe[title="Select Web Content"]')
+			.locator('*[data-qa-id="row"]');
+		this.uiElementsPage = new UIElementsPage(page);
+		this.webContentDisplay = page
+			.getByText('Select web content to make it visible')
+			.first();
+		this.webContentDisplayAddButton = page
+			.getByLabel(
+				'Asset PublisherDocuments and MediaMenu DisplayWeb Content Display'
+			)
+			.locator('li')
+			.filter({hasText: 'Web Content Display'})
+			.getByLabel('Add Content');
+		this.webContentDisplayContent = page.locator(
+			'[id^="portlet_com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE"]'
+		);
+		this.webContentDisplayOptionsContent =
+			this.webContentDisplayContent.getByLabel('Options');
+		this.webContentDisplayOptionsWidget = page
+			.locator(
+				'[id^="portlet-topper-toolbar_com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_"]'
+			)
+			.getByLabel('Options');
+		this.webContentDisplayWidget = page.getByText(
+			'Web Content Display Info: This application is not visible to users yet. Select w'
+		);
+	}
+
+	async addWebContentWithDisplay() {
+		await this.webContentDisplay.waitFor({state: 'visible'});
+		await this.webContentDisplayContent.hover();
+		await this.webContentDisplayOptionsContent.click();
+		await this.configurationOption.click();
+		await this.selectButton.waitFor({state: 'visible'});
+		await this.selectButton.click();
+		await this.selectWebContentButton.click();
+		if (!this.saveButton.isVisible) {
+			await this.selectWebContentButton.click();
+		}
+		await this.saveButton.click();
+		await this.uiElementsPage.closeClickable.click();
+		await this.page
+			.locator('header')
+			.filter({hasText: 'Web Content Display'})
+			.waitFor({state: 'visible'});
+	}
+
+	async addWebContentWithWidget() {
+		await this.webContentDisplayAddButton.click();
+		await this.uiElementsPage.pageCreatedAlert.waitFor({state: 'hidden'});
+		await this.uiElementsPage.pageUpdatedAlert.waitFor({state: 'hidden'});
+		await this.webContentDisplayWidget.hover();
+		await this.webContentDisplayOptionsWidget.waitFor({state: 'visible'});
+		await this.webContentDisplayOptionsWidget.click();
+		await this.configurationOption.click();
+		await this.page
+			.getByText('Success:The application was added to the page.')
+			.waitFor({state: 'hidden'});
+		await this.selectButton.waitFor({state: 'visible'});
+		await this.selectButton.click();
+		await this.selectWebContentButton.click();
+		if (!this.saveButton.isVisible) {
+			await this.selectWebContentButton.click();
+		}
+		await this.saveButton.click();
+	}
+}

--- a/modules/test/playwright/pages/layout-admin-web/ContentPage.ts
+++ b/modules/test/playwright/pages/layout-admin-web/ContentPage.ts
@@ -1,0 +1,40 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page} from '@playwright/test';
+
+import {UIElementsPage} from '../uielements/UIElementsPage';
+
+export class ContentPage {
+	readonly fragmentsAndWidgetsPanel: Locator;
+	readonly page: Page;
+	readonly pageEditor: Locator;
+	readonly panelSearch: Locator;
+	readonly uiElementsPage: UIElementsPage;
+	readonly webContentDisplayDraggable: Locator;
+
+	constructor(page: Page) {
+		this.page = page;
+		this.uiElementsPage = new UIElementsPage(page);
+
+		this.fragmentsAndWidgetsPanel = page
+			.getByLabel('Fragments and Widgets Panel')
+			.getByRole('banner');
+		this.pageEditor = page.locator('#page-editor div').nth(1);
+		this.panelSearch = page.getByPlaceholder('Search...');
+		this.webContentDisplayDraggable = page
+			.getByText('Web Content Display')
+			.first();
+	}
+
+	async addWebContentDisplayToPage() {
+		await this.fragmentsAndWidgetsPanel.waitFor({state: 'visible'});
+		await this.panelSearch.click();
+		await this.panelSearch.fill('web content');
+		await this.webContentDisplayDraggable.waitFor({state: 'visible'});
+		await this.webContentDisplayDraggable.dragTo(this.pageEditor);
+		await this.uiElementsPage.pageCreatedAlert.waitFor({state: 'hidden'});
+	}
+}

--- a/modules/test/playwright/pages/layout-admin-web/WidgetPage.ts
+++ b/modules/test/playwright/pages/layout-admin-web/WidgetPage.ts
@@ -6,23 +6,31 @@
 import {Locator, Page} from '@playwright/test';
 
 export class WidgetPage {
-	readonly page: Page;
+	readonly addApplicationButton: Locator;
 	readonly controlMenuAddButton: Locator;
 	readonly controlMenuAddPanelContentTab: Locator;
+	readonly page: Page;
 
 	constructor(page: Page) {
 		this.page = page;
 
+		this.addApplicationButton = page
+			.locator('ul')
+			.filter({hasText: 'Open Applications MenuCtrl+Alt+A'})
+			.getByLabel('Add');
 		this.controlMenuAddButton = page
 			.locator('.control-menu-nav-item')
 			.getByRole('button', {
 				exact: true,
 				name: 'Add',
 			});
-
 		this.controlMenuAddPanelContentTab = page.getByText('Content', {
 			exact: true,
 		});
+	}
+
+	async clickToAddApplication() {
+		await this.addApplicationButton.click();
 	}
 
 	async clickControlMenuAddButton() {

--- a/modules/test/playwright/pages/product-navigation-applications-menu/ApplicationsMenuPage.ts
+++ b/modules/test/playwright/pages/product-navigation-applications-menu/ApplicationsMenuPage.ts
@@ -26,17 +26,25 @@ export class ApplicationsMenuPage {
 	private readonly jobSchedulerMenuItem: Locator;
 	private readonly oAuth2Administration: Locator;
 	private readonly objectsMenuItem: Locator;
-	readonly page: Page;
+	private readonly page: Page;
 	private readonly paymentsMenuItem: Locator;
 	private readonly processBuilderItem: Locator;
 	private readonly productsMenuItem: Locator;
 	private readonly serviceAccountsItem: Locator;
+	private readonly sitesItem: Locator;
+	private readonly systemSettingsItem: Locator;
+	private readonly serverAdministrationItem: Locator;
+	private readonly siteTemplatesButton: Locator;
 	private readonly usersAndOrganizationsItem: Locator;
 
 	constructor(page: Page) {
 		this.accountsItem = page.getByRole('menuitem', {
 			exact: true,
 			name: 'Accounts',
+		});
+		this.aiCreatorLink = page.getByRole('link', {
+			exact: true,
+			name: 'AI Creator',
 		});
 		this.announcementsItem = page.getByRole('menuitem', {
 			exact: true,
@@ -65,6 +73,10 @@ export class ApplicationsMenuPage {
 		});
 		this.controlPanelButton = page.getByRole('tab', {
 			name: 'Control Panel',
+		});
+		this.gogoShellItem = page.getByRole('menuitem', {
+			exact: true,
+			name: 'Gogo Shell',
 		});
 		this.homePage = new HomePage(page);
 		this.dataMigrationCenterMenuItem = page.getByRole('menuitem', {
@@ -104,21 +116,29 @@ export class ApplicationsMenuPage {
 			exact: true,
 			name: 'Products',
 		});
-		this.usersAndOrganizationsItem = page.getByRole('menuitem', {
-			exact: true,
-			name: 'Users and Organizations',
-		});
 		this.serviceAccountsItem = page.getByRole('menuitem', {
 			exact: true,
 			name: 'Service Accounts',
 		});
-		this.aiCreatorLink = page.getByRole('link', {
+		this.serverAdministrationItem = page.getByRole('menuitem', {
 			exact: true,
-			name: 'AI Creator',
+			name: 'Server Administration',
 		});
-		this.gogoShellItem = page.getByRole('menuitem', {
+		this.sitesItem = page.getByRole('menuitem', {
 			exact: true,
-			name: 'Gogo Shell',
+			name: 'Sites',
+		});
+		this.siteTemplatesButton = page.getByRole('menuitem', {
+			exact: true,
+			name: 'Site Templates',
+		});
+		this.systemSettingsItem = page.getByRole('menuitem', {
+			exact: true,
+			name: 'System Settings',
+		});
+		this.usersAndOrganizationsItem = page.getByRole('menuitem', {
+			exact: true,
+			name: 'Users and Organizations',
 		});
 	}
 
@@ -178,6 +198,26 @@ export class ApplicationsMenuPage {
 	async goToObjects() {
 		await this.goToControlPanel();
 		await this.objectsMenuItem.click();
+	}
+
+	async goToServerAdministration() {
+		await this.goToControlPanel();
+		await this.serverAdministrationItem.click();
+	}
+
+	async goToSiteTemplates() {
+		await this.goToControlPanel();
+		await this.siteTemplatesButton.click();
+	}
+
+	async goToSites() {
+		await this.goToControlPanel();
+		await this.sitesItem.click();
+	}
+
+	async goToSystemSettings() {
+		await this.goToControlPanel();
+		await this.systemSettingsItem.click();
 	}
 
 	async goToInstanceSettings() {

--- a/modules/test/playwright/pages/product-navigation-control-menu-web/ProductMenuPage.ts
+++ b/modules/test/playwright/pages/product-navigation-control-menu-web/ProductMenuPage.ts
@@ -1,0 +1,69 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+// @ts-ignore
+
+import {Locator, Page} from '@playwright/test';
+
+export class ProductMenuPage {
+	readonly contentAndDataButton: Locator;
+	readonly page: Page;
+	readonly pagesButton: Locator;
+	readonly productMenuButton: Locator;
+	readonly productMenuHeader: Locator;
+	readonly siteBuilderButton: Locator;
+	readonly webContentButton: Locator;
+
+	constructor(page: Page) {
+		this.page = page;
+		this.contentAndDataButton = page.getByRole('menuitem', {
+			name: 'Content & Data',
+		});
+		this.pagesButton = page.getByRole('menuitem', {name: 'Pages'});
+		this.productMenuButton = page.getByLabel('Open Product Menu');
+		this.productMenuHeader = page.locator(
+			'[id="_com_liferay_product_navigation_product_menu_web_portlet_ProductMenuPortlet_site_administrationHeading"] div'
+		);
+		this.siteBuilderButton = page.getByRole('menuitem', {
+			name: 'Site Builder',
+		});
+		this.webContentButton = page.getByRole('menuitem', {
+			name: 'Web Content',
+		});
+	}
+
+	async goToWebContent() {
+		await this.contentAndDataButton.click();
+		await this.webContentButton.click();
+	}
+
+	async goToPages() {
+		await this.siteBuilderButton.click();
+		await this.pagesButton.click();
+	}
+
+	async clickSpecificPage(pageName: string) {
+		await this.pagesButton.click();
+		await this.page.getByLabel(pageName, {exact: true}).click();
+	}
+
+	async getSiteTemplateUrl(templateName: string) {
+		return await this.page.getByText(templateName).getAttribute('href');
+	}
+
+	async checkIfAdecuateProductMenu(templateName: string) {
+		await this.productMenuHeader
+			.filter({hasText: templateName})
+			.nth(2)
+			.isVisible();
+	}
+
+	async openProductMenuIfClosed() {
+		if (!(await this.contentAndDataButton.isVisible())) {
+			await this.productMenuButton.click();
+			await this.contentAndDataButton.isVisible();
+		}
+	}
+}

--- a/modules/test/playwright/pages/server-admin-web/ServerAdministrationPage.ts
+++ b/modules/test/playwright/pages/server-admin-web/ServerAdministrationPage.ts
@@ -1,0 +1,36 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page} from '@playwright/test';
+
+import {UIElementsPage} from '../uielements/UIElementsPage';
+
+export class ServerAdministrationPage {
+	readonly page: Page;
+	readonly uiElementsPage;
+
+	private readonly executeButton: Locator;
+	private readonly scriptBox: Locator;
+	private readonly scriptLink: Locator;
+
+	constructor(page: Page) {
+		this.uiElementsPage = new UIElementsPage(page);
+		this.page = page;
+
+		this.executeButton = page.getByRole('button', {name: 'Execute'});
+		this.scriptBox = page.getByLabel('Script');
+		this.scriptLink = page.getByRole('link', {name: 'Script'});
+	}
+
+	async executeScript(script: string) {
+		await this.scriptLink.click();
+		await this.scriptBox.click();
+		await this.scriptBox.press('Control+a');
+		await this.scriptBox.fill(script);
+		await this.executeButton.click();
+		await this.uiElementsPage.anySuccessAlert.waitFor({state: 'visible'});
+		await this.uiElementsPage.anySuccessAlert.waitFor({state: 'hidden'});
+	}
+}

--- a/modules/test/playwright/pages/site-admin-web/SitesPage.ts
+++ b/modules/test/playwright/pages/site-admin-web/SitesPage.ts
@@ -1,0 +1,58 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {FrameLocator, Locator, Page} from '@playwright/test';
+
+import {UIElementsPage} from '../uielements/UIElementsPage';
+
+export class SitesPage {
+	readonly page: Page;
+
+	readonly addButton: Locator;
+	readonly addSiteButton: Locator;
+	readonly addSiteIFrame: FrameLocator;
+	readonly customSiteTemplatesItem: Locator;
+	readonly defaultPagesAsPrivateCheck: Locator;
+	readonly nameBox: Locator;
+	readonly uiElementsPage;
+
+	constructor(page: Page) {
+		this.uiElementsPage = new UIElementsPage(page);
+		this.page = page;
+
+		this.addSiteButton = page.getByRole('link', {name: 'Add Site'});
+		this.customSiteTemplatesItem = page.getByRole('menuitem', {
+			name: 'Custom Site Templates',
+		});
+		this.addSiteIFrame = page.frameLocator('iframe[title="Add Site"]');
+		this.nameBox = this.addSiteIFrame.getByLabel('Name Required');
+		this.defaultPagesAsPrivateCheck = this.addSiteIFrame.getByLabel(
+			'Create default pages as private (available only to members). If unchecked, they will be public (available to anyone).'
+		);
+		this.addButton = this.addSiteIFrame.getByRole('button', {name: 'Add'});
+	}
+
+	async createSiteFromTemplate(
+		templateName: string,
+		siteName: string
+	): Promise<string> {
+		await this.addSiteButton.click();
+		await this.customSiteTemplatesItem.click();
+		await this.page
+			.getByRole('button', {name: `Select Template: ${templateName}`})
+			.click();
+		await this.nameBox.fill(siteName);
+		await this.defaultPagesAsPrivateCheck.check();
+		await this.addButton.click();
+		await this.page.waitForURL(/(.)settings(.)/);
+		await this.page.getByRole('link', {name: 'Site Configuration'}).click();
+		await this.page.getByLabel('Site ID').waitFor({state: 'visible'});
+		const siteId = await this.page
+			.getByLabel('Site ID')
+			.getAttribute('value');
+
+		return siteId as string;
+	}
+}

--- a/modules/test/playwright/pages/uielements/UIElementsPage.ts
+++ b/modules/test/playwright/pages/uielements/UIElementsPage.ts
@@ -1,0 +1,43 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page} from '@playwright/test';
+
+export class UIElementsPage {
+	readonly addButton: Locator;
+	readonly alertMessage: Locator;
+	readonly anySuccessAlert: Locator;
+	readonly closeClickable: Locator;
+	readonly newButton: Locator;
+	readonly pageCreatedAlert: Locator;
+	readonly pageUpdatedAlert: Locator;
+	readonly publishButton: Locator;
+	readonly saveButton: Locator;
+	readonly setupUpdatedAlert: Locator;
+
+	constructor(page: Page) {
+		this.newButton = page.getByRole('button', {name: 'New'});
+		this.addButton = page.getByRole('button', {name: 'Add'});
+		this.alertMessage = page.locator('div.content >> div.alert-info');
+		this.saveButton = page.getByRole('button', {name: 'Save'});
+		this.pageCreatedAlert = page.getByText(
+			'Success:The page was created successfully.'
+		);
+		this.pageUpdatedAlert = page.getByText(
+			'Success:The page was updated successfully.'
+		);
+		this.setupUpdatedAlert = page.getByText(
+			'Success:You have successfully updated the setup.'
+		);
+		this.anySuccessAlert = page.getByText('successfully.');
+		this.closeClickable = page.getByLabel('close', {exact: true});
+		this.publishButton = page.getByLabel('Publish', {exact: true});
+	}
+
+	async clickNewButton() {
+		await this.newButton.waitFor({state: 'visible'});
+		await this.newButton.click();
+	}
+}

--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -21,6 +21,7 @@ import {config as journalWebConfig} from './tests/journal-web/config';
 import {config as knowledgeBaseWebConfig} from './tests/knowledge-base-web/config';
 import {config as layoutAdminWebConfig} from './tests/layout-admin-web/config';
 import {config as layoutContentPageEditorWebConfig} from './tests/layout-content-page-editor-web/config';
+import {config as layoutSetPrototypeWebConfig} from './tests/layout-set-prototype-web/config';
 import {config as layoutTaglib} from './tests/layout-taglib/config';
 import {config as lockedItemsConfig} from './tests/locked-items-web/config';
 import {config as objectWebConfig} from './tests/object-web/config';
@@ -54,6 +55,7 @@ export default defineConfig({
 		knowledgeBaseWebConfig,
 		layoutAdminWebConfig,
 		layoutContentPageEditorWebConfig,
+		layoutSetPrototypeWebConfig,
 		layoutTaglib,
 		lockedItemsConfig,
 		objectWebConfig,

--- a/modules/test/playwright/tests/journal-web/pages/JournalPage.ts
+++ b/modules/test/playwright/tests/journal-web/pages/JournalPage.ts
@@ -14,6 +14,11 @@ export class JournalPage {
 	readonly createBasicWebContentLink: Locator;
 	readonly newButton: Locator;
 	readonly permissionsFrameLocator: FrameLocator;
+	readonly publishButton: Locator;
+	readonly templatesLink: Locator;
+	readonly webContentTitleBox: Locator;
+	readonly webContentBodyIFrame: FrameLocator;
+	readonly webContentBodyTextBox: Locator;
 
 	constructor(page: Page) {
 		this.page = page;
@@ -25,12 +30,40 @@ export class JournalPage {
 		this.permissionsFrameLocator = page.frameLocator(
 			'iframe[title="Permissions"]'
 		);
+		this.templatesLink = page.getByRole('link', {name: 'Templates'});
+		this.publishButton = page.getByRole('button', {name: 'Publish'});
+		this.webContentTitleBox = page
+			.locator('xpath=//input[contains(@id,"title")]')
+			.first();
+		this.webContentBodyIFrame = page
+			.getByRole('application', {
+				name: /Rich Text Editor, _com_liferay_journal_web_portlet_JournalPortlet_ddm\$\$content\$.*\$en_US/,
+			})
+			.frameLocator('iframe');
+		this.webContentBodyTextBox =
+			this.webContentBodyIFrame.getByRole('textbox');
 	}
 
 	async goto(siteUrl?: Site['friendlyUrlPath']) {
 		await this.page.goto(
 			`/group${siteUrl || '/guest'}${PORTLET_URLS.journal}`
 		);
+	}
+
+	async createBasicArticle(webContentName: string, text: string) {
+		await this.webContentTitleBox.fill(webContentName);
+		await this.page.waitForSelector('iframe');
+		await this.webContentBodyTextBox.fill(text);
+		await this.webContentBodyTextBox.click({button: 'left'});
+		await this.webContentBodyTextBox.press('Backspace');
+		await this.webContentTitleBox.click({button: 'left'});
+		await this.webContentTitleBox.press('Backspace');
+		await this.publishButton.click();
+		await this.page
+			.locator(
+				'[id="_com_liferay_journal_web_portlet_JournalPortlet_successMessageWithLink"]'
+			)
+			.waitFor({state: 'visible'});
 	}
 
 	async goToCreateArticle(structureName?: string) {

--- a/modules/test/playwright/tests/layout-admin-web/fixtures/pagesPagesTest.ts
+++ b/modules/test/playwright/tests/layout-admin-web/fixtures/pagesPagesTest.ts
@@ -7,13 +7,18 @@
 
 import {test} from '@playwright/test';
 
+import {StaticPagesPage} from '../pages/StaticPagesPage';
 import {UtilityPageConfigurationPage} from '../pages/UtilityPageConfigurationPage';
 import {UtilityPagesPage} from '../pages/UtilityPagesPage';
 
 const pagesPagesTest = test.extend<{
+	staticPagesPage: StaticPagesPage;
 	utilityPageConfigurationPage: UtilityPageConfigurationPage;
 	utilityPagesPage: UtilityPagesPage;
 }>({
+	staticPagesPage: async ({page}, use) => {
+		await use(new StaticPagesPage(page));
+	},
 	utilityPageConfigurationPage: async ({page}, use) => {
 		await use(new UtilityPageConfigurationPage(page));
 	},

--- a/modules/test/playwright/tests/layout-admin-web/pages/StaticPagesPage.ts
+++ b/modules/test/playwright/tests/layout-admin-web/pages/StaticPagesPage.ts
@@ -1,0 +1,113 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+// @ts-ignore
+
+import {FrameLocator, Locator, Page} from '@playwright/test';
+
+import {liferayConfig} from '../../../liferay.config';
+import {UIElementsPage} from '../../../pages/uielements/UIElementsPage';
+import {reloadUntilVisible} from '../../../utils/reloadUntilVisible';
+
+export class StaticPagesPage {
+	readonly addButton: Locator;
+	readonly addPageIFrame: FrameLocator;
+	readonly addTemplatePageButton: Locator;
+	readonly blankTypeButton: Locator;
+	readonly homePageLink: Locator;
+	readonly oneColumnButton: Locator;
+	readonly page: Page;
+	readonly pageTitleBox: Locator;
+	readonly uiElementsPage: UIElementsPage;
+	readonly widgetPageButton: Locator;
+
+	constructor(page: Page) {
+		this.page = page;
+		this.uiElementsPage = new UIElementsPage(page);
+
+		this.addPageIFrame = page.frameLocator('iframe[title="Add Page"]');
+		this.addTemplatePageButton = page.getByRole('menuitem', {
+			name: 'Add Site Template Page',
+		});
+		this.addButton = this.addPageIFrame.getByRole('button', {name: 'Add'});
+		this.blankTypeButton = page.getByRole('button', {name: 'Blank'});
+		this.homePageLink = page.getByLabel('Home', {exact: true});
+		this.oneColumnButton = page.getByText('1 Column', {exact: true});
+		this.pageTitleBox = this.addPageIFrame.locator(
+			'input[id="_com_liferay_layout_admin_web_portlet_GroupPagesPortlet_name"]'
+		);
+		this.widgetPageButton = page.getByRole('button', {name: 'Widget Page'});
+	}
+
+	async addContentPage(pageName: string) {
+		await this.blankTypeButton.waitFor({state: 'visible'});
+		await this.blankTypeButton.click();
+		await this.pageTitleBox.fill(pageName);
+		await this.addButton.click();
+		await this.page
+			.getByTitle(`Go to ${pageName}`)
+			.waitFor({state: 'visible'});
+	}
+
+	async addWidgetPage(pageName: string) {
+		await this.widgetPageButton.waitFor({state: 'visible'});
+		await this.widgetPageButton.click();
+		await this.pageTitleBox.waitFor({state: 'attached'});
+		await this.pageTitleBox.hover();
+		await this.pageTitleBox.click();
+		await this.pageTitleBox.fill(pageName);
+		await this.addButton.waitFor({state: 'attached'});
+		await this.addButton.hover();
+		await this.addButton.click();
+		await this.page
+			.getByText('Success:The page was created successfully.')
+			.waitFor({state: 'visible'});
+		await this.oneColumnButton.click();
+		await this.uiElementsPage.saveButton.click();
+		await this.page
+			.getByText('Success:The page was updated successfully.')
+			.waitFor({state: 'visible'});
+	}
+	async checkIfWebContentAddedToHome(
+		siteName: string,
+		webContentBody: string
+	) {
+		await this.page.goto(
+			liferayConfig.environment.baseUrl + `/group/${siteName}`
+		);
+		const myLocator = this.page.getByRole('link', {
+			name: `Go to ${siteName}`,
+		});
+		await reloadUntilVisible({
+			myLocator,
+			page: this.page,
+		});
+		await this.page
+			.getByText(webContentBody)
+			.waitFor({state: 'visible', timeout: 3000});
+		await this.page.getByText(webContentBody).isVisible();
+	}
+
+	async checkIfWebContentAdded(
+		siteName: string,
+		webContentName: string,
+		webContentBody: string
+	) {
+		await this.page.goto(
+			liferayConfig.environment.baseUrl + `/group/${siteName}`
+		);
+		const myLocator = this.page.getByText(webContentName);
+		await reloadUntilVisible({
+			myLocator,
+			page: this.page,
+		});
+		await this.page
+			.getByRole('menuitem', {name: webContentName})
+			.waitFor({state: 'visible'});
+		await this.page.getByRole('menuitem', {name: webContentName}).click();
+		await this.page.getByText(webContentBody).waitFor({state: 'visible'});
+		await this.page.getByText(webContentBody).isVisible();
+	}
+}

--- a/modules/test/playwright/tests/layout-set-prototype-web/config.ts
+++ b/modules/test/playwright/tests/layout-set-prototype-web/config.ts
@@ -1,0 +1,14 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {devices} from '@playwright/test';
+
+export const config = {
+	name: 'layout-set-prototype-web',
+	testDir: 'tests/layout-set-prototype-web',
+	use: {
+		...devices['Desktop Chrome'],
+	},
+};

--- a/modules/test/playwright/tests/layout-set-prototype-web/fixtures/layoutSetPrototypePageTest.ts
+++ b/modules/test/playwright/tests/layout-set-prototype-web/fixtures/layoutSetPrototypePageTest.ts
@@ -1,0 +1,20 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+// @ts-ignore
+
+import {test} from '@playwright/test';
+
+import {LayoutSetPrototypePage} from '../pages/LayoutSetPrototypePage';
+
+const layoutSetPrototypePageTest = test.extend<{
+	layoutSetPrototypePage: LayoutSetPrototypePage;
+}>({
+	layoutSetPrototypePage: async ({page}, use) => {
+		await use(new LayoutSetPrototypePage(page));
+	},
+});
+
+export {layoutSetPrototypePageTest};

--- a/modules/test/playwright/tests/layout-set-prototype-web/pages/LayoutSetPrototypePage.ts
+++ b/modules/test/playwright/tests/layout-set-prototype-web/pages/LayoutSetPrototypePage.ts
@@ -1,0 +1,33 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+// @ts-ignore
+
+import {Locator, Page} from '@playwright/test';
+
+export class LayoutSetPrototypePage {
+	readonly addLink: Locator;
+	readonly nameBox: Locator;
+	readonly page: Page;
+	readonly saveButton: Locator;
+
+	constructor(page: Page) {
+		this.page = page;
+		this.addLink = page.getByRole('link', {name: 'Add'});
+		this.nameBox = page.getByPlaceholder('Name');
+		this.saveButton = page.getByRole('button', {name: 'Save'});
+	}
+
+	async addSiteTemplate(templateName: string) {
+		await this.addLink.click();
+		await this.nameBox.click();
+		await this.nameBox.fill(templateName);
+		await this.saveButton.click();
+	}
+
+	async getSiteTemplateUrl(templateName: string) {
+		return await this.page.getByText(templateName).getAttribute('href');
+	}
+}

--- a/modules/test/playwright/tests/layout-set-prototype-web/siteTemplatesWithWebContent.spec.ts
+++ b/modules/test/playwright/tests/layout-set-prototype-web/siteTemplatesWithWebContent.spec.ts
@@ -1,0 +1,402 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Page, expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
+import {applicationsMenuPageTest} from '../../fixtures/applicationsMenuPageTest';
+import {contentPagesTest} from '../../fixtures/contentPagesTest';
+import {loginTest} from '../../fixtures/loginTest';
+import {productMenuPageTest} from '../../fixtures/productMenuPageTest';
+import {serverAdministrationPageTest} from '../../fixtures/serverAdministrationPageTest';
+import {sitesPageTest} from '../../fixtures/sitesPageTest';
+import {systemSettingsPageTest} from '../../fixtures/systemSettingsPageTest';
+import {uiElementsPageTest} from '../../fixtures/uiElementsTest';
+import {webContentDisplayPageTest} from '../../fixtures/webContentDisplayPageTest';
+import {widgetPagesTest} from '../../fixtures/widgetPagesTest';
+import {ApiHelpers} from '../../helpers/ApiHelpers';
+import {LayoutSetPrototype} from '../../helpers/json-web-services/JSONWebServicesLayoutSetPrototypeApiHelper';
+import {WebContentDisplayPage} from '../../pages/journal-content-web/WebContentDisplayPage';
+import {ContentPage} from '../../pages/layout-admin-web/ContentPage';
+import {WidgetPage} from '../../pages/layout-admin-web/WidgetPage';
+import {ApplicationsMenuPage} from '../../pages/product-navigation-applications-menu/ApplicationsMenuPage';
+import {ProductMenuPage} from '../../pages/product-navigation-control-menu-web/ProductMenuPage';
+import {UIElementsPage} from '../../pages/uielements/UIElementsPage';
+import getRandomString from '../../utils/getRandomString';
+import {journalPagesTest} from '../journal-web/fixtures/journalPagesTest';
+import {JournalPage} from '../journal-web/pages/JournalPage';
+import {pagesPagesTest} from '../layout-admin-web/fixtures/pagesPagesTest';
+import {StaticPagesPage} from '../layout-admin-web/pages/StaticPagesPage';
+import {layoutSetPrototypePageTest} from './fixtures/layoutSetPrototypePageTest';
+import {LayoutSetPrototypePage} from './pages/LayoutSetPrototypePage';
+
+export const test = mergeTests(
+	applicationsMenuPageTest,
+	journalPagesTest,
+	apiHelpersTest,
+	layoutSetPrototypePageTest,
+	productMenuPageTest,
+	uiElementsPageTest,
+	pagesPagesTest,
+	widgetPagesTest,
+	webContentDisplayPageTest,
+	contentPagesTest,
+	serverAdministrationPageTest,
+	sitesPageTest,
+	systemSettingsPageTest,
+	loginTest()
+);
+
+const webContentName1: string = getRandomString();
+const webContentName2: string = getRandomString();
+const webContentText1: string = getRandomString();
+const webContentText2: string = getRandomString();
+
+test('can switch template with web content on widget page', async ({
+	apiHelpers,
+	applicationsMenuPage,
+	journalPage,
+	layoutSetPrototypePage,
+	page,
+	productMenuPage,
+	serverAdministrationPage,
+	sitesPage,
+	staticPagesPage,
+	systemSettingsPage,
+	uiElementsPage,
+	webContentDisplayPage,
+	widgetPage,
+}) => {
+	const widgetTemplateName1: string = getRandomString();
+	const widgetTemplateName2: string = getRandomString();
+	const siteName: string = getRandomString();
+
+	await systemSettingsPage.disablePrivatePages();
+
+	await createSiteTemplateWithWebContentOnWidgetPage({
+		applicationsMenuPage,
+		journalPage,
+		layoutSetPrototypePage,
+		page,
+		productMenuPage,
+		staticPagesPage,
+		templateName: widgetTemplateName1,
+		text: `${webContentText1} `,
+		uiElementsPage,
+		webContentDisplayPage,
+		webContentName: `${webContentName1} `,
+		widgetPage,
+	});
+
+	await createSiteTemplateWithWebContentOnWidgetPage({
+		applicationsMenuPage,
+		journalPage,
+		layoutSetPrototypePage,
+		page,
+		productMenuPage,
+		staticPagesPage,
+		templateName: widgetTemplateName2,
+		text: `${webContentText2} `,
+		uiElementsPage,
+		webContentDisplayPage,
+		webContentName: `${webContentName2} `,
+		widgetPage,
+	});
+	const layoutSetPrototypes: LayoutSetPrototype[] =
+		await apiHelpers.jsonWebServicesLayoutSetPrototype.getLayoutSetPrototypes();
+	const layoutSetPrototype1 = await getLayoutTemplateByName(
+		layoutSetPrototypes,
+		widgetTemplateName1
+	);
+	const layoutSetPrototype2 = await getLayoutTemplateByName(
+		layoutSetPrototypes,
+		widgetTemplateName2
+	);
+	await applicationsMenuPage.goToSites();
+	const siteId = await sitesPage.createSiteFromTemplate(
+		widgetTemplateName1,
+		siteName
+	);
+
+	await applicationsMenuPage.goToServerAdministration();
+
+	const script = `
+    import com.liferay.portal.kernel.service.LayoutSetLocalServiceUtil;
+    String siteTemplateUUID = "${layoutSetPrototype2.uuid}";
+    long siteId = ${siteId};
+    LayoutSetLocalServiceUtil.updateLayoutSetPrototypeLinkEnabled(siteId, true, true, siteTemplateUUID);
+    `;
+	await serverAdministrationPage.executeScript(script);
+
+	await applicationsMenuPage.goToSites();
+
+	await staticPagesPage.checkIfWebContentAdded(
+		siteName,
+		widgetTemplateName2,
+		webContentText2
+	);
+
+	// tearDown
+
+	await deleteSiteAndLayoutSetPrototypes(
+		apiHelpers,
+		siteId,
+		layoutSetPrototype1.layoutSetPrototypeId.toString(),
+		layoutSetPrototype2.layoutSetPrototypeId.toString()
+	);
+});
+
+test('can switch template with web content on content page', async ({
+	apiHelpers,
+	applicationsMenuPage,
+	contentPage,
+	journalPage,
+	layoutSetPrototypePage,
+	page,
+	productMenuPage,
+	serverAdministrationPage,
+	sitesPage,
+	staticPagesPage,
+	systemSettingsPage,
+	uiElementsPage,
+	webContentDisplayPage,
+}) => {
+	await systemSettingsPage.disablePrivatePages();
+
+	const contentTemplateName1: string = getRandomString();
+	const contentTemplateName2: string = getRandomString();
+	const siteName: string = getRandomString();
+
+	await createSiteTemplateWithWebContentOnContentPage({
+		applicationsMenuPage,
+		contentPage,
+		journalPage,
+		layoutSetPrototypePage,
+		page,
+		productMenuPage,
+		staticPagesPage,
+		templateName: contentTemplateName1,
+		text: `${webContentText1} `,
+		uiElementsPage,
+		webContentDisplayPage,
+		webContentName: `${webContentName1} `,
+	});
+
+	await createSiteTemplateWithWebContentOnContentPage({
+		applicationsMenuPage,
+		contentPage,
+		journalPage,
+		layoutSetPrototypePage,
+		page,
+		productMenuPage,
+		staticPagesPage,
+		templateName: contentTemplateName2,
+		text: `${webContentText2} `,
+		uiElementsPage,
+		webContentDisplayPage,
+		webContentName: `${webContentName2} `,
+	});
+
+	const layoutSetPrototypes: LayoutSetPrototype[] =
+		await apiHelpers.jsonWebServicesLayoutSetPrototype.getLayoutSetPrototypes();
+	const layoutSetPrototype1 = await getLayoutTemplateByName(
+		layoutSetPrototypes,
+		contentTemplateName1
+	);
+	const layoutSetPrototype2 = await getLayoutTemplateByName(
+		layoutSetPrototypes,
+		contentTemplateName2
+	);
+
+	await applicationsMenuPage.goToSites();
+	const siteId = await sitesPage.createSiteFromTemplate(
+		contentTemplateName1,
+		siteName
+	);
+	await applicationsMenuPage.goToSites();
+	await staticPagesPage.checkIfWebContentAdded(
+		siteName,
+		contentTemplateName1,
+		webContentText1
+	);
+
+	await applicationsMenuPage.goToServerAdministration();
+
+	const script = `
+    import com.liferay.portal.kernel.service.LayoutSetLocalServiceUtil;
+    String siteTemplateUUID = "${layoutSetPrototype2.uuid}";
+    long siteId = ${siteId};
+    LayoutSetLocalServiceUtil.updateLayoutSetPrototypeLinkEnabled(siteId, true, true, siteTemplateUUID);
+    `;
+	await serverAdministrationPage.executeScript(script);
+
+	await staticPagesPage.checkIfWebContentAdded(
+		siteName,
+		contentTemplateName2,
+		webContentText2
+	);
+
+	// tearDown
+
+	await deleteSiteAndLayoutSetPrototypes(
+		apiHelpers,
+		siteId,
+		layoutSetPrototype1.layoutSetPrototypeId.toString(),
+		layoutSetPrototype2.layoutSetPrototypeId.toString()
+	);
+});
+
+async function deleteSiteAndLayoutSetPrototypes(
+	apiHelpers: ApiHelpers,
+	siteId: string,
+	...layoutSetPrototypeIds: string[]
+) {
+	let response = await apiHelpers.headlessSite.deleteSite(siteId);
+	if (!response.ok()) {
+		response = await apiHelpers.headlessSite.deleteSite(siteId);
+	}
+	expect(response.ok()).toBe(true);
+	for (const prototypeId of layoutSetPrototypeIds) {
+		await apiHelpers.jsonWebServicesLayoutSetPrototype.deleteLayoutSetPrototypes(
+			prototypeId
+		);
+	}
+}
+
+async function getLayoutTemplateByName(
+	layoutSetPrototypes: LayoutSetPrototype[],
+	targetName: string
+): Promise<LayoutSetPrototype> {
+	const targetLayout = layoutSetPrototypes.find(
+		(layoutSetPrototype) =>
+			layoutSetPrototype.nameCurrentValue === targetName
+	);
+
+	if (targetLayout) {
+		return {
+			layoutSetPrototypeId: targetLayout.layoutSetPrototypeId,
+			nameCurrentValue: targetLayout.nameCurrentValue,
+			uuid: targetLayout.uuid,
+		};
+	}
+	else {
+		return {
+			layoutSetPrototypeId: undefined,
+			nameCurrentValue: undefined,
+			uuid: undefined,
+		};
+	}
+}
+
+async function createSiteTemplateWithWebContentOnWidgetPage({
+	applicationsMenuPage,
+	journalPage,
+	layoutSetPrototypePage,
+	page,
+	productMenuPage,
+	staticPagesPage,
+	templateName,
+	text,
+	uiElementsPage,
+	webContentDisplayPage,
+	webContentName,
+	widgetPage,
+}: {
+	applicationsMenuPage: ApplicationsMenuPage;
+	journalPage: JournalPage;
+	layoutSetPrototypePage: LayoutSetPrototypePage;
+	page: Page;
+	productMenuPage: ProductMenuPage;
+	staticPagesPage: StaticPagesPage;
+	templateName: string;
+	text: string;
+	uiElementsPage: UIElementsPage;
+	webContentDisplayPage: WebContentDisplayPage;
+	webContentName: string;
+	widgetPage: WidgetPage;
+}): Promise<void> {
+	await applicationsMenuPage.goToSiteTemplates();
+	await layoutSetPrototypePage.addSiteTemplate(templateName);
+	await applicationsMenuPage.goToSiteTemplates();
+	const siteTemplateUrl = await layoutSetPrototypePage.getSiteTemplateUrl(
+		templateName
+	);
+	await page.goto(siteTemplateUrl);
+	await productMenuPage.checkIfAdecuateProductMenu(templateName);
+	await productMenuPage.openProductMenuIfClosed();
+	await productMenuPage.goToWebContent();
+	await journalPage.goToCreateArticle();
+	await journalPage.createBasicArticle(webContentName, text);
+
+	await productMenuPage.goToPages();
+	await uiElementsPage.clickNewButton();
+	if (!staticPagesPage.addTemplatePageButton.isVisible) {
+		await uiElementsPage.clickNewButton();
+	}
+	await staticPagesPage.addTemplatePageButton.waitFor({state: 'visible'});
+	await staticPagesPage.addTemplatePageButton.click();
+	await staticPagesPage.addWidgetPage(templateName);
+
+	await productMenuPage.clickSpecificPage(templateName);
+	await widgetPage.clickToAddApplication();
+	await webContentDisplayPage.addWebContentWithWidget();
+	await uiElementsPage.setupUpdatedAlert.waitFor({state: 'hidden'});
+	await uiElementsPage.closeClickable.click();
+	await webContentDisplayPage.webContentDisplayWidget.waitFor({
+		state: 'visible',
+	});
+}
+
+async function createSiteTemplateWithWebContentOnContentPage({
+	applicationsMenuPage,
+	contentPage,
+	journalPage,
+	layoutSetPrototypePage,
+	page,
+	productMenuPage,
+	staticPagesPage,
+	templateName,
+	text,
+	uiElementsPage,
+	webContentDisplayPage,
+	webContentName,
+}: {
+	applicationsMenuPage: ApplicationsMenuPage;
+	contentPage: ContentPage;
+	journalPage: JournalPage;
+	layoutSetPrototypePage: LayoutSetPrototypePage;
+	page: Page;
+	productMenuPage: ProductMenuPage;
+	staticPagesPage: StaticPagesPage;
+	templateName: string;
+	text: string;
+	uiElementsPage: UIElementsPage;
+	webContentDisplayPage: WebContentDisplayPage;
+	webContentName: string;
+}): Promise<void> {
+	await applicationsMenuPage.goToSiteTemplates();
+	await layoutSetPrototypePage.addSiteTemplate(templateName);
+	await applicationsMenuPage.goToSiteTemplates();
+	const siteTemplateUrl = await layoutSetPrototypePage.getSiteTemplateUrl(
+		templateName
+	);
+
+	await page.goto(siteTemplateUrl);
+	await productMenuPage.checkIfAdecuateProductMenu(templateName);
+	await productMenuPage.openProductMenuIfClosed();
+	await productMenuPage.goToWebContent();
+	await journalPage.goToCreateArticle();
+	await journalPage.createBasicArticle(webContentName, text);
+
+	await productMenuPage.goToPages();
+	await uiElementsPage.clickNewButton();
+	await staticPagesPage.addTemplatePageButton.waitFor({state: 'visible'});
+	await staticPagesPage.addTemplatePageButton.click();
+	await staticPagesPage.addContentPage(templateName);
+
+	await contentPage.addWebContentDisplayToPage();
+	await webContentDisplayPage.addWebContentWithDisplay();
+	await uiElementsPage.publishButton.click();
+}

--- a/modules/test/playwright/tests/layout-set-prototype-web/test.properties
+++ b/modules/test/playwright/tests/layout-set-prototype-web/test.properties
@@ -1,0 +1,5 @@
+##
+## Testray
+##
+
+    testray.main.component.name=Site Templates

--- a/modules/test/playwright/types/site.d.ts
+++ b/modules/test/playwright/types/site.d.ts
@@ -6,4 +6,6 @@ type Site = {
 	friendlyUrlPath: string;
 	id: string;
 	name?: string;
+	templateKey?: number;
+	templateType?: string;
 };

--- a/modules/test/playwright/utils/reloadUntilVisible.ts
+++ b/modules/test/playwright/utils/reloadUntilVisible.ts
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page} from '@playwright/test';
+
+export async function reloadUntilVisible({
+	maxAttempts = 5,
+	myLocator,
+	page,
+}: {
+	maxAttempts?: number;
+	myLocator: Locator;
+	page: Page;
+}) {
+	let attempts = 0;
+
+	while (attempts < maxAttempts) {
+		const element = await myLocator.first();
+		if (!(await element.isVisible())) {
+			await page.reload();
+		}
+		else {
+			break;
+		}
+		attempts++;
+	}
+}

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutSetLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutSetLocalServiceImpl.java
@@ -278,6 +278,19 @@ public class LayoutSetLocalServiceImpl extends LayoutSetLocalServiceBaseImpl {
 				layoutSetPrototypeLinkEnabled = false;
 			}
 
+			if (!layoutSetPrototypeUuid.equals(
+					layoutSet.getLayoutSetPrototypeUuid())) {
+
+				UnicodeProperties unicodeProperties =
+					layoutSet.getSettingsProperties();
+
+				unicodeProperties.remove(Sites.LAST_MERGE_TIME);
+				unicodeProperties.remove(Sites.LAST_RESET_TIME);
+				unicodeProperties.remove(Sites.LAST_MERGE_VERSION);
+
+				layoutSet.setSettingsProperties(unicodeProperties);
+			}
+
 			layoutSet.setLayoutSetPrototypeUuid(layoutSetPrototypeUuid);
 			layoutSet.setLayoutSetPrototypeLinkEnabled(
 				layoutSetPrototypeLinkEnabled);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPD-19990

---

NOTE: This PR is LPP related: https://liferay.atlassian.net/browse/LPP-53073

---