### PR TITLE
LPD-21278 Quarantine failing headless tests

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/sitetemplates/usecase/SitetemplatesUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/sitetemplates/usecase/SitetemplatesUsecase.testcase
@@ -598,7 +598,7 @@ definition {
 	@description = "This is a use case for LPS-86487. Page links on sites which were created in site templates should redirect correctly to other pages."
 	@priority = 3
 	test SiteTemplatePageLinkInWebContentRedirectCorrectly {
-		property portal.acceptance = "true";
+		property portal.acceptance = "quarantine";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/StagingUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/StagingUsecase.testcase
@@ -2213,7 +2213,7 @@ definition {
 	@description = "This is a use case for LPS-123156 and LPS-185203 TC-1: The summary of the failed publishing processes can be viewed."
 	@priority = 3
 	test TrashEntryReferencePublishing {
-		property portal.acceptance = "true";
+		property portal.acceptance = "quarantine";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 		property testray.component.names = "Training";


### PR DESCRIPTION
**Description**
Quarantine failing release tests to reduce impact on release testing analysis. Please unquarantine the tests as each fix is implemented in their respective follow up tickets.

**JIRA Ticket**
https://liferay.atlassian.net/browse/LPD-21278