### PR TITLE
LPD-18212 Consider the GraphQL namespace when managing the GraphQL errors

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -1063,14 +1063,19 @@ public class GraphQLServletExtender {
 				graphQLSchemaBuilder, processingElementsContainer,
 				queryGraphQLObjectTypeBuilder);
 
-			_registerNamespace(
-				ServletData::getMutation, mutationGraphQLObjectTypeBuilder,
-				graphQLSchemaBuilder, true, processingElementsContainer,
-				servletDatas);
-			_registerNamespace(
-				ServletData::getQuery, queryGraphQLObjectTypeBuilder,
-				graphQLSchemaBuilder, false, processingElementsContainer,
-				servletDatas);
+			Set<String> graphQLNamespaces = new HashSet<>();
+
+			graphQLNamespaces.addAll(
+				_registerNamespace(
+					ServletData::getMutation, mutationGraphQLObjectTypeBuilder,
+					graphQLSchemaBuilder, true, processingElementsContainer,
+					servletDatas));
+
+			graphQLNamespaces.addAll(
+				_registerNamespace(
+					ServletData::getQuery, queryGraphQLObjectTypeBuilder,
+					graphQLSchemaBuilder, false, processingElementsContainer,
+					servletDatas));
 
 			graphQLSchemaBuilder.mutation(
 				mutationGraphQLObjectTypeBuilder.build());
@@ -1102,7 +1107,7 @@ public class GraphQLServletExtender {
 				GraphQLObjectMapper.newBuilder();
 
 			objectMapperBuilder.withGraphQLErrorHandler(
-				new LiferayGraphQLErrorHandler());
+				new LiferayGraphQLErrorHandler(graphQLNamespaces));
 			objectMapperBuilder.withObjectMapperProvider(
 				() -> {
 					ObjectMapper objectMapper = new ObjectMapper();
@@ -1682,29 +1687,32 @@ public class GraphQLServletExtender {
 		}
 	}
 
-	private void _registerNamespace(
+	private Set<String> _registerNamespace(
 		Function<ServletData, Object> function,
 		GraphQLObjectType.Builder graphQLObjectTypeBuilder,
 		GraphQLSchema.Builder graphQLSchemaBuilder, boolean mutation,
 		ProcessingElementsContainer processingElementsContainer,
 		List<ServletData> servletDatas) {
 
+		Set<String> graphQLNamespaces = new HashSet<>();
+
 		for (ServletData servletData : servletDatas) {
-			Set<String> graphQLNamespaces = new HashSet<>();
+			Set<String> servletDataGraphQLNamespaces = new HashSet<>();
 
 			if (FeatureFlagManagerUtil.isEnabled("LPD-10789")) {
 				String graphQLNamespace = _getGraphQLNamespace(servletData);
 
 				if (graphQLNamespace != null) {
-					graphQLNamespaces.add(graphQLNamespace);
+					servletDataGraphQLNamespaces.add(graphQLNamespace);
 				}
 			}
 
 			if (servletData.getGraphQLNamespace() != null) {
-				graphQLNamespaces.add(servletData.getGraphQLNamespace());
+				servletDataGraphQLNamespaces.add(
+					servletData.getGraphQLNamespace());
 			}
 
-			if (graphQLNamespaces.isEmpty()) {
+			if (servletDataGraphQLNamespaces.isEmpty()) {
 				continue;
 			}
 
@@ -1733,7 +1741,7 @@ public class GraphQLServletExtender {
 			Map<Method, LiferayMethodDataFetcher> liferayMethodDataFetchers =
 				new HashMap<>();
 
-			for (String graphQLNamespace : graphQLNamespaces) {
+			for (String graphQLNamespace : servletDataGraphQLNamespaces) {
 				GraphQLObjectType.Builder builder =
 					new GraphQLObjectType.Builder();
 
@@ -1798,8 +1806,12 @@ public class GraphQLServletExtender {
 						(DataFetcher<Object>)
 							dataFetchingEnvironment -> new Object()
 					).build());
+
+				graphQLNamespaces.add(graphQLNamespace);
 			}
 		}
+
+		return graphQLNamespaces;
 	}
 
 	private void _replaceFieldDefinition(
@@ -2344,6 +2356,10 @@ public class GraphQLServletExtender {
 	private static class LiferayGraphQLErrorHandler
 		implements GraphQLErrorHandler {
 
+		public LiferayGraphQLErrorHandler(Set<String> graphQLNamespaces) {
+			_graphQLNamespaces = graphQLNamespaces;
+		}
+
 		@Override
 		public List<GraphQLError> processErrors(
 			List<GraphQLError> graphQLErrors) {
@@ -2480,6 +2496,10 @@ public class GraphQLServletExtender {
 				path = Collections.emptyList();
 			}
 
+			if (!path.isEmpty() && _graphQLNamespaces.contains(path.get(0))) {
+				path = ListUtil.subList(path, 1, path.size());
+			}
+
 			if (path.size() <= 1) {
 				return true;
 			}
@@ -2487,6 +2507,8 @@ public class GraphQLServletExtender {
 			return StringUtil.containsIgnoreCase(
 				(String)path.get(path.size() - 1), "parent");
 		}
+
+		private final Set<String> _graphQLNamespaces;
 
 	}
 

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
@@ -36,6 +36,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.ws.rs.NotFoundException;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -347,6 +349,18 @@ public class GraphQLServletTest {
 				"JSONObject/data", "JSONObject/testPath_v1_0",
 				"JSONObject/testDTO"));
 
+		Assert.assertEquals(
+			"Not Found",
+			JSONUtil.getValueAsString(
+				_invoke(
+					new GraphQLField(
+						"testPath_v1_0",
+						new GraphQLField(
+							"testNotFoundDTO", new GraphQLField("id"))),
+					"query"),
+				"JSONArray/errors", "Object/0", "JSONObject/extensions",
+				"Object/code"));
+
 		// Without namespace (backwards compatibility)
 
 		_assertEquals(
@@ -359,6 +373,15 @@ public class GraphQLServletTest {
 						new GraphQLField("string")),
 					"query"),
 				"JSONObject/data", "JSONObject/testDTO"));
+
+		Assert.assertEquals(
+			"Not Found",
+			JSONUtil.getValueAsString(
+				_invoke(
+					new GraphQLField("testNotFoundDTO", new GraphQLField("id")),
+					"query"),
+				"JSONArray/errors", "Object/0", "JSONObject/extensions",
+				"Object/code"));
 	}
 
 	@Test
@@ -605,6 +628,11 @@ public class GraphQLServletTest {
 			@GraphQLName("pageSize") int pageSize) {
 
 			return new TestDTOPage(page, pageSize);
+		}
+
+		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+		public TestDTO testNotFoundDTO() {
+			throw new NotFoundException();
 		}
 
 		@GraphQLTypeExtension(TestDTO.class)


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPD-18212

---

The purpose of this PR is to consider the new GraphQL namespace when validating if the GraphQL error must be processed when it comes from a namespaced query/mutation