### PR TITLE
LPD-22155: Allow user to filter MultiselectPicklist Object Fields using Objects REST API

### DIFF
--- a/modules/apps/object/object-api/bnd.bnd
+++ b/modules/apps/object/object-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object API
 Bundle-SymbolicName: com.liferay.object.api
-Bundle-Version: 88.1.0
+Bundle-Version: 89.0.0
 Export-Package:\
 	com.liferay.object.action.engine,\
 	com.liferay.object.action.executor,\

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/odata/filter/expression/field/predicate/provider/FieldPredicateProvider.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/odata/filter/expression/field/predicate/provider/FieldPredicateProvider.java
@@ -6,6 +6,7 @@
 package com.liferay.object.odata.filter.expression.field.predicate.provider;
 
 import com.liferay.petra.sql.dsl.Column;
+import com.liferay.petra.sql.dsl.expression.Expression;
 import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.portal.odata.filter.expression.BinaryExpression;
 
@@ -17,21 +18,61 @@ import java.util.function.Function;
  */
 public interface FieldPredicateProvider {
 
-	public Predicate getBinaryExpressionPredicate(
+	public default Predicate getBinaryExpressionPredicate(
+		Expression<?> objectDefinitionColumnSupplierExpression,
+		BinaryExpression.Operation operation, Object fieldValue) {
+
+		return null;
+	}
+
+	public default Predicate getBinaryExpressionPredicate(
 		Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
 		Object left, long objectDefinitionId,
-		BinaryExpression.Operation operation, Object right);
+		BinaryExpression.Operation operation, Object right) {
 
-	public Predicate getContainsPredicate(
-		Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
-		Object fieldValue);
+		return null;
+	}
 
-	public Predicate getInPredicate(
-		Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
-		List<Object> rights);
+	public default Predicate getContainsPredicate(
+		Expression<?> objectDefinitionColumnSupplierExpression,
+		Object fieldValue) {
 
-	public Predicate getStartsWithPredicate(
+		return null;
+	}
+
+	public default Predicate getContainsPredicate(
 		Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
-		Object fieldValue);
+		Object fieldValue) {
+
+		return null;
+	}
+
+	public default Predicate getInPredicate(
+		Expression<?> objectDefinitionColumnSupplierExpression,
+		List<Object> rights) {
+
+		return null;
+	}
+
+	public default Predicate getInPredicate(
+		Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
+		List<Object> rights) {
+
+		return null;
+	}
+
+	public default Predicate getStartsWithPredicate(
+		Expression<?> objectDefinitionColumnSupplierExpression,
+		Object fieldValue) {
+
+		return null;
+	}
+
+	public default Predicate getStartsWithPredicate(
+		Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
+		Object fieldValue) {
+
+		return null;
+	}
 
 }

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/odata/filter/expression/field/predicate/provider/FieldPredicateProvider.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/odata/filter/expression/field/predicate/provider/FieldPredicateProvider.java
@@ -6,7 +6,6 @@
 package com.liferay.object.odata.filter.expression.field.predicate.provider;
 
 import com.liferay.petra.sql.dsl.Column;
-import com.liferay.petra.sql.dsl.expression.Expression;
 import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.portal.odata.filter.expression.BinaryExpression;
 
@@ -18,61 +17,21 @@ import java.util.function.Function;
  */
 public interface FieldPredicateProvider {
 
-	public default Predicate getBinaryExpressionPredicate(
-		Expression<?> objectDefinitionColumnSupplierExpression,
-		BinaryExpression.Operation operation, Object fieldValue) {
-
-		return null;
-	}
-
-	public default Predicate getBinaryExpressionPredicate(
+	public Predicate getBinaryExpressionPredicate(
 		Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
 		Object left, long objectDefinitionId,
-		BinaryExpression.Operation operation, Object right) {
+		BinaryExpression.Operation operation, Object right);
 
-		return null;
-	}
-
-	public default Predicate getContainsPredicate(
-		Expression<?> objectDefinitionColumnSupplierExpression,
-		Object fieldValue) {
-
-		return null;
-	}
-
-	public default Predicate getContainsPredicate(
+	public Predicate getContainsPredicate(
 		Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
-		Object fieldValue) {
+		String fieldName, Object fieldValue);
 
-		return null;
-	}
-
-	public default Predicate getInPredicate(
-		Expression<?> objectDefinitionColumnSupplierExpression,
-		List<Object> rights) {
-
-		return null;
-	}
-
-	public default Predicate getInPredicate(
+	public Predicate getInPredicate(
 		Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
-		List<Object> rights) {
+		Object left, List<Object> rights);
 
-		return null;
-	}
-
-	public default Predicate getStartsWithPredicate(
-		Expression<?> objectDefinitionColumnSupplierExpression,
-		Object fieldValue) {
-
-		return null;
-	}
-
-	public default Predicate getStartsWithPredicate(
+	public Predicate getStartsWithPredicate(
 		Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
-		Object fieldValue) {
-
-		return null;
-	}
+		String fieldName, Object fieldValue);
 
 }

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/odata/filter/expression/field/predicate/provider/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/odata/filter/expression/field/predicate/provider/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/odata/filter/expression/field/predicate/provider/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/odata/filter/expression/field/predicate/provider/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 2.0.0

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
@@ -24,11 +24,9 @@ import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.petra.function.UnsafeBiFunction;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.sql.dsl.Column;
-import com.liferay.petra.sql.dsl.DSLFunctionFactoryUtil;
 import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.petra.sql.dsl.spi.expression.DefaultPredicate;
 import com.liferay.petra.sql.dsl.spi.expression.Operand;
-import com.liferay.petra.sql.dsl.spi.expression.Scalar;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
@@ -364,13 +362,6 @@ public class PredicateExpressionVisitorImpl
 		_serviceTrackerMap = serviceTrackerMap;
 	}
 
-	private Predicate _contains(
-		Column<?, ?> column,
-		com.liferay.petra.sql.dsl.expression.Expression<String> expression) {
-
-		return column.like(expression);
-	}
-
 	private Predicate _contains(Column<?, ?> column, Object value) {
 		return column.like(StringPool.PERCENT + value + StringPool.PERCENT);
 	}
@@ -396,39 +387,21 @@ public class PredicateExpressionVisitorImpl
 				objectField.getBusinessType(),
 				ObjectFieldConstants.BUSINESS_TYPE_MULTISELECT_PICKLIST)) {
 
-			Object value = _getValue(fieldName, objectDefinition, fieldValue);
+			fieldPredicateProvider = _serviceTrackerMap.getService(
+				objectField.getBusinessType());
 
-			return _contains(
-				_getColumn(fieldName, objectDefinition),
-				DSLFunctionFactoryUtil.concat(
-					new Scalar<>(StringPool.PERCENT),
-					new Scalar<>(value.toString()),
-					new Scalar<>(StringPool.PERCENT)));
+			if (fieldPredicateProvider != null) {
+				Object value = _getValue(
+					fieldName, objectDefinition, fieldValue);
+
+				return fieldPredicateProvider.getContainsPredicate(
+					_getColumn(fieldName, objectDefinition), value);
+			}
 		}
 
 		return _contains(
 			_getColumn(fieldName, objectDefinition),
 			_getValue(fieldName, objectDefinition, fieldValue));
-	}
-
-	private Predicate _eq(
-		Object fieldName, Object fieldValue,
-		ObjectDefinition objectDefinition) {
-
-		Object value = _getValue(fieldName, objectDefinition, fieldValue);
-
-		com.liferay.petra.sql.dsl.expression.Expression<String> rightValue =
-			DSLFunctionFactoryUtil.concat(
-				new Scalar<>("%, "), new Scalar<>(value.toString()),
-				new Scalar<>(", %"));
-
-		com.liferay.petra.sql.dsl.expression.Expression<String> leftValue =
-			DSLFunctionFactoryUtil.concat(
-				new Scalar<>(", "),
-				_getDSLExpression(fieldName, objectDefinition),
-				new Scalar<>(", "));
-
-		return leftValue.like(rightValue);
 	}
 
 	private ObjectRelationship _fetchObjectRelationship(
@@ -497,6 +470,23 @@ public class PredicateExpressionVisitorImpl
 		if (fieldPredicateProvider != null) {
 			return fieldPredicateProvider.getInPredicate(
 				name -> _getColumn(name, objectDefinition), rights);
+		}
+
+		ObjectField objectField = _objectFieldLocalService.fetchObjectField(
+			objectDefinition.getObjectDefinitionId(), String.valueOf(left));
+
+		if ((objectField != null) &&
+			StringUtil.equals(
+				objectField.getBusinessType(),
+				ObjectFieldConstants.BUSINESS_TYPE_MULTISELECT_PICKLIST)) {
+
+			fieldPredicateProvider = _serviceTrackerMap.getService(
+				objectField.getBusinessType());
+
+			if (fieldPredicateProvider != null) {
+				return fieldPredicateProvider.getInPredicate(
+					_getDSLExpression(left, objectDefinition), rights);
+			}
 		}
 
 		return _getColumn(
@@ -645,12 +635,14 @@ public class PredicateExpressionVisitorImpl
 				Predicate.withParentheses((Predicate)right));
 		}
 		else {
+			FieldPredicateProvider fieldPredicateProvider = null;
+
 			ObjectField objectField = _objectFieldLocalService.fetchObjectField(
 				objectDefinition.getObjectDefinitionId(), String.valueOf(left));
 
 			if (objectField == null) {
-				FieldPredicateProvider fieldPredicateProvider =
-					_serviceTrackerMap.getService(String.valueOf(left));
+				fieldPredicateProvider = _serviceTrackerMap.getService(
+					String.valueOf(left));
 
 				if (fieldPredicateProvider != null) {
 					predicate =
@@ -665,11 +657,23 @@ public class PredicateExpressionVisitorImpl
 						ObjectFieldConstants.
 							BUSINESS_TYPE_MULTISELECT_PICKLIST)) {
 
-				if (Objects.equals(BinaryExpression.Operation.EQ, operation)) {
-					predicate = _eq(left, right, objectDefinition);
-				}
-				else {
-					predicate = _contains(left, right, objectDefinition);
+				fieldPredicateProvider = _serviceTrackerMap.getService(
+					objectField.getBusinessType());
+
+				if (fieldPredicateProvider != null) {
+					if (Objects.equals(
+							BinaryExpression.Operation.EQ, operation)) {
+
+						predicate =
+							fieldPredicateProvider.getBinaryExpressionPredicate(
+								_getDSLExpression(left, objectDefinition),
+								_getValue(left, objectDefinition, right));
+					}
+					else {
+						predicate = fieldPredicateProvider.getContainsPredicate(
+							_getColumn(left, objectDefinition),
+							_getValue(left, objectDefinition, right));
+					}
 				}
 			}
 		}
@@ -821,24 +825,13 @@ public class PredicateExpressionVisitorImpl
 			objectDefinition.getObjectDefinitionId(),
 			String.valueOf(fieldName));
 
-		if ((objectField != null) &&
-			StringUtil.equals(
-				objectField.getBusinessType(),
-				ObjectFieldConstants.BUSINESS_TYPE_MULTISELECT_PICKLIST)) {
+		fieldPredicateProvider = _serviceTrackerMap.getService(
+			objectField.getBusinessType());
 
-			Object value = _getValue(fieldName, objectDefinition, fieldValue);
-
-			com.liferay.petra.sql.dsl.expression.Expression<String> rightValue =
-				DSLFunctionFactoryUtil.concat(
-					new Scalar<>("%, " + value + "%, %"));
-
-			com.liferay.petra.sql.dsl.expression.Expression<String> leftValue =
-				DSLFunctionFactoryUtil.concat(
-					new Scalar<>(", "),
-					_getDSLExpression(fieldName, objectDefinition),
-					new Scalar<>(", "));
-
-			return leftValue.like(rightValue);
+		if (fieldPredicateProvider != null) {
+			return fieldPredicateProvider.getStartsWithPredicate(
+				_getDSLExpression(fieldName, objectDefinition),
+				_getValue(fieldName, objectDefinition, fieldValue));
 		}
 
 		return _startsWith(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
@@ -364,6 +364,13 @@ public class PredicateExpressionVisitorImpl
 		_serviceTrackerMap = serviceTrackerMap;
 	}
 
+	private Predicate _contains(
+		Column<?, ?> column,
+		com.liferay.petra.sql.dsl.expression.Expression<String> expression) {
+
+		return column.like(expression);
+	}
+
 	private Predicate _contains(Column<?, ?> column, Object value) {
 		return column.like(StringPool.PERCENT + value + StringPool.PERCENT);
 	}
@@ -378,6 +385,25 @@ public class PredicateExpressionVisitorImpl
 		if (fieldPredicateProvider != null) {
 			return fieldPredicateProvider.getContainsPredicate(
 				name -> _getColumn(name, objectDefinition), fieldValue);
+		}
+
+		ObjectField objectField = _objectFieldLocalService.fetchObjectField(
+			objectDefinition.getObjectDefinitionId(),
+			String.valueOf(fieldName));
+
+		if ((objectField != null) &&
+			StringUtil.equals(
+				objectField.getBusinessType(),
+				ObjectFieldConstants.BUSINESS_TYPE_MULTISELECT_PICKLIST)) {
+
+			Object value = _getValue(fieldName, objectDefinition, fieldValue);
+
+			return _contains(
+				_getColumn(fieldName, objectDefinition),
+				DSLFunctionFactoryUtil.concat(
+					new Scalar<>(StringPool.PERCENT),
+					new Scalar<>(value.toString()),
+					new Scalar<>(StringPool.PERCENT)));
 		}
 
 		return _contains(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
@@ -791,6 +791,30 @@ public class PredicateExpressionVisitorImpl
 				name -> _getColumn(name, objectDefinition), fieldValue);
 		}
 
+		ObjectField objectField = _objectFieldLocalService.fetchObjectField(
+			objectDefinition.getObjectDefinitionId(),
+			String.valueOf(fieldName));
+
+		if ((objectField != null) &&
+			StringUtil.equals(
+				objectField.getBusinessType(),
+				ObjectFieldConstants.BUSINESS_TYPE_MULTISELECT_PICKLIST)) {
+
+			Object value = _getValue(fieldName, objectDefinition, fieldValue);
+
+			com.liferay.petra.sql.dsl.expression.Expression<String> rightValue =
+				DSLFunctionFactoryUtil.concat(
+					new Scalar<>("%, " + value + "%, %"));
+
+			com.liferay.petra.sql.dsl.expression.Expression<String> leftValue =
+				DSLFunctionFactoryUtil.concat(
+					new Scalar<>(", "),
+					_getDSLExpression(fieldName, objectDefinition),
+					new Scalar<>(", "));
+
+			return leftValue.like(rightValue);
+		}
+
 		return _startsWith(
 			_getColumn(fieldName, objectDefinition),
 			_getValue(fieldName, objectDefinition, fieldValue));

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
@@ -371,28 +371,14 @@ public class PredicateExpressionVisitorImpl
 		ObjectDefinition objectDefinition) {
 
 		FieldPredicateProvider fieldPredicateProvider =
-			_serviceTrackerMap.getService(String.valueOf(fieldName));
+			_getFieldPredicateProvider(
+				String.valueOf(fieldName), objectDefinition);
 
 		if (fieldPredicateProvider != null) {
 			return fieldPredicateProvider.getContainsPredicate(
-				name -> _getColumn(name, objectDefinition), fieldValue);
-		}
-
-		ObjectField objectField = _objectFieldLocalService.fetchObjectField(
-			objectDefinition.getObjectDefinitionId(),
-			String.valueOf(fieldName));
-
-		if (objectField != null) {
-			fieldPredicateProvider = _serviceTrackerMap.getService(
-				objectField.getBusinessType());
-
-			if (fieldPredicateProvider != null) {
-				Object value = _getValue(
-					fieldName, objectDefinition, fieldValue);
-
-				return fieldPredicateProvider.getContainsPredicate(
-					_getColumn(fieldName, objectDefinition), value);
-			}
+				name -> _getColumn(name, objectDefinition),
+				String.valueOf(fieldName),
+				_getValue(fieldName, objectDefinition, fieldValue));
 		}
 
 		return _contains(
@@ -428,17 +414,6 @@ public class PredicateExpressionVisitorImpl
 			entityField.getFilterableName(null));
 	}
 
-	private com.liferay.petra.sql.dsl.expression.Expression<String>
-		_getDSLExpression(Object fieldName, ObjectDefinition objectDefinition) {
-
-		EntityField entityField = _getEntityField(fieldName, objectDefinition);
-
-		return (com.liferay.petra.sql.dsl.expression.Expression<String>)
-			_objectFieldLocalService.getColumn(
-				objectDefinition.getObjectDefinitionId(),
-				entityField.getFilterableName(null));
-	}
-
 	private EntityField _getEntityField(
 		Object fieldName, ObjectDefinition objectDefinition) {
 
@@ -457,28 +432,35 @@ public class PredicateExpressionVisitorImpl
 		return entityModel.getEntityFieldsMap();
 	}
 
+	private FieldPredicateProvider _getFieldPredicateProvider(
+		String fieldName, ObjectDefinition objectDefinition) {
+
+		FieldPredicateProvider fieldPredicateProvider =
+			_serviceTrackerMap.getService(fieldName);
+
+		if (fieldPredicateProvider != null) {
+			return fieldPredicateProvider;
+		}
+
+		ObjectField objectField = _objectFieldLocalService.fetchObjectField(
+			objectDefinition.getObjectDefinitionId(), fieldName);
+
+		if (objectField != null) {
+			return _serviceTrackerMap.getService(objectField.getBusinessType());
+		}
+
+		return null;
+	}
+
 	private Predicate _getInPredicate(
 		Object left, ObjectDefinition objectDefinition, List<Object> rights) {
 
 		FieldPredicateProvider fieldPredicateProvider =
-			_serviceTrackerMap.getService(String.valueOf(left));
+			_getFieldPredicateProvider(String.valueOf(left), objectDefinition);
 
 		if (fieldPredicateProvider != null) {
 			return fieldPredicateProvider.getInPredicate(
-				name -> _getColumn(name, objectDefinition), rights);
-		}
-
-		ObjectField objectField = _objectFieldLocalService.fetchObjectField(
-			objectDefinition.getObjectDefinitionId(), String.valueOf(left));
-
-		if (objectField != null) {
-			fieldPredicateProvider = _serviceTrackerMap.getService(
-				objectField.getBusinessType());
-
-			if (fieldPredicateProvider != null) {
-				return fieldPredicateProvider.getInPredicate(
-					_getDSLExpression(left, objectDefinition), rights);
-			}
+				name -> _getColumn(name, objectDefinition), left, rights);
 		}
 
 		return _getColumn(
@@ -627,41 +609,15 @@ public class PredicateExpressionVisitorImpl
 				Predicate.withParentheses((Predicate)right));
 		}
 		else {
-			FieldPredicateProvider fieldPredicateProvider = null;
+			FieldPredicateProvider fieldPredicateProvider =
+				_getFieldPredicateProvider(
+					String.valueOf(left), objectDefinition);
 
-			ObjectField objectField = _objectFieldLocalService.fetchObjectField(
-				objectDefinition.getObjectDefinitionId(), String.valueOf(left));
-
-			if (objectField == null) {
-				fieldPredicateProvider = _serviceTrackerMap.getService(
-					String.valueOf(left));
-
-				if (fieldPredicateProvider != null) {
-					predicate =
-						fieldPredicateProvider.getBinaryExpressionPredicate(
-							name -> _getColumn(name, objectDefinition), left,
-							objectDefinition.getObjectDefinitionId(), operation,
-							right);
-				}
-			}
-			else {
-				fieldPredicateProvider = _serviceTrackerMap.getService(
-					objectField.getBusinessType());
-
-				if (fieldPredicateProvider != null) {
-					Object object = _getValue(left, objectDefinition, right);
-
-					if (operation instanceof BinaryExpression.Operation) {
-						predicate =
-							fieldPredicateProvider.getBinaryExpressionPredicate(
-								_getDSLExpression(left, objectDefinition),
-								operation, object);
-					}
-					else {
-						predicate = fieldPredicateProvider.getContainsPredicate(
-							_getColumn(left, objectDefinition), object);
-					}
-				}
+			if (fieldPredicateProvider != null) {
+				predicate = fieldPredicateProvider.getBinaryExpressionPredicate(
+					name -> _getColumn(name, objectDefinition), left,
+					objectDefinition.getObjectDefinitionId(), operation,
+					_getValue(left, objectDefinition, right));
 			}
 		}
 
@@ -801,24 +757,13 @@ public class PredicateExpressionVisitorImpl
 		ObjectDefinition objectDefinition) {
 
 		FieldPredicateProvider fieldPredicateProvider =
-			_serviceTrackerMap.getService(String.valueOf(fieldName));
+			_getFieldPredicateProvider(
+				String.valueOf(fieldName), objectDefinition);
 
 		if (fieldPredicateProvider != null) {
 			return fieldPredicateProvider.getStartsWithPredicate(
-				name -> _getColumn(name, objectDefinition), fieldValue);
-		}
-
-		ObjectField objectField = _objectFieldLocalService.fetchObjectField(
-			objectDefinition.getObjectDefinitionId(),
-			String.valueOf(fieldName));
-
-		fieldPredicateProvider = _serviceTrackerMap.getService(
-			objectField.getBusinessType());
-
-		if (fieldPredicateProvider != null) {
-			return fieldPredicateProvider.getStartsWithPredicate(
-				_getDSLExpression(fieldName, objectDefinition),
-				_getValue(fieldName, objectDefinition, fieldValue));
+				name -> _getColumn(name, objectDefinition),
+				String.valueOf(fieldName), fieldValue);
 		}
 
 		return _startsWith(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
@@ -382,11 +382,7 @@ public class PredicateExpressionVisitorImpl
 			objectDefinition.getObjectDefinitionId(),
 			String.valueOf(fieldName));
 
-		if ((objectField != null) &&
-			StringUtil.equals(
-				objectField.getBusinessType(),
-				ObjectFieldConstants.BUSINESS_TYPE_MULTISELECT_PICKLIST)) {
-
+		if (objectField != null) {
 			fieldPredicateProvider = _serviceTrackerMap.getService(
 				objectField.getBusinessType());
 
@@ -475,11 +471,7 @@ public class PredicateExpressionVisitorImpl
 		ObjectField objectField = _objectFieldLocalService.fetchObjectField(
 			objectDefinition.getObjectDefinitionId(), String.valueOf(left));
 
-		if ((objectField != null) &&
-			StringUtil.equals(
-				objectField.getBusinessType(),
-				ObjectFieldConstants.BUSINESS_TYPE_MULTISELECT_PICKLIST)) {
-
+		if (objectField != null) {
 			fieldPredicateProvider = _serviceTrackerMap.getService(
 				objectField.getBusinessType());
 
@@ -652,27 +644,22 @@ public class PredicateExpressionVisitorImpl
 							right);
 				}
 			}
-			else if (StringUtil.equals(
-						objectField.getBusinessType(),
-						ObjectFieldConstants.
-							BUSINESS_TYPE_MULTISELECT_PICKLIST)) {
-
+			else {
 				fieldPredicateProvider = _serviceTrackerMap.getService(
 					objectField.getBusinessType());
 
 				if (fieldPredicateProvider != null) {
-					if (Objects.equals(
-							BinaryExpression.Operation.EQ, operation)) {
+					Object object = _getValue(left, objectDefinition, right);
 
+					if (operation instanceof BinaryExpression.Operation) {
 						predicate =
 							fieldPredicateProvider.getBinaryExpressionPredicate(
 								_getDSLExpression(left, objectDefinition),
-								_getValue(left, objectDefinition, right));
+								operation, object);
 					}
 					else {
 						predicate = fieldPredicateProvider.getContainsPredicate(
-							_getColumn(left, objectDefinition),
-							_getValue(left, objectDefinition, right));
+							_getColumn(left, objectDefinition), object);
 					}
 				}
 			}

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
@@ -24,9 +24,11 @@ import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.petra.function.UnsafeBiFunction;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.sql.dsl.Column;
+import com.liferay.petra.sql.dsl.DSLFunctionFactoryUtil;
 import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.petra.sql.dsl.spi.expression.DefaultPredicate;
 import com.liferay.petra.sql.dsl.spi.expression.Operand;
+import com.liferay.petra.sql.dsl.spi.expression.Scalar;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
@@ -383,6 +385,26 @@ public class PredicateExpressionVisitorImpl
 			_getValue(fieldName, objectDefinition, fieldValue));
 	}
 
+	private Predicate _eq(
+		Object fieldName, Object fieldValue,
+		ObjectDefinition objectDefinition) {
+
+		Object value = _getValue(fieldName, objectDefinition, fieldValue);
+
+		com.liferay.petra.sql.dsl.expression.Expression<String> rightValue =
+			DSLFunctionFactoryUtil.concat(
+				new Scalar<>("%, "), new Scalar<>(value.toString()),
+				new Scalar<>(", %"));
+
+		com.liferay.petra.sql.dsl.expression.Expression<String> leftValue =
+			DSLFunctionFactoryUtil.concat(
+				new Scalar<>(", "),
+				_getDSLExpression(fieldName, objectDefinition),
+				new Scalar<>(", "));
+
+		return leftValue.like(rightValue);
+	}
+
 	private ObjectRelationship _fetchObjectRelationship(
 		ObjectDefinition objectDefinition, String objectRelationshipName) {
 
@@ -409,6 +431,17 @@ public class PredicateExpressionVisitorImpl
 		return (Column<?, Object>)_objectFieldLocalService.getColumn(
 			objectDefinition.getObjectDefinitionId(),
 			entityField.getFilterableName(null));
+	}
+
+	private com.liferay.petra.sql.dsl.expression.Expression<String>
+		_getDSLExpression(Object fieldName, ObjectDefinition objectDefinition) {
+
+		EntityField entityField = _getEntityField(fieldName, objectDefinition);
+
+		return (com.liferay.petra.sql.dsl.expression.Expression<String>)
+			_objectFieldLocalService.getColumn(
+				objectDefinition.getObjectDefinitionId(),
+				entityField.getFilterableName(null));
 	}
 
 	private EntityField _getEntityField(
@@ -606,7 +639,12 @@ public class PredicateExpressionVisitorImpl
 						ObjectFieldConstants.
 							BUSINESS_TYPE_MULTISELECT_PICKLIST)) {
 
-				predicate = _contains(left, right, objectDefinition);
+				if (Objects.equals(BinaryExpression.Operation.EQ, operation)) {
+					predicate = _eq(left, right, objectDefinition);
+				}
+				else {
+					predicate = _contains(left, right, objectDefinition);
+				}
 			}
 		}
 

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/field/predicate/provider/KeywordsFieldPredicateProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/field/predicate/provider/KeywordsFieldPredicateProvider.java
@@ -47,7 +47,7 @@ public class KeywordsFieldPredicateProvider implements FieldPredicateProvider {
 	@Override
 	public Predicate getContainsPredicate(
 		Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
-		Object fieldValue) {
+		String fieldName, Object fieldValue) {
 
 		return _getKeywordsPredicate(
 			objectDefinitionColumnSupplier,
@@ -58,7 +58,7 @@ public class KeywordsFieldPredicateProvider implements FieldPredicateProvider {
 	@Override
 	public Predicate getInPredicate(
 		Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
-		List<Object> rights) {
+		Object left, List<Object> rights) {
 
 		return _getKeywordsPredicate(
 			objectDefinitionColumnSupplier,
@@ -70,7 +70,7 @@ public class KeywordsFieldPredicateProvider implements FieldPredicateProvider {
 	@Override
 	public Predicate getStartsWithPredicate(
 		Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
-		Object fieldValue) {
+		String fieldName, Object fieldValue) {
 
 		return _getKeywordsPredicate(
 			objectDefinitionColumnSupplier,

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/field/predicate/provider/MultiselectPicklistFieldPredicateProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/field/predicate/provider/MultiselectPicklistFieldPredicateProvider.java
@@ -7,6 +7,7 @@ package com.liferay.object.rest.internal.odata.filter.expression.field.predicate
 
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.odata.filter.expression.field.predicate.provider.FieldPredicateProvider;
+import com.liferay.petra.sql.dsl.Column;
 import com.liferay.petra.sql.dsl.DSLFunctionFactoryUtil;
 import com.liferay.petra.sql.dsl.expression.Expression;
 import com.liferay.petra.sql.dsl.expression.Predicate;
@@ -19,6 +20,7 @@ import com.liferay.portal.odata.filter.expression.MethodExpression;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Function;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -34,8 +36,9 @@ public class MultiselectPicklistFieldPredicateProvider
 
 	@Override
 	public Predicate getBinaryExpressionPredicate(
-		Expression<?> objectDefinitionColumnSupplierExpression,
-		BinaryExpression.Operation operation, Object fieldValue) {
+		Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
+		Object left, long objectDefinitionId,
+		BinaryExpression.Operation operation, Object right) {
 
 		if (!Objects.equals(operation, BinaryExpression.Operation.EQ)) {
 			throw new UnsupportedOperationException(
@@ -44,26 +47,29 @@ public class MultiselectPicklistFieldPredicateProvider
 		}
 
 		Expression<String> columnFieldExpression = _getFormatedColumnExpression(
-			(Expression<String>)objectDefinitionColumnSupplierExpression);
+			(Expression<String>)objectDefinitionColumnSupplier.apply(
+				String.valueOf(left)));
 
 		return columnFieldExpression.like(
-			_getFieldValueExpression(null, fieldValue));
+			_getFieldValueExpression(null, right));
 	}
 
 	@Override
 	public Predicate getContainsPredicate(
-		Expression<?> objectDefinitionColumnSupplierExpression,
-		Object fieldValue) {
+		Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
+		String fieldName, Object fieldValue) {
 
-		return objectDefinitionColumnSupplierExpression.like(
-			_getFieldValueExpression(
-				MethodExpression.Type.CONTAINS, fieldValue));
+		return objectDefinitionColumnSupplier.apply(
+			fieldName
+		).like(
+			_getFieldValueExpression(MethodExpression.Type.CONTAINS, fieldValue)
+		);
 	}
 
 	@Override
 	public Predicate getInPredicate(
-		Expression<?> objectDefinitionColumnSupplierExpression,
-		List<Object> rights) {
+		Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
+		Object left, List<Object> rights) {
 
 		if (ListUtil.isEmpty(rights)) {
 			return null;
@@ -74,13 +80,13 @@ public class MultiselectPicklistFieldPredicateProvider
 		for (Object right : rights) {
 			if (predicate == null) {
 				predicate = getBinaryExpressionPredicate(
-					objectDefinitionColumnSupplierExpression,
+					objectDefinitionColumnSupplier, left, 0,
 					BinaryExpression.Operation.EQ, right);
 			}
 			else {
 				predicate = predicate.or(
 					getBinaryExpressionPredicate(
-						objectDefinitionColumnSupplierExpression,
+						objectDefinitionColumnSupplier, left, 0,
 						BinaryExpression.Operation.EQ, right));
 			}
 		}
@@ -90,11 +96,12 @@ public class MultiselectPicklistFieldPredicateProvider
 
 	@Override
 	public Predicate getStartsWithPredicate(
-		Expression<?> objectDefinitionColumnSupplierExpression,
-		Object fieldValue) {
+		Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
+		String fieldName, Object fieldValue) {
 
 		Expression<String> columnFieldExpression = _getFormatedColumnExpression(
-			(Expression<String>)objectDefinitionColumnSupplierExpression);
+			(Expression<String>)objectDefinitionColumnSupplier.apply(
+				fieldName));
 
 		return columnFieldExpression.like(
 			_getFieldValueExpression(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/field/predicate/provider/MultiselectPicklistFieldPredicateProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/field/predicate/provider/MultiselectPicklistFieldPredicateProvider.java
@@ -1,0 +1,62 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.rest.internal.odata.filter.expression.field.predicate.provider;
+
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.odata.filter.expression.field.predicate.provider.FieldPredicateProvider;
+import com.liferay.petra.sql.dsl.Column;
+import com.liferay.petra.sql.dsl.expression.Predicate;
+import com.liferay.portal.odata.filter.expression.BinaryExpression;
+
+import java.util.List;
+import java.util.function.Function;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Sergio Jiménez del Coso
+ */
+@Component(
+	property = "field.predicate.provider.key=" + ObjectFieldConstants.BUSINESS_TYPE_MULTISELECT_PICKLIST,
+	service = FieldPredicateProvider.class
+)
+public class MultiselectPicklistFieldPredicateProvider
+	implements FieldPredicateProvider {
+
+	@Override
+	public Predicate getBinaryExpressionPredicate(
+		Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
+		Object left, long objectDefinitionId,
+		BinaryExpression.Operation operation, Object right) {
+
+		return null;
+	}
+
+	@Override
+	public Predicate getContainsPredicate(
+		Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
+		Object fieldValue) {
+
+		return null;
+	}
+
+	@Override
+	public Predicate getInPredicate(
+		Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
+		List<Object> rights) {
+
+		return null;
+	}
+
+	@Override
+	public Predicate getStartsWithPredicate(
+		Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
+		Object fieldValue) {
+
+		return null;
+	}
+
+}

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/field/predicate/provider/MultiselectPicklistFieldPredicateProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/field/predicate/provider/MultiselectPicklistFieldPredicateProvider.java
@@ -40,18 +40,26 @@ public class MultiselectPicklistFieldPredicateProvider
 		Object left, long objectDefinitionId,
 		BinaryExpression.Operation operation, Object right) {
 
-		if (!Objects.equals(operation, BinaryExpression.Operation.EQ)) {
-			throw new UnsupportedOperationException(
-				operation +
-					" is not supported in MultiselectPicklist Object Fields");
+		Expression<String> columnFieldExpression =
+			(Expression<String>)objectDefinitionColumnSupplier.apply(
+				String.valueOf(left));
+
+		if (Objects.equals(operation, BinaryExpression.Operation.EQ)) {
+			Expression<String> formatedColumnExpression =
+				DSLFunctionFactoryUtil.concat(
+					new Scalar<>(_SCALAR_EXPRESSION), columnFieldExpression,
+					new Scalar<>(_SCALAR_EXPRESSION));
+
+			return formatedColumnExpression.like(
+				_getFieldValueExpression(String.valueOf(right), null));
+		}
+		else if (Objects.equals(operation, BinaryExpression.Operation.NE)) {
+			return columnFieldExpression.neq(String.valueOf(right));
 		}
 
-		Expression<String> columnFieldExpression = _getFormatedColumnExpression(
-			(Expression<String>)objectDefinitionColumnSupplier.apply(
-				String.valueOf(left)));
-
-		return columnFieldExpression.like(
-			_getFieldValueExpression(null, right));
+		throw new UnsupportedOperationException(
+			operation +
+				" is not supported in MultiselectPicklist Object Fields");
 	}
 
 	@Override
@@ -62,7 +70,8 @@ public class MultiselectPicklistFieldPredicateProvider
 		return objectDefinitionColumnSupplier.apply(
 			fieldName
 		).like(
-			_getFieldValueExpression(MethodExpression.Type.CONTAINS, fieldValue)
+			_getFieldValueExpression(
+				String.valueOf(fieldValue), MethodExpression.Type.CONTAINS)
 		);
 	}
 
@@ -99,49 +108,46 @@ public class MultiselectPicklistFieldPredicateProvider
 		Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
 		String fieldName, Object fieldValue) {
 
-		Expression<String> columnFieldExpression = _getFormatedColumnExpression(
-			(Expression<String>)objectDefinitionColumnSupplier.apply(
-				fieldName));
+		Expression<String> columnFieldExpression =
+			DSLFunctionFactoryUtil.concat(
+				new Scalar<>(_SCALAR_EXPRESSION),
+				(Expression<String>)objectDefinitionColumnSupplier.apply(
+					fieldName),
+				new Scalar<>(_SCALAR_EXPRESSION));
 
 		return columnFieldExpression.like(
 			_getFieldValueExpression(
-				MethodExpression.Type.STARTS_WITH, fieldValue));
+				String.valueOf(fieldValue), MethodExpression.Type.STARTS_WITH));
 	}
 
 	private Expression<String> _getFieldValueExpression(
-		MethodExpression.Type methodExpressionType, Object fieldValue) {
+		String fieldValue, MethodExpression.Type methodExpressionType) {
+
+		String expressionString = null;
 
 		if (Objects.equals(
 				methodExpressionType, MethodExpression.Type.CONTAINS)) {
 
-			return DSLFunctionFactoryUtil.concat(
-				new Scalar<>(StringPool.PERCENT),
-				new Scalar<>(fieldValue.toString()),
-				new Scalar<>(StringPool.PERCENT));
+			expressionString = StringBundler.concat(
+				StringPool.PERCENT, fieldValue, StringPool.PERCENT);
 		}
 		else if (Objects.equals(
 					methodExpressionType, MethodExpression.Type.STARTS_WITH)) {
 
-			return DSLFunctionFactoryUtil.concat(
-				new Scalar<>("%, " + fieldValue + "%, %"));
+			expressionString = StringBundler.concat(
+				StringPool.PERCENT, _SCALAR_EXPRESSION, fieldValue,
+				StringPool.PERCENT, _SCALAR_EXPRESSION, StringPool.PERCENT);
+		}
+		else {
+			expressionString = StringBundler.concat(
+				StringPool.PERCENT, _SCALAR_EXPRESSION, fieldValue,
+				_SCALAR_EXPRESSION, StringPool.PERCENT);
 		}
 
-		return DSLFunctionFactoryUtil.concat(
-			new Scalar<>("%, "), new Scalar<>(fieldValue.toString()),
-			new Scalar<>(", %"));
+		return new Scalar<>(expressionString);
 	}
 
-	private Expression<String> _getFormatedColumnExpression(
-		Expression<String> expression) {
-
-		StringBundler sb = new StringBundler(2);
-
-		sb.append(StringPool.COMMA);
-		sb.append(StringPool.SPACE);
-
-		return DSLFunctionFactoryUtil.concat(
-			new Scalar<>(sb.toString()), expression,
-			new Scalar<>(sb.toString()));
-	}
+	private static final String _SCALAR_EXPRESSION =
+		StringPool.COMMA + StringPool.SPACE;
 
 }

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/field/predicate/provider/MultiselectPicklistFieldPredicateProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/field/predicate/provider/MultiselectPicklistFieldPredicateProvider.java
@@ -14,6 +14,7 @@ import com.liferay.petra.sql.dsl.spi.expression.Scalar;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.odata.filter.expression.BinaryExpression;
 import com.liferay.portal.odata.filter.expression.MethodExpression;
 
 import java.util.List;
@@ -34,7 +35,13 @@ public class MultiselectPicklistFieldPredicateProvider
 	@Override
 	public Predicate getBinaryExpressionPredicate(
 		Expression<?> objectDefinitionColumnSupplierExpression,
-		Object fieldValue) {
+		BinaryExpression.Operation operation, Object fieldValue) {
+
+		if (!Objects.equals(operation, BinaryExpression.Operation.EQ)) {
+			throw new UnsupportedOperationException(
+				operation +
+					" is not supported in MultiselectPicklist Object Fields");
+		}
 
 		Expression<String> columnFieldExpression = _getFormatedColumnExpression(
 			(Expression<String>)objectDefinitionColumnSupplierExpression);
@@ -67,12 +74,14 @@ public class MultiselectPicklistFieldPredicateProvider
 		for (Object right : rights) {
 			if (predicate == null) {
 				predicate = getBinaryExpressionPredicate(
-					objectDefinitionColumnSupplierExpression, right);
+					objectDefinitionColumnSupplierExpression,
+					BinaryExpression.Operation.EQ, right);
 			}
 			else {
 				predicate = predicate.or(
 					getBinaryExpressionPredicate(
-						objectDefinitionColumnSupplierExpression, right));
+						objectDefinitionColumnSupplierExpression,
+						BinaryExpression.Operation.EQ, right));
 			}
 		}
 

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/field/predicate/provider/MultiselectPicklistFieldPredicateProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/field/predicate/provider/MultiselectPicklistFieldPredicateProvider.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
@@ -7,12 +7,17 @@ package com.liferay.object.rest.internal.odata.filter.expression.field.predicate
 
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.odata.filter.expression.field.predicate.provider.FieldPredicateProvider;
-import com.liferay.petra.sql.dsl.Column;
+import com.liferay.petra.sql.dsl.DSLFunctionFactoryUtil;
+import com.liferay.petra.sql.dsl.expression.Expression;
 import com.liferay.petra.sql.dsl.expression.Predicate;
-import com.liferay.portal.odata.filter.expression.BinaryExpression;
+import com.liferay.petra.sql.dsl.spi.expression.Scalar;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.odata.filter.expression.MethodExpression;
 
 import java.util.List;
-import java.util.function.Function;
+import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -28,35 +33,99 @@ public class MultiselectPicklistFieldPredicateProvider
 
 	@Override
 	public Predicate getBinaryExpressionPredicate(
-		Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
-		Object left, long objectDefinitionId,
-		BinaryExpression.Operation operation, Object right) {
+		Expression<?> objectDefinitionColumnSupplierExpression,
+		Object fieldValue) {
 
-		return null;
+		Expression<String> columnFieldExpression = _getFormatedColumnExpression(
+			(Expression<String>)objectDefinitionColumnSupplierExpression);
+
+		return columnFieldExpression.like(
+			_getFieldValueExpression(null, fieldValue));
 	}
 
 	@Override
 	public Predicate getContainsPredicate(
-		Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
+		Expression<?> objectDefinitionColumnSupplierExpression,
 		Object fieldValue) {
 
-		return null;
+		return objectDefinitionColumnSupplierExpression.like(
+			_getFieldValueExpression(
+				MethodExpression.Type.CONTAINS, fieldValue));
 	}
 
 	@Override
 	public Predicate getInPredicate(
-		Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
+		Expression<?> objectDefinitionColumnSupplierExpression,
 		List<Object> rights) {
 
-		return null;
+		if (ListUtil.isEmpty(rights)) {
+			return null;
+		}
+
+		Predicate predicate = null;
+
+		for (Object right : rights) {
+			if (predicate == null) {
+				predicate = getBinaryExpressionPredicate(
+					objectDefinitionColumnSupplierExpression, right);
+			}
+			else {
+				predicate = predicate.or(
+					getBinaryExpressionPredicate(
+						objectDefinitionColumnSupplierExpression, right));
+			}
+		}
+
+		return predicate;
 	}
 
 	@Override
 	public Predicate getStartsWithPredicate(
-		Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
+		Expression<?> objectDefinitionColumnSupplierExpression,
 		Object fieldValue) {
 
-		return null;
+		Expression<String> columnFieldExpression = _getFormatedColumnExpression(
+			(Expression<String>)objectDefinitionColumnSupplierExpression);
+
+		return columnFieldExpression.like(
+			_getFieldValueExpression(
+				MethodExpression.Type.STARTS_WITH, fieldValue));
+	}
+
+	private Expression<String> _getFieldValueExpression(
+		MethodExpression.Type methodExpressionType, Object fieldValue) {
+
+		if (Objects.equals(
+				methodExpressionType, MethodExpression.Type.CONTAINS)) {
+
+			return DSLFunctionFactoryUtil.concat(
+				new Scalar<>(StringPool.PERCENT),
+				new Scalar<>(fieldValue.toString()),
+				new Scalar<>(StringPool.PERCENT));
+		}
+		else if (Objects.equals(
+					methodExpressionType, MethodExpression.Type.STARTS_WITH)) {
+
+			return DSLFunctionFactoryUtil.concat(
+				new Scalar<>("%, " + fieldValue + "%, %"));
+		}
+
+		return DSLFunctionFactoryUtil.concat(
+			new Scalar<>("%, "), new Scalar<>(fieldValue.toString()),
+			new Scalar<>(", %"));
+	}
+
+	private Expression<String> _getFormatedColumnExpression(
+		Expression<String> expression) {
+
+		StringBundler sb = new StringBundler(2);
+
+		sb.append(StringPool.COMMA);
+		sb.append(StringPool.SPACE);
+
+		return DSLFunctionFactoryUtil.concat(
+			new Scalar<>(sb.toString()), expression,
+			new Scalar<>(sb.toString()));
 	}
 
 }

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/field/predicate/provider/TaxonomyCategoryIdsFieldPredicateProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/field/predicate/provider/TaxonomyCategoryIdsFieldPredicateProvider.java
@@ -47,7 +47,7 @@ public class TaxonomyCategoryIdsFieldPredicateProvider
 	@Override
 	public Predicate getContainsPredicate(
 		Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
-		Object fieldValue) {
+		String fieldName, Object fieldValue) {
 
 		throw new UnsupportedOperationException(
 			"Unsupported method getContainsPredicate for taxonomyCategoryIds");
@@ -56,7 +56,7 @@ public class TaxonomyCategoryIdsFieldPredicateProvider
 	@Override
 	public Predicate getInPredicate(
 		Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
-		List<Object> rights) {
+		Object left, List<Object> rights) {
 
 		return _getTaxonomyCategoryIdsPredicate(
 			objectDefinitionColumnSupplier,
@@ -69,7 +69,7 @@ public class TaxonomyCategoryIdsFieldPredicateProvider
 	@Override
 	public Predicate getStartsWithPredicate(
 		Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
-		Object fieldValue) {
+		String fieldName, Object fieldValue) {
 
 		throw new UnsupportedOperationException(
 			"Unsupported method getStartsWithPredicate for " +

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -2408,7 +2408,9 @@ public class ObjectEntryResourceTest {
 			HashMapBuilder.<String, Serializable>put(
 				_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1
 			).put(
-				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST, _LIST_TYPE_ENTRY_KEY_1
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				(Serializable)Arrays.asList(
+					_LIST_TYPE_ENTRY_KEY_1, _LIST_TYPE_ENTRY_KEY_2)
 			).build(),
 			_TAG_1);
 		_objectEntry2 = ObjectEntryTestUtil.addObjectEntry(
@@ -2416,9 +2418,11 @@ public class ObjectEntryResourceTest {
 			HashMapBuilder.<String, Serializable>put(
 				_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2
 			).put(
-				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST, _LIST_TYPE_ENTRY_KEY_1
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				(Serializable)Arrays.asList(
+					_LIST_TYPE_ENTRY_KEY_1, _LIST_TYPE_ENTRY_KEY_2)
 			).build(),
-			_TAG_1);
+			_TAG_2);
 
 		// Many to many relationship, custom object field
 
@@ -2457,6 +2461,14 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
+					"%s/%s/any(k:k ne '%s')", _objectRelationship1.getName(),
+					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+					_LIST_TYPE_ENTRY_KEY_1)),
+			_objectDefinition1);
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
 					"%s/%s/any(k:startswith(k,'%s'))",
 					_objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
@@ -2470,29 +2482,36 @@ public class ObjectEntryResourceTest {
 			_escape(
 				String.format(
 					"%s/keywords/any(k:contains(k,'%s'))",
-					_objectRelationship1.getName(), _TAG_1.substring(1))),
+					_objectRelationship1.getName(), _TAG_2.substring(1))),
 			_objectDefinition1);
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
 					"%s/keywords/any(k:k eq '%s')",
-					_objectRelationship1.getName(), _TAG_1)),
+					_objectRelationship1.getName(), _TAG_2)),
 			_objectDefinition1);
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
 					"%s/keywords/any(k:k in ('%s', '%s'))",
-					_objectRelationship1.getName(), _TAG_1,
+					_objectRelationship1.getName(), _TAG_2,
 					RandomTestUtil.randomString())),
 			_objectDefinition1);
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
+					"%s/keywords/any(k:k ne '%s')",
+					_objectRelationship1.getName(), _TAG_1)),
+			_objectDefinition1);
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
 					"%s/keywords/any(k:startswith(k,'%s'))",
-					_objectRelationship1.getName(), _TAG_1.substring(0, 2))),
+					_objectRelationship1.getName(), _TAG_2.substring(0, 2))),
 			_objectDefinition1);
 
 		// Many to many relationship (other side), custom object field
@@ -2527,6 +2546,14 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
 			_escape(
 				String.format(
+					"%s/%s/any(k:k ne '%s')", _objectRelationship1.getName(),
+					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+					_LIST_TYPE_ENTRY_KEY_1)),
+			_objectDefinition2);
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
 					"%s/%s/any(k:startswith(k,'%s'))",
 					_objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
@@ -2556,6 +2583,13 @@ public class ObjectEntryResourceTest {
 					"%s/keywords/any(k:k in ('%s', '%s'))",
 					_objectRelationship1.getName(), _TAG_1,
 					RandomTestUtil.randomString())),
+			_objectDefinition2);
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/keywords/any(k:k ne '%s')",
+					_objectRelationship1.getName(), _TAG_2)),
 			_objectDefinition2);
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
@@ -2634,6 +2668,23 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
+					"%s/%s/any(k:k ne '%s')", _objectRelationship1.getName(),
+					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+					_LIST_TYPE_ENTRY_KEY_1)),
+			_objectDefinition1);
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s/%s/any(k:k ne '%s')", _objectRelationship1.getName(),
+					_objectRelationship1.getName(),
+					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+					_LIST_TYPE_ENTRY_KEY_1)),
+			_objectDefinition1);
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
 					"%s/%s/any(k:startswith(k,'%s'))",
 					_objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
@@ -2690,6 +2741,14 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
+					"%s/%s/any(k:k ne '%s')", _objectRelationship1.getName(),
+					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+					_LIST_TYPE_ENTRY_KEY_1)),
+			_objectDefinition1);
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
 					"%s/%s/any(k:startswith(k,'%s'))",
 					_objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
@@ -2703,29 +2762,36 @@ public class ObjectEntryResourceTest {
 			_escape(
 				String.format(
 					"%s/keywords/any(k:contains(k,'%s'))",
-					_objectRelationship1.getName(), _TAG_1.substring(1))),
+					_objectRelationship1.getName(), _TAG_2.substring(1))),
 			_objectDefinition1);
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
 					"%s/keywords/any(k:k eq '%s')",
-					_objectRelationship1.getName(), _TAG_1)),
+					_objectRelationship1.getName(), _TAG_2)),
 			_objectDefinition1);
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
 					"%s/keywords/any(k:k in ('%s', '%s'))",
-					_objectRelationship1.getName(), _TAG_1,
+					_objectRelationship1.getName(), _TAG_2,
 					RandomTestUtil.randomString())),
 			_objectDefinition1);
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
+					"%s/keywords/any(k:k ne '%s')",
+					_objectRelationship1.getName(), _TAG_1)),
+			_objectDefinition1);
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
 					"%s/keywords/any(k:startswith(k,'%s'))",
-					_objectRelationship1.getName(), _TAG_1.substring(0, 2))),
+					_objectRelationship1.getName(), _TAG_2.substring(0, 2))),
 			_objectDefinition1);
 
 		// One to many relationship (other side), custom object field
@@ -2760,6 +2826,14 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
 			_escape(
 				String.format(
+					"%s/%s/any(k:k ne '%s')", _objectRelationship1.getName(),
+					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+					_LIST_TYPE_ENTRY_KEY_1)),
+			_objectDefinition2);
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
 					"%s/%s/any(k:startswith(k,'%s'))",
 					_objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
@@ -2789,6 +2863,13 @@ public class ObjectEntryResourceTest {
 					"%s/keywords/any(k:k in ('%s', '%s'))",
 					_objectRelationship1.getName(), _TAG_1,
 					RandomTestUtil.randomString())),
+			_objectDefinition2);
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
+			_escape(
+				String.format(
+					"%s/keywords/any(k:k ne '%s')",
+					_objectRelationship1.getName(), _TAG_2)),
 			_objectDefinition2);
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2,
@@ -2867,6 +2948,23 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
+					"%s/%s/any(k:k ne '%s')", _objectRelationship1.getName(),
+					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+					_LIST_TYPE_ENTRY_KEY_1)),
+			_objectDefinition1);
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s/%s/any(k:k ne '%s')", _objectRelationship1.getName(),
+					_objectRelationship1.getName(),
+					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+					_LIST_TYPE_ENTRY_KEY_1)),
+			_objectDefinition1);
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
 					"%s/%s/any(k:startswith(k,'%s'))",
 					_objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
@@ -2901,17 +2999,17 @@ public class ObjectEntryResourceTest {
 			HashMapBuilder.<String, Serializable>put(
 				_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2
 			).put(
-				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST, _LIST_TYPE_ENTRY_KEY_1
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST, _LIST_TYPE_ENTRY_KEY_2
 			).build(),
-			_TAG_1);
+			_TAG_2);
 		_objectEntry3 = ObjectEntryTestUtil.addObjectEntry(
 			_objectDefinition3,
 			HashMapBuilder.<String, Serializable>put(
 				_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3
 			).put(
-				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST, _LIST_TYPE_ENTRY_KEY_1
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST, _LIST_TYPE_ENTRY_KEY_3
 			).build(),
-			_TAG_1);
+			_TAG_3);
 
 		// Many to many relationship, custom object field
 
@@ -2931,7 +3029,7 @@ public class ObjectEntryResourceTest {
 					"%s/%s/%s/any(k:k eq '%s')", _objectRelationship1.getName(),
 					_objectRelationship2.getName(),
 					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
-					_LIST_TYPE_ENTRY_KEY_1)),
+					_LIST_TYPE_ENTRY_KEY_3)),
 			_objectDefinition1);
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
@@ -2941,7 +3039,16 @@ public class ObjectEntryResourceTest {
 					_objectRelationship1.getName(),
 					_objectRelationship2.getName(),
 					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
-					_LIST_TYPE_ENTRY_KEY_1)),
+					_LIST_TYPE_ENTRY_KEY_3)),
+			_objectDefinition1);
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s/%s/any(k:k ne '%s')", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+					_LIST_TYPE_ENTRY_KEY_2)),
 			_objectDefinition1);
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
@@ -2951,7 +3058,7 @@ public class ObjectEntryResourceTest {
 					_objectRelationship1.getName(),
 					_objectRelationship2.getName(),
 					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
-					_LIST_TYPE_ENTRY_KEY_1)),
+					_LIST_TYPE_ENTRY_KEY_3)),
 			_objectDefinition1);
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
@@ -2961,7 +3068,7 @@ public class ObjectEntryResourceTest {
 					_objectRelationship1.getName(),
 					_objectRelationship2.getName(),
 					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
-					_LIST_TYPE_ENTRY_KEY_1, RandomTestUtil.randomString())),
+					_LIST_TYPE_ENTRY_KEY_3, RandomTestUtil.randomString())),
 			_objectDefinition1);
 
 		// Many to many relationship, system object field
@@ -2972,7 +3079,7 @@ public class ObjectEntryResourceTest {
 				String.format(
 					"%s/%s/keywords/any(k:k eq '%s')",
 					_objectRelationship1.getName(),
-					_objectRelationship2.getName(), _TAG_1)),
+					_objectRelationship2.getName(), _TAG_3)),
 			_objectDefinition1);
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
@@ -2980,7 +3087,15 @@ public class ObjectEntryResourceTest {
 				String.format(
 					"%s/%s/keywords/any(k:contains(k,'%s'))",
 					_objectRelationship1.getName(),
-					_objectRelationship2.getName(), _TAG_1.substring(1))),
+					_objectRelationship2.getName(), _TAG_3.substring(1))),
+			_objectDefinition1);
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s/keywords/any(k:k ne '%s')",
+					_objectRelationship1.getName(),
+					_objectRelationship2.getName(), _TAG_1)),
 			_objectDefinition1);
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
@@ -2988,7 +3103,7 @@ public class ObjectEntryResourceTest {
 				String.format(
 					"%s/%s/keywords/any(k:startswith(k,'%s'))",
 					_objectRelationship1.getName(),
-					_objectRelationship2.getName(), _TAG_1.substring(0, 2))),
+					_objectRelationship2.getName(), _TAG_3.substring(0, 2))),
 			_objectDefinition1);
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
@@ -2996,7 +3111,7 @@ public class ObjectEntryResourceTest {
 				String.format(
 					"%s/%s/keywords/any(k:k in ('%s', '%s'))",
 					_objectRelationship1.getName(),
-					_objectRelationship2.getName(), _TAG_1,
+					_objectRelationship2.getName(), _TAG_3,
 					RandomTestUtil.randomString())),
 			_objectDefinition1);
 
@@ -3020,6 +3135,15 @@ public class ObjectEntryResourceTest {
 					_objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
 					_LIST_TYPE_ENTRY_KEY_1)),
+			_objectDefinition3);
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
+			_escape(
+				String.format(
+					"%s/%s/%s/any(k:k ne '%s')", _objectRelationship2.getName(),
+					_objectRelationship1.getName(),
+					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+					_LIST_TYPE_ENTRY_KEY_3)),
 			_objectDefinition3);
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
@@ -3064,6 +3188,14 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
 			_escape(
 				String.format(
+					"%s/%s/keywords/any(k:k ne '%s')",
+					_objectRelationship2.getName(),
+					_objectRelationship1.getName(), _TAG_3)),
+			_objectDefinition3);
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
+			_escape(
+				String.format(
 					"%s/%s/keywords/any(k:startswith(k,'%s'))",
 					_objectRelationship2.getName(),
 					_objectRelationship1.getName(), _TAG_1.substring(0, 2))),
@@ -3101,7 +3233,7 @@ public class ObjectEntryResourceTest {
 					"%s/%s/%s/any(k:k eq '%s')", _objectRelationship1.getName(),
 					_objectRelationship2.getName(),
 					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
-					_LIST_TYPE_ENTRY_KEY_1)),
+					_LIST_TYPE_ENTRY_KEY_3)),
 			_objectDefinition1);
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
@@ -3109,6 +3241,15 @@ public class ObjectEntryResourceTest {
 				String.format(
 					"%s/%s/%s/any(k:contains(k,'%s'))",
 					_objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+					_LIST_TYPE_ENTRY_KEY_3)),
+			_objectDefinition1);
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s/%s/any(k:k ne '%s')", _objectRelationship1.getName(),
 					_objectRelationship2.getName(),
 					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
 					_LIST_TYPE_ENTRY_KEY_1)),
@@ -3121,7 +3262,7 @@ public class ObjectEntryResourceTest {
 					_objectRelationship1.getName(),
 					_objectRelationship2.getName(),
 					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
-					_LIST_TYPE_ENTRY_KEY_1)),
+					_LIST_TYPE_ENTRY_KEY_3)),
 			_objectDefinition1);
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
@@ -3131,7 +3272,7 @@ public class ObjectEntryResourceTest {
 					_objectRelationship1.getName(),
 					_objectRelationship2.getName(),
 					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
-					_LIST_TYPE_ENTRY_KEY_1, RandomTestUtil.randomString())),
+					_LIST_TYPE_ENTRY_KEY_3, RandomTestUtil.randomString())),
 			_objectDefinition1);
 
 		// One to many relationship, system object field
@@ -3142,7 +3283,7 @@ public class ObjectEntryResourceTest {
 				String.format(
 					"%s/%s/keywords/any(k:k eq '%s')",
 					_objectRelationship1.getName(),
-					_objectRelationship2.getName(), _TAG_1)),
+					_objectRelationship2.getName(), _TAG_3)),
 			_objectDefinition1);
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
@@ -3150,7 +3291,15 @@ public class ObjectEntryResourceTest {
 				String.format(
 					"%s/%s/keywords/any(k:contains(k,'%s'))",
 					_objectRelationship1.getName(),
-					_objectRelationship2.getName(), _TAG_1.substring(1))),
+					_objectRelationship2.getName(), _TAG_3.substring(1))),
+			_objectDefinition1);
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s/keywords/any(k:k ne '%s')",
+					_objectRelationship1.getName(),
+					_objectRelationship2.getName(), _TAG_1)),
 			_objectDefinition1);
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
@@ -3158,7 +3307,7 @@ public class ObjectEntryResourceTest {
 				String.format(
 					"%s/%s/keywords/any(k:startswith(k,'%s'))",
 					_objectRelationship1.getName(),
-					_objectRelationship2.getName(), _TAG_1.substring(0, 2))),
+					_objectRelationship2.getName(), _TAG_3.substring(0, 2))),
 			_objectDefinition1);
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
@@ -3166,7 +3315,7 @@ public class ObjectEntryResourceTest {
 				String.format(
 					"%s/%s/keywords/any(k:k in ('%s', '%s'))",
 					_objectRelationship1.getName(),
-					_objectRelationship2.getName(), _TAG_1,
+					_objectRelationship2.getName(), _TAG_3,
 					RandomTestUtil.randomString())),
 			_objectDefinition1);
 
@@ -3190,6 +3339,15 @@ public class ObjectEntryResourceTest {
 					_objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
 					_LIST_TYPE_ENTRY_KEY_1)),
+			_objectDefinition3);
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
+			_escape(
+				String.format(
+					"%s/%s/%s/any(k:k ne '%s')", _objectRelationship2.getName(),
+					_objectRelationship1.getName(),
+					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+					_LIST_TYPE_ENTRY_KEY_3)),
 			_objectDefinition3);
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
@@ -3229,6 +3387,14 @@ public class ObjectEntryResourceTest {
 					"%s/%s/keywords/any(k:contains(k,'%s'))",
 					_objectRelationship2.getName(),
 					_objectRelationship1.getName(), _TAG_1.substring(1))),
+			_objectDefinition3);
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
+			_escape(
+				String.format(
+					"%s/%s/keywords/any(k:k ne '%s')",
+					_objectRelationship2.getName(),
+					_objectRelationship1.getName(), _TAG_3)),
 			_objectDefinition3);
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
@@ -11517,6 +11683,12 @@ public class ObjectEntryResourceTest {
 	private static final int _OBJECT_FIELD_VALUE_4 = RandomTestUtil.randomInt();
 
 	private static final String _TAG_1 = StringUtil.toLowerCase(
+		RandomTestUtil.randomString());
+
+	private static final String _TAG_2 = StringUtil.toLowerCase(
+		RandomTestUtil.randomString());
+
+	private static final String _TAG_3 = StringUtil.toLowerCase(
 		RandomTestUtil.randomString());
 
 	private static AssetVocabulary _assetVocabulary;

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -2239,167 +2239,6 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
-	public void testFilterByLambdaOperatorsObjectEntriesByMultiselectPicklistField()
-		throws Exception {
-
-		ObjectEntryTestUtil.addObjectEntry(
-			_objectDefinition1,
-			HashMapBuilder.<String, Serializable>put(
-				_OBJECT_FIELD_NAME_1, RandomTestUtil.randomString()
-			).put(
-				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST, _LIST_TYPE_ENTRY_KEY_1
-			).build(),
-			_TAG_1);
-		ObjectEntryTestUtil.addObjectEntry(
-			_objectDefinition1,
-			HashMapBuilder.<String, Serializable>put(
-				_OBJECT_FIELD_NAME_1, RandomTestUtil.randomString()
-			).put(
-				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
-				(Serializable)Arrays.asList(
-					_LIST_TYPE_ENTRY_KEY_1, _LIST_TYPE_ENTRY_KEY_2)
-			).build(),
-			_TAG_1);
-		ObjectEntryTestUtil.addObjectEntry(
-			_objectDefinition1,
-			HashMapBuilder.<String, Serializable>put(
-				_OBJECT_FIELD_NAME_1, RandomTestUtil.randomString()
-			).put(
-				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
-				(Serializable)Arrays.asList(
-					_LIST_TYPE_ENTRY_KEY_1, _LIST_TYPE_ENTRY_KEY_2,
-					_LIST_TYPE_ENTRY_KEY_3)
-			).build(),
-			_TAG_1);
-
-		_assertFilteredObjectEntries(
-			3,
-			String.format(
-				"%s/any(k:contains(k,'%s'))",
-				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
-				_LIST_TYPE_ENTRY_KEY_1.substring(1)));
-		_assertFilteredObjectEntries(
-			2,
-			String.format(
-				"%s/any(k:contains(k,'%s'))",
-				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
-				_LIST_TYPE_ENTRY_KEY_2.substring(1)));
-		_assertFilteredObjectEntries(
-			1,
-			String.format(
-				"%s/any(k:contains(k,'%s'))",
-				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
-				_LIST_TYPE_ENTRY_KEY_3.substring(1)));
-		_assertFilteredObjectEntries(
-			0,
-			String.format(
-				"%s/any(k:contains(k,'%s'))",
-				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
-				RandomTestUtil.randomString()));
-
-		_assertFilteredObjectEntries(
-			3,
-			String.format(
-				"%s/any(k:k eq '%s')", _OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
-				_LIST_TYPE_ENTRY_KEY_1));
-		_assertFilteredObjectEntries(
-			2,
-			String.format(
-				"%s/any(k:k eq '%s')", _OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
-				_LIST_TYPE_ENTRY_KEY_2));
-		_assertFilteredObjectEntries(
-			1,
-			String.format(
-				"%s/any(k:k eq '%s')", _OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
-				_LIST_TYPE_ENTRY_KEY_3));
-		_assertFilteredObjectEntries(
-			0,
-			String.format(
-				"%s/any(k:k eq '%s')", _OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
-				RandomTestUtil.randomString()));
-
-		_assertFilteredObjectEntries(
-			3,
-			String.format(
-				"%s/any(k:k in ('%s','%s'))",
-				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST, _LIST_TYPE_ENTRY_KEY_1,
-				_LIST_TYPE_ENTRY_KEY_2));
-		_assertFilteredObjectEntries(
-			2,
-			String.format(
-				"%s/any(k:k in ('%s','%s'))",
-				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST, _LIST_TYPE_ENTRY_KEY_2,
-				_LIST_TYPE_ENTRY_KEY_3));
-		_assertFilteredObjectEntries(
-			0,
-			String.format(
-				"%s/any(k:k in ('%s','%s'))",
-				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
-				RandomTestUtil.randomString(), RandomTestUtil.randomString()));
-
-		_assertFilteredObjectEntries(
-			2,
-			String.format(
-				"%s/any(k:k ne '%s')", _OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
-				_LIST_TYPE_ENTRY_KEY_1));
-		_assertFilteredObjectEntries(
-			3,
-			String.format(
-				"%s/any(k:k ne '%s')", _OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
-				_LIST_TYPE_ENTRY_KEY_2));
-		_assertFilteredObjectEntries(
-			3,
-			String.format(
-				"%s/any(k:k ne '%s')", _OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
-				_LIST_TYPE_ENTRY_KEY_3));
-		_assertFilteredObjectEntries(
-			3,
-			String.format(
-				"%s/any(k:k ne '%s')", _OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
-				RandomTestUtil.randomString()));
-
-		_assertFilteredObjectEntries(
-			3,
-			String.format(
-				"%s/any(k:startswith(k,'%s'))",
-				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST, "a"));
-		_assertFilteredObjectEntries(
-			2,
-			String.format(
-				"%s/any(k:startswith(k,'%s'))",
-				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST, "b"));
-		_assertFilteredObjectEntries(
-			1,
-			String.format(
-				"%s/any(k:startswith(k,'%s'))",
-				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST, "c"));
-		_assertFilteredObjectEntries(
-			3,
-			String.format(
-				"%s/any(k:startswith(k,'%s'))",
-				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
-				_LIST_TYPE_ENTRY_KEY_1));
-		_assertFilteredObjectEntries(
-			2,
-			String.format(
-				"%s/any(k:startswith(k,'%s'))",
-				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
-				_LIST_TYPE_ENTRY_KEY_2));
-		_assertFilteredObjectEntries(
-			1,
-			String.format(
-				"%s/any(k:startswith(k,'%s'))",
-				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
-				_LIST_TYPE_ENTRY_KEY_3));
-		_assertFilteredObjectEntries(
-			0,
-			String.format(
-				"%s/any(k:startswith(k,'%s'))",
-				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
-				RandomTestUtil.randomString()));
-	}
-
-	@Test
 	public void testFilterByLambdaOperatorsObjectEntriesByRelatedObjectEntriesFields()
 		throws Exception {
 
@@ -5155,6 +4994,185 @@ public class ObjectEntryResourceTest {
 		_assertFilteredObjectEntries(3, "keywords/any(k:k in ('tag1','tag2'))");
 		_assertFilteredObjectEntries(2, "keywords/any(k:k in ('tag2','tag3'))");
 		_assertFilteredObjectEntries(0, "keywords/any(k:k in ('1234','5678'))");
+	}
+
+	@Test
+	public void testGetObjectEntryFilteredByMultiselectPicklistField()
+		throws Exception {
+
+		ObjectEntryTestUtil.addObjectEntry(
+			_objectDefinition1,
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_1, RandomTestUtil.randomString()
+			).put(
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST, _LIST_TYPE_ENTRY_KEY_1
+			).build(),
+			_TAG_1);
+		ObjectEntryTestUtil.addObjectEntry(
+			_objectDefinition1,
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_1, RandomTestUtil.randomString()
+			).put(
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				(Serializable)Arrays.asList(
+					_LIST_TYPE_ENTRY_KEY_1, _LIST_TYPE_ENTRY_KEY_2)
+			).build(),
+			_TAG_1);
+		ObjectEntryTestUtil.addObjectEntry(
+			_objectDefinition1,
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_1, RandomTestUtil.randomString()
+			).put(
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				(Serializable)Arrays.asList(
+					_LIST_TYPE_ENTRY_KEY_1, _LIST_TYPE_ENTRY_KEY_2,
+					_LIST_TYPE_ENTRY_KEY_3)
+			).build(),
+			_TAG_1);
+
+		_assertFilteredObjectEntries(
+			3,
+			String.format(
+				"%s/any(k:contains(k,'%s'))",
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				_LIST_TYPE_ENTRY_KEY_1.substring(1)));
+		_assertFilteredObjectEntries(
+			2,
+			String.format(
+				"%s/any(k:contains(k,'%s'))",
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				_LIST_TYPE_ENTRY_KEY_2.substring(1)));
+		_assertFilteredObjectEntries(
+			1,
+			String.format(
+				"%s/any(k:contains(k,'%s'))",
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				_LIST_TYPE_ENTRY_KEY_3.substring(1)));
+		_assertFilteredObjectEntries(
+			0,
+			String.format(
+				"%s/any(k:contains(k,'%s'))",
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				RandomTestUtil.randomString()));
+
+		_assertFilteredObjectEntries(
+			3,
+			String.format(
+				"%s/any(k:k eq '%s')", _OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				_LIST_TYPE_ENTRY_KEY_1));
+		_assertFilteredObjectEntries(
+			2,
+			String.format(
+				"%s/any(k:k eq '%s')", _OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				_LIST_TYPE_ENTRY_KEY_2));
+		_assertFilteredObjectEntries(
+			1,
+			String.format(
+				"%s/any(k:k eq '%s')", _OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				_LIST_TYPE_ENTRY_KEY_3));
+		_assertFilteredObjectEntries(
+			0,
+			String.format(
+				"%s/any(k:k eq '%s')", _OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				RandomTestUtil.randomString()));
+		_assertFilteredObjectEntries(
+			0,
+			String.format(
+				"%s/any(k:k eq '%s')", _OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				_LIST_TYPE_ENTRY_KEY_1.substring(1)));
+		_assertFilteredObjectEntries(
+			0,
+			String.format(
+				"%s/any(k:k eq '%s')", _OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				_LIST_TYPE_ENTRY_KEY_2.substring(1)));
+		_assertFilteredObjectEntries(
+			0,
+			String.format(
+				"%s/any(k:k eq '%s')", _OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				_LIST_TYPE_ENTRY_KEY_3.substring(1)));
+
+		_assertFilteredObjectEntries(
+			3,
+			String.format(
+				"%s/any(k:k in ('%s','%s'))",
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST, _LIST_TYPE_ENTRY_KEY_1,
+				_LIST_TYPE_ENTRY_KEY_2));
+		_assertFilteredObjectEntries(
+			2,
+			String.format(
+				"%s/any(k:k in ('%s','%s'))",
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST, _LIST_TYPE_ENTRY_KEY_2,
+				_LIST_TYPE_ENTRY_KEY_3));
+		_assertFilteredObjectEntries(
+			0,
+			String.format(
+				"%s/any(k:k in ('%s','%s'))",
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				RandomTestUtil.randomString(), RandomTestUtil.randomString()));
+
+		_assertFilteredObjectEntries(
+			2,
+			String.format(
+				"%s/any(k:k ne '%s')", _OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				_LIST_TYPE_ENTRY_KEY_1));
+		_assertFilteredObjectEntries(
+			3,
+			String.format(
+				"%s/any(k:k ne '%s')", _OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				_LIST_TYPE_ENTRY_KEY_2));
+		_assertFilteredObjectEntries(
+			3,
+			String.format(
+				"%s/any(k:k ne '%s')", _OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				_LIST_TYPE_ENTRY_KEY_3));
+		_assertFilteredObjectEntries(
+			3,
+			String.format(
+				"%s/any(k:k ne '%s')", _OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				RandomTestUtil.randomString()));
+
+		_assertFilteredObjectEntries(
+			3,
+			String.format(
+				"%s/any(k:startswith(k,'%s'))",
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				_LIST_TYPE_ENTRY_KEY_1.substring(0, 2)));
+		_assertFilteredObjectEntries(
+			2,
+			String.format(
+				"%s/any(k:startswith(k,'%s'))",
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				_LIST_TYPE_ENTRY_KEY_2.substring(0, 2)));
+		_assertFilteredObjectEntries(
+			1,
+			String.format(
+				"%s/any(k:startswith(k,'%s'))",
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				_LIST_TYPE_ENTRY_KEY_3.substring(0, 2)));
+		_assertFilteredObjectEntries(
+			3,
+			String.format(
+				"%s/any(k:startswith(k,'%s'))",
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				_LIST_TYPE_ENTRY_KEY_1));
+		_assertFilteredObjectEntries(
+			2,
+			String.format(
+				"%s/any(k:startswith(k,'%s'))",
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				_LIST_TYPE_ENTRY_KEY_2));
+		_assertFilteredObjectEntries(
+			1,
+			String.format(
+				"%s/any(k:startswith(k,'%s'))",
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				_LIST_TYPE_ENTRY_KEY_3));
+		_assertFilteredObjectEntries(
+			0,
+			String.format(
+				"%s/any(k:startswith(k,'%s'))",
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				RandomTestUtil.randomString()));
 	}
 
 	@Test

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -2245,7 +2245,7 @@ public class ObjectEntryResourceTest {
 		ObjectEntryTestUtil.addObjectEntry(
 			_objectDefinition1,
 			HashMapBuilder.<String, Serializable>put(
-				_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1
+				_OBJECT_FIELD_NAME_1, RandomTestUtil.randomString()
 			).put(
 				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST, _LIST_TYPE_ENTRY_KEY_1
 			).build(),
@@ -2253,7 +2253,7 @@ public class ObjectEntryResourceTest {
 		ObjectEntryTestUtil.addObjectEntry(
 			_objectDefinition1,
 			HashMapBuilder.<String, Serializable>put(
-				_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_2
+				_OBJECT_FIELD_NAME_1, RandomTestUtil.randomString()
 			).put(
 				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
 				(Serializable)Arrays.asList(
@@ -2263,7 +2263,7 @@ public class ObjectEntryResourceTest {
 		ObjectEntryTestUtil.addObjectEntry(
 			_objectDefinition1,
 			HashMapBuilder.<String, Serializable>put(
-				_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_2
+				_OBJECT_FIELD_NAME_1, RandomTestUtil.randomString()
 			).put(
 				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
 				(Serializable)Arrays.asList(
@@ -2271,6 +2271,31 @@ public class ObjectEntryResourceTest {
 					_LIST_TYPE_ENTRY_KEY_3)
 			).build(),
 			_TAG_1);
+
+		_assertFilteredObjectEntries(
+			3,
+			String.format(
+				"%s/any(k:contains(k,'%s'))",
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				_LIST_TYPE_ENTRY_KEY_1.substring(1)));
+		_assertFilteredObjectEntries(
+			2,
+			String.format(
+				"%s/any(k:contains(k,'%s'))",
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				_LIST_TYPE_ENTRY_KEY_2.substring(1)));
+		_assertFilteredObjectEntries(
+			1,
+			String.format(
+				"%s/any(k:contains(k,'%s'))",
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				_LIST_TYPE_ENTRY_KEY_3.substring(1)));
+		_assertFilteredObjectEntries(
+			0,
+			String.format(
+				"%s/any(k:contains(k,'%s'))",
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				RandomTestUtil.randomString()));
 
 		_assertFilteredObjectEntries(
 			3,
@@ -2292,6 +2317,25 @@ public class ObjectEntryResourceTest {
 			String.format(
 				"%s/any(k:k eq '%s')", _OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
 				RandomTestUtil.randomString()));
+
+		_assertFilteredObjectEntries(
+			3,
+			String.format(
+				"%s/any(k:k in ('%s','%s'))",
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST, _LIST_TYPE_ENTRY_KEY_1,
+				_LIST_TYPE_ENTRY_KEY_2));
+		_assertFilteredObjectEntries(
+			2,
+			String.format(
+				"%s/any(k:k in ('%s','%s'))",
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST, _LIST_TYPE_ENTRY_KEY_2,
+				_LIST_TYPE_ENTRY_KEY_3));
+		_assertFilteredObjectEntries(
+			0,
+			String.format(
+				"%s/any(k:k in ('%s','%s'))",
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				RandomTestUtil.randomString(), RandomTestUtil.randomString()));
 
 		_assertFilteredObjectEntries(
 			2,
@@ -2353,50 +2397,6 @@ public class ObjectEntryResourceTest {
 				"%s/any(k:startswith(k,'%s'))",
 				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
 				RandomTestUtil.randomString()));
-
-		_assertFilteredObjectEntries(
-			3,
-			String.format(
-				"%s/any(k:contains(k,'%s'))",
-				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
-				_LIST_TYPE_ENTRY_KEY_1.substring(1)));
-		_assertFilteredObjectEntries(
-			2,
-			String.format(
-				"%s/any(k:contains(k,'%s'))",
-				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
-				_LIST_TYPE_ENTRY_KEY_2.substring(1)));
-		_assertFilteredObjectEntries(
-			1,
-			String.format(
-				"%s/any(k:contains(k,'%s'))",
-				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
-				_LIST_TYPE_ENTRY_KEY_3.substring(1)));
-		_assertFilteredObjectEntries(
-			0,
-			String.format(
-				"%s/any(k:contains(k,'%s'))",
-				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
-				RandomTestUtil.randomString()));
-
-		_assertFilteredObjectEntries(
-			3,
-			String.format(
-				"%s/any(k:k in ('%s','%s'))",
-				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST, _LIST_TYPE_ENTRY_KEY_1,
-				_LIST_TYPE_ENTRY_KEY_2));
-		_assertFilteredObjectEntries(
-			2,
-			String.format(
-				"%s/any(k:k in ('%s','%s'))",
-				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST, _LIST_TYPE_ENTRY_KEY_2,
-				_LIST_TYPE_ENTRY_KEY_3));
-		_assertFilteredObjectEntries(
-			0,
-			String.format(
-				"%s/any(k:k in ('%s','%s'))",
-				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
-				RandomTestUtil.randomString(), RandomTestUtil.randomString()));
 	}
 
 	@Test
@@ -3026,6 +3026,16 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
+					"%s/%s/%s/any(k:contains(k,'%s'))",
+					_objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+					_LIST_TYPE_ENTRY_KEY_3)),
+			_objectDefinition1);
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
 					"%s/%s/%s/any(k:k eq '%s')", _objectRelationship1.getName(),
 					_objectRelationship2.getName(),
 					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
@@ -3035,11 +3045,11 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
-					"%s/%s/%s/any(k:contains(k,'%s'))",
+					"%s/%s/%s/any(k:k in ('%s', '%s'))",
 					_objectRelationship1.getName(),
 					_objectRelationship2.getName(),
 					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
-					_LIST_TYPE_ENTRY_KEY_3)),
+					_LIST_TYPE_ENTRY_KEY_3, RandomTestUtil.randomString())),
 			_objectDefinition1);
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
@@ -3060,19 +3070,17 @@ public class ObjectEntryResourceTest {
 					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
 					_LIST_TYPE_ENTRY_KEY_3)),
 			_objectDefinition1);
+
+		// Many to many relationship, system object field
+
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
-					"%s/%s/%s/any(k:k in ('%s', '%s'))",
+					"%s/%s/keywords/any(k:contains(k,'%s'))",
 					_objectRelationship1.getName(),
-					_objectRelationship2.getName(),
-					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
-					_LIST_TYPE_ENTRY_KEY_3, RandomTestUtil.randomString())),
+					_objectRelationship2.getName(), _TAG_3.substring(1))),
 			_objectDefinition1);
-
-		// Many to many relationship, system object field
-
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
@@ -3085,9 +3093,10 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
-					"%s/%s/keywords/any(k:contains(k,'%s'))",
+					"%s/%s/keywords/any(k:k in ('%s', '%s'))",
 					_objectRelationship1.getName(),
-					_objectRelationship2.getName(), _TAG_3.substring(1))),
+					_objectRelationship2.getName(), _TAG_3,
+					RandomTestUtil.randomString())),
 			_objectDefinition1);
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
@@ -3105,18 +3114,19 @@ public class ObjectEntryResourceTest {
 					_objectRelationship1.getName(),
 					_objectRelationship2.getName(), _TAG_3.substring(0, 2))),
 			_objectDefinition1);
-		_assertFilterString(
-			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
-			_escape(
-				String.format(
-					"%s/%s/keywords/any(k:k in ('%s', '%s'))",
-					_objectRelationship1.getName(),
-					_objectRelationship2.getName(), _TAG_3,
-					RandomTestUtil.randomString())),
-			_objectDefinition1);
 
 		// Many to many relationship (other side), custom object field
 
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
+			_escape(
+				String.format(
+					"%s/%s/%s/any(k:contains(k,'%s'))",
+					_objectRelationship2.getName(),
+					_objectRelationship1.getName(),
+					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+					_LIST_TYPE_ENTRY_KEY_1)),
+			_objectDefinition3);
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
 			_escape(
@@ -3130,11 +3140,11 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
 			_escape(
 				String.format(
-					"%s/%s/%s/any(k:contains(k,'%s'))",
+					"%s/%s/%s/any(k:k in ('%s', '%s'))",
 					_objectRelationship2.getName(),
 					_objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
-					_LIST_TYPE_ENTRY_KEY_1)),
+					_LIST_TYPE_ENTRY_KEY_1, RandomTestUtil.randomString())),
 			_objectDefinition3);
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
@@ -3155,19 +3165,17 @@ public class ObjectEntryResourceTest {
 					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
 					_LIST_TYPE_ENTRY_KEY_1)),
 			_objectDefinition3);
+
+		// Many to many relationship (other side), system object field
+
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
 			_escape(
 				String.format(
-					"%s/%s/%s/any(k:k in ('%s', '%s'))",
+					"%s/%s/keywords/any(k:contains(k,'%s'))",
 					_objectRelationship2.getName(),
-					_objectRelationship1.getName(),
-					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
-					_LIST_TYPE_ENTRY_KEY_1, RandomTestUtil.randomString())),
+					_objectRelationship1.getName(), _TAG_1.substring(1))),
 			_objectDefinition3);
-
-		// Many to many relationship (other side), system object field
-
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
 			_escape(
@@ -3180,9 +3188,10 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
 			_escape(
 				String.format(
-					"%s/%s/keywords/any(k:contains(k,'%s'))",
+					"%s/%s/keywords/any(k:k in ('%s', '%s'))",
 					_objectRelationship2.getName(),
-					_objectRelationship1.getName(), _TAG_1.substring(1))),
+					_objectRelationship1.getName(), _TAG_1,
+					RandomTestUtil.randomString())),
 			_objectDefinition3);
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
@@ -3199,15 +3208,6 @@ public class ObjectEntryResourceTest {
 					"%s/%s/keywords/any(k:startswith(k,'%s'))",
 					_objectRelationship2.getName(),
 					_objectRelationship1.getName(), _TAG_1.substring(0, 2))),
-			_objectDefinition3);
-		_assertFilterString(
-			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
-			_escape(
-				String.format(
-					"%s/%s/keywords/any(k:k in ('%s', '%s'))",
-					_objectRelationship2.getName(),
-					_objectRelationship1.getName(), _TAG_1,
-					RandomTestUtil.randomString())),
 			_objectDefinition3);
 
 		_objectRelationshipLocalService.deleteObjectRelationship(
@@ -3230,6 +3230,16 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
+					"%s/%s/%s/any(k:contains(k,'%s'))",
+					_objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+					_LIST_TYPE_ENTRY_KEY_3)),
+			_objectDefinition1);
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
 					"%s/%s/%s/any(k:k eq '%s')", _objectRelationship1.getName(),
 					_objectRelationship2.getName(),
 					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
@@ -3239,11 +3249,11 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
-					"%s/%s/%s/any(k:contains(k,'%s'))",
+					"%s/%s/%s/any(k:k in ('%s', '%s'))",
 					_objectRelationship1.getName(),
 					_objectRelationship2.getName(),
 					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
-					_LIST_TYPE_ENTRY_KEY_3)),
+					_LIST_TYPE_ENTRY_KEY_3, RandomTestUtil.randomString())),
 			_objectDefinition1);
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
@@ -3264,19 +3274,17 @@ public class ObjectEntryResourceTest {
 					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
 					_LIST_TYPE_ENTRY_KEY_3)),
 			_objectDefinition1);
+
+		// One to many relationship, system object field
+
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
-					"%s/%s/%s/any(k:k in ('%s', '%s'))",
+					"%s/%s/keywords/any(k:contains(k,'%s'))",
 					_objectRelationship1.getName(),
-					_objectRelationship2.getName(),
-					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
-					_LIST_TYPE_ENTRY_KEY_3, RandomTestUtil.randomString())),
+					_objectRelationship2.getName(), _TAG_3.substring(1))),
 			_objectDefinition1);
-
-		// One to many relationship, system object field
-
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
@@ -3289,9 +3297,10 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 			_escape(
 				String.format(
-					"%s/%s/keywords/any(k:contains(k,'%s'))",
+					"%s/%s/keywords/any(k:k in ('%s', '%s'))",
 					_objectRelationship1.getName(),
-					_objectRelationship2.getName(), _TAG_3.substring(1))),
+					_objectRelationship2.getName(), _TAG_3,
+					RandomTestUtil.randomString())),
 			_objectDefinition1);
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
@@ -3309,18 +3318,19 @@ public class ObjectEntryResourceTest {
 					_objectRelationship1.getName(),
 					_objectRelationship2.getName(), _TAG_3.substring(0, 2))),
 			_objectDefinition1);
-		_assertFilterString(
-			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
-			_escape(
-				String.format(
-					"%s/%s/keywords/any(k:k in ('%s', '%s'))",
-					_objectRelationship1.getName(),
-					_objectRelationship2.getName(), _TAG_3,
-					RandomTestUtil.randomString())),
-			_objectDefinition1);
 
 		// One to many relationship (other side), custom object field
 
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
+			_escape(
+				String.format(
+					"%s/%s/%s/any(k:contains(k,'%s'))",
+					_objectRelationship2.getName(),
+					_objectRelationship1.getName(),
+					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+					_LIST_TYPE_ENTRY_KEY_1)),
+			_objectDefinition3);
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
 			_escape(
@@ -3334,11 +3344,11 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
 			_escape(
 				String.format(
-					"%s/%s/%s/any(k:contains(k,'%s'))",
+					"%s/%s/%s/any(k:k in ('%s', '%s'))",
 					_objectRelationship2.getName(),
 					_objectRelationship1.getName(),
 					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
-					_LIST_TYPE_ENTRY_KEY_1)),
+					_LIST_TYPE_ENTRY_KEY_1, RandomTestUtil.randomString())),
 			_objectDefinition3);
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
@@ -3359,19 +3369,17 @@ public class ObjectEntryResourceTest {
 					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
 					_LIST_TYPE_ENTRY_KEY_1)),
 			_objectDefinition3);
+
+		// One to many relationship (other side), system object field
+
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
 			_escape(
 				String.format(
-					"%s/%s/%s/any(k:k in ('%s', '%s'))",
+					"%s/%s/keywords/any(k:contains(k,'%s'))",
 					_objectRelationship2.getName(),
-					_objectRelationship1.getName(),
-					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
-					_LIST_TYPE_ENTRY_KEY_1, RandomTestUtil.randomString())),
+					_objectRelationship1.getName(), _TAG_1.substring(1))),
 			_objectDefinition3);
-
-		// One to many relationship (other side), system object field
-
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
 			_escape(
@@ -3384,9 +3392,10 @@ public class ObjectEntryResourceTest {
 			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
 			_escape(
 				String.format(
-					"%s/%s/keywords/any(k:contains(k,'%s'))",
+					"%s/%s/keywords/any(k:k in ('%s', '%s'))",
 					_objectRelationship2.getName(),
-					_objectRelationship1.getName(), _TAG_1.substring(1))),
+					_objectRelationship1.getName(), _TAG_1,
+					RandomTestUtil.randomString())),
 			_objectDefinition3);
 		_assertFilterString(
 			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
@@ -3403,15 +3412,6 @@ public class ObjectEntryResourceTest {
 					"%s/%s/keywords/any(k:startswith(k,'%s'))",
 					_objectRelationship2.getName(),
 					_objectRelationship1.getName(), _TAG_1.substring(0, 2))),
-			_objectDefinition3);
-		_assertFilterString(
-			_OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3,
-			_escape(
-				String.format(
-					"%s/%s/keywords/any(k:k in ('%s', '%s'))",
-					_objectRelationship2.getName(),
-					_objectRelationship1.getName(), _TAG_1,
-					RandomTestUtil.randomString())),
 			_objectDefinition3);
 	}
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -2239,6 +2239,167 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
+	public void testFilterByLambdaOperatorsObjectEntriesByMultiselectPicklistField()
+		throws Exception {
+
+		ObjectEntryTestUtil.addObjectEntry(
+			_objectDefinition1,
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1
+			).put(
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST, _LIST_TYPE_ENTRY_KEY_1
+			).build(),
+			_TAG_1);
+		ObjectEntryTestUtil.addObjectEntry(
+			_objectDefinition1,
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_2
+			).put(
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				(Serializable)Arrays.asList(
+					_LIST_TYPE_ENTRY_KEY_1, _LIST_TYPE_ENTRY_KEY_2)
+			).build(),
+			_TAG_1);
+		ObjectEntryTestUtil.addObjectEntry(
+			_objectDefinition1,
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_2
+			).put(
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				(Serializable)Arrays.asList(
+					_LIST_TYPE_ENTRY_KEY_1, _LIST_TYPE_ENTRY_KEY_2,
+					_LIST_TYPE_ENTRY_KEY_3)
+			).build(),
+			_TAG_1);
+
+		_assertFilteredObjectEntries(
+			3,
+			String.format(
+				"%s/any(k:k eq '%s')", _OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				_LIST_TYPE_ENTRY_KEY_1));
+		_assertFilteredObjectEntries(
+			2,
+			String.format(
+				"%s/any(k:k eq '%s')", _OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				_LIST_TYPE_ENTRY_KEY_2));
+		_assertFilteredObjectEntries(
+			1,
+			String.format(
+				"%s/any(k:k eq '%s')", _OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				_LIST_TYPE_ENTRY_KEY_3));
+		_assertFilteredObjectEntries(
+			0,
+			String.format(
+				"%s/any(k:k eq '%s')", _OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				RandomTestUtil.randomString()));
+
+		_assertFilteredObjectEntries(
+			2,
+			String.format(
+				"%s/any(k:k ne '%s')", _OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				_LIST_TYPE_ENTRY_KEY_1));
+		_assertFilteredObjectEntries(
+			3,
+			String.format(
+				"%s/any(k:k ne '%s')", _OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				_LIST_TYPE_ENTRY_KEY_2));
+		_assertFilteredObjectEntries(
+			3,
+			String.format(
+				"%s/any(k:k ne '%s')", _OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				_LIST_TYPE_ENTRY_KEY_3));
+		_assertFilteredObjectEntries(
+			3,
+			String.format(
+				"%s/any(k:k ne '%s')", _OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				RandomTestUtil.randomString()));
+
+		_assertFilteredObjectEntries(
+			3,
+			String.format(
+				"%s/any(k:startswith(k,'%s'))",
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST, "a"));
+		_assertFilteredObjectEntries(
+			2,
+			String.format(
+				"%s/any(k:startswith(k,'%s'))",
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST, "b"));
+		_assertFilteredObjectEntries(
+			1,
+			String.format(
+				"%s/any(k:startswith(k,'%s'))",
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST, "c"));
+		_assertFilteredObjectEntries(
+			3,
+			String.format(
+				"%s/any(k:startswith(k,'%s'))",
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				_LIST_TYPE_ENTRY_KEY_1));
+		_assertFilteredObjectEntries(
+			2,
+			String.format(
+				"%s/any(k:startswith(k,'%s'))",
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				_LIST_TYPE_ENTRY_KEY_2));
+		_assertFilteredObjectEntries(
+			1,
+			String.format(
+				"%s/any(k:startswith(k,'%s'))",
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				_LIST_TYPE_ENTRY_KEY_3));
+		_assertFilteredObjectEntries(
+			0,
+			String.format(
+				"%s/any(k:startswith(k,'%s'))",
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				RandomTestUtil.randomString()));
+
+		_assertFilteredObjectEntries(
+			3,
+			String.format(
+				"%s/any(k:contains(k,'%s'))",
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				_LIST_TYPE_ENTRY_KEY_1.substring(1)));
+		_assertFilteredObjectEntries(
+			2,
+			String.format(
+				"%s/any(k:contains(k,'%s'))",
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				_LIST_TYPE_ENTRY_KEY_2.substring(1)));
+		_assertFilteredObjectEntries(
+			1,
+			String.format(
+				"%s/any(k:contains(k,'%s'))",
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				_LIST_TYPE_ENTRY_KEY_3.substring(1)));
+		_assertFilteredObjectEntries(
+			0,
+			String.format(
+				"%s/any(k:contains(k,'%s'))",
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				RandomTestUtil.randomString()));
+
+		_assertFilteredObjectEntries(
+			3,
+			String.format(
+				"%s/any(k:k in ('%s','%s'))",
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST, _LIST_TYPE_ENTRY_KEY_1,
+				_LIST_TYPE_ENTRY_KEY_2));
+		_assertFilteredObjectEntries(
+			2,
+			String.format(
+				"%s/any(k:k in ('%s','%s'))",
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST, _LIST_TYPE_ENTRY_KEY_2,
+				_LIST_TYPE_ENTRY_KEY_3));
+		_assertFilteredObjectEntries(
+			0,
+			String.format(
+				"%s/any(k:k in ('%s','%s'))",
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				RandomTestUtil.randomString(), RandomTestUtil.randomString()));
+	}
+
+	@Test
 	public void testFilterByLambdaOperatorsObjectEntriesByRelatedObjectEntriesFields()
 		throws Exception {
 


### PR DESCRIPTION
## Motivation
The aim of this PR is to fix filtering MultiselectPicklist Object Fields using REST APIs. At the moment, this Object Field will support to be filtered using these operators: `CONTAINS`, IN, `STARTSWITH`, `EQUALS` and `NOT EQUALS`. Otherwise, it will throw a `UnsupportedOperationException`.

**What is new?**
- Support `MultiselectPicklist` Object Fields with `FieldsProvider` implementation.
- Add tests cases for that update previous test cases.


**JIRA Related Ticket**
https://liferay.atlassian.net/browse/LPD-22155