### PR TITLE
LPD-22778 Fix flakiness of the BatchEngineExportTaskExecutorTest.testExportBlogPostingsToJSONLFileWithFieldNames test

### DIFF
--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BaseBatchEngineTaskExecutorTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BaseBatchEngineTaskExecutorTest.java
@@ -107,9 +107,7 @@ public class BaseBatchEngineTaskExecutorTest {
 				new TestBlogPostingBatchEngineTaskItemDelegate(),
 				new HashMapDictionary<String, String>());
 
-		initialCount = blogsEntryLocalService.getGroupEntriesCount(
-			TestPropsValues.getGroupId(),
-			new QueryDefinition<>(WorkflowConstants.STATUS_APPROVED));
+		initialCount = getBlogEntriesCount();
 	}
 
 	@After
@@ -411,11 +409,13 @@ public class BaseBatchEngineTaskExecutorTest {
 	}
 
 	protected void assertBlogsEntriesCount() throws Exception {
-		Assert.assertEquals(
-			initialCount + ROWS_COUNT,
-			blogsEntryLocalService.getGroupEntriesCount(
-				TestPropsValues.getGroupId(),
-				new QueryDefinition<>(WorkflowConstants.STATUS_APPROVED)));
+		Assert.assertEquals(initialCount + ROWS_COUNT, getBlogEntriesCount());
+	}
+
+	protected int getBlogEntriesCount() throws Exception {
+		return blogsEntryLocalService.getGroupEntriesCount(
+			TestPropsValues.getGroupId(),
+			new QueryDefinition<>(WorkflowConstants.STATUS_APPROVED));
 	}
 
 	protected static final String[] FIELD_NAMES = {

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BaseBatchEngineTaskExecutorTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BaseBatchEngineTaskExecutorTest.java
@@ -106,6 +106,10 @@ public class BaseBatchEngineTaskExecutorTest {
 				BatchEngineTaskItemDelegate.class.getName(),
 				new TestBlogPostingBatchEngineTaskItemDelegate(),
 				new HashMapDictionary<String, String>());
+
+		initialCount = blogsEntryLocalService.getGroupEntriesCount(
+			TestPropsValues.getGroupId(),
+			new QueryDefinition<>(WorkflowConstants.STATUS_APPROVED));
 	}
 
 	@After
@@ -408,7 +412,7 @@ public class BaseBatchEngineTaskExecutorTest {
 
 	protected void assertBlogsEntriesCount() throws Exception {
 		Assert.assertEquals(
-			ROWS_COUNT,
+			initialCount + ROWS_COUNT,
 			blogsEntryLocalService.getGroupEntriesCount(
 				TestPropsValues.getGroupId(),
 				new QueryDefinition<>(WorkflowConstants.STATUS_APPROVED)));
@@ -428,6 +432,7 @@ public class BaseBatchEngineTaskExecutorTest {
 
 	protected final DateFormat dateFormat = new SimpleDateFormat(
 		"yyyy-MM-dd'T'HH:mm:ssX");
+	protected int initialCount;
 	protected User user;
 
 	private ServiceRegistration<?>

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BaseBatchEngineTaskExecutorTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BaseBatchEngineTaskExecutorTest.java
@@ -110,8 +110,6 @@ public class BaseBatchEngineTaskExecutorTest {
 
 	@After
 	public void tearDown() throws Exception {
-		blogsEntryLocalService.deleteEntries(TestPropsValues.getGroupId());
-
 		_batchEngineTaskItemDelegateServiceRegistration.unregister();
 	}
 

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BaseBatchEngineTaskExecutorTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BaseBatchEngineTaskExecutorTest.java
@@ -61,6 +61,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -94,7 +95,13 @@ public class BaseBatchEngineTaskExecutorTest {
 	public void setUp() throws Exception {
 		user = TestPropsValues.getUser();
 
-		baseDate = dateFormat.parse(dateFormat.format(new Date()));
+		Date date = new Date();
+
+		Instant instant = date.toInstant();
+
+		instant = instant.truncatedTo(ChronoUnit.MINUTES);
+
+		baseDate = Date.from(instant);
 
 		Bundle bundle = FrameworkUtil.getBundle(
 			BatchEngineImportTaskExecutorTest.class);
@@ -212,7 +219,7 @@ public class BaseBatchEngineTaskExecutorTest {
 					Field.ENTRY_CLASS_PK),
 				searchContext -> {
 					searchContext.setAttribute(
-						Field.STATUS, WorkflowConstants.STATUS_APPROVED);
+						Field.STATUS, WorkflowConstants.STATUS_ANY);
 					searchContext.setCompanyId(contextCompany.getCompanyId());
 					searchContext.setGroupIds(new long[] {siteId});
 				},
@@ -415,7 +422,7 @@ public class BaseBatchEngineTaskExecutorTest {
 	protected int getBlogEntriesCount() throws Exception {
 		return blogsEntryLocalService.getGroupEntriesCount(
 			TestPropsValues.getGroupId(),
-			new QueryDefinition<>(WorkflowConstants.STATUS_APPROVED));
+			new QueryDefinition<>(WorkflowConstants.STATUS_ANY));
 	}
 
 	protected static final String[] FIELD_NAMES = {

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineExportTaskExecutorTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineExportTaskExecutorTest.java
@@ -120,12 +120,15 @@ public class BatchEngineExportTaskExecutorTest
 
 		_exportBlogPostings("CSV", fieldNames, _parameters);
 
+		List<Object[]> rowValuesList = _readRowValuesList(
+			_csvFilterFunction,
+			_batchEngineExportTaskLocalService.getBatchEngineExportTask(
+				_batchEngineExportTask.getBatchEngineExportTaskId()));
+
+		Assert.assertEquals(rowValuesList.toString(), 1, rowValuesList.size());
+
 		_assertExportedValues(
-			Collections.singletonList(blogsEntries.get(1)), fieldNames,
-			_readRowValuesList(
-				_csvFilterFunction,
-				_batchEngineExportTaskLocalService.getBatchEngineExportTask(
-					_batchEngineExportTask.getBatchEngineExportTaskId())));
+			blogsEntries.get(1), fieldNames, rowValuesList.get(0));
 	}
 
 	@Test
@@ -278,85 +281,91 @@ public class BatchEngineExportTaskExecutorTest
 	}
 
 	private void _assertExportedValues(
+			BlogsEntry blogsEntry, List<String> fieldNames, Object[] rowValues)
+		throws Exception {
+
+		Set<String> fieldNamesSet = new HashSet<>(fieldNames);
+
+		int index = 0;
+
+		if (fieldNamesSet.isEmpty() || fieldNamesSet.contains(FIELD_NAMES[0])) {
+			Assert.assertEquals(blogsEntry.getSubtitle(), rowValues[index++]);
+		}
+
+		if (fieldNamesSet.isEmpty() || fieldNamesSet.contains(FIELD_NAMES[1])) {
+			Assert.assertEquals(blogsEntry.getContent(), rowValues[index++]);
+		}
+
+		if (fieldNamesSet.isEmpty() || fieldNamesSet.contains(FIELD_NAMES[2])) {
+			Object value = rowValues[index++];
+
+			if (value instanceof String) {
+				value = dateFormat.parse((String)value);
+			}
+
+			Assert.assertEquals(blogsEntry.getDisplayDate(), value);
+		}
+
+		if (fieldNamesSet.isEmpty() || fieldNamesSet.contains(FIELD_NAMES[3])) {
+			Assert.assertEquals(blogsEntry.getTitle(), rowValues[index++]);
+		}
+
+		if (fieldNamesSet.isEmpty() || fieldNamesSet.contains("id")) {
+			Object value = rowValues[index++];
+
+			if (value instanceof String) {
+				value = GetterUtil.getLong(value);
+			}
+
+			if (value instanceof Double) {
+				Double doubleValue = (Double)value;
+
+				value = doubleValue.longValue();
+			}
+
+			Assert.assertEquals(blogsEntry.getEntryId(), value);
+		}
+
+		if (fieldNamesSet.isEmpty() || fieldNamesSet.contains("siteId")) {
+			Object value = rowValues[index];
+
+			if (value instanceof String) {
+				value = GetterUtil.getLong(value);
+			}
+
+			if (value instanceof Double) {
+				Double doubleValue = (Double)value;
+
+				value = doubleValue.longValue();
+			}
+
+			Assert.assertEquals(blogsEntry.getGroupId(), value);
+		}
+	}
+
+	private void _assertExportedValues(
 			List<BlogsEntry> blogsEntries, List<String> fieldNames,
 			List<Object[]> rowValuesList)
 		throws Exception {
 
-		blogsEntries.sort(Comparator.comparing(BlogsEntry::getSubtitle));
-		rowValuesList.sort(
-			Comparator.comparing(rowValues -> (String)rowValues[0]));
+		blogsEntries.sort(Comparator.comparing(BlogsEntry::getEntryId));
 
-		Set<String> fieldNamesSet = new HashSet<>(fieldNames);
+		if (fieldNames.contains("id")) {
+			rowValuesList.sort(
+				Comparator.comparing(
+					rowValues -> GetterUtil.getLong(
+						rowValues[fieldNames.indexOf("id")])));
+		}
+		else {
+			rowValuesList.sort(
+				Comparator.comparing(rowValues -> (Long)rowValues[4]));
+		}
 
 		for (int i = 0; i < blogsEntries.size(); i++) {
 			BlogsEntry blogsEntry = blogsEntries.get(i);
-			Object[] rowValues = rowValuesList.get(i);
+			Object[] rowValues = rowValuesList.get(i + initialCount);
 
-			int index = 0;
-
-			if (fieldNamesSet.isEmpty() ||
-				fieldNamesSet.contains(FIELD_NAMES[0])) {
-
-				Assert.assertEquals(
-					blogsEntry.getSubtitle(), rowValues[index++]);
-			}
-
-			if (fieldNamesSet.isEmpty() ||
-				fieldNamesSet.contains(FIELD_NAMES[1])) {
-
-				Assert.assertEquals(
-					blogsEntry.getContent(), rowValues[index++]);
-			}
-
-			if (fieldNamesSet.isEmpty() ||
-				fieldNamesSet.contains(FIELD_NAMES[2])) {
-
-				Object value = rowValues[index++];
-
-				if (value instanceof String) {
-					value = dateFormat.parse((String)value);
-				}
-
-				Assert.assertEquals(blogsEntry.getDisplayDate(), value);
-			}
-
-			if (fieldNamesSet.isEmpty() ||
-				fieldNamesSet.contains(FIELD_NAMES[3])) {
-
-				Assert.assertEquals(blogsEntry.getTitle(), rowValues[index++]);
-			}
-
-			if (fieldNamesSet.isEmpty() || fieldNamesSet.contains("id")) {
-				Object value = rowValues[index++];
-
-				if (value instanceof String) {
-					value = GetterUtil.getLong(value);
-				}
-
-				if (value instanceof Double) {
-					Double doubleValue = (Double)value;
-
-					value = doubleValue.longValue();
-				}
-
-				Assert.assertEquals(blogsEntry.getEntryId(), value);
-			}
-
-			if (fieldNamesSet.isEmpty() || fieldNamesSet.contains("siteId")) {
-				Object value = rowValues[index];
-
-				if (value instanceof String) {
-					value = GetterUtil.getLong(value);
-				}
-
-				if (value instanceof Double) {
-					Double doubleValue = (Double)value;
-
-					value = doubleValue.longValue();
-				}
-
-				Assert.assertEquals(blogsEntry.getGroupId(), value);
-			}
+			_assertExportedValues(blogsEntry, fieldNames, rowValues);
 		}
 	}
 
@@ -373,9 +382,11 @@ public class BatchEngineExportTaskExecutorTest
 		}
 		else {
 			Assert.assertEquals(
-				ROWS_COUNT, batchEngineExportTask.getProcessedItemsCount());
+				initialCount + ROWS_COUNT,
+				batchEngineExportTask.getProcessedItemsCount());
 			Assert.assertEquals(
-				ROWS_COUNT, batchEngineExportTask.getTotalItemsCount());
+				initialCount + ROWS_COUNT,
+				batchEngineExportTask.getTotalItemsCount());
 		}
 	}
 

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineExportTaskExecutorTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineExportTaskExecutorTest.java
@@ -40,7 +40,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.zip.ZipInputStream;
@@ -90,7 +89,8 @@ public class BatchEngineExportTaskExecutorTest
 				LoggerTestUtil.ERROR)) {
 
 			_testExportBlogPostingsToCSVFile(
-				Collections.emptyList(), line -> new Object[0], _parameters);
+				Collections.emptyList(), line -> new Object[0], _parameters,
+				false);
 
 			_assertEmptyFieldNames(logCapture);
 		}
@@ -102,7 +102,7 @@ public class BatchEngineExportTaskExecutorTest
 
 		_testExportBlogPostingsToCSVFile(
 			Arrays.asList("articleBody", "datePublished", "headline", "id"),
-			_csvFilterFunction, _parameters);
+			_csvFilterFunction, _parameters, true);
 	}
 
 	@Test
@@ -234,7 +234,8 @@ public class BatchEngineExportTaskExecutorTest
 				Collections.emptyList(), rowValues -> new Object[0],
 				HashMapBuilder.<String, Serializable>put(
 					"siteId", TestPropsValues.getGroupId()
-				).build());
+				).build(),
+				false);
 		}
 	}
 
@@ -249,7 +250,8 @@ public class BatchEngineExportTaskExecutorTest
 			},
 			HashMapBuilder.<String, Serializable>put(
 				"siteId", TestPropsValues.getGroupId()
-			).build());
+			).build(),
+			true);
 	}
 
 	public abstract class BlogPostingMixin {
@@ -369,25 +371,30 @@ public class BatchEngineExportTaskExecutorTest
 		}
 	}
 
-	private void _assertItemsCount(
+	private void _assertFailedTask(
 		BatchEngineExportTask batchEngineExportTask) {
 
-		if (Objects.equals(
-				batchEngineExportTask.getExecuteStatus(),
-				BatchEngineTaskExecuteStatus.FAILED.toString())) {
+		Assert.assertEquals(
+			BatchEngineTaskExecuteStatus.FAILED.toString(),
+			batchEngineExportTask.getExecuteStatus());
 
-			Assert.assertEquals(
-				0, batchEngineExportTask.getProcessedItemsCount());
-			Assert.assertEquals(0, batchEngineExportTask.getTotalItemsCount());
-		}
-		else {
-			Assert.assertEquals(
-				initialCount + ROWS_COUNT,
-				batchEngineExportTask.getProcessedItemsCount());
-			Assert.assertEquals(
-				initialCount + ROWS_COUNT,
-				batchEngineExportTask.getTotalItemsCount());
-		}
+		Assert.assertEquals(0, batchEngineExportTask.getProcessedItemsCount());
+		Assert.assertEquals(0, batchEngineExportTask.getTotalItemsCount());
+	}
+
+	private void _assertSuccessTask(
+		BatchEngineExportTask batchEngineExportTask) {
+
+		Assert.assertEquals(
+			BatchEngineTaskExecuteStatus.COMPLETED.toString(),
+			batchEngineExportTask.getExecuteStatus());
+
+		Assert.assertEquals(
+			initialCount + ROWS_COUNT,
+			batchEngineExportTask.getProcessedItemsCount());
+		Assert.assertEquals(
+			initialCount + ROWS_COUNT,
+			batchEngineExportTask.getTotalItemsCount());
 	}
 
 	private void _exportBlogPostings(
@@ -442,7 +449,7 @@ public class BatchEngineExportTaskExecutorTest
 
 	private void _testExportBlogPostingsToCSVFile(
 			List<String> fieldNames, Function<String, Object[]> filterFunction,
-			Map<String, Serializable> parameters)
+			Map<String, Serializable> parameters, boolean success)
 		throws Exception {
 
 		List<BlogsEntry> blogsEntries = addBlogsEntries();
@@ -455,15 +462,13 @@ public class BatchEngineExportTaskExecutorTest
 			_batchEngineExportTaskLocalService.getBatchEngineExportTask(
 				_batchEngineExportTask.getBatchEngineExportTaskId());
 
-		_assertItemsCount(batchEngineExportTask);
-
-		if (fieldNames.isEmpty()) {
-			Assert.assertEquals(
-				BatchEngineTaskExecuteStatus.FAILED.toString(),
-				batchEngineExportTask.getExecuteStatus());
+		if (!success) {
+			_assertFailedTask(batchEngineExportTask);
 
 			return;
 		}
+
+		_assertSuccessTask(batchEngineExportTask);
 
 		_assertExportedValues(
 			blogsEntries, fieldNames,
@@ -486,7 +491,7 @@ public class BatchEngineExportTaskExecutorTest
 			_batchEngineExportTaskLocalService.getBatchEngineExportTask(
 				_batchEngineExportTask.getBatchEngineExportTaskId());
 
-		_assertItemsCount(batchEngineExportTask);
+		_assertSuccessTask(batchEngineExportTask);
 
 		List<BlogPosting> blogPostings = _objectMapper.readValue(
 			_getZipInputStream(
@@ -520,7 +525,7 @@ public class BatchEngineExportTaskExecutorTest
 			_batchEngineExportTaskLocalService.getBatchEngineExportTask(
 				_batchEngineExportTask.getBatchEngineExportTaskId());
 
-		_assertItemsCount(batchEngineExportTask);
+		_assertSuccessTask(batchEngineExportTask);
 
 		UnsyncBufferedReader unsyncBufferedReader = new UnsyncBufferedReader(
 			new InputStreamReader(
@@ -551,7 +556,7 @@ public class BatchEngineExportTaskExecutorTest
 	private void _testExportBlogPostingsToXLSFile(
 			List<String> fieldNames,
 			Function<Object[], Object[]> filterFunction,
-			Map<String, Serializable> parameters)
+			Map<String, Serializable> parameters, boolean success)
 		throws Exception {
 
 		List<BlogsEntry> blogsEntries = addBlogsEntries();
@@ -564,15 +569,13 @@ public class BatchEngineExportTaskExecutorTest
 			_batchEngineExportTaskLocalService.getBatchEngineExportTask(
 				_batchEngineExportTask.getBatchEngineExportTaskId());
 
-		_assertItemsCount(batchEngineExportTask);
-
-		if (fieldNames.isEmpty()) {
-			Assert.assertEquals(
-				BatchEngineTaskExecuteStatus.FAILED.toString(),
-				batchEngineExportTask.getExecuteStatus());
+		if (!success) {
+			_assertFailedTask(batchEngineExportTask);
 
 			return;
 		}
+
+		_assertSuccessTask(batchEngineExportTask);
 
 		XSSFWorkbook xssfWorkbook = new XSSFWorkbook(
 			_getZipInputStream(

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineExportTaskExecutorTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineExportTaskExecutorTest.java
@@ -17,6 +17,7 @@ import com.liferay.batch.engine.service.BatchEngineExportTaskLocalService;
 import com.liferay.blogs.model.BlogsEntry;
 import com.liferay.petra.io.unsync.UnsyncBufferedReader;
 import com.liferay.petra.string.CharPool;
+import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -51,7 +52,6 @@ import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -61,6 +61,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Ivica Cardic
  */
+@DataGuard(scope = DataGuard.Scope.METHOD)
 @RunWith(Arquillian.class)
 public class BatchEngineExportTaskExecutorTest
 	extends BaseBatchEngineTaskExecutorTest {
@@ -78,17 +79,6 @@ public class BatchEngineExportTaskExecutorTest
 		_parameters = HashMapBuilder.<String, Serializable>put(
 			"siteId", TestPropsValues.getGroupId()
 		).build();
-	}
-
-	@After
-	@Override
-	public void tearDown() throws Exception {
-		super.tearDown();
-
-		if (_batchEngineExportTask != null) {
-			_batchEngineExportTaskLocalService.deleteBatchEngineExportTask(
-				_batchEngineExportTask.getBatchEngineExportTaskId());
-		}
 	}
 
 	@Test

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineImportTaskExecutorTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineImportTaskExecutorTest.java
@@ -27,6 +27,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryDefinition;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -72,6 +73,7 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 /**
  * @author Ivica Cardic
  */
+@DataGuard(scope = DataGuard.Scope.METHOD)
 @RunWith(Arquillian.class)
 public class BatchEngineImportTaskExecutorTest
 	extends BaseBatchEngineTaskExecutorTest {

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineImportTaskExecutorTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineImportTaskExecutorTest.java
@@ -772,9 +772,7 @@ public class BatchEngineImportTaskExecutorTest
 			itemsCount, _batchEngineImportTask.getTotalItemsCount());
 		Assert.assertEquals(
 			initialCount + itemsCount - invalidItemRowNumbers.size(),
-			blogsEntryLocalService.getGroupEntriesCount(
-				TestPropsValues.getGroupId(),
-				new QueryDefinition<>(WorkflowConstants.STATUS_APPROVED)));
+			getBlogEntriesCount());
 
 		List<BatchEngineImportTaskError> batchEngineImportTaskErrors =
 			_batchEngineImportTaskErrorLocalService.
@@ -822,11 +820,7 @@ public class BatchEngineImportTaskExecutorTest
 		Assert.assertEquals(
 			invalidItemRowNumber, batchEngineImportTaskError.getItemIndex());
 
-		Assert.assertEquals(
-			initialCount,
-			blogsEntryLocalService.getGroupEntriesCount(
-				TestPropsValues.getGroupId(),
-				new QueryDefinition<>(WorkflowConstants.STATUS_APPROVED)));
+		Assert.assertEquals(initialCount, getBlogEntriesCount());
 
 		List<LogEntry> logEntries = logCapture.getLogEntries();
 

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineImportTaskExecutorTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineImportTaskExecutorTest.java
@@ -731,20 +731,21 @@ public class BatchEngineImportTaskExecutorTest
 		assertBlogsEntriesCount();
 
 		List<BlogsEntry> blogsEntries = new ArrayList<>(
-			blogsEntryLocalService.getGroupEntriesCount(
+			blogsEntryLocalService.getGroupEntries(
 				TestPropsValues.getGroupId(),
-				new QueryDefinition<>(WorkflowConstants.STATUS_APPROVED)));
+				new QueryDefinition<>(WorkflowConstants.STATUS_ANY)));
 
 		blogsEntries.sort(Comparator.comparingLong(BlogsEntry::getEntryId));
 
-		for (int i = 0; i < blogsEntries.size(); i++) {
-			BlogsEntry blogsEntry = blogsEntries.get(i);
+		for (int i = 0; i < ROWS_COUNT; i++) {
+			BlogsEntry blogsEntry = blogsEntries.get(i + initialCount);
 
 			Assert.assertEquals(
 				"alternativeHeadline" + i, blogsEntry.getSubtitle());
 			Assert.assertEquals("articleBody" + i, blogsEntry.getContent());
 			Assert.assertEquals(
-				_toTime(baseDate, i), _toTime(blogsEntry.getDisplayDate(), 0));
+				_toTime(baseDate, i - 1000),
+				_toTime(blogsEntry.getDisplayDate(), 0));
 			Assert.assertEquals("headline" + i, blogsEntry.getTitle());
 		}
 	}
@@ -756,7 +757,7 @@ public class BatchEngineImportTaskExecutorTest
 			initialCount,
 			blogsEntryLocalService.getGroupEntriesCount(
 				TestPropsValues.getGroupId(),
-				new QueryDefinition<>(WorkflowConstants.STATUS_APPROVED)));
+				new QueryDefinition<>(WorkflowConstants.STATUS_ANY)));
 	}
 
 	private void _assertInvalidFileImportWithOnErrorContinueStrategy(
@@ -839,27 +840,25 @@ public class BatchEngineImportTaskExecutorTest
 	private void _assertUpdatedBlogPostings() throws Exception {
 		Assert.assertEquals(
 			ROWS_COUNT, _batchEngineImportTask.getProcessedItemsCount());
-		Assert.assertEquals(
-			ROWS_COUNT,
-			blogsEntryLocalService.getGroupEntriesCount(
-				TestPropsValues.getGroupId(),
-				new QueryDefinition<>(WorkflowConstants.STATUS_SCHEDULED)));
+
+		assertBlogsEntriesCount();
 
 		List<BlogsEntry> blogsEntries = new ArrayList<>(
-			blogsEntryLocalService.getGroupEntriesCount(
+			blogsEntryLocalService.getGroupEntries(
 				TestPropsValues.getGroupId(),
-				new QueryDefinition<>(WorkflowConstants.STATUS_SCHEDULED)));
+				new QueryDefinition<>(WorkflowConstants.STATUS_ANY)));
 
 		blogsEntries.sort(Comparator.comparingLong(BlogsEntry::getEntryId));
 
-		for (int i = 0; i < blogsEntries.size(); i++) {
-			BlogsEntry blogsEntry = blogsEntries.get(i);
+		for (int i = 0; i < ROWS_COUNT; i++) {
+			BlogsEntry blogsEntry = blogsEntries.get(i + initialCount);
 
 			Assert.assertEquals(
 				"alternativeHeadline" + i + i, blogsEntry.getSubtitle());
 			Assert.assertEquals("articleBody" + i + i, blogsEntry.getContent());
 			Assert.assertEquals(
-				_toTime(baseDate, i), _toTime(blogsEntry.getDisplayDate(), 0));
+				_toTime(baseDate, i + 100),
+				_toTime(blogsEntry.getDisplayDate(), 0));
 			Assert.assertEquals("headline" + i + i, blogsEntry.getTitle());
 		}
 	}

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineImportTaskExecutorTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineImportTaskExecutorTest.java
@@ -753,7 +753,7 @@ public class BatchEngineImportTaskExecutorTest
 		Assert.assertEquals(
 			ROWS_COUNT, _batchEngineImportTask.getProcessedItemsCount());
 		Assert.assertEquals(
-			0,
+			initialCount,
 			blogsEntryLocalService.getGroupEntriesCount(
 				TestPropsValues.getGroupId(),
 				new QueryDefinition<>(WorkflowConstants.STATUS_APPROVED)));
@@ -771,7 +771,7 @@ public class BatchEngineImportTaskExecutorTest
 		Assert.assertEquals(
 			itemsCount, _batchEngineImportTask.getTotalItemsCount());
 		Assert.assertEquals(
-			itemsCount - invalidItemRowNumbers.size(),
+			initialCount + itemsCount - invalidItemRowNumbers.size(),
 			blogsEntryLocalService.getGroupEntriesCount(
 				TestPropsValues.getGroupId(),
 				new QueryDefinition<>(WorkflowConstants.STATUS_APPROVED)));
@@ -823,7 +823,7 @@ public class BatchEngineImportTaskExecutorTest
 			invalidItemRowNumber, batchEngineImportTaskError.getItemIndex());
 
 		Assert.assertEquals(
-			0,
+			initialCount,
 			blogsEntryLocalService.getGroupEntriesCount(
 				TestPropsValues.getGroupId(),
 				new QueryDefinition<>(WorkflowConstants.STATUS_APPROVED)));


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPD-22778

---

The purpose of this ticket is to fix the flakiness of the `BatchEngineExportTaskExecutorTest.testExportBlogPostingsToJSONLFileWithFieldNames` test.

I have detected the flakiness comes from the usages of the service layer because we are filtering by some workflow statuses. However, as it is not needed, I have created this PR to stop using those filters and always returning all the Blog Postings, independently of the status (it is not relevant for this use case).

Furthermore, I have detected some assertions that were not being performed and some optimizations have been included too.