### PR TITLE
LPD-23105 Fix test

### DIFF
--- a/modules/apps/dispatch/dispatch-test/src/testIntegration/java/com/liferay/dispatch/service/test/DispatchTriggerLocalServiceTest.java
+++ b/modules/apps/dispatch/dispatch-test/src/testIntegration/java/com/liferay/dispatch/service/test/DispatchTriggerLocalServiceTest.java
@@ -425,8 +425,22 @@ public class DispatchTriggerLocalServiceTest {
 			expectedDispatchTrigger.getCronExpression(),
 			actualDispatchTrigger.getCronExpression());
 		Assert.assertNotNull(actualDispatchTrigger.getStartDate());
+
+		DispatchTaskClusterMode expectedDispatchTaskClusterMode =
+			DispatchTaskClusterMode.valueOf(
+				expectedDispatchTrigger.getDispatchTaskClusterMode());
+
+		if ((expectedDispatchTaskClusterMode ==
+				DispatchTaskClusterMode.ALL_NODES) &&
+			_dispatchTaskExecutorRegistry.isClusterModeSingle(
+				expectedDispatchTrigger.getDispatchTaskExecutorType())) {
+
+			expectedDispatchTaskClusterMode =
+				DispatchTaskClusterMode.SINGLE_NODE_MEMORY_CLUSTERED;
+		}
+
 		Assert.assertEquals(
-			expectedDispatchTrigger.getDispatchTaskClusterMode(),
+			expectedDispatchTaskClusterMode.getMode(),
 			actualDispatchTrigger.getDispatchTaskClusterMode());
 
 		DispatchLog dispatchLog =


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPD-23105

---

The purpose of this ticket is to fix the integration test `DispatchTriggerLocalServiceTest.testUpdateDispatchTrigger`.

As we are generating randomly some data, such as the `DispatchTaskClusterMode` and the `DispatchTaskExecutor`, there is a case with a wrong expected value. In this PR we have updated the expected value just in a possible case based on the randomly combination of both random values.