### PR TITLE
LPD-21457

### DIFF
--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/macros/CommerceWidget.macro
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/macros/CommerceWidget.macro
@@ -872,6 +872,14 @@ definition {
 		}
 	}
 
+	@summary = "Default summary"
+	macro viewCheckboxNotChecked(fieldName = null, fieldValue = null) {
+		AssertNotChecked.assertNotCheckedNotVisible(
+			key_fieldName = ${fieldName},
+			key_fieldValue = ${fieldValue},
+			locator1 = "FormViewBuilder#CHECKBOX_LABEL");
+	}
+
 	@summary = "This macro can be used for asserting user information from Organization Management Chart"
 	macro viewUserInformationAtSidebar(userBirthday = null, userEmailAddress = null, userFirstName = null, userID = null, userImage = null, userLanguage = null, userLastName = null, userMiddleName = null, userPrefix = null, userScreenName = null, userSuffix = null) {
 		if (isSet(viewCurrentInfo)) {

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/paths/CommerceEntry.path
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/paths/CommerceEntry.path
@@ -747,7 +747,7 @@
 </tr>
 <tr>
 	<td>PAGINATION_ITEMS_PER_PAGE_SELECT</td>
-	<td>//div[contains(@id,'${key_id}')]//../button[contains(@class,'dropdown-toggle btn btn-unstyled')]</td>
+	<td>//div[contains(@id,'${key_id}')]//div[contains (@class,'pagination')]/button[contains(@class,'dropdown-toggle btn btn-unstyled')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CommerceDisplayPageTemplates.testcase
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CommerceDisplayPageTemplates.testcase
@@ -949,7 +949,7 @@ definition {
 		task ("Then verifies the mapped fragments are visible") {
 			var baseURL = PropsUtil.get("portal.url");
 
-			CommerceDisplayPageTemplates.viewMappedFragmentsText(fragmentsTextList = "${baseURL}/web/minium/p/simple-product,1/1/50 1:01 AM,1/1/51 1:01 AM");
+			CommerceDisplayPageTemplates.viewMappedFragmentsText(fragmentsTextList = "${baseURL}/web/minium/p/simple-product,1/1/24 1:01 AM,1/1/25 1:01 AM");
 		}
 	}
 

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CommerceFacets.testcase
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CommerceFacets.testcase
@@ -290,7 +290,7 @@ definition {
 			SearchFacets.clearFacet();
 
 			for (var searchFieldValue : list "48,112") {
-				FormViewBuilder.viewCheckboxNotChecked(
+				CommerceWidget.viewCheckboxNotChecked(
 					fieldName = "Option Facet",
 					fieldValue = ${searchFieldValue});
 			}
@@ -316,7 +316,7 @@ definition {
 			SearchFacets.clearFacet();
 
 			for (var searchFieldValue : list "Steel,Rubber") {
-				FormViewBuilder.viewCheckboxNotChecked(
+				CommerceWidget.viewCheckboxNotChecked(
 					fieldName = "Specification Facet",
 					fieldValue = ${searchFieldValue});
 			}
@@ -342,7 +342,7 @@ definition {
 			SearchFacets.clearFacet();
 
 			for (var searchFieldValue : list "$ 0.00 - $ 49.99,$ 50.00 - $ 99.99") {
-				FormViewBuilder.viewCheckboxNotChecked(
+				CommerceWidget.viewCheckboxNotChecked(
 					fieldName = "Price Range Facet",
 					fieldValue = ${searchFieldValue});
 			}

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/contributor/test/FragmentCollectionContributorPropagationTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/contributor/test/FragmentCollectionContributorPropagationTest.java
@@ -204,7 +204,12 @@ public class FragmentCollectionContributorPropagationTest {
 
 			List<LogEntry> logEntries = logCapture.getLogEntries();
 
-			Assert.assertTrue(logEntries.toString(), logEntries.isEmpty());
+			for (LogEntry logEntry : logEntries) {
+				Assert.assertEquals(
+					"No theme found for specified theme id " +
+						"not_registered_theme. Returning the default theme.",
+					logEntry.getMessage());
+			}
 		}
 		finally {
 			try {

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/template/servlet/RESTClientHttpRequest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/template/servlet/RESTClientHttpRequest.java
@@ -5,7 +5,6 @@
 
 package com.liferay.portal.vulcan.internal.template.servlet;
 
-import com.liferay.portal.kernel.servlet.DynamicServletRequest;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.servlet.HttpMethods;
 import com.liferay.portal.kernel.servlet.PortalSessionThreadLocal;
@@ -37,7 +36,6 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import javax.servlet.http.HttpUpgradeHandler;
@@ -78,8 +76,20 @@ public class RESTClientHttpRequest implements HttpServletRequest {
 					PortalSessionThreadLocal.getHttpSession();
 
 				if (httpSession != null) {
-					return (String)httpSession.getAttribute(
+					String csrfToken = (String)httpSession.getAttribute(
 						WebKeys.AUTHENTICATION_TOKEN + "#CSRF");
+
+					if (csrfToken != null) {
+						httpSession = httpServletRequest.getSession(false);
+
+						if (httpSession != null) {
+							httpSession.setAttribute(
+								WebKeys.AUTHENTICATION_TOKEN + "#CSRF",
+								csrfToken);
+						}
+					}
+
+					return csrfToken;
 				}
 
 				return null;
@@ -352,18 +362,6 @@ public class RESTClientHttpRequest implements HttpServletRequest {
 
 	@Override
 	public HttpSession getSession(boolean create) {
-		HttpServletRequestWrapper httpServletRequestWrapper =
-			(HttpServletRequestWrapper)_httpServletRequest;
-
-		ServletRequest servletRequest = httpServletRequestWrapper.getRequest();
-
-		if (servletRequest instanceof DynamicServletRequest) {
-			DynamicServletRequest dynamicServletRequest =
-				(DynamicServletRequest)servletRequest;
-
-			return dynamicServletRequest.getSession(create);
-		}
-
 		return _httpServletRequest.getSession(create);
 	}
 

--- a/modules/test/playwright/fixtures/isolatedSiteTest.ts
+++ b/modules/test/playwright/fixtures/isolatedSiteTest.ts
@@ -3,22 +3,24 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {mergeTests, test} from '@playwright/test';
+import {mergeTests} from '@playwright/test';
 
 import {ApiHelpers} from '../helpers/ApiHelpers';
 import getRandomString from '../utils/getRandomString';
-import {loginTest} from './loginTest';
+import {backendPageTest} from './backendPageTest';
 
-const isolatedSiteFixture = test.extend<{
+const test = mergeTests(backendPageTest);
+
+const isolatedSiteTest = test.extend<{
 	site: Site;
 }>({
 	site: [
-		async ({page}, use) => {
-			await page.goto('/');
+		async ({backendPage}, use) => {
+			await backendPage.goto('/');
 
-			const apiHelpers = new ApiHelpers(page);
+			const apiHelpers = new ApiHelpers(backendPage);
 
-			let site;
+			let site: Site;
 
 			try {
 
@@ -47,7 +49,5 @@ const isolatedSiteFixture = test.extend<{
 		{auto: true},
 	],
 });
-
-const isolatedSiteTest = mergeTests(loginTest(), isolatedSiteFixture);
 
 export {isolatedSiteTest};

--- a/modules/test/playwright/tests/client-extension-web/editorConfigContributor.spec.ts
+++ b/modules/test/playwright/tests/client-extension-web/editorConfigContributor.spec.ts
@@ -8,6 +8,7 @@ import {expect, mergeTests} from '@playwright/test';
 import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
 import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../fixtures/loginTest';
 import {liferayConfig} from '../../liferay.config';
 import getRandomString from '../../utils/getRandomString';
 import getPageDefinition from '../layout-content-page-editor-web/utils/getPageDefinition';
@@ -19,13 +20,14 @@ import {editorSamplesPageTest} from './fixtures/editorSamplesPageTest';
 export const test = mergeTests(
 	apiHelpersTest,
 	clientExtensionsPageTest,
+	editEditorConfigContributorPageTest,
 	editorSamplesPageTest,
 	featureFlagsTest({
 		'LPS-178052': true,
 		'LPS-186870': true,
 	}),
 	isolatedSiteTest,
-	editEditorConfigContributorPageTest
+	loginTest()
 );
 
 test('Create, edit and delete editor config contributor client extension @LPS-186870', async ({

--- a/modules/test/playwright/tests/fragment-web/pages/FragmentEditorPage.ts
+++ b/modules/test/playwright/tests/fragment-web/pages/FragmentEditorPage.ts
@@ -18,6 +18,8 @@ export class FragmentEditorPage {
 
 		// Go to Configuration Tab
 
+		await this.page.getByRole('tab', {name: 'Configuration'}).waitFor();
+
 		await this.page.getByRole('tab', {name: 'Configuration'}).click();
 		await this.page.getByText('Add the JSON configuration').waitFor();
 

--- a/modules/test/playwright/tests/fragment-web/pages/FragmentsPage.ts
+++ b/modules/test/playwright/tests/fragment-web/pages/FragmentsPage.ts
@@ -5,6 +5,7 @@
 
 import {Page} from '@playwright/test';
 
+import fillAndClickOutside from '../../../utils/fillAndClickOutside';
 import {PORTLET_URLS} from '../../../utils/portletUrls';
 import {waitForSuccessAlert} from '../../../utils/waitForSuccessAlert';
 
@@ -24,7 +25,11 @@ export class FragmentsPage {
 	async createFragmentSet(name: string) {
 		await this.page.getByTitle('Add Fragment Set').click();
 
-		await this.page.getByPlaceholder('Name').fill(name);
+		const nameInput = this.page.getByPlaceholder('Name');
+
+		await nameInput.waitFor();
+
+		await fillAndClickOutside(this.page, nameInput, name);
 
 		await this.page.getByRole('button', {name: 'Save'}).click();
 

--- a/modules/test/playwright/tests/frontend-data-set-views-web/creationActions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/creationActions.spec.ts
@@ -214,7 +214,8 @@ export const fragmentTest = mergeTests(
 		'LPS-178052': true,
 	}),
 	fdsFragmentPageTest,
-	isolatedSiteTest
+	isolatedSiteTest,
+	loginTest()
 );
 
 fragmentTest.describe('Creation Actions in the fragment', () => {

--- a/modules/test/playwright/tests/frontend-data-set-views-web/itemActions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/itemActions.spec.ts
@@ -131,7 +131,8 @@ export const fragmentTest = mergeTests(
 		'LPS-178052': true,
 	}),
 	fdsFragmentPageTest,
-	isolatedSiteTest
+	isolatedSiteTest,
+	loginTest()
 );
 
 fragmentTest.describe('Item Actions in the fragment', () => {

--- a/modules/test/playwright/tests/frontend-data-set-views-web/settings.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/settings.spec.ts
@@ -203,7 +203,8 @@ export const fragmentTest = mergeTests(
 		'LPS-178052': true,
 	}),
 	fdsFragmentPageTest,
-	isolatedSiteTest
+	isolatedSiteTest,
+	loginTest()
 );
 
 fragmentTest.describe('Data Set Default Visualization Mode in fragment', () => {

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -9,6 +9,7 @@ import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
 import {applicationsMenuPageTest} from '../../fixtures/applicationsMenuPageTest';
 import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../fixtures/loginTest';
 import {workflowPagesTest} from '../../fixtures/workflowPagesTest';
 import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import fillAndClickOutside from '../../utils/fillAndClickOutside';
@@ -44,6 +45,7 @@ const baseTest = mergeTests(
 	applicationsMenuPageTest,
 	isolatedSiteTest,
 	journalPagesTest,
+	loginTest(),
 	workflowPagesTest
 );
 

--- a/modules/test/playwright/tests/journal-web/journalTemplate.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalTemplate.spec.ts
@@ -7,12 +7,14 @@ import {expect, mergeTests} from '@playwright/test';
 
 import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../fixtures/loginTest';
 import {journalPagesTest} from './fixtures/journalPagesTest';
 
 export const test = mergeTests(
 	apiHelpersTest,
 	isolatedSiteTest,
-	journalPagesTest
+	journalPagesTest,
+	loginTest()
 );
 
 const RESERVED_VARIABLES = [

--- a/modules/test/playwright/tests/knowledge-base-web/knowledge-base-web.spec.ts
+++ b/modules/test/playwright/tests/knowledge-base-web/knowledge-base-web.spec.ts
@@ -9,6 +9,7 @@ import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
 import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {knowledgeBasePages} from '../../fixtures/knowledgeBasePagesTest';
+import {loginTest} from '../../fixtures/loginTest';
 import getRandomString from '../../utils/getRandomString';
 
 const testFeatureFlagsEnabled = mergeTests(
@@ -17,7 +18,8 @@ const testFeatureFlagsEnabled = mergeTests(
 		'LPS-188058': true,
 	}),
 	isolatedSiteTest,
-	knowledgeBasePages
+	knowledgeBasePages,
+	loginTest()
 );
 
 const testFeatureFlagsDisabled = mergeTests(
@@ -26,7 +28,8 @@ const testFeatureFlagsDisabled = mergeTests(
 		'LPS-188058': false,
 	}),
 	isolatedSiteTest,
-	knowledgeBasePages
+	knowledgeBasePages,
+	loginTest()
 );
 
 testFeatureFlagsDisabled(

--- a/modules/test/playwright/tests/layout-admin-web/millerColumns.spec.ts
+++ b/modules/test/playwright/tests/layout-admin-web/millerColumns.spec.ts
@@ -9,6 +9,7 @@ import {pagesAdminPageTest} from '../../fixtures/PagesAdminPageTest';
 import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
 import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../fixtures/loginTest';
 import getRandomString from '../../utils/getRandomString';
 
 export const test = mergeTests(
@@ -18,6 +19,7 @@ export const test = mergeTests(
 		'LPS-196847': true,
 	}),
 	isolatedSiteTest,
+	loginTest(),
 	pagesAdminPageTest
 );
 

--- a/modules/test/playwright/tests/layout-admin-web/utilityPageConfiguration.spec.ts
+++ b/modules/test/playwright/tests/layout-admin-web/utilityPageConfiguration.spec.ts
@@ -7,6 +7,7 @@ import {expect, mergeTests} from '@playwright/test';
 
 import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../fixtures/loginTest';
 import getRandomString from '../../utils/getRandomString';
 import {pageEditorPagesTest} from '../layout-content-page-editor-web/fixtures/pageEditorPagesTest';
 import {pagesPagesTest} from './fixtures/pagesPagesTest';
@@ -14,6 +15,7 @@ import {pagesPagesTest} from './fixtures/pagesPagesTest';
 export const test = mergeTests(
 	apiHelpersTest,
 	isolatedSiteTest,
+	loginTest(),
 	pageEditorPagesTest,
 	pagesPagesTest
 );

--- a/modules/test/playwright/tests/layout-content-page-editor-web/advancedFragmentConfiguration.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/advancedFragmentConfiguration.spec.ts
@@ -141,7 +141,10 @@ test('checks that the advanced configuration of a fragment appears in its corres
 	// Add a new fragment set and a fragment inside it
 
 	const setName = getRandomString();
+
 	await fragmentsPage.createFragmentSet(setName);
+
+	await fragmentsPage.goto(site.friendlyUrlPath);
 
 	await fragmentsPage.createFragment(setName, 'My Fragment');
 

--- a/modules/test/playwright/tests/layout-content-page-editor-web/advancedFragmentConfiguration.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/advancedFragmentConfiguration.spec.ts
@@ -22,8 +22,8 @@ export const test = mergeTests(
 		'LPS-178052': true,
 	}),
 	fragmentsPagesTest,
-	loginTest(),
 	isolatedSiteTest,
+	loginTest(),
 	pageEditorPagesTest
 );
 

--- a/modules/test/playwright/tests/layout-content-page-editor-web/experiences.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/experiences.spec.ts
@@ -51,7 +51,7 @@ test('allows renaming an experience', async ({
 	await expect(page.getByLabel('Experience: E1 edited')).toBeVisible();
 });
 
-test('allows changing the segment of an existing experience', async ({
+test.skip('allows changing the segment of an existing experience', async ({
 	apiHelpers,
 	page,
 	pageEditorPage,
@@ -135,7 +135,7 @@ test('creates new experiences as expected', async ({
 	await expect(page.getByText('Heading Example')).toBeVisible();
 });
 
-test('keeps modal open when canceling segment creation', async ({
+test.skip('keeps modal open when canceling segment creation', async ({
 	apiHelpers,
 	page,
 	pageEditorPage,

--- a/modules/test/playwright/tests/layout-content-page-editor-web/experiences.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/experiences.spec.ts
@@ -8,6 +8,7 @@ import {expect, mergeTests} from '@playwright/test';
 import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
 import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../fixtures/loginTest';
 import getRandomString from '../../utils/getRandomString';
 import {pageEditorPagesTest} from './fixtures/pageEditorPagesTest';
 import getFragmentDefinition from './utils/getFragmentDefinition';
@@ -19,6 +20,7 @@ export const test = mergeTests(
 		'LPS-178052': true,
 	}),
 	isolatedSiteTest,
+	loginTest(),
 	pageEditorPagesTest
 );
 

--- a/modules/test/playwright/tests/layout-content-page-editor-web/keyboard.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/keyboard.spec.ts
@@ -8,6 +8,7 @@ import {expect, mergeTests} from '@playwright/test';
 import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
 import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../fixtures/loginTest';
 import {expectElementToHaveClass} from '../../utils/expectElementToHaveClass';
 import getRandomString from '../../utils/getRandomString';
 import {pageEditorPagesTest} from './fixtures/pageEditorPagesTest';
@@ -20,6 +21,7 @@ export const test = mergeTests(
 		'LPS-178052': true,
 	}),
 	isolatedSiteTest,
+	loginTest(),
 	pageEditorPagesTest
 );
 

--- a/modules/test/playwright/tests/layout-content-page-editor-web/pageContents.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/pageContents.spec.ts
@@ -8,6 +8,7 @@ import {expect, mergeTests} from '@playwright/test';
 import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
 import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../fixtures/loginTest';
 import getRandomString from '../../utils/getRandomString';
 import {pageEditorPagesTest} from './fixtures/pageEditorPagesTest';
 import getFragmentDefinition from './utils/getFragmentDefinition';
@@ -19,6 +20,7 @@ export const test = mergeTests(
 		'LPS-178052': true,
 	}),
 	isolatedSiteTest,
+	loginTest(),
 	pageEditorPagesTest
 );
 

--- a/modules/test/playwright/tests/layout-content-page-editor-web/pages/PageEditorPage.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/pages/PageEditorPage.ts
@@ -136,7 +136,8 @@ export class PageEditorPage {
 
 		await waitForSuccessAlert(
 			this.page,
-			'Success:The experience was created successfully.'
+			'Success:The experience was created successfully.',
+			{autoClose: false}
 		);
 	}
 
@@ -173,7 +174,8 @@ export class PageEditorPage {
 
 		await waitForSuccessAlert(
 			this.page,
-			'Success:The experience was duplicated successfully.'
+			'Success:The experience was duplicated successfully.',
+			{autoClose: false}
 		);
 	}
 
@@ -237,7 +239,8 @@ export class PageEditorPage {
 
 		await waitForSuccessAlert(
 			this.page,
-			'Success:The experience was updated successfully.'
+			'Success:The experience was updated successfully.',
+			{autoClose: false}
 		);
 	}
 
@@ -283,7 +286,8 @@ export class PageEditorPage {
 
 		await waitForSuccessAlert(
 			this.page,
-			'Success:The experience was updated successfully.'
+			'Success:The experience was updated successfully.',
+			{autoClose: false}
 		);
 	}
 

--- a/modules/test/playwright/tests/layout-content-page-editor-web/sidebar.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/sidebar.spec.ts
@@ -9,6 +9,7 @@ import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
 import {applicationsMenuPageTest} from '../../fixtures/applicationsMenuPageTest';
 import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../fixtures/loginTest';
 import getRandomString from '../../utils/getRandomString';
 import {pageEditorPagesTest} from './fixtures/pageEditorPagesTest';
 
@@ -20,6 +21,7 @@ export const test = mergeTests(
 		'LPS-178052': true,
 	}),
 	isolatedSiteTest,
+	loginTest(),
 	pageEditorPagesTest
 );
 

--- a/modules/test/playwright/tests/layout-content-page-editor-web/stylesPanel.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/stylesPanel.spec.ts
@@ -8,6 +8,7 @@ import {expect, mergeTests} from '@playwright/test';
 import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
 import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../fixtures/loginTest';
 import fillAndClickOutside from '../../utils/fillAndClickOutside';
 import getRandomString from '../../utils/getRandomString';
 import {pageEditorPagesTest} from './fixtures/pageEditorPagesTest';
@@ -20,6 +21,7 @@ export const test = mergeTests(
 		'LPS-178052': true,
 	}),
 	isolatedSiteTest,
+	loginTest(),
 	pageEditorPagesTest
 );
 

--- a/modules/test/playwright/tests/layout-content-page-editor-web/undoRedo.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/undoRedo.spec.ts
@@ -8,6 +8,7 @@ import {expect, mergeTests} from '@playwright/test';
 import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
 import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../fixtures/loginTest';
 import getRandomString from '../../utils/getRandomString';
 import {pageEditorPagesTest} from './fixtures/pageEditorPagesTest';
 import getFragmentDefinition from './utils/getFragmentDefinition';
@@ -19,6 +20,7 @@ export const test = mergeTests(
 		'LPS-178052': true,
 	}),
 	isolatedSiteTest,
+	loginTest(),
 	pageEditorPagesTest
 );
 

--- a/modules/test/playwright/tests/layout-content-page-editor-web/viewport.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/viewport.spec.ts
@@ -8,6 +8,7 @@ import {expect, mergeTests} from '@playwright/test';
 import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
 import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../fixtures/loginTest';
 import getRandomString from '../../utils/getRandomString';
 import {pageEditorPagesTest} from './fixtures/pageEditorPagesTest';
 import getFragmentDefinition from './utils/getFragmentDefinition';
@@ -18,6 +19,7 @@ export const test = mergeTests(
 		'LPS-178052': true,
 	}),
 	isolatedSiteTest,
+	loginTest(),
 	pageEditorPagesTest
 );
 

--- a/modules/test/playwright/tests/layout-taglib/fixtures/pageSelectorPagesTest.ts
+++ b/modules/test/playwright/tests/layout-taglib/fixtures/pageSelectorPagesTest.ts
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {test} from '@playwright/test';
+
+import {PageSelectorPage} from '../pages/PageSelectorPage';
+
+const pageSelectorPagesTest = test.extend<{
+	pageSelectorPage: PageSelectorPage;
+}>({
+	pageSelectorPage: async ({page}, use) => {
+		await use(new PageSelectorPage(page));
+	},
+});
+
+export {pageSelectorPagesTest};

--- a/modules/test/playwright/tests/layout-taglib/pageSelector.spec.ts
+++ b/modules/test/playwright/tests/layout-taglib/pageSelector.spec.ts
@@ -11,6 +11,7 @@ import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../fixtures/loginTest';
 import getRandomString from '../../utils/getRandomString';
 import {navigationMenusPagesTest} from '../site-navigation-admin-web/fixtures/navigationMenusPagesTest';
+import {pageSelectorPagesTest} from './fixtures/pageSelectorPagesTest';
 
 export const test = mergeTests(
 	apiHelpersTest,
@@ -20,12 +21,14 @@ export const test = mergeTests(
 	}),
 	isolatedSiteTest,
 	loginTest(),
-	navigationMenusPagesTest
+	navigationMenusPagesTest,
+	pageSelectorPagesTest
 );
 
 test('load more works properly in search results', async ({
 	apiHelpers,
 	navigationMenusPage,
+	pageSelectorPage,
 	site,
 }) => {
 
@@ -53,68 +56,51 @@ test('load more works properly in search results', async ({
 
 	await navigationMenusPage.createNavigationMenu(getRandomString());
 
-	const modal = await navigationMenusPage.openAddPageModal();
+	await navigationMenusPage.openAddPageModal();
 
-	const loadMoreButton = modal.locator('.load-more-btn');
+	// Store modal instance in variable so we can search for things inside it
+
+	const modal = await pageSelectorPage.getModal();
 
 	// Search for another string and check empty state
 
-	await modal.getByPlaceholder('Search').fill('Orange');
+	await pageSelectorPage.search('Orange');
 
 	await expect(modal.getByText('No Results Found')).toBeVisible();
 
 	// Search for Lemon pages, check it shows all results and does not show Load More button
 
-	await modal.getByPlaceholder('Search').fill('Lem');
+	await pageSelectorPage.search('Lem');
 
-	await modal.locator('.loading-animation').waitFor();
-	await modal.locator('.loading-animation').waitFor({state: 'hidden'});
+	await expect(modal.locator('.search-result')).toHaveCount(15);
 
-	await expect(
-		modal.locator('.search-result').getByText('Lemon')
-	).toHaveCount(15);
-
-	await expect(loadMoreButton).not.toBeVisible();
+	await expect(modal.getByText('Load More Results')).not.toBeVisible();
 
 	// Check only Lem substring is marked
 
-	const firstResult = await modal
-		.locator('.search-result')
-		.getByText('Lemon')
-		.first();
+	const firstResult = await modal.locator('.search-result').first();
 
 	await expect(firstResult.locator('mark')).toHaveText('Lem');
 
 	// Search for Apple pages, check it initially shows 20 items
 
-	await modal.getByPlaceholder('Search').fill('App');
+	await pageSelectorPage.search('App');
 
-	await modal.locator('.loading-animation').waitFor();
-	await modal.locator('.loading-animation').waitFor({state: 'hidden'});
-
-	await expect(
-		modal.locator('.search-result').getByText('Apple')
-	).toHaveCount(20);
+	await expect(modal.locator('.search-result')).toHaveCount(20);
 
 	// Load more items and check it loads all results and button disappears
 
-	await loadMoreButton.click();
+	await pageSelectorPage.loadMore();
 
-	await loadMoreButton.locator('.loading-animation').waitFor();
-	await loadMoreButton
-		.locator('.loading-animation')
-		.waitFor({state: 'hidden'});
+	await expect(modal.locator('.search-result')).toHaveCount(30);
 
-	await expect(
-		modal.locator('.search-result').getByText('Apple')
-	).toHaveCount(30);
-
-	await expect(loadMoreButton).not.toBeVisible();
+	await expect(modal.getByText('Load More Results')).not.toBeVisible();
 });
 
 test('checks the correct label for restricted page in the layout tree', async ({
 	apiHelpers,
 	navigationMenusPage,
+	pageSelectorPage,
 	site,
 }) => {
 
@@ -139,7 +125,9 @@ test('checks the correct label for restricted page in the layout tree', async ({
 
 	await navigationMenusPage.createNavigationMenu(getRandomString());
 
-	const modal = await navigationMenusPage.openAddPageModal();
+	await navigationMenusPage.openAddPageModal();
+
+	const modal = await pageSelectorPage.getModal();
 
 	// Check the correct label for restricted page
 

--- a/modules/test/playwright/tests/layout-taglib/pageSelector.spec.ts
+++ b/modules/test/playwright/tests/layout-taglib/pageSelector.spec.ts
@@ -8,6 +8,7 @@ import {expect, mergeTests} from '@playwright/test';
 import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
 import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../fixtures/loginTest';
 import getRandomString from '../../utils/getRandomString';
 import {navigationMenusPagesTest} from '../site-navigation-admin-web/fixtures/navigationMenusPagesTest';
 
@@ -18,6 +19,7 @@ export const test = mergeTests(
 		'LPS-196847': true,
 	}),
 	isolatedSiteTest,
+	loginTest(),
 	navigationMenusPagesTest
 );
 

--- a/modules/test/playwright/tests/layout-taglib/pages/PageSelectorPage.ts
+++ b/modules/test/playwright/tests/layout-taglib/pages/PageSelectorPage.ts
@@ -1,0 +1,42 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {FrameLocator, Page} from '@playwright/test';
+
+export class PageSelectorPage {
+	readonly page: Page;
+
+	readonly modal: FrameLocator;
+
+	constructor(page: Page) {
+		this.page = page;
+
+		this.modal = page.frameLocator('iframe[title="Select Pages"]');
+	}
+
+	async getModal(): Promise<FrameLocator> {
+		return this.modal;
+	}
+
+	async loadMore() {
+		const loadMoreButton = this.modal.locator('.load-more-btn');
+
+		await loadMoreButton.click();
+
+		await loadMoreButton.locator('.loading-animation').waitFor();
+		await loadMoreButton
+			.locator('.loading-animation')
+			.waitFor({state: 'hidden'});
+	}
+
+	async search(query: string) {
+		await this.modal.getByPlaceholder('Search').fill(query);
+
+		await this.modal.locator('.loading-animation').waitFor();
+		await this.modal
+			.locator('.loading-animation')
+			.waitFor({state: 'hidden'});
+	}
+}

--- a/modules/test/playwright/tests/product-navigation-control-menu-web/addContentPanel.spec.ts
+++ b/modules/test/playwright/tests/product-navigation-control-menu-web/addContentPanel.spec.ts
@@ -7,6 +7,7 @@ import {expect, mergeTests} from '@playwright/test';
 
 import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../fixtures/loginTest';
 import {widgetPagesTest} from '../../fixtures/widgetPagesTest';
 import getRandomString from '../../utils/getRandomString';
 import addApprovedStructuredContent from '../../utils/structured-content/addApprovedStructuredContent';
@@ -19,6 +20,7 @@ import getBasicWebContentStructureId from '../../utils/structured-content/getBas
 export const test = mergeTests(
 	apiHelpersTest,
 	isolatedSiteTest,
+	loginTest(),
 	widgetPagesTest
 );
 

--- a/modules/test/playwright/tests/product-navigation-control-menu-web/layoutHeader.spec.ts
+++ b/modules/test/playwright/tests/product-navigation-control-menu-web/layoutHeader.spec.ts
@@ -8,6 +8,7 @@ import {expect, mergeTests} from '@playwright/test';
 import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
 import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../fixtures/loginTest';
 import getRandomString from '../../utils/getRandomString';
 
 export const test = mergeTests(
@@ -16,7 +17,8 @@ export const test = mergeTests(
 		'LPS-178052': true,
 		'LPS-196847': true,
 	}),
-	isolatedSiteTest
+	isolatedSiteTest,
+	loginTest()
 );
 
 test('checks the correct label for restricted page in the page heading', async ({

--- a/modules/test/playwright/tests/product-navigation-product-menu-web/pageTree.spec.ts
+++ b/modules/test/playwright/tests/product-navigation-product-menu-web/pageTree.spec.ts
@@ -8,6 +8,7 @@ import {expect, mergeTests} from '@playwright/test';
 import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
 import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../fixtures/loginTest';
 import getRandomString from '../../utils/getRandomString';
 import {pageEditorPagesTest} from '../layout-content-page-editor-web/fixtures/pageEditorPagesTest';
 
@@ -18,6 +19,7 @@ export const test = mergeTests(
 		'LPS-196847': true,
 	}),
 	isolatedSiteTest,
+	loginTest(),
 	pageEditorPagesTest
 );
 

--- a/modules/test/playwright/tests/site-navigation-admin-web/pages/NavigationMenusPage.ts
+++ b/modules/test/playwright/tests/site-navigation-admin-web/pages/NavigationMenusPage.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {FrameLocator, Locator, Page} from '@playwright/test';
+import {Locator, Page} from '@playwright/test';
 
 import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
 import {PORTLET_URLS} from '../../../utils/portletUrls';
@@ -28,7 +28,7 @@ export class NavigationMenusPage {
 		);
 	}
 
-	async openAddPageModal(): Promise<FrameLocator> {
+	async openAddPageModal() {
 		await clickAndExpectToBeVisible({
 			autoClick: true,
 			target: this.page.getByRole('menuitem', {name: 'Page'}),
@@ -40,8 +40,6 @@ export class NavigationMenusPage {
 		);
 
 		await modal.getByPlaceholder('Search').waitFor();
-
-		return modal;
 	}
 
 	async createNavigationMenu(name: string) {

--- a/modules/test/playwright/tests/style-book-web/previewSelector.spec.ts
+++ b/modules/test/playwright/tests/style-book-web/previewSelector.spec.ts
@@ -9,6 +9,7 @@ import {styleBookPageTest} from '../../fixtures/StyleBookPageTest';
 import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
 import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../fixtures/loginTest';
 import getRandomString from '../../utils/getRandomString';
 
 export const test = mergeTests(
@@ -18,6 +19,7 @@ export const test = mergeTests(
 		'LPS-196847': true,
 	}),
 	isolatedSiteTest,
+	loginTest(),
 	styleBookPageTest
 );
 

--- a/modules/test/playwright/utils/waitForSuccessAlert.ts
+++ b/modules/test/playwright/utils/waitForSuccessAlert.ts
@@ -6,7 +6,8 @@ import {Page} from '@playwright/test';
  */
 export async function waitForSuccessAlert(
 	page: Page,
-	text = 'Success:Your request completed successfully.'
+	text = 'Success:Your request completed successfully.',
+	{autoClose} = {autoClose: true}
 ) {
 	const alert = page.locator('.alert-success', {
 		hasText: text,
@@ -14,7 +15,9 @@ export async function waitForSuccessAlert(
 
 	await alert.waitFor();
 
-	await alert.getByLabel('Close').click();
+	if (autoClose) {
+		await alert.getByLabel('Close').click();
 
-	await alert.waitFor({state: 'hidden'});
+		await alert.waitFor({state: 'hidden'});
+	}
 }

--- a/test.properties
+++ b/test.properties
@@ -8584,7 +8584,6 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
     test.batch.names[relevant]=\
         ${test.batch.names[stable]},\
         empty-osgi-core-dir-mysql57-jdk8,\
-        lpkg-controller-mysql57-jdk8,\
         modules-integration-mysql57-jdk8,\
         modules-semantic-versioning-jdk8,\
         modules-unit-jdk8,\


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-21457

Resent from https://github.com/liferay-headless/liferay-portal/pull/1970, using the alternative solution.

Original message:

Forwarded from https://github.com/liferay-core-infra/liferay-portal/pull/6872

There is also some additional context in [this Slack thread](https://liferay.slack.com/archives/C01FP01V5L0/p1712772586011219).  I understand this is a complex issue, so please let me know if you have any questions or concerns.  Thanks!

Original message:

I chose this solution because it seems to have the smallest impact on the portal, while fixing the original issue and not causing regressions.  The problem is after we add the `CSRF` token to the request, sometimes the requests are wrapped in a `HttpServletRequestWrapper`, which means their session object is of type `HttpSessionAdapter`, which only returns attributes which are namespaced by the given context.  This means we fail to retrieve the `CSRF` token we added to the session earlier, since it was not namespaced, and there is no way to access it from the `HttpSessionAdapter` whatsoever.  The solution here is to simply unwrap the request, and retrieve the `StandardSessionFacade` object instead, which doesn't consider namespacing, allowing us to access the `CSRF` token we added earlier.

I've also created [this potential solution](https://github.com/ChrisKian/liferay-portal/commit/a516aea2af553043aa8f729f274f6907ebc6ea70), which would instead add the `CSRF` token to the `HttpSessionAdapter` when making a request from the `RESTClientHttpRequest` class.  The `CSRF` token attribute gets namespaced with the current context, thus we can retrieve it later.  This solution requires no unwrapping, but only takes the `CSRF` token into account; no other attributes are added to the `HttpSessionAdapter`.  This may be a good thing, since again, it has very little impact on the portal.

Lastly, I tried adding a similar logic to [SessionAuthToken](https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/security/auth/SessionAuthToken.java#L212-L253), however I found the context changes in some situations, thus the CSRF token has a different namespace, and cannot be retrieved.

Please let me know if you have any questions regarding either solution, and if there is anything I should change.  Thanks!

Original message:

> I've been able to resolve this issue using a similar approach to [LPD-15645](https://liferay.atlassian.net/browse/LPD-15645) in that some requests are wrapped, thus the true session is not exposed.  In my testing of [LPP-53494](https://liferay.atlassian.net/browse/LPP-53494), I've found both the `UploadServletRequest` and a form of a `ProtectedServletRequest` (more specifically, the [DirectRequestDispatcherFactoryUtil.DirectRequestDispatcherServletRequest](https://github.com/liferay/liferay-portal/blob/master/portal-kernel/src/com/liferay/portal/kernel/servlet/DirectRequestDispatcherFactoryUtil.java#L119)) are used, since the ticket describes two possible ways of reproducing the same issue.
> 
> I'm not fully confident in this issue, as you mentioned before we shouldn't unwrap protected sessions.  However, I'm not really sure how else to proceed.  Also, this doesn't cause a regression for [LPD-19377](https://liferay.atlassian.net/browse/LPD-19377), which is important as well.

CC @4lejandrito 