### PR TITLE
LPD-23580 Assert the checkbox is selected before starting the test and set the default values of the Settings once the tests have finished

### DIFF
--- a/modules/apps/batch-planner/batch-planner-test/src/testFunctional/macros/ImportExport.macro
+++ b/modules/apps/batch-planner/batch-planner-test/src/testFunctional/macros/ImportExport.macro
@@ -463,6 +463,17 @@ definition {
 	}
 
 	@summary = "Default summary"
+	macro resetDefaultValues() {
+		if (IsElementPresent(locator1 = "Icon#HISTORY_VERTICAL_ELLIPSIS")) {
+			Click(locator1 = "Icon#HISTORY_VERTICAL_ELLIPSIS");
+
+			MenuItem.clickNoError(menuItem = "Reset Default Values");
+
+			Alert.viewSuccessMessage();
+		}
+	}
+
+	@summary = "Default summary"
 	macro saveAsTemplate(templateName = null) {
 		WaitForElementPresent(
 			key_text = "Save as Template",
@@ -505,6 +516,17 @@ definition {
 		Button.click(button = "Start Import");
 
 		WaitForElementPresent(locator1 = "ImportExport#EXECUTION_SUCCESS");
+	}
+
+	@summary = "Default summary"
+	macro tearDownSettingsConfigurations() {
+		StagingNavigator.openToConfigInInstanceSettings(portlet = "Export/Import, Staging");
+
+		ImportExport.resetDefaultValues();
+
+		StagingNavigator.openToConfigInSystemSettings(portlet = "Export/Import, Staging");
+
+		ImportExport.resetDefaultValues();
 	}
 
 	@summary = "Default summary"

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/exportimport/ExportImportValidation.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/exportimport/ExportImportValidation.testcase
@@ -14,6 +14,8 @@ definition {
 	}
 
 	tearDown {
+		ImportExport.tearDownSettingsConfigurations();
+
 		var testPortalInstance = PropsUtil.get("test.portal.instance");
 
 		if (${testPortalInstance} == "true") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/exportimport/ExportImportValidation.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/exportimport/ExportImportValidation.testcase
@@ -33,6 +33,10 @@ definition {
 		task ("When: Not set URL Pattern in System Settings") {
 			StagingNavigator.openToConfigInSystemSettings(portlet = "Export/Import, Staging");
 
+			AssertElementPresent(
+				checkboxName = "Validate Layout References",
+				locator1 = "Checkbox#ANY_CHECKBOX_CHECKED");
+
 			AssertTextEquals(
 				locator1 = "ExportImport#URL_PATTERN",
 				value1 = "");
@@ -165,6 +169,10 @@ definition {
 
 		task ("Given: Add multiple URL Pattern in System Settings") {
 			StagingNavigator.openToConfigInSystemSettings(portlet = "Export/Import, Staging");
+
+			AssertElementPresent(
+				checkboxName = "Validate Layout References",
+				locator1 = "Checkbox#ANY_CHECKBOX_CHECKED");
 
 			ExportImport.configureURLPattern(urlPattern = "/dl/*");
 


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPD-23580

---

The purpose of this ticket is to fix the acceptance tests that are failing due to the `java.lang.Exception: "Your request failed to complete." is not present` error.

I have performed the following changes:

- Ensuring the check box of the validation is set to true before executing the test.
- Ensuring the instance and system settings are set to the default values once each test is finished