### PR TITLE
LPD-23650 Check the failure before validating the Summary, as the button appears once the process is not running anymore

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/StagingUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/StagingUsecase.testcase
@@ -2307,6 +2307,8 @@ definition {
 				category = "Publishing",
 				portlet = "Staging");
 
+			Staging.viewProcessResult(failureExpected = "true");
+
 			LexiconEntry.gotoEntryMenuItem(
 				menuItem = "Summary",
 				rowEntry = "Publication Name");


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPD-21234

---

The purpose of this ticket is to fix the `StagingUsecase#TrashEntryReferencePublishing` acceptance test.

The problem seems to be the missing `Summary` option when the three dots is pressed.

The only way I have been able to reproduce a similar behaviour is, once a Staging process has started, press the three dot button. It will only appear the text "Relaunch".

Once the process is finished with success status, if I press the button again, it shows the "Summary" menu but it is overlapped by the previously existing menu with only one option.

![image](https://github.com/liferay-headless/liferay-portal/assets/32699538/1bc93b6b-cd5a-45d6-a89c-44d7d08f2a39)

For that, this PR includes a validation until the status of the staging process is an ended status (in this case, FAILED)
