### PR TITLE
LPD-23367: Hide Detect Category Names from CSV File checkbox in Data Migration Center

### DIFF
--- a/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/import/edit_batch_planner_plan.jsp
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/import/edit_batch_planner_plan.jsp
@@ -96,7 +96,7 @@ renderResponse.setTitle(editable ? LanguageUtil.get(request, "edit-template") : 
 								/>
 							</clay:alert>
 
-							<div class="mt-2">
+							<div class="d-none mt-2">
 								<clay:checkbox
 									checked="<%= false %>"
 									disabled="<%= true %>"


### PR DESCRIPTION
**What is new?**
- Hide `Detect Category Names from CSV File` check box because it is not being used. However, it is not deleted because this could be useful for any moment.

**Note:** No need to create a test case for this because we are not changing the behavior of this checkbox which was disabled all the time.

**Before PR**
![Screenshot from 2024-04-19 11-25-26](https://github.com/liferay-headless/liferay-portal/assets/44723449/803de88b-8845-4f04-91df-85bbba0a71f6)

**After PR**
![Screenshot from 2024-04-19 11-25-52](https://github.com/liferay-headless/liferay-portal/assets/44723449/e83d6e1e-cd49-4375-86bb-7c9ed3c6a6c9)


**JIRA Related Ticket**
https://liferay.atlassian.net/browse/LPD-23367 