### PR TITLE
LPD-24118 Make GraphQL recognize the PrincipalException.MustHavePermissions and throw it's respective 404 error

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
@@ -2476,7 +2477,9 @@ public class GraphQLServletExtender {
 
 			if ((throwable != null) &&
 				(throwable.getCause() instanceof NotFoundException ||
-				 throwable.getCause() instanceof NoSuchModelException)) {
+				 throwable.getCause() instanceof NoSuchModelException ||
+				 throwable.getCause() instanceof
+					 PrincipalException.MustHavePermission)) {
 
 				return true;
 			}

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
@@ -12,6 +12,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -358,6 +359,18 @@ public class GraphQLServletTest {
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
 
+		Assert.assertEquals(
+			"Not Found",
+			JSONUtil.getValueAsString(
+				_invoke(
+					new GraphQLField(
+						"testPath_v1_0",
+						new GraphQLField(
+							"testNoPermissionOverDTO", new GraphQLField("id"))),
+					"query"),
+				"JSONArray/errors", "Object/0", "JSONObject/extensions",
+				"Object/code"));
+
 		// Without namespace (backwards compatibility)
 
 		_assertEquals(
@@ -376,6 +389,16 @@ public class GraphQLServletTest {
 			JSONUtil.getValueAsString(
 				_invoke(
 					new GraphQLField("testNotFoundDTO", new GraphQLField("id")),
+					"query"),
+				"JSONArray/errors", "Object/0", "JSONObject/extensions",
+				"Object/code"));
+
+		Assert.assertEquals(
+			"Not Found",
+			JSONUtil.getValueAsString(
+				_invoke(
+					new GraphQLField(
+						"testNoPermissionOverDTO", new GraphQLField("id")),
 					"query"),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
@@ -564,6 +587,14 @@ public class GraphQLServletTest {
 			@GraphQLName("pageSize") int pageSize) {
 
 			return new TestDTOPage(page, pageSize);
+		}
+
+		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+		public TestDTO testNoPermissionOverDTO()
+			throws PrincipalException.MustHavePermission {
+
+			throw new PrincipalException.MustHavePermission(
+				0L, StringUtil.randomString());
 		}
 
 		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField


### PR DESCRIPTION
**What's changed?:**
- Now the errors infrastructure of GraphQL take the PrincipalException.MustHavePermissions exception into account.
- Instead of returning a generic Internal Server Error message, a Not Found (as in REST) is returned.
- The GraphQLServletTest now checks if this exception outputs the wanted error.

See the following **Jira Tickets**: [LPD-24118](https://liferay.atlassian.net/browse/LPD-24118) / [LPP-53683](https://liferay.atlassian.net/browse/LPP-53683)