### PR TITLE
LPD-22028 Follow up changes for performance tests in general

### DIFF
--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-test/src/testIntegration/java/com/liferay/headless/batch/engine/resource/v1_0/test/ExportImportTaskResourcePerformanceTest.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-test/src/testIntegration/java/com/liferay/headless/batch/engine/resource/v1_0/test/ExportImportTaskResourcePerformanceTest.java
@@ -332,7 +332,7 @@ public class ExportImportTaskResourcePerformanceTest {
 
 		try (TestEntityPerformanceTimer itemCountPerformanceTimer =
 				new TestEntityPerformanceTimer(
-					count, className + "#export", maxExportTime)) {
+					count, maxExportTime, className + "#export")) {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
 
@@ -386,7 +386,7 @@ public class ExportImportTaskResourcePerformanceTest {
 
 		try (TestEntityPerformanceTimer itemCountPerformanceTimer =
 				new TestEntityPerformanceTimer(
-					count, className + "#download", maxDownloadTime)) {
+					count, maxDownloadTime, className + "#download")) {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
 
@@ -427,7 +427,7 @@ public class ExportImportTaskResourcePerformanceTest {
 			classNamePartsMap.get("className"), count);
 
 		try (Closeable closeable = new TestEntityPerformanceTimer(
-				count, className, maxTime)) {
+				count, maxTime, className)) {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
 
@@ -503,19 +503,19 @@ public class ExportImportTaskResourcePerformanceTest {
 	private class TestEntityPerformanceTimer extends PerformanceTimer {
 
 		public TestEntityPerformanceTimer(
-			int count, String name, long maxTime) {
+			int count, long maxTime, String name) {
 
 			this(
-				count, getInvokerName(null, name), System.currentTimeMillis(),
-				maxTime, null);
+				count, null, maxTime, getInvokerName(null, name),
+				System.currentTimeMillis());
 		}
 
 		public TestEntityPerformanceTimer(
-			int count, String name, long maxTime, Path logFilePath) {
+			int count, Path logFilePath, long maxTime, String name) {
 
 			this(
-				count, getInvokerName(null, name), System.currentTimeMillis(),
-				maxTime, logFilePath);
+				count, logFilePath, maxTime, getInvokerName(null, name),
+				System.currentTimeMillis());
 		}
 
 		@Override
@@ -540,10 +540,10 @@ public class ExportImportTaskResourcePerformanceTest {
 		}
 
 		protected TestEntityPerformanceTimer(
-			int count, String name, long startTime, long maxTime,
-			Path logFilePath) {
+			int count, Path logFilePath, long maxTime, String name,
+			long startTime) {
 
-			super(name, startTime, maxTime, logFilePath);
+			super(logFilePath, maxTime, name, startTime);
 
 			_count = count;
 		}

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/test/ExportImportPerformanceTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/test/ExportImportPerformanceTest.java
@@ -179,7 +179,7 @@ public class ExportImportPerformanceTest {
 
 	@Test
 	public void testExportGroupToLAR() throws Exception {
-		try (Closeable closeable = new PerformanceTimer(1000, _logFilePath)) {
+		try (Closeable closeable = new PerformanceTimer(_logFilePath, 1000)) {
 			Map<String, Serializable> exportLayoutSettingsMap =
 				_exportImportConfigurationSettingsMapFactory.
 					buildExportLayoutSettingsMap(
@@ -216,7 +216,7 @@ public class ExportImportPerformanceTest {
 		File file = _exportImportLocalService.exportLayoutsAsFile(
 			_exportImportConfiguration);
 
-		try (Closeable closeable = new PerformanceTimer(1000, _logFilePath)) {
+		try (Closeable closeable = new PerformanceTimer(_logFilePath, 1000)) {
 			Map<String, Serializable> importLayoutSettingsMap =
 				_exportImportConfigurationSettingsMapFactory.
 					buildImportLayoutSettingsMap(
@@ -237,7 +237,7 @@ public class ExportImportPerformanceTest {
 
 	@Test
 	public void testInitialStagingPublication() throws Exception {
-		try (Closeable closeable = new PerformanceTimer(10000, _logFilePath)) {
+		try (Closeable closeable = new PerformanceTimer(_logFilePath, 10000)) {
 			_stagingLocalService.enableLocalStaging(
 				TestPropsValues.getUserId(), _group, false, false,
 				_serviceContext);
@@ -274,7 +274,7 @@ public class ExportImportPerformanceTest {
 			_group, _layoutSetPrototype.getLayoutSetPrototypeId(), 0, true,
 			true);
 
-		try (Closeable closeable = new PerformanceTimer(1000, _logFilePath)) {
+		try (Closeable closeable = new PerformanceTimer(_logFilePath, 1000)) {
 			MergeLayoutPrototypesThreadLocal.clearMergeComplete();
 
 			_sites.mergeLayoutSetPrototypeLayouts(
@@ -287,7 +287,7 @@ public class ExportImportPerformanceTest {
 		_stagingLocalService.enableLocalStaging(
 			TestPropsValues.getUserId(), _group, false, false, _serviceContext);
 
-		try (Closeable closeable = new PerformanceTimer(1000, _logFilePath)) {
+		try (Closeable closeable = new PerformanceTimer(_logFilePath, 1000)) {
 			Group stagingGroup = _group.getStagingGroup();
 
 			Map<String, Serializable> stagingSettingsMap =

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryPerformanceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryPerformanceTest.java
@@ -103,7 +103,7 @@ public class ObjectEntryPerformanceTest {
 
 	@Test
 	public void testGetObjectEntries() throws Exception {
-		try (Closeable closeable = new PerformanceTimer(60000, _logFilePath)) {
+		try (Closeable closeable = new PerformanceTimer(_logFilePath, 60000)) {
 			_objectEntries = _objectEntryLocalService.getObjectEntries(
 				0, _objectDefinition.getObjectDefinitionId(), QueryUtil.ALL_POS,
 				QueryUtil.ALL_POS);

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-jsp-compiler-test/src/testIntegration/java/com/liferay/portal/osgi/web/servlet/jsp/compiler/test/JspServletPerformanceTest.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-jsp-compiler-test/src/testIntegration/java/com/liferay/portal/osgi/web/servlet/jsp/compiler/test/JspServletPerformanceTest.java
@@ -10,9 +10,9 @@ import com.liferay.petra.io.unsync.UnsyncByteArrayInputStream;
 import com.liferay.petra.io.unsync.UnsyncByteArrayOutputStream;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.test.performance.PerformanceTimer;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.util.HtmlUtil;
-import com.liferay.portal.kernel.util.LoggingTimer;
 import com.liferay.portal.kernel.util.URLUtil;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -109,7 +109,7 @@ public class JspServletPerformanceTest {
 
 		_test(_FILE_NAME_EL_EXPRESSION_UNDEFINED_SCOPED_VARIABLES_JSP, 1);
 
-		try (LoggingTimer loggingTimer = new LoggingTimer()) {
+		try (PerformanceTimer performanceTimer = new PerformanceTimer(5000)) {
 			_test(
 				_FILE_NAME_EL_EXPRESSION_UNDEFINED_SCOPED_VARIABLES_JSP,
 				_NUMBER_OF_REQUESTS);
@@ -120,7 +120,7 @@ public class JspServletPerformanceTest {
 	public void testElExpressionWithUndefinedVariablesJsp() throws Exception {
 		_test(_FILE_NAME_EL_EXPRESSION_UNDEFINED_VARIABLES_JSP, 1);
 
-		try (LoggingTimer loggingTimer = new LoggingTimer()) {
+		try (PerformanceTimer performanceTimer = new PerformanceTimer(1000)) {
 			_test(
 				_FILE_NAME_EL_EXPRESSION_UNDEFINED_VARIABLES_JSP,
 				_NUMBER_OF_REQUESTS);
@@ -131,7 +131,7 @@ public class JspServletPerformanceTest {
 	public void testJsp() throws Exception {
 		_test(_FILE_NAME_TEST_JSP, 1);
 
-		try (LoggingTimer loggingTimer = new LoggingTimer()) {
+		try (PerformanceTimer performanceTimer = new PerformanceTimer(1000)) {
 			_test(_FILE_NAME_TEST_JSP, _NUMBER_OF_REQUESTS);
 		}
 	}

--- a/modules/core/petra/petra-url-pattern-mapper/src/test/java/com/liferay/petra/url/pattern/mapper/internal/BaseURLPatternMapperPerformanceTestCase.java
+++ b/modules/core/petra/petra-url-pattern-mapper/src/test/java/com/liferay/petra/url/pattern/mapper/internal/BaseURLPatternMapperPerformanceTestCase.java
@@ -6,10 +6,10 @@
 package com.liferay.petra.url.pattern.mapper.internal;
 
 import com.liferay.petra.url.pattern.mapper.URLPatternMapper;
+import com.liferay.portal.kernel.test.performance.PerformanceTimer;
 
 import java.util.BitSet;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -23,25 +23,20 @@ public abstract class BaseURLPatternMapperPerformanceTestCase
 		URLPatternMapper<Integer> urlPatternMapper = createURLPatternMapper(
 			createValues());
 
-		long start = System.currentTimeMillis();
+		try (PerformanceTimer performanceTimer =
+				new SystemOutLoggerPerformanceTimer(
+					_CI_MULTIPLIER * testConsumeValuesExpectedTime(),
+					"Iterated 100 thousand times")) {
 
-		for (int i = 0; i < 100000; i++) {
-			for (String urlPath : expectedURLPatternIndexesMap.keySet()) {
-				urlPatternMapper.consumeValues(
-					__ -> {
-					},
-					urlPath);
+			for (int i = 0; i < 100000; i++) {
+				for (String urlPath : expectedURLPatternIndexesMap.keySet()) {
+					urlPatternMapper.consumeValues(
+						__ -> {
+						},
+						urlPath);
+				}
 			}
 		}
-
-		long end = System.currentTimeMillis();
-
-		long delta = end - start;
-
-		System.out.println("Iterated 100 thousand times in " + delta + " ms");
-
-		Assert.assertTrue(
-			delta < (_CI_MULTIPLIER * testConsumeValuesExpectedTime()));
 	}
 
 	@Test
@@ -54,26 +49,21 @@ public abstract class BaseURLPatternMapperPerformanceTestCase
 		URLPatternMapper<Integer> urlPatternMapper = createURLPatternMapper(
 			createValues());
 
-		long start = System.currentTimeMillis();
+		try (PerformanceTimer performanceTimer =
+				new SystemOutLoggerPerformanceTimer(
+					_CI_MULTIPLIER * testConsumeValuesOrderedExpectedTime(),
+					"Iterated 100 thousand times")) {
 
-		for (int i = 0; i < 100000; i++) {
-			for (String urlPath : expectedURLPatternIndexesMap.keySet()) {
-				urlPatternMapper.consumeValues(bitSet::set, urlPath);
+			for (int i = 0; i < 100000; i++) {
+				for (String urlPath : expectedURLPatternIndexesMap.keySet()) {
+					urlPatternMapper.consumeValues(bitSet::set, urlPath);
 
-				for (int j = bitSet.nextSetBit(0); j >= 0;
-					 j = bitSet.nextSetBit(j + 1)) {
+					for (int j = bitSet.nextSetBit(0); j >= 0;
+						 j = bitSet.nextSetBit(j + 1)) {
+					}
 				}
 			}
 		}
-
-		long end = System.currentTimeMillis();
-
-		long delta = end - start;
-
-		System.out.println("Iterated 100 thousand times in " + delta + " ms");
-
-		Assert.assertTrue(
-			delta < (_CI_MULTIPLIER * testConsumeValuesOrderedExpectedTime()));
 	}
 
 	@Test
@@ -81,22 +71,17 @@ public abstract class BaseURLPatternMapperPerformanceTestCase
 		URLPatternMapper<Integer> urlPatternMapper = createURLPatternMapper(
 			createValues());
 
-		long start = System.currentTimeMillis();
+		try (PerformanceTimer performanceTimer =
+				new SystemOutLoggerPerformanceTimer(
+					_CI_MULTIPLIER * testGetValueExpectedTime(),
+					"Iterated 100 thousand times")) {
 
-		for (int i = 0; i < 100000; i++) {
-			for (String urlPath : expectedURLPatternIndexesMap.keySet()) {
-				urlPatternMapper.getValue(urlPath);
+			for (int i = 0; i < 100000; i++) {
+				for (String urlPath : expectedURLPatternIndexesMap.keySet()) {
+					urlPatternMapper.getValue(urlPath);
+				}
 			}
 		}
-
-		long end = System.currentTimeMillis();
-
-		long delta = end - start;
-
-		System.out.println("Iterated 100 thousand times in " + delta + " ms");
-
-		Assert.assertTrue(
-			delta < (_CI_MULTIPLIER * testGetValueExpectedTime()));
 	}
 
 	@Test
@@ -104,22 +89,17 @@ public abstract class BaseURLPatternMapperPerformanceTestCase
 		URLPatternMapper<Integer> urlPatternMapper = createURLPatternMapper(
 			createValues());
 
-		long start = System.currentTimeMillis();
+		try (PerformanceTimer performanceTimer =
+				new SystemOutLoggerPerformanceTimer(
+					_CI_MULTIPLIER * testGetValuesExpectedTime(),
+					"Iterated 100 thousand times")) {
 
-		for (int i = 0; i < 100000; i++) {
-			for (String urlPath : expectedURLPatternIndexesMap.keySet()) {
-				urlPatternMapper.getValues(urlPath);
+			for (int i = 0; i < 100000; i++) {
+				for (String urlPath : expectedURLPatternIndexesMap.keySet()) {
+					urlPatternMapper.getValues(urlPath);
+				}
 			}
 		}
-
-		long end = System.currentTimeMillis();
-
-		long delta = end - start;
-
-		System.out.println("Iterated 100 thousand times in " + delta + " ms");
-
-		Assert.assertTrue(
-			delta < (_CI_MULTIPLIER * testGetValuesExpectedTime()));
 	}
 
 	/**
@@ -148,5 +128,24 @@ public abstract class BaseURLPatternMapperPerformanceTestCase
 	 * To avoid random heavy CI load
 	 */
 	private static final int _CI_MULTIPLIER = 3;
+
+	private class SystemOutLoggerPerformanceTimer extends PerformanceTimer {
+
+		public SystemOutLoggerPerformanceTimer(long maxTime, String name) {
+			this(maxTime, name, System.currentTimeMillis());
+		}
+
+		protected SystemOutLoggerPerformanceTimer(
+			long maxTime, String name, long startTime) {
+
+			super(null, maxTime, name, startTime);
+		}
+
+		@Override
+		protected void log(String message) {
+			System.out.println(message);
+		}
+
+	}
 
 }

--- a/portal-test/src/com/liferay/portal/kernel/test/performance/PerformanceTimer.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/performance/PerformanceTimer.java
@@ -26,42 +26,42 @@ import org.junit.Assert;
  */
 public class PerformanceTimer implements Closeable {
 
-	public PerformanceTimer(Class<?> clazz, String name, long maxTime) {
+	public PerformanceTimer(Class<?> clazz, long maxTime, String name) {
 		this(
-			getInvokerName(clazz, name), System.currentTimeMillis(), maxTime,
-			null);
+			null, maxTime, getInvokerName(clazz, name),
+			System.currentTimeMillis());
 	}
 
 	public PerformanceTimer(
-		Class<?> clazz, String name, long maxTime, Path logFilePath) {
+		Class<?> clazz, Path logFilePath, long maxTime, String name) {
 
 		this(
-			getInvokerName(clazz, name), System.currentTimeMillis(), maxTime,
-			logFilePath);
+			logFilePath, maxTime, getInvokerName(clazz, name),
+			System.currentTimeMillis());
 	}
 
 	public PerformanceTimer(long maxTime) {
 		this(
-			getInvokerName(null, null), System.currentTimeMillis(), maxTime,
-			null);
+			null, maxTime, getInvokerName(null, null),
+			System.currentTimeMillis());
 	}
 
-	public PerformanceTimer(long maxTime, Path logFilePath) {
+	public PerformanceTimer(long maxTime, String name) {
 		this(
-			getInvokerName(null, null), System.currentTimeMillis(), maxTime,
-			logFilePath);
+			null, maxTime, getInvokerName(null, name),
+			System.currentTimeMillis());
 	}
 
-	public PerformanceTimer(String name, long maxTime) {
+	public PerformanceTimer(Path logFilePath, long maxTime) {
 		this(
-			getInvokerName(null, name), System.currentTimeMillis(), maxTime,
-			null);
+			logFilePath, maxTime, getInvokerName(null, null),
+			System.currentTimeMillis());
 	}
 
-	public PerformanceTimer(String name, long maxTime, Path logFilePath) {
+	public PerformanceTimer(Path logFilePath, long maxTime, String name) {
 		this(
-			getInvokerName(null, name), System.currentTimeMillis(), maxTime,
-			logFilePath);
+			logFilePath, maxTime, getInvokerName(null, name),
+			System.currentTimeMillis());
 	}
 
 	@Override
@@ -106,12 +106,13 @@ public class PerformanceTimer implements Closeable {
 	}
 
 	protected PerformanceTimer(
-		String name, long startTime, long maxTime, Path logFilePath) {
+		Path logFilePath, long maxTime, String name, long startTime) {
 
+		_logFilePath = logFilePath;
+
+		this.maxTime = maxTime;
 		this.name = name;
 		this.startTime = startTime;
-		this.maxTime = maxTime;
-		_logFilePath = logFilePath;
 
 		log("Starting " + name);
 	}


### PR DESCRIPTION
[LPD-22028](https://liferay.atlassian.net/browse/LPD-22028)

Follow up changes based on Brian's request: https://github.com/brianchandotcom/liferay-portal/pull/149437#issuecomment-2066682467
* Constructor vars sorted for `PerformanceTimer` and related classes
* Applied `PerformanceTimer` to all other `*PerformanceTest.java` classes

I've modified [JspServletPerformanceTest](https://github.com/liferay/liferay-portal/blob/master/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-jsp-compiler-test/src/testIntegration/java/com/liferay/portal/osgi/web/servlet/jsp/compiler/test/JspServletPerformanceTest.java) as well and I've set the default `maxTime` values based on https://github.com/liferay-core-infra/liferay-portal/pull/6864

cc: @ericyanLr
