### PR TITLE
LPD-24246 Semantic Version Error - Export/Import

### DIFF
--- a/modules/apps/export-import/export-import-test-util/bnd.bnd
+++ b/modules/apps/export-import/export-import-test-util/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Export Import Test Utilities
 Bundle-SymbolicName: com.liferay.exportimport.test.util
-Bundle-Version: 6.0.2
+Bundle-Version: 6.1.0
 Export-Package:\
 	com.liferay.exportimport.test.util,\
 	com.liferay.exportimport.test.util.constants,\

--- a/modules/apps/export-import/export-import-test-util/src/main/resources/com/liferay/exportimport/test/util/lar/packageinfo
+++ b/modules/apps/export-import/export-import-test-util/src/main/resources/com/liferay/exportimport/test/util/lar/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0


### PR DESCRIPTION
The semantic version test is failling in the CI daily routine.
[Here's the log](https://testray.liferay.com/reports/production/logs/2024-04/test-1-27/test-portal-testsuite-upstream(master)/2878/modules-semantic-versioning-jdk8/0/1/jenkins-console.txt.gz?authuser=0)