### PR TITLE
How to redirect an old base URI to a new base URI

### DIFF
--- a/modules/apps/portal/portal-url-rewrite-filter/src/main/resources/com/liferay/portal/url/rewrite/filter/internal/dependencies/urlrewrite.xml
+++ b/modules/apps/portal/portal-url-rewrite-filter/src/main/resources/com/liferay/portal/url/rewrite/filter/internal/dependencies/urlrewrite.xml
@@ -26,4 +26,8 @@
 		<from>^/web/guest/community/forums/message_boards(.{0,2000})$</from>
 		<to type="permanent-redirect">%{context-path}/web/guest/community/forums/-/message_boards$1</to>
 	</rule>
+	<rule>
+		<from>^/o/old-base-uri/(.*)$</from>
+		<to type="permanent-redirect">%{context-path}/o/new-base-uri/$1</to>
+	</rule>
 </urlrewrite>


### PR DESCRIPTION
See https://liferay.slack.com/archives/C5E1CRLJY/p1714385684293659.

Deploy the `portal-url-rewrite-filter` module and:
```
curl -I http://localhost:8080/o/old-base-uri/v1.0/openapi.json
```

```
HTTP/1.1 301
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
Location: /o/new-base-uri/v1.0/openapi.json
Transfer-Encoding: chunked
```
