### PR TITLE
LPD-24078: Allow users to sort parent entities with data from the related elements ( Many to One relationship )

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -9754,6 +9754,9 @@ public class ObjectEntryResourceTest {
 				endpoint1, jsonObject2, jsonObject1,
 				String.format("%s/creator", _objectRelationship1.getName()));
 			_testSortByFieldName(
+				endpoint1, jsonObject2, jsonObject1,
+				String.format("%s/creatorId", _objectRelationship1.getName()));
+			_testSortByFieldName(
 				endpoint1, jsonObject1, jsonObject2,
 				String.format(
 					"%s/dateCreated", _objectRelationship1.getName()));
@@ -9779,7 +9782,9 @@ public class ObjectEntryResourceTest {
 					_objectRelationship2.getName()));
 			_testSortByFieldName(
 				endpoint1, jsonObject2, jsonObject1,
-				String.format("%s/creatorId", _objectRelationship1.getName()));
+				String.format(
+					"%s/%s/creatorId", _objectRelationship1.getName(),
+					_objectRelationship2.getName()));
 			_testSortByFieldName(
 				endpoint1, jsonObject1, jsonObject2,
 				String.format(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -10535,17 +10535,6 @@ public class ObjectEntryResourceTest {
 				"%s/%s:asc", _objectRelationship1.getName(),
 				_OBJECT_FIELD_NAME_TEXT));
 
-		_objectRelationship2 = ObjectRelationshipTestUtil.addObjectRelationship(
-			_objectDefinition2, _objectDefinition1, TestPropsValues.getUserId(),
-			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
-
-		_testSortByUnsupportedObjectField(
-			"Unable to sort by a many to one related object field",
-			_objectDefinition1,
-			String.format(
-				"%s/%s:asc", _objectRelationship2.getName(),
-				_OBJECT_FIELD_NAME_TEXT));
-
 		_testSortByUnsupportedObjectField(
 			"Unable to sort by property: objectDefinitionId",
 			_objectDefinition1, "objectDefinitionId");

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -7916,6 +7916,887 @@ public class ObjectEntryResourceTest {
 
 	@FeatureFlags("LPD-18730")
 	@Test
+	public void testSortByManyToOneRelationshipCustomObjectFields()
+		throws Exception {
+
+		_objectRelationship1 = ObjectRelationshipTestUtil.addObjectRelationship(
+			_objectDefinition2, _objectDefinition1, TestPropsValues.getUserId(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+		_objectRelationship2 = ObjectRelationshipTestUtil.addObjectRelationship(
+			_objectDefinition3, _objectDefinition2, TestPropsValues.getUserId(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		String endpoint1 = _getEndpoint(
+			TestPropsValues.getGroupId(), _objectDefinition1);
+		String endpoint2 = _getEndpoint(
+			TestPropsValues.getGroupId(), _objectDefinition2);
+		String endpoint3 = _getEndpoint(
+			TestPropsValues.getGroupId(), _objectDefinition3);
+
+		BigDecimal randomBigDecimal = new BigDecimal(
+			RandomTestUtil.randomDouble());
+		Date randomDate1 = RandomTestUtil.nextDate();
+		Date randomDate2 = RandomTestUtil.nextDate();
+		float randomFloat1 = RandomTestUtil.randomFloat();
+		int randomInt = RandomTestUtil.randomInt();
+		long randomLong = RandomTestUtil.randomLong(
+			ObjectFieldValidationConstants.BUSINESS_TYPE_LONG_VALUE_MIN,
+			ObjectFieldValidationConstants.BUSINESS_TYPE_LONG_VALUE_MAX);
+		String randomString1 = RandomTestUtil.randomString();
+		String randomString2 = RandomTestUtil.randomString();
+
+		JSONObject depth1JSONObject1 = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				_OBJECT_FIELD_NAME_BOOLEAN, false
+			).put(
+				_OBJECT_FIELD_NAME_DATE, _dateFormat.format(randomDate1)
+			).put(
+				_OBJECT_FIELD_NAME_DATE_TIME,
+				_dateTimeDateFormat.format(randomDate2)
+			).put(
+				_OBJECT_FIELD_NAME_DECIMAL, randomFloat1
+			).put(
+				_OBJECT_FIELD_NAME_INTEGER, randomInt
+			).put(
+				_OBJECT_FIELD_NAME_LONG_INTEGER, randomLong
+			).put(
+				_OBJECT_FIELD_NAME_LONG_TEXT, "a" + randomString1
+			).put(
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				JSONUtil.putAll(_LIST_TYPE_ENTRY_KEY_1, _LIST_TYPE_ENTRY_KEY_2)
+			).put(
+				_OBJECT_FIELD_NAME_PICKLIST, _LIST_TYPE_ENTRY_KEY_1
+			).put(
+				_OBJECT_FIELD_NAME_PRECISION_DECIMAL, randomBigDecimal
+			).put(
+				_OBJECT_FIELD_NAME_TEXT, "a" + randomString2
+			).toString(),
+			endpoint2, Http.Method.POST);
+
+		JSONObject depth1JSONObject2 = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				_OBJECT_FIELD_NAME_BOOLEAN, true
+			).put(
+				_OBJECT_FIELD_NAME_DATE,
+				() -> _dateFormat.format(
+					new Date(randomDate1.getTime() + (2 * 24 * 3600 * 1000)))
+			).put(
+				_OBJECT_FIELD_NAME_DATE_TIME,
+				_dateTimeDateFormat.format(
+					new Date(randomDate2.getTime() + 2000))
+			).put(
+				_OBJECT_FIELD_NAME_DECIMAL, randomFloat1 + 2
+			).put(
+				_OBJECT_FIELD_NAME_INTEGER, randomInt + 2
+			).put(
+				_OBJECT_FIELD_NAME_LONG_INTEGER, randomLong + 2
+			).put(
+				_OBJECT_FIELD_NAME_LONG_TEXT, "c" + randomString1
+			).put(
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				JSONUtil.putAll(_LIST_TYPE_ENTRY_KEY_2, _LIST_TYPE_ENTRY_KEY_3)
+			).put(
+				_OBJECT_FIELD_NAME_PICKLIST, _LIST_TYPE_ENTRY_KEY_2
+			).put(
+				_OBJECT_FIELD_NAME_PRECISION_DECIMAL,
+				randomBigDecimal.add(new BigDecimal(2))
+			).put(
+				_OBJECT_FIELD_NAME_TEXT, "c" + randomString2
+			).toString(),
+			endpoint2, Http.Method.POST);
+
+		JSONObject depth2JSONObject1 = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				_OBJECT_FIELD_NAME_BOOLEAN, false
+			).put(
+				_OBJECT_FIELD_NAME_DATE, _dateFormat.format(randomDate1)
+			).put(
+				_OBJECT_FIELD_NAME_DATE_TIME,
+				_dateTimeDateFormat.format(randomDate2)
+			).put(
+				_OBJECT_FIELD_NAME_DECIMAL, randomFloat1
+			).put(
+				_OBJECT_FIELD_NAME_INTEGER, randomInt
+			).put(
+				_OBJECT_FIELD_NAME_LONG_INTEGER, randomLong
+			).put(
+				_OBJECT_FIELD_NAME_LONG_TEXT, "a" + randomString1
+			).put(
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				JSONUtil.putAll(_LIST_TYPE_ENTRY_KEY_1, _LIST_TYPE_ENTRY_KEY_2)
+			).put(
+				_OBJECT_FIELD_NAME_PICKLIST, _LIST_TYPE_ENTRY_KEY_1
+			).put(
+				_OBJECT_FIELD_NAME_PRECISION_DECIMAL, randomBigDecimal
+			).put(
+				_OBJECT_FIELD_NAME_TEXT, "a" + randomString2
+			).toString(),
+			endpoint3, Http.Method.POST);
+
+		JSONObject depth2JSONObject2 = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				_OBJECT_FIELD_NAME_BOOLEAN, true
+			).put(
+				_OBJECT_FIELD_NAME_DATE,
+				() -> _dateFormat.format(
+					new Date(randomDate1.getTime() + (2 * 24 * 3600 * 1000)))
+			).put(
+				_OBJECT_FIELD_NAME_DATE_TIME,
+				_dateTimeDateFormat.format(
+					new Date(randomDate2.getTime() + 2000))
+			).put(
+				_OBJECT_FIELD_NAME_DECIMAL, randomFloat1 + 2
+			).put(
+				_OBJECT_FIELD_NAME_INTEGER, randomInt + 2
+			).put(
+				_OBJECT_FIELD_NAME_LONG_INTEGER, randomLong + 2
+			).put(
+				_OBJECT_FIELD_NAME_LONG_TEXT, "c" + randomString1
+			).put(
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				JSONUtil.putAll(_LIST_TYPE_ENTRY_KEY_2, _LIST_TYPE_ENTRY_KEY_3)
+			).put(
+				_OBJECT_FIELD_NAME_PICKLIST, _LIST_TYPE_ENTRY_KEY_2
+			).put(
+				_OBJECT_FIELD_NAME_PRECISION_DECIMAL,
+				randomBigDecimal.add(new BigDecimal(2))
+			).put(
+				_OBJECT_FIELD_NAME_TEXT, "c" + randomString2
+			).toString(),
+			endpoint3, Http.Method.POST);
+
+		JSONObject jsonObject1 = HTTPTestUtil.invokeToJSONObject(
+			JSONFactoryUtil.getNullJSON(
+			).toString(),
+			endpoint1, Http.Method.POST);
+
+		JSONObject jsonObject2 = HTTPTestUtil.invokeToJSONObject(
+			JSONFactoryUtil.getNullJSON(
+			).toString(),
+			endpoint1, Http.Method.POST);
+
+		JSONObject jsonObject3 = HTTPTestUtil.invokeToJSONObject(
+			JSONFactoryUtil.getNullJSON(
+			).toString(),
+			endpoint1, Http.Method.POST);
+
+		JSONObject jsonObject4 = HTTPTestUtil.invokeToJSONObject(
+			JSONFactoryUtil.getNullJSON(
+			).toString(),
+			endpoint1, Http.Method.POST);
+
+		HTTPTestUtil.invokeToJSONObject(
+			null,
+			String.format(
+				"%s/%d/%s/%d", endpoint2, depth1JSONObject1.getLong("id"),
+				_objectRelationship1.getName(), jsonObject1.getLong("id")),
+			Http.Method.PUT);
+
+		HTTPTestUtil.invokeToJSONObject(
+			null,
+			String.format(
+				"%s/%d/%s/%d", endpoint2, depth1JSONObject1.getLong("id"),
+				_objectRelationship1.getName(), jsonObject2.getLong("id")),
+			Http.Method.PUT);
+
+		HTTPTestUtil.invokeToJSONObject(
+			null,
+			String.format(
+				"%s/%d/%s/%d", endpoint2, depth1JSONObject2.getLong("id"),
+				_objectRelationship1.getName(), jsonObject3.getLong("id")),
+			Http.Method.PUT);
+
+		HTTPTestUtil.invokeToJSONObject(
+			null,
+			String.format(
+				"%s/%d/%s/%d", endpoint2, depth1JSONObject2.getLong("id"),
+				_objectRelationship1.getName(), jsonObject4.getLong("id")),
+			Http.Method.PUT);
+
+		HTTPTestUtil.invokeToJSONObject(
+			null,
+			String.format(
+				"%s/%d/%s/%d", endpoint3, depth2JSONObject1.getLong("id"),
+				_objectRelationship2.getName(),
+				depth1JSONObject1.getLong("id")),
+			Http.Method.PUT);
+
+		HTTPTestUtil.invokeToJSONObject(
+			null,
+			String.format(
+				"%s/%d/%s/%d", endpoint3, depth2JSONObject2.getLong("id"),
+				_objectRelationship2.getName(),
+				depth1JSONObject2.getLong("id")),
+			Http.Method.PUT);
+
+		try {
+
+			// Depth 1
+
+			_testSortByManyToOneRelationshipCustomObjectFields(
+				endpoint1, endpoint2, jsonObject1, jsonObject2, jsonObject3,
+				jsonObject4, depth1JSONObject1, depth1JSONObject2,
+				String.format(
+					"%s/%s", _objectRelationship1.getName(),
+					_OBJECT_FIELD_NAME_BOOLEAN));
+
+			_testSortByManyToOneRelationshipCustomObjectFields(
+				endpoint1, endpoint2, jsonObject1, jsonObject2, jsonObject3,
+				jsonObject4, depth1JSONObject1, depth1JSONObject2,
+				String.format(
+					"%s/%s", _objectRelationship1.getName(),
+					_OBJECT_FIELD_NAME_DATE));
+			_testSortByManyToOneRelationshipCustomObjectFields(
+				endpoint1, endpoint2, jsonObject1, jsonObject2, jsonObject3,
+				jsonObject4, depth1JSONObject1, depth1JSONObject2,
+				String.format(
+					"%s/%s", _objectRelationship1.getName(),
+					_OBJECT_FIELD_NAME_DATE_TIME));
+			_testSortByManyToOneRelationshipCustomObjectFields(
+				endpoint1, endpoint2, jsonObject1, jsonObject2, jsonObject3,
+				jsonObject4, depth1JSONObject1, depth1JSONObject2,
+				String.format(
+					"%s/%s", _objectRelationship1.getName(),
+					_OBJECT_FIELD_NAME_DECIMAL));
+			_testSortByManyToOneRelationshipCustomObjectFields(
+				endpoint1, endpoint2, jsonObject1, jsonObject2, jsonObject3,
+				jsonObject4, depth1JSONObject1, depth1JSONObject2,
+				String.format(
+					"%s/%s", _objectRelationship1.getName(),
+					_OBJECT_FIELD_NAME_INTEGER));
+			_testSortByManyToOneRelationshipCustomObjectFields(
+				endpoint1, endpoint2, jsonObject1, jsonObject2, jsonObject3,
+				jsonObject4, depth1JSONObject1, depth1JSONObject2,
+				String.format(
+					"%s/%s", _objectRelationship1.getName(),
+					_OBJECT_FIELD_NAME_LONG_INTEGER));
+			_testSortByManyToOneRelationshipCustomObjectFields(
+				endpoint1, endpoint2, jsonObject1, jsonObject2, jsonObject3,
+				jsonObject4, depth1JSONObject1, depth1JSONObject2,
+				String.format(
+					"%s/%s", _objectRelationship1.getName(),
+					_OBJECT_FIELD_NAME_LONG_TEXT));
+			_testSortByManyToOneRelationshipCustomObjectFields(
+				endpoint1, endpoint2, jsonObject1, jsonObject2, jsonObject3,
+				jsonObject4, depth1JSONObject1, depth1JSONObject2,
+				String.format(
+					"%s/%s", _objectRelationship1.getName(),
+					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST));
+			_testSortByManyToOneRelationshipCustomObjectFields(
+				endpoint1, endpoint2, jsonObject1, jsonObject2, jsonObject3,
+				jsonObject4, depth1JSONObject1, depth1JSONObject2,
+				String.format(
+					"%s/%s", _objectRelationship1.getName(),
+					_OBJECT_FIELD_NAME_PICKLIST));
+			_testSortByManyToOneRelationshipCustomObjectFields(
+				endpoint1, endpoint2, jsonObject1, jsonObject2, jsonObject3,
+				jsonObject4, depth1JSONObject1, depth1JSONObject2,
+				String.format(
+					"%s/%s", _objectRelationship1.getName(),
+					_OBJECT_FIELD_NAME_PRECISION_DECIMAL));
+			_testSortByManyToOneRelationshipCustomObjectFields(
+				endpoint1, endpoint2, jsonObject1, jsonObject2, jsonObject3,
+				jsonObject4, depth1JSONObject1, depth1JSONObject2,
+				String.format(
+					"%s/%s", _objectRelationship1.getName(),
+					_OBJECT_FIELD_NAME_TEXT));
+
+			// Depth 2
+
+			_testSortByManyToOneRelationshipCustomObjectFields(
+				endpoint1, endpoint3, jsonObject1, jsonObject2, jsonObject3,
+				jsonObject4, depth2JSONObject1, depth2JSONObject2,
+				String.format(
+					"%s/%s/%s", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_OBJECT_FIELD_NAME_BOOLEAN));
+
+			_testSortByManyToOneRelationshipCustomObjectFields(
+				endpoint1, endpoint3, jsonObject1, jsonObject2, jsonObject3,
+				jsonObject4, depth2JSONObject1, depth2JSONObject2,
+				String.format(
+					"%s/%s/%s", _objectRelationship1.getName(),
+					_objectRelationship2.getName(), _OBJECT_FIELD_NAME_DATE));
+			_testSortByManyToOneRelationshipCustomObjectFields(
+				endpoint1, endpoint3, jsonObject1, jsonObject2, jsonObject3,
+				jsonObject4, depth2JSONObject1, depth2JSONObject2,
+				String.format(
+					"%s/%s/%s", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_OBJECT_FIELD_NAME_DATE_TIME));
+			_testSortByManyToOneRelationshipCustomObjectFields(
+				endpoint1, endpoint3, jsonObject1, jsonObject2, jsonObject3,
+				jsonObject4, depth2JSONObject1, depth2JSONObject2,
+				String.format(
+					"%s/%s/%s", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_OBJECT_FIELD_NAME_DECIMAL));
+			_testSortByManyToOneRelationshipCustomObjectFields(
+				endpoint1, endpoint3, jsonObject1, jsonObject2, jsonObject3,
+				jsonObject4, depth2JSONObject1, depth2JSONObject2,
+				String.format(
+					"%s/%s/%s", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_OBJECT_FIELD_NAME_INTEGER));
+			_testSortByManyToOneRelationshipCustomObjectFields(
+				endpoint1, endpoint3, jsonObject1, jsonObject2, jsonObject3,
+				jsonObject4, depth2JSONObject1, depth2JSONObject2,
+				String.format(
+					"%s/%s/%s", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_OBJECT_FIELD_NAME_LONG_INTEGER));
+			_testSortByManyToOneRelationshipCustomObjectFields(
+				endpoint1, endpoint3, jsonObject1, jsonObject2, jsonObject3,
+				jsonObject4, depth2JSONObject1, depth2JSONObject2,
+				String.format(
+					"%s/%s/%s", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_OBJECT_FIELD_NAME_LONG_TEXT));
+			_testSortByManyToOneRelationshipCustomObjectFields(
+				endpoint1, endpoint3, jsonObject1, jsonObject2, jsonObject3,
+				jsonObject4, depth2JSONObject1, depth2JSONObject2,
+				String.format(
+					"%s/%s/%s", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST));
+			_testSortByManyToOneRelationshipCustomObjectFields(
+				endpoint1, endpoint3, jsonObject1, jsonObject2, jsonObject3,
+				jsonObject4, depth2JSONObject1, depth2JSONObject2,
+				String.format(
+					"%s/%s/%s", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_OBJECT_FIELD_NAME_PICKLIST));
+			_testSortByManyToOneRelationshipCustomObjectFields(
+				endpoint1, endpoint3, jsonObject1, jsonObject2, jsonObject3,
+				jsonObject4, depth2JSONObject1, depth2JSONObject2,
+				String.format(
+					"%s/%s/%s", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_OBJECT_FIELD_NAME_PRECISION_DECIMAL));
+			_testSortByManyToOneRelationshipCustomObjectFields(
+				endpoint1, endpoint3, jsonObject1, jsonObject2, jsonObject3,
+				jsonObject4, depth2JSONObject1, depth2JSONObject2,
+				String.format(
+					"%s/%s/%s", _objectRelationship1.getName(),
+					_objectRelationship2.getName(), _OBJECT_FIELD_NAME_TEXT));
+
+			// Sort by several fields
+
+			_testSortByManyToOneRelationshipCustomObjectFields(
+				endpoint1, endpoint2, jsonObject1, jsonObject2, jsonObject3,
+				jsonObject4, depth1JSONObject1, depth1JSONObject2,
+				String.format(
+					"%s/%s", _objectRelationship1.getName(),
+					_OBJECT_FIELD_NAME_BOOLEAN),
+				String.format(
+					"%s/%s", _objectRelationship1.getName(),
+					_OBJECT_FIELD_NAME_DATE),
+				String.format(
+					"%s/%s", _objectRelationship1.getName(),
+					_OBJECT_FIELD_NAME_DATE_TIME),
+				String.format(
+					"%s/%s", _objectRelationship1.getName(),
+					_OBJECT_FIELD_NAME_DECIMAL),
+				String.format(
+					"%s/%s", _objectRelationship1.getName(),
+					_OBJECT_FIELD_NAME_INTEGER),
+				String.format(
+					"%s/%s", _objectRelationship1.getName(),
+					_OBJECT_FIELD_NAME_LONG_INTEGER),
+				String.format(
+					"%s/%s", _objectRelationship1.getName(),
+					_OBJECT_FIELD_NAME_LONG_TEXT),
+				String.format(
+					"%s/%s", _objectRelationship1.getName(),
+					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST),
+				String.format(
+					"%s/%s", _objectRelationship1.getName(),
+					_OBJECT_FIELD_NAME_PICKLIST),
+				String.format(
+					"%s/%s", _objectRelationship1.getName(),
+					_OBJECT_FIELD_NAME_PRECISION_DECIMAL),
+				String.format(
+					"%s/%s", _objectRelationship1.getName(),
+					_OBJECT_FIELD_NAME_TEXT));
+
+			_testSortByManyToOneRelationshipCustomObjectFields(
+				endpoint1, endpoint3, jsonObject1, jsonObject2, jsonObject3,
+				jsonObject4, depth2JSONObject1, depth2JSONObject2,
+				String.format(
+					"%s/%s/%s", _objectRelationship1.getName(),
+					_objectRelationship2.getName(), _OBJECT_FIELD_NAME_BOOLEAN),
+				String.format(
+					"%s/%s/%s", _objectRelationship1.getName(),
+					_objectRelationship2.getName(), _OBJECT_FIELD_NAME_DATE),
+				String.format(
+					"%s/%s/%s", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_OBJECT_FIELD_NAME_DATE_TIME),
+				String.format(
+					"%s/%s/%s", _objectRelationship1.getName(),
+					_objectRelationship2.getName(), _OBJECT_FIELD_NAME_DECIMAL),
+				String.format(
+					"%s/%s/%s", _objectRelationship1.getName(),
+					_objectRelationship2.getName(), _OBJECT_FIELD_NAME_INTEGER),
+				String.format(
+					"%s/%s/%s", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_OBJECT_FIELD_NAME_LONG_INTEGER),
+				String.format(
+					"%s/%s/%s", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_OBJECT_FIELD_NAME_LONG_TEXT),
+				String.format(
+					"%s/%s/%s", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST),
+				String.format(
+					"%s/%s/%s", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_OBJECT_FIELD_NAME_PICKLIST),
+				String.format(
+					"%s/%s/%s", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_OBJECT_FIELD_NAME_PRECISION_DECIMAL),
+				String.format(
+					"%s/%s/%s", _objectRelationship1.getName(),
+					_objectRelationship2.getName(), _OBJECT_FIELD_NAME_TEXT));
+		}
+		finally {
+			if (jsonObject1 != null) {
+				_objectEntryLocalService.deleteObjectEntry(
+					jsonObject1.getLong("id"));
+			}
+
+			if (jsonObject2 != null) {
+				_objectEntryLocalService.deleteObjectEntry(
+					jsonObject2.getLong("id"));
+			}
+
+			if (jsonObject3 != null) {
+				_objectEntryLocalService.deleteObjectEntry(
+					jsonObject3.getLong("id"));
+			}
+
+			if (jsonObject4 != null) {
+				_objectEntryLocalService.deleteObjectEntry(
+					jsonObject4.getLong("id"));
+			}
+
+			if (depth1JSONObject1 != null) {
+				_objectEntryLocalService.deleteObjectEntry(
+					depth1JSONObject1.getLong("id"));
+			}
+
+			if (depth1JSONObject2 != null) {
+				_objectEntryLocalService.deleteObjectEntry(
+					depth1JSONObject2.getLong("id"));
+			}
+
+			if (depth2JSONObject1 != null) {
+				_objectEntryLocalService.deleteObjectEntry(
+					depth2JSONObject1.getLong("id"));
+			}
+
+			if (depth2JSONObject2 != null) {
+				_objectEntryLocalService.deleteObjectEntry(
+					depth2JSONObject2.getLong("id"));
+			}
+		}
+	}
+
+	@FeatureFlags("LPD-18730")
+	@Test
+	public void testSortByManyToOneRelationshipSystemObjectFields()
+		throws Exception {
+
+		_objectRelationship1 = ObjectRelationshipTestUtil.addObjectRelationship(
+			_objectDefinition2, _objectDefinition1, TestPropsValues.getUserId(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+		_objectRelationship2 = ObjectRelationshipTestUtil.addObjectRelationship(
+			_objectDefinition3, _objectDefinition2, TestPropsValues.getUserId(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+
+		_addResourcePermission(
+			ObjectActionKeys.ADD_OBJECT_ENTRY, _objectDefinition2, role);
+		_addResourcePermission(
+			ObjectActionKeys.ADD_OBJECT_ENTRY, _objectDefinition3, role);
+
+		User user1 = _addUser("test1", "test1");
+		User user2 = _addUser("test2", "test2");
+		User user3 = _addUser("test3", "test3");
+
+		_roleLocalService.addUserRole(user1.getUserId(), role.getRoleId());
+		_roleLocalService.addUserRole(user2.getUserId(), role.getRoleId());
+		_roleLocalService.addUserRole(user3.getUserId(), role.getRoleId());
+
+		_objectDefinition1.setEnableObjectEntryDraft(true);
+		_objectDefinition2.setEnableObjectEntryDraft(true);
+		_objectDefinition3.setEnableObjectEntryDraft(true);
+
+		_objectDefinition1 =
+			_objectDefinitionLocalService.updateObjectDefinition(
+				_objectDefinition1);
+		_objectDefinition2 =
+			_objectDefinitionLocalService.updateObjectDefinition(
+				_objectDefinition2);
+		_objectDefinition3 =
+			_objectDefinitionLocalService.updateObjectDefinition(
+				_objectDefinition3);
+
+		String endpoint1 = _getEndpoint(
+			TestPropsValues.getGroupId(), _objectDefinition1);
+		String endpoint2 = _getEndpoint(
+			TestPropsValues.getGroupId(), _objectDefinition2);
+		String endpoint3 = _getEndpoint(
+			TestPropsValues.getGroupId(), _objectDefinition3);
+
+		JSONObject[] manyToOneDepth1JSONObjects = new JSONObject[2];
+
+		HTTPTestUtil.customize(
+		).withCredentials(
+			"test2@liferay.com", "test2"
+		).apply(
+			() ->
+				manyToOneDepth1JSONObjects[0] = HTTPTestUtil.invokeToJSONObject(
+					JSONUtil.put(
+						"externalReferenceCode", "ERC1_1"
+					).put(
+						"status",
+						JSONUtil.put("code", WorkflowConstants.STATUS_DRAFT)
+					).toString(),
+					endpoint2, Http.Method.POST)
+		);
+
+		HTTPTestUtil.customize(
+		).withCredentials(
+			"test3@liferay.com", "test3"
+		).apply(
+			() ->
+				manyToOneDepth1JSONObjects[1] = HTTPTestUtil.invokeToJSONObject(
+					JSONUtil.put(
+						"externalReferenceCode", "ERC2_1"
+					).put(
+						"status",
+						JSONUtil.put("code", WorkflowConstants.STATUS_DRAFT)
+					).toString(),
+					endpoint2, Http.Method.POST)
+		);
+
+		JSONObject[] manyToOneDepth2JSONObjects = new JSONObject[2];
+
+		HTTPTestUtil.customize(
+		).withCredentials(
+			"test2@liferay.com", "test2"
+		).apply(
+			() ->
+				manyToOneDepth2JSONObjects[0] = HTTPTestUtil.invokeToJSONObject(
+					JSONUtil.put(
+						"externalReferenceCode", "ERC1_2"
+					).put(
+						"status",
+						JSONUtil.put("code", WorkflowConstants.STATUS_DRAFT)
+					).toString(),
+					endpoint3, Http.Method.POST)
+		);
+
+		HTTPTestUtil.customize(
+		).withCredentials(
+			"test1@liferay.com", "test1"
+		).apply(
+			() ->
+				manyToOneDepth2JSONObjects[1] = HTTPTestUtil.invokeToJSONObject(
+					JSONUtil.put(
+						"externalReferenceCode", "ERC2_2"
+					).put(
+						"status",
+						JSONUtil.put("code", WorkflowConstants.STATUS_DRAFT)
+					).toString(),
+					endpoint3, Http.Method.POST)
+		);
+
+		JSONObject jsonObject1 = HTTPTestUtil.invokeToJSONObject(
+			JSONFactoryUtil.getNullJSON(
+			).toString(),
+			endpoint1, Http.Method.POST);
+
+		JSONObject jsonObject2 = HTTPTestUtil.invokeToJSONObject(
+			JSONFactoryUtil.getNullJSON(
+			).toString(),
+			endpoint1, Http.Method.POST);
+
+		JSONObject jsonObject3 = HTTPTestUtil.invokeToJSONObject(
+			JSONFactoryUtil.getNullJSON(
+			).toString(),
+			endpoint1, Http.Method.POST);
+
+		JSONObject jsonObject4 = HTTPTestUtil.invokeToJSONObject(
+			JSONFactoryUtil.getNullJSON(
+			).toString(),
+			endpoint1, Http.Method.POST);
+
+		HTTPTestUtil.invokeToJSONObject(
+			null,
+			String.format(
+				"%s/%d/%s/%d", endpoint2,
+				manyToOneDepth1JSONObjects[0].getLong("id"),
+				_objectRelationship1.getName(), jsonObject1.getLong("id")),
+			Http.Method.PUT);
+
+		HTTPTestUtil.invokeToJSONObject(
+			null,
+			String.format(
+				"%s/%d/%s/%d", endpoint2,
+				manyToOneDepth1JSONObjects[0].getLong("id"),
+				_objectRelationship1.getName(), jsonObject2.getLong("id")),
+			Http.Method.PUT);
+
+		HTTPTestUtil.invokeToJSONObject(
+			null,
+			String.format(
+				"%s/%d/%s/%d", endpoint2,
+				manyToOneDepth1JSONObjects[1].getLong("id"),
+				_objectRelationship1.getName(), jsonObject3.getLong("id")),
+			Http.Method.PUT);
+
+		HTTPTestUtil.invokeToJSONObject(
+			null,
+			String.format(
+				"%s/%d/%s/%d", endpoint2,
+				manyToOneDepth1JSONObjects[1].getLong("id"),
+				_objectRelationship1.getName(), jsonObject4.getLong("id")),
+			Http.Method.PUT);
+
+		HTTPTestUtil.invokeToJSONObject(
+			null,
+			String.format(
+				"%s/%d/%s/%d", endpoint3,
+				manyToOneDepth2JSONObjects[0].getLong("id"),
+				_objectRelationship2.getName(),
+				manyToOneDepth1JSONObjects[0].getLong("id")),
+			Http.Method.PUT);
+
+		HTTPTestUtil.invokeToJSONObject(
+			null,
+			String.format(
+				"%s/%d/%s/%d", endpoint3,
+				manyToOneDepth2JSONObjects[1].getLong("id"),
+				_objectRelationship2.getName(),
+				manyToOneDepth1JSONObjects[1].getLong("id")),
+			Http.Method.PUT);
+
+		HTTPTestUtil.customize(
+		).withCredentials(
+			"test2@liferay.com", "test2"
+		).apply(
+			() ->
+				manyToOneDepth1JSONObjects[0] = HTTPTestUtil.invokeToJSONObject(
+					JSONUtil.put(
+						_OBJECT_FIELD_NAME_2, RandomTestUtil.randomString()
+					).toString(),
+					endpoint2 + "/by-external-reference-code/ERC1_1",
+					Http.Method.PATCH)
+		);
+
+		HTTPTestUtil.customize(
+		).withCredentials(
+			"test3@liferay.com", "test3"
+		).apply(
+			() ->
+				manyToOneDepth1JSONObjects[1] = HTTPTestUtil.invokeToJSONObject(
+					JSONUtil.put(
+						_OBJECT_FIELD_NAME_2, RandomTestUtil.randomString()
+					).toString(),
+					endpoint2 + "/by-external-reference-code/ERC2_1",
+					Http.Method.PATCH)
+		);
+
+		HTTPTestUtil.customize(
+		).withCredentials(
+			"test2@liferay.com", "test2"
+		).apply(
+			() ->
+				manyToOneDepth2JSONObjects[0] = HTTPTestUtil.invokeToJSONObject(
+					JSONUtil.put(
+						_OBJECT_FIELD_NAME_3, RandomTestUtil.randomString()
+					).toString(),
+					endpoint3 + "/by-external-reference-code/ERC1_2",
+					Http.Method.PATCH)
+		);
+
+		HTTPTestUtil.customize(
+		).withCredentials(
+			"test1@liferay.com", "test1"
+		).apply(
+			() ->
+				manyToOneDepth2JSONObjects[1] = HTTPTestUtil.invokeToJSONObject(
+					JSONUtil.put(
+						_OBJECT_FIELD_NAME_3, RandomTestUtil.randomString()
+					).toString(),
+					endpoint3 + "/by-external-reference-code/ERC2_2",
+					Http.Method.PATCH)
+		);
+
+		try {
+
+			// Depth 1
+
+			_testSortByFieldName(
+				endpoint1, jsonObject1, jsonObject2, jsonObject3, jsonObject4,
+				String.format("%s/creator", _objectRelationship1.getName()));
+			_testSortByFieldName(
+				endpoint1, jsonObject1, jsonObject2, jsonObject3, jsonObject4,
+				String.format("%s/creatorId", _objectRelationship1.getName()));
+			_testSortByFieldName(
+				endpoint1, jsonObject1, jsonObject2, jsonObject3, jsonObject4,
+				String.format(
+					"%s/dateCreated", _objectRelationship1.getName()));
+			_testSortByFieldName(
+				endpoint1, jsonObject1, jsonObject2, jsonObject3, jsonObject4,
+				String.format(
+					"%s/dateModified", _objectRelationship1.getName()));
+			_testSortByFieldName(
+				endpoint1, jsonObject1, jsonObject2, jsonObject3, jsonObject4,
+				String.format(
+					"%s/externalReferenceCode",
+					_objectRelationship1.getName()));
+			_testSortByFieldName(
+				endpoint1, jsonObject1, jsonObject2, jsonObject3, jsonObject4,
+				String.format("%s/id", _objectRelationship1.getName()));
+
+			// Depth 2
+
+			_testSortByFieldName(
+				endpoint1, jsonObject3, jsonObject4, jsonObject1, jsonObject2,
+				String.format(
+					"%s/%s/creator", _objectRelationship1.getName(),
+					_objectRelationship2.getName()));
+			_testSortByFieldName(
+				endpoint1, jsonObject3, jsonObject4, jsonObject1, jsonObject2,
+				String.format(
+					"%s/%s/creatorId", _objectRelationship1.getName(),
+					_objectRelationship2.getName()));
+			_testSortByFieldName(
+				endpoint1, jsonObject1, jsonObject2, jsonObject3, jsonObject4,
+				String.format(
+					"%s/%s/dateCreated", _objectRelationship1.getName(),
+					_objectRelationship2.getName()));
+			_testSortByFieldName(
+				endpoint1, jsonObject1, jsonObject2, jsonObject3, jsonObject4,
+				String.format(
+					"%s/%s/dateModified", _objectRelationship1.getName(),
+					_objectRelationship2.getName()));
+			_testSortByFieldName(
+				endpoint1, jsonObject1, jsonObject2, jsonObject3, jsonObject4,
+				String.format(
+					"%s/%s/externalReferenceCode",
+					_objectRelationship1.getName(),
+					_objectRelationship2.getName()));
+			_testSortByFieldName(
+				endpoint1, jsonObject1, jsonObject2, jsonObject3, jsonObject4,
+				String.format(
+					"%s/%s/id", _objectRelationship1.getName(),
+					_objectRelationship2.getName()));
+			_testSortByFieldName(
+				endpoint1, jsonObject1, jsonObject2, jsonObject3, jsonObject4,
+				String.format("%s/userId", _objectRelationship1.getName()));
+
+			// Sort by several fields
+
+			_testSortByFieldName(
+				endpoint1, jsonObject1, jsonObject2, jsonObject3, jsonObject4,
+				String.format("%s/dateCreated", _objectRelationship1.getName()),
+				String.format("%s/id", _objectRelationship1.getName()),
+				String.format(
+					"%s/%s/dateCreated", _objectRelationship1.getName(),
+					_objectRelationship2.getName()),
+				String.format(
+					"%s/%s/id", _objectRelationship1.getName(),
+					_objectRelationship2.getName()));
+			_testSortByFieldName(
+				endpoint1, jsonObject1, jsonObject2, jsonObject3, jsonObject4,
+				String.format("%s/creator", _objectRelationship1.getName()),
+				String.format("%s/creatorId", _objectRelationship1.getName()),
+				String.format(
+					"%s/dateModified", _objectRelationship1.getName()),
+				String.format(
+					"%s/externalReferenceCode", _objectRelationship1.getName()),
+				String.format("%s/userId", _objectRelationship1.getName()),
+				String.format(
+					"%s/%s/creator", _objectRelationship1.getName(),
+					_objectRelationship2.getName()),
+				String.format(
+					"%s/%s/creatorId", _objectRelationship1.getName(),
+					_objectRelationship2.getName()),
+				String.format(
+					"%s/%s/dateModified", _objectRelationship1.getName(),
+					_objectRelationship2.getName()),
+				String.format(
+					"%s/%s/externalReferenceCode",
+					_objectRelationship1.getName(),
+					_objectRelationship2.getName()),
+				String.format(
+					"%s/%s/userId", _objectRelationship1.getName(),
+					_objectRelationship2.getName()));
+
+			// TODO LPD-20530
+
+			_assertFailure(
+				ComparisonFailure.class,
+				() -> _testSortByFieldName(
+					endpoint1, jsonObject1, jsonObject2, jsonObject3,
+					jsonObject4,
+					String.format(
+						"%s/status", _objectRelationship1.getName())));
+			_assertFailure(
+				ComparisonFailure.class,
+				() -> _testSortByFieldName(
+					endpoint1, jsonObject1, jsonObject2, jsonObject3,
+					jsonObject4,
+					String.format(
+						"%s/%s/status", _objectRelationship1.getName(),
+						_objectRelationship2.getName())));
+		}
+		finally {
+			if (jsonObject1 != null) {
+				_objectEntryLocalService.deleteObjectEntry(
+					jsonObject1.getLong("id"));
+			}
+
+			if (jsonObject2 != null) {
+				_objectEntryLocalService.deleteObjectEntry(
+					jsonObject2.getLong("id"));
+			}
+
+			if (jsonObject3 != null) {
+				_objectEntryLocalService.deleteObjectEntry(
+					jsonObject3.getLong("id"));
+			}
+
+			if (jsonObject4 != null) {
+				_objectEntryLocalService.deleteObjectEntry(
+					jsonObject4.getLong("id"));
+			}
+
+			for (JSONObject jsonObject :
+					ArrayUtil.append(
+						manyToOneDepth1JSONObjects,
+						manyToOneDepth2JSONObjects)) {
+
+				if (jsonObject == null) {
+					continue;
+				}
+
+				_objectEntryLocalService.deleteObjectEntry(
+					jsonObject.getLong("id"));
+			}
+		}
+	}
+
+	@FeatureFlags("LPD-18730")
+	@Test
 	public void testSortByOneToManyRelationshipCustomObjectFields()
 		throws Exception {
 
@@ -11492,6 +12373,39 @@ public class ObjectEntryResourceTest {
 
 	private void _testSortByFieldName(
 			String endpoint, JSONObject expectedJSONObject1,
+			JSONObject expectedJSONObject2, JSONObject expectedJSONObject3,
+			JSONObject expectedJSONObject4, String... fieldNames)
+		throws Exception {
+
+		JSONObject pageJSONObject = HTTPTestUtil.invokeToJSONObject(
+			null,
+			StringBundler.concat(
+				endpoint, "?sort=",
+				URLCodec.encodeURL(
+					StringUtil.merge(fieldNames, ":asc,") + ":asc")),
+			Http.Method.GET);
+
+		_assertItem(0, pageJSONObject, "id", expectedJSONObject1.getLong("id"));
+		_assertItem(1, pageJSONObject, "id", expectedJSONObject2.getLong("id"));
+		_assertItem(2, pageJSONObject, "id", expectedJSONObject3.getLong("id"));
+		_assertItem(3, pageJSONObject, "id", expectedJSONObject4.getLong("id"));
+
+		pageJSONObject = HTTPTestUtil.invokeToJSONObject(
+			null,
+			StringBundler.concat(
+				endpoint, "?sort=",
+				URLCodec.encodeURL(
+					StringUtil.merge(fieldNames, ":desc,") + ":desc")),
+			Http.Method.GET);
+
+		_assertItem(0, pageJSONObject, "id", expectedJSONObject3.getLong("id"));
+		_assertItem(1, pageJSONObject, "id", expectedJSONObject4.getLong("id"));
+		_assertItem(2, pageJSONObject, "id", expectedJSONObject1.getLong("id"));
+		_assertItem(3, pageJSONObject, "id", expectedJSONObject2.getLong("id"));
+	}
+
+	private void _testSortByFieldName(
+			String endpoint, JSONObject expectedJSONObject1,
 			JSONObject expectedJSONObject2, String... fieldNames)
 		throws Exception {
 
@@ -11516,6 +12430,57 @@ public class ObjectEntryResourceTest {
 
 		_assertItem(0, pageJSONObject, "id", expectedJSONObject2.getLong("id"));
 		_assertItem(1, pageJSONObject, "id", expectedJSONObject1.getLong("id"));
+	}
+
+	private void _testSortByManyToOneRelationshipCustomObjectFields(
+			String endpoint1, String endpoint2, JSONObject expectedJSONObject1,
+			JSONObject expectedJSONObject2, JSONObject expectedJSONObject3,
+			JSONObject expectedJSONObject4, JSONObject relatedJSONObject1,
+			JSONObject relatedJSONObject2, String... fieldNames)
+		throws Exception {
+
+		_testSortByFieldName(
+			endpoint1, expectedJSONObject1, expectedJSONObject2,
+			expectedJSONObject3, expectedJSONObject4, fieldNames);
+
+		JSONObject valuesJSONObject1 = JSONFactoryUtil.createJSONObject();
+		JSONObject valuesJSONObject2 = JSONFactoryUtil.createJSONObject();
+
+		for (String fieldName : fieldNames) {
+			String objectFieldName = StringUtil.extractLast(fieldName, "/");
+
+			valuesJSONObject1.put(
+				objectFieldName, relatedJSONObject1.get(objectFieldName));
+			valuesJSONObject2.put(
+				objectFieldName, relatedJSONObject2.get(objectFieldName));
+		}
+
+		try {
+			HTTPTestUtil.invokeToJSONObject(
+				valuesJSONObject2.toString(),
+				endpoint2 + "/" + relatedJSONObject1.getLong("id"),
+				Http.Method.PATCH);
+
+			HTTPTestUtil.invokeToJSONObject(
+				valuesJSONObject1.toString(),
+				endpoint2 + "/" + relatedJSONObject2.getLong("id"),
+				Http.Method.PATCH);
+
+			_testSortByFieldName(
+				endpoint1, expectedJSONObject3, expectedJSONObject4,
+				expectedJSONObject1, expectedJSONObject2, fieldNames);
+		}
+		finally {
+			HTTPTestUtil.invokeToJSONObject(
+				valuesJSONObject1.toString(),
+				endpoint2 + "/" + relatedJSONObject1.getLong("id"),
+				Http.Method.PATCH);
+
+			HTTPTestUtil.invokeToJSONObject(
+				valuesJSONObject2.toString(),
+				endpoint2 + "/" + relatedJSONObject2.getLong("id"),
+				Http.Method.PATCH);
+		}
 	}
 
 	private void _testSortByOneToManyRelationshipCustomObjectFields(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -7916,6 +7916,488 @@ public class ObjectEntryResourceTest {
 
 	@FeatureFlags("LPD-18730")
 	@Test
+	public void testSortByManyToOneAndOneToManyRelationshipsCustomObjectFields()
+		throws Exception {
+
+		_objectRelationship1 = ObjectRelationshipTestUtil.addObjectRelationship(
+			_objectDefinition2, _objectDefinition1, TestPropsValues.getUserId(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+		_objectRelationship2 = ObjectRelationshipTestUtil.addObjectRelationship(
+			_objectDefinition2, _objectDefinition3, TestPropsValues.getUserId(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		String endpoint1 = _getEndpoint(
+			TestPropsValues.getGroupId(), _objectDefinition1);
+		String endpoint2 = _getEndpoint(
+			TestPropsValues.getGroupId(), _objectDefinition2);
+		String endpoint3 = _getEndpoint(
+			TestPropsValues.getGroupId(), _objectDefinition3);
+
+		BigDecimal randomBigDecimal = new BigDecimal(
+			RandomTestUtil.randomDouble());
+		Date randomDate1 = RandomTestUtil.nextDate();
+		Date randomDate2 = RandomTestUtil.nextDate();
+		float randomFloat1 = RandomTestUtil.randomFloat();
+		int randomInt = RandomTestUtil.randomInt();
+		long randomLong = RandomTestUtil.randomLong(
+			ObjectFieldValidationConstants.BUSINESS_TYPE_LONG_VALUE_MIN,
+			ObjectFieldValidationConstants.BUSINESS_TYPE_LONG_VALUE_MAX);
+		String randomString1 = RandomTestUtil.randomString();
+		String randomString2 = RandomTestUtil.randomString();
+
+		JSONObject depth1JSONObject1 = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				_OBJECT_FIELD_NAME_BOOLEAN, false
+			).put(
+				_OBJECT_FIELD_NAME_DATE, _dateFormat.format(randomDate1)
+			).put(
+				_OBJECT_FIELD_NAME_DATE_TIME,
+				_dateTimeDateFormat.format(randomDate2)
+			).put(
+				_OBJECT_FIELD_NAME_DECIMAL, randomFloat1
+			).put(
+				_OBJECT_FIELD_NAME_INTEGER, randomInt
+			).put(
+				_OBJECT_FIELD_NAME_LONG_INTEGER, randomLong
+			).put(
+				_OBJECT_FIELD_NAME_LONG_TEXT, "a" + randomString1
+			).put(
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				JSONUtil.putAll(_LIST_TYPE_ENTRY_KEY_1, _LIST_TYPE_ENTRY_KEY_2)
+			).put(
+				_OBJECT_FIELD_NAME_PICKLIST, _LIST_TYPE_ENTRY_KEY_1
+			).put(
+				_OBJECT_FIELD_NAME_PRECISION_DECIMAL, randomBigDecimal
+			).put(
+				_OBJECT_FIELD_NAME_TEXT, "a" + randomString2
+			).toString(),
+			endpoint2, Http.Method.POST);
+
+		JSONObject depth1JSONObject2 = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				_OBJECT_FIELD_NAME_BOOLEAN, true
+			).put(
+				_OBJECT_FIELD_NAME_DATE,
+				() -> _dateFormat.format(
+					new Date(randomDate1.getTime() + (2 * 24 * 3600 * 1000)))
+			).put(
+				_OBJECT_FIELD_NAME_DATE_TIME,
+				_dateTimeDateFormat.format(
+					new Date(randomDate2.getTime() + 2000))
+			).put(
+				_OBJECT_FIELD_NAME_DECIMAL, randomFloat1 + 2
+			).put(
+				_OBJECT_FIELD_NAME_INTEGER, randomInt + 2
+			).put(
+				_OBJECT_FIELD_NAME_LONG_INTEGER, randomLong + 2
+			).put(
+				_OBJECT_FIELD_NAME_LONG_TEXT, "c" + randomString1
+			).put(
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				JSONUtil.putAll(_LIST_TYPE_ENTRY_KEY_2, _LIST_TYPE_ENTRY_KEY_3)
+			).put(
+				_OBJECT_FIELD_NAME_PICKLIST, _LIST_TYPE_ENTRY_KEY_2
+			).put(
+				_OBJECT_FIELD_NAME_PRECISION_DECIMAL,
+				randomBigDecimal.add(new BigDecimal(2))
+			).put(
+				_OBJECT_FIELD_NAME_TEXT, "c" + randomString2
+			).toString(),
+			endpoint2, Http.Method.POST);
+
+		JSONObject depth2JSONObject1 = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				_OBJECT_FIELD_NAME_BOOLEAN, false
+			).put(
+				_OBJECT_FIELD_NAME_DATE, _dateFormat.format(randomDate1)
+			).put(
+				_OBJECT_FIELD_NAME_DATE_TIME,
+				_dateTimeDateFormat.format(randomDate2)
+			).put(
+				_OBJECT_FIELD_NAME_DECIMAL, randomFloat1
+			).put(
+				_OBJECT_FIELD_NAME_INTEGER, randomInt
+			).put(
+				_OBJECT_FIELD_NAME_LONG_INTEGER, randomLong
+			).put(
+				_OBJECT_FIELD_NAME_LONG_TEXT, "a" + randomString1
+			).put(
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				JSONUtil.putAll(_LIST_TYPE_ENTRY_KEY_1, _LIST_TYPE_ENTRY_KEY_2)
+			).put(
+				_OBJECT_FIELD_NAME_PICKLIST, _LIST_TYPE_ENTRY_KEY_1
+			).put(
+				_OBJECT_FIELD_NAME_PRECISION_DECIMAL, randomBigDecimal
+			).put(
+				_OBJECT_FIELD_NAME_TEXT, "a" + randomString2
+			).toString(),
+			endpoint3, Http.Method.POST);
+
+		JSONObject depth2JSONObject2 = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				_OBJECT_FIELD_NAME_BOOLEAN, false
+			).put(
+				_OBJECT_FIELD_NAME_DATE,
+				() -> _dateFormat.format(
+					new Date(randomDate1.getTime() + (2 * 24 * 3600 * 1000)))
+			).put(
+				_OBJECT_FIELD_NAME_DATE_TIME,
+				_dateTimeDateFormat.format(
+					new Date(randomDate2.getTime() + 2000))
+			).put(
+				_OBJECT_FIELD_NAME_DECIMAL, randomFloat1 + 2
+			).put(
+				_OBJECT_FIELD_NAME_INTEGER, randomInt + 2
+			).put(
+				_OBJECT_FIELD_NAME_LONG_INTEGER, randomLong + 2
+			).put(
+				_OBJECT_FIELD_NAME_LONG_TEXT, "c" + randomString1
+			).put(
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				JSONUtil.putAll(_LIST_TYPE_ENTRY_KEY_1, _LIST_TYPE_ENTRY_KEY_2)
+			).put(
+				_OBJECT_FIELD_NAME_PICKLIST, _LIST_TYPE_ENTRY_KEY_2
+			).put(
+				_OBJECT_FIELD_NAME_PRECISION_DECIMAL,
+				randomBigDecimal.add(new BigDecimal(2))
+			).put(
+				_OBJECT_FIELD_NAME_TEXT, "c" + randomString2
+			).toString(),
+			endpoint3, Http.Method.POST);
+
+		JSONObject depth2JSONObject3 = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				_OBJECT_FIELD_NAME_BOOLEAN, true
+			).put(
+				_OBJECT_FIELD_NAME_DATE,
+				() -> _dateFormat.format(
+					new Date(randomDate1.getTime() + (24 * 3600 * 1000)))
+			).put(
+				_OBJECT_FIELD_NAME_DATE_TIME,
+				_dateTimeDateFormat.format(
+					new Date(randomDate2.getTime() + 1000))
+			).put(
+				_OBJECT_FIELD_NAME_DECIMAL, randomFloat1 + 1
+			).put(
+				_OBJECT_FIELD_NAME_INTEGER, randomInt + 1
+			).put(
+				_OBJECT_FIELD_NAME_LONG_INTEGER, randomLong + 1
+			).put(
+				_OBJECT_FIELD_NAME_LONG_TEXT, "b" + randomString1
+			).put(
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				JSONUtil.putAll(_LIST_TYPE_ENTRY_KEY_2, _LIST_TYPE_ENTRY_KEY_3)
+			).put(
+				_OBJECT_FIELD_NAME_PICKLIST, _LIST_TYPE_ENTRY_KEY_2
+			).put(
+				_OBJECT_FIELD_NAME_PRECISION_DECIMAL,
+				randomBigDecimal.add(BigDecimal.ONE)
+			).put(
+				_OBJECT_FIELD_NAME_TEXT, "b" + randomString2
+			).toString(),
+			endpoint3, Http.Method.POST);
+
+		JSONObject depth2JSONObject4 = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				_OBJECT_FIELD_NAME_BOOLEAN, true
+			).put(
+				_OBJECT_FIELD_NAME_DATE,
+				() -> _dateFormat.format(
+					new Date(randomDate1.getTime() + (3 * 24 * 3600 * 1000)))
+			).put(
+				_OBJECT_FIELD_NAME_DATE_TIME,
+				_dateTimeDateFormat.format(
+					new Date(randomDate2.getTime() + 3000))
+			).put(
+				_OBJECT_FIELD_NAME_DECIMAL, randomFloat1 + 3
+			).put(
+				_OBJECT_FIELD_NAME_INTEGER, randomInt + 3
+			).put(
+				_OBJECT_FIELD_NAME_LONG_INTEGER, randomLong + 3
+			).put(
+				_OBJECT_FIELD_NAME_LONG_TEXT, "d" + randomString1
+			).put(
+				_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST,
+				JSONUtil.putAll(_LIST_TYPE_ENTRY_KEY_2, _LIST_TYPE_ENTRY_KEY_3)
+			).put(
+				_OBJECT_FIELD_NAME_PICKLIST, _LIST_TYPE_ENTRY_KEY_3
+			).put(
+				_OBJECT_FIELD_NAME_PRECISION_DECIMAL,
+				randomBigDecimal.add(new BigDecimal(3))
+			).put(
+				_OBJECT_FIELD_NAME_TEXT, "d" + randomString2
+			).toString(),
+			endpoint3, Http.Method.POST);
+
+		JSONObject jsonObject1 = HTTPTestUtil.invokeToJSONObject(
+			JSONFactoryUtil.getNullJSON(
+			).toString(),
+			endpoint1, Http.Method.POST);
+
+		JSONObject jsonObject2 = HTTPTestUtil.invokeToJSONObject(
+			JSONFactoryUtil.getNullJSON(
+			).toString(),
+			endpoint1, Http.Method.POST);
+
+		JSONObject jsonObject3 = HTTPTestUtil.invokeToJSONObject(
+			JSONFactoryUtil.getNullJSON(
+			).toString(),
+			endpoint1, Http.Method.POST);
+
+		JSONObject jsonObject4 = HTTPTestUtil.invokeToJSONObject(
+			JSONFactoryUtil.getNullJSON(
+			).toString(),
+			endpoint1, Http.Method.POST);
+
+		HTTPTestUtil.invokeToJSONObject(
+			null,
+			String.format(
+				"%s/%d/%s/%d", endpoint2, depth1JSONObject1.getLong("id"),
+				_objectRelationship1.getName(), jsonObject1.getLong("id")),
+			Http.Method.PUT);
+
+		HTTPTestUtil.invokeToJSONObject(
+			null,
+			String.format(
+				"%s/%d/%s/%d", endpoint2, depth1JSONObject1.getLong("id"),
+				_objectRelationship1.getName(), jsonObject2.getLong("id")),
+			Http.Method.PUT);
+
+		HTTPTestUtil.invokeToJSONObject(
+			null,
+			String.format(
+				"%s/%d/%s/%d", endpoint2, depth1JSONObject2.getLong("id"),
+				_objectRelationship1.getName(), jsonObject3.getLong("id")),
+			Http.Method.PUT);
+
+		HTTPTestUtil.invokeToJSONObject(
+			null,
+			String.format(
+				"%s/%d/%s/%d", endpoint2, depth1JSONObject2.getLong("id"),
+				_objectRelationship1.getName(), jsonObject4.getLong("id")),
+			Http.Method.PUT);
+
+		HTTPTestUtil.invokeToJSONObject(
+			null,
+			String.format(
+				"%s/%d/%s/%d", endpoint2, depth1JSONObject1.getLong("id"),
+				_objectRelationship2.getName(),
+				depth2JSONObject1.getLong("id")),
+			Http.Method.PUT);
+
+		HTTPTestUtil.invokeToJSONObject(
+			null,
+			String.format(
+				"%s/%d/%s/%d", endpoint2, depth1JSONObject1.getLong("id"),
+				_objectRelationship2.getName(),
+				depth2JSONObject2.getLong("id")),
+			Http.Method.PUT);
+
+		HTTPTestUtil.invokeToJSONObject(
+			null,
+			String.format(
+				"%s/%d/%s/%d", endpoint3, depth1JSONObject2.getLong("id"),
+				_objectRelationship2.getName(),
+				depth2JSONObject3.getLong("id")),
+			Http.Method.PUT);
+
+		HTTPTestUtil.invokeToJSONObject(
+			null,
+			String.format(
+				"%s/%d/%s/%d", endpoint3, depth1JSONObject2.getLong("id"),
+				_objectRelationship2.getName(),
+				depth2JSONObject4.getLong("id")),
+			Http.Method.PUT);
+
+		try {
+			_testSortByManyToAndOneToManyRelationshipsCustomObjectFields(
+				endpoint1, endpoint3, jsonObject3, jsonObject4, jsonObject1,
+				jsonObject2, depth2JSONObject1, depth2JSONObject2,
+				depth2JSONObject3, depth2JSONObject4,
+				String.format(
+					"%s/%s/%s", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_OBJECT_FIELD_NAME_BOOLEAN));
+			_testSortByManyToAndOneToManyRelationshipsCustomObjectFields(
+				endpoint1, endpoint3, jsonObject3, jsonObject4, jsonObject1,
+				jsonObject2, depth2JSONObject1, depth2JSONObject2,
+				depth2JSONObject3, depth2JSONObject4,
+				String.format(
+					"%s/%s/%s", _objectRelationship1.getName(),
+					_objectRelationship2.getName(), _OBJECT_FIELD_NAME_DATE));
+			_testSortByManyToAndOneToManyRelationshipsCustomObjectFields(
+				endpoint1, endpoint3, jsonObject3, jsonObject4, jsonObject1,
+				jsonObject2, depth2JSONObject1, depth2JSONObject2,
+				depth2JSONObject3, depth2JSONObject4,
+				String.format(
+					"%s/%s/%s", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_OBJECT_FIELD_NAME_DATE_TIME));
+			_testSortByManyToAndOneToManyRelationshipsCustomObjectFields(
+				endpoint1, endpoint3, jsonObject3, jsonObject4, jsonObject1,
+				jsonObject2, depth2JSONObject1, depth2JSONObject2,
+				depth2JSONObject3, depth2JSONObject4,
+				String.format(
+					"%s/%s/%s", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_OBJECT_FIELD_NAME_DECIMAL));
+			_testSortByManyToAndOneToManyRelationshipsCustomObjectFields(
+				endpoint1, endpoint3, jsonObject3, jsonObject4, jsonObject1,
+				jsonObject2, depth2JSONObject1, depth2JSONObject2,
+				depth2JSONObject3, depth2JSONObject4,
+				String.format(
+					"%s/%s/%s", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_OBJECT_FIELD_NAME_INTEGER));
+			_testSortByManyToAndOneToManyRelationshipsCustomObjectFields(
+				endpoint1, endpoint3, jsonObject3, jsonObject4, jsonObject1,
+				jsonObject2, depth2JSONObject1, depth2JSONObject2,
+				depth2JSONObject3, depth2JSONObject4,
+				String.format(
+					"%s/%s/%s", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_OBJECT_FIELD_NAME_LONG_INTEGER));
+			_testSortByManyToAndOneToManyRelationshipsCustomObjectFields(
+				endpoint1, endpoint3, jsonObject3, jsonObject4, jsonObject1,
+				jsonObject2, depth2JSONObject1, depth2JSONObject2,
+				depth2JSONObject3, depth2JSONObject4,
+				String.format(
+					"%s/%s/%s", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_OBJECT_FIELD_NAME_LONG_TEXT));
+			_testSortByManyToAndOneToManyRelationshipsCustomObjectFields(
+				endpoint1, endpoint3, jsonObject3, jsonObject4, jsonObject1,
+				jsonObject2, depth2JSONObject1, depth2JSONObject2,
+				depth2JSONObject3, depth2JSONObject4,
+				String.format(
+					"%s/%s/%s", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST));
+			_testSortByManyToAndOneToManyRelationshipsCustomObjectFields(
+				endpoint1, endpoint3, jsonObject3, jsonObject4, jsonObject1,
+				jsonObject2, depth2JSONObject1, depth2JSONObject2,
+				depth2JSONObject3, depth2JSONObject4,
+				String.format(
+					"%s/%s/%s", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_OBJECT_FIELD_NAME_PICKLIST));
+			_testSortByManyToAndOneToManyRelationshipsCustomObjectFields(
+				endpoint1, endpoint3, jsonObject3, jsonObject4, jsonObject1,
+				jsonObject2, depth2JSONObject1, depth2JSONObject2,
+				depth2JSONObject3, depth2JSONObject4,
+				String.format(
+					"%s/%s/%s", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_OBJECT_FIELD_NAME_PRECISION_DECIMAL));
+			_testSortByManyToAndOneToManyRelationshipsCustomObjectFields(
+				endpoint1, endpoint3, jsonObject3, jsonObject4, jsonObject1,
+				jsonObject2, depth2JSONObject1, depth2JSONObject2,
+				depth2JSONObject3, depth2JSONObject4,
+				String.format(
+					"%s/%s/%s", _objectRelationship1.getName(),
+					_objectRelationship2.getName(), _OBJECT_FIELD_NAME_TEXT));
+
+			// Sort by several fields
+
+			_testSortByManyToAndOneToManyRelationshipsCustomObjectFields(
+				endpoint1, endpoint3, jsonObject3, jsonObject4, jsonObject1,
+				jsonObject2, depth2JSONObject1, depth2JSONObject2,
+				depth2JSONObject3, depth2JSONObject4,
+				String.format(
+					"%s/%s/%s", _objectRelationship1.getName(),
+					_objectRelationship2.getName(), _OBJECT_FIELD_NAME_BOOLEAN),
+				String.format(
+					"%s/%s/%s", _objectRelationship1.getName(),
+					_objectRelationship2.getName(), _OBJECT_FIELD_NAME_DATE),
+				String.format(
+					"%s/%s/%s", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_OBJECT_FIELD_NAME_DATE_TIME),
+				String.format(
+					"%s/%s/%s", _objectRelationship1.getName(),
+					_objectRelationship2.getName(), _OBJECT_FIELD_NAME_DECIMAL),
+				String.format(
+					"%s/%s/%s", _objectRelationship1.getName(),
+					_objectRelationship2.getName(), _OBJECT_FIELD_NAME_INTEGER),
+				String.format(
+					"%s/%s/%s", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_OBJECT_FIELD_NAME_LONG_INTEGER),
+				String.format(
+					"%s/%s/%s", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_OBJECT_FIELD_NAME_LONG_TEXT),
+				String.format(
+					"%s/%s/%s", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST),
+				String.format(
+					"%s/%s/%s", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_OBJECT_FIELD_NAME_PICKLIST),
+				String.format(
+					"%s/%s/%s", _objectRelationship1.getName(),
+					_objectRelationship2.getName(),
+					_OBJECT_FIELD_NAME_PRECISION_DECIMAL),
+				String.format(
+					"%s/%s/%s", _objectRelationship1.getName(),
+					_objectRelationship2.getName(), _OBJECT_FIELD_NAME_TEXT));
+		}
+		finally {
+			if (jsonObject1 != null) {
+				_objectEntryLocalService.deleteObjectEntry(
+					jsonObject1.getLong("id"));
+			}
+
+			if (jsonObject2 != null) {
+				_objectEntryLocalService.deleteObjectEntry(
+					jsonObject2.getLong("id"));
+			}
+
+			if (jsonObject3 != null) {
+				_objectEntryLocalService.deleteObjectEntry(
+					jsonObject3.getLong("id"));
+			}
+
+			if (jsonObject4 != null) {
+				_objectEntryLocalService.deleteObjectEntry(
+					jsonObject4.getLong("id"));
+			}
+
+			if (depth2JSONObject1 != null) {
+				_objectEntryLocalService.deleteObjectEntry(
+					depth2JSONObject1.getLong("id"));
+			}
+
+			if (depth2JSONObject2 != null) {
+				_objectEntryLocalService.deleteObjectEntry(
+					depth2JSONObject2.getLong("id"));
+			}
+
+			if (depth2JSONObject3 != null) {
+				_objectEntryLocalService.deleteObjectEntry(
+					depth2JSONObject3.getLong("id"));
+			}
+
+			if (depth2JSONObject4 != null) {
+				_objectEntryLocalService.deleteObjectEntry(
+					depth2JSONObject4.getLong("id"));
+			}
+
+			if (depth1JSONObject1 != null) {
+				_objectEntryLocalService.deleteObjectEntry(
+					depth1JSONObject1.getLong("id"));
+			}
+
+			if (depth1JSONObject2 != null) {
+				_objectEntryLocalService.deleteObjectEntry(
+					depth1JSONObject2.getLong("id"));
+			}
+		}
+	}
+
+	@FeatureFlags("LPD-18730")
+	@Test
 	public void testSortByManyToOneRelationshipCustomObjectFields()
 		throws Exception {
 
@@ -12435,6 +12917,84 @@ public class ObjectEntryResourceTest {
 
 		_assertItem(0, pageJSONObject, "id", expectedJSONObject2.getLong("id"));
 		_assertItem(1, pageJSONObject, "id", expectedJSONObject1.getLong("id"));
+	}
+
+	private void _testSortByManyToAndOneToManyRelationshipsCustomObjectFields(
+			String endpoint1, String endpoint2, JSONObject expectedJSONObject1,
+			JSONObject expectedJSONObject2, JSONObject expectedJSONObject3,
+			JSONObject expectedJSONObject4, JSONObject relatedJSONObject1,
+			JSONObject relatedJSONObject2, JSONObject relatedJSONObject3,
+			JSONObject relatedJSONObject4, String... fieldNames)
+		throws Exception {
+
+		_testSortByFieldName(
+			endpoint1, expectedJSONObject1, expectedJSONObject2,
+			expectedJSONObject3, expectedJSONObject4, fieldNames);
+
+		JSONObject valuesJSONObject1 = JSONFactoryUtil.createJSONObject();
+		JSONObject valuesJSONObject2 = JSONFactoryUtil.createJSONObject();
+		JSONObject valuesJSONObject3 = JSONFactoryUtil.createJSONObject();
+		JSONObject valuesJSONObject4 = JSONFactoryUtil.createJSONObject();
+
+		for (String fieldName : fieldNames) {
+			String objectFieldName = StringUtil.extractLast(fieldName, "/");
+
+			valuesJSONObject1.put(
+				objectFieldName, relatedJSONObject1.get(objectFieldName));
+			valuesJSONObject2.put(
+				objectFieldName, relatedJSONObject2.get(objectFieldName));
+			valuesJSONObject3.put(
+				objectFieldName, relatedJSONObject3.get(objectFieldName));
+			valuesJSONObject4.put(
+				objectFieldName, relatedJSONObject4.get(objectFieldName));
+		}
+
+		try {
+			HTTPTestUtil.invokeToJSONObject(
+				valuesJSONObject3.toString(),
+				endpoint2 + "/" + relatedJSONObject1.getLong("id"),
+				Http.Method.PATCH);
+
+			HTTPTestUtil.invokeToJSONObject(
+				valuesJSONObject4.toString(),
+				endpoint2 + "/" + relatedJSONObject2.getLong("id"),
+				Http.Method.PATCH);
+
+			HTTPTestUtil.invokeToJSONObject(
+				valuesJSONObject1.toString(),
+				endpoint2 + "/" + relatedJSONObject3.getLong("id"),
+				Http.Method.PATCH);
+
+			HTTPTestUtil.invokeToJSONObject(
+				valuesJSONObject2.toString(),
+				endpoint2 + "/" + relatedJSONObject4.getLong("id"),
+				Http.Method.PATCH);
+
+			_testSortByFieldName(
+				endpoint1, expectedJSONObject1, expectedJSONObject2,
+				expectedJSONObject3, expectedJSONObject4, fieldNames);
+		}
+		finally {
+			HTTPTestUtil.invokeToJSONObject(
+				valuesJSONObject1.toString(),
+				endpoint2 + "/" + relatedJSONObject1.getLong("id"),
+				Http.Method.PATCH);
+
+			HTTPTestUtil.invokeToJSONObject(
+				valuesJSONObject2.toString(),
+				endpoint2 + "/" + relatedJSONObject2.getLong("id"),
+				Http.Method.PATCH);
+
+			HTTPTestUtil.invokeToJSONObject(
+				valuesJSONObject3.toString(),
+				endpoint2 + "/" + relatedJSONObject3.getLong("id"),
+				Http.Method.PATCH);
+
+			HTTPTestUtil.invokeToJSONObject(
+				valuesJSONObject4.toString(),
+				endpoint2 + "/" + relatedJSONObject4.getLong("id"),
+				Http.Method.PATCH);
+		}
 	}
 
 	private void _testSortByManyToOneRelationshipCustomObjectFields(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/sort/BaseSortDSLQueryVisitor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/sort/BaseSortDSLQueryVisitor.java
@@ -41,7 +41,7 @@ public abstract class BaseSortDSLQueryVisitor {
 		throws PortalException;
 
 	protected DSLQuery addLeftJoin(
-		Column<?, Long> column, DSLQuery dslQuery, Table<?> joinTable,
+		Column<?, Long> column1, Column<?, Long> column2, DSLQuery dslQuery,
 		Table<?> table) {
 
 		Stack<BaseASTNode> allBaseASTNodes = getAllBaseASTNodes(
@@ -49,16 +49,12 @@ public abstract class BaseSortDSLQueryVisitor {
 
 		JoinStep joinStep = (JoinStep)allBaseASTNodes.pop();
 
-		BaseASTNode baseASTNode = null;
+		if (column2 == null) {
+			column2 = getPrimaryKeyColumn(getTable(joinStep));
+		}
 
-		if (joinTable != null) {
-			baseASTNode = (BaseASTNode)joinStep.leftJoinOn(
-				table, column.eq(getPrimaryKeyColumn(joinTable)));
-		}
-		else {
-			baseASTNode = (BaseASTNode)joinStep.leftJoinOn(
-				table, column.eq(getPrimaryKeyColumn(getTable(joinStep))));
-		}
+		BaseASTNode baseASTNode = (BaseASTNode)joinStep.leftJoinOn(
+			table, column1.eq(column2));
 
 		return updateParents(baseASTNode, allBaseASTNodes);
 	}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/sort/BaseSortDSLQueryVisitor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/sort/BaseSortDSLQueryVisitor.java
@@ -41,15 +41,24 @@ public abstract class BaseSortDSLQueryVisitor {
 		throws PortalException;
 
 	protected DSLQuery addLeftJoin(
-		Column<?, Long> column, DSLQuery dslQuery, Table<?> table) {
+		Column<?, Long> column, DSLQuery dslQuery, Table<?> joinTable,
+		Table<?> table) {
 
 		Stack<BaseASTNode> allBaseASTNodes = getAllBaseASTNodes(
 			JoinStep.class, dslQuery);
 
 		JoinStep joinStep = (JoinStep)allBaseASTNodes.pop();
 
-		BaseASTNode baseASTNode = (BaseASTNode)joinStep.leftJoinOn(
-			table, column.eq(getPrimaryKeyColumn(getTable(joinStep))));
+		BaseASTNode baseASTNode = null;
+
+		if (joinTable != null) {
+			baseASTNode = (BaseASTNode)joinStep.leftJoinOn(
+				table, column.eq(getPrimaryKeyColumn(joinTable)));
+		}
+		else {
+			baseASTNode = (BaseASTNode)joinStep.leftJoinOn(
+				table, column.eq(getPrimaryKeyColumn(getTable(joinStep))));
+		}
 
 		return updateParents(baseASTNode, allBaseASTNodes);
 	}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/sort/ObjectEntry1ToMRelationshipSortDSLQueryVisitor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/sort/ObjectEntry1ToMRelationshipSortDSLQueryVisitor.java
@@ -67,7 +67,7 @@ public class ObjectEntry1ToMRelationshipSortDSLQueryVisitor
 			dslQuery = addLeftJoin(
 				(Column<DynamicObjectDefinitionTable, Long>)
 					dynamicObjectDefinitionTable.getColumn(dbColumnName),
-				dslQuery, null, dynamicObjectDefinitionTable);
+				null, dslQuery, dynamicObjectDefinitionTable);
 		}
 
 		Stack<BaseASTNode> allBaseASTNodes = getAllBaseASTNodes(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/sort/ObjectEntry1ToMRelationshipSortDSLQueryVisitor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/sort/ObjectEntry1ToMRelationshipSortDSLQueryVisitor.java
@@ -67,7 +67,7 @@ public class ObjectEntry1ToMRelationshipSortDSLQueryVisitor
 			dslQuery = addLeftJoin(
 				(Column<DynamicObjectDefinitionTable, Long>)
 					dynamicObjectDefinitionTable.getColumn(dbColumnName),
-				dslQuery, dynamicObjectDefinitionTable);
+				dslQuery, null, dynamicObjectDefinitionTable);
 		}
 
 		Stack<BaseASTNode> allBaseASTNodes = getAllBaseASTNodes(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/sort/ObjectEntryFieldSortDSLQueryVisitor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/sort/ObjectEntryFieldSortDSLQueryVisitor.java
@@ -73,7 +73,7 @@ public class ObjectEntryFieldSortDSLQueryVisitor
 
 		if (!contains(dslQuery, fieldTable)) {
 			dslQuery = addLeftJoin(
-				getPrimaryKeyColumn(fieldTable), dslQuery, null, fieldTable);
+				getPrimaryKeyColumn(fieldTable), null, dslQuery, fieldTable);
 		}
 
 		OrderByExpression orderByExpression = _getOrderByExpression(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/sort/ObjectEntryFieldSortDSLQueryVisitor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/sort/ObjectEntryFieldSortDSLQueryVisitor.java
@@ -73,7 +73,7 @@ public class ObjectEntryFieldSortDSLQueryVisitor
 
 		if (!contains(dslQuery, fieldTable)) {
 			dslQuery = addLeftJoin(
-				getPrimaryKeyColumn(fieldTable), dslQuery, fieldTable);
+				getPrimaryKeyColumn(fieldTable), dslQuery, null, fieldTable);
 		}
 
 		OrderByExpression orderByExpression = _getOrderByExpression(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/sort/ObjectEntryMTo1RelationshipSortDSLQueryVisitor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/sort/ObjectEntryMTo1RelationshipSortDSLQueryVisitor.java
@@ -51,17 +51,32 @@ public class ObjectEntryMTo1RelationshipSortDSLQueryVisitor
 			"r_", objectRelationship.getName(), "_",
 			relatedObjectDefinition.getPKObjectFieldName());
 
+		String formatedRelationshipPathName = StringUtil.replace(
+			relationshipSort.getFieldPath(), CharPool.FORWARD_SLASH,
+			CharPool.UNDERLINE);
+
 		DynamicObjectDefinitionTable relatedDynamicObjectDefinitionTable =
 			(DynamicObjectDefinitionTable)getAliasedTable(
-				StringUtil.replace(
-					relationshipSort.getFieldPath(), CharPool.FORWARD_SLASH,
-					CharPool.UNDERLINE),
-				_getDynamicObjectDefinitionTable(relatedObjectDefinition));
+				formatedRelationshipPathName,
+				_toDynamicObjectDefinitionTable(relatedObjectDefinition));
 
 		if (!contains(dslQuery, relatedDynamicObjectDefinitionTable)) {
 			DynamicObjectDefinitionTable dynamicObjectDefinitionTable =
 				_getDynamicObjectDefinitionTable(
 					relationshipSort.getObjectDefinition(), dbColumnName);
+
+			if (!contains(dslQuery, dynamicObjectDefinitionTable)) {
+				dynamicObjectDefinitionTable =
+					(DynamicObjectDefinitionTable)getAliasedTable(
+						StringUtil.removeLast(
+							formatedRelationshipPathName,
+							"_" + objectRelationship.getName()),
+						dynamicObjectDefinitionTable);
+
+				dslQuery = addLeftJoin(
+					dynamicObjectDefinitionTable.getPrimaryKeyColumn(),
+					dslQuery, null, dynamicObjectDefinitionTable);
+			}
 
 			dslQuery = addLeftJoin(
 				(Column<DynamicObjectDefinitionTable, Long>)
@@ -94,6 +109,29 @@ public class ObjectEntryMTo1RelationshipSortDSLQueryVisitor
 	}
 
 	private DynamicObjectDefinitionTable _getDynamicObjectDefinitionTable(
+			ObjectDefinition objectDefinition, String objectFieldName)
+		throws PortalException {
+
+		DynamicObjectDefinitionTable dynamicObjectDefinitionTable =
+			_toDynamicObjectDefinitionTable(objectDefinition);
+
+		Column<DynamicObjectDefinitionTable, Long> column =
+			(Column<DynamicObjectDefinitionTable, Long>)
+				dynamicObjectDefinitionTable.getColumn(objectFieldName);
+
+		if (column == null) {
+			dynamicObjectDefinitionTable = new DynamicObjectDefinitionTable(
+				objectDefinition,
+				objectFieldLocalService.getObjectFields(
+					objectDefinition.getObjectDefinitionId(),
+					objectDefinition.getExtensionDBTableName()),
+				objectDefinition.getExtensionDBTableName());
+		}
+
+		return dynamicObjectDefinitionTable;
+	}
+
+	private DynamicObjectDefinitionTable _toDynamicObjectDefinitionTable(
 			ObjectDefinition objectDefinition)
 		throws PortalException {
 
@@ -103,38 +141,6 @@ public class ObjectEntryMTo1RelationshipSortDSLQueryVisitor
 				objectDefinition.getObjectDefinitionId(),
 				objectDefinition.getDBTableName()),
 			objectDefinition.getDBTableName());
-	}
-
-	private DynamicObjectDefinitionTable _getDynamicObjectDefinitionTable(
-			ObjectDefinition objectDefinition, String objectFieldName)
-		throws PortalException {
-
-		DynamicObjectDefinitionTable dynamicObjectDefinitionTable =
-			_getDynamicObjectDefinitionTable(objectDefinition);
-
-		Column<DynamicObjectDefinitionTable, Long> column =
-			(Column<DynamicObjectDefinitionTable, Long>)
-				dynamicObjectDefinitionTable.getColumn(objectFieldName);
-
-		if (column == null) {
-			dynamicObjectDefinitionTable =
-				_getExtensionDynamicObjectDefinitionTable(objectDefinition);
-		}
-
-		return dynamicObjectDefinitionTable;
-	}
-
-	private DynamicObjectDefinitionTable
-			_getExtensionDynamicObjectDefinitionTable(
-				ObjectDefinition objectDefinition)
-		throws PortalException {
-
-		return new DynamicObjectDefinitionTable(
-			objectDefinition,
-			objectFieldLocalService.getObjectFields(
-				objectDefinition.getObjectDefinitionId(),
-				objectDefinition.getExtensionDBTableName()),
-			objectDefinition.getExtensionDBTableName());
 	}
 
 }

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/sort/ObjectEntryMTo1RelationshipSortDSLQueryVisitor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/sort/ObjectEntryMTo1RelationshipSortDSLQueryVisitor.java
@@ -62,17 +62,14 @@ public class ObjectEntryMTo1RelationshipSortDSLQueryVisitor
 
 		if (!contains(dslQuery, relatedDynamicObjectDefinitionTable)) {
 			DynamicObjectDefinitionTable dynamicObjectDefinitionTable =
-				_getDynamicObjectDefinitionTable(
-					relationshipSort.getObjectDefinition(), dbColumnName);
+				(DynamicObjectDefinitionTable)getAliasedTable(
+					StringUtil.removeLast(
+						formatedRelationshipPathName,
+						"_" + objectRelationship.getName()),
+					_getDynamicObjectDefinitionTable(
+						relationshipSort.getObjectDefinition(), dbColumnName));
 
 			if (!contains(dslQuery, dynamicObjectDefinitionTable)) {
-				dynamicObjectDefinitionTable =
-					(DynamicObjectDefinitionTable)getAliasedTable(
-						StringUtil.removeLast(
-							formatedRelationshipPathName,
-							"_" + objectRelationship.getName()),
-						dynamicObjectDefinitionTable);
-
 				dslQuery = addLeftJoin(
 					dynamicObjectDefinitionTable.getPrimaryKeyColumn(),
 					dslQuery, null, dynamicObjectDefinitionTable);

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/sort/ObjectEntryMTo1RelationshipSortDSLQueryVisitor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/sort/ObjectEntryMTo1RelationshipSortDSLQueryVisitor.java
@@ -58,23 +58,31 @@ public class ObjectEntryMTo1RelationshipSortDSLQueryVisitor
 		DynamicObjectDefinitionTable relatedDynamicObjectDefinitionTable =
 			(DynamicObjectDefinitionTable)getAliasedTable(
 				formatedRelationshipPathName,
-				_toDynamicObjectDefinitionTable(relatedObjectDefinition));
+				new DynamicObjectDefinitionTable(
+					relatedObjectDefinition,
+					objectFieldLocalService.getObjectFields(
+						relatedObjectDefinition.getObjectDefinitionId(),
+						relatedObjectDefinition.getDBTableName()),
+					relatedObjectDefinition.getDBTableName()));
+
+		ObjectDefinition objectDefinition =
+			relationshipSort.getObjectDefinition();
+
+		DynamicObjectDefinitionTable dynamicObjectDefinitionTable =
+			(DynamicObjectDefinitionTable)getAliasedTable(
+				StringUtil.removeLast(
+					formatedRelationshipPathName,
+					"_" + objectRelationship.getName()),
+				objectFieldLocalService.getTable(
+					objectDefinition.getObjectDefinitionId(), dbColumnName));
+
+		if (!contains(dslQuery, dynamicObjectDefinitionTable)) {
+			dslQuery = addLeftJoin(
+				dynamicObjectDefinitionTable.getPrimaryKeyColumn(), dslQuery,
+				null, dynamicObjectDefinitionTable);
+		}
 
 		if (!contains(dslQuery, relatedDynamicObjectDefinitionTable)) {
-			DynamicObjectDefinitionTable dynamicObjectDefinitionTable =
-				(DynamicObjectDefinitionTable)getAliasedTable(
-					StringUtil.removeLast(
-						formatedRelationshipPathName,
-						"_" + objectRelationship.getName()),
-					_getDynamicObjectDefinitionTable(
-						relationshipSort.getObjectDefinition(), dbColumnName));
-
-			if (!contains(dslQuery, dynamicObjectDefinitionTable)) {
-				dslQuery = addLeftJoin(
-					dynamicObjectDefinitionTable.getPrimaryKeyColumn(),
-					dslQuery, null, dynamicObjectDefinitionTable);
-			}
-
 			dslQuery = addLeftJoin(
 				(Column<DynamicObjectDefinitionTable, Long>)
 					dynamicObjectDefinitionTable.getColumn(dbColumnName),
@@ -103,41 +111,6 @@ public class ObjectEntryMTo1RelationshipSortDSLQueryVisitor
 			));
 
 		return updateParents(baseASTNode, allBaseASTNodes);
-	}
-
-	private DynamicObjectDefinitionTable _getDynamicObjectDefinitionTable(
-			ObjectDefinition objectDefinition, String objectFieldName)
-		throws PortalException {
-
-		DynamicObjectDefinitionTable dynamicObjectDefinitionTable =
-			_toDynamicObjectDefinitionTable(objectDefinition);
-
-		Column<DynamicObjectDefinitionTable, Long> column =
-			(Column<DynamicObjectDefinitionTable, Long>)
-				dynamicObjectDefinitionTable.getColumn(objectFieldName);
-
-		if (column == null) {
-			dynamicObjectDefinitionTable = new DynamicObjectDefinitionTable(
-				objectDefinition,
-				objectFieldLocalService.getObjectFields(
-					objectDefinition.getObjectDefinitionId(),
-					objectDefinition.getExtensionDBTableName()),
-				objectDefinition.getExtensionDBTableName());
-		}
-
-		return dynamicObjectDefinitionTable;
-	}
-
-	private DynamicObjectDefinitionTable _toDynamicObjectDefinitionTable(
-			ObjectDefinition objectDefinition)
-		throws PortalException {
-
-		return new DynamicObjectDefinitionTable(
-			objectDefinition,
-			objectFieldLocalService.getObjectFields(
-				objectDefinition.getObjectDefinitionId(),
-				objectDefinition.getDBTableName()),
-			objectDefinition.getDBTableName());
 	}
 
 }

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/sort/ObjectEntryMTo1RelationshipSortDSLQueryVisitor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/sort/ObjectEntryMTo1RelationshipSortDSLQueryVisitor.java
@@ -78,16 +78,16 @@ public class ObjectEntryMTo1RelationshipSortDSLQueryVisitor
 
 		if (!contains(dslQuery, dynamicObjectDefinitionTable)) {
 			dslQuery = addLeftJoin(
-				dynamicObjectDefinitionTable.getPrimaryKeyColumn(), dslQuery,
-				null, dynamicObjectDefinitionTable);
+				dynamicObjectDefinitionTable.getPrimaryKeyColumn(), null,
+				dslQuery, dynamicObjectDefinitionTable);
 		}
 
 		if (!contains(dslQuery, relatedDynamicObjectDefinitionTable)) {
 			dslQuery = addLeftJoin(
 				(Column<DynamicObjectDefinitionTable, Long>)
 					dynamicObjectDefinitionTable.getColumn(dbColumnName),
-				dslQuery, relatedDynamicObjectDefinitionTable,
-				relatedDynamicObjectDefinitionTable);
+				relatedDynamicObjectDefinitionTable.getPrimaryKeyColumn(),
+				dslQuery, relatedDynamicObjectDefinitionTable);
 		}
 
 		Stack<BaseASTNode> allBaseASTNodes = getAllBaseASTNodes(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/sort/ObjectEntryMTo1RelationshipSortDSLQueryVisitor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/sort/ObjectEntryMTo1RelationshipSortDSLQueryVisitor.java
@@ -1,0 +1,140 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.internal.sort;
+
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectRelationship;
+import com.liferay.object.petra.sql.dsl.DynamicObjectDefinitionTable;
+import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.petra.sql.dsl.Column;
+import com.liferay.petra.sql.dsl.expression.Expression;
+import com.liferay.petra.sql.dsl.query.DSLQuery;
+import com.liferay.petra.sql.dsl.query.GroupByStep;
+import com.liferay.petra.sql.dsl.spi.ast.BaseASTNode;
+import com.liferay.petra.sql.dsl.spi.query.GroupBy;
+import com.liferay.petra.sql.dsl.spi.query.Select;
+import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.util.Stack;
+
+/**
+ * @author Sergio Jiménez del Coso
+ */
+public class ObjectEntryMTo1RelationshipSortDSLQueryVisitor
+	extends BaseSortDSLQueryVisitor {
+
+	public ObjectEntryMTo1RelationshipSortDSLQueryVisitor(
+		ObjectFieldLocalService objectFieldLocalService,
+		ObjectRelationshipLocalService objectRelationshipLocalService) {
+
+		super(objectFieldLocalService, objectRelationshipLocalService);
+	}
+
+	public DSLQuery visit(DSLQuery dslQuery, Sort sort) throws PortalException {
+		RelationshipSort relationshipSort = (RelationshipSort)sort;
+
+		ObjectRelationship objectRelationship =
+			relationshipSort.getObjectRelationship();
+
+		ObjectDefinition relatedObjectDefinition =
+			relationshipSort.getRelatedObjectDefinition();
+
+		String dbColumnName = StringBundler.concat(
+			"r_", objectRelationship.getName(), "_",
+			relatedObjectDefinition.getPKObjectFieldName());
+
+		DynamicObjectDefinitionTable relatedDynamicObjectDefinitionTable =
+			(DynamicObjectDefinitionTable)getAliasedTable(
+				StringUtil.replace(
+					relationshipSort.getFieldPath(), CharPool.FORWARD_SLASH,
+					CharPool.UNDERLINE),
+				_getDynamicObjectDefinitionTable(relatedObjectDefinition));
+
+		if (!contains(dslQuery, relatedDynamicObjectDefinitionTable)) {
+			DynamicObjectDefinitionTable dynamicObjectDefinitionTable =
+				_getDynamicObjectDefinitionTable(
+					relationshipSort.getObjectDefinition(), dbColumnName);
+
+			dslQuery = addLeftJoin(
+				(Column<DynamicObjectDefinitionTable, Long>)
+					dynamicObjectDefinitionTable.getColumn(dbColumnName),
+				dslQuery, relatedDynamicObjectDefinitionTable,
+				relatedDynamicObjectDefinitionTable);
+		}
+
+		Stack<BaseASTNode> allBaseASTNodes = getAllBaseASTNodes(
+			GroupByStep.class, dslQuery);
+
+		if (ListUtil.exists(allBaseASTNodes, GroupBy.class::isInstance)) {
+			return dslQuery;
+		}
+
+		GroupByStep groupByStep = (GroupByStep)allBaseASTNodes.pop();
+
+		Stack<BaseASTNode> selectAllBaseASTNodes = getAllBaseASTNodes(
+			Select.class, dslQuery);
+
+		Select select = (Select)selectAllBaseASTNodes.pop();
+
+		BaseASTNode baseASTNode = (BaseASTNode)groupByStep.groupBy(
+			select.getExpressions(
+			).toArray(
+				new Expression[0]
+			));
+
+		return updateParents(baseASTNode, allBaseASTNodes);
+	}
+
+	private DynamicObjectDefinitionTable _getDynamicObjectDefinitionTable(
+			ObjectDefinition objectDefinition)
+		throws PortalException {
+
+		return new DynamicObjectDefinitionTable(
+			objectDefinition,
+			objectFieldLocalService.getObjectFields(
+				objectDefinition.getObjectDefinitionId(),
+				objectDefinition.getDBTableName()),
+			objectDefinition.getDBTableName());
+	}
+
+	private DynamicObjectDefinitionTable _getDynamicObjectDefinitionTable(
+			ObjectDefinition objectDefinition, String objectFieldName)
+		throws PortalException {
+
+		DynamicObjectDefinitionTable dynamicObjectDefinitionTable =
+			_getDynamicObjectDefinitionTable(objectDefinition);
+
+		Column<DynamicObjectDefinitionTable, Long> column =
+			(Column<DynamicObjectDefinitionTable, Long>)
+				dynamicObjectDefinitionTable.getColumn(objectFieldName);
+
+		if (column == null) {
+			dynamicObjectDefinitionTable =
+				_getExtensionDynamicObjectDefinitionTable(objectDefinition);
+		}
+
+		return dynamicObjectDefinitionTable;
+	}
+
+	private DynamicObjectDefinitionTable
+			_getExtensionDynamicObjectDefinitionTable(
+				ObjectDefinition objectDefinition)
+		throws PortalException {
+
+		return new DynamicObjectDefinitionTable(
+			objectDefinition,
+			objectFieldLocalService.getObjectFields(
+				objectDefinition.getObjectDefinitionId(),
+				objectDefinition.getExtensionDBTableName()),
+			objectDefinition.getExtensionDBTableName());
+	}
+
+}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/sort/SortDSLQueryVisitor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/sort/SortDSLQueryVisitor.java
@@ -101,19 +101,22 @@ public class SortDSLQueryVisitor extends BaseSortDSLQueryVisitor {
 					" related object field");
 		}
 
+		BaseSortDSLQueryVisitor baseSortDSLQueryVisitor = null;
+
 		if (objectDefinition.getObjectDefinitionId() !=
 				objectRelationship.getObjectDefinitionId1()) {
 
-			throw new InvalidSortException(
-				"Unable to sort by a many to one related object field");
+			baseSortDSLQueryVisitor =
+				new ObjectEntryMTo1RelationshipSortDSLQueryVisitor(
+					objectFieldLocalService, objectRelationshipLocalService);
 		}
-
-		ObjectEntry1ToMRelationshipSortDSLQueryVisitor
-			objectEntry1ToMRelationshipSortDSLQueryVisitor =
+		else {
+			baseSortDSLQueryVisitor =
 				new ObjectEntry1ToMRelationshipSortDSLQueryVisitor(
 					objectFieldLocalService, objectRelationshipLocalService);
+		}
 
-		return objectEntry1ToMRelationshipSortDSLQueryVisitor.visit(
+		return baseSortDSLQueryVisitor.visit(
 			dslQuery,
 			new RelationshipSort(
 				objectDefinition, objectRelationship, path,


### PR DESCRIPTION
## Motivation
The idea of this PR is to sort the parent entities data from their related elements in a Many to One relationship. As well as, with this is solution, it is possible to combine several sorts between Many to One relationships nested and One to Many relationships.

**What is new?**
- Creation of a `ObjectEntryMTo1RelationshipSortDSLQueryVisitor` implementation where all the logic to combine Many to One relationships is here.
- Update base `addLeftJoin` method. This method is very useful in order to create the `LEFT JOIN` query, however we have to take care in which table is located the relationship field.
- Add tests cases: 
1. Test case for Many to One relationship with `depthSort >=1`. It also test Custom Fields and System Fields.
2. Test case combining Many to One and One to Many relationship.

**JIRA Related Ticket**
https://liferay.atlassian.net/browse/LPD-24078