### PR TITLE
LPD-25201 Transform the scope alias from the CX to an existing one (ignoring case) if the original does not exist and there is an existing one that matches ignoring cases

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/configuration/OAuth2ProviderApplicationHeadlessServerConfigurationFactory.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/configuration/OAuth2ProviderApplicationHeadlessServerConfigurationFactory.java
@@ -9,8 +9,10 @@ import com.liferay.oauth2.provider.configuration.OAuth2ProviderApplicationHeadle
 import com.liferay.oauth2.provider.constants.ClientProfile;
 import com.liferay.oauth2.provider.constants.GrantType;
 import com.liferay.oauth2.provider.model.OAuth2Application;
+import com.liferay.oauth2.provider.scope.liferay.ScopeLocator;
 import com.liferay.oauth2.provider.util.OAuth2SecureRandomGenerator;
 import com.liferay.osgi.util.configuration.ConfigurationFactoryUtil;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.petra.string.StringUtil;
@@ -25,6 +27,7 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.util.PropsValues;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -33,6 +36,7 @@ import java.util.Objects;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Raymond Augé
@@ -64,9 +68,25 @@ public class OAuth2ProviderApplicationHeadlessServerConfigurationFactory
 							OAuth2ProviderApplicationHeadlessServerConfiguration.class,
 							properties);
 
-				List<String> scopeAliasesList = ListUtil.fromArray(
+				Collection<String> scopeAliases = _scopeLocator.getScopeAliases(
+					companyId);
+
+				List<String> scopeAliasesList = TransformUtil.transformToList(
 					oAuth2ProviderApplicationHeadlessServerConfiguration.
-						scopes());
+						scopes(),
+					scopeAlias -> {
+						if (!scopeAliases.contains(scopeAlias)) {
+							for (String curScopeAlias : scopeAliases) {
+								if (StringUtil.equalsIgnoreCase(
+										curScopeAlias, scopeAlias)) {
+
+									return curScopeAlias;
+								}
+							}
+						}
+
+						return scopeAlias;
+					});
 
 				oAuth2Application = _addOrUpdateOAuth2Application(
 					companyId, externalReferenceCode,
@@ -230,5 +250,8 @@ public class OAuth2ProviderApplicationHeadlessServerConfigurationFactory
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		OAuth2ProviderApplicationHeadlessServerConfigurationFactory.class);
+
+	@Reference
+	private ScopeLocator _scopeLocator;
 
 }


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPD-25201

---

The purpose of this ticket is to support the Client Extensions that creates an OAuth2 application in the following situation:

- If there is an existing scope alias that is equal to a given in the CX but ignoring case.

So, for example, given the existing scope alias: `c_student.everything` and the scope alias in the Client Extension: `C_Student.everything`, as that scope does not exist in Liferay but there is an existing one that is equals ignoring case, the one that will be set is the existing one `c_student.everything`.