### PR TITLE
LPD-25627 | Show Object name instead of Table name for elements in data migration center

### DIFF
--- a/modules/apps/batch-engine/batch-engine-test/src/testFunctional/tests/ExportEntitiesOfJsontIncludeAction.testcase
+++ b/modules/apps/batch-engine/batch-engine-test/src/testFunctional/tests/ExportEntitiesOfJsontIncludeAction.testcase
@@ -26,8 +26,8 @@ definition {
 				fieldValue = "Stock Entry");
 		}
 
-		task ("When in Import/Export: Export File exporting Entity Type C_Stock (v1_0 - Liferay Object REST) in Export File Format: JSONT") {
-			ImportExport.exportEntityWithAllFieldsInJsontFormat(entityType = "C_Stock (v1_0 - Liferay Object REST)");
+		task ("When in Import/Export: Export File exporting Entity Type Stock (v1.0 - Liferay Object REST) in Export File Format: JSONT") {
+			ImportExport.exportEntityWithAllFieldsInJsontFormat(entityType = "Stock (v1.0 - Liferay Object REST)");
 		}
 	}
 

--- a/modules/apps/batch-engine/batch-engine-test/src/testFunctional/tests/ExportOfJsontIncludeConfigurationObject.testcase
+++ b/modules/apps/batch-engine/batch-engine-test/src/testFunctional/tests/ExportOfJsontIncludeConfigurationObject.testcase
@@ -28,7 +28,7 @@ definition {
 	@priority = 3
 	test JSONTConfigurationObjectContainsCallbackURL {
 		task ("When in Import/Export: exporting DSEnvelope Entity type with JSONT format with all fields to include selected") {
-			ImportExport.exportEntityWithAllFieldsInJsontFormat(entityType = "BlogPosting (v1_0 - Liferay Headless Delivery)");
+			ImportExport.exportEntityWithAllFieldsInJsontFormat(entityType = "BlogPosting (v1.0 - Liferay Headless Delivery)");
 		}
 
 		task ("And When I download generated file") {
@@ -54,7 +54,7 @@ definition {
 				name = "Stock",
 				requiredStringFieldName = "name");
 
-			ImportExport.exportEntityWithAllFieldsInJsontFormat(entityType = "C_Stock (v1_0 - Liferay Object REST)");
+			ImportExport.exportEntityWithAllFieldsInJsontFormat(entityType = "Stock (v1.0 - Liferay Object REST)");
 		}
 
 		task ("And When I download generated file") {
@@ -74,7 +74,7 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("When in Import/Export: exporting Blog Posting Entity type with JSONT format with all fields to include selected") {
-			ImportExport.exportEntityWithAllFieldsInJsontFormat(entityType = "BlogPosting (v1_0 - Liferay Headless Delivery)");
+			ImportExport.exportEntityWithAllFieldsInJsontFormat(entityType = "BlogPosting (v1.0 - Liferay Headless Delivery)");
 		}
 
 		task ("And When I download generated file") {
@@ -96,7 +96,7 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("When in Import/Export: exporting NotificationTemplate Entity type with JSONT format with all fields to include selected") {
-			ImportExport.exportEntityWithAllFieldsInJsontFormat(entityType = "NotificationTemplate (v1_0 - Liferay Notification REST)");
+			ImportExport.exportEntityWithAllFieldsInJsontFormat(entityType = "NotificationTemplate (v1.0 - Liferay Notification REST)");
 		}
 
 		task ("And When I download generated file") {
@@ -116,7 +116,7 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("When in Import/Export: exporting Role (Headless Admin) Entity type with JSONT format with all fields to include selected") {
-			ImportExport.exportEntityWithAllFieldsInJsontFormat(entityType = "Role (v1_0 - Liferay Headless Admin User)");
+			ImportExport.exportEntityWithAllFieldsInJsontFormat(entityType = "Role (v1.0 - Liferay Headless Admin User)");
 		}
 
 		task ("And When I download generated file") {
@@ -140,7 +140,7 @@ definition {
 				name = "Stock",
 				requiredStringFieldName = "name");
 
-			ImportExport.exportEntityWithAllFieldsInJsontFormat(entityType = "C_Stock (v1_0 - Liferay Object REST)");
+			ImportExport.exportEntityWithAllFieldsInJsontFormat(entityType = "Stock (v1.0 - Liferay Object REST)");
 		}
 
 		task ("And When I download generated file") {
@@ -160,7 +160,7 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("When in Import/Export: exporting UserGroup Entity type with JSONT format with all fields to include selected") {
-			ImportExport.exportEntityWithAllFieldsInJsontFormat(entityType = "UserGroup (v1_0 - Liferay Headless Admin User)");
+			ImportExport.exportEntityWithAllFieldsInJsontFormat(entityType = "UserGroup (v1.0 - Liferay Headless Admin User)");
 		}
 
 		task ("And When I download generated file") {
@@ -180,7 +180,7 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("When in Import/Export: exporting Admin User Entity type with JSONT format with all fields to include selected") {
-			ImportExport.exportEntityWithAllFieldsInJsontFormat(entityType = "Account (v1_0 - Liferay Headless Admin User)");
+			ImportExport.exportEntityWithAllFieldsInJsontFormat(entityType = "Account (v1.0 - Liferay Headless Admin User)");
 		}
 
 		task ("And When I download generated file") {
@@ -200,7 +200,7 @@ definition {
 	@priority = 3
 	test JSONTConfigurationObjectContainsVersion {
 		task ("When in Import/Export: exporting Catalog Commerce Entity type with JSONT format with all fields to include selected") {
-			ImportExport.exportEntityWithAllFieldsInJsontFormat(entityType = "Catalog (v1_0 - Liferay Headless Commerce Admin Catalog)");
+			ImportExport.exportEntityWithAllFieldsInJsontFormat(entityType = "Catalog (v1.0 - Liferay Headless Commerce Admin Catalog)");
 		}
 
 		task ("And When I download generated file") {

--- a/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/EnableOnlySupportedFieldTypesForCSVExportViaUI.testcase
+++ b/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/EnableOnlySupportedFieldTypesForCSVExportViaUI.testcase
@@ -54,7 +54,7 @@ definition {
 
 		task ("When selecting custom object entity type with CSV format") {
 			ImportExport.configureExport(
-				entityType = "C_Test (v1_0 - Liferay Object REST)",
+				entityType = "Test (v1.0 - Liferay Object REST)",
 				exportFileFormat = "CSV");
 		}
 
@@ -77,7 +77,7 @@ definition {
 
 		task ("And Given selecting custom object entity type with CSV format") {
 			ImportExport.configureExport(
-				entityType = "C_Test (v1_0 - Liferay Object REST)",
+				entityType = "Test (v1.0 - Liferay Object REST)",
 				exportFileFormat = "CSV");
 		}
 
@@ -102,7 +102,7 @@ definition {
 
 		task ("When selecting custom object entity type with CSV format") {
 			ImportExport.configureExport(
-				entityType = "C_Test (v1_0 - Liferay Object REST)",
+				entityType = "Test (v1.0 - Liferay Object REST)",
 				exportFileFormat = "CSV");
 		}
 

--- a/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/ExportObjectDefinitions.testcase
+++ b/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/ExportObjectDefinitions.testcase
@@ -37,7 +37,7 @@ definition {
 
 		task ("When I export ObjectDefinition to a JSON format file in Import/Export center") {
 			ImportExport.exportAndUnzipFile(
-				entityType = "ObjectDefinition (v1_0 - Liferay Object Admin REST)",
+				entityType = "ObjectDefinition (v1.0 - Liferay Object Admin REST)",
 				exportFields = "active,label,name",
 				exportFileFormat = "JSON");
 		}
@@ -66,7 +66,7 @@ definition {
 
 		task ("When I export ObjectDefinition to a JSONL format file in Import/Export center") {
 			ImportExport.exportAndUnzipFile(
-				entityType = "ObjectDefinition (v1_0 - Liferay Object Admin REST)",
+				entityType = "ObjectDefinition (v1.0 - Liferay Object Admin REST)",
 				exportFields = "name",
 				exportFileFormat = "JSONL");
 		}
@@ -87,7 +87,7 @@ definition {
 
 		task ("When I export ObjectDefinition to a JSON format file in Import/Export center") {
 			ImportExport.exportAndUnzipFile(
-				entityType = "ObjectDefinition (v1_0 - Liferay Object Admin REST)",
+				entityType = "ObjectDefinition (v1.0 - Liferay Object Admin REST)",
 				exportFileFormat = "JSON");
 		}
 
@@ -115,7 +115,7 @@ definition {
 
 		task ("When I export ObjectDefinition with only objectFields mapped to a JSONT format file in Import/Export center") {
 			ImportExport.exportAndUnzipFile(
-				entityType = "ObjectDefinition (v1_0 - Liferay Object Admin REST)",
+				entityType = "ObjectDefinition (v1.0 - Liferay Object Admin REST)",
 				exportFields = "objectFields",
 				exportFileFormat = "JSONT");
 		}
@@ -137,7 +137,7 @@ definition {
 	test CanSeeExportFileDialog {
 		task ("When export ObjectDefinition to a JSON format file in Import/Export center") {
 			ImportExport.exportAndUnzipFile(
-				entityType = "ObjectDefinition (v1_0 - Liferay Object Admin REST)",
+				entityType = "ObjectDefinition (v1.0 - Liferay Object Admin REST)",
 				exportFileFormat = "JSON");
 		}
 

--- a/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/HideOptionsForEntitiesInImportAndExport.testcase
+++ b/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/HideOptionsForEntitiesInImportAndExport.testcase
@@ -31,7 +31,7 @@ definition {
 		task ("When I select OrderItem entity type to import") {
 			ImportExport.gotoImport();
 
-			ImportExport.selectEntity(entityType = "OrderItem (v1_0 - Liferay Headless Commerce Admin Order)");
+			ImportExport.selectEntity(entityType = "OrderItem (v1.0 - Liferay Headless Commerce Admin Order)");
 		}
 
 		task ("Then the available Import Strategy is Add or Update Records") {
@@ -55,13 +55,13 @@ definition {
 
 		task ("Then the available Import Strategy is Only Add New Records for BlogPostingImage,DispatchTrigger") {
 			ImportExport.assertStrategiesForEntityTypes(
-				entityTypes = "BlogPostingImage (v1_0 - Liferay Headless Delivery),DispatchTrigger (v1_0 - Liferay Dispatch REST)",
+				entityTypes = "BlogPostingImage (v1.0 - Liferay Headless Delivery),DispatchTrigger (v1.0 - Liferay Dispatch REST)",
 				importStrategy = "Only Add New Records");
 		}
 
 		task ("And Then the available Update Strategy is empty for BlogPostingImage,DispatchTrigger") {
 			ImportExport.assertStrategiesForEntityTypes(
-				entityTypes = "BlogPostingImage (v1_0 - Liferay Headless Delivery),DispatchTrigger (v1_0 - Liferay Dispatch REST)",
+				entityTypes = "BlogPostingImage (v1.0 - Liferay Headless Delivery),DispatchTrigger (v1.0 - Liferay Dispatch REST)",
 				updateStrategy = "");
 		}
 	}
@@ -74,13 +74,13 @@ definition {
 
 		task ("Then the available Import Strategy is Only Add New Records for Comment,keyword, WorkflowDefinition") {
 			ImportExport.assertStrategiesForEntityTypes(
-				entityTypes = "Comment (v1_0 - Liferay Headless Delivery),Keyword (v1_0 - Liferay Headless Admin Taxonomy),WorkflowDefinition (v1_0 - Liferay Headless Admin Workflow)",
+				entityTypes = "Comment (v1.0 - Liferay Headless Delivery),Keyword (v1.0 - Liferay Headless Admin Taxonomy),WorkflowDefinition (v1.0 - Liferay Headless Admin Workflow)",
 				importStrategy = "Only Add New Records");
 		}
 
 		task ("And Then the available Update Strategy is Overwrite Records for Comment,keyword, WorkflowDefinition") {
 			ImportExport.assertStrategiesForEntityTypes(
-				entityTypes = "Comment (v1_0 - Liferay Headless Delivery),Keyword (v1_0 - Liferay Headless Admin Taxonomy),WorkflowDefinition (v1_0 - Liferay Headless Admin Workflow)",
+				entityTypes = "Comment (v1.0 - Liferay Headless Delivery),Keyword (v1.0 - Liferay Headless Admin Taxonomy),WorkflowDefinition (v1.0 - Liferay Headless Admin Workflow)",
 				updateStrategy = "Overwrite Records");
 		}
 	}
@@ -93,13 +93,13 @@ definition {
 
 		task ("Then the available Import Strategy is Only Add New Records for ObjectAction,DocumentFolder") {
 			ImportExport.assertStrategiesForEntityTypes(
-				entityTypes = "ObjectAction (v1_0 - Liferay Object Admin REST),DocumentFolder (v1_0 - Liferay Headless Delivery)",
+				entityTypes = "ObjectAction (v1.0 - Liferay Object Admin REST),DocumentFolder (v1.0 - Liferay Headless Delivery)",
 				importStrategy = "Only Add New Records");
 		}
 
 		task ("And Then the available Update Strategy are Update Changed Record Fields/Overwrite Records for ObjectAction,DocumentFolder") {
 			ImportExport.assertStrategiesForEntityTypes(
-				entityTypes = "ObjectAction (v1_0 - Liferay Object Admin REST),DocumentFolder (v1_0 - Liferay Headless Delivery)",
+				entityTypes = "ObjectAction (v1.0 - Liferay Object Admin REST),DocumentFolder (v1.0 - Liferay Headless Delivery)",
 				updateStrategy = "Update Changed Record Fields Overwrite Records");
 		}
 	}
@@ -112,13 +112,13 @@ definition {
 
 		task ("Then the available Import Strategy is Only Add New Records for CommerceAccount,Catalog") {
 			ImportExport.assertStrategiesForEntityTypes(
-				entityTypes = "Account (v1_0 - Liferay Headless Commerce Admin Account),Catalog (v1_0 - Liferay Headless Commerce Admin Catalog)",
+				entityTypes = "Account (v1.0 - Liferay Headless Commerce Admin Account),Catalog (v1.0 - Liferay Headless Commerce Admin Catalog)",
 				importStrategy = "Only Add New Records");
 		}
 
 		task ("And Then the available Update Strategy is empty for CommerceAccount,Catalog") {
 			ImportExport.assertStrategiesForEntityTypes(
-				entityTypes = "Account (v1_0 - Liferay Headless Commerce Admin Account),Catalog (v1_0 - Liferay Headless Commerce Admin Catalog)",
+				entityTypes = "Account (v1.0 - Liferay Headless Commerce Admin Account),Catalog (v1.0 - Liferay Headless Commerce Admin Catalog)",
 				updateStrategy = "Update Changed Record Fields");
 		}
 	}
@@ -143,13 +143,13 @@ definition {
 
 		task ("Then the available Import Strategy are Add or Update Records/Only Add New Records for Account,blogPosting,StructuredContent,ObjectDefinition,C_Student") {
 			ImportExport.assertStrategiesForEntityTypes(
-				entityTypes = "Account (v1_0 - Liferay Headless Admin User), BlogPosting (v1_0 - Liferay Headless Delivery), StructuredContent (v1_0 - Liferay Headless Delivery),ObjectDefinition (v1_0 - Liferay Object Admin REST), C_Student (v1_0 - Liferay Object REST)",
+				entityTypes = "Account (v1.0 - Liferay Headless Admin User), BlogPosting (v1.0 - Liferay Headless Delivery), StructuredContent (v1.0 - Liferay Headless Delivery),ObjectDefinition (v1.0 - Liferay Object Admin REST), Student (v1.0 - Liferay Object REST)",
 				importStrategy = "Only Add New Records Add or Update Records");
 		}
 
 		task ("And Then the available Update Strategy are Update Changed Record Fields/Overwrite Records for Account,blogPosting,StructuredContent,ObjectDefinition,C_Student") {
 			ImportExport.assertStrategiesForEntityTypes(
-				entityTypes = "Account (v1_0 - Liferay Headless Admin User), BlogPosting (v1_0 - Liferay Headless Delivery), StructuredContent (v1_0 - Liferay Headless Delivery),ObjectDefinition (v1_0 - Liferay Object Admin REST), C_Student (v1_0 - Liferay Object REST)",
+				entityTypes = "Account (v1.0 - Liferay Headless Admin User), BlogPosting (v1.0 - Liferay Headless Delivery), StructuredContent (v1.0 - Liferay Headless Delivery),ObjectDefinition (v1.0 - Liferay Object Admin REST), Student (v1.0 - Liferay Object REST)",
 				updateStrategy = "Update Changed Record Fields Overwrite Records");
 		}
 	}
@@ -159,7 +159,7 @@ definition {
 		task ("When I select Shipment as the entity type to import") {
 			ImportExport.gotoImport();
 
-			ImportExport.selectEntity(entityType = "Shipment (v1_0 - Liferay Headless Commerce Admin Shipment)");
+			ImportExport.selectEntity(entityType = "Shipment (v1.0 - Liferay Headless Commerce Admin Shipment)");
 		}
 
 		task ("Then the available Import Strategy are Add or Update Reconds/Only Add New Records") {
@@ -183,7 +183,7 @@ definition {
 			ImportExport.gotoExport();
 
 			ImportExport.configureExport(
-				entityType = "BlogPosting (v1_0 - Liferay Headless Delivery)",
+				entityType = "BlogPosting (v1.0 - Liferay Headless Delivery)",
 				exportFileFormat = "JSONL");
 		}
 
@@ -202,7 +202,7 @@ definition {
 			ImportExport.gotoExport();
 
 			ImportExport.configureExport(
-				entityType = "ObjectDefinition (v1_0 - Liferay Object Admin REST)",
+				entityType = "ObjectDefinition (v1.0 - Liferay Object Admin REST)",
 				exportFileFormat = "JSONT");
 		}
 
@@ -221,7 +221,7 @@ definition {
 			ImportExport.gotoExport();
 
 			ImportExport.configureExport(
-				entityType = "Account (v1_0 - Liferay Headless Admin User)",
+				entityType = "Account (v1.0 - Liferay Headless Admin User)",
 				exportFileFormat = "JSONT");
 		}
 

--- a/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/ImportAndExportObjects.testcase
+++ b/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/ImportAndExportObjects.testcase
@@ -41,7 +41,7 @@ definition {
 
 			ImportExport.gotoImport();
 
-			ImportExport.selectEntity(entityType = "C_Student (v1_0 - Liferay Object REST)");
+			ImportExport.selectEntity(entityType = "Student (v1.0 - Liferay Object REST)");
 		}
 
 		task ("When I download a sample file of this entity") {
@@ -105,7 +105,7 @@ definition {
 
 		task ("When user export custom object as entity type") {
 			ImportExport.exportAndUnzipFile(
-				entityType = "C_Subject (v1_0 - Liferay Object REST)",
+				entityType = "Subject (v1.0 - Liferay Object REST)",
 				exportFields = "Attribute Code",
 				exportFileFormat = "JSON");
 		}
@@ -164,7 +164,7 @@ definition {
 
 		task ("When user export custom object as entity type") {
 			ImportExport.exportAndUnzipFile(
-				entityType = "C_Student (v1_0 - Liferay Object REST)",
+				entityType = "Student (v1.0 - Liferay Object REST)",
 				exportFields = "Attribute Code",
 				exportFileFormat = "JSON");
 		}
@@ -197,7 +197,7 @@ definition {
 
 		task ("When user export custom object as entity type and map attribute codes") {
 			ImportExport.exportAndUnzipFile(
-				entityType = "C_Student (v1_0 - Liferay Object REST)",
+				entityType = "Student (v1.0 - Liferay Object REST)",
 				exportFields = "Attribute Code",
 				exportFileFormat = "JSON");
 		}
@@ -222,7 +222,7 @@ definition {
 
 		task ("When user export custom object with all attribute codes selected") {
 			ImportExport.exportAndUnzipFile(
-				entityType = "C_Student (v1_0 - Liferay Object REST)",
+				entityType = "Student (v1.0 - Liferay Object REST)",
 				exportFields = "Attribute Code",
 				exportFileFormat = "JSON");
 		}
@@ -254,7 +254,7 @@ definition {
 
 		task ("When save as template with a template name") {
 			ImportExport.configureExport(
-				entityType = "C_Student (v1_0 - Liferay Object REST)",
+				entityType = "Student (v1.0 - Liferay Object REST)",
 				exportFields = "Attribute Code",
 				exportFileFormat = "JSON");
 
@@ -282,7 +282,7 @@ definition {
 				requiredStringFieldName = "name");
 
 			ImportExport.importFile(
-				entityType = "C_Student (v1_0 - Liferay Object REST)",
+				entityType = "Student (v1.0 - Liferay Object REST)",
 				fieldMappings = "name:Student Name,externalReferenceCode:External Reference Code",
 				fileName = "csv_student_import.csv",
 				noImport = "true");
@@ -318,7 +318,7 @@ definition {
 
 			ImportExport.gotoExport();
 
-			ImportExport.selectEntity(entityType = "C_Student (v1_0 - Liferay Object REST)");
+			ImportExport.selectEntity(entityType = "Student (v1.0 - Liferay Object REST)");
 		}
 
 		task ("Then no error in server console") {

--- a/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/ImportEntitiesWithPartiallyUpdate.testcase
+++ b/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/ImportEntitiesWithPartiallyUpdate.testcase
@@ -45,7 +45,7 @@ definition {
 			var siteName = TestCase.getSiteName();
 
 			ImportExport.configureImport(
-				entityType = "BlogPosting (v1_0 - Liferay Headless Delivery)",
+				entityType = "BlogPosting (v1.0 - Liferay Headless Delivery)",
 				fieldMappings = "articleBody:articleBody,headline:headline,externalReferenceCode:externalReferenceCode",
 				fileName = "json_blogPosting_import.json",
 				importStrategy = "Only Add New Records",
@@ -92,7 +92,7 @@ definition {
 
 		task ("And Given Add or Update records with Update Changed Record Fields selectd include uploading valid JSON file with 3 accounts including existing one with only required fields") {
 			ImportExport.configureImport(
-				entityType = "Account (v1_0 - Liferay Headless Admin User)",
+				entityType = "Account (v1.0 - Liferay Headless Admin User)",
 				fieldMappings = "name:name,type:type,externalReferenceCode:externalReferenceCode",
 				fileName = "json_account_import.json",
 				importStrategy = "Add or Update Records",
@@ -141,7 +141,7 @@ definition {
 
 		task ("And Given Add or Update records and Overwrite Records by default selected with uploading valid JSON file with 2 accounts including existing one with only required fields") {
 			ImportExport.configureImport(
-				entityType = "Account (v1_0 - Liferay Headless Admin User)",
+				entityType = "Account (v1.0 - Liferay Headless Admin User)",
 				fieldMappings = "name:name,externalReferenceCode:externalReferenceCode",
 				fileName = "json_account_import_name_only.json",
 				importStrategy = "Add or Update Records",

--- a/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/ImportExport.testcase
+++ b/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/ImportExport.testcase
@@ -30,7 +30,7 @@ definition {
 
 		task ("Given a completed import") {
 			ImportExport.importFile(
-				entityType = "Account (v1_0 - Liferay Headless Admin User)",
+				entityType = "Account (v1.0 - Liferay Headless Admin User)",
 				fieldMappings = "name:Account Name,type:Account Type,description:Account Description,externalReferenceCode:External Reference Code",
 				fileName = "csv_account_import.csv");
 		}
@@ -72,7 +72,7 @@ definition {
 		}
 
 		task ("When the user selects an entity and clicks on the Download a Sample File for This Entity button") {
-			ImportExport.selectEntity(entityType = "ObjectDefinition (v1_0 - Liferay Object Admin REST)");
+			ImportExport.selectEntity(entityType = "ObjectDefinition (v1.0 - Liferay Object Admin REST)");
 
 			Click.clickAt(locator1 = "ImportExport#SAMPLE_FILE_DOWNLOAD_BUTTON");
 		}
@@ -110,7 +110,7 @@ definition {
 
 		task ("When the user selects specific channel fields for export and exports the channels in CSV format") {
 			ImportExport.exportAndUnzipFile(
-				entityType = "Channel (v1_0 - Liferay Headless Commerce Admin Channel)",
+				entityType = "Channel (v1.0 - Liferay Headless Commerce Admin Channel)",
 				exportFields = "name,type,currencyCode",
 				exportFileFormat = "CSV");
 		}
@@ -135,7 +135,7 @@ definition {
 
 			UploadDependencyFile.uploadFile(fileName = "csv_account_import.csv");
 
-			ImportExport.selectEntity(entityType = "Account (v1_0 - Liferay Headless Admin User)");
+			ImportExport.selectEntity(entityType = "Account (v1.0 - Liferay Headless Admin User)");
 		}
 
 		task ("When the user maps only specific fields and imports the file") {
@@ -203,7 +203,7 @@ definition {
 
 		task ("When the user selects CSV as Export File Format and exports the accounts") {
 			ImportExport.exportAndUnzipFile(
-				entityType = "Account (v1_0 - Liferay Headless Admin User)",
+				entityType = "Account (v1.0 - Liferay Headless Admin User)",
 				exportFields = "name,type,description,externalReferenceCode",
 				exportFileFormat = "CSV");
 		}
@@ -244,7 +244,7 @@ definition {
 		task ("When the user exports the accounts in CSV format with Contains Headers not checked") {
 			ImportExport.exportAndUnzipFile(
 				containsHeaders = "false",
-				entityType = "Account (v1_0 - Liferay Headless Admin User)",
+				entityType = "Account (v1.0 - Liferay Headless Admin User)",
 				exportFields = "name,type,description,externalReferenceCode",
 				exportFileFormat = "CSV");
 		}
@@ -263,11 +263,11 @@ definition {
 
 		task ("Given Object Definition import and export") {
 			ImportExport.importFile(
-				entityType = "ObjectDefinition (v1_0 - Liferay Object Admin REST)",
+				entityType = "ObjectDefinition (v1.0 - Liferay Object Admin REST)",
 				fileName = "json_objectDefinition_import_approved.json");
 
 			ImportExport.exportAndUnzipFile(
-				entityType = "ObjectDefinition (v1_0 - Liferay Object Admin REST)",
+				entityType = "ObjectDefinition (v1.0 - Liferay Object Admin REST)",
 				exportFileFormat = "JSON");
 		}
 
@@ -303,7 +303,7 @@ definition {
 			ImportExport.gotoImport();
 
 			ImportExport.configureImport(
-				entityType = "ObjectDefinition (v1_0 - Liferay Object Admin REST)",
+				entityType = "ObjectDefinition (v1.0 - Liferay Object Admin REST)",
 				fileName = "objectDefinition_import.json",
 				templateName = "Test Object Definition Import Template");
 
@@ -312,7 +312,7 @@ definition {
 			ImportExport.gotoExport();
 
 			ImportExport.configureExport(
-				entityType = "ObjectDefinition (v1_0 - Liferay Object Admin REST)",
+				entityType = "ObjectDefinition (v1.0 - Liferay Object Admin REST)",
 				exportFileFormat = "JSON",
 				templateName = "Test Object Definition Export Template");
 		}
@@ -344,7 +344,7 @@ definition {
 			ImportExport.gotoImport();
 
 			ImportExport.configureImport(
-				entityType = "Account (v1_0 - Liferay Headless Admin User)",
+				entityType = "Account (v1.0 - Liferay Headless Admin User)",
 				fieldMappings = "name:Account Name,type:Account Type,description:Account Description,externalReferenceCode:External Reference Code",
 				fileName = "csv_account_import.csv");
 		}
@@ -403,7 +403,7 @@ definition {
 				checkboxName = "Headers",
 				locator1 = "Checkbox#ANY_CHECKBOX");
 
-			ImportExport.selectEntity(entityType = "Account (v1_0 - Liferay Headless Admin User)");
+			ImportExport.selectEntity(entityType = "Account (v1.0 - Liferay Headless Admin User)");
 		}
 
 		task ("Then the user should be able to map account fields to columns in the CSV file") {
@@ -456,7 +456,7 @@ definition {
 		}
 
 		task ("When import objectDefinition with an existing json file in which status is approved") {
-			ImportExport.selectEntity(entityType = "ObjectDefinition (v1_0 - Liferay Object Admin REST)");
+			ImportExport.selectEntity(entityType = "ObjectDefinition (v1.0 - Liferay Object Admin REST)");
 
 			UploadDependencyFile.uploadFile(fileName = "json_objectDefinition_import_approved.json");
 
@@ -497,7 +497,7 @@ definition {
 		}
 
 		task ("When import objectDefinition with an existing json file in which the status is draft") {
-			ImportExport.selectEntity(entityType = "ObjectDefinition (v1_0 - Liferay Object Admin REST)");
+			ImportExport.selectEntity(entityType = "ObjectDefinition (v1.0 - Liferay Object Admin REST)");
 
 			UploadDependencyFile.uploadFile(fileName = "json_objectDefinition_import_draft.json");
 
@@ -534,11 +534,11 @@ definition {
 
 		task ("Given Object Definition import and export") {
 			ImportExport.importFile(
-				entityType = "ObjectDefinition (v1_0 - Liferay Object Admin REST)",
+				entityType = "ObjectDefinition (v1.0 - Liferay Object Admin REST)",
 				fileName = "json_objectDefinition_import_approved.json");
 
 			ImportExport.exportAndUnzipFile(
-				entityType = "ObjectDefinition (v1_0 - Liferay Object Admin REST)",
+				entityType = "ObjectDefinition (v1.0 - Liferay Object Admin REST)",
 				exportFileFormat = "JSON");
 		}
 
@@ -586,7 +586,7 @@ definition {
 			ImportExport.gotoExport();
 
 			ImportExport.configureExport(
-				entityType = "ObjectDefinition (v1_0 - Liferay Object Admin REST)",
+				entityType = "ObjectDefinition (v1.0 - Liferay Object Admin REST)",
 				exportFields = "name,objectFields,active,externalReferenceCode",
 				exportFileFormat = "JSON",
 				templateName = "Test Object Definition Export Template");
@@ -605,7 +605,7 @@ definition {
 
 		task ("Then the export should be configured according to the template") {
 			ImportExport.assertExportTemplate(
-				entityType = "ObjectDefinition (v1_0 - Liferay Object Admin REST)",
+				entityType = "ObjectDefinition (v1.0 - Liferay Object Admin REST)",
 				exportFields = "name,objectFields,active,externalReferenceCode",
 				exportFileFormat = "JSON",
 				templateName = "Test Object Definition Export Template");
@@ -623,7 +623,7 @@ definition {
 			ImportExport.gotoImport();
 
 			ImportExport.configureImport(
-				entityType = "ObjectDefinition (v1_0 - Liferay Object Admin REST)",
+				entityType = "ObjectDefinition (v1.0 - Liferay Object Admin REST)",
 				fileName = "objectDefinition_import.json",
 				templateName = "Test Object Definition Import Template");
 		}
@@ -641,7 +641,7 @@ definition {
 
 		task ("Then the import should be configured according to the template") {
 			ImportExport.assertImportTemplate(
-				entityType = "ObjectDefinition (v1_0 - Liferay Object Admin REST)",
+				entityType = "ObjectDefinition (v1.0 - Liferay Object Admin REST)",
 				templateName = "Test Object Definition Import Template");
 		}
 	}
@@ -657,7 +657,7 @@ definition {
 			ImportExport.gotoExport();
 
 			ImportExport.configureExport(
-				entityType = "ObjectDefinition (v1_0 - Liferay Object Admin REST)",
+				entityType = "ObjectDefinition (v1.0 - Liferay Object Admin REST)",
 				exportFields = "name,objectFields,active,externalReferenceCode",
 				exportFileFormat = "JSON");
 		}
@@ -686,7 +686,7 @@ definition {
 			ImportExport.gotoImport();
 
 			ImportExport.configureImport(
-				entityType = "ObjectDefinition (v1_0 - Liferay Object Admin REST)",
+				entityType = "ObjectDefinition (v1.0 - Liferay Object Admin REST)",
 				fileName = "objectDefinition_import.json");
 		}
 
@@ -712,7 +712,7 @@ definition {
 			ImportExport.gotoImport();
 
 			ImportExport.configureImport(
-				entityType = "ObjectDefinition (v1_0 - Liferay Object Admin REST)",
+				entityType = "ObjectDefinition (v1.0 - Liferay Object Admin REST)",
 				fileName = "objectDefinition_import.json",
 				templateName = "Test Object Definition Import Template");
 		}
@@ -761,11 +761,11 @@ definition {
 	test CanSearchExecutions {
 		task ("Given object definition import and export") {
 			ImportExport.importFile(
-				entityType = "ObjectDefinition (v1_0 - Liferay Object Admin REST)",
+				entityType = "ObjectDefinition (v1.0 - Liferay Object Admin REST)",
 				fileName = "json_objectDefinition_import_approved.json");
 
 			ImportExport.exportAndUnzipFile(
-				entityType = "ObjectDefinition (v1_0 - Liferay Object Admin REST)",
+				entityType = "ObjectDefinition (v1.0 - Liferay Object Admin REST)",
 				exportFileFormat = "JSON");
 		}
 
@@ -819,7 +819,7 @@ definition {
 			ImportExport.gotoImport();
 
 			ImportExport.configureImport(
-				entityType = "ObjectDefinition (v1_0 - Liferay Object Admin REST)",
+				entityType = "ObjectDefinition (v1.0 - Liferay Object Admin REST)",
 				fileName = "objectDefinition_import.json",
 				templateName = "Test Object Definition Import Template");
 
@@ -828,7 +828,7 @@ definition {
 			ImportExport.gotoExport();
 
 			ImportExport.configureExport(
-				entityType = "ObjectDefinition (v1_0 - Liferay Object Admin REST)",
+				entityType = "ObjectDefinition (v1.0 - Liferay Object Admin REST)",
 				exportFields = "name,objectFields,active,externalReferenceCode",
 				exportFileFormat = "JSON",
 				templateName = "Test Object Definition Export Template");
@@ -892,7 +892,7 @@ definition {
 			ImportExport.gotoExport();
 
 			ImportExport.configureExport(
-				entityType = "ObjectDefinition (v1_0 - Liferay Object Admin REST)",
+				entityType = "ObjectDefinition (v1.0 - Liferay Object Admin REST)",
 				exportFields = "name,objectFields,active,externalReferenceCode",
 				exportFileFormat = "JSON",
 				templateName = "Test Account Export Template");
@@ -955,7 +955,7 @@ definition {
 			ImportExport.gotoExport();
 
 			ImportExport.configureExport(
-				entityType = "ObjectDefinition (v1_0 - Liferay Object Admin REST)",
+				entityType = "ObjectDefinition (v1.0 - Liferay Object Admin REST)",
 				exportFields = "",
 				exportFileFormat = "JSON");
 
@@ -1016,7 +1016,7 @@ definition {
 			ImportExport.gotoImport();
 
 			ImportExport.configureImport(
-				entityType = "Account (v1_0 - Liferay Headless Admin User)",
+				entityType = "Account (v1.0 - Liferay Headless Admin User)",
 				fieldMappings = "name:Account Name,type:Account Type,description:Account Description,externalReferenceCode:External Reference Code",
 				fileName = "csv_account_import_error.csv",
 				stopImportOnError = "true");
@@ -1063,7 +1063,7 @@ definition {
 			ImportExport.gotoImport();
 
 			ImportExport.configureImport(
-				entityType = "Account (v1_0 - Liferay Headless Admin User)",
+				entityType = "Account (v1.0 - Liferay Headless Admin User)",
 				fieldMappings = "name:Account Name,type:Account Type,description:Account Description,externalReferenceCode:External Reference Code",
 				fileName = "csv_account_import_error.csv",
 				stopImportOnError = "true");
@@ -1079,7 +1079,7 @@ definition {
 
 		task ("And given a succesful import") {
 			ImportExport.importFile(
-				entityType = "Account (v1_0 - Liferay Headless Admin User)",
+				entityType = "Account (v1.0 - Liferay Headless Admin User)",
 				fieldMappings = "name:Account Name,type:Account Type,description:Account Description,externalReferenceCode:External Reference Code",
 				fileName = "csv_account_import.csv");
 		}
@@ -1135,7 +1135,7 @@ definition {
 			ImportExport.gotoImport();
 
 			ImportExport.configureImport(
-				entityType = "Account (v1_0 - Liferay Headless Admin User)",
+				entityType = "Account (v1.0 - Liferay Headless Admin User)",
 				fieldMappings = "name:Account Name,type:Account Type,description:Account Description,externalReferenceCode:External Reference Code",
 				fileName = "csv_account_import_error.csv",
 				stopImportOnError = "true");
@@ -1191,7 +1191,7 @@ definition {
 		}
 
 		task ("When I select the entity type") {
-			ImportExport.selectEntity(entityType = "Account (v1_0 - Liferay Headless Admin User)");
+			ImportExport.selectEntity(entityType = "Account (v1.0 - Liferay Headless Admin User)");
 		}
 
 		task ("Then the fields are automatically mapped") {
@@ -1217,7 +1217,7 @@ definition {
 		}
 
 		task ("Then I can see all available entity types to export") {
-			ImportExport.assertAvailableEntityTypes(entityTypes = "ObjectDefinition (v1_0 - Liferay Object Admin REST)");
+			ImportExport.assertAvailableEntityTypes(entityTypes = "ObjectDefinition (v1.0 - Liferay Object Admin REST)");
 		}
 	}
 
@@ -1234,7 +1234,7 @@ definition {
 		}
 
 		task ("Then I can see all available entity types to import") {
-			ImportExport.assertAvailableEntityTypes(entityTypes = "ObjectDefinition (v1_0 - Liferay Object Admin REST)");
+			ImportExport.assertAvailableEntityTypes(entityTypes = "ObjectDefinition (v1.0 - Liferay Object Admin REST)");
 		}
 	}
 
@@ -1252,7 +1252,7 @@ definition {
 		}
 
 		task ("When I select the entity type") {
-			ImportExport.selectEntity(entityType = "ObjectDefinition (v1_0 - Liferay Object Admin REST)");
+			ImportExport.selectEntity(entityType = "ObjectDefinition (v1.0 - Liferay Object Admin REST)");
 		}
 
 		task ("Then the fields are automatically mapped") {
@@ -1274,7 +1274,7 @@ definition {
 		}
 
 		task ("When I select the entity type") {
-			ImportExport.selectEntity(entityType = "ObjectDefinition (v1_0 - Liferay Object Admin REST)");
+			ImportExport.selectEntity(entityType = "ObjectDefinition (v1.0 - Liferay Object Admin REST)");
 		}
 
 		task ("Then the fields are automatically mapped") {
@@ -1294,7 +1294,7 @@ definition {
 			ImportExport.gotoImport();
 
 			ImportExport.configureImport(
-				entityType = "Account (v1_0 - Liferay Headless Admin User)",
+				entityType = "Account (v1.0 - Liferay Headless Admin User)",
 				fieldMappings = "name:Account Name,type:Account Type,description:Account Description,externalReferenceCode:External Reference Code",
 				fileName = "csv_account_import_error.csv",
 				stopImportOnError = "true");
@@ -1336,7 +1336,7 @@ definition {
 
 			UploadDependencyFile.uploadFile(fileName = "csv_account_import.csv");
 
-			ImportExport.selectEntity(entityType = "Account (v1_0 - Liferay Headless Admin User)");
+			ImportExport.selectEntity(entityType = "Account (v1.0 - Liferay Headless Admin User)");
 		}
 
 		task ("When the user maps the import fields") {
@@ -1360,7 +1360,7 @@ definition {
 			ImportExport.gotoImport();
 
 			ImportExport.configureImport(
-				entityType = "Account (v1_0 - Liferay Headless Admin User)",
+				entityType = "Account (v1.0 - Liferay Headless Admin User)",
 				fieldMappings = "name:Account Name,type:Account Type,description:Account Description,externalReferenceCode:External Reference Code",
 				fileName = "csv_account_import.csv");
 		}
@@ -1394,7 +1394,7 @@ definition {
 
 		task ("Given a failed account import in which one of 3 rows was skipped due to an error in the second row") {
 			ImportExport.importFile(
-				entityType = "Account (v1_0 - Liferay Headless Admin User)",
+				entityType = "Account (v1.0 - Liferay Headless Admin User)",
 				fieldMappings = "name:Account Name,type:Account Type,description:Account Description,externalReferenceCode:External Reference Code",
 				fileName = "csv_account_import_error.csv",
 				stopImportOnError = "false");
@@ -1429,7 +1429,7 @@ definition {
 
 			UploadDependencyFile.uploadFile(fileName = "json_account_import.json");
 
-			ImportExport.selectEntity(entityType = "Account (v1_0 - Liferay Headless Admin User)");
+			ImportExport.selectEntity(entityType = "Account (v1.0 - Liferay Headless Admin User)");
 		}
 
 		task ("When the user maps the import fields") {
@@ -1453,7 +1453,7 @@ definition {
 			ImportExport.gotoImport();
 
 			ImportExport.configureImport(
-				entityType = "Channel (v1_0 - Liferay Headless Commerce Admin Channel)",
+				entityType = "Channel (v1.0 - Liferay Headless Commerce Admin Channel)",
 				fieldMappings = "currencyCode:currencyCode,name:name,type:type",
 				fileName = "json_channel_import.json");
 		}
@@ -1488,7 +1488,7 @@ definition {
 
 			UploadDependencyFile.uploadFile(fileName = "jsonl_account_import.jsonl");
 
-			ImportExport.selectEntity(entityType = "Account (v1_0 - Liferay Headless Admin User)");
+			ImportExport.selectEntity(entityType = "Account (v1.0 - Liferay Headless Admin User)");
 		}
 
 		task ("When the user maps the import fields") {
@@ -1512,7 +1512,7 @@ definition {
 			ImportExport.gotoImport();
 
 			ImportExport.configureImport(
-				entityType = "Channel (v1_0 - Liferay Headless Commerce Admin Channel)",
+				entityType = "Channel (v1.0 - Liferay Headless Commerce Admin Channel)",
 				fieldMappings = "currencyCode:currencyCode,name:name,type:type",
 				fileName = "jsonl_channel_import.jsonl");
 		}
@@ -1547,7 +1547,7 @@ definition {
 		}
 
 		task ("When the user selects the import entity") {
-			ImportExport.selectEntity(entityType = "Channel (v1_0 - Liferay Headless Commerce Admin Channel)");
+			ImportExport.selectEntity(entityType = "Channel (v1.0 - Liferay Headless Commerce Admin Channel)");
 		}
 
 		task ("Then the required and optional fields should be shown for that entity.") {

--- a/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/ImportObjectDefinitions.testcase
+++ b/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/ImportObjectDefinitions.testcase
@@ -40,7 +40,7 @@ definition {
 
 		task ("When I import the JSON file which contains the student object definition extended by a new field and a new object definition") {
 			ImportExport.importFile(
-				entityType = "ObjectDefinition (v1_0 - Liferay Object Admin REST)",
+				entityType = "ObjectDefinition (v1.0 - Liferay Object Admin REST)",
 				fileName = "multiple_objectDefinitions_import_create_update.json");
 		}
 
@@ -75,7 +75,7 @@ definition {
 
 		task ("When I import with select Only Add New Records in Import Strategy and uncheck Stop the Import on Error") {
 			ImportExport.importFile(
-				entityType = "ObjectDefinition (v1_0 - Liferay Object Admin REST)",
+				entityType = "ObjectDefinition (v1.0 - Liferay Object Admin REST)",
 				fileName = "multiple_objectDefinitions_import_create_update.json",
 				importStrategy = "Only Add New Records",
 				stopImportOnError = "false");
@@ -92,7 +92,7 @@ definition {
 
 		task ("When I use import/export center to import the object definition with JSONL file") {
 			ImportExport.importFile(
-				entityType = "ObjectDefinition (v1_0 - Liferay Object Admin REST)",
+				entityType = "ObjectDefinition (v1.0 - Liferay Object Admin REST)",
 				fileName = "student_objectDefinition_import_create.jsonl");
 		}
 
@@ -115,7 +115,7 @@ definition {
 
 		task ("And Given I export ObjectDefinition to a JSONL format file in Import/Export center") {
 			ImportExport.exportAndUnzipFile(
-				entityType = "ObjectDefinition (v1_0 - Liferay Object Admin REST)",
+				entityType = "ObjectDefinition (v1.0 - Liferay Object Admin REST)",
 				exportFields = "externalReferenceCode,label,name,objectFields,pluralLabel,scope,status",
 				exportFileFormat = "JSONL");
 		}
@@ -126,7 +126,7 @@ definition {
 
 		task ("When I import the exported student object with JSONL file") {
 			ImportExport.importFile(
-				entityType = "ObjectDefinition (v1_0 - Liferay Object Admin REST)",
+				entityType = "ObjectDefinition (v1.0 - Liferay Object Admin REST)",
 				tempFile = "export.jsonl");
 		}
 
@@ -141,7 +141,7 @@ definition {
 
 		task ("When importing the object definition with fields externalReferenceCode,name,label,pluralLabel,scope,status and custom text field in the JSON file") {
 			ImportExport.importFile(
-				entityType = "ObjectDefinition (v1_0 - Liferay Object Admin REST)",
+				entityType = "ObjectDefinition (v1.0 - Liferay Object Admin REST)",
 				fileName = "student_additional_objectDefinition_import_create.json",
 				noImport = "true");
 		}
@@ -167,7 +167,7 @@ definition {
 
 		task ("When I import a JSONL file with an additional custom field and unchecking Stop the Import on Error and choosing Only Add New Records as Import Strategy") {
 			ImportExport.importFile(
-				entityType = "ObjectDefinition (v1_0 - Liferay Object Admin REST)",
+				entityType = "ObjectDefinition (v1.0 - Liferay Object Admin REST)",
 				fileName = "student_additional_objectDefinition_import_create.jsonl",
 				importStrategy = "Only Add New Records",
 				stopImportOnError = "false");

--- a/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/SupportExportObjectEntriesAtInstancelevel.testcase
+++ b/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/SupportExportObjectEntriesAtInstancelevel.testcase
@@ -82,13 +82,13 @@ definition {
 	test ActionsNodeAreAvailableInDonwloadedFile {
 		property portal.acceptance = "true";
 
-		task ("And Given 'C_Student (v1_0 - Liferay Object REST)' as Entity Type in Data Migration Center --> Export File") {
-			ImportExport.selectEntity(entityType = "C_Student (v1_0 - Liferay Object REST)");
+		task ("And Given 'Student (v1.0 - Liferay Object REST)' as Entity Type in Data Migration Center --> Export File") {
+			ImportExport.selectEntity(entityType = "Student (v1.0 - Liferay Object REST)");
 		}
 
 		task ("When exporting file in JSONL format with all fields selected") {
 			ImportExport.configureExport(
-				entityType = "C_Student (v1_0 - Liferay Object REST)",
+				entityType = "Student (v1.0 - Liferay Object REST)",
 				exportFields = "Attribute Code",
 				exportFileFormat = "JSONL");
 
@@ -113,8 +113,8 @@ definition {
 		property custom.properties = "feature.flag.LPS-186620=true";
 		property portal.acceptance = "true";
 
-		task ("When 'Account (v1_0 - Liferay Headless Admin User)' as Entity Type in Data Migration Center --> Export File") {
-			ImportExport.selectEntity(entityType = "Account (v1_0 - Liferay Headless Admin User)");
+		task ("When 'Account (v1.0 - Liferay Headless Admin User)' as Entity Type in Data Migration Center --> Export File") {
+			ImportExport.selectEntity(entityType = "Account (v1.0 - Liferay Headless Admin User)");
 		}
 
 		task ("Then the list of fields to select contains all the fields available with GET request except the relationship nodes") {
@@ -132,9 +132,9 @@ definition {
 	test CanDownloadFiledWithAllFieldsSelected {
 		property portal.acceptance = "true";
 
-		task ("And Given 'C_Student (v1_0 - Liferay Object REST)' as Entity Type in Data Migration Center --> Export File") {
+		task ("And Given 'Student (v1.0 - Liferay Object REST)' as Entity Type in Data Migration Center --> Export File") {
 			ImportExport.configureExport(
-				entityType = "C_Student (v1_0 - Liferay Object REST)",
+				entityType = "Student (v1.0 - Liferay Object REST)",
 				exportFileFormat = "JSON");
 		}
 
@@ -177,13 +177,13 @@ definition {
 	test CanExportSpecificFieldsWithJSONTConfigurationNode {
 		property portal.acceptance = "true";
 
-		task ("And Given 'C_Student (v1_0 - Liferay Object REST)' as Entity Type in Data Migration Center --> Export File") {
-			ImportExport.selectEntity(entityType = "C_Student (v1_0 - Liferay Object REST)");
+		task ("And Given 'Student (v1.0 - Liferay Object REST)' as Entity Type in Data Migration Center --> Export File") {
+			ImportExport.selectEntity(entityType = "Student (v1.0 - Liferay Object REST)");
 		}
 
 		task ("When exporting file in JSONT format with field 'name' selected") {
 			ImportExport.configureExport(
-				entityType = "C_Student (v1_0 - Liferay Object REST)",
+				entityType = "Student (v1.0 - Liferay Object REST)",
 				exportFields = "name",
 				exportFileFormat = "JSONT");
 
@@ -217,13 +217,13 @@ definition {
 		property custom.properties = "feature.flag.LPS-186620=true";
 		property portal.acceptance = "true";
 
-		task ("And Given 'Account (v1_0 - Liferay Headless Admin User)' as Entity Type in Data Migration Center --> Export File") {
-			ImportExport.selectEntity(entityType = "Account (v1_0 - Liferay Headless Admin User)");
+		task ("And Given 'Account (v1.0 - Liferay Headless Admin User)' as Entity Type in Data Migration Center --> Export File") {
+			ImportExport.selectEntity(entityType = "Account (v1.0 - Liferay Headless Admin User)");
 		}
 
 		task ("When exporting file in JSONT format with all fields selected") {
 			ImportExport.configureExport(
-				entityType = "Account (v1_0 - Liferay Headless Admin User)",
+				entityType = "Account (v1.0 - Liferay Headless Admin User)",
 				exportFields = "Attribute Code",
 				exportFileFormat = "JSONT");
 
@@ -265,8 +265,8 @@ definition {
 	test CanSelectFromAllExistingFields {
 		property portal.acceptance = "true";
 
-		task ("When selecting 'C_Student (v1_0 - Liferay Object REST)' as Entity Type in Data Migration Center --> Export File") {
-			ImportExport.selectEntity(entityType = "C_Student (v1_0 - Liferay Object REST)");
+		task ("When selecting 'Student (v1.0 - Liferay Object REST)' as Entity Type in Data Migration Center --> Export File") {
+			ImportExport.selectEntity(entityType = "Student (v1.0 - Liferay Object REST)");
 		}
 
 		task ("Then the list of fields to select contains all the fields available with GET request except the relationship nodes") {

--- a/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/SupportExportObjectEntriesAtSiteLevel.testcase
+++ b/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/SupportExportObjectEntriesAtSiteLevel.testcase
@@ -103,8 +103,8 @@ definition {
 	test CanDownloadFileWithAllFieldsSelected {
 		property portal.acceptance = "true";
 
-		task ("And Given 'C_Student (v1_0 - Liferay Object REST)' as Entity Type in Data Migration Center --> Export File") {
-			ImportExport.selectEntity(entityType = "C_Student (v1_0 - Liferay Object REST)");
+		task ("And Given 'Student (v1.0 - Liferay Object REST)' as Entity Type in Data Migration Center --> Export File") {
+			ImportExport.selectEntity(entityType = "Student (v1.0 - Liferay Object REST)");
 		}
 
 		task ("When exporting file in JSON format with all fields selected") {
@@ -150,11 +150,11 @@ definition {
 	test CanExportSpecificFieldsWithJSONTConfigurationNode {
 		property portal.acceptance = "true";
 
-		task ("And Given 'C_Student (v1_0 - Liferay Object REST)' as Entity Type and current site as Scope in Data Migration Center --> Export File") {
+		task ("And Given 'Student (v1.0 - Liferay Object REST)' as Entity Type and current site as Scope in Data Migration Center --> Export File") {
 			var scope = TestCase.getSiteName();
 
 			ImportExport.configureExport(
-				entityType = "C_Student (v1_0 - Liferay Object REST)",
+				entityType = "Student (v1.0 - Liferay Object REST)",
 				exportFileFormat = "JSONT",
 				scope = ${scope});
 		}
@@ -191,8 +191,8 @@ definition {
 	test CannotSeeScopeSelectorForObjectDefinitionsScopedByCompany {
 		property portal.acceptance = "true";
 
-		task ("When 'C_University (v1_0 - Liferay Object REST)' as Entity Type in Data Migration Center --> Export File") {
-			ImportExport.selectEntity(entityType = "C_University (v1_0 - Liferay Object REST)");
+		task ("When 'University (v1.0 - Liferay Object REST)' as Entity Type in Data Migration Center --> Export File") {
+			ImportExport.selectEntity(entityType = "University (v1.0 - Liferay Object REST)");
 		}
 
 		task ("Then 'Scope' selector is not present") {
@@ -208,8 +208,8 @@ definition {
 			HeadlessSite.addSite(siteName = "test");
 		}
 
-		task ("And Given 'C_Student (v1_0 - Liferay Object REST)' as Entity Type and default site as scope in Data Migration Center --> Export File") {
-			ImportExport.selectEntity(entityType = "C_Student (v1_0 - Liferay Object REST)");
+		task ("And Given 'Student (v1.0 - Liferay Object REST)' as Entity Type and default site as scope in Data Migration Center --> Export File") {
+			ImportExport.selectEntity(entityType = "Student (v1.0 - Liferay Object REST)");
 		}
 
 		task ("When click the scope selector") {
@@ -227,8 +227,8 @@ definition {
 	test CanSelectAllExistingFields {
 		property portal.acceptance = "true";
 
-		task ("When selecting 'C_Student (v1_0 - Liferay Object REST)' as Entity Type in Data Migration Center --> Export File") {
-			ImportExport.selectEntity(entityType = "C_Student (v1_0 - Liferay Object REST)");
+		task ("When selecting 'Student (v1.0 - Liferay Object REST)' as Entity Type in Data Migration Center --> Export File") {
+			ImportExport.selectEntity(entityType = "Student (v1.0 - Liferay Object REST)");
 		}
 
 		task ("Then the list of fields to select contains all the fields available with GET request") {
@@ -242,8 +242,8 @@ definition {
 	test CanSelectGlobalSiteAsScope {
 		property portal.acceptance = "true";
 
-		task ("When 'C_Student (v1_0 - Liferay Object REST)' as Entity Type in Data Migration Center --> Export File") {
-			ImportExport.selectEntity(entityType = "C_Student (v1_0 - Liferay Object REST)");
+		task ("When 'Student (v1.0 - Liferay Object REST)' as Entity Type in Data Migration Center --> Export File") {
+			ImportExport.selectEntity(entityType = "Student (v1.0 - Liferay Object REST)");
 		}
 
 		task ("Then Global site available as scope") {

--- a/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/SupportImportObjectEntriesAtInstanceLevel.testcase
+++ b/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/SupportImportObjectEntriesAtInstanceLevel.testcase
@@ -88,13 +88,13 @@ definition {
 	test CanCreateAndUpdateExistingObjectEntriesWithSameFile {
 		property portal.acceptance = "true";
 
-		task ("When importing .jsonl file as 'C_Student' Entity Type with default settings") {
+		task ("When importing .jsonl file as 'Student' Entity Type with default settings") {
 			ImportExport.replaceAttachmentIdAndHrefInFile(
 				en_US_plural_label = "students",
 				fileName = "multiple_objectEntries_import_create_update.jsonl");
 
 			ImportExport.importFile(
-				entityType = "C_Student (v1_0 - Liferay Object REST)",
+				entityType = "Student (v1.0 - Liferay Object REST)",
 				fileName = "multiple_objectEntries_import_create_update.jsonl");
 		}
 
@@ -129,13 +129,13 @@ definition {
 	test CanCreateObjectEntry {
 		property portal.acceptance = "true";
 
-		task ("When importing .json file as 'C_Student' Entity Type with default setting") {
+		task ("When importing .json file as 'Student' Entity Type with default setting") {
 			ImportExport.replaceAttachmentIdAndHrefInFile(
 				en_US_plural_label = "students",
 				fileName = "objectEntry_import_create.json");
 
 			ImportExport.importFile(
-				entityType = "C_Student (v1_0 - Liferay Object REST)",
+				entityType = "Student (v1.0 - Liferay Object REST)",
 				fileName = "objectEntry_import_create.json");
 		}
 
@@ -161,13 +161,13 @@ definition {
 	test CanCreateObjectEntryFromFileContainingExistingAndNewWithUncheckedStopImportOnError {
 		property portal.acceptance = "true";
 
-		task ("When importing .jsonl file as 'C_Student' Entity Type with 'Only Add New Records Import Strategy', 'Stop the Import on Error' unchecked") {
+		task ("When importing .jsonl file as 'Student' Entity Type with 'Only Add New Records Import Strategy', 'Stop the Import on Error' unchecked") {
 			ImportExport.replaceAttachmentIdAndHrefInFile(
 				en_US_plural_label = "students",
 				fileName = "multiple_objectEntries_import_create.jsonl");
 
 			ImportExport.importFile(
-				entityType = "C_Student (v1_0 - Liferay Object REST)",
+				entityType = "Student (v1.0 - Liferay Object REST)",
 				fileName = "multiple_objectEntries_import_create.jsonl",
 				importStrategy = "Only Add New Records",
 				stopImportOnError = "false");
@@ -188,9 +188,9 @@ definition {
 	test CannotCreateObjectEntryWithoutRequiredFields {
 		property portal.acceptance = "true";
 
-		task ("When importing .json file as 'C_Student' Entity Type with default setting") {
+		task ("When importing .json file as 'Student' Entity Type with default setting") {
 			ImportExport.importFile(
-				entityType = "C_Student (v1_0 - Liferay Object REST)",
+				entityType = "Student (v1.0 - Liferay Object REST)",
 				fileName = "objectEntry_import_without_required_fields.json",
 				noImport = "true");
 
@@ -208,9 +208,9 @@ definition {
 	test CanUpdateObjectEntry {
 		property portal.acceptance = "true";
 
-		task ("When importing .jsonl file as 'C_Student' Entity Type with default setting") {
+		task ("When importing .jsonl file as 'Student' Entity Type with default setting") {
 			ImportExport.importFile(
-				entityType = "C_Student (v1_0 - Liferay Object REST)",
+				entityType = "Student (v1.0 - Liferay Object REST)",
 				fileName = "objectEntry_import_update.jsonl");
 		}
 

--- a/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/SupportImportObjectEntriesWithSiteScope.testcase
+++ b/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/SupportImportObjectEntriesWithSiteScope.testcase
@@ -94,14 +94,14 @@ definition {
 	test CanCreateAndUpdateExistingSiteScopedObjectEntriesWithSameFile {
 		property portal.acceptance = "true";
 
-		task ("When importing .jsonl file as 'C_Student' Entity Type with default settings") {
+		task ("When importing .jsonl file as 'Student' Entity Type with default settings") {
 			ImportExport.replaceAttachmentIdAndHrefInFile(
 				en_US_plural_label = "students",
 				fileName = "multiple_site_scope_objectEntries_import_create_update.jsonl",
 				scopeKey = "true");
 
 			ImportExport.importFile(
-				entityType = "C_Student (v1_0 - Liferay Object REST)",
+				entityType = "Student (v1.0 - Liferay Object REST)",
 				fileName = "multiple_site_scope_objectEntries_import_create_update.jsonl",
 				scope = "true");
 		}
@@ -139,9 +139,9 @@ definition {
 	test CanCreateSiteScopedObjectEntryFromFileContainingExistingAndNewWithUncheckedStopImportOnError {
 		property portal.acceptance = "true";
 
-		task ("When importing .json file as 'C_Student' Entity Type with 'Only Add New Records Import Strategy', 'Stop the Import on Error' unchecked") {
+		task ("When importing .json file as 'Student' Entity Type with 'Only Add New Records Import Strategy', 'Stop the Import on Error' unchecked") {
 			ImportExport.importFile(
-				entityType = "C_Student (v1_0 - Liferay Object REST)",
+				entityType = "Student (v1.0 - Liferay Object REST)",
 				fileName = "multiple_site_scope_objectEntries_import_create.jsonl",
 				importStrategy = "Only Add New Records",
 				scope = "true",
@@ -165,9 +165,9 @@ definition {
 	test CannotCreateSiteScopedObjectEntryWithoutRequiredFields {
 		property portal.acceptance = "true";
 
-		task ("When importing .json file as 'C_Student' Entity Type with default setting") {
+		task ("When importing .json file as 'Student' Entity Type with default setting") {
 			ImportExport.importFile(
-				entityType = "C_Student (v1_0 - Liferay Object REST)",
+				entityType = "Student (v1.0 - Liferay Object REST)",
 				fileName = "site_scope_objectEntry_import_without_required_fields.json",
 				noImport = "true",
 				scope = "true");
@@ -186,12 +186,12 @@ definition {
 	test CanSeeScopeSelecterInImportFile {
 		property portal.acceptance = "true";
 
-		task ("When 'C_Student' as Entity Type in Data Migration Center -> Import File") {
+		task ("When 'Student' as Entity Type in Data Migration Center -> Import File") {
 			ImportExport.openImportExportAdmin();
 
 			ImportExport.gotoImport();
 
-			ImportExport.selectEntity(entityType = "C_Student (v1_0 - Liferay Object REST)");
+			ImportExport.selectEntity(entityType = "Student (v1.0 - Liferay Object REST)");
 		}
 
 		task ("Then 'Scope' is present with default and Global sites in dropdown list") {
@@ -209,9 +209,9 @@ definition {
 	test CanUpdateSiteScopedObjectEntry {
 		property portal.acceptance = "true";
 
-		task ("When importing .jsonl file as 'C_Student' Entity Type with default setting") {
+		task ("When importing .jsonl file as 'Student' Entity Type with default setting") {
 			ImportExport.importFile(
-				entityType = "C_Student (v1_0 - Liferay Object REST)",
+				entityType = "Student (v1.0 - Liferay Object REST)",
 				fileName = "site_scope_objectEntry_import_update.jsonl",
 				scope = "true");
 		}

--- a/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/display/context/EditBatchPlannerPlanDisplayContext.java
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/display/context/EditBatchPlannerPlanDisplayContext.java
@@ -17,7 +17,6 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.PortalUtil;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.ArrayList;
@@ -180,20 +179,8 @@ public class EditBatchPlannerPlanDisplayContext {
 		for (Map.Entry<String, String> entry :
 				internalClassNameKeyCategories.entrySet()) {
 
-			String internalClassNameKey = entry.getKey();
-
-			String[] internalClassNameKeyParts = StringUtil.split(
-				internalClassNameKey, StringPool.PERIOD);
-
 			internalClassNameKeySelectOptions.add(
-				new SelectOption(
-					String.format(
-						"%s (%s - %s)",
-						TaskItemUtil.getSimpleClassName(internalClassNameKey),
-						internalClassNameKeyParts
-							[internalClassNameKeyParts.length - 2],
-						entry.getValue()),
-					internalClassNameKey));
+				new SelectOption(entry.getValue(), entry.getKey()));
 		}
 
 		internalClassNameKeySelectOptions.sort(

--- a/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/portlet/action/EditBatchPlannerPlanMVCRenderCommand.java
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/portlet/action/EditBatchPlannerPlanMVCRenderCommand.java
@@ -22,7 +22,6 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.SetUtil;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegateRegistry;
@@ -91,16 +90,12 @@ public class EditBatchPlannerPlanMVCRenderCommand implements MVCRenderCommand {
 						getVulcanBatchEngineTaskItemDelegate(
 							companyId, entityClassName);
 
-			String[] internalClassNameKeyParts = StringUtil.split(
-				entityClassName, StringPool.PERIOD);
-
 			internalClassNameKeyCategories.put(
 				entityClassName,
 				String.format(
 					"%s (%s - %s)",
 					vulcanBatchEngineTaskItemDelegate.getResourceName(),
-					internalClassNameKeyParts
-						[internalClassNameKeyParts.length - 2],
+					vulcanBatchEngineTaskItemDelegate.getVersion(),
 					_getInternalClassNameKeyCategory(
 						FrameworkUtil.getBundle(
 							vulcanBatchEngineTaskItemDelegate.getClass()))));

--- a/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/portlet/action/EditBatchPlannerPlanMVCRenderCommand.java
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/portlet/action/EditBatchPlannerPlanMVCRenderCommand.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegateRegistry;
@@ -90,11 +91,19 @@ public class EditBatchPlannerPlanMVCRenderCommand implements MVCRenderCommand {
 						getVulcanBatchEngineTaskItemDelegate(
 							companyId, entityClassName);
 
+			String[] internalClassNameKeyParts = StringUtil.split(
+				entityClassName, StringPool.PERIOD);
+
 			internalClassNameKeyCategories.put(
 				entityClassName,
-				_getInternalClassNameKeyCategory(
-					FrameworkUtil.getBundle(
-						vulcanBatchEngineTaskItemDelegate.getClass())));
+				String.format(
+					"%s (%s - %s)",
+					vulcanBatchEngineTaskItemDelegate.getResourceName(),
+					internalClassNameKeyParts
+						[internalClassNameKeyParts.length - 2],
+					_getInternalClassNameKeyCategory(
+						FrameworkUtil.getBundle(
+							vulcanBatchEngineTaskItemDelegate.getClass()))));
 		}
 
 		return internalClassNameKeyCategories;

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/BaseCTCollectionResourceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/BaseCTCollectionResourceImpl.java
@@ -934,6 +934,10 @@ public abstract class BaseCTCollectionResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "CTCollection";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/BaseCTEntryResourceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/BaseCTEntryResourceImpl.java
@@ -201,6 +201,10 @@ public abstract class BaseCTEntryResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "CTEntry";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/BaseCTProcessResourceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/BaseCTProcessResourceImpl.java
@@ -322,6 +322,10 @@ public abstract class BaseCTProcessResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "CTProcess";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/BaseCTRemoteResourceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/BaseCTRemoteResourceImpl.java
@@ -549,6 +549,10 @@ public abstract class BaseCTRemoteResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "CTRemote";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountAddressResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountAddressResourceImpl.java
@@ -755,6 +755,10 @@ public abstract class BaseAccountAddressResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "AccountAddress";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountChannelEntryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountChannelEntryResourceImpl.java
@@ -2468,6 +2468,10 @@ public abstract class BaseAccountChannelEntryResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "AccountChannelEntry";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountChannelShippingOptionResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountChannelShippingOptionResourceImpl.java
@@ -526,6 +526,10 @@ public abstract class BaseAccountChannelShippingOptionResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "AccountChannelShippingOption";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountMemberResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountMemberResourceImpl.java
@@ -604,6 +604,10 @@ public abstract class BaseAccountMemberResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "AccountMember";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountOrganizationResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountOrganizationResourceImpl.java
@@ -537,6 +537,10 @@ public abstract class BaseAccountOrganizationResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "AccountOrganization";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountResourceImpl.java
@@ -713,6 +713,10 @@ public abstract class BaseAccountResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Account";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAdminAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAdminAccountGroupResourceImpl.java
@@ -475,6 +475,10 @@ public abstract class BaseAdminAccountGroupResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "AdminAccountGroup";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseAttachmentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseAttachmentResourceImpl.java
@@ -845,6 +845,10 @@ public abstract class BaseAttachmentResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Attachment";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseCatalogResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseCatalogResourceImpl.java
@@ -643,6 +643,10 @@ public abstract class BaseCatalogResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Catalog";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseCategoryResourceImpl.java
@@ -259,6 +259,10 @@ public abstract class BaseCategoryResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Category";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseCurrencyResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseCurrencyResourceImpl.java
@@ -458,6 +458,10 @@ public abstract class BaseCurrencyResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Currency";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseDiagramResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseDiagramResourceImpl.java
@@ -349,6 +349,10 @@ public abstract class BaseDiagramResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Diagram";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseGroupedProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseGroupedProductResourceImpl.java
@@ -459,6 +459,10 @@ public abstract class BaseGroupedProductResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "GroupedProduct";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseLinkedProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseLinkedProductResourceImpl.java
@@ -150,6 +150,10 @@ public abstract class BaseLinkedProductResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "LinkedProduct";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseLowStockActionResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseLowStockActionResourceImpl.java
@@ -195,6 +195,10 @@ public abstract class BaseLowStockActionResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "LowStockAction";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseMappedProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseMappedProductResourceImpl.java
@@ -565,6 +565,10 @@ public abstract class BaseMappedProductResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "MappedProduct";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionCategoryResourceImpl.java
@@ -470,6 +470,10 @@ public abstract class BaseOptionCategoryResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "OptionCategory";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionResourceImpl.java
@@ -562,6 +562,10 @@ public abstract class BaseOptionResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Option";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionValueResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionValueResourceImpl.java
@@ -601,6 +601,10 @@ public abstract class BaseOptionValueResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "OptionValue";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BasePinResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BasePinResourceImpl.java
@@ -460,6 +460,10 @@ public abstract class BasePinResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Pin";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductAccountGroupResourceImpl.java
@@ -312,6 +312,10 @@ public abstract class BaseProductAccountGroupResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "ProductAccountGroup";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductChannelResourceImpl.java
@@ -302,6 +302,10 @@ public abstract class BaseProductChannelResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "ProductChannel";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductGroupProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductGroupProductResourceImpl.java
@@ -441,6 +441,10 @@ public abstract class BaseProductGroupProductResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "ProductGroupProduct";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductGroupResourceImpl.java
@@ -562,6 +562,10 @@ public abstract class BaseProductGroupResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "ProductGroup";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductOptionResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductOptionResourceImpl.java
@@ -437,6 +437,10 @@ public abstract class BaseProductOptionResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "ProductOption";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductOptionValueResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductOptionValueResourceImpl.java
@@ -384,6 +384,10 @@ public abstract class BaseProductOptionValueResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "ProductOptionValue";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductResourceImpl.java
@@ -782,6 +782,10 @@ public abstract class BaseProductResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Product";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductSpecificationResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductSpecificationResourceImpl.java
@@ -388,6 +388,10 @@ public abstract class BaseProductSpecificationResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "ProductSpecification";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseRelatedProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseRelatedProductResourceImpl.java
@@ -473,6 +473,10 @@ public abstract class BaseRelatedProductResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "RelatedProduct";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseSkuResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseSkuResourceImpl.java
@@ -734,6 +734,10 @@ public abstract class BaseSkuResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Sku";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseSkuUnitOfMeasureResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseSkuUnitOfMeasureResourceImpl.java
@@ -488,6 +488,10 @@ public abstract class BaseSkuUnitOfMeasureResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "SkuUnitOfMeasure";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseSpecificationResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseSpecificationResourceImpl.java
@@ -484,6 +484,10 @@ public abstract class BaseSpecificationResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Specification";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseAccountAddressChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseAccountAddressChannelResourceImpl.java
@@ -377,6 +377,10 @@ public abstract class BaseAccountAddressChannelResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "AccountAddressChannel";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseChannelAccountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseChannelAccountResourceImpl.java
@@ -396,6 +396,10 @@ public abstract class BaseChannelAccountResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "ChannelAccount";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseChannelResourceImpl.java
@@ -799,6 +799,10 @@ public abstract class BaseChannelResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Channel";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BasePaymentMethodGroupRelOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BasePaymentMethodGroupRelOrderTypeResourceImpl.java
@@ -304,6 +304,10 @@ public abstract class BasePaymentMethodGroupRelOrderTypeResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "PaymentMethodGroupRelOrderType";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BasePaymentMethodGroupRelTermResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BasePaymentMethodGroupRelTermResourceImpl.java
@@ -299,6 +299,10 @@ public abstract class BasePaymentMethodGroupRelTermResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "PaymentMethodGroupRelTerm";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseShippingFixedOptionOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseShippingFixedOptionOrderTypeResourceImpl.java
@@ -303,6 +303,10 @@ public abstract class BaseShippingFixedOptionOrderTypeResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "ShippingFixedOptionOrderType";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseShippingFixedOptionTermResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseShippingFixedOptionTermResourceImpl.java
@@ -299,6 +299,10 @@ public abstract class BaseShippingFixedOptionTermResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "ShippingFixedOptionTerm";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseShippingMethodResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseShippingMethodResourceImpl.java
@@ -227,6 +227,10 @@ public abstract class BaseShippingMethodResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "ShippingMethod";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseTaxCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseTaxCategoryResourceImpl.java
@@ -246,6 +246,10 @@ public abstract class BaseTaxCategoryResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "TaxCategory";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseReplenishmentItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseReplenishmentItemResourceImpl.java
@@ -645,6 +645,10 @@ public abstract class BaseReplenishmentItemResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "ReplenishmentItem";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseWarehouseChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseWarehouseChannelResourceImpl.java
@@ -444,6 +444,10 @@ public abstract class BaseWarehouseChannelResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "WarehouseChannel";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseWarehouseItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseWarehouseItemResourceImpl.java
@@ -687,6 +687,10 @@ public abstract class BaseWarehouseItemResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "WarehouseItem";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseWarehouseOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseWarehouseOrderTypeResourceImpl.java
@@ -445,6 +445,10 @@ public abstract class BaseWarehouseOrderTypeResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "WarehouseOrderType";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseWarehouseResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseWarehouseResourceImpl.java
@@ -499,6 +499,10 @@ public abstract class BaseWarehouseResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Warehouse";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderItemResourceImpl.java
@@ -857,6 +857,10 @@ public abstract class BaseOrderItemResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "OrderItem";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderNoteResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderNoteResourceImpl.java
@@ -577,6 +577,10 @@ public abstract class BaseOrderNoteResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "OrderNote";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderResourceImpl.java
@@ -562,6 +562,10 @@ public abstract class BaseOrderResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Order";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleAccountGroupResourceImpl.java
@@ -453,6 +453,10 @@ public abstract class BaseOrderRuleAccountGroupResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "OrderRuleAccountGroup";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleAccountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleAccountResourceImpl.java
@@ -435,6 +435,10 @@ public abstract class BaseOrderRuleAccountResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "OrderRuleAccount";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleChannelResourceImpl.java
@@ -443,6 +443,10 @@ public abstract class BaseOrderRuleChannelResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "OrderRuleChannel";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleOrderTypeResourceImpl.java
@@ -434,6 +434,10 @@ public abstract class BaseOrderRuleOrderTypeResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "OrderRuleOrderType";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleResourceImpl.java
@@ -554,6 +554,10 @@ public abstract class BaseOrderRuleResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "OrderRule";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderTypeChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderTypeChannelResourceImpl.java
@@ -438,6 +438,10 @@ public abstract class BaseOrderTypeChannelResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "OrderTypeChannel";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderTypeResourceImpl.java
@@ -616,6 +616,10 @@ public abstract class BaseOrderTypeResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "OrderType";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseTermOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseTermOrderTypeResourceImpl.java
@@ -432,6 +432,10 @@ public abstract class BaseTermOrderTypeResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "TermOrderType";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseTermResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseTermResourceImpl.java
@@ -543,6 +543,10 @@ public abstract class BaseTermResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Term";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-payment-impl/src/main/java/com/liferay/headless/commerce/admin/payment/internal/resource/v1_0/BasePaymentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-payment-impl/src/main/java/com/liferay/headless/commerce/admin/payment/internal/resource/v1_0/BasePaymentResourceImpl.java
@@ -621,6 +621,10 @@ public abstract class BasePaymentResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Payment";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountAccountGroupResourceImpl.java
@@ -448,6 +448,10 @@ public abstract class BaseDiscountAccountGroupResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "DiscountAccountGroup";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountCategoryResourceImpl.java
@@ -428,6 +428,10 @@ public abstract class BaseDiscountCategoryResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "DiscountCategory";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountProductResourceImpl.java
@@ -428,6 +428,10 @@ public abstract class BaseDiscountProductResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "DiscountProduct";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountResourceImpl.java
@@ -532,6 +532,10 @@ public abstract class BaseDiscountResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Discount";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountRuleResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountRuleResourceImpl.java
@@ -440,6 +440,10 @@ public abstract class BaseDiscountRuleResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "DiscountRule";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BasePriceEntryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BasePriceEntryResourceImpl.java
@@ -578,6 +578,10 @@ public abstract class BasePriceEntryResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "PriceEntry";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BasePriceListAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BasePriceListAccountGroupResourceImpl.java
@@ -450,6 +450,10 @@ public abstract class BasePriceListAccountGroupResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "PriceListAccountGroup";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BasePriceListResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BasePriceListResourceImpl.java
@@ -552,6 +552,10 @@ public abstract class BasePriceListResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "PriceList";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseTierPriceResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseTierPriceResourceImpl.java
@@ -577,6 +577,10 @@ public abstract class BaseTierPriceResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "TierPrice";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountAccountGroupResourceImpl.java
@@ -463,6 +463,10 @@ public abstract class BaseDiscountAccountGroupResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "DiscountAccountGroup";
+	}
+
 	public String getVersion() {
 		return "v2.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountAccountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountAccountResourceImpl.java
@@ -442,6 +442,10 @@ public abstract class BaseDiscountAccountResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "DiscountAccount";
+	}
+
 	public String getVersion() {
 		return "v2.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountCategoryResourceImpl.java
@@ -442,6 +442,10 @@ public abstract class BaseDiscountCategoryResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "DiscountCategory";
+	}
+
 	public String getVersion() {
 		return "v2.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountChannelResourceImpl.java
@@ -442,6 +442,10 @@ public abstract class BaseDiscountChannelResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "DiscountChannel";
+	}
+
 	public String getVersion() {
 		return "v2.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountOrderTypeResourceImpl.java
@@ -443,6 +443,10 @@ public abstract class BaseDiscountOrderTypeResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "DiscountOrderType";
+	}
+
 	public String getVersion() {
 		return "v2.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountProductGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountProductGroupResourceImpl.java
@@ -463,6 +463,10 @@ public abstract class BaseDiscountProductGroupResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "DiscountProductGroup";
+	}
+
 	public String getVersion() {
 		return "v2.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountProductResourceImpl.java
@@ -442,6 +442,10 @@ public abstract class BaseDiscountProductResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "DiscountProduct";
+	}
+
 	public String getVersion() {
 		return "v2.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountResourceImpl.java
@@ -554,6 +554,10 @@ public abstract class BaseDiscountResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Discount";
+	}
+
 	public String getVersion() {
 		return "v2.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountRuleResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountRuleResourceImpl.java
@@ -488,6 +488,10 @@ public abstract class BaseDiscountRuleResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "DiscountRule";
+	}
+
 	public String getVersion() {
 		return "v2.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountSkuResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountSkuResourceImpl.java
@@ -428,6 +428,10 @@ public abstract class BaseDiscountSkuResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "DiscountSku";
+	}
+
 	public String getVersion() {
 		return "v2.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceEntryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceEntryResourceImpl.java
@@ -603,6 +603,10 @@ public abstract class BasePriceEntryResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "PriceEntry";
+	}
+
 	public String getVersion() {
 		return "v2.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListAccountGroupResourceImpl.java
@@ -453,6 +453,10 @@ public abstract class BasePriceListAccountGroupResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "PriceListAccountGroup";
+	}
+
 	public String getVersion() {
 		return "v2.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListAccountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListAccountResourceImpl.java
@@ -435,6 +435,10 @@ public abstract class BasePriceListAccountResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "PriceListAccount";
+	}
+
 	public String getVersion() {
 		return "v2.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListChannelResourceImpl.java
@@ -443,6 +443,10 @@ public abstract class BasePriceListChannelResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "PriceListChannel";
+	}
+
 	public String getVersion() {
 		return "v2.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListDiscountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListDiscountResourceImpl.java
@@ -426,6 +426,10 @@ public abstract class BasePriceListDiscountResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "PriceListDiscount";
+	}
+
 	public String getVersion() {
 		return "v2.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListOrderTypeResourceImpl.java
@@ -426,6 +426,10 @@ public abstract class BasePriceListOrderTypeResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "PriceListOrderType";
+	}
+
 	public String getVersion() {
 		return "v2.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListResourceImpl.java
@@ -554,6 +554,10 @@ public abstract class BasePriceListResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "PriceList";
+	}
+
 	public String getVersion() {
 		return "v2.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierCategoryResourceImpl.java
@@ -467,6 +467,10 @@ public abstract class BasePriceModifierCategoryResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "PriceModifierCategory";
+	}
+
 	public String getVersion() {
 		return "v2.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierProductGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierProductGroupResourceImpl.java
@@ -474,6 +474,10 @@ public abstract class BasePriceModifierProductGroupResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "PriceModifierProductGroup";
+	}
+
 	public String getVersion() {
 		return "v2.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierProductResourceImpl.java
@@ -465,6 +465,10 @@ public abstract class BasePriceModifierProductResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "PriceModifierProduct";
+	}
+
 	public String getVersion() {
 		return "v2.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierResourceImpl.java
@@ -611,6 +611,10 @@ public abstract class BasePriceModifierResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "PriceModifier";
+	}
+
 	public String getVersion() {
 		return "v2.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseTierPriceResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseTierPriceResourceImpl.java
@@ -579,6 +579,10 @@ public abstract class BaseTierPriceResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "TierPrice";
+	}
+
 	public String getVersion() {
 		return "v2.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/BaseShipmentItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/BaseShipmentItemResourceImpl.java
@@ -490,6 +490,10 @@ public abstract class BaseShipmentItemResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "ShipmentItem";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/BaseShipmentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/BaseShipmentResourceImpl.java
@@ -862,6 +862,10 @@ public abstract class BaseShipmentResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Shipment";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseAvailabilityEstimateResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseAvailabilityEstimateResourceImpl.java
@@ -402,6 +402,10 @@ public abstract class BaseAvailabilityEstimateResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "AvailabilityEstimate";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseMeasurementUnitResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseMeasurementUnitResourceImpl.java
@@ -711,6 +711,10 @@ public abstract class BaseMeasurementUnitResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "MeasurementUnit";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseTaxCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseTaxCategoryResourceImpl.java
@@ -366,6 +366,10 @@ public abstract class BaseTaxCategoryResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "TaxCategory";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseWarehouseResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseWarehouseResourceImpl.java
@@ -373,6 +373,10 @@ public abstract class BaseWarehouseResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Warehouse";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartCommentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartCommentResourceImpl.java
@@ -672,6 +672,10 @@ public abstract class BaseCartCommentResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "CartComment";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartItemResourceImpl.java
@@ -750,6 +750,10 @@ public abstract class BaseCartItemResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "CartItem";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartResourceImpl.java
@@ -1016,6 +1016,10 @@ public abstract class BaseCartResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Cart";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BasePaymentMethodResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BasePaymentMethodResourceImpl.java
@@ -255,6 +255,10 @@ public abstract class BasePaymentMethodResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "PaymentMethod";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseShippingMethodResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseShippingMethodResourceImpl.java
@@ -256,6 +256,10 @@ public abstract class BaseShippingMethodResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "ShippingMethod";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseAccountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseAccountResourceImpl.java
@@ -196,6 +196,10 @@ public abstract class BaseAccountResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Account";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseAttachmentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseAttachmentResourceImpl.java
@@ -218,6 +218,10 @@ public abstract class BaseAttachmentResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Attachment";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseCategoryResourceImpl.java
@@ -160,6 +160,10 @@ public abstract class BaseCategoryResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Category";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseChannelResourceImpl.java
@@ -234,6 +234,10 @@ public abstract class BaseChannelResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Channel";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseLinkedProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseLinkedProductResourceImpl.java
@@ -168,6 +168,10 @@ public abstract class BaseLinkedProductResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "LinkedProduct";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseMappedProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseMappedProductResourceImpl.java
@@ -180,6 +180,10 @@ public abstract class BaseMappedProductResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "MappedProduct";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BasePinResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BasePinResourceImpl.java
@@ -243,6 +243,10 @@ public abstract class BasePinResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Pin";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseProductOptionResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseProductOptionResourceImpl.java
@@ -213,6 +213,10 @@ public abstract class BaseProductOptionResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "ProductOption";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseProductOptionValueResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseProductOptionValueResourceImpl.java
@@ -445,6 +445,10 @@ public abstract class BaseProductOptionValueResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "ProductOptionValue";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseProductResourceImpl.java
@@ -222,6 +222,10 @@ public abstract class BaseProductResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Product";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseProductSpecificationResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseProductSpecificationResourceImpl.java
@@ -218,6 +218,10 @@ public abstract class BaseProductSpecificationResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "ProductSpecification";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseRelatedProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseRelatedProductResourceImpl.java
@@ -171,6 +171,10 @@ public abstract class BaseRelatedProductResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "RelatedProduct";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseSkuResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseSkuResourceImpl.java
@@ -592,6 +592,10 @@ public abstract class BaseSkuResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Sku";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseWishListItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseWishListItemResourceImpl.java
@@ -316,6 +316,10 @@ public abstract class BaseWishListItemResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "WishListItem";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseWishListResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseWishListResourceImpl.java
@@ -434,6 +434,10 @@ public abstract class BaseWishListResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "WishList";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/BasePlacedOrderCommentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/BasePlacedOrderCommentResourceImpl.java
@@ -336,6 +336,10 @@ public abstract class BasePlacedOrderCommentResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "PlacedOrderComment";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/BasePlacedOrderItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/BasePlacedOrderItemResourceImpl.java
@@ -405,6 +405,10 @@ public abstract class BasePlacedOrderItemResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "PlacedOrderItem";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/BasePlacedOrderItemShipmentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/BasePlacedOrderItemShipmentResourceImpl.java
@@ -267,6 +267,10 @@ public abstract class BasePlacedOrderItemShipmentResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "PlacedOrderItemShipment";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/BasePlacedOrderResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/BasePlacedOrderResourceImpl.java
@@ -360,6 +360,10 @@ public abstract class BasePlacedOrderResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "PlacedOrder";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionFieldLinkResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionFieldLinkResourceImpl.java
@@ -238,6 +238,10 @@ public abstract class BaseDataDefinitionFieldLinkResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "DataDefinitionFieldLink";
+	}
+
 	public String getVersion() {
 		return "v2.0";
 	}

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionResourceImpl.java
@@ -827,6 +827,10 @@ public abstract class BaseDataDefinitionResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "DataDefinition";
+	}
+
 	public String getVersion() {
 		return "v2.0";
 	}

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataLayoutResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataLayoutResourceImpl.java
@@ -657,6 +657,10 @@ public abstract class BaseDataLayoutResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "DataLayout";
+	}
+
 	public String getVersion() {
 		return "v2.0";
 	}

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataListViewResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataListViewResourceImpl.java
@@ -576,6 +576,10 @@ public abstract class BaseDataListViewResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "DataListView";
+	}
+
 	public String getVersion() {
 		return "v2.0";
 	}

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordCollectionResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordCollectionResourceImpl.java
@@ -854,6 +854,10 @@ public abstract class BaseDataRecordCollectionResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "DataRecordCollection";
+	}
+
 	public String getVersion() {
 		return "v2.0";
 	}

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordResourceImpl.java
@@ -893,6 +893,10 @@ public abstract class BaseDataRecordResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "DataRecord";
+	}
+
 	public String getVersion() {
 		return "v2.0";
 	}

--- a/modules/apps/digital-signature/digital-signature-rest-impl/src/main/java/com/liferay/digital/signature/rest/internal/resource/v1_0/BaseDSEnvelopeResourceImpl.java
+++ b/modules/apps/digital-signature/digital-signature-rest-impl/src/main/java/com/liferay/digital/signature/rest/internal/resource/v1_0/BaseDSEnvelopeResourceImpl.java
@@ -434,6 +434,10 @@ public abstract class BaseDSEnvelopeResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "DSEnvelope";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/dispatch/dispatch-rest-impl/src/main/java/com/liferay/dispatch/rest/internal/resource/v1_0/BaseDispatchTriggerResourceImpl.java
+++ b/modules/apps/dispatch/dispatch-rest-impl/src/main/java/com/liferay/dispatch/rest/internal/resource/v1_0/BaseDispatchTriggerResourceImpl.java
@@ -319,6 +319,10 @@ public abstract class BaseDispatchTriggerResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "DispatchTrigger";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/BaseCountryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/BaseCountryResourceImpl.java
@@ -713,6 +713,10 @@ public abstract class BaseCountryResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Country";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/BaseRegionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/BaseRegionResourceImpl.java
@@ -776,6 +776,10 @@ public abstract class BaseRegionResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Region";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/BaseListTypeDefinitionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/BaseListTypeDefinitionResourceImpl.java
@@ -703,6 +703,10 @@ public abstract class BaseListTypeDefinitionResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "ListTypeDefinition";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/BaseListTypeEntryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/BaseListTypeEntryResourceImpl.java
@@ -698,6 +698,10 @@ public abstract class BaseListTypeEntryResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "ListTypeEntry";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseKeywordResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseKeywordResourceImpl.java
@@ -1192,6 +1192,10 @@ public abstract class BaseKeywordResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Keyword";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
@@ -1219,6 +1219,10 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "TaxonomyCategory";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyVocabularyResourceImpl.java
@@ -1693,6 +1693,10 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "TaxonomyVocabulary";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountGroupResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountGroupResourceImpl.java
@@ -1006,6 +1006,10 @@ public abstract class BaseAccountGroupResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "AccountGroup";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountResourceImpl.java
@@ -1194,6 +1194,10 @@ public abstract class BaseAccountResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Account";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountRoleResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountRoleResourceImpl.java
@@ -865,6 +865,10 @@ public abstract class BaseAccountRoleResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "AccountRole";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseEmailAddressResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseEmailAddressResourceImpl.java
@@ -563,6 +563,10 @@ public abstract class BaseEmailAddressResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "EmailAddress";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseOrganizationResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseOrganizationResourceImpl.java
@@ -1525,6 +1525,10 @@ public abstract class BaseOrganizationResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Organization";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BasePhoneResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BasePhoneResourceImpl.java
@@ -551,6 +551,10 @@ public abstract class BasePhoneResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Phone";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BasePostalAddressResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BasePostalAddressResourceImpl.java
@@ -963,6 +963,10 @@ public abstract class BasePostalAddressResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "PostalAddress";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseRoleResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseRoleResourceImpl.java
@@ -802,6 +802,10 @@ public abstract class BaseRoleResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Role";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSegmentResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSegmentResourceImpl.java
@@ -261,6 +261,10 @@ public abstract class BaseSegmentResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Segment";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSegmentUserResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSegmentUserResourceImpl.java
@@ -152,6 +152,10 @@ public abstract class BaseSegmentUserResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "SegmentUser";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSiteResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSiteResourceImpl.java
@@ -199,6 +199,10 @@ public abstract class BaseSiteResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Site";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSubscriptionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSubscriptionResourceImpl.java
@@ -206,6 +206,10 @@ public abstract class BaseSubscriptionResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Subscription";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserAccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserAccountResourceImpl.java
@@ -2117,6 +2117,10 @@ public abstract class BaseUserAccountResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "UserAccount";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserGroupResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserGroupResourceImpl.java
@@ -832,6 +832,10 @@ public abstract class BaseUserGroupResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "UserGroup";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseWebUrlResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseWebUrlResourceImpl.java
@@ -551,6 +551,10 @@ public abstract class BaseWebUrlResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "WebUrl";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseAssigneeResourceImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseAssigneeResourceImpl.java
@@ -149,6 +149,10 @@ public abstract class BaseAssigneeResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Assignee";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseTransitionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseTransitionResourceImpl.java
@@ -190,6 +190,10 @@ public abstract class BaseTransitionResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Transition";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseWorkflowDefinitionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseWorkflowDefinitionResourceImpl.java
@@ -695,6 +695,10 @@ public abstract class BaseWorkflowDefinitionResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "WorkflowDefinition";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseWorkflowInstanceResourceImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseWorkflowInstanceResourceImpl.java
@@ -419,6 +419,10 @@ public abstract class BaseWorkflowInstanceResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "WorkflowInstance";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseWorkflowLogResourceImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseWorkflowLogResourceImpl.java
@@ -391,6 +391,10 @@ public abstract class BaseWorkflowLogResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "WorkflowLog";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseWorkflowTaskResourceImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/BaseWorkflowTaskResourceImpl.java
@@ -873,6 +873,10 @@ public abstract class BaseWorkflowTaskResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "WorkflowTask";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingImageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingImageResourceImpl.java
@@ -538,6 +538,10 @@ public abstract class BaseBlogPostingImageResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "BlogPostingImage";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingResourceImpl.java
@@ -1389,6 +1389,10 @@ public abstract class BaseBlogPostingResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "BlogPosting";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseCommentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseCommentResourceImpl.java
@@ -1891,6 +1891,10 @@ public abstract class BaseCommentResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Comment";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentElementResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentElementResourceImpl.java
@@ -435,6 +435,10 @@ public abstract class BaseContentElementResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "ContentElement";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentSetElementResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentSetElementResourceImpl.java
@@ -406,6 +406,10 @@ public abstract class BaseContentSetElementResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "ContentSetElement";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentStructureResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentStructureResourceImpl.java
@@ -910,6 +910,10 @@ public abstract class BaseContentStructureResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "ContentStructure";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentTemplateResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentTemplateResourceImpl.java
@@ -495,6 +495,10 @@ public abstract class BaseContentTemplateResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "ContentTemplate";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentFolderResourceImpl.java
@@ -1932,6 +1932,10 @@ public abstract class BaseDocumentFolderResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "DocumentFolder";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentResourceImpl.java
@@ -2186,6 +2186,10 @@ public abstract class BaseDocumentResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Document";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseArticleResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseArticleResourceImpl.java
@@ -1985,6 +1985,10 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "KnowledgeBaseArticle";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseAttachmentResourceImpl.java
@@ -652,6 +652,10 @@ public abstract class BaseKnowledgeBaseAttachmentResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "KnowledgeBaseAttachment";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseFolderResourceImpl.java
@@ -1268,6 +1268,10 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "KnowledgeBaseFolder";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseLanguageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseLanguageResourceImpl.java
@@ -333,6 +333,10 @@ public abstract class BaseLanguageResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Language";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardAttachmentResourceImpl.java
@@ -881,6 +881,10 @@ public abstract class BaseMessageBoardAttachmentResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "MessageBoardAttachment";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardMessageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardMessageResourceImpl.java
@@ -1992,6 +1992,10 @@ public abstract class BaseMessageBoardMessageResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "MessageBoardMessage";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardSectionResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardSectionResourceImpl.java
@@ -1248,6 +1248,10 @@ public abstract class BaseMessageBoardSectionResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "MessageBoardSection";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardThreadResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardThreadResourceImpl.java
@@ -1635,6 +1635,10 @@ public abstract class BaseMessageBoardThreadResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "MessageBoardThread";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseNavigationMenuResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseNavigationMenuResourceImpl.java
@@ -844,6 +844,10 @@ public abstract class BaseNavigationMenuResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "NavigationMenu";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseSitePageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseSitePageResourceImpl.java
@@ -687,6 +687,10 @@ public abstract class BaseSitePageResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "SitePage";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentFolderResourceImpl.java
@@ -2012,6 +2012,10 @@ public abstract class BaseStructuredContentFolderResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "StructuredContentFolder";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
@@ -2691,6 +2691,10 @@ public abstract class BaseStructuredContentResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "StructuredContent";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiNodeResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiNodeResourceImpl.java
@@ -1068,6 +1068,10 @@ public abstract class BaseWikiNodeResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "WikiNode";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageAttachmentResourceImpl.java
@@ -606,6 +606,10 @@ public abstract class BaseWikiPageAttachmentResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "WikiPageAttachment";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageResourceImpl.java
@@ -1027,6 +1027,10 @@ public abstract class BaseWikiPageResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "WikiPage";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormDocumentResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormDocumentResourceImpl.java
@@ -220,6 +220,10 @@ public abstract class BaseFormDocumentResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "FormDocument";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormRecordResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormRecordResourceImpl.java
@@ -491,6 +491,10 @@ public abstract class BaseFormRecordResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "FormRecord";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormResourceImpl.java
@@ -324,6 +324,10 @@ public abstract class BaseFormResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Form";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormStructureResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormStructureResourceImpl.java
@@ -262,6 +262,10 @@ public abstract class BaseFormStructureResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "FormStructure";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/headless/headless-user-notification/headless-user-notification-impl/src/main/java/com/liferay/headless/user/notification/internal/resource/v1_0/BaseUserNotificationResourceImpl.java
+++ b/modules/apps/headless/headless-user-notification/headless-user-notification-impl/src/main/java/com/liferay/headless/user/notification/internal/resource/v1_0/BaseUserNotificationResourceImpl.java
@@ -365,6 +365,10 @@ public abstract class BaseUserNotificationResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "UserNotification";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/notification/notification-rest-impl/src/main/java/com/liferay/notification/rest/internal/resource/v1_0/BaseNotificationQueueEntryResourceImpl.java
+++ b/modules/apps/notification/notification-rest-impl/src/main/java/com/liferay/notification/rest/internal/resource/v1_0/BaseNotificationQueueEntryResourceImpl.java
@@ -505,6 +505,10 @@ public abstract class BaseNotificationQueueEntryResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "NotificationQueueEntry";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/notification/notification-rest-impl/src/main/java/com/liferay/notification/rest/internal/resource/v1_0/BaseNotificationTemplateResourceImpl.java
+++ b/modules/apps/notification/notification-rest-impl/src/main/java/com/liferay/notification/rest/internal/resource/v1_0/BaseNotificationTemplateResourceImpl.java
@@ -832,6 +832,10 @@ public abstract class BaseNotificationTemplateResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "NotificationTemplate";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectActionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectActionResourceImpl.java
@@ -728,6 +728,10 @@ public abstract class BaseObjectActionResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "ObjectAction";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectDefinitionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectDefinitionResourceImpl.java
@@ -836,6 +836,10 @@ public abstract class BaseObjectDefinitionResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "ObjectDefinition";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectFieldResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectFieldResourceImpl.java
@@ -782,6 +782,10 @@ public abstract class BaseObjectFieldResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "ObjectField";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectFolderResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectFolderResourceImpl.java
@@ -641,6 +641,10 @@ public abstract class BaseObjectFolderResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "ObjectFolder";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectLayoutResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectLayoutResourceImpl.java
@@ -643,6 +643,10 @@ public abstract class BaseObjectLayoutResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "ObjectLayout";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectRelationshipResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectRelationshipResourceImpl.java
@@ -734,6 +734,10 @@ public abstract class BaseObjectRelationshipResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "ObjectRelationship";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectValidationRuleResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectValidationRuleResourceImpl.java
@@ -794,6 +794,10 @@ public abstract class BaseObjectValidationRuleResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "ObjectValidationRule";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectViewResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectViewResourceImpl.java
@@ -673,6 +673,10 @@ public abstract class BaseObjectViewResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "ObjectView";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryResourceImpl.java
@@ -1299,6 +1299,10 @@ public abstract class BaseObjectEntryResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "ObjectEntry";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
@@ -216,6 +216,11 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 	}
 
 	@Override
+	public String getResourceName() {
+		return _objectDefinition.getShortName();
+	}
+
+	@Override
 	public ObjectEntry getScopeScopeKeyByExternalReferenceCode(
 			String scopeKey, String externalReferenceCode)
 		throws Exception {

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/ScopeObjectAPIsForDifferentInstances.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/ScopeObjectAPIsForDifferentInstances.testcase
@@ -220,8 +220,8 @@ definition {
 			ImportExport.gotoExport();
 		}
 
-		task ("Then C_Student is not in the available Entity Type list") {
-			AssertTextNotPresent(value1 = "C_Student (v1_0 - Liferay Object REST)");
+		task ("Then Student is not in the available Entity Type list") {
+			AssertTextNotPresent(value1 = "Student (v1.0 - Liferay Object REST)");
 		}
 	}
 

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectFieldsAutoIncrement.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectFieldsAutoIncrement.testcase
@@ -142,7 +142,7 @@ definition {
 
 		task ("and Given the object entry is exported") {
 			ImportExport.exportAndUnzipFile(
-				entityType = "C_Shoe (v1_0 - Liferay Object REST)",
+				entityType = "Shoe (v1.0 - Liferay Object REST)",
 				exportFileFormat = "JSON");
 		}
 
@@ -164,7 +164,7 @@ definition {
 				locator1 = "TextInput#FILE",
 				value1 = ${filePath});
 
-			ImportExport.selectEntity(entityType = "C_Shoe (v1_0 - Liferay Object REST)");
+			ImportExport.selectEntity(entityType = "Shoe (v1.0 - Liferay Object REST)");
 
 			WaitForElementPresent(locator1 = "ImportExport#IMPORT_MAPPING_HEADER");
 		}

--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/BaseSearchResultResourceImpl.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/BaseSearchResultResourceImpl.java
@@ -190,6 +190,10 @@ public abstract class BaseSearchResultResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "SearchResult";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Vulcan API
 Bundle-SymbolicName: com.liferay.portal.vulcan.api
-Bundle-Version: 42.0.6
+Bundle-Version: 42.1.0
 Export-Package:\
 	com.liferay.portal.vulcan.accept.language,\
 	com.liferay.portal.vulcan.aggregation,\

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/batch/engine/VulcanBatchEngineTaskItemDelegate.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/batch/engine/VulcanBatchEngineTaskItemDelegate.java
@@ -56,6 +56,10 @@ public interface VulcanBatchEngineTaskItemDelegate<T> {
 		return getClass();
 	}
 
+	public default String getResourceName() {
+		return null;
+	}
+
 	public default String getVersion() {
 		return "v1.0";
 	}

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/batch/engine/packageinfo
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/batch/engine/packageinfo
@@ -1,1 +1,1 @@
-version 8.0.0
+version 8.1.0

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/BaseAccountCategoryForecastResourceImpl.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/BaseAccountCategoryForecastResourceImpl.java
@@ -185,6 +185,10 @@ public abstract class BaseAccountCategoryForecastResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "AccountCategoryForecast";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/BaseAccountForecastResourceImpl.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/BaseAccountForecastResourceImpl.java
@@ -175,6 +175,10 @@ public abstract class BaseAccountForecastResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "AccountForecast";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/BaseSkuForecastResourceImpl.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/BaseSkuForecastResourceImpl.java
@@ -173,6 +173,10 @@ public abstract class BaseSkuForecastResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "SkuForecast";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseAssigneeMetricResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseAssigneeMetricResourceImpl.java
@@ -159,6 +159,10 @@ public abstract class BaseAssigneeMetricResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "AssigneeMetric";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseAssigneeResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseAssigneeResourceImpl.java
@@ -143,6 +143,10 @@ public abstract class BaseAssigneeResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Assignee";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseCalendarResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseCalendarResourceImpl.java
@@ -187,6 +187,10 @@ public abstract class BaseCalendarResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Calendar";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseIndexResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseIndexResourceImpl.java
@@ -217,6 +217,10 @@ public abstract class BaseIndexResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Index";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseInstanceResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseInstanceResourceImpl.java
@@ -597,6 +597,10 @@ public abstract class BaseInstanceResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Instance";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseNodeMetricResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseNodeMetricResourceImpl.java
@@ -190,6 +190,10 @@ public abstract class BaseNodeMetricResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "NodeMetric";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseNodeResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseNodeResourceImpl.java
@@ -360,6 +360,10 @@ public abstract class BaseNodeResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Node";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessMetricResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessMetricResourceImpl.java
@@ -285,6 +285,10 @@ public abstract class BaseProcessMetricResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "ProcessMetric";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessResourceImpl.java
@@ -407,6 +407,10 @@ public abstract class BaseProcessResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Process";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessVersionResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessVersionResourceImpl.java
@@ -215,6 +215,10 @@ public abstract class BaseProcessVersionResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "ProcessVersion";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseReindexStatusResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseReindexStatusResourceImpl.java
@@ -192,6 +192,10 @@ public abstract class BaseReindexStatusResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "ReindexStatus";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseRoleResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseRoleResourceImpl.java
@@ -222,6 +222,10 @@ public abstract class BaseRoleResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Role";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseSLAResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseSLAResourceImpl.java
@@ -544,6 +544,10 @@ public abstract class BaseSLAResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "SLA";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseTaskResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseTaskResourceImpl.java
@@ -508,6 +508,10 @@ public abstract class BaseTaskResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Task";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseTimeRangeResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseTimeRangeResourceImpl.java
@@ -187,6 +187,10 @@ public abstract class BaseTimeRangeResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "TimeRange";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/dxp/apps/saml/saml-admin-rest-impl/src/main/java/com/liferay/saml/admin/rest/internal/resource/v1_0/BaseSamlProviderResourceImpl.java
+++ b/modules/dxp/apps/saml/saml-admin-rest-impl/src/main/java/com/liferay/saml/admin/rest/internal/resource/v1_0/BaseSamlProviderResourceImpl.java
@@ -248,6 +248,10 @@ public abstract class BaseSamlProviderResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "SamlProvider";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseFieldMappingInfoResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseFieldMappingInfoResourceImpl.java
@@ -241,6 +241,10 @@ public abstract class BaseFieldMappingInfoResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "FieldMappingInfo";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseKeywordQueryContributorResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseKeywordQueryContributorResourceImpl.java
@@ -199,6 +199,10 @@ public abstract class BaseKeywordQueryContributorResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "KeywordQueryContributor";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseMLModelResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseMLModelResourceImpl.java
@@ -159,6 +159,10 @@ public abstract class BaseMLModelResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "MLModel";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseModelPrefilterContributorResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseModelPrefilterContributorResourceImpl.java
@@ -199,6 +199,10 @@ public abstract class BaseModelPrefilterContributorResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "ModelPrefilterContributor";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseQueryPrefilterContributorResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseQueryPrefilterContributorResourceImpl.java
@@ -199,6 +199,10 @@ public abstract class BaseQueryPrefilterContributorResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "QueryPrefilterContributor";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPBlueprintResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPBlueprintResourceImpl.java
@@ -792,6 +792,10 @@ public abstract class BaseSXPBlueprintResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "SXPBlueprint";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPElementResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPElementResourceImpl.java
@@ -824,6 +824,10 @@ public abstract class BaseSXPElementResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "SXPElement";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPParameterContributorDefinitionResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPParameterContributorDefinitionResourceImpl.java
@@ -203,6 +203,10 @@ public abstract class BaseSXPParameterContributorDefinitionResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "SXPParameterContributorDefinition";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSearchIndexResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSearchIndexResourceImpl.java
@@ -189,6 +189,10 @@ public abstract class BaseSearchIndexResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "SearchIndex";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSearchableAssetNameDisplayResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSearchableAssetNameDisplayResourceImpl.java
@@ -145,6 +145,10 @@ public abstract class BaseSearchableAssetNameDisplayResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "SearchableAssetNameDisplay";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSearchableAssetNameResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSearchableAssetNameResourceImpl.java
@@ -199,6 +199,10 @@ public abstract class BaseSearchableAssetNameResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "SearchableAssetName";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/BaseExperimentResourceImpl.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/BaseExperimentResourceImpl.java
@@ -214,6 +214,10 @@ public abstract class BaseExperimentResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Experiment";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/BaseStatusResourceImpl.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/BaseStatusResourceImpl.java
@@ -233,6 +233,10 @@ public abstract class BaseStatusResourceImpl
 		return null;
 	}
 
+	public String getResourceName() {
+		return "Status";
+	}
+
 	public String getVersion() {
 		return "v1.0";
 	}

--- a/modules/test/playwright/tests/batch-planner/export.spec.ts
+++ b/modules/test/playwright/tests/batch-planner/export.spec.ts
@@ -67,7 +67,7 @@ test('can export as JSONT', async ({apiHelpers, dataMigrationCenterPage}) => {
 		JSON.parse(
 			await dataMigrationCenterPage.exportFile(
 				'JSONT',
-				'Stock (v1_0 - Liferay Object REST)',
+				'Stock (v1.0 - Liferay Object REST)',
 				['name']
 			)
 		)
@@ -125,7 +125,7 @@ test('can export as JSON with excluded fields', async ({
 		JSON.parse(
 			await dataMigrationCenterPage.exportFile(
 				'JSON',
-				'Stock (v1_0 - Liferay Object REST)',
+				'Stock (v1.0 - Liferay Object REST)',
 				['name']
 			)
 		)
@@ -302,7 +302,7 @@ test('can export as JSON with all field types mapped', async ({
 		JSON.parse(
 			await dataMigrationCenterPage.exportFile(
 				'JSON',
-				'Stock (v1_0 - Liferay Object REST)',
+				'Stock (v1.0 - Liferay Object REST)',
 				[
 					'creator',
 					'customAttachment',
@@ -362,7 +362,7 @@ test('can export as JSONL with excluded fields', async ({
 	expect(
 		await dataMigrationCenterPage.exportFile(
 			'JSONL',
-			'Stock (v1_0 - Liferay Object REST)',
+			'Stock (v1.0 - Liferay Object REST)',
 			['name']
 		)
 	).toBe('{"name":"Stock Entry"}\n');
@@ -386,7 +386,7 @@ test('can see correct custom object name in dropdown', async ({
 		await dataMigrationCenterPage.page
 			.getByLabel('Entity Type')
 			.textContent()
-	).toContain('Stock (v1_0 - Liferay Object REST)');
+	).toContain('Stock (v1.0 - Liferay Object REST)');
 
 	await apiHelpers.objectAdmin.deleteObjectDefinition(objectDefinition.id);
 });

--- a/modules/test/playwright/tests/batch-planner/export.spec.ts
+++ b/modules/test/playwright/tests/batch-planner/export.spec.ts
@@ -377,7 +377,7 @@ test('can see correct custom object name in dropdown', async ({
 	const objectDefinition = await apiHelpers.objectAdmin.postObjectDefinition(
 		stockObjectDefinition
 	);
-	await apiHelpers.object.postObjectEntry(stockObjectEntry, 'c/stocks');
+	await apiHelpers.objectEntry.postObjectEntry(stockObjectEntry, 'c/stocks');
 
 	await dataMigrationCenterPage.goto();
 	await dataMigrationCenterPage.goToExportFile();

--- a/modules/test/playwright/tests/batch-planner/export.spec.ts
+++ b/modules/test/playwright/tests/batch-planner/export.spec.ts
@@ -67,7 +67,7 @@ test('can export as JSONT', async ({apiHelpers, dataMigrationCenterPage}) => {
 		JSON.parse(
 			await dataMigrationCenterPage.exportFile(
 				'JSONT',
-				'C_Stock (v1_0 - Liferay Object REST)',
+				'Stock (v1_0 - Liferay Object REST)',
 				['name']
 			)
 		)
@@ -125,7 +125,7 @@ test('can export as JSON with excluded fields', async ({
 		JSON.parse(
 			await dataMigrationCenterPage.exportFile(
 				'JSON',
-				'C_Stock (v1_0 - Liferay Object REST)',
+				'Stock (v1_0 - Liferay Object REST)',
 				['name']
 			)
 		)
@@ -302,7 +302,7 @@ test('can export as JSON with all field types mapped', async ({
 		JSON.parse(
 			await dataMigrationCenterPage.exportFile(
 				'JSON',
-				'C_Stock (v1_0 - Liferay Object REST)',
+				'Stock (v1_0 - Liferay Object REST)',
 				[
 					'creator',
 					'customAttachment',
@@ -362,7 +362,7 @@ test('can export as JSONL with excluded fields', async ({
 	expect(
 		await dataMigrationCenterPage.exportFile(
 			'JSONL',
-			'C_Stock (v1_0 - Liferay Object REST)',
+			'Stock (v1_0 - Liferay Object REST)',
 			['name']
 		)
 	).toBe('{"name":"Stock Entry"}\n');
@@ -379,14 +379,14 @@ test('can see correct custom object name in dropdown', async ({
 	);
 	await apiHelpers.object.postObjectEntry(stockObjectEntry, 'c/stocks');
 
-	await dataMigrationCenterPage.goto()
+	await dataMigrationCenterPage.goto();
 	await dataMigrationCenterPage.goToExportFile();
 
 	expect(
-		await dataMigrationCenterPage.page.getByLabel('Entity Type').textContent()
-	).toContain('Stock (v1_0 - Liferay Object REST)')
+		await dataMigrationCenterPage.page
+			.getByLabel('Entity Type')
+			.textContent()
+	).toContain('Stock (v1_0 - Liferay Object REST)');
 
 	await apiHelpers.objectAdmin.deleteObjectDefinition(objectDefinition.id);
 });
-
-

--- a/modules/test/playwright/tests/batch-planner/export.spec.ts
+++ b/modules/test/playwright/tests/batch-planner/export.spec.ts
@@ -369,3 +369,24 @@ test('can export as JSONL with excluded fields', async ({
 
 	await apiHelpers.objectAdmin.deleteObjectDefinition(objectDefinition.id);
 });
+
+test('can see correct custom object name in dropdown', async ({
+	apiHelpers,
+	dataMigrationCenterPage,
+}) => {
+	const objectDefinition = await apiHelpers.objectAdmin.postObjectDefinition(
+		stockObjectDefinition
+	);
+	await apiHelpers.object.postObjectEntry(stockObjectEntry, 'c/stocks');
+
+	await dataMigrationCenterPage.goto()
+	await dataMigrationCenterPage.goToExportFile();
+
+	expect(
+		await dataMigrationCenterPage.page.getByLabel('Entity Type').textContent()
+	).toContain('Stock (v1_0 - Liferay Object REST)')
+
+	await apiHelpers.objectAdmin.deleteObjectDefinition(objectDefinition.id);
+});
+
+

--- a/modules/test/playwright/tests/batch-planner/import.spec.ts
+++ b/modules/test/playwright/tests/batch-planner/import.spec.ts
@@ -1279,7 +1279,7 @@ test('can see correct custom object name in dropdown', async ({
 		await dataMigrationCenterPage.page
 			.getByLabel('Entity Type')
 			.textContent()
-	).toContain('Stock (v1_0 - Liferay Object REST)');
+	).toContain('Stock (v1.0 - Liferay Object REST)');
 
 	await apiHelpers.objectAdmin.deleteObjectDefinition(objectDefinition.id);
 });

--- a/modules/test/playwright/tests/batch-planner/import.spec.ts
+++ b/modules/test/playwright/tests/batch-planner/import.spec.ts
@@ -1264,7 +1264,7 @@ test('can see correct custom object name in dropdown', async ({
 		},
 	});
 
-	await apiHelpers.object.postObjectEntry(
+	await apiHelpers.objectEntry.postObjectEntry(
 		{
 			externalReferenceCode: 'nameERC',
 			name: 'Stock Entry',

--- a/modules/test/playwright/tests/batch-planner/import.spec.ts
+++ b/modules/test/playwright/tests/batch-planner/import.spec.ts
@@ -1229,57 +1229,57 @@ test('cannot import empty CSV file', async ({
 	await apiHelpers.objectAdmin.deleteObjectDefinition(response.id);
 });
 
-
 test('can see correct custom object name in dropdown', async ({
 	apiHelpers,
 	dataMigrationCenterPage,
 }) => {
-	const objectDefinition = await apiHelpers.objectAdmin.postObjectDefinition(
-		{
-			active: true,
-			externalReferenceCode: 'stockERC',
-			label: {
-				en_US: 'stock',
-			},
-			name: 'Stock',
-			objectFields: [
-				{
-					DBType: 'String',
-					businessType: 'Text',
-					externalReferenceCode: 'nameERC',
-					indexed: true,
-					indexedAsKeyword: true,
-					label: {
-						en_US: 'name',
-					},
-					name: 'name',
-					required: true,
+	const objectDefinition = await apiHelpers.objectAdmin.postObjectDefinition({
+		active: true,
+		externalReferenceCode: 'stockERC',
+		label: {
+			en_US: 'stock',
+		},
+		name: 'Stock',
+		objectFields: [
+			{
+				DBType: 'String',
+				businessType: 'Text',
+				externalReferenceCode: 'nameERC',
+				indexed: true,
+				indexedAsKeyword: true,
+				label: {
+					en_US: 'name',
 				},
-			],
-			pluralLabel: {
-				en_US: 'stocks',
+				name: 'name',
+				required: true,
 			},
-			portlet: true,
-			scope: 'company',
-			status: {
-				code: 0,
-			},
-		}
-	);
-	
-	await apiHelpers.object.postObjectEntry({
-		externalReferenceCode: 'nameERC',
-		name: 'Stock Entry',
-	}, 'c/stocks');
+		],
+		pluralLabel: {
+			en_US: 'stocks',
+		},
+		portlet: true,
+		scope: 'company',
+		status: {
+			code: 0,
+		},
+	});
 
-	await dataMigrationCenterPage.goto()
+	await apiHelpers.object.postObjectEntry(
+		{
+			externalReferenceCode: 'nameERC',
+			name: 'Stock Entry',
+		},
+		'c/stocks'
+	);
+
+	await dataMigrationCenterPage.goto();
 	await dataMigrationCenterPage.goToImportFile();
 
 	expect(
-		await dataMigrationCenterPage.page.getByLabel('Entity Type').textContent()
-	).toContain('Stock (v1_0 - Liferay Object REST)')
+		await dataMigrationCenterPage.page
+			.getByLabel('Entity Type')
+			.textContent()
+	).toContain('Stock (v1_0 - Liferay Object REST)');
 
 	await apiHelpers.objectAdmin.deleteObjectDefinition(objectDefinition.id);
 });
-
-

--- a/modules/test/playwright/tests/batch-planner/import.spec.ts
+++ b/modules/test/playwright/tests/batch-planner/import.spec.ts
@@ -1228,3 +1228,58 @@ test('cannot import empty CSV file', async ({
 
 	await apiHelpers.objectAdmin.deleteObjectDefinition(response.id);
 });
+
+
+test('can see correct custom object name in dropdown', async ({
+	apiHelpers,
+	dataMigrationCenterPage,
+}) => {
+	const objectDefinition = await apiHelpers.objectAdmin.postObjectDefinition(
+		{
+			active: true,
+			externalReferenceCode: 'stockERC',
+			label: {
+				en_US: 'stock',
+			},
+			name: 'Stock',
+			objectFields: [
+				{
+					DBType: 'String',
+					businessType: 'Text',
+					externalReferenceCode: 'nameERC',
+					indexed: true,
+					indexedAsKeyword: true,
+					label: {
+						en_US: 'name',
+					},
+					name: 'name',
+					required: true,
+				},
+			],
+			pluralLabel: {
+				en_US: 'stocks',
+			},
+			portlet: true,
+			scope: 'company',
+			status: {
+				code: 0,
+			},
+		}
+	);
+	
+	await apiHelpers.object.postObjectEntry({
+		externalReferenceCode: 'nameERC',
+		name: 'Stock Entry',
+	}, 'c/stocks');
+
+	await dataMigrationCenterPage.goto()
+	await dataMigrationCenterPage.goToImportFile();
+
+	expect(
+		await dataMigrationCenterPage.page.getByLabel('Entity Type').textContent()
+	).toContain('Stock (v1_0 - Liferay Object REST)')
+
+	await apiHelpers.objectAdmin.deleteObjectDefinition(objectDefinition.id);
+});
+
+

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -885,6 +885,10 @@ public abstract class Base${schemaName}ResourceImpl
 			return null;
 		}
 
+		public String getResourceName() {
+			return "${schemaName}";
+		}
+
 		public String getVersion() {
 			return "${freeMarkerTool.getVersion(openAPIYAML)}";
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/security/SAML.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/security/SAML.testcase
@@ -3264,7 +3264,7 @@ definition {
 			ImportExport.gotoImport();
 
 			ImportExport.configureImport(
-				entityType = "SamlProvider (v1_0 - Liferay SAML Admin REST)",
+				entityType = "SamlProvider (v1.0 - Liferay SAML Admin REST)",
 				fileName = "identity-provider-configuration.json",
 				importStrategy = "Only Add New Records");
 
@@ -3319,7 +3319,7 @@ definition {
 			ImportExport.gotoImport();
 
 			ImportExport.configureImport(
-				entityType = "SamlProvider (v1_0 - Liferay SAML Admin REST)",
+				entityType = "SamlProvider (v1.0 - Liferay SAML Admin REST)",
 				fileName = "service-provider-configuration.json",
 				importStrategy = "Only Add New Records");
 
@@ -3383,7 +3383,7 @@ definition {
 			ImportExport.gotoImport();
 
 			ImportExport.configureImport(
-				entityType = "SamlProvider (v1_0 - Liferay SAML Admin REST)",
+				entityType = "SamlProvider (v1.0 - Liferay SAML Admin REST)",
 				fileName = "service-provider-configuration.json",
 				importStrategy = "Only Add New Records");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/security/SAMLUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/security/SAMLUpgrade.testcase
@@ -45,7 +45,7 @@ definition {
 			ImportExport.gotoImport();
 
 			ImportExport.configureImport(
-				entityType = "SamlProvider (v1_0 - Liferay SAML Admin REST)",
+				entityType = "SamlProvider (v1.0 - Liferay SAML Admin REST)",
 				fileName = "identity-provider-configuration.json",
 				importStrategy = "Only Add New Records");
 
@@ -98,7 +98,7 @@ definition {
 			ImportExport.gotoImport();
 
 			ImportExport.configureImport(
-				entityType = "SamlProvider (v1_0 - Liferay SAML Admin REST)",
+				entityType = "SamlProvider (v1.0 - Liferay SAML Admin REST)",
 				fileName = "identity-provider-configuration.json",
 				importStrategy = "Only Add New Records");
 
@@ -151,7 +151,7 @@ definition {
 			ImportExport.gotoImport();
 
 			ImportExport.configureImport(
-				entityType = "SamlProvider (v1_0 - Liferay SAML Admin REST)",
+				entityType = "SamlProvider (v1.0 - Liferay SAML Admin REST)",
 				fileName = "identity-provider-configuration.json",
 				importStrategy = "Only Add New Records");
 
@@ -205,7 +205,7 @@ definition {
 			ImportExport.gotoImport();
 
 			ImportExport.configureImport(
-				entityType = "SamlProvider (v1_0 - Liferay SAML Admin REST)",
+				entityType = "SamlProvider (v1.0 - Liferay SAML Admin REST)",
 				fileName = "identity-provider-configuration.json",
 				importStrategy = "Only Add New Records");
 


### PR DESCRIPTION
Description: Previously, we showed the table name (eg. `C_Students`). Now we want to show the Object name (eg. `Students`). Furthermore, we want to show the version with a format `v1.0` instead of the current one: `v1_0`.

Screenshots:
![image](https://github.com/liferay-headless/liferay-portal/assets/32699538/5d235a4a-64db-4e5d-a8a1-c9d46aedf668)
![image](https://github.com/liferay-headless/liferay-portal/assets/32699538/2769ec60-b5c0-4fb5-bdf6-6766fab05486)

Jira Ticket: https://liferay.atlassian.net/browse/LPD-25627