### PR TITLE
LPD-2239 Make GraphQL recognize the SecurityExceptions and throw it's respective 403 error

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -2395,6 +2395,19 @@ public class GraphQLServletExtender {
 			return processedErrors;
 		}
 
+		private Throwable _getCauseThrowable(GraphQLError graphQLError) {
+			ExceptionWhileDataFetching exceptionWhileDataFetching =
+				(ExceptionWhileDataFetching)graphQLError;
+
+			Throwable throwable = exceptionWhileDataFetching.getException();
+
+			if (throwable instanceof InvocationTargetException) {
+				return throwable.getCause();
+			}
+
+			return throwable;
+		}
+
 		private GraphQLError _getExtendedGraphQLError(
 			GraphQLError graphQLError, Response.Status status) {
 
@@ -2444,14 +2457,10 @@ public class GraphQLServletExtender {
 				return false;
 			}
 
-			ExceptionWhileDataFetching exceptionWhileDataFetching =
-				(ExceptionWhileDataFetching)graphQLError;
+			Throwable throwable = _getCauseThrowable(graphQLError);
 
-			Throwable throwable = exceptionWhileDataFetching.getException();
-
-			if ((throwable != null) &&
-				((throwable.getCause() instanceof ForbiddenException) ||
-				 (throwable instanceof SecurityException))) {
+			if (throwable instanceof ForbiddenException ||
+				throwable instanceof SecurityException) {
 
 				return true;
 			}
@@ -2464,16 +2473,11 @@ public class GraphQLServletExtender {
 				return false;
 			}
 
-			ExceptionWhileDataFetching exceptionWhileDataFetching =
-				(ExceptionWhileDataFetching)graphQLError;
+			Throwable throwable = _getCauseThrowable(graphQLError);
 
-			Throwable throwable = exceptionWhileDataFetching.getException();
-
-			if ((throwable != null) &&
-				(throwable.getCause() instanceof NotFoundException ||
-				 throwable.getCause() instanceof NoSuchModelException ||
-				 throwable.getCause() instanceof
-					 PrincipalException.MustHavePermission)) {
+			if (throwable instanceof NoSuchModelException ||
+				throwable instanceof NotFoundException ||
+				throwable instanceof PrincipalException.MustHavePermission) {
 
 				return true;
 			}

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -2395,19 +2395,6 @@ public class GraphQLServletExtender {
 			return processedErrors;
 		}
 
-		private Throwable _getCauseThrowable(GraphQLError graphQLError) {
-			ExceptionWhileDataFetching exceptionWhileDataFetching =
-				(ExceptionWhileDataFetching)graphQLError;
-
-			Throwable throwable = exceptionWhileDataFetching.getException();
-
-			if (throwable instanceof InvocationTargetException) {
-				return throwable.getCause();
-			}
-
-			return throwable;
-		}
-
 		private GraphQLError _getExtendedGraphQLError(
 			GraphQLError graphQLError, Response.Status status) {
 
@@ -2426,6 +2413,19 @@ public class GraphQLServletExtender {
 					).build()
 				).build()
 			).build();
+		}
+
+		private Throwable _getThrowable(GraphQLError graphQLError) {
+			ExceptionWhileDataFetching exceptionWhileDataFetching =
+				(ExceptionWhileDataFetching)graphQLError;
+
+			Throwable throwable = exceptionWhileDataFetching.getException();
+
+			if (throwable instanceof InvocationTargetException) {
+				return throwable.getCause();
+			}
+
+			return throwable;
 		}
 
 		private boolean _isClientErrorException(GraphQLError graphQLError) {
@@ -2457,7 +2457,7 @@ public class GraphQLServletExtender {
 				return false;
 			}
 
-			Throwable throwable = _getCauseThrowable(graphQLError);
+			Throwable throwable = _getThrowable(graphQLError);
 
 			if (throwable instanceof ForbiddenException ||
 				throwable instanceof SecurityException) {
@@ -2473,7 +2473,7 @@ public class GraphQLServletExtender {
 				return false;
 			}
 
-			Throwable throwable = _getCauseThrowable(graphQLError);
+			Throwable throwable = _getThrowable(graphQLError);
 
 			if (throwable instanceof NoSuchModelException ||
 				throwable instanceof NotFoundException ||

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -2369,14 +2369,7 @@ public class GraphQLServletExtender {
 					continue;
 				}
 
-				String message = graphQLError.getMessage();
-
-				if (message.contains("SecurityException")) {
-					processedErrors.add(
-						_getExtendedGraphQLError(
-							graphQLError, Response.Status.UNAUTHORIZED));
-				}
-				else if (_isForbiddenException(graphQLError)) {
+				if (_isForbiddenException(graphQLError)) {
 					processedErrors.add(
 						_getExtendedGraphQLError(
 							graphQLError, Response.Status.FORBIDDEN));
@@ -2457,7 +2450,8 @@ public class GraphQLServletExtender {
 			Throwable throwable = exceptionWhileDataFetching.getException();
 
 			if ((throwable != null) &&
-				(throwable.getCause() instanceof ForbiddenException)) {
+				((throwable.getCause() instanceof ForbiddenException) ||
+				 (throwable instanceof SecurityException))) {
 
 				return true;
 			}

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
@@ -360,18 +360,6 @@ public class GraphQLServletTest {
 				"Object/code"));
 
 		Assert.assertEquals(
-			"Forbidden",
-			JSONUtil.getValueAsString(
-				_invoke(
-					new GraphQLField(
-						"testPath_v1_0",
-						new GraphQLField(
-							"testNonauthorizedUser", new GraphQLField("id"))),
-					"query"),
-				"JSONArray/errors", "Object/0", "JSONObject/extensions",
-				"Object/code"));
-
-		Assert.assertEquals(
 			"Not Found",
 			JSONUtil.getValueAsString(
 				_invoke(
@@ -379,6 +367,18 @@ public class GraphQLServletTest {
 						"testPath_v1_0",
 						new GraphQLField(
 							"testNotFoundDTO", new GraphQLField("id"))),
+					"query"),
+				"JSONArray/errors", "Object/0", "JSONObject/extensions",
+				"Object/code"));
+
+		Assert.assertEquals(
+			"Forbidden",
+			JSONUtil.getValueAsString(
+				_invoke(
+					new GraphQLField(
+						"testPath_v1_0",
+						new GraphQLField(
+							"testUnauthorizedUser", new GraphQLField("id"))),
 					"query"),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
@@ -407,20 +407,20 @@ public class GraphQLServletTest {
 				"Object/code"));
 
 		Assert.assertEquals(
-			"Forbidden",
+			"Not Found",
 			JSONUtil.getValueAsString(
 				_invoke(
-					new GraphQLField(
-						"testNonauthorizedUser", new GraphQLField("id")),
+					new GraphQLField("testNotFoundDTO", new GraphQLField("id")),
 					"query"),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
 
 		Assert.assertEquals(
-			"Not Found",
+			"Forbidden",
 			JSONUtil.getValueAsString(
 				_invoke(
-					new GraphQLField("testNotFoundDTO", new GraphQLField("id")),
+					new GraphQLField(
+						"testUnauthorizedUser", new GraphQLField("id")),
 					"query"),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
@@ -612,11 +612,6 @@ public class GraphQLServletTest {
 		}
 
 		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
-		public TestDTO testNonauthorizedUser() throws SecurityException {
-			throw new SecurityException();
-		}
-
-		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
 		public TestDTO testNoPermissionOverDTO()
 			throws PrincipalException.MustHavePermission {
 
@@ -627,6 +622,11 @@ public class GraphQLServletTest {
 		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
 		public TestDTO testNotFoundDTO() {
 			throw new NotFoundException();
+		}
+
+		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+		public TestDTO testUnauthorizedUser() throws SecurityException {
+			throw new SecurityException();
 		}
 
 		@GraphQLTypeExtension(TestDTO.class)

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/GraphQLServletTest.java
@@ -360,6 +360,18 @@ public class GraphQLServletTest {
 				"Object/code"));
 
 		Assert.assertEquals(
+			"Forbidden",
+			JSONUtil.getValueAsString(
+				_invoke(
+					new GraphQLField(
+						"testPath_v1_0",
+						new GraphQLField(
+							"testNonauthorizedUser", new GraphQLField("id"))),
+					"query"),
+				"JSONArray/errors", "Object/0", "JSONObject/extensions",
+				"Object/code"));
+
+		Assert.assertEquals(
 			"Not Found",
 			JSONUtil.getValueAsString(
 				_invoke(
@@ -390,6 +402,16 @@ public class GraphQLServletTest {
 				_invoke(
 					new GraphQLField(
 						"testNoPermissionOverDTO", new GraphQLField("id")),
+					"query"),
+				"JSONArray/errors", "Object/0", "JSONObject/extensions",
+				"Object/code"));
+
+		Assert.assertEquals(
+			"Forbidden",
+			JSONUtil.getValueAsString(
+				_invoke(
+					new GraphQLField(
+						"testNonauthorizedUser", new GraphQLField("id")),
 					"query"),
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
@@ -587,6 +609,11 @@ public class GraphQLServletTest {
 			@GraphQLName("pageSize") int pageSize) {
 
 			return new TestDTOPage(page, pageSize);
+		}
+
+		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+		public TestDTO testNonauthorizedUser() throws SecurityException {
+			throw new SecurityException();
 		}
 
 		@com.liferay.portal.vulcan.graphql.annotation.GraphQLField


### PR DESCRIPTION
**What's changed?:**
- Now the errors infrastructure of GraphQL take the SecurityExceptions exception into account.
- Instead of returning a generic Internal Server Error message, a Forbidden (as in REST) is returned.
- The GraphQLServletTest now checks if this exception outputs the wanted error.

See the following **Jira Ticket**: [LPD-2239](https://liferay.atlassian.net/browse/LPD-2239) 