### PR TITLE
LPD-26417 Initial data is not propagated if conflict on friendlyURL when switching to a different site template using `LayoutSetLocalServiceUtil.updateLayoutSetPrototypeLinkEnabled()`

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exportimport/data/handler/StagedLayoutSetStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exportimport/data/handler/StagedLayoutSetStagedModelDataHandler.java
@@ -310,7 +310,12 @@ public class StagedLayoutSetStagedModelDataHandler
 			if ((sourcePrototypeLayout == null) &&
 				_layoutLocalService.hasLayout(
 					layout.getUuid(), layout.getGroupId(),
-					layout.isPrivateLayout())) {
+					layout.isPrivateLayout()) &&
+				!layout.getLayoutSet(
+				).getSettings(
+				).contains(
+					Sites.MERGE_FAIL_FRIENDLY_URL_LAYOUTS
+				)) {
 
 				_layoutLocalService.deleteLayout(
 					layout, ServiceContextThreadLocal.getServiceContext());

--- a/modules/test/playwright/pages/configuration-admin-web/SystemSettingsPage.ts
+++ b/modules/test/playwright/pages/configuration-admin-web/SystemSettingsPage.ts
@@ -13,7 +13,6 @@ export class SystemSettingsPage {
 	readonly page: Page;
 	readonly disabledFeaturesSection: Locator;
 	readonly disablePrivatePagesOption: Locator;
-	readonly updateButton: Locator;
 	readonly releaseFeatureFlagsLink: Locator;
 	private uiElementsPage;
 
@@ -31,7 +30,6 @@ export class SystemSettingsPage {
 		this.releaseFeatureFlagsLink = page.getByRole('link', {
 			name: 'Release Feature Flags',
 		});
-		this.updateButton = page.getByRole('button', {name: 'Update'});
 	}
 
 	async disablePrivatePages() {
@@ -39,7 +37,10 @@ export class SystemSettingsPage {
 		await this.releaseFeatureFlagsLink.click();
 		await this.disabledFeaturesSection.click();
 		await this.disablePrivatePagesOption.click();
-		await this.updateButton.click();
+		const submitButton = await this.page.$(
+			'button[data-qa-id="submitConfiguration"]'
+		);
+		await submitButton.click();
 		await this.uiElementsPage.anySuccessAlert.waitFor({state: 'visible'});
 	}
 

--- a/modules/test/playwright/tests/layout-set-prototype-web/siteTemplatesWithWebContent.spec.ts
+++ b/modules/test/playwright/tests/layout-set-prototype-web/siteTemplatesWithWebContent.spec.ts
@@ -248,6 +248,104 @@ test('can switch template with web content on content page', async ({
 	);
 });
 
+test('can switch template with web content on home page', async ({
+	apiHelpers,
+	applicationsMenuPage,
+	contentPage,
+	journalPage,
+	layoutSetPrototypePage,
+	page,
+	productMenuPage,
+	serverAdministrationPage,
+	sitesPage,
+	staticPagesPage,
+	systemSettingsPage,
+	uiElementsPage,
+	webContentDisplayPage,
+}) => {
+	await systemSettingsPage.disablePrivatePages();
+
+	const contentTemplateName1: string = getRandomString();
+	const contentTemplateName2: string = getRandomString();
+	const siteName: string = getRandomString();
+
+	await createSiteTemplateWithWebContentOnHomePage({
+		applicationsMenuPage,
+		contentPage,
+		journalPage,
+		layoutSetPrototypePage,
+		page,
+		productMenuPage,
+		staticPagesPage,
+		templateName: contentTemplateName1,
+		text: `${webContentText1} `,
+		uiElementsPage,
+		webContentDisplayPage,
+		webContentName: `${webContentName1} `,
+	});
+
+	await createSiteTemplateWithWebContentOnHomePage({
+		applicationsMenuPage,
+		contentPage,
+		journalPage,
+		layoutSetPrototypePage,
+		page,
+		productMenuPage,
+		staticPagesPage,
+		templateName: contentTemplateName2,
+		text: `${webContentText2} `,
+		uiElementsPage,
+		webContentDisplayPage,
+		webContentName: `${webContentName2} `,
+	});
+
+	const layoutSetPrototypes: LayoutSetPrototype[] =
+		await apiHelpers.jsonWebServicesLayoutSetPrototype.getLayoutSetPrototypes();
+	const layoutSetPrototype1 = await getLayoutTemplateByName(
+		layoutSetPrototypes,
+		contentTemplateName1
+	);
+	const layoutSetPrototype2 = await getLayoutTemplateByName(
+		layoutSetPrototypes,
+		contentTemplateName2
+	);
+
+	await applicationsMenuPage.goToSites();
+	const siteId = await sitesPage.createSiteFromTemplate(
+		contentTemplateName1,
+		siteName
+	);
+	await applicationsMenuPage.goToSites();
+	await staticPagesPage.checkIfWebContentAddedToHome(
+		siteName,
+		webContentText1
+	);
+
+	await applicationsMenuPage.goToServerAdministration();
+
+	const script = `
+    import com.liferay.portal.kernel.service.LayoutSetLocalServiceUtil;
+    String siteTemplateUUID = "${layoutSetPrototype2.uuid}";
+    long siteId = ${siteId};
+    LayoutSetLocalServiceUtil.updateLayoutSetPrototypeLinkEnabled(siteId, true, true, siteTemplateUUID);
+    `;
+	await serverAdministrationPage.executeScript(script);
+
+	await staticPagesPage.checkIfWebContentAddedToHome(
+		siteName,
+		webContentText1
+	);
+
+	// tearDown
+
+	await deleteSiteAndLayoutSetPrototypes(
+		apiHelpers,
+		siteId,
+		layoutSetPrototype1.layoutSetPrototypeId.toString(),
+		layoutSetPrototype2.layoutSetPrototypeId.toString()
+	);
+});
+
 async function deleteSiteAndLayoutSetPrototypes(
 	apiHelpers: ApiHelpers,
 	siteId: string,
@@ -396,6 +494,54 @@ async function createSiteTemplateWithWebContentOnContentPage({
 	await staticPagesPage.addTemplatePageButton.click();
 	await staticPagesPage.addContentPage(templateName);
 
+	await contentPage.addWebContentDisplayToPage();
+	await webContentDisplayPage.addWebContentWithDisplay();
+	await uiElementsPage.publishButton.click();
+}
+
+async function createSiteTemplateWithWebContentOnHomePage({
+	applicationsMenuPage,
+	contentPage,
+	journalPage,
+	layoutSetPrototypePage,
+	page,
+	productMenuPage,
+	staticPagesPage,
+	templateName,
+	text,
+	uiElementsPage,
+	webContentDisplayPage,
+	webContentName,
+}: {
+	applicationsMenuPage: ApplicationsMenuPage;
+	contentPage: ContentPage;
+	journalPage: JournalPage;
+	layoutSetPrototypePage: LayoutSetPrototypePage;
+	page: Page;
+	productMenuPage: ProductMenuPage;
+	staticPagesPage: StaticPagesPage;
+	templateName: string;
+	text: string;
+	uiElementsPage: UIElementsPage;
+	webContentDisplayPage: WebContentDisplayPage;
+	webContentName: string;
+}): Promise<void> {
+	await applicationsMenuPage.goToSiteTemplates();
+	await layoutSetPrototypePage.addSiteTemplate(templateName);
+	await applicationsMenuPage.goToSiteTemplates();
+	const siteTemplateUrl = await layoutSetPrototypePage.getSiteTemplateUrl(
+		templateName
+	);
+
+	await page.goto(siteTemplateUrl);
+	await productMenuPage.checkIfAdecuateProductMenu(templateName);
+	await productMenuPage.openProductMenuIfClosed();
+	await productMenuPage.goToWebContent();
+	await journalPage.goToCreateArticle();
+	await journalPage.createBasicArticle(webContentName, text);
+
+	await productMenuPage.goToPages();
+	await staticPagesPage.homePageLink.click();
 	await contentPage.addWebContentDisplayToPage();
 	await webContentDisplayPage.addWebContentWithDisplay();
 	await uiElementsPage.publishButton.click();


### PR DESCRIPTION
https://issues.liferay.com/browse/LPD-26417