### PR TITLE
LPD-25201 Support lowercase scopes from CX

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/configuration/OAuth2ProviderApplicationHeadlessServerConfigurationFactory.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/configuration/OAuth2ProviderApplicationHeadlessServerConfigurationFactory.java
@@ -9,8 +9,10 @@ import com.liferay.oauth2.provider.configuration.OAuth2ProviderApplicationHeadle
 import com.liferay.oauth2.provider.constants.ClientProfile;
 import com.liferay.oauth2.provider.constants.GrantType;
 import com.liferay.oauth2.provider.model.OAuth2Application;
+import com.liferay.oauth2.provider.scope.liferay.ScopeLocator;
 import com.liferay.oauth2.provider.util.OAuth2SecureRandomGenerator;
 import com.liferay.osgi.util.configuration.ConfigurationFactoryUtil;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.petra.string.StringUtil;
@@ -25,6 +27,7 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.util.PropsValues;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -33,6 +36,7 @@ import java.util.Objects;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Raymond Augé
@@ -64,9 +68,25 @@ public class OAuth2ProviderApplicationHeadlessServerConfigurationFactory
 							OAuth2ProviderApplicationHeadlessServerConfiguration.class,
 							properties);
 
-				List<String> scopeAliasesList = ListUtil.fromArray(
+				Collection<String> scopeAliases = _scopeLocator.getScopeAliases(
+					companyId);
+
+				List<String> scopeAliasesList = TransformUtil.transformToList(
 					oAuth2ProviderApplicationHeadlessServerConfiguration.
-						scopes());
+						scopes(),
+					scopeAlias -> {
+						if (!scopeAliases.contains(scopeAlias)) {
+							for (String curScopeAlias : scopeAliases) {
+								if (StringUtil.equalsIgnoreCase(
+										curScopeAlias, scopeAlias)) {
+
+									return curScopeAlias;
+								}
+							}
+						}
+
+						return scopeAlias;
+					});
 
 				oAuth2Application = _addOrUpdateOAuth2Application(
 					companyId, externalReferenceCode,
@@ -230,5 +250,8 @@ public class OAuth2ProviderApplicationHeadlessServerConfigurationFactory
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		OAuth2ProviderApplicationHeadlessServerConfigurationFactory.class);
+
+	@Reference
+	private ScopeLocator _scopeLocator;
 
 }

--- a/modules/apps/object/object-rest-test/build.gradle
+++ b/modules/apps/object/object-rest-test/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:headless:headless-admin-taxonomy:headless-admin-taxonomy-client")
 	testIntegrationImplementation project(":apps:headless:headless-admin-user:headless-admin-user-api")
 	testIntegrationImplementation project(":apps:list-type:list-type-api")
+	testIntegrationImplementation project(":apps:oauth2-provider:oauth2-provider-api")
 	testIntegrationImplementation project(":apps:object:object-api")
 	testIntegrationImplementation project(":apps:object:object-rest-api")
 	testIntegrationImplementation project(":apps:object:object-rest-test-util")

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/oauth2/provider/configuration/test/ObjectDefinitionOAuth2ProviderApplicationHeadlessServerConfigurationFactoryTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/oauth2/provider/configuration/test/ObjectDefinitionOAuth2ProviderApplicationHeadlessServerConfigurationFactoryTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.object.rest.internal.oauth2.scope.alias.mapper.test;
+package com.liferay.object.rest.internal.oauth2.provider.configuration.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.oauth2.provider.model.OAuth2Application;
@@ -38,7 +38,8 @@ import org.junit.runner.RunWith;
  * @author Carlos Correa
  */
 @RunWith(Arquillian.class)
-public class ObjectDefinitionScopeAliasMapperTest {
+public class
+	ObjectDefinitionOAuth2ProviderApplicationHeadlessServerConfigurationFactoryTest {
 
 	@ClassRule
 	@Rule

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/oauth2/scope/alias/mapper/test/ObjectDefinitionScopeAliasMapperTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/oauth2/scope/alias/mapper/test/ObjectDefinitionScopeAliasMapperTest.java
@@ -1,0 +1,187 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.rest.internal.oauth2.scope.alias.mapper.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.oauth2.provider.model.OAuth2Application;
+import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
+import com.liferay.oauth2.provider.service.OAuth2ApplicationScopeAliasesLocalService;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.field.util.ObjectFieldUtil;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.petra.function.UnsafeRunnable;
+import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.TextFormatter;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Carlos Correa
+ */
+@RunWith(Arquillian.class)
+public class ObjectDefinitionScopeAliasMapperTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void test() throws Exception {
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				"AAA" + RandomTestUtil.randomString() + "aaa",
+				Collections.singletonList(
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
+						RandomTestUtil.randomString(),
+						"x" + RandomTestUtil.randomString(), false)),
+				ObjectDefinitionConstants.SCOPE_COMPANY);
+
+		String name = objectDefinition.getName();
+
+		String lowerCaseName = StringUtil.toLowerCase(name);
+
+		_testWithOAuth2ProviderApplicationHeadlessServerConfiguration(
+			lowerCaseName + ".everything", objectDefinition,
+			lowerCaseName + ".everything");
+
+		_testWithOAuth2ProviderApplicationHeadlessServerConfiguration(
+			lowerCaseName + ".everything", objectDefinition,
+			name + ".everything");
+
+		_withBundlePrefixHandlerFactoryConfiguration(
+			objectDefinition,
+			() -> _testWithOAuth2ProviderApplicationHeadlessServerConfiguration(
+				"com.liferay.object.rest.impl/" + lowerCaseName + "/everything",
+				objectDefinition,
+				"com.liferay.object.rest.impl/" + lowerCaseName +
+					"/everything"));
+
+		_withBundlePrefixHandlerFactoryConfiguration(
+			objectDefinition,
+			() -> _testWithOAuth2ProviderApplicationHeadlessServerConfiguration(
+				"com.liferay.object.rest.impl/" + lowerCaseName + "/everything",
+				objectDefinition,
+				"com.liferay.object.rest.impl/" + name + "/everything"));
+	}
+
+	private OAuth2Application _getOAuth2Application(
+		long companyId, String name) {
+
+		for (OAuth2Application oAuth2Application :
+				_oAuth2ApplicationLocalService.getOAuth2Applications(
+					companyId)) {
+
+			if (StringUtil.equals(name, oAuth2Application.getName())) {
+				return oAuth2Application;
+			}
+		}
+
+		return null;
+	}
+
+	private void _testWithOAuth2ProviderApplicationHeadlessServerConfiguration(
+			String expectedScope, ObjectDefinition objectDefinition,
+			String scope)
+		throws Exception {
+
+		String pid = ConfigurationTestUtil.createFactoryConfiguration(
+			"com.liferay.oauth2.provider.configuration." +
+				"OAuth2ProviderApplicationHeadlessServerConfiguration",
+			HashMapDictionaryBuilder.<String, Object>put(
+				"baseURL",
+				"${portalURL}/o/" +
+					TextFormatter.formatPlural(objectDefinition.getShortName())
+			).put(
+				"companyId", objectDefinition.getCompanyId()
+			).put(
+				"description", RandomTestUtil.randomString()
+			).put(
+				"homePageURL", "http://localhost:8080"
+			).put(
+				"name", objectDefinition.getName()
+			).put(
+				"projectId", objectDefinition.getName()
+			).put(
+				"projectName", objectDefinition.getName()
+			).put(
+				"properties", new String[0]
+			).put(
+				"scopes", new String[] {scope}
+			).build());
+
+		try {
+			OAuth2Application oAuth2Application = _getOAuth2Application(
+				objectDefinition.getCompanyId(), objectDefinition.getName());
+
+			List<String> scopeAliases =
+				_oAuth2ApplicationScopeAliasesLocalService.getScopeAliasesList(
+					oAuth2Application.getOAuth2ApplicationScopeAliasesId());
+
+			Assert.assertEquals(
+				Collections.singleton(expectedScope),
+				new HashSet<>(scopeAliases));
+		}
+		finally {
+			ConfigurationTestUtil.deleteConfiguration(pid);
+		}
+	}
+
+	private void _withBundlePrefixHandlerFactoryConfiguration(
+			ObjectDefinition objectDefinition,
+			UnsafeRunnable<Exception> unsafeRunnable)
+		throws Exception {
+
+		String pid = ConfigurationTestUtil.createFactoryConfiguration(
+			"com.liferay.oauth2.provider.scope.internal.configuration." +
+				"BundlePrefixHandlerFactoryConfiguration",
+			HashMapDictionaryBuilder.<String, Object>put(
+				"delimiter", "/"
+			).put(
+				"include.bundle.symbolic.name", true
+			).put(
+				"osgi.jaxrs.name", objectDefinition.getOSGiJaxRsName()
+			).put(
+				"service.properties", new String[] {"osgi.jaxrs.name"}
+			).build());
+
+		try {
+			unsafeRunnable.run();
+		}
+		finally {
+			ConfigurationTestUtil.deleteConfiguration(pid);
+		}
+	}
+
+	@Inject
+	private OAuth2ApplicationLocalService _oAuth2ApplicationLocalService;
+
+	@Inject
+	private OAuth2ApplicationScopeAliasesLocalService
+		_oAuth2ApplicationScopeAliasesLocalService;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+}


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPD-25201

---

The purpose of this ticket is to support the Client Extensions that creates an OAuth2 application in the following situation:

- If there is an existing scope alias that is equal to a given in the CX but ignoring case.

So, for example, given the existing scope alias: `c_student.everything` and the scope alias in the Client Extension: `C_Student.everything`, as that scope does not exist in Liferay but there is an existing one that is equals ignoring case, the one that will be set is the existing one `c_student.everything`.