### PR TITLE
LPD-24168 We should execute portletDataContext.getExportDataElement only if layoutIds doesn't contains layout.getLayoutId()

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exportimport/data/handler/StagedLayoutSetStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exportimport/data/handler/StagedLayoutSetStagedModelDataHandler.java
@@ -486,16 +486,17 @@ public class StagedLayoutSetStagedModelDataHandler
 
 			Layout layout = (Layout)stagedModel;
 
-			Element layoutElement = portletDataContext.getExportDataElement(
-				layout);
+			if (!ArrayUtil.contains(layoutIds, layout.getLayoutId())) {
+				Element layoutElement = portletDataContext.getExportDataElement(
+					layout);
 
-			if (!ArrayUtil.contains(layoutIds, layout.getLayoutId()) &&
-				(layoutElement.attributeValue(Constants.ACTION) == null)) {
-
-				layoutElement.addAttribute(Constants.ACTION, Constants.SKIP);
-				layoutElement.addAttribute(
-					"layout-parent-layout-id",
-					String.valueOf(layout.getParentLayoutId()));
+				if (layoutElement.attributeValue(Constants.ACTION) == null) {
+					layoutElement.addAttribute(
+						Constants.ACTION, Constants.SKIP);
+					layoutElement.addAttribute(
+						"layout-parent-layout-id",
+						String.valueOf(layout.getParentLayoutId()));
+				}
 
 				continue;
 			}


### PR DESCRIPTION
Motivation
-----
Fix 3 tests failures in [AssetPublisherExportImportTest](https://testray.liferay.com/#/project/34754/routines/129511/build/8701497/case-result/8711819)

Proposed Solution
-----

Moves getExportDataElement inside if just to avoid to calculate it when it is not necessary, for some reason we are adding some logic when we are calling this method.

```
Element layoutElement = portletDataContext.getExportDataElement(
	layout);
```

This pr doesn't need tests since it is fixing some tests failures in AssetPublisherExportImportTest