### PR TITLE
LPD-27960 - Expose Object's localizable fields (<field> + _i18n) in GraphQL

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/graphql/dto/v1_0/ObjectDefinitionGraphQLDTOContributor.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/graphql/dto/v1_0/ObjectDefinitionGraphQLDTOContributor.java
@@ -141,6 +141,13 @@ public class ObjectDefinitionGraphQLDTOContributor
 					GraphQLDTOProperty.of(relationshipName, Map.class));
 			}
 			else {
+				if (objectField.isLocalized()) {
+					graphQLDTOProperties.add(
+						GraphQLDTOProperty.of(
+							objectField.getI18nObjectFieldName(), true,
+							Map.class));
+				}
+
 				graphQLDTOProperties.add(
 					GraphQLDTOProperty.of(
 						objectField.getName(),

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/graphql/v1_0/test/ObjectDefinitionGraphQLTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/graphql/v1_0/test/ObjectDefinitionGraphQLTest.java
@@ -536,6 +536,23 @@ public class ObjectDefinitionGraphQLTest {
 					"JSONObject/c", "JSONObject/" + pluralName,
 					"JSONArray/items"));
 
+			// Unknown "Accept-Language" header
+
+			Assert.assertEquals(
+				JSONUtil.putAll(
+					JSONUtil.put(
+						_OBJECT_FIELD_NAME_LONG_TEXT, "longTextEng"
+					).put(
+						_OBJECT_FIELD_NAME_RICH_TEXT, "<p>richTextEng</p>"
+					).put(
+						_OBJECT_FIELD_NAME_TEXT, "textEng"
+					)
+				).toString(),
+				JSONUtil.getValueAsString(
+					_invoke("unknown", graphQLField), "JSONObject/data",
+					"JSONObject/c", "JSONObject/" + pluralName,
+					"JSONArray/items"));
+
 			// Without "Accept-Language" header
 
 			Assert.assertEquals(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/graphql/v1_0/test/ObjectDefinitionGraphQLTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/graphql/v1_0/test/ObjectDefinitionGraphQLTest.java
@@ -482,8 +482,14 @@ public class ObjectDefinitionGraphQLTest {
 						new GraphQLField(
 							"items",
 							new GraphQLField(_OBJECT_FIELD_NAME_LONG_TEXT),
+							new GraphQLField(
+								_OBJECT_FIELD_NAME_LONG_TEXT + "_i18n"),
 							new GraphQLField(_OBJECT_FIELD_NAME_RICH_TEXT),
-							new GraphQLField(_OBJECT_FIELD_NAME_TEXT)))));
+							new GraphQLField(
+								_OBJECT_FIELD_NAME_RICH_TEXT + "_i18n"),
+							new GraphQLField(_OBJECT_FIELD_NAME_TEXT),
+							new GraphQLField(
+								_OBJECT_FIELD_NAME_TEXT + "_i18n")))));
 
 			// "Accept-Language" header
 
@@ -492,9 +498,30 @@ public class ObjectDefinitionGraphQLTest {
 					JSONUtil.put(
 						_OBJECT_FIELD_NAME_LONG_TEXT, "longTextEsp"
 					).put(
+						_OBJECT_FIELD_NAME_LONG_TEXT + "_i18n",
+						JSONUtil.put(
+							"en_US", "longTextEng"
+						).put(
+							"es_ES", "longTextEsp"
+						)
+					).put(
 						_OBJECT_FIELD_NAME_RICH_TEXT, "<p>richTextEsp</p>"
 					).put(
+						_OBJECT_FIELD_NAME_RICH_TEXT + "_i18n",
+						JSONUtil.put(
+							"en_US", "<p>richTextEng</p>"
+						).put(
+							"es_ES", "<p>richTextEsp</p>"
+						)
+					).put(
 						_OBJECT_FIELD_NAME_TEXT, "textEsp"
+					).put(
+						_OBJECT_FIELD_NAME_TEXT + "_i18n",
+						JSONUtil.put(
+							"en_US", "textEng"
+						).put(
+							"es_ES", "textEsp"
+						)
 					)
 				).toString(),
 				JSONUtil.getValueAsString(
@@ -509,9 +536,30 @@ public class ObjectDefinitionGraphQLTest {
 					JSONUtil.put(
 						_OBJECT_FIELD_NAME_LONG_TEXT, "longTextEng"
 					).put(
+						_OBJECT_FIELD_NAME_LONG_TEXT + "_i18n",
+						JSONUtil.put(
+							"en_US", "longTextEng"
+						).put(
+							"es_ES", "longTextEsp"
+						)
+					).put(
 						_OBJECT_FIELD_NAME_RICH_TEXT, "<p>richTextEng</p>"
 					).put(
+						_OBJECT_FIELD_NAME_RICH_TEXT + "_i18n",
+						JSONUtil.put(
+							"en_US", "<p>richTextEng</p>"
+						).put(
+							"es_ES", "<p>richTextEsp</p>"
+						)
+					).put(
 						_OBJECT_FIELD_NAME_TEXT, "textEng"
+					).put(
+						_OBJECT_FIELD_NAME_TEXT + "_i18n",
+						JSONUtil.put(
+							"en_US", "textEng"
+						).put(
+							"es_ES", "textEsp"
+						)
 					)
 				).toString(),
 				JSONUtil.getValueAsString(
@@ -526,9 +574,30 @@ public class ObjectDefinitionGraphQLTest {
 					JSONUtil.put(
 						_OBJECT_FIELD_NAME_LONG_TEXT, ""
 					).put(
+						_OBJECT_FIELD_NAME_LONG_TEXT + "_i18n",
+						JSONUtil.put(
+							"en_US", "longTextEng"
+						).put(
+							"es_ES", "longTextEsp"
+						)
+					).put(
 						_OBJECT_FIELD_NAME_RICH_TEXT, ""
 					).put(
+						_OBJECT_FIELD_NAME_RICH_TEXT + "_i18n",
+						JSONUtil.put(
+							"en_US", "<p>richTextEng</p>"
+						).put(
+							"es_ES", "<p>richTextEsp</p>"
+						)
+					).put(
 						_OBJECT_FIELD_NAME_TEXT, ""
+					).put(
+						_OBJECT_FIELD_NAME_TEXT + "_i18n",
+						JSONUtil.put(
+							"en_US", "textEng"
+						).put(
+							"es_ES", "textEsp"
+						)
 					)
 				).toString(),
 				JSONUtil.getValueAsString(
@@ -543,9 +612,30 @@ public class ObjectDefinitionGraphQLTest {
 					JSONUtil.put(
 						_OBJECT_FIELD_NAME_LONG_TEXT, "longTextEng"
 					).put(
+						_OBJECT_FIELD_NAME_LONG_TEXT + "_i18n",
+						JSONUtil.put(
+							"en_US", "longTextEng"
+						).put(
+							"es_ES", "longTextEsp"
+						)
+					).put(
 						_OBJECT_FIELD_NAME_RICH_TEXT, "<p>richTextEng</p>"
 					).put(
+						_OBJECT_FIELD_NAME_RICH_TEXT + "_i18n",
+						JSONUtil.put(
+							"en_US", "<p>richTextEng</p>"
+						).put(
+							"es_ES", "<p>richTextEsp</p>"
+						)
+					).put(
 						_OBJECT_FIELD_NAME_TEXT, "textEng"
+					).put(
+						_OBJECT_FIELD_NAME_TEXT + "_i18n",
+						JSONUtil.put(
+							"en_US", "textEng"
+						).put(
+							"es_ES", "textEsp"
+						)
 					)
 				).toString(),
 				JSONUtil.getValueAsString(
@@ -560,9 +650,30 @@ public class ObjectDefinitionGraphQLTest {
 					JSONUtil.put(
 						_OBJECT_FIELD_NAME_LONG_TEXT, "longTextEng"
 					).put(
+						_OBJECT_FIELD_NAME_LONG_TEXT + "_i18n",
+						JSONUtil.put(
+							"en_US", "longTextEng"
+						).put(
+							"es_ES", "longTextEsp"
+						)
+					).put(
 						_OBJECT_FIELD_NAME_RICH_TEXT, "<p>richTextEng</p>"
 					).put(
+						_OBJECT_FIELD_NAME_RICH_TEXT + "_i18n",
+						JSONUtil.put(
+							"en_US", "<p>richTextEng</p>"
+						).put(
+							"es_ES", "<p>richTextEsp</p>"
+						)
+					).put(
 						_OBJECT_FIELD_NAME_TEXT, "textEng"
+					).put(
+						_OBJECT_FIELD_NAME_TEXT + "_i18n",
+						JSONUtil.put(
+							"en_US", "textEng"
+						).put(
+							"es_ES", "textEsp"
+						)
 					)
 				).toString(),
 				JSONUtil.getValueAsString(

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/data/fetcher/GraphQLDTOContributorDataFetcher.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/data/fetcher/GraphQLDTOContributorDataFetcher.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.vulcan.internal.graphql.data.fetcher;
 
 import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerList;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.vulcan.graphql.dto.GraphQLDTOContributor;
 import com.liferay.portal.vulcan.graphql.dto.GraphQLDTOProperty;
 import com.liferay.portal.vulcan.graphql.validation.GraphQLRequestContext;
@@ -19,7 +20,10 @@ import java.io.Serializable;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.HttpMethod;
 
 /**
  * @author Carlos Correa
@@ -43,6 +47,8 @@ public class GraphQLDTOContributorDataFetcher extends BaseDataFetcher {
 			graphQLDTOContributorDataFetchingProcessor;
 		_graphQLDTOProperty = graphQLDTOProperty;
 		_operation = operation;
+
+		_httpMethod = _httpMethods.get(operation);
 	}
 
 	public GraphQLDTOContributorDataFetcher(
@@ -66,6 +72,15 @@ public class GraphQLDTOContributorDataFetcher extends BaseDataFetcher {
 			HttpServletRequest httpServletRequest,
 			HttpServletResponse httpServletResponse)
 		throws Exception {
+
+		httpServletRequest = new HttpServletRequestWrapper(httpServletRequest) {
+
+			@Override
+			public String getMethod() {
+				return _httpMethod;
+			}
+
+		};
 
 		if (_operation == GraphQLDTOContributor.Operation.CREATE) {
 			return _graphQLDTOContributorDataFetchingProcessor.create(
@@ -125,10 +140,26 @@ public class GraphQLDTOContributorDataFetcher extends BaseDataFetcher {
 			"Operation not supported: " + _operation);
 	}
 
+	private static final Map<GraphQLDTOContributor.Operation, String>
+		_httpMethods = HashMapBuilder.put(
+			GraphQLDTOContributor.Operation.CREATE, HttpMethod.POST
+		).put(
+			GraphQLDTOContributor.Operation.DELETE, HttpMethod.DELETE
+		).put(
+			GraphQLDTOContributor.Operation.GET, HttpMethod.GET
+		).put(
+			GraphQLDTOContributor.Operation.GET_RELATIONSHIP, HttpMethod.GET
+		).put(
+			GraphQLDTOContributor.Operation.LIST, HttpMethod.GET
+		).put(
+			GraphQLDTOContributor.Operation.UPDATE, HttpMethod.PUT
+		).build();
+
 	private final GraphQLDTOContributor _graphQLDTOContributor;
 	private final GraphQLDTOContributorDataFetchingProcessor
 		_graphQLDTOContributorDataFetchingProcessor;
 	private final GraphQLDTOProperty _graphQLDTOProperty;
+	private final String _httpMethod;
 	private final GraphQLDTOContributor.Operation _operation;
 
 }


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPD-19649

---

The purpose of this ticket is to expose the localizable fields of any Object Definition in the GraphQL **queries** (not in mutations yet).