### PR TITLE
LPD-27055 Fix and unignore ManageCategoriesForObjectEntries#CanUpdateSiteScopedObjectEntryWithTaxonomyCategoryOfDifferentSiteScope

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testFunctional/macros/TaxonomyVocabularyAPI.macro
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testFunctional/macros/TaxonomyVocabularyAPI.macro
@@ -63,7 +63,7 @@ definition {
 		if (isSet(externalReferenceCode)) {
 			var apiWithErc = "by-external-reference-code/${externalReferenceCode}";
 
-			var api = StringUtil.add(${api}, ${apiWithErc}, "/");
+			var api = '''${api}/${apiWithErc}''';
 		}
 
 		if (isSet(filterValue)) {

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/ManageCategoriesForObjectEntries.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/ManageCategoriesForObjectEntries.testcase
@@ -290,7 +290,6 @@ definition {
 
 	@description = "LPS-186852. The category to set is not being validated if it belongs to the same site or a parent one"
 	@disable-webdriver = "true"
-	@ignore = "true"
 	@priority = 3
 	test CanUpdateSiteScopedObjectEntryWithTaxonomyCategoryOfDifferentSiteScope {
 		property portal.acceptance = "true";

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/group/JSONGroupAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/group/JSONGroupAPI.macro
@@ -520,6 +520,10 @@ definition {
 			token = ${token});
 		var userLoginInfo = JSONUtil2.formatJSONUser();
 
+		if (${groupName} == "Global") {
+			var groupName = ${companyId};
+		}
+
 		var curl = '''
 			${portalURL}/api/jsonws/group/get-group \
 				-u ${userLoginInfo} \


### PR DESCRIPTION
**What's changed?:**
- Adapted the way the CURLs of delete by ERC endpoints were generated so that the trailing slash isn't added.
- Fixed test by transforming the Global site name to the `companyId`.
- Unignored the test

See the following Jira Ticket: [LPD-27055](https://liferay.atlassian.net/browse/LPD-27055)