### PR TITLE
LPD-27908 Adding playwright tests to the Headless Functional routine

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -5948,7 +5948,16 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
     # Headless Functional
     #
 
-    test.batch.names[headless-functional]=functional-tomcat90-mysql57-jdk8
+    playwright.test.project[playwright-js-tomcat90-mysql57-jdk8][headless-functional]=\
+        batch-planner,\
+        export-import-web,\
+        headless-builder-impl,\
+        headless-builder-web,\
+        layout-set-prototype-web
+
+    test.batch.names[headless-functional]=\
+        functional-tomcat90-mysql57-jdk8,\
+        playwright-js-tomcat90-mysql57-jdk8
 
     test.batch.dist.app.servers[headless-functional]=tomcat
 


### PR DESCRIPTION
This is a follow-up commit for the https://issues.liferay.com/browse/LPD-27908
The playwright tests weren't running in the headless-functional routine, only in the main headless routine