### PR TITLE
LPD-25633 Batch reindex improvement PoC

### DIFF
--- a/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/BatchEngineTaskItemDelegate.java
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/BatchEngineTaskItemDelegate.java
@@ -50,6 +50,10 @@ public interface BatchEngineTaskItemDelegate<T> {
 		return null;
 	}
 
+	public default String getModelClassName() {
+		return null;
+	}
+
 	public boolean hasCreateStrategy(String createStrategy);
 
 	public boolean hasUpdateStrategy(String updateStrategy);

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineImportTaskExecutorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineImportTaskExecutorImpl.java
@@ -39,6 +39,8 @@ import com.liferay.portal.configuration.module.configuration.ConfigurationProvid
 import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
@@ -297,6 +299,17 @@ public class BatchEngineImportTaskExecutorImpl
 		Map<String, Serializable> parameters = _getParameters(
 			batchEngineImportTask);
 
+		Indexer<?> indexer = IndexerRegistryUtil.getIndexer(
+			batchEngineTaskItemDelegate.getModelClassName());
+
+		boolean indexerEnabled = false;
+
+		if (indexer != null) {
+			indexerEnabled = indexer.isIndexerEnabled();
+
+			indexer.setIndexerEnabled(false);
+		}
+
 		try (BatchEngineImportTaskItemReader batchEngineImportTaskItemReader =
 				_getBatchEngineImportTaskItemReader(
 					batchEngineImportTask,
@@ -364,6 +377,20 @@ public class BatchEngineImportTaskExecutorImpl
 				_commitItems(
 					batchEngineImportTask, batchEngineTaskItemDelegateExecutor,
 					items, processedItemsCount);
+			}
+
+			if (indexer != null) {
+				indexer.setIndexerEnabled(true);
+
+				indexer.reindex(
+					new String[] {
+						String.valueOf(batchEngineImportTask.getCompanyId())
+					});
+			}
+		}
+		finally {
+			if (indexer != null) {
+				indexer.setIndexerEnabled(indexerEnabled);
 			}
 		}
 	}

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineImportTaskExecutorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineImportTaskExecutorImpl.java
@@ -44,6 +44,9 @@ import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.transaction.Propagation;
+import com.liferay.portal.kernel.transaction.TransactionConfig;
+import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 
 import java.io.InputStream;
@@ -184,16 +187,23 @@ public class BatchEngineImportTaskExecutorImpl
 			List<Object> items, int processedItemsCount)
 		throws Throwable {
 
-		batchEngineTaskItemDelegateExecutor.saveItems(
-			_createBatchEngineImportStrategy(batchEngineImportTask),
-			BatchEngineTaskOperation.valueOf(
-				batchEngineImportTask.getOperation()),
-			items);
+		TransactionInvokerUtil.invoke(
+			_transactionConfig,
+			() -> {
+				batchEngineTaskItemDelegateExecutor.saveItems(
+					_createBatchEngineImportStrategy(batchEngineImportTask),
+					BatchEngineTaskOperation.valueOf(
+						batchEngineImportTask.getOperation()),
+					items);
 
-		batchEngineImportTask.setProcessedItemsCount(processedItemsCount);
+				batchEngineImportTask.setProcessedItemsCount(
+					processedItemsCount);
 
-		_batchEngineImportTaskLocalService.updateBatchEngineImportTask(
-			batchEngineImportTask);
+				_batchEngineImportTaskLocalService.updateBatchEngineImportTask(
+					batchEngineImportTask);
+
+				return null;
+			});
 	}
 
 	private BatchEngineImportStrategy _createBatchEngineImportStrategy(
@@ -436,6 +446,10 @@ public class BatchEngineImportTaskExecutorImpl
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		BatchEngineImportTaskExecutorImpl.class);
+
+	private static final TransactionConfig _transactionConfig =
+		TransactionConfig.Factory.create(
+			Propagation.REQUIRES_NEW, new Class<?>[] {Exception.class});
 
 	@Reference
 	private BatchEngineImportTaskErrorLocalService

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
@@ -188,6 +188,11 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 	}
 
 	@Override
+	public String getModelClassName() {
+		return _objectDefinition.getClassName();
+	}
+
+	@Override
 	public Page<ObjectEntry> getObjectEntriesPage(
 			Boolean flatten, String search, Aggregation aggregation,
 			Filter filter, Pagination pagination, Sort[] sorts)

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/batch/engine/VulcanBatchEngineTaskItemDelegate.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/batch/engine/VulcanBatchEngineTaskItemDelegate.java
@@ -52,6 +52,10 @@ public interface VulcanBatchEngineTaskItemDelegate<T> {
 	public EntityModel getEntityModel(Map<String, List<String>> multivaluedMap)
 		throws Exception;
 
+	public default String getModelClassName() {
+		return null;
+	}
+
 	public default Class<?> getResourceClass() {
 		return getClass();
 	}

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/batch/engine/VulcanBatchEngineTaskItemDelegateAdaptor.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/batch/engine/VulcanBatchEngineTaskItemDelegateAdaptor.java
@@ -109,6 +109,11 @@ public class VulcanBatchEngineTaskItemDelegateAdaptor<T>
 	}
 
 	@Override
+	public String getModelClassName() {
+		return _vulcanBatchEngineTaskItemDelegate.getModelClassName();
+	}
+
+	@Override
 	public boolean hasCreateStrategy(String createStrategy) {
 		Set<String> createStrategies =
 			_vulcanBatchEngineTaskItemDelegate.getAvailableCreateStrategies();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-25633.

This PR disables reindexing during a batch import and performs a bulk indexing at the end. We see the import times reduce in ~50% (see [my comment](https://liferay.atlassian.net/browse/LPD-25633?focusedCommentId=2669160)). This is just a proof of concept and the next points (at least) should be addressed:
1. The reindex should only be disabled for the current thread.
2. The bulk reindex should just go through the newly added / modified entities, not all of them. With the current code, the time will be a function of the amount of elements in the DB and not the elements in the batch process.

