### PR TITLE
LPD-29780 After restarting the portal, "Single Node (Memory Clustered)" type of jobs are not scheduled

### DIFF
--- a/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/internal/messaging/DispatchConfigurator.java
+++ b/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/internal/messaging/DispatchConfigurator.java
@@ -11,6 +11,7 @@ import com.liferay.dispatch.executor.DispatchTaskClusterMode;
 import com.liferay.dispatch.internal.helper.DispatchTriggerHelper;
 import com.liferay.dispatch.model.DispatchTrigger;
 import com.liferay.dispatch.service.DispatchTriggerLocalService;
+import com.liferay.portal.kernel.cluster.ClusterMasterExecutor;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.messaging.Destination;
@@ -77,8 +78,32 @@ public class DispatchConfigurator {
 		_serviceRegistration = bundleContext.registerService(
 			Destination.class, destination, properties);
 
-		DispatchTaskClusterMode dispatchTaskClusterMode =
-			DispatchTaskClusterMode.ALL_NODES;
+		_scheduleJobsByClusterMode(DispatchTaskClusterMode.ALL_NODES);
+
+		if (_clusterMasterExecutor.isMaster()) {
+			_scheduleJobsByClusterMode(
+				DispatchTaskClusterMode.SINGLE_NODE_MEMORY_CLUSTERED);
+			_scheduleJobsByClusterMode(
+				DispatchTaskClusterMode.SINGLE_NODE_PERSISTED);
+		}
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_unscheduleJobsByClusterMode(DispatchTaskClusterMode.ALL_NODES);
+
+		if (_clusterMasterExecutor.isMaster()) {
+			_unscheduleJobsByClusterMode(
+				DispatchTaskClusterMode.SINGLE_NODE_MEMORY_CLUSTERED);
+			_unscheduleJobsByClusterMode(
+				DispatchTaskClusterMode.SINGLE_NODE_PERSISTED);
+		}
+
+		_serviceRegistration.unregister();
+	}
+
+	private void _scheduleJobsByClusterMode(
+		DispatchTaskClusterMode dispatchTaskClusterMode) {
 
 		for (DispatchTrigger dispatchTrigger :
 				_dispatchTriggerLocalService.getDispatchTriggers(
@@ -97,10 +122,8 @@ public class DispatchConfigurator {
 		}
 	}
 
-	@Deactivate
-	protected void deactivate() {
-		DispatchTaskClusterMode dispatchTaskClusterMode =
-			DispatchTaskClusterMode.ALL_NODES;
+	private void _unscheduleJobsByClusterMode(
+		DispatchTaskClusterMode dispatchTaskClusterMode) {
 
 		for (DispatchTrigger dispatchTrigger :
 				_dispatchTriggerLocalService.getDispatchTriggers(
@@ -109,14 +132,15 @@ public class DispatchConfigurator {
 			_dispatchTriggerHelper.deleteSchedulerJob(
 				dispatchTrigger, dispatchTaskClusterMode.getStorageType());
 		}
-
-		_serviceRegistration.unregister();
 	}
 
 	private static final int _MAXIMUM_QUEUE_SIZE = 100;
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		DispatchConfigurator.class);
+
+	@Reference
+	private ClusterMasterExecutor _clusterMasterExecutor;
 
 	@Reference
 	private DestinationFactory _destinationFactory;

--- a/modules/apps/dispatch/dispatch-service/src/test/java/com/liferay/dispatch/internal/messaging/DispatchConfiguratorTest.java
+++ b/modules/apps/dispatch/dispatch-service/src/test/java/com/liferay/dispatch/internal/messaging/DispatchConfiguratorTest.java
@@ -1,0 +1,339 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.dispatch.internal.messaging;
+
+import com.liferay.dispatch.executor.DispatchTaskClusterMode;
+import com.liferay.dispatch.internal.helper.DispatchTriggerHelper;
+import com.liferay.dispatch.model.DispatchTrigger;
+import com.liferay.dispatch.service.DispatchTriggerLocalService;
+import com.liferay.portal.kernel.cluster.ClusterMasterExecutor;
+import com.liferay.portal.kernel.messaging.Destination;
+import com.liferay.portal.kernel.messaging.DestinationFactory;
+import com.liferay.portal.kernel.module.util.SystemBundleUtil;
+import com.liferay.portal.kernel.scheduler.StorageType;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+
+/**
+ * @author Vendel Toreki
+ */
+public class DispatchConfiguratorTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		ReflectionTestUtil.setFieldValue(
+			_dispatchConfigurator, "_clusterMasterExecutor",
+			_clusterMasterExecutor);
+		ReflectionTestUtil.setFieldValue(
+			_dispatchConfigurator, "_destinationFactory", _destinationFactory);
+		ReflectionTestUtil.setFieldValue(
+			_dispatchConfigurator, "_dispatchTriggerHelper",
+			_dispatchTriggerHelper);
+		ReflectionTestUtil.setFieldValue(
+			_dispatchConfigurator, "_dispatchTriggerLocalService",
+			_dispatchTriggerLocalService);
+
+		Mockito.when(
+			_destinationFactory.createDestination(Mockito.any())
+		).thenReturn(
+			Mockito.mock(Destination.class)
+		);
+
+		_allNodesDispatchTrigger = Mockito.mock(DispatchTrigger.class);
+
+		Mockito.when(
+			_dispatchTriggerLocalService.getDispatchTriggers(
+				true, DispatchTaskClusterMode.ALL_NODES)
+		).thenReturn(
+			ListUtil.fromArray(_allNodesDispatchTrigger)
+		);
+
+		_singleNodeMemoryClusteredDispatchTrigger = Mockito.mock(
+			DispatchTrigger.class);
+
+		Mockito.when(
+			_dispatchTriggerLocalService.getDispatchTriggers(
+				true, DispatchTaskClusterMode.SINGLE_NODE_MEMORY_CLUSTERED)
+		).thenReturn(
+			ListUtil.fromArray(_singleNodeMemoryClusteredDispatchTrigger)
+		);
+
+		_singleNodePersistedDispatchTrigger = Mockito.mock(
+			DispatchTrigger.class);
+
+		Mockito.when(
+			_dispatchTriggerLocalService.getDispatchTriggers(
+				true, DispatchTaskClusterMode.SINGLE_NODE_PERSISTED)
+		).thenReturn(
+			ListUtil.fromArray(_singleNodePersistedDispatchTrigger)
+		);
+	}
+
+	@Test
+	public void testOnActivationSchedulesAllTypeOfJobsOnMasterNode()
+		throws Exception {
+
+		Mockito.when(
+			_clusterMasterExecutor.isMaster()
+		).thenReturn(
+			true
+		);
+
+		ReflectionTestUtil.invoke(
+			_dispatchConfigurator, "activate",
+			new Class<?>[] {BundleContext.class}, _bundleContext);
+
+		Mockito.verify(
+			_dispatchTriggerLocalService, Mockito.times(1)
+		).getDispatchTriggers(
+			Mockito.eq(true), Mockito.eq(DispatchTaskClusterMode.ALL_NODES)
+		);
+
+		Mockito.verify(
+			_dispatchTriggerLocalService, Mockito.times(1)
+		).getDispatchTriggers(
+			Mockito.eq(true),
+			Mockito.eq(DispatchTaskClusterMode.SINGLE_NODE_MEMORY_CLUSTERED)
+		);
+
+		Mockito.verify(
+			_dispatchTriggerLocalService, Mockito.times(1)
+		).getDispatchTriggers(
+			Mockito.eq(true),
+			Mockito.eq(DispatchTaskClusterMode.SINGLE_NODE_PERSISTED)
+		);
+
+		Mockito.verify(
+			_dispatchTriggerHelper, Mockito.times(1)
+		).addSchedulerJob(
+			Mockito.same(_allNodesDispatchTrigger),
+			Mockito.eq(StorageType.MEMORY), Mockito.any()
+		);
+
+		Mockito.verify(
+			_dispatchTriggerHelper, Mockito.times(1)
+		).addSchedulerJob(
+			Mockito.same(_singleNodeMemoryClusteredDispatchTrigger),
+			Mockito.eq(StorageType.MEMORY_CLUSTERED), Mockito.any()
+		);
+
+		Mockito.verify(
+			_dispatchTriggerHelper, Mockito.times(1)
+		).addSchedulerJob(
+			Mockito.same(_singleNodePersistedDispatchTrigger),
+			Mockito.eq(StorageType.PERSISTED), Mockito.any()
+		);
+	}
+
+	@Test
+	public void testOnActivationSchedulesOnlyAllNodesJobs() throws Exception {
+		Mockito.when(
+			_clusterMasterExecutor.isMaster()
+		).thenReturn(
+			false
+		);
+
+		ReflectionTestUtil.invoke(
+			_dispatchConfigurator, "activate",
+			new Class<?>[] {BundleContext.class}, _bundleContext);
+
+		Mockito.verify(
+			_dispatchTriggerLocalService, Mockito.times(1)
+		).getDispatchTriggers(
+			Mockito.eq(true), Mockito.eq(DispatchTaskClusterMode.ALL_NODES)
+		);
+
+		Mockito.verify(
+			_dispatchTriggerLocalService, Mockito.never()
+		).getDispatchTriggers(
+			Mockito.eq(true),
+			Mockito.eq(DispatchTaskClusterMode.SINGLE_NODE_MEMORY_CLUSTERED)
+		);
+
+		Mockito.verify(
+			_dispatchTriggerLocalService, Mockito.never()
+		).getDispatchTriggers(
+			Mockito.eq(true),
+			Mockito.eq(DispatchTaskClusterMode.SINGLE_NODE_PERSISTED)
+		);
+
+		Mockito.verify(
+			_dispatchTriggerHelper, Mockito.times(1)
+		).addSchedulerJob(
+			Mockito.same(_allNodesDispatchTrigger),
+			Mockito.eq(StorageType.MEMORY), Mockito.any()
+		);
+
+		Mockito.verify(
+			_dispatchTriggerHelper, Mockito.never()
+		).addSchedulerJob(
+			Mockito.same(_singleNodeMemoryClusteredDispatchTrigger),
+			Mockito.eq(StorageType.MEMORY), Mockito.any()
+		);
+
+		Mockito.verify(
+			_dispatchTriggerHelper, Mockito.never()
+		).addSchedulerJob(
+			Mockito.same(_singleNodePersistedDispatchTrigger),
+			Mockito.eq(StorageType.PERSISTED), Mockito.any()
+		);
+	}
+
+	@Test
+	public void testOnDeactivationUnschedulesAllTypeOfJobsOnMasterNode()
+		throws Exception {
+
+		Mockito.when(
+			_clusterMasterExecutor.isMaster()
+		).thenReturn(
+			true
+		);
+
+		ServiceRegistration<Destination> serviceRegistration = Mockito.mock(
+			ServiceRegistration.class);
+
+		ReflectionTestUtil.setFieldValue(
+			_dispatchConfigurator, "_serviceRegistration", serviceRegistration);
+
+		ReflectionTestUtil.invoke(
+			_dispatchConfigurator, "deactivate", new Class<?>[0]);
+
+		Mockito.verify(
+			_dispatchTriggerLocalService, Mockito.times(1)
+		).getDispatchTriggers(
+			Mockito.eq(true), Mockito.eq(DispatchTaskClusterMode.ALL_NODES)
+		);
+
+		Mockito.verify(
+			_dispatchTriggerLocalService, Mockito.times(1)
+		).getDispatchTriggers(
+			Mockito.eq(true),
+			Mockito.eq(DispatchTaskClusterMode.SINGLE_NODE_MEMORY_CLUSTERED)
+		);
+
+		Mockito.verify(
+			_dispatchTriggerLocalService, Mockito.times(1)
+		).getDispatchTriggers(
+			Mockito.eq(true),
+			Mockito.eq(DispatchTaskClusterMode.SINGLE_NODE_PERSISTED)
+		);
+
+		Mockito.verify(
+			_dispatchTriggerHelper, Mockito.times(1)
+		).deleteSchedulerJob(
+			Mockito.same(_allNodesDispatchTrigger),
+			Mockito.eq(StorageType.MEMORY)
+		);
+
+		Mockito.verify(
+			_dispatchTriggerHelper, Mockito.times(1)
+		).deleteSchedulerJob(
+			Mockito.same(_singleNodeMemoryClusteredDispatchTrigger),
+			Mockito.eq(StorageType.MEMORY_CLUSTERED)
+		);
+
+		Mockito.verify(
+			_dispatchTriggerHelper, Mockito.times(1)
+		).deleteSchedulerJob(
+			Mockito.same(_singleNodePersistedDispatchTrigger),
+			Mockito.eq(StorageType.PERSISTED)
+		);
+	}
+
+	@Test
+	public void testOnDeactivationUnschedulesOnlyAllNodesJobs()
+		throws Exception {
+
+		Mockito.when(
+			_clusterMasterExecutor.isMaster()
+		).thenReturn(
+			false
+		);
+
+		ServiceRegistration<Destination> serviceRegistration = Mockito.mock(
+			ServiceRegistration.class);
+
+		ReflectionTestUtil.setFieldValue(
+			_dispatchConfigurator, "_serviceRegistration", serviceRegistration);
+
+		ReflectionTestUtil.invoke(
+			_dispatchConfigurator, "deactivate", new Class<?>[0]);
+
+		Mockito.verify(
+			_dispatchTriggerLocalService, Mockito.times(1)
+		).getDispatchTriggers(
+			Mockito.eq(true), Mockito.eq(DispatchTaskClusterMode.ALL_NODES)
+		);
+
+		Mockito.verify(
+			_dispatchTriggerLocalService, Mockito.never()
+		).getDispatchTriggers(
+			Mockito.eq(true),
+			Mockito.eq(DispatchTaskClusterMode.SINGLE_NODE_MEMORY_CLUSTERED)
+		);
+
+		Mockito.verify(
+			_dispatchTriggerLocalService, Mockito.never()
+		).getDispatchTriggers(
+			Mockito.eq(true),
+			Mockito.eq(DispatchTaskClusterMode.SINGLE_NODE_PERSISTED)
+		);
+
+		Mockito.verify(
+			_dispatchTriggerHelper, Mockito.times(1)
+		).deleteSchedulerJob(
+			Mockito.same(_allNodesDispatchTrigger),
+			Mockito.eq(StorageType.MEMORY)
+		);
+
+		Mockito.verify(
+			_dispatchTriggerHelper, Mockito.never()
+		).deleteSchedulerJob(
+			Mockito.same(_singleNodeMemoryClusteredDispatchTrigger),
+			Mockito.eq(StorageType.MEMORY)
+		);
+
+		Mockito.verify(
+			_dispatchTriggerHelper, Mockito.never()
+		).deleteSchedulerJob(
+			Mockito.same(_singleNodePersistedDispatchTrigger),
+			Mockito.eq(StorageType.PERSISTED)
+		);
+	}
+
+	private DispatchTrigger _allNodesDispatchTrigger;
+	private final BundleContext _bundleContext =
+		SystemBundleUtil.getBundleContext();
+	private final ClusterMasterExecutor _clusterMasterExecutor = Mockito.mock(
+		ClusterMasterExecutor.class);
+	private final DestinationFactory _destinationFactory = Mockito.mock(
+		DestinationFactory.class);
+	private final DispatchConfigurator _dispatchConfigurator =
+		new DispatchConfigurator();
+	private final DispatchTriggerHelper _dispatchTriggerHelper = Mockito.mock(
+		DispatchTriggerHelper.class);
+	private final DispatchTriggerLocalService _dispatchTriggerLocalService =
+		Mockito.mock(DispatchTriggerLocalService.class);
+	private DispatchTrigger _singleNodeMemoryClusteredDispatchTrigger;
+	private DispatchTrigger _singleNodePersistedDispatchTrigger;
+
+}

--- a/modules/apps/dispatch/dispatch-service/src/test/java/com/liferay/dispatch/internal/messaging/DispatchConfiguratorTest.java
+++ b/modules/apps/dispatch/dispatch-service/src/test/java/com/liferay/dispatch/internal/messaging/DispatchConfiguratorTest.java
@@ -86,41 +86,41 @@ public class DispatchConfiguratorTest {
 		_dispatchConfigurator.activate(_bundleContext);
 
 		Mockito.verify(
-			_dispatchTriggerLocalService, Mockito.times(1)
+			_dispatchTriggerLocalService
 		).getDispatchTriggers(
 			Mockito.eq(true), Mockito.eq(DispatchTaskClusterMode.ALL_NODES)
 		);
 
 		Mockito.verify(
-			_dispatchTriggerLocalService, Mockito.times(1)
+			_dispatchTriggerLocalService
 		).getDispatchTriggers(
 			Mockito.eq(true),
 			Mockito.eq(DispatchTaskClusterMode.SINGLE_NODE_MEMORY_CLUSTERED)
 		);
 
 		Mockito.verify(
-			_dispatchTriggerLocalService, Mockito.times(1)
+			_dispatchTriggerLocalService
 		).getDispatchTriggers(
 			Mockito.eq(true),
 			Mockito.eq(DispatchTaskClusterMode.SINGLE_NODE_PERSISTED)
 		);
 
 		Mockito.verify(
-			_dispatchTriggerHelper, Mockito.times(1)
+			_dispatchTriggerHelper
 		).addSchedulerJob(
 			Mockito.same(_allNodesDispatchTrigger),
 			Mockito.eq(StorageType.MEMORY), Mockito.any()
 		);
 
 		Mockito.verify(
-			_dispatchTriggerHelper, Mockito.times(1)
+			_dispatchTriggerHelper
 		).addSchedulerJob(
 			Mockito.same(_singleNodeMemoryClusteredDispatchTrigger),
 			Mockito.eq(StorageType.MEMORY_CLUSTERED), Mockito.any()
 		);
 
 		Mockito.verify(
-			_dispatchTriggerHelper, Mockito.times(1)
+			_dispatchTriggerHelper
 		).addSchedulerJob(
 			Mockito.same(_singleNodePersistedDispatchTrigger),
 			Mockito.eq(StorageType.PERSISTED), Mockito.any()
@@ -138,7 +138,7 @@ public class DispatchConfiguratorTest {
 		_dispatchConfigurator.activate(_bundleContext);
 
 		Mockito.verify(
-			_dispatchTriggerLocalService, Mockito.times(1)
+			_dispatchTriggerLocalService
 		).getDispatchTriggers(
 			Mockito.eq(true), Mockito.eq(DispatchTaskClusterMode.ALL_NODES)
 		);
@@ -158,7 +158,7 @@ public class DispatchConfiguratorTest {
 		);
 
 		Mockito.verify(
-			_dispatchTriggerHelper, Mockito.times(1)
+			_dispatchTriggerHelper
 		).addSchedulerJob(
 			Mockito.same(_allNodesDispatchTrigger),
 			Mockito.eq(StorageType.MEMORY), Mockito.any()
@@ -198,41 +198,41 @@ public class DispatchConfiguratorTest {
 		_dispatchConfigurator.deactivate();
 
 		Mockito.verify(
-			_dispatchTriggerLocalService, Mockito.times(1)
+			_dispatchTriggerLocalService
 		).getDispatchTriggers(
 			Mockito.eq(true), Mockito.eq(DispatchTaskClusterMode.ALL_NODES)
 		);
 
 		Mockito.verify(
-			_dispatchTriggerLocalService, Mockito.times(1)
+			_dispatchTriggerLocalService
 		).getDispatchTriggers(
 			Mockito.eq(true),
 			Mockito.eq(DispatchTaskClusterMode.SINGLE_NODE_MEMORY_CLUSTERED)
 		);
 
 		Mockito.verify(
-			_dispatchTriggerLocalService, Mockito.times(1)
+			_dispatchTriggerLocalService
 		).getDispatchTriggers(
 			Mockito.eq(true),
 			Mockito.eq(DispatchTaskClusterMode.SINGLE_NODE_PERSISTED)
 		);
 
 		Mockito.verify(
-			_dispatchTriggerHelper, Mockito.times(1)
+			_dispatchTriggerHelper
 		).deleteSchedulerJob(
 			Mockito.same(_allNodesDispatchTrigger),
 			Mockito.eq(StorageType.MEMORY)
 		);
 
 		Mockito.verify(
-			_dispatchTriggerHelper, Mockito.times(1)
+			_dispatchTriggerHelper
 		).deleteSchedulerJob(
 			Mockito.same(_singleNodeMemoryClusteredDispatchTrigger),
 			Mockito.eq(StorageType.MEMORY_CLUSTERED)
 		);
 
 		Mockito.verify(
-			_dispatchTriggerHelper, Mockito.times(1)
+			_dispatchTriggerHelper
 		).deleteSchedulerJob(
 			Mockito.same(_singleNodePersistedDispatchTrigger),
 			Mockito.eq(StorageType.PERSISTED)
@@ -258,7 +258,7 @@ public class DispatchConfiguratorTest {
 		_dispatchConfigurator.deactivate();
 
 		Mockito.verify(
-			_dispatchTriggerLocalService, Mockito.times(1)
+			_dispatchTriggerLocalService
 		).getDispatchTriggers(
 			Mockito.eq(true), Mockito.eq(DispatchTaskClusterMode.ALL_NODES)
 		);
@@ -278,7 +278,7 @@ public class DispatchConfiguratorTest {
 		);
 
 		Mockito.verify(
-			_dispatchTriggerHelper, Mockito.times(1)
+			_dispatchTriggerHelper
 		).deleteSchedulerJob(
 			Mockito.same(_allNodesDispatchTrigger),
 			Mockito.eq(StorageType.MEMORY)

--- a/modules/apps/dispatch/dispatch-service/src/test/java/com/liferay/dispatch/internal/messaging/DispatchConfiguratorTest.java
+++ b/modules/apps/dispatch/dispatch-service/src/test/java/com/liferay/dispatch/internal/messaging/DispatchConfiguratorTest.java
@@ -180,9 +180,7 @@ public class DispatchConfiguratorTest {
 	}
 
 	@Test
-	public void testOnDeactivationUnschedulesAllTypeOfJobsOnMasterNode()
-		throws Exception {
-
+	public void testOnDeactivationUnschedulesAllTypeOfJobsOnMasterNode() {
 		Mockito.when(
 			_clusterMasterExecutor.isMaster()
 		).thenReturn(
@@ -240,9 +238,7 @@ public class DispatchConfiguratorTest {
 	}
 
 	@Test
-	public void testOnDeactivationUnschedulesOnlyAllNodesJobs()
-		throws Exception {
-
+	public void testOnDeactivationUnschedulesOnlyAllNodesJobs() {
 		Mockito.when(
 			_clusterMasterExecutor.isMaster()
 		).thenReturn(

--- a/modules/apps/dispatch/dispatch-service/src/test/java/com/liferay/dispatch/internal/messaging/DispatchConfiguratorTest.java
+++ b/modules/apps/dispatch/dispatch-service/src/test/java/com/liferay/dispatch/internal/messaging/DispatchConfiguratorTest.java
@@ -83,9 +83,7 @@ public class DispatchConfiguratorTest {
 			true
 		);
 
-		ReflectionTestUtil.invoke(
-			_dispatchConfigurator, "activate",
-			new Class<?>[] {BundleContext.class}, _bundleContext);
+		_dispatchConfigurator.activate(_bundleContext);
 
 		Mockito.verify(
 			_dispatchTriggerLocalService, Mockito.times(1)
@@ -137,9 +135,7 @@ public class DispatchConfiguratorTest {
 			false
 		);
 
-		ReflectionTestUtil.invoke(
-			_dispatchConfigurator, "activate",
-			new Class<?>[] {BundleContext.class}, _bundleContext);
+		_dispatchConfigurator.activate(_bundleContext);
 
 		Mockito.verify(
 			_dispatchTriggerLocalService, Mockito.times(1)
@@ -199,8 +195,7 @@ public class DispatchConfiguratorTest {
 		ReflectionTestUtil.setFieldValue(
 			_dispatchConfigurator, "_serviceRegistration", serviceRegistration);
 
-		ReflectionTestUtil.invoke(
-			_dispatchConfigurator, "deactivate", new Class<?>[0]);
+		_dispatchConfigurator.deactivate();
 
 		Mockito.verify(
 			_dispatchTriggerLocalService, Mockito.times(1)
@@ -260,8 +255,7 @@ public class DispatchConfiguratorTest {
 		ReflectionTestUtil.setFieldValue(
 			_dispatchConfigurator, "_serviceRegistration", serviceRegistration);
 
-		ReflectionTestUtil.invoke(
-			_dispatchConfigurator, "deactivate", new Class<?>[0]);
+		_dispatchConfigurator.deactivate();
 
 		Mockito.verify(
 			_dispatchTriggerLocalService, Mockito.times(1)

--- a/modules/apps/dispatch/dispatch-service/src/test/java/com/liferay/dispatch/internal/messaging/DispatchConfiguratorTest.java
+++ b/modules/apps/dispatch/dispatch-service/src/test/java/com/liferay/dispatch/internal/messaging/DispatchConfiguratorTest.java
@@ -23,7 +23,10 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
@@ -40,25 +43,13 @@ public class DispatchConfiguratorTest {
 
 	@Before
 	public void setUp() {
-		ReflectionTestUtil.setFieldValue(
-			_dispatchConfigurator, "_clusterMasterExecutor",
-			_clusterMasterExecutor);
-		ReflectionTestUtil.setFieldValue(
-			_dispatchConfigurator, "_destinationFactory", _destinationFactory);
-		ReflectionTestUtil.setFieldValue(
-			_dispatchConfigurator, "_dispatchTriggerHelper",
-			_dispatchTriggerHelper);
-		ReflectionTestUtil.setFieldValue(
-			_dispatchConfigurator, "_dispatchTriggerLocalService",
-			_dispatchTriggerLocalService);
+		MockitoAnnotations.initMocks(this);
 
 		Mockito.when(
 			_destinationFactory.createDestination(Mockito.any())
 		).thenReturn(
 			Mockito.mock(Destination.class)
 		);
-
-		_allNodesDispatchTrigger = Mockito.mock(DispatchTrigger.class);
 
 		Mockito.when(
 			_dispatchTriggerLocalService.getDispatchTriggers(
@@ -67,18 +58,12 @@ public class DispatchConfiguratorTest {
 			ListUtil.fromArray(_allNodesDispatchTrigger)
 		);
 
-		_singleNodeMemoryClusteredDispatchTrigger = Mockito.mock(
-			DispatchTrigger.class);
-
 		Mockito.when(
 			_dispatchTriggerLocalService.getDispatchTriggers(
 				true, DispatchTaskClusterMode.SINGLE_NODE_MEMORY_CLUSTERED)
 		).thenReturn(
 			ListUtil.fromArray(_singleNodeMemoryClusteredDispatchTrigger)
 		);
-
-		_singleNodePersistedDispatchTrigger = Mockito.mock(
-			DispatchTrigger.class);
 
 		Mockito.when(
 			_dispatchTriggerLocalService.getDispatchTriggers(
@@ -320,20 +305,32 @@ public class DispatchConfiguratorTest {
 		);
 	}
 
+	@Mock
 	private DispatchTrigger _allNodesDispatchTrigger;
+
 	private final BundleContext _bundleContext =
 		SystemBundleUtil.getBundleContext();
-	private final ClusterMasterExecutor _clusterMasterExecutor = Mockito.mock(
-		ClusterMasterExecutor.class);
-	private final DestinationFactory _destinationFactory = Mockito.mock(
-		DestinationFactory.class);
+
+	@Mock
+	private ClusterMasterExecutor _clusterMasterExecutor;
+
+	@Mock
+	private DestinationFactory _destinationFactory;
+
+	@InjectMocks
 	private final DispatchConfigurator _dispatchConfigurator =
 		new DispatchConfigurator();
-	private final DispatchTriggerHelper _dispatchTriggerHelper = Mockito.mock(
-		DispatchTriggerHelper.class);
-	private final DispatchTriggerLocalService _dispatchTriggerLocalService =
-		Mockito.mock(DispatchTriggerLocalService.class);
+
+	@Mock
+	private DispatchTriggerHelper _dispatchTriggerHelper;
+
+	@Mock
+	private DispatchTriggerLocalService _dispatchTriggerLocalService;
+
+	@Mock
 	private DispatchTrigger _singleNodeMemoryClusteredDispatchTrigger;
+
+	@Mock
 	private DispatchTrigger _singleNodePersistedDispatchTrigger;
 
 }


### PR DESCRIPTION
[LPD-29780](https://liferay.atlassian.net/browse/LPD-29780)

Schedule all type of jobs when restarting the portal:
* `All Nodes`
* `Single Node (Memory Clustered)`, only when on master node
* `Single Node (Persisted)`, only when on master node