### PR TITLE
LPD-33577 Jobs are not rescheduled in the cluster, when the master node is stopped and a new master is selected

### DIFF
--- a/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/internal/messaging/DispatchConfigurator.java
+++ b/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/internal/messaging/DispatchConfigurator.java
@@ -193,7 +193,7 @@ public class DispatchConfigurator {
 
 		@Override
 		protected void doMasterTokenReleased() throws Exception {
-			_deleteScheduledJobs();
+			_addScheduledJobs();
 		}
 
 	}

--- a/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/internal/messaging/DispatchConfigurator.java
+++ b/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/internal/messaging/DispatchConfigurator.java
@@ -11,7 +11,9 @@ import com.liferay.dispatch.executor.DispatchTaskClusterMode;
 import com.liferay.dispatch.internal.helper.DispatchTriggerHelper;
 import com.liferay.dispatch.model.DispatchTrigger;
 import com.liferay.dispatch.service.DispatchTriggerLocalService;
+import com.liferay.portal.kernel.cluster.BaseClusterMasterTokenTransitionListener;
 import com.liferay.portal.kernel.cluster.ClusterMasterExecutor;
+import com.liferay.portal.kernel.cluster.ClusterMasterTokenTransitionListener;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.messaging.Destination;
@@ -42,6 +44,14 @@ public class DispatchConfigurator {
 			new DestinationConfiguration(
 				DestinationConfiguration.DESTINATION_TYPE_PARALLEL,
 				DispatchConstants.EXECUTOR_DESTINATION_NAME);
+
+		if (_clusterMasterExecutor.isEnabled()) {
+			_dispatchClusterMasterTokenTransitionListener =
+				new DispatchClusterMasterTokenTransitionListener();
+
+			_clusterMasterExecutor.addClusterMasterTokenTransitionListener(
+				_dispatchClusterMasterTokenTransitionListener);
+		}
 
 		destinationConfiguration.setMaximumQueueSize(_MAXIMUM_QUEUE_SIZE);
 
@@ -78,6 +88,22 @@ public class DispatchConfigurator {
 		_serviceRegistration = bundleContext.registerService(
 			Destination.class, destination, properties);
 
+		_addScheduledJobs();
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_deleteScheduledJobs();
+
+		_serviceRegistration.unregister();
+
+		if (_clusterMasterExecutor.isEnabled()) {
+			_clusterMasterExecutor.removeClusterMasterTokenTransitionListener(
+				_dispatchClusterMasterTokenTransitionListener);
+		}
+	}
+
+	private void _addScheduledJobs() {
 		for (DispatchTrigger dispatchTrigger :
 				_dispatchTriggerLocalService.getDispatchTriggers(true)) {
 
@@ -102,8 +128,7 @@ public class DispatchConfigurator {
 		}
 	}
 
-	@Deactivate
-	protected void deactivate() {
+	private void _deleteScheduledJobs() {
 		for (DispatchTrigger dispatchTrigger :
 				_dispatchTriggerLocalService.getDispatchTriggers(true)) {
 
@@ -118,8 +143,6 @@ public class DispatchConfigurator {
 			_dispatchTriggerHelper.deleteSchedulerJob(
 				dispatchTrigger, dispatchTaskClusterMode.getStorageType());
 		}
-
-		_serviceRegistration.unregister();
 	}
 
 	private boolean _isSchedulable(
@@ -149,6 +172,9 @@ public class DispatchConfigurator {
 	@Reference
 	private DestinationFactory _destinationFactory;
 
+	private ClusterMasterTokenTransitionListener
+		_dispatchClusterMasterTokenTransitionListener;
+
 	@Reference
 	private DispatchTriggerHelper _dispatchTriggerHelper;
 
@@ -156,5 +182,20 @@ public class DispatchConfigurator {
 	private DispatchTriggerLocalService _dispatchTriggerLocalService;
 
 	private ServiceRegistration<Destination> _serviceRegistration;
+
+	private class DispatchClusterMasterTokenTransitionListener
+		extends BaseClusterMasterTokenTransitionListener {
+
+		@Override
+		protected void doMasterTokenAcquired() throws Exception {
+			_addScheduledJobs();
+		}
+
+		@Override
+		protected void doMasterTokenReleased() throws Exception {
+			_deleteScheduledJobs();
+		}
+
+	}
 
 }

--- a/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/internal/messaging/DispatchConfigurator.java
+++ b/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/internal/messaging/DispatchConfigurator.java
@@ -21,8 +21,6 @@ import com.liferay.portal.kernel.messaging.DestinationConfiguration;
 import com.liferay.portal.kernel.messaging.DestinationFactory;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 
-import java.util.Dictionary;
-import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadPoolExecutor;
 
 import org.osgi.framework.BundleContext;
@@ -54,8 +52,7 @@ public class DispatchConfigurator {
 				DispatchConstants.EXECUTOR_DESTINATION_NAME);
 
 		destinationConfiguration.setMaximumQueueSize(_MAXIMUM_QUEUE_SIZE);
-
-		RejectedExecutionHandler rejectedExecutionHandler =
+		destinationConfiguration.setRejectedExecutionHandler(
 			new ThreadPoolExecutor.CallerRunsPolicy() {
 
 				@Override
@@ -72,21 +69,16 @@ public class DispatchConfigurator {
 					super.rejectedExecution(runnable, threadPoolExecutor);
 				}
 
-			};
-
-		destinationConfiguration.setRejectedExecutionHandler(
-			rejectedExecutionHandler);
+			});
 
 		Destination destination = _destinationFactory.createDestination(
 			destinationConfiguration);
 
-		Dictionary<String, Object> properties =
+		_serviceRegistration = bundleContext.registerService(
+			Destination.class, destination,
 			HashMapDictionaryBuilder.<String, Object>put(
 				"destination.name", destination.getName()
-			).build();
-
-		_serviceRegistration = bundleContext.registerService(
-			Destination.class, destination, properties);
+			).build());
 
 		_addScheduledJobs();
 	}

--- a/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/internal/messaging/DispatchConfigurator.java
+++ b/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/internal/messaging/DispatchConfigurator.java
@@ -40,11 +40,6 @@ public class DispatchConfigurator {
 
 	@Activate
 	protected void activate(BundleContext bundleContext) {
-		DestinationConfiguration destinationConfiguration =
-			new DestinationConfiguration(
-				DestinationConfiguration.DESTINATION_TYPE_PARALLEL,
-				DispatchConstants.EXECUTOR_DESTINATION_NAME);
-
 		if (_clusterMasterExecutor.isEnabled()) {
 			_dispatchClusterMasterTokenTransitionListener =
 				new DispatchClusterMasterTokenTransitionListener();
@@ -52,6 +47,11 @@ public class DispatchConfigurator {
 			_clusterMasterExecutor.addClusterMasterTokenTransitionListener(
 				_dispatchClusterMasterTokenTransitionListener);
 		}
+
+		DestinationConfiguration destinationConfiguration =
+			new DestinationConfiguration(
+				DestinationConfiguration.DESTINATION_TYPE_PARALLEL,
+				DispatchConstants.EXECUTOR_DESTINATION_NAME);
 
 		destinationConfiguration.setMaximumQueueSize(_MAXIMUM_QUEUE_SIZE);
 

--- a/modules/apps/dispatch/dispatch-service/src/test/java/com/liferay/dispatch/internal/messaging/DispatchConfiguratorTest.java
+++ b/modules/apps/dispatch/dispatch-service/src/test/java/com/liferay/dispatch/internal/messaging/DispatchConfiguratorTest.java
@@ -507,16 +507,16 @@ public class DispatchConfiguratorTest {
 
 		Mockito.verify(
 			_dispatchTriggerHelper
-		).deleteSchedulerJob(
+		).addSchedulerJob(
 			Mockito.same(_allNodesDispatchTrigger),
-			Mockito.eq(StorageType.MEMORY)
+			Mockito.eq(StorageType.MEMORY), Mockito.any()
 		);
 
 		Mockito.verify(
 			_dispatchTriggerHelper, Mockito.never()
-		).deleteSchedulerJob(
+		).addSchedulerJob(
 			Mockito.same(_notApplicableDispatchTrigger),
-			Mockito.eq(StorageType.MEMORY)
+			Mockito.eq(StorageType.MEMORY), Mockito.any()
 		);
 
 		_dispatchConfigurator.deactivate();

--- a/modules/apps/dispatch/dispatch-service/src/test/java/com/liferay/dispatch/internal/messaging/DispatchConfiguratorTest.java
+++ b/modules/apps/dispatch/dispatch-service/src/test/java/com/liferay/dispatch/internal/messaging/DispatchConfiguratorTest.java
@@ -10,6 +10,7 @@ import com.liferay.dispatch.internal.helper.DispatchTriggerHelper;
 import com.liferay.dispatch.model.DispatchTrigger;
 import com.liferay.dispatch.service.DispatchTriggerLocalService;
 import com.liferay.portal.kernel.cluster.ClusterMasterExecutor;
+import com.liferay.portal.kernel.cluster.ClusterMasterTokenTransitionListener;
 import com.liferay.portal.kernel.messaging.Destination;
 import com.liferay.portal.kernel.messaging.DestinationFactory;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
@@ -23,6 +24,7 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -84,6 +86,39 @@ public class DispatchConfiguratorTest {
 			_singleNodePersistedDispatchTrigger.getDispatchTaskClusterMode()
 		).thenReturn(
 			DispatchTaskClusterMode.SINGLE_NODE_PERSISTED.getMode()
+		);
+	}
+
+	@Test
+	public void testNoClusterNoListener() throws Exception {
+		Mockito.when(
+			_clusterMasterExecutor.isEnabled()
+		).thenReturn(
+			false
+		);
+
+		Mockito.when(
+			_clusterMasterExecutor.isMaster()
+		).thenReturn(
+			false
+		);
+
+		_dispatchConfigurator.activate(_bundleContext);
+
+		Mockito.reset(_dispatchTriggerHelper);
+
+		Mockito.verify(
+			_clusterMasterExecutor, Mockito.never()
+		).addClusterMasterTokenTransitionListener(
+			Mockito.any()
+		);
+
+		_dispatchConfigurator.deactivate();
+
+		Mockito.verify(
+			_clusterMasterExecutor, Mockito.never()
+		).removeClusterMasterTokenTransitionListener(
+			Mockito.any()
 		);
 	}
 
@@ -342,6 +377,154 @@ public class DispatchConfiguratorTest {
 		).deleteSchedulerJob(
 			Mockito.same(_singleNodePersistedDispatchTrigger),
 			Mockito.eq(StorageType.PERSISTED)
+		);
+	}
+
+	@Test
+	public void testOnMasterTokenAcquired() throws Exception {
+		Mockito.when(
+			_clusterMasterExecutor.isEnabled()
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
+			_clusterMasterExecutor.isMaster()
+		).thenReturn(
+			false
+		);
+
+		ArgumentCaptor<ClusterMasterTokenTransitionListener> argumentCaptor =
+			ArgumentCaptor.forClass(ClusterMasterTokenTransitionListener.class);
+
+		_dispatchConfigurator.activate(_bundleContext);
+
+		Mockito.reset(_dispatchTriggerHelper);
+
+		Mockito.verify(
+			_clusterMasterExecutor
+		).addClusterMasterTokenTransitionListener(
+			argumentCaptor.capture()
+		);
+
+		Mockito.when(
+			_clusterMasterExecutor.isMaster()
+		).thenReturn(
+			true
+		);
+
+		ClusterMasterTokenTransitionListener
+			clusterMasterTokenTransitionListener = argumentCaptor.getValue();
+
+		clusterMasterTokenTransitionListener.masterTokenAcquired();
+
+		Mockito.verify(
+			_dispatchTriggerLocalService, Mockito.times(2)
+		).getDispatchTriggers(
+			Mockito.eq(true)
+		);
+
+		Mockito.verify(
+			_dispatchTriggerHelper
+		).addSchedulerJob(
+			Mockito.same(_allNodesDispatchTrigger),
+			Mockito.eq(StorageType.MEMORY), Mockito.any()
+		);
+
+		Mockito.verify(
+			_dispatchTriggerHelper, Mockito.never()
+		).addSchedulerJob(
+			Mockito.same(_notApplicableDispatchTrigger),
+			Mockito.eq(StorageType.MEMORY), Mockito.any()
+		);
+
+		Mockito.verify(
+			_dispatchTriggerHelper
+		).addSchedulerJob(
+			Mockito.same(_singleNodeMemoryClusteredDispatchTrigger),
+			Mockito.eq(StorageType.MEMORY_CLUSTERED), Mockito.any()
+		);
+
+		Mockito.verify(
+			_dispatchTriggerHelper
+		).addSchedulerJob(
+			Mockito.same(_singleNodePersistedDispatchTrigger),
+			Mockito.eq(StorageType.PERSISTED), Mockito.any()
+		);
+
+		_dispatchConfigurator.deactivate();
+
+		Mockito.verify(
+			_clusterMasterExecutor
+		).removeClusterMasterTokenTransitionListener(
+			Mockito.same(clusterMasterTokenTransitionListener)
+		);
+	}
+
+	@Test
+	public void testOnMasterTokenReleased() throws Exception {
+		Mockito.when(
+			_clusterMasterExecutor.isEnabled()
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
+			_clusterMasterExecutor.isMaster()
+		).thenReturn(
+			true
+		);
+
+		ArgumentCaptor<ClusterMasterTokenTransitionListener> argumentCaptor =
+			ArgumentCaptor.forClass(ClusterMasterTokenTransitionListener.class);
+
+		_dispatchConfigurator.activate(_bundleContext);
+
+		Mockito.reset(_dispatchTriggerHelper);
+
+		Mockito.verify(
+			_clusterMasterExecutor
+		).addClusterMasterTokenTransitionListener(
+			argumentCaptor.capture()
+		);
+
+		Mockito.when(
+			_clusterMasterExecutor.isMaster()
+		).thenReturn(
+			false
+		);
+
+		ClusterMasterTokenTransitionListener
+			clusterMasterTokenTransitionListener = argumentCaptor.getValue();
+
+		clusterMasterTokenTransitionListener.masterTokenReleased();
+
+		Mockito.verify(
+			_dispatchTriggerLocalService, Mockito.times(2)
+		).getDispatchTriggers(
+			Mockito.eq(true)
+		);
+
+		Mockito.verify(
+			_dispatchTriggerHelper
+		).deleteSchedulerJob(
+			Mockito.same(_allNodesDispatchTrigger),
+			Mockito.eq(StorageType.MEMORY)
+		);
+
+		Mockito.verify(
+			_dispatchTriggerHelper, Mockito.never()
+		).deleteSchedulerJob(
+			Mockito.same(_notApplicableDispatchTrigger),
+			Mockito.eq(StorageType.MEMORY)
+		);
+
+		_dispatchConfigurator.deactivate();
+
+		Mockito.verify(
+			_clusterMasterExecutor
+		).removeClusterMasterTokenTransitionListener(
+			Mockito.same(clusterMasterTokenTransitionListener)
 		);
 	}
 


### PR DESCRIPTION
[LPD-33577](https://liferay.atlassian.net/browse/LPD-33577)

Jobs are automatically removed from the scheduler whenever a cluster master token is either acquired or released, so only adding them is required.

Release can happen in a scenario where a connection is lost and restored between cluster nodes: connection loss results in multiple nodes taking the master role and when it's restored, one of the masters has to release its token. In this case, only ALL_NODES jobs will be added on that specific node.