### PR TITLE
LPD-32638 Adding new rule to relevant suite to execute the headles-staging tests when a staging related file is modified everywhere in the portal

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -909,6 +909,7 @@
         semantic-versioning-rule,\
         service-builder-rule,\
         stable-rule,\
+        staging-rule,\
         workspaces-rule
 
     test.batch.class.names.excludes[unit-jdk8][relevant]=\
@@ -1197,6 +1198,20 @@
         modules-unit-jdk8_stable,\
         playwright-js-tomcat90-mysql57-jdk8_stable,\
         unit-jdk8_stable
+
+    #
+    # Staging Rule
+    #
+
+    modified.files.includes[staging-rule][relevant]=**/exportimport/**/*.java
+
+    modules.includes.required.test.batch.class.names.includes[staging-rule][relevant][modules-unit-jdk8]=${test.batch.class.names.includes[headless-staging]}
+
+    modules.includes.required.test.batch.class.names.includes[staging-rule][relevant][modules-integration-mysql57-jdk8]=${test.batch.class.names.includes[headless-staging]}
+
+    test.batch.names[staging-rule][relevant]=\
+        modules-integration-mysql57-jdk8,\
+        modules-unit-jdk8
 
     #
     # Workspaces Rule

--- a/test.properties
+++ b/test.properties
@@ -1203,7 +1203,9 @@
     # Staging Rule
     #
 
-    modified.files.includes[staging-rule][relevant]=**/exportimport/**/*.java
+    modified.files.includes[staging-rule][relevant]=\
+        **/*Staging*.java,\
+        **/exportimport/**/*.java
 
     modules.includes.required.test.batch.class.names.includes[staging-rule][relevant][modules-unit-jdk8]=${test.batch.class.names.includes[headless-staging]}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPD-32638

This PR adds a new relevant rule with the new rules engine to execute the headless-staging integration and unit tests when a staging related file is modified anywhere in the portal.
Functional tests are excluded as it was decided some time ago that relevant suite would not execute functional tests.
To check for more information, see the associated [LPD-29779](https://liferay.atlassian.net/browse/LPD-29779).

To check for the execution of the new rule when a staging file is modified, check https://github.com/LuisOrtiz89/liferay-portal/pull/28 and https://github.com/magjed4289/liferay-portal/pull/1261