### PR TITLE
LPD-35228 Technical Task | Add additional tests for the coverage of LPD-34463

### DIFF
--- a/modules/core/petra/petra-http-invoker/src/test/java/com/liferay/petra/http/invoker/HttpInvokerTest.java
+++ b/modules/core/petra/petra-http-invoker/src/test/java/com/liferay/petra/http/invoker/HttpInvokerTest.java
@@ -71,6 +71,32 @@ public class HttpInvokerTest {
 			httpURLConnection.getRequestMethod());
 	}
 
+	@Test
+	public void testPathReplacement()
+		throws IllegalAccessException, NoSuchFieldException {
+
+		_testPathReplacement("\\\\");
+		_testPathReplacement("$");
+	}
+
+	private void _testPathReplacement(String specialCharacter)
+		throws IllegalAccessException, NoSuchFieldException {
+
+		HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+		httpInvoker.path("/api/users/{name}");
+
+		httpInvoker.path("name", "value" + specialCharacter);
+
+		Field pathField = HttpInvoker.class.getDeclaredField("_path");
+
+		pathField.setAccessible(true);
+
+		String actualPath = (String)pathField.get(httpInvoker);
+
+		Assert.assertEquals("/api/users/value" + specialCharacter, actualPath);
+	}
+
 	private static final Field _httpMethodField;
 
 	static {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPD-35228

Leaving just two test cases as the rest of special characters were working with the old `path(name, value)` method:

```
_testPathReplacement(".");
_testPathReplacement("*");
_testPathReplacement("+");
_testPathReplacement("?");
_testPathReplacement("^");
_testPathReplacement("|");
_testPathReplacement("(");
_testPathReplacement(")");
_testPathReplacement("{");
_testPathReplacement("}");
_testPathReplacement("[");
_testPathReplacement("]");
_testPathReplacement("/");
_testPathReplacement("%");
_testPathReplacement("@");
_testPathReplacement(":");
_testPathReplacement(";");
_testPathReplacement("&");
_testPathReplacement("=");
_testPathReplacement("\"");
_testPathReplacement("'");
_testPathReplacement("<");
_testPathReplacement(">");
_testPathReplacement("\n");
_testPathReplacement("\t");
```

cc @4lejandrito 