### PR TITLE
LPD-35302 | Add Playwright Site creation for OOTB Site Templates

### DIFF
--- a/modules/test/playwright/pages/site-admin-web/SitesPage.ts
+++ b/modules/test/playwright/pages/site-admin-web/SitesPage.ts
@@ -15,6 +15,7 @@ export class SitesPage {
 	readonly addSiteIFrame: FrameLocator;
 	readonly customSiteTemplatesItem: Locator;
 	readonly defaultPagesAsPrivateCheck: Locator;
+	readonly liferayTemplatesItem: Locator;
 	readonly nameBox: Locator;
 	readonly uiElementsPage: UIElementsPage;
 
@@ -34,6 +35,9 @@ export class SitesPage {
 			.getByLabel(
 				'Create default pages as private (available only to members). If unchecked, they will be public (available to anyone).'
 			);
+		this.liferayTemplatesItem = page.getByRole('menuitem', {
+			name: 'Provided by Liferay',
+		});
 		this.nameBox = page
 			.frameLocator('iframe[title="Add Site"]')
 			.getByLabel('Name Required');
@@ -42,10 +46,16 @@ export class SitesPage {
 
 	async createSiteFromTemplate(
 		templateName: string,
-		siteName: string
+		siteName: string,
+		isCustomSiteTemplate: boolean = true
 	): Promise<string> {
 		await this.addSiteButton.click();
-		await this.customSiteTemplatesItem.click();
+		if (isCustomSiteTemplate) {
+			await this.customSiteTemplatesItem.click();
+		}
+		else {
+			await this.liferayTemplatesItem.click();
+		}
 		await this.page
 			.getByRole('button', {name: `Select Template: ${templateName}`})
 			.click();

--- a/modules/test/playwright/pages/site-admin-web/SitesPage.ts
+++ b/modules/test/playwright/pages/site-admin-web/SitesPage.ts
@@ -60,7 +60,9 @@ export class SitesPage {
 			.getByRole('button', {name: `Select Template: ${templateName}`})
 			.click();
 		await this.nameBox.fill(siteName);
-		await this.defaultPagesAsPrivateCheck.check();
+		if (isCustomSiteTemplate) {
+			await this.defaultPagesAsPrivateCheck.check();
+		}
 		await this.addButton.click();
 		await this.page.waitForURL(/(.)settings(.)/);
 		await this.page.getByRole('link', {name: 'Site Configuration'}).click();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-35302

See this Slack thread for more context: https://liferay.slack.com/archives/C5E1CRLJY/p1724956751885209

We need a way to cleanly create sites in a virtual instance, so the easiest way to implement this was to leverage the existing `SitesPage.ts` file to also accommodate for default Liferay templates.

These changes have no impact on existing tests, or any tests using custom site templates for that matter.

Please let me know if you have any questions or feedback.  Thanks!