### PR TITLE
LPD-35430 correcting component name

### DIFF
--- a/modules/apps/portal-vulcan/test.properties
+++ b/modules/apps/portal-vulcan/test.properties
@@ -25,4 +25,4 @@
 ## Testray
 ##
 
-    testray.main.component.name=Headless
+    testray.main.component.name=REST Infrastructure

--- a/test.properties
+++ b/test.properties
@@ -12023,7 +12023,7 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
         Headless Discovery Application,\
         Job Scheduler,\
         Object Entries REST APIs,\
-        REST infrastructure (vulcan),\
+        REST Infrastructure,\
         Site Templates,\
         Staging,\
         Upgrades Staging


### PR DESCRIPTION
Headless component was not used in testray.team.headless.component.names, also title casing REST Infrastructure