### PR TITLE
LPD-33603

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -6668,6 +6668,7 @@ paths:
             tags: ["DocumentFolder"]
     "/asset-libraries/{assetLibraryId}/document-metadata-sets":
         post:
+            operationId: postAssetLibraryDocumentMetadataSetsPage
             parameters:
                 - in: path
                   name: assetLibraryId
@@ -13149,6 +13150,7 @@ paths:
             tags: ["DocumentFolder"]
     "/sites/{siteId}/document-metadata-sets":
         post:
+            operationId: postSiteDocumentMetadataSetsPage
             parameters:
                 - in: path
                   name: siteId

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -6667,6 +6667,37 @@ paths:
                                 type: array
             tags: ["DocumentFolder"]
     "/asset-libraries/{assetLibraryId}/document-metadata-sets":
+        post:
+            parameters:
+                - in: path
+                  name: assetLibraryId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "../../../data-engine/data-engine-rest-impl/rest-openapi.yaml#DataDefinition"
+                    application/xml:
+                        schema:
+                            $ref: "../../../data-engine/data-engine-rest-impl/rest-openapi.yaml#DataDefinition"
+
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/DocumentMetadataSet"
+                                type: array
+                        application/xml:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/DocumentMetadataSet"
+                                type: array
+            tags: ["DocumentMetadataSet"]
         get:
             operationId: getAssetLibraryDocumentMetadataSetsPage
             parameters:
@@ -13117,6 +13148,37 @@ paths:
                                 type: array
             tags: ["DocumentFolder"]
     "/sites/{siteId}/document-metadata-sets":
+        post:
+            parameters:
+                - in: path
+                  name: siteId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "../../../data-engine/data-engine-rest-impl/rest-openapi.yaml#DataDefinition"
+                    application/xml:
+                        schema:
+                            $ref: "../../../data-engine/data-engine-rest-impl/rest-openapi.yaml#DataDefinition"
+
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/DocumentMetadataSet"
+                                type: array
+                        application/xml:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/DocumentMetadataSet"
+                                type: array
+            tags: ["DocumentMetadataSet"]
         get:
             operationId: getSiteDocumentMetadataSetsPage
             parameters:


### PR DESCRIPTION
Based on the discussion with @4lejandrito on https://liferay.slack.com/archives/C5E1CRLJY/p1725978455654709 , I'd like to ask for your help in determining if this is an intended behaviour or not:

Seems like buildRest generates `operationId` for POST methods in plural form `s` and with `Page` suffix.
eg: `postAssetLibraryDocumentMetadataSetsPage`
I think the correct operationId would be `postAssetLibraryDocumentMetadataSet`