### PR TITLE
LPD-27473 Internal server error when sending the Object Entry `status` field without the `code` subfield

### DIFF
--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/Status.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/Status.java
@@ -28,6 +28,8 @@ import java.util.function.Supplier;
 
 import javax.annotation.Generated;
 
+import javax.validation.constraints.NotNull;
+
 import javax.xml.bind.annotation.XmlRootElement;
 
 /**
@@ -37,6 +39,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 @Generated("")
 @GraphQLName("Status")
 @JsonFilter("Liferay.Vulcan")
+@Schema(requiredProperties = {"code"})
 @XmlRootElement(name = "Status")
 public class Status implements Serializable {
 
@@ -82,6 +85,7 @@ public class Status implements Serializable {
 
 	@GraphQLField
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@NotNull
 	protected Integer code;
 
 	@JsonIgnore

--- a/modules/apps/object/object-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-rest-impl/rest-openapi.yaml
@@ -158,6 +158,8 @@ components:
                     type: string
                 label_i18n:
                     type: string
+            required:
+                - code
             type: object
         TaxonomyCategoryBrief:
             properties:

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -7232,6 +7232,44 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
+	public void testPostCustomObjectEntryWithCodeSubfield() throws Exception {
+
+		// Without status field
+
+		Assert.assertEquals(
+			200,
+			HTTPTestUtil.invokeToHttpCode(
+				JSONUtil.put(
+					_OBJECT_FIELD_NAME_1, RandomTestUtil.randomString()
+				).toString(),
+				_objectDefinition1.getRESTContextPath(), Http.Method.POST));
+
+		// With code subfield inside status
+
+		Assert.assertEquals(
+			200,
+			HTTPTestUtil.invokeToHttpCode(
+				JSONUtil.put(
+					_OBJECT_FIELD_NAME_1, RandomTestUtil.randomString()
+				).put(
+					"status", JSONUtil.put("code", 0)
+				).toString(),
+				_objectDefinition1.getRESTContextPath(), Http.Method.POST));
+
+		// Without code subfield inside status
+
+		Assert.assertEquals(
+			400,
+			HTTPTestUtil.invokeToHttpCode(
+				JSONUtil.put(
+					_OBJECT_FIELD_NAME_1, RandomTestUtil.randomString()
+				).put(
+					"status", JSONUtil.put("label", "approved")
+				).toString(),
+				_objectDefinition1.getRESTContextPath(), Http.Method.POST));
+	}
+
+	@Test
 	public void testPostCustomObjectEntryWithDuplicateExternalReferenceCode()
 		throws Exception {
 


### PR DESCRIPTION
**What's changed?:**
- The _code_ subfield is now required within the _status_ field
- Tests have been added to validate server's response

**How to test it?:**
- Execute both of the following curl commands:
```
curl -X POST -u test@liferay.com:test -H 'Content-type: application/json' -d '{
            "enableCategorization": true,
            "externalReferenceCode": "STUDENT",
            "label": {
                "en_US": "Student"
            },
            "modifiable": true,
            "name": "Student",
            "objectFields": [
                {
                    "DBType": "String",
                    "businessType": "Text",
                    "externalReferenceCode": "STUDENT_NAME",
                    "indexed": true,
                    "indexedAsKeyword": false,
                    "indexedLanguageId": "en_US",
                    "label": {
                        "en_US": "studentName"
                    },
                    "name": "studentName",
                    "required": false,
                    "state": false,
                    "system": false,
                    "type": "String"
                }
            ],
            "panelCategoryKey": "",
            "parameterRequired": false,
            "pluralLabel": {
                "en_US": "Students"
            },
            "portlet": false,
            "scope": "company",
            "status": {
                "code": 0
            },
            "system": false
        }' http://localhost:8080/o/object-admin/v1.0/object-definitions
```


```
curl -X POST \
     -u 'test@liferay.com:test' \
     http://localhost:8080/o/c/students \
     -H 'Content-type: application/json' \
     -d '{
            "studentName": "student 1",
            "status" : {
               "label" : "approved"
            }
         }'
```

A 400 HTTP error would be returned because the code subfield is necessary.

See the following Jira Ticket: [LPD-27473](https://liferay.atlassian.net/browse/LPD-27473)