### PR TITLE
LPD-36693 Fix HeadlessBuilderOpenAPIResourceTest

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/resources/com/liferay/headless/builder/resource/test/dependencies/expected_openapi.json
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/resources/com/liferay/headless/builder/resource/test/dependencies/expected_openapi.json
@@ -261,8 +261,7 @@
 						"type": "string"
 					},
 					"attachmentProperty": {
-						"$ref": "#/components/schemas/FileEntry",
-						"description": "attachmentProperty description"
+						"$ref": "#/components/schemas/FileEntry"
 					},
 					"booleanProperty": {
 						"description": "booleanProperty description",
@@ -305,8 +304,7 @@
 						"type": "array"
 					},
 					"picklistProperty": {
-						"$ref": "#/components/schemas/ListEntry",
-						"description": "picklistProperty description"
+						"$ref": "#/components/schemas/ListEntry"
 					},
 					"precisionDecimalProperty": {
 						"description": "precisionDecimalProperty description",


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-36693. After using swagger to serialize the openapi descriptions are no longer included in $refed schemas. This is [as per spec](https://swagger.io/docs/specification/using-ref/#sibling).