### PR TITLE
LPD-37219 Prioritize the locale from the accept-language

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/accept/language/AcceptLanguageImpl.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/accept/language/AcceptLanguageImpl.java
@@ -9,6 +9,7 @@ import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.exception.NoSuchUserException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -112,6 +113,17 @@ public class AcceptLanguageImpl implements AcceptLanguage {
 		List<Locale> locales = getLocales();
 
 		if (ListUtil.isNotEmpty(locales)) {
+			if (locales.size() == 1) {
+				return locales.get(0);
+			}
+
+			String acceptLanguage = _httpServletRequest.getHeader(
+				HttpHeaders.ACCEPT_LANGUAGE);
+
+			if (LanguageUtil.isAvailableLanguageCode(acceptLanguage)) {
+				return LocaleUtil.fromLanguageId(acceptLanguage);
+			}
+
 			return locales.get(0);
 		}
 

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/test/AcceptLanguageContextProviderTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/test/AcceptLanguageContextProviderTest.java
@@ -73,7 +73,8 @@ public class AcceptLanguageContextProviderTest {
 			Arrays.asList(
 				LocaleUtil.BRAZIL, new Locale("ca", "ES", "VALENCIA"),
 				LocaleUtil.GERMAN, LocaleUtil.JAPAN, new Locale("sr_RS_latin"),
-				LocaleUtil.TAIWAN),
+				LocaleUtil.TAIWAN, LocaleUtil.UK, LocaleUtil.US,
+				LocaleUtil.ENGLISH),
 			LocaleUtil.TAIWAN);
 
 		_company = CompanyLocalServiceUtil.getCompany(_company.getCompanyId());
@@ -150,6 +151,14 @@ public class AcceptLanguageContextProviderTest {
 		Assert.assertEquals(srLocale, acceptLanguage.getPreferredLocale());
 
 		// One partial locale
+
+		acceptLanguage = _contextProvider.createContext(
+			new MockMessage(
+				new AcceptLanguageMockHttpServletRequest(
+					method, user, LocaleUtil.ENGLISH)));
+
+		Assert.assertEquals(
+			LocaleUtil.ENGLISH, acceptLanguage.getPreferredLocale());
 
 		acceptLanguage = _contextProvider.createContext(
 			new MockMessage(


### PR DESCRIPTION
Related issue: https://liferay.atlassian.net/browse/LPD-37219
Related LPP: https://liferay.atlassian.net/browse/LPP-55212

Hi team, 
I believe the headless team is responsible for the portal-vulcan code. If not, please let me know :smile: 

### Motivation
When creating web content, the user can choose a language using the translation button and fill the fields with values. In the database, we persist the languageId, the field, and its value. The issue occurs when the portal contains a partial locale (`en`), which is a substring of other locales (`en_AU,en_US,en_GB,en_NZ`). The user filled in the values for the language `en`, but the database persisted that value for another locale different than `en`.

The accept-language of the request was `en` but the method `getPreferredLocale()` returned an incorrect value to the frontend.
![8e13f256-715f-4ed8-82b2-74b0d608638e](https://github.com/user-attachments/assets/fd532667-7542-45f1-a8b0-7c4b82a9ac26)


### Solution
When the method `getPreferredLocale()` is executed, verify the size of the variable `locales` and prioritize the locale from accept-language whenever possible.