### PR TITLE
LPD-37767 Greater than filter for the dateModified fiels does not work properly with custom objects in MySQL

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
@@ -26,6 +26,7 @@ import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.sql.dsl.Column;
 import com.liferay.petra.sql.dsl.DSLFunctionFactoryUtil;
 import com.liferay.petra.sql.dsl.expression.Predicate;
+import com.liferay.petra.sql.dsl.spi.expression.DSLFunction;
 import com.liferay.petra.sql.dsl.spi.expression.DefaultPredicate;
 import com.liferay.petra.sql.dsl.spi.expression.Operand;
 import com.liferay.petra.string.StringBundler;
@@ -628,6 +629,18 @@ public class PredicateExpressionVisitorImpl
 
 		if (predicate != null) {
 			return predicate;
+		}
+
+		if (Objects.equals(
+				_getEntityField(
+					left, objectDefinition
+				).getType(),
+				EntityField.Type.DATE_TIME)) {
+
+			return BinaryExpressionConverterUtil.getExpressionPredicate(
+				(DSLFunction)DSLFunctionFactoryUtil.date2sec(
+					_getColumn(left, objectDefinition)),
+				operation, _getValue(left, objectDefinition, right));
 		}
 
 		return BinaryExpressionConverterUtil.getExpressionPredicate(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
@@ -638,7 +638,7 @@ public class PredicateExpressionVisitorImpl
 				EntityField.Type.DATE_TIME)) {
 
 			return BinaryExpressionConverterUtil.getExpressionPredicate(
-				(DSLFunction)DSLFunctionFactoryUtil.date2sec(
+				(DSLFunction)DSLFunctionFactoryUtil.truncateToSeconds(
 					_getColumn(left, objectDefinition)),
 				operation, _getValue(left, objectDefinition, right));
 		}

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -5119,6 +5119,38 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
+	public void testGetObjectEntriesFilteredByDateModified() throws Exception {
+		_objectEntry1 = ObjectEntryTestUtil.addObjectEntry(
+			_objectDefinition1, _OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1);
+
+		_objectEntry2 = ObjectEntryTestUtil.addObjectEntry(
+			_objectDefinition1, _OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_2);
+
+		_objectEntry1.setModifiedDate(
+			_dateTimeDateFormat.parse("2023-09-20T10:00:00.150Z"));
+		_objectEntry2.setModifiedDate(
+			_dateTimeDateFormat.parse("2023-09-20T10:05:00.450Z"));
+
+		_objectEntry1 = _objectEntryLocalService.updateObjectEntry(
+			_objectEntry1);
+		_objectEntry2 = _objectEntryLocalService.updateObjectEntry(
+			_objectEntry2);
+
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_2,
+			URLCodec.encodeURL("dateModified gt 2023-09-20T10:00:00Z"),
+			_objectDefinition1);
+
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			URLCodec.encodeURL("dateModified lt 2023-09-20T10:05:00Z"),
+			_objectDefinition1);
+
+		_assertFilteredObjectEntries(2, "dateModified ge 2023-09-20T10:00:00Z");
+		_assertFilteredObjectEntries(2, "dateModified le 2023-09-20T10:05:00Z");
+	}
+
+	@Test
 	public void testGetObjectEntriesWithPagination() throws Exception {
 		ObjectEntryTestUtil.addObjectEntry(
 			_objectDefinition6, _OBJECT_FIELD_NAME_TEXT,

--- a/modules/core/petra/petra-sql-dsl-api/src/main/java/com/liferay/petra/sql/dsl/DSLFunctionFactoryUtil.java
+++ b/modules/core/petra/petra-sql-dsl-api/src/main/java/com/liferay/petra/sql/dsl/DSLFunctionFactoryUtil.java
@@ -87,6 +87,10 @@ public class DSLFunctionFactoryUtil {
 		return _DSL_FUNCTION_FACTORY.countDistinct(expression);
 	}
 
+	public static Expression<String> date2sec(Expression<?> expression) {
+		return _DSL_FUNCTION_FACTORY.date2sec(expression);
+	}
+
 	public static <N extends Number> Expression<N> divide(
 		Expression<N> expression1, Expression<N> expression2) {
 

--- a/modules/core/petra/petra-sql-dsl-api/src/main/java/com/liferay/petra/sql/dsl/DSLFunctionFactoryUtil.java
+++ b/modules/core/petra/petra-sql-dsl-api/src/main/java/com/liferay/petra/sql/dsl/DSLFunctionFactoryUtil.java
@@ -87,10 +87,6 @@ public class DSLFunctionFactoryUtil {
 		return _DSL_FUNCTION_FACTORY.countDistinct(expression);
 	}
 
-	public static Expression<String> date2sec(Expression<?> expression) {
-		return _DSL_FUNCTION_FACTORY.date2sec(expression);
-	}
-
 	public static <N extends Number> Expression<N> divide(
 		Expression<N> expression1, Expression<N> expression2) {
 
@@ -147,6 +143,12 @@ public class DSLFunctionFactoryUtil {
 		Expression<? extends Number> expression) {
 
 		return _DSL_FUNCTION_FACTORY.sum(expression);
+	}
+
+	public static Expression<String> truncateToSeconds(
+		Expression<?> expression) {
+
+		return _DSL_FUNCTION_FACTORY.truncateToSeconds(expression);
 	}
 
 	public static Expression<Long> withParentheses(Expression<?> expression) {

--- a/modules/core/petra/petra-sql-dsl-api/src/main/java/com/liferay/petra/sql/dsl/factory/DSLFunctionFactory.java
+++ b/modules/core/petra/petra-sql-dsl-api/src/main/java/com/liferay/petra/sql/dsl/factory/DSLFunctionFactory.java
@@ -47,6 +47,8 @@ public interface DSLFunctionFactory {
 
 	public Expression<Long> countDistinct(Expression<?> expression);
 
+	public Expression<String> date2sec(Expression<?> expression);
+
 	public <N extends Number> Expression<N> divide(
 		Expression<N> expression1, Expression<N> expression2);
 

--- a/modules/core/petra/petra-sql-dsl-api/src/main/java/com/liferay/petra/sql/dsl/factory/DSLFunctionFactory.java
+++ b/modules/core/petra/petra-sql-dsl-api/src/main/java/com/liferay/petra/sql/dsl/factory/DSLFunctionFactory.java
@@ -47,8 +47,6 @@ public interface DSLFunctionFactory {
 
 	public Expression<Long> countDistinct(Expression<?> expression);
 
-	public Expression<String> date2sec(Expression<?> expression);
-
 	public <N extends Number> Expression<N> divide(
 		Expression<N> expression1, Expression<N> expression2);
 
@@ -76,6 +74,8 @@ public interface DSLFunctionFactory {
 		Expression<N> expression, N value);
 
 	public Expression<Number> sum(Expression<? extends Number> expression);
+
+	public Expression<String> truncateToSeconds(Expression<?> expression);
 
 	public Expression<Long> withParentheses(Expression<?> expression);
 

--- a/modules/core/petra/petra-sql-dsl-spi/src/main/java/com/liferay/petra/sql/dsl/spi/expression/DSLFunctionType.java
+++ b/modules/core/petra/petra-sql-dsl-spi/src/main/java/com/liferay/petra/sql/dsl/spi/expression/DSLFunctionType.java
@@ -29,6 +29,9 @@ public class DSLFunctionType {
 	public static final DSLFunctionType CONCAT = new DSLFunctionType(
 		"CONCAT(", ")");
 
+	public static final DSLFunctionType DATE2SEC = new DSLFunctionType(
+		"DATE2SEC(", ")");
+
 	public static final DSLFunctionType DIVISION = new DSLFunctionType(" / ");
 
 	public static final DSLFunctionType LOWER = new DSLFunctionType(

--- a/modules/core/petra/petra-sql-dsl-spi/src/main/java/com/liferay/petra/sql/dsl/spi/expression/DSLFunctionType.java
+++ b/modules/core/petra/petra-sql-dsl-spi/src/main/java/com/liferay/petra/sql/dsl/spi/expression/DSLFunctionType.java
@@ -29,9 +29,6 @@ public class DSLFunctionType {
 	public static final DSLFunctionType CONCAT = new DSLFunctionType(
 		"CONCAT(", ")");
 
-	public static final DSLFunctionType DATE2SEC = new DSLFunctionType(
-		"DATE2SEC(", ")");
-
 	public static final DSLFunctionType DIVISION = new DSLFunctionType(" / ");
 
 	public static final DSLFunctionType LOWER = new DSLFunctionType(
@@ -42,6 +39,9 @@ public class DSLFunctionType {
 
 	public static final DSLFunctionType SUBTRACTION = new DSLFunctionType(
 		" - ");
+
+	public static final DSLFunctionType TRUNCATE_TO_SECONDS =
+		new DSLFunctionType("TRUNCATE_TO_SECONDS(", ")");
 
 	public static final DSLFunctionType WITH_PARENTHESES = new DSLFunctionType(
 		"(", ")");

--- a/modules/core/petra/petra-sql-dsl-spi/src/main/java/com/liferay/petra/sql/dsl/spi/factory/DefaultDSLFunctionFactory.java
+++ b/modules/core/petra/petra-sql-dsl-spi/src/main/java/com/liferay/petra/sql/dsl/spi/factory/DefaultDSLFunctionFactory.java
@@ -99,6 +99,11 @@ public class DefaultDSLFunctionFactory implements DSLFunctionFactory {
 	}
 
 	@Override
+	public Expression<String> date2sec(Expression<?> expression) {
+		return new DSLFunction<>(DSLFunctionType.DATE2SEC, expression);
+	}
+
+	@Override
 	public <N extends Number> Expression<N> divide(
 		Expression<N> expression1, Expression<N> expression2) {
 

--- a/modules/core/petra/petra-sql-dsl-spi/src/main/java/com/liferay/petra/sql/dsl/spi/factory/DefaultDSLFunctionFactory.java
+++ b/modules/core/petra/petra-sql-dsl-spi/src/main/java/com/liferay/petra/sql/dsl/spi/factory/DefaultDSLFunctionFactory.java
@@ -99,11 +99,6 @@ public class DefaultDSLFunctionFactory implements DSLFunctionFactory {
 	}
 
 	@Override
-	public Expression<String> date2sec(Expression<?> expression) {
-		return new DSLFunction<>(DSLFunctionType.DATE2SEC, expression);
-	}
-
-	@Override
 	public <N extends Number> Expression<N> divide(
 		Expression<N> expression1, Expression<N> expression2) {
 
@@ -170,6 +165,12 @@ public class DefaultDSLFunctionFactory implements DSLFunctionFactory {
 	@Override
 	public Expression<Number> sum(Expression<? extends Number> expression) {
 		return new AggregateExpression<>(false, expression, "sum");
+	}
+
+	@Override
+	public Expression<String> truncateToSeconds(Expression<?> expression) {
+		return new DSLFunction<>(
+			DSLFunctionType.TRUNCATE_TO_SECONDS, expression);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/dao/sql/transformer/BaseSQLTransformerLogic.java
+++ b/portal-impl/src/com/liferay/portal/dao/sql/transformer/BaseSQLTransformerLogic.java
@@ -98,6 +98,16 @@ public abstract class BaseSQLTransformerLogic implements SQLTransformerLogic {
 		return sqlFunctionTransformer::transform;
 	}
 
+	protected Function<String, String> getDateFormatFunction() {
+		Pattern pattern = getDateFormatPattern();
+
+		return (String sql) -> replaceDateFormat(pattern.matcher(sql));
+	}
+
+	protected Pattern getDateFormatPattern() {
+		return Pattern.compile("DATE2SEC\\((.+?)\\)", Pattern.CASE_INSENSITIVE);
+	}
+
 	protected Function<String, String> getDropTableIfExistsTextFunction() {
 		Pattern pattern = getDropTableIfExistsTextPattern();
 
@@ -222,6 +232,10 @@ public abstract class BaseSQLTransformerLogic implements SQLTransformerLogic {
 
 	protected String replaceCastText(Matcher matcher) {
 		return matcher.replaceAll("$1");
+	}
+
+	protected String replaceDateFormat(Matcher matcher) {
+		return matcher.replaceAll("DATE_FORMAT($1, '%Y-%m-%dT%H:%i:%sZ')");
 	}
 
 	protected String replaceDropTableIfExistsText(Matcher matcher) {

--- a/portal-impl/src/com/liferay/portal/dao/sql/transformer/BaseSQLTransformerLogic.java
+++ b/portal-impl/src/com/liferay/portal/dao/sql/transformer/BaseSQLTransformerLogic.java
@@ -105,7 +105,8 @@ public abstract class BaseSQLTransformerLogic implements SQLTransformerLogic {
 	}
 
 	protected Pattern getDateFormatPattern() {
-		return Pattern.compile("DATE2SEC\\((.+?)\\)", Pattern.CASE_INSENSITIVE);
+		return Pattern.compile(
+			"TRUNCATE_TO_SECONDS\\((.+?)\\)", Pattern.CASE_INSENSITIVE);
 	}
 
 	protected Function<String, String> getDropTableIfExistsTextFunction() {

--- a/portal-impl/src/com/liferay/portal/dao/sql/transformer/DB2SQLTransformerLogic.java
+++ b/portal-impl/src/com/liferay/portal/dao/sql/transformer/DB2SQLTransformerLogic.java
@@ -27,7 +27,7 @@ public class DB2SQLTransformerLogic extends BaseSQLTransformerLogic {
 		Function[] functions = {
 			getAggregationFunction(), getBooleanFunction(),
 			getCastClobTextFunction(), getCastLongFunction(),
-			getCastTextFunction(), getConcatFunction(),
+			getCastTextFunction(), getConcatFunction(), getDateFormatFunction(),
 			getDropTableIfExistsTextFunction(), getIntegerDivisionFunction(),
 			getNullDateFunction(), _getCaseWhenThenFunction(),
 			_getLikeFunction(), _getSelectFunction()

--- a/portal-impl/src/com/liferay/portal/dao/sql/transformer/HypersonicSQLTransformerLogic.java
+++ b/portal-impl/src/com/liferay/portal/dao/sql/transformer/HypersonicSQLTransformerLogic.java
@@ -24,8 +24,9 @@ public class HypersonicSQLTransformerLogic extends BaseSQLTransformerLogic {
 		Function[] functions = {
 			getAggregationFunction(), getBooleanFunction(),
 			getCastClobTextFunction(), getCastLongFunction(),
-			getCastTextFunction(), getDropTableIfExistsTextFunction(),
-			getIntegerDivisionFunction(), getNullDateFunction()
+			getCastTextFunction(), getDateFormatFunction(),
+			getDropTableIfExistsTextFunction(), getIntegerDivisionFunction(),
+			getNullDateFunction()
 		};
 
 		if (!db.isSupportsStringCaseSensitiveQuery()) {

--- a/portal-impl/src/com/liferay/portal/dao/sql/transformer/MySQLSQLTransformerLogic.java
+++ b/portal-impl/src/com/liferay/portal/dao/sql/transformer/MySQLSQLTransformerLogic.java
@@ -23,8 +23,8 @@ public class MySQLSQLTransformerLogic extends BaseSQLTransformerLogic {
 			getAggregationFunction(), getBitwiseCheckFunction(),
 			getBooleanFunction(), getCastClobTextFunction(),
 			getCastLongFunction(), getCastTextFunction(),
-			getDropTableIfExistsTextFunction(), getIntegerDivisionFunction(),
-			getNullDateFunction()
+			getDateFormatFunction(), getDropTableIfExistsTextFunction(),
+			getIntegerDivisionFunction(), getNullDateFunction()
 		};
 
 		if (!db.isSupportsStringCaseSensitiveQuery()) {

--- a/portal-impl/src/com/liferay/portal/dao/sql/transformer/OracleSQLTransformerLogic.java
+++ b/portal-impl/src/com/liferay/portal/dao/sql/transformer/OracleSQLTransformerLogic.java
@@ -26,7 +26,7 @@ public class OracleSQLTransformerLogic extends BaseSQLTransformerLogic {
 		Function[] functions = {
 			getAggregationFunction(), getBooleanFunction(),
 			getCastClobTextFunction(), getCastLongFunction(),
-			getCastTextFunction(), getConcatFunction(),
+			getCastTextFunction(), getConcatFunction(), getDateFormatFunction(),
 			getDropTableIfExistsTextFunction(), getIntegerDivisionFunction(),
 			getNullDateFunction(), _getEscapeFunction(),
 			_getNotEqualsBlankStringFunction()

--- a/portal-impl/src/com/liferay/portal/dao/sql/transformer/PostgreSQLTransformerLogic.java
+++ b/portal-impl/src/com/liferay/portal/dao/sql/transformer/PostgreSQLTransformerLogic.java
@@ -26,9 +26,9 @@ public class PostgreSQLTransformerLogic extends BaseSQLTransformerLogic {
 			getAggregationFunction(), getBitwiseCheckFunction(),
 			getBooleanFunction(), getCastClobTextFunction(),
 			getCastLongFunction(), getCastTextFunction(),
-			getDropTableIfExistsTextFunction(), getInstrFunction(),
-			getIntegerDivisionFunction(), _getNegativeComparisonFunction(),
-			_getNullDateFunction()
+			getDateFormatFunction(), getDropTableIfExistsTextFunction(),
+			getInstrFunction(), getIntegerDivisionFunction(),
+			_getNegativeComparisonFunction(), _getNullDateFunction()
 		};
 
 		if (!db.isSupportsStringCaseSensitiveQuery()) {

--- a/portal-impl/src/com/liferay/portal/dao/sql/transformer/SQLServerSQLTransformerLogic.java
+++ b/portal-impl/src/com/liferay/portal/dao/sql/transformer/SQLServerSQLTransformerLogic.java
@@ -23,9 +23,10 @@ public class SQLServerSQLTransformerLogic extends BaseSQLTransformerLogic {
 			getAggregationFunction(), getBitwiseCheckFunction(),
 			getBooleanFunction(), getCastClobTextFunction(),
 			getCastLongFunction(), getCastTextFunction(), getConcatFunction(),
-			getDropTableIfExistsTextFunction(), getInstrFunction(),
-			getIntegerDivisionFunction(), getLengthFunction(), getModFunction(),
-			getNullDateFunction(), getSubstrFunction()
+			getDateFormatFunction(), getDropTableIfExistsTextFunction(),
+			getInstrFunction(), getIntegerDivisionFunction(),
+			getLengthFunction(), getModFunction(), getNullDateFunction(),
+			getSubstrFunction()
 		};
 
 		if (!db.isSupportsStringCaseSensitiveQuery()) {

--- a/portal-impl/src/com/liferay/portal/dao/sql/transformer/SybaseSQLTransformerLogic.java
+++ b/portal-impl/src/com/liferay/portal/dao/sql/transformer/SybaseSQLTransformerLogic.java
@@ -23,9 +23,10 @@ public class SybaseSQLTransformerLogic extends BaseSQLTransformerLogic {
 		super(db);
 
 		Function[] functions = {
-			getAggregationFunction(), getBitwiseCheckFunction(),
-			getBooleanFunction(), getCastClobTextFunction(),
-			getCastLongFunction(), getCastTextFunction(), getConcatFunction(),
+			getDateFormatFunction(), getAggregationFunction(),
+			getBitwiseCheckFunction(), getBooleanFunction(),
+			getCastClobTextFunction(), getCastLongFunction(),
+			getCastTextFunction(), getConcatFunction(), getDateFormatFunction(),
 			getDropTableIfExistsTextFunction(), getInstrFunction(),
 			getIntegerDivisionFunction(), getLengthFunction(), getModFunction(),
 			getNullDateFunction(), getSubstrFunction(), _getCrossJoinFunction(),

--- a/portal-impl/test/unit/com/liferay/portal/dao/sql/transformer/BaseSQLTransformerLogicTestCase.java
+++ b/portal-impl/test/unit/com/liferay/portal/dao/sql/transformer/BaseSQLTransformerLogicTestCase.java
@@ -240,12 +240,13 @@ public abstract class BaseSQLTransformerLogicTestCase {
 	}
 
 	protected String getDateFormatOriginalSQL() {
-		return "select foo from Foo where TRUNCATE_TO_SECONDS(foo)";
+		return "select foo from Foo where TRUNCATE_TO_SECONDS(foo) = " +
+			"2024-10-04 12:34:56";
 	}
 
 	protected String getDateFormatTransformedSQL() {
 		return "select foo from Foo where DATE_FORMAT(foo, " +
-			"'%Y-%m-%dT%H:%i:%sZ')";
+			"'%Y-%m-%dT%H:%i:%sZ') = 2024-10-04 12:34:56";
 	}
 
 	protected String getDropTableIfExistsTextOriginalSQL() {

--- a/portal-impl/test/unit/com/liferay/portal/dao/sql/transformer/BaseSQLTransformerLogicTestCase.java
+++ b/portal-impl/test/unit/com/liferay/portal/dao/sql/transformer/BaseSQLTransformerLogicTestCase.java
@@ -240,7 +240,7 @@ public abstract class BaseSQLTransformerLogicTestCase {
 	}
 
 	protected String getDateFormatOriginalSQL() {
-		return "select foo from Foo where DATE2SEC(foo)";
+		return "select foo from Foo where TRUNCATE_TO_SECONDS(foo)";
 	}
 
 	protected String getDateFormatTransformedSQL() {

--- a/portal-impl/test/unit/com/liferay/portal/dao/sql/transformer/BaseSQLTransformerLogicTestCase.java
+++ b/portal-impl/test/unit/com/liferay/portal/dao/sql/transformer/BaseSQLTransformerLogicTestCase.java
@@ -83,6 +83,13 @@ public abstract class BaseSQLTransformerLogicTestCase {
 	}
 
 	@Test
+	public void testReplaceDate() {
+		Assert.assertEquals(
+			getDateFormatTransformedSQL(),
+			sqlTransformer.transform(getDateFormatOriginalSQL()));
+	}
+
+	@Test
 	public void testReplaceDropTableIfExistsText() {
 		Assert.assertEquals(
 			getDropTableIfExistsTextTransformedSQL(),
@@ -230,6 +237,15 @@ public abstract class BaseSQLTransformerLogicTestCase {
 
 	protected String getCrossJoinTransformedSQL() {
 		return getCrossJoinOriginalSQL();
+	}
+
+	protected String getDateFormatOriginalSQL() {
+		return "select foo from Foo where DATE2SEC(foo)";
+	}
+
+	protected String getDateFormatTransformedSQL() {
+		return "select foo from Foo where DATE_FORMAT(foo, " +
+			"'%Y-%m-%dT%H:%i:%sZ')";
 	}
 
 	protected String getDropTableIfExistsTextOriginalSQL() {


### PR DESCRIPTION
**What's changed?**
This PR addresses the issue of date format mismatch when querying MySQL. Specifically, when filtering fields of type `DATE_TIME` (defined in the entity type), the query now ensures the retrieved values are formatted correctly, removing microseconds to align with the OData format used for filtering. This change ensures consistency in date comparisons and resolves filtering discrepancies.

See the following Jira Ticket: [LPD-37767)](https://liferay.atlassian.net/browse/LPD-37767)

TODO:

- [ ] Adapt tranformer for all DBs.
- [ ] Analyze business type (`DATE`) and entity type (`DATE_TIME`) discrepancy for `modifiedDate` and `createDate` fields)
- [ ] Fix similar filtering issue for fields with business type set to `DATE_TIME`