### PR TITLE
LPD-37815 Incorrect generation of operationId from restBuilder. Ex: Address -> Addres

### DIFF
--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-api/bnd.bnd
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Commerce Delivery Cart API
 Bundle-SymbolicName: com.liferay.headless.commerce.delivery.cart.api
-Bundle-Version: 22.2.1
+Bundle-Version: 23.0.0
 Export-Package:\
 	com.liferay.headless.commerce.delivery.cart.dto.v1_0,\
 	com.liferay.headless.commerce.delivery.cart.resource.v1_0

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-api/src/main/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/AddressResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-api/src/main/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/AddressResource.java
@@ -43,11 +43,11 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface AddressResource {
 
-	public Address getCartByExternalReferenceCodeBillingAddres(
+	public Address getCartByExternalReferenceCodeBillingAddress(
 			String externalReferenceCode)
 		throws Exception;
 
-	public Address getCartByExternalReferenceCodeShippingAddres(
+	public Address getCartByExternalReferenceCodeShippingAddress(
 			String externalReferenceCode)
 		throws Exception;
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-api/src/main/resources/com/liferay/headless/commerce/delivery/cart/resource/v1_0/packageinfo
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-api/src/main/resources/com/liferay/headless/commerce/delivery/cart/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 13.1.0
+version 14.0.0

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-client/src/main/java/com/liferay/headless/commerce/delivery/cart/client/resource/v1_0/AddressResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-client/src/main/java/com/liferay/headless/commerce/delivery/cart/client/resource/v1_0/AddressResource.java
@@ -31,21 +31,21 @@ public interface AddressResource {
 		return new Builder();
 	}
 
-	public Address getCartByExternalReferenceCodeBillingAddres(
+	public Address getCartByExternalReferenceCodeBillingAddress(
 			String externalReferenceCode)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			getCartByExternalReferenceCodeBillingAddresHttpResponse(
+			getCartByExternalReferenceCodeBillingAddressHttpResponse(
 				String externalReferenceCode)
 		throws Exception;
 
-	public Address getCartByExternalReferenceCodeShippingAddres(
+	public Address getCartByExternalReferenceCodeShippingAddress(
 			String externalReferenceCode)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			getCartByExternalReferenceCodeShippingAddresHttpResponse(
+			getCartByExternalReferenceCodeShippingAddressHttpResponse(
 				String externalReferenceCode)
 		throws Exception;
 
@@ -169,12 +169,12 @@ public interface AddressResource {
 
 	public static class AddressResourceImpl implements AddressResource {
 
-		public Address getCartByExternalReferenceCodeBillingAddres(
+		public Address getCartByExternalReferenceCodeBillingAddress(
 				String externalReferenceCode)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				getCartByExternalReferenceCodeBillingAddresHttpResponse(
+				getCartByExternalReferenceCodeBillingAddressHttpResponse(
 					externalReferenceCode);
 
 			String content = httpResponse.getContent();
@@ -238,7 +238,7 @@ public interface AddressResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				getCartByExternalReferenceCodeBillingAddresHttpResponse(
+				getCartByExternalReferenceCodeBillingAddressHttpResponse(
 					String externalReferenceCode)
 			throws Exception {
 
@@ -276,12 +276,12 @@ public interface AddressResource {
 			return httpInvoker.invoke();
 		}
 
-		public Address getCartByExternalReferenceCodeShippingAddres(
+		public Address getCartByExternalReferenceCodeShippingAddress(
 				String externalReferenceCode)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				getCartByExternalReferenceCodeShippingAddresHttpResponse(
+				getCartByExternalReferenceCodeShippingAddressHttpResponse(
 					externalReferenceCode);
 
 			String content = httpResponse.getContent();
@@ -345,7 +345,7 @@ public interface AddressResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				getCartByExternalReferenceCodeShippingAddresHttpResponse(
+				getCartByExternalReferenceCodeShippingAddressHttpResponse(
 					String externalReferenceCode)
 			throws Exception {
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/rest-openapi.yaml
@@ -724,7 +724,7 @@ components:
 info:
     description:
         "Headless Delivery Commerce Cart API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.delivery.cart.client', and version '4.0.43'."
+        artifact ID 'com.liferay.headless.commerce.delivery.cart.client', and version '4.0.44'."
     license:
         name: Apache 2.0
         url: http://www.apache.org/licenses/LICENSE-2.0.html

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/graphql/query/v1_0/Query.java
@@ -130,10 +130,10 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {cartByExternalReferenceCodeBillingAddres(externalReferenceCode: ___){city, country, countryISOCode, description, externalReferenceCode, id, latitude, longitude, name, phoneNumber, region, regionISOCode, street1, street2, street3, type, typeId, vatNumber, zip}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {cartByExternalReferenceCodeBillingAddress(externalReferenceCode: ___){city, country, countryISOCode, description, externalReferenceCode, id, latitude, longitude, name, phoneNumber, region, regionISOCode, street1, street2, street3, type, typeId, vatNumber, zip}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(description = "Retrieve cart billing address.")
-	public Address cartByExternalReferenceCodeBillingAddres(
+	public Address cartByExternalReferenceCodeBillingAddress(
 			@GraphQLName("externalReferenceCode") String externalReferenceCode)
 		throws Exception {
 
@@ -141,17 +141,17 @@ public class Query {
 			_addressResourceComponentServiceObjects,
 			this::_populateResourceContext,
 			addressResource ->
-				addressResource.getCartByExternalReferenceCodeBillingAddres(
+				addressResource.getCartByExternalReferenceCodeBillingAddress(
 					externalReferenceCode));
 	}
 
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {cartByExternalReferenceCodeShippingAddres(externalReferenceCode: ___){city, country, countryISOCode, description, externalReferenceCode, id, latitude, longitude, name, phoneNumber, region, regionISOCode, street1, street2, street3, type, typeId, vatNumber, zip}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {cartByExternalReferenceCodeShippingAddress(externalReferenceCode: ___){city, country, countryISOCode, description, externalReferenceCode, id, latitude, longitude, name, phoneNumber, region, regionISOCode, street1, street2, street3, type, typeId, vatNumber, zip}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(description = "Retrieve cart billing address.")
-	public Address cartByExternalReferenceCodeShippingAddres(
+	public Address cartByExternalReferenceCodeShippingAddress(
 			@GraphQLName("externalReferenceCode") String externalReferenceCode)
 		throws Exception {
 
@@ -159,7 +159,7 @@ public class Query {
 			_addressResourceComponentServiceObjects,
 			this::_populateResourceContext,
 			addressResource ->
-				addressResource.getCartByExternalReferenceCodeShippingAddres(
+				addressResource.getCartByExternalReferenceCodeShippingAddress(
 					externalReferenceCode));
 	}
 
@@ -758,32 +758,6 @@ public class Query {
 	}
 
 	@GraphQLTypeExtension(Cart.class)
-	public class GetCartByExternalReferenceCodeShippingAddresTypeExtension {
-
-		public GetCartByExternalReferenceCodeShippingAddresTypeExtension(
-			Cart cart) {
-
-			_cart = cart;
-		}
-
-		@GraphQLField(description = "Retrieve cart billing address.")
-		public Address byExternalReferenceCodeShippingAddres()
-			throws Exception {
-
-			return _applyComponentServiceObjects(
-				_addressResourceComponentServiceObjects,
-				Query.this::_populateResourceContext,
-				addressResource ->
-					addressResource.
-						getCartByExternalReferenceCodeShippingAddres(
-							_cart.getExternalReferenceCode()));
-		}
-
-		private Cart _cart;
-
-	}
-
-	@GraphQLTypeExtension(Cart.class)
 	public class GetCartDeliveryTermsPageTypeExtension {
 
 		public GetCartDeliveryTermsPageTypeExtension(Cart cart) {
@@ -986,22 +960,51 @@ public class Query {
 	}
 
 	@GraphQLTypeExtension(Cart.class)
-	public class GetCartByExternalReferenceCodeBillingAddresTypeExtension {
+	public class GetCartByExternalReferenceCodeBillingAddressTypeExtension {
 
-		public GetCartByExternalReferenceCodeBillingAddresTypeExtension(
+		public GetCartByExternalReferenceCodeBillingAddressTypeExtension(
 			Cart cart) {
 
 			_cart = cart;
 		}
 
 		@GraphQLField(description = "Retrieve cart billing address.")
-		public Address byExternalReferenceCodeBillingAddres() throws Exception {
+		public Address byExternalReferenceCodeBillingAddress()
+			throws Exception {
+
 			return _applyComponentServiceObjects(
 				_addressResourceComponentServiceObjects,
 				Query.this::_populateResourceContext,
 				addressResource ->
-					addressResource.getCartByExternalReferenceCodeBillingAddres(
-						_cart.getExternalReferenceCode()));
+					addressResource.
+						getCartByExternalReferenceCodeBillingAddress(
+							_cart.getExternalReferenceCode()));
+		}
+
+		private Cart _cart;
+
+	}
+
+	@GraphQLTypeExtension(Cart.class)
+	public class GetCartByExternalReferenceCodeShippingAddressTypeExtension {
+
+		public GetCartByExternalReferenceCodeShippingAddressTypeExtension(
+			Cart cart) {
+
+			_cart = cart;
+		}
+
+		@GraphQLField(description = "Retrieve cart billing address.")
+		public Address byExternalReferenceCodeShippingAddress()
+			throws Exception {
+
+			return _applyComponentServiceObjects(
+				_addressResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				addressResource ->
+					addressResource.
+						getCartByExternalReferenceCodeShippingAddress(
+							_cart.getExternalReferenceCode()));
 		}
 
 		private Cart _cart;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -324,15 +324,15 @@ public class ServletDataImpl implements ServletData {
 							"postCartShippingMethodsPageExportBatch"));
 
 					put(
-						"query#cartByExternalReferenceCodeBillingAddres",
+						"query#cartByExternalReferenceCodeBillingAddress",
 						new ObjectValuePair<>(
 							AddressResourceImpl.class,
-							"getCartByExternalReferenceCodeBillingAddres"));
+							"getCartByExternalReferenceCodeBillingAddress"));
 					put(
-						"query#cartByExternalReferenceCodeShippingAddres",
+						"query#cartByExternalReferenceCodeShippingAddress",
 						new ObjectValuePair<>(
 							AddressResourceImpl.class,
-							"getCartByExternalReferenceCodeShippingAddres"));
+							"getCartByExternalReferenceCodeShippingAddress"));
 					put(
 						"query#cartBillingAddres",
 						new ObjectValuePair<>(
@@ -476,11 +476,6 @@ public class ServletDataImpl implements ServletData {
 						new ObjectValuePair<>(
 							TermResourceImpl.class, "getCartPaymentTermsPage"));
 					put(
-						"query#Cart.byExternalReferenceCodeShippingAddres",
-						new ObjectValuePair<>(
-							AddressResourceImpl.class,
-							"getCartByExternalReferenceCodeShippingAddres"));
-					put(
 						"query#Cart.deliveryTerms",
 						new ObjectValuePair<>(
 							TermResourceImpl.class,
@@ -522,10 +517,15 @@ public class ServletDataImpl implements ServletData {
 							CartCommentResourceImpl.class,
 							"getCartCommentByExternalReferenceCode"));
 					put(
-						"query#Cart.byExternalReferenceCodeBillingAddres",
+						"query#Cart.byExternalReferenceCodeBillingAddress",
 						new ObjectValuePair<>(
 							AddressResourceImpl.class,
-							"getCartByExternalReferenceCodeBillingAddres"));
+							"getCartByExternalReferenceCodeBillingAddress"));
+					put(
+						"query#Cart.byExternalReferenceCodeShippingAddress",
+						new ObjectValuePair<>(
+							AddressResourceImpl.class,
+							"getCartByExternalReferenceCodeShippingAddress"));
 					put(
 						"query#Cart.comments",
 						new ObjectValuePair<>(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/AddressResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/AddressResourceImpl.java
@@ -51,7 +51,7 @@ public class AddressResourceImpl extends BaseAddressResourceImpl {
 	}
 
 	@Override
-	public Address getCartByExternalReferenceCodeBillingAddres(
+	public Address getCartByExternalReferenceCodeBillingAddress(
 			String externalReferenceCode)
 		throws Exception {
 
@@ -76,7 +76,7 @@ public class AddressResourceImpl extends BaseAddressResourceImpl {
 	}
 
 	@Override
-	public Address getCartByExternalReferenceCodeShippingAddres(
+	public Address getCartByExternalReferenceCodeShippingAddress(
 			String externalReferenceCode)
 		throws Exception {
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseAddressResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseAddressResourceImpl.java
@@ -66,7 +66,7 @@ public abstract class BaseAddressResourceImpl implements AddressResource {
 	)
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Address getCartByExternalReferenceCodeBillingAddres(
+	public Address getCartByExternalReferenceCodeBillingAddress(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.validation.constraints.NotNull
 			@javax.ws.rs.PathParam("externalReferenceCode")
@@ -101,7 +101,7 @@ public abstract class BaseAddressResourceImpl implements AddressResource {
 	)
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Address getCartByExternalReferenceCodeShippingAddres(
+	public Address getCartByExternalReferenceCodeShippingAddress(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.validation.constraints.NotNull
 			@javax.ws.rs.PathParam("externalReferenceCode")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -42,7 +42,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Headless Delivery Commerce Cart API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.delivery.cart.client', and version '4.0.43'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery Commerce Cart API", version = "v1.0")
+	info = @Info(description = "Headless Delivery Commerce Cart API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.delivery.cart.client', and version '4.0.44'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery Commerce Cart API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/AddressResourceTest.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/AddressResourceTest.java
@@ -132,7 +132,7 @@ public class AddressResourceTest extends BaseAddressResourceTestCase {
 
 	@Override
 	protected Address
-			testGetCartByExternalReferenceCodeBillingAddres_addAddress()
+			testGetCartByExternalReferenceCodeBillingAddress_addAddress()
 		throws Exception {
 
 		return _toAddress(_getCommerceAddress());
@@ -140,7 +140,7 @@ public class AddressResourceTest extends BaseAddressResourceTestCase {
 
 	@Override
 	protected String
-			testGetCartByExternalReferenceCodeBillingAddres_getExternalReferenceCode(
+			testGetCartByExternalReferenceCodeBillingAddress_getExternalReferenceCode(
 				Address address)
 		throws Exception {
 
@@ -149,7 +149,7 @@ public class AddressResourceTest extends BaseAddressResourceTestCase {
 
 	@Override
 	protected Address
-			testGetCartByExternalReferenceCodeShippingAddres_addAddress()
+			testGetCartByExternalReferenceCodeShippingAddress_addAddress()
 		throws Exception {
 
 		return _toAddress(_getCommerceAddress());
@@ -157,7 +157,7 @@ public class AddressResourceTest extends BaseAddressResourceTestCase {
 
 	@Override
 	protected String
-			testGetCartByExternalReferenceCodeShippingAddres_getExternalReferenceCode(
+			testGetCartByExternalReferenceCodeShippingAddress_getExternalReferenceCode(
 				Address address)
 		throws Exception {
 
@@ -188,7 +188,7 @@ public class AddressResourceTest extends BaseAddressResourceTestCase {
 
 	@Override
 	protected String
-			testGraphQLGetCartByExternalReferenceCodeBillingAddres_getExternalReferenceCode(
+			testGraphQLGetCartByExternalReferenceCodeBillingAddress_getExternalReferenceCode(
 				Address address)
 		throws Exception {
 
@@ -197,7 +197,7 @@ public class AddressResourceTest extends BaseAddressResourceTestCase {
 
 	@Override
 	protected String
-			testGraphQLGetCartByExternalReferenceCodeShippingAddres_getExternalReferenceCode(
+			testGraphQLGetCartByExternalReferenceCodeShippingAddress_getExternalReferenceCode(
 				Address address)
 		throws Exception {
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseAddressResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseAddressResourceTestCase.java
@@ -199,15 +199,15 @@ public abstract class BaseAddressResourceTestCase {
 	}
 
 	@Test
-	public void testGetCartByExternalReferenceCodeBillingAddres()
+	public void testGetCartByExternalReferenceCodeBillingAddress()
 		throws Exception {
 
 		Address postAddress =
-			testGetCartByExternalReferenceCodeBillingAddres_addAddress();
+			testGetCartByExternalReferenceCodeBillingAddress_addAddress();
 
 		Address getAddress =
-			addressResource.getCartByExternalReferenceCodeBillingAddres(
-				testGetCartByExternalReferenceCodeBillingAddres_getExternalReferenceCode(
+			addressResource.getCartByExternalReferenceCodeBillingAddress(
+				testGetCartByExternalReferenceCodeBillingAddress_getExternalReferenceCode(
 					postAddress));
 
 		assertEquals(postAddress, getAddress);
@@ -215,7 +215,7 @@ public abstract class BaseAddressResourceTestCase {
 	}
 
 	protected String
-			testGetCartByExternalReferenceCodeBillingAddres_getExternalReferenceCode(
+			testGetCartByExternalReferenceCodeBillingAddress_getExternalReferenceCode(
 				Address address)
 		throws Exception {
 
@@ -223,7 +223,7 @@ public abstract class BaseAddressResourceTestCase {
 	}
 
 	protected Address
-			testGetCartByExternalReferenceCodeBillingAddres_addAddress()
+			testGetCartByExternalReferenceCodeBillingAddress_addAddress()
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -231,11 +231,11 @@ public abstract class BaseAddressResourceTestCase {
 	}
 
 	@Test
-	public void testGraphQLGetCartByExternalReferenceCodeBillingAddres()
+	public void testGraphQLGetCartByExternalReferenceCodeBillingAddress()
 		throws Exception {
 
 		Address address =
-			testGraphQLGetCartByExternalReferenceCodeBillingAddres_addAddress();
+			testGraphQLGetCartByExternalReferenceCodeBillingAddress_addAddress();
 
 		// No namespace
 
@@ -246,19 +246,19 @@ public abstract class BaseAddressResourceTestCase {
 					JSONUtil.getValueAsString(
 						invokeGraphQLQuery(
 							new GraphQLField(
-								"cartByExternalReferenceCodeBillingAddres",
+								"cartByExternalReferenceCodeBillingAddress",
 								new HashMap<String, Object>() {
 									{
 										put(
 											"externalReferenceCode",
 											"\"" +
-												testGraphQLGetCartByExternalReferenceCodeBillingAddres_getExternalReferenceCode(
+												testGraphQLGetCartByExternalReferenceCodeBillingAddress_getExternalReferenceCode(
 													address) + "\"");
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
-						"Object/cartByExternalReferenceCodeBillingAddres"))));
+						"Object/cartByExternalReferenceCodeBillingAddress"))));
 
 		// Using the namespace headlessCommerceDeliveryCart_v1_0
 
@@ -271,24 +271,24 @@ public abstract class BaseAddressResourceTestCase {
 							new GraphQLField(
 								"headlessCommerceDeliveryCart_v1_0",
 								new GraphQLField(
-									"cartByExternalReferenceCodeBillingAddres",
+									"cartByExternalReferenceCodeBillingAddress",
 									new HashMap<String, Object>() {
 										{
 											put(
 												"externalReferenceCode",
 												"\"" +
-													testGraphQLGetCartByExternalReferenceCodeBillingAddres_getExternalReferenceCode(
+													testGraphQLGetCartByExternalReferenceCodeBillingAddress_getExternalReferenceCode(
 														address) + "\"");
 										}
 									},
 									getGraphQLFields()))),
 						"JSONObject/data",
 						"JSONObject/headlessCommerceDeliveryCart_v1_0",
-						"Object/cartByExternalReferenceCodeBillingAddres"))));
+						"Object/cartByExternalReferenceCodeBillingAddress"))));
 	}
 
 	protected String
-			testGraphQLGetCartByExternalReferenceCodeBillingAddres_getExternalReferenceCode(
+			testGraphQLGetCartByExternalReferenceCodeBillingAddress_getExternalReferenceCode(
 				Address address)
 		throws Exception {
 
@@ -296,7 +296,7 @@ public abstract class BaseAddressResourceTestCase {
 	}
 
 	@Test
-	public void testGraphQLGetCartByExternalReferenceCodeBillingAddresNotFound()
+	public void testGraphQLGetCartByExternalReferenceCodeBillingAddressNotFound()
 		throws Exception {
 
 		String irrelevantExternalReferenceCode =
@@ -309,7 +309,7 @@ public abstract class BaseAddressResourceTestCase {
 			JSONUtil.getValueAsString(
 				invokeGraphQLQuery(
 					new GraphQLField(
-						"cartByExternalReferenceCodeBillingAddres",
+						"cartByExternalReferenceCodeBillingAddress",
 						new HashMap<String, Object>() {
 							{
 								put(
@@ -330,7 +330,7 @@ public abstract class BaseAddressResourceTestCase {
 					new GraphQLField(
 						"headlessCommerceDeliveryCart_v1_0",
 						new GraphQLField(
-							"cartByExternalReferenceCodeBillingAddres",
+							"cartByExternalReferenceCodeBillingAddress",
 							new HashMap<String, Object>() {
 								{
 									put(
@@ -344,22 +344,22 @@ public abstract class BaseAddressResourceTestCase {
 	}
 
 	protected Address
-			testGraphQLGetCartByExternalReferenceCodeBillingAddres_addAddress()
+			testGraphQLGetCartByExternalReferenceCodeBillingAddress_addAddress()
 		throws Exception {
 
 		return testGraphQLAddress_addAddress();
 	}
 
 	@Test
-	public void testGetCartByExternalReferenceCodeShippingAddres()
+	public void testGetCartByExternalReferenceCodeShippingAddress()
 		throws Exception {
 
 		Address postAddress =
-			testGetCartByExternalReferenceCodeShippingAddres_addAddress();
+			testGetCartByExternalReferenceCodeShippingAddress_addAddress();
 
 		Address getAddress =
-			addressResource.getCartByExternalReferenceCodeShippingAddres(
-				testGetCartByExternalReferenceCodeShippingAddres_getExternalReferenceCode(
+			addressResource.getCartByExternalReferenceCodeShippingAddress(
+				testGetCartByExternalReferenceCodeShippingAddress_getExternalReferenceCode(
 					postAddress));
 
 		assertEquals(postAddress, getAddress);
@@ -367,7 +367,7 @@ public abstract class BaseAddressResourceTestCase {
 	}
 
 	protected String
-			testGetCartByExternalReferenceCodeShippingAddres_getExternalReferenceCode(
+			testGetCartByExternalReferenceCodeShippingAddress_getExternalReferenceCode(
 				Address address)
 		throws Exception {
 
@@ -375,7 +375,7 @@ public abstract class BaseAddressResourceTestCase {
 	}
 
 	protected Address
-			testGetCartByExternalReferenceCodeShippingAddres_addAddress()
+			testGetCartByExternalReferenceCodeShippingAddress_addAddress()
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -383,11 +383,11 @@ public abstract class BaseAddressResourceTestCase {
 	}
 
 	@Test
-	public void testGraphQLGetCartByExternalReferenceCodeShippingAddres()
+	public void testGraphQLGetCartByExternalReferenceCodeShippingAddress()
 		throws Exception {
 
 		Address address =
-			testGraphQLGetCartByExternalReferenceCodeShippingAddres_addAddress();
+			testGraphQLGetCartByExternalReferenceCodeShippingAddress_addAddress();
 
 		// No namespace
 
@@ -398,19 +398,19 @@ public abstract class BaseAddressResourceTestCase {
 					JSONUtil.getValueAsString(
 						invokeGraphQLQuery(
 							new GraphQLField(
-								"cartByExternalReferenceCodeShippingAddres",
+								"cartByExternalReferenceCodeShippingAddress",
 								new HashMap<String, Object>() {
 									{
 										put(
 											"externalReferenceCode",
 											"\"" +
-												testGraphQLGetCartByExternalReferenceCodeShippingAddres_getExternalReferenceCode(
+												testGraphQLGetCartByExternalReferenceCodeShippingAddress_getExternalReferenceCode(
 													address) + "\"");
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
-						"Object/cartByExternalReferenceCodeShippingAddres"))));
+						"Object/cartByExternalReferenceCodeShippingAddress"))));
 
 		// Using the namespace headlessCommerceDeliveryCart_v1_0
 
@@ -423,24 +423,24 @@ public abstract class BaseAddressResourceTestCase {
 							new GraphQLField(
 								"headlessCommerceDeliveryCart_v1_0",
 								new GraphQLField(
-									"cartByExternalReferenceCodeShippingAddres",
+									"cartByExternalReferenceCodeShippingAddress",
 									new HashMap<String, Object>() {
 										{
 											put(
 												"externalReferenceCode",
 												"\"" +
-													testGraphQLGetCartByExternalReferenceCodeShippingAddres_getExternalReferenceCode(
+													testGraphQLGetCartByExternalReferenceCodeShippingAddress_getExternalReferenceCode(
 														address) + "\"");
 										}
 									},
 									getGraphQLFields()))),
 						"JSONObject/data",
 						"JSONObject/headlessCommerceDeliveryCart_v1_0",
-						"Object/cartByExternalReferenceCodeShippingAddres"))));
+						"Object/cartByExternalReferenceCodeShippingAddress"))));
 	}
 
 	protected String
-			testGraphQLGetCartByExternalReferenceCodeShippingAddres_getExternalReferenceCode(
+			testGraphQLGetCartByExternalReferenceCodeShippingAddress_getExternalReferenceCode(
 				Address address)
 		throws Exception {
 
@@ -448,7 +448,7 @@ public abstract class BaseAddressResourceTestCase {
 	}
 
 	@Test
-	public void testGraphQLGetCartByExternalReferenceCodeShippingAddresNotFound()
+	public void testGraphQLGetCartByExternalReferenceCodeShippingAddressNotFound()
 		throws Exception {
 
 		String irrelevantExternalReferenceCode =
@@ -461,7 +461,7 @@ public abstract class BaseAddressResourceTestCase {
 			JSONUtil.getValueAsString(
 				invokeGraphQLQuery(
 					new GraphQLField(
-						"cartByExternalReferenceCodeShippingAddres",
+						"cartByExternalReferenceCodeShippingAddress",
 						new HashMap<String, Object>() {
 							{
 								put(
@@ -482,7 +482,7 @@ public abstract class BaseAddressResourceTestCase {
 					new GraphQLField(
 						"headlessCommerceDeliveryCart_v1_0",
 						new GraphQLField(
-							"cartByExternalReferenceCodeShippingAddres",
+							"cartByExternalReferenceCodeShippingAddress",
 							new HashMap<String, Object>() {
 								{
 									put(
@@ -496,7 +496,7 @@ public abstract class BaseAddressResourceTestCase {
 	}
 
 	protected Address
-			testGraphQLGetCartByExternalReferenceCodeShippingAddres_addAddress()
+			testGraphQLGetCartByExternalReferenceCodeShippingAddress_addAddress()
 		throws Exception {
 
 		return testGraphQLAddress_addAddress();

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-api/bnd.bnd
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Commerce Delivery Order API
 Bundle-SymbolicName: com.liferay.headless.commerce.delivery.order.api
-Bundle-Version: 4.4.1
+Bundle-Version: 5.0.0
 Export-Package:\
 	com.liferay.headless.commerce.delivery.order.dto.v1_0,\
 	com.liferay.headless.commerce.delivery.order.resource.v1_0

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-api/src/main/java/com/liferay/headless/commerce/delivery/order/resource/v1_0/PlacedOrderAddressResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-api/src/main/java/com/liferay/headless/commerce/delivery/order/resource/v1_0/PlacedOrderAddressResource.java
@@ -53,11 +53,11 @@ public interface PlacedOrderAddressResource {
 				String externalReferenceCode)
 		throws Exception;
 
-	public PlacedOrderAddress getPlacedOrderPlacedOrderBillingAddres(
+	public PlacedOrderAddress getPlacedOrderPlacedOrderBillingAddress(
 			Long placedOrderId)
 		throws Exception;
 
-	public PlacedOrderAddress getPlacedOrderPlacedOrderShippingAddres(
+	public PlacedOrderAddress getPlacedOrderPlacedOrderShippingAddress(
 			Long placedOrderId)
 		throws Exception;
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-api/src/main/resources/com/liferay/headless/commerce/delivery/order/resource/v1_0/packageinfo
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-api/src/main/resources/com/liferay/headless/commerce/delivery/order/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 3.3.0
+version 4.0.0

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-client/src/main/java/com/liferay/headless/commerce/delivery/order/client/resource/v1_0/PlacedOrderAddressResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-client/src/main/java/com/liferay/headless/commerce/delivery/order/client/resource/v1_0/PlacedOrderAddressResource.java
@@ -51,21 +51,21 @@ public interface PlacedOrderAddressResource {
 				String externalReferenceCode)
 		throws Exception;
 
-	public PlacedOrderAddress getPlacedOrderPlacedOrderBillingAddres(
+	public PlacedOrderAddress getPlacedOrderPlacedOrderBillingAddress(
 			Long placedOrderId)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			getPlacedOrderPlacedOrderBillingAddresHttpResponse(
+			getPlacedOrderPlacedOrderBillingAddressHttpResponse(
 				Long placedOrderId)
 		throws Exception;
 
-	public PlacedOrderAddress getPlacedOrderPlacedOrderShippingAddres(
+	public PlacedOrderAddress getPlacedOrderPlacedOrderShippingAddress(
 			Long placedOrderId)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			getPlacedOrderPlacedOrderShippingAddresHttpResponse(
+			getPlacedOrderPlacedOrderShippingAddressHttpResponse(
 				Long placedOrderId)
 		throws Exception;
 
@@ -394,12 +394,12 @@ public interface PlacedOrderAddressResource {
 			return httpInvoker.invoke();
 		}
 
-		public PlacedOrderAddress getPlacedOrderPlacedOrderBillingAddres(
+		public PlacedOrderAddress getPlacedOrderPlacedOrderBillingAddress(
 				Long placedOrderId)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				getPlacedOrderPlacedOrderBillingAddresHttpResponse(
+				getPlacedOrderPlacedOrderBillingAddressHttpResponse(
 					placedOrderId);
 
 			String content = httpResponse.getContent();
@@ -463,7 +463,7 @@ public interface PlacedOrderAddressResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				getPlacedOrderPlacedOrderBillingAddresHttpResponse(
+				getPlacedOrderPlacedOrderBillingAddressHttpResponse(
 					Long placedOrderId)
 			throws Exception {
 
@@ -501,12 +501,12 @@ public interface PlacedOrderAddressResource {
 			return httpInvoker.invoke();
 		}
 
-		public PlacedOrderAddress getPlacedOrderPlacedOrderShippingAddres(
+		public PlacedOrderAddress getPlacedOrderPlacedOrderShippingAddress(
 				Long placedOrderId)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				getPlacedOrderPlacedOrderShippingAddresHttpResponse(
+				getPlacedOrderPlacedOrderShippingAddressHttpResponse(
 					placedOrderId);
 
 			String content = httpResponse.getContent();
@@ -570,7 +570,7 @@ public interface PlacedOrderAddressResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				getPlacedOrderPlacedOrderShippingAddresHttpResponse(
+				getPlacedOrderPlacedOrderShippingAddressHttpResponse(
 					Long placedOrderId)
 			throws Exception {
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/rest-openapi.yaml
@@ -782,7 +782,7 @@ components:
 info:
     description:
         "Headless Delivery Commerce Order API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.delivery.order.client', and version '1.0.25'."
+        artifact ID 'com.liferay.headless.commerce.delivery.order.client', and version '1.0.26'."
     license:
         name: Apache 2.0
         url: http://www.apache.org/licenses/LICENSE-2.0.html

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/graphql/query/v1_0/Query.java
@@ -408,10 +408,10 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {placedOrderPlacedOrderBillingAddres(placedOrderId: ___){city, country, countryISOCode, description, externalReferenceCode, id, latitude, longitude, name, phoneNumber, region, regionISOCode, street1, street2, street3, type, typeId, vatNumber, zip}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {placedOrderPlacedOrderBillingAddress(placedOrderId: ___){city, country, countryISOCode, description, externalReferenceCode, id, latitude, longitude, name, phoneNumber, region, regionISOCode, street1, street2, street3, type, typeId, vatNumber, zip}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(description = "Retrieve placed order billing address.")
-	public PlacedOrderAddress placedOrderPlacedOrderBillingAddres(
+	public PlacedOrderAddress placedOrderPlacedOrderBillingAddress(
 			@GraphQLName("placedOrderId") Long placedOrderId)
 		throws Exception {
 
@@ -420,16 +420,16 @@ public class Query {
 			this::_populateResourceContext,
 			placedOrderAddressResource ->
 				placedOrderAddressResource.
-					getPlacedOrderPlacedOrderBillingAddres(placedOrderId));
+					getPlacedOrderPlacedOrderBillingAddress(placedOrderId));
 	}
 
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {placedOrderPlacedOrderShippingAddres(placedOrderId: ___){city, country, countryISOCode, description, externalReferenceCode, id, latitude, longitude, name, phoneNumber, region, regionISOCode, street1, street2, street3, type, typeId, vatNumber, zip}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {placedOrderPlacedOrderShippingAddress(placedOrderId: ___){city, country, countryISOCode, description, externalReferenceCode, id, latitude, longitude, name, phoneNumber, region, regionISOCode, street1, street2, street3, type, typeId, vatNumber, zip}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(description = "Retrieve placed order shipping address.")
-	public PlacedOrderAddress placedOrderPlacedOrderShippingAddres(
+	public PlacedOrderAddress placedOrderPlacedOrderShippingAddress(
 			@GraphQLName("placedOrderId") Long placedOrderId)
 		throws Exception {
 
@@ -438,7 +438,7 @@ public class Query {
 			this::_populateResourceContext,
 			placedOrderAddressResource ->
 				placedOrderAddressResource.
-					getPlacedOrderPlacedOrderShippingAddres(placedOrderId));
+					getPlacedOrderPlacedOrderShippingAddress(placedOrderId));
 	}
 
 	/**
@@ -879,30 +879,6 @@ public class Query {
 	}
 
 	@GraphQLTypeExtension(PlacedOrder.class)
-	public class GetPlacedOrderPlacedOrderShippingAddresTypeExtension {
-
-		public GetPlacedOrderPlacedOrderShippingAddresTypeExtension(
-			PlacedOrder placedOrder) {
-
-			_placedOrder = placedOrder;
-		}
-
-		@GraphQLField(description = "Retrieve placed order shipping address.")
-		public PlacedOrderAddress placedOrderShippingAddres() throws Exception {
-			return _applyComponentServiceObjects(
-				_placedOrderAddressResourceComponentServiceObjects,
-				Query.this::_populateResourceContext,
-				placedOrderAddressResource ->
-					placedOrderAddressResource.
-						getPlacedOrderPlacedOrderShippingAddres(
-							_placedOrder.getId()));
-		}
-
-		private PlacedOrder _placedOrder;
-
-	}
-
-	@GraphQLTypeExtension(PlacedOrder.class)
 	public class
 		GetPlacedOrderByExternalReferenceCodePlacedOrderItemsPageTypeExtension {
 
@@ -1116,30 +1092,6 @@ public class Query {
 				orderTransitionResource -> new OrderTransitionPage(
 					orderTransitionResource.getPlacedOrderOrderTransitionsPage(
 						_placedOrder.getId())));
-		}
-
-		private PlacedOrder _placedOrder;
-
-	}
-
-	@GraphQLTypeExtension(PlacedOrder.class)
-	public class GetPlacedOrderPlacedOrderBillingAddresTypeExtension {
-
-		public GetPlacedOrderPlacedOrderBillingAddresTypeExtension(
-			PlacedOrder placedOrder) {
-
-			_placedOrder = placedOrder;
-		}
-
-		@GraphQLField(description = "Retrieve placed order billing address.")
-		public PlacedOrderAddress placedOrderBillingAddres() throws Exception {
-			return _applyComponentServiceObjects(
-				_placedOrderAddressResourceComponentServiceObjects,
-				Query.this::_populateResourceContext,
-				placedOrderAddressResource ->
-					placedOrderAddressResource.
-						getPlacedOrderPlacedOrderBillingAddres(
-							_placedOrder.getId()));
 		}
 
 		private PlacedOrder _placedOrder;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -243,15 +243,15 @@ public class ServletDataImpl implements ServletData {
 							PlacedOrderAddressResourceImpl.class,
 							"getPlacedOrderByExternalReferenceCodePlacedOrderShippingAddress"));
 					put(
-						"query#placedOrderPlacedOrderBillingAddres",
+						"query#placedOrderPlacedOrderBillingAddress",
 						new ObjectValuePair<>(
 							PlacedOrderAddressResourceImpl.class,
-							"getPlacedOrderPlacedOrderBillingAddres"));
+							"getPlacedOrderPlacedOrderBillingAddress"));
 					put(
-						"query#placedOrderPlacedOrderShippingAddres",
+						"query#placedOrderPlacedOrderShippingAddress",
 						new ObjectValuePair<>(
 							PlacedOrderAddressResourceImpl.class,
-							"getPlacedOrderPlacedOrderShippingAddres"));
+							"getPlacedOrderPlacedOrderShippingAddress"));
 					put(
 						"query#placedOrderCommentByExternalReferenceCode",
 						new ObjectValuePair<>(
@@ -349,11 +349,6 @@ public class ServletDataImpl implements ServletData {
 							PlacedOrderResourceImpl.class,
 							"getChannelByExternalReferenceCodePlacedOrdersPage"));
 					put(
-						"query#PlacedOrder.placedOrderShippingAddres",
-						new ObjectValuePair<>(
-							PlacedOrderAddressResourceImpl.class,
-							"getPlacedOrderPlacedOrderShippingAddres"));
-					put(
 						"query#PlacedOrder.byExternalReferenceCodePlacedOrderItems",
 						new ObjectValuePair<>(
 							PlacedOrderItemResourceImpl.class,
@@ -392,11 +387,6 @@ public class ServletDataImpl implements ServletData {
 						new ObjectValuePair<>(
 							OrderTransitionResourceImpl.class,
 							"getPlacedOrderOrderTransitionsPage"));
-					put(
-						"query#PlacedOrder.placedOrderBillingAddres",
-						new ObjectValuePair<>(
-							PlacedOrderAddressResourceImpl.class,
-							"getPlacedOrderPlacedOrderBillingAddres"));
 					put(
 						"query#PlacedOrder.itemByExternalReferenceCode",
 						new ObjectValuePair<>(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/BasePlacedOrderAddressResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/BasePlacedOrderAddressResourceImpl.java
@@ -145,7 +145,7 @@ public abstract class BasePlacedOrderAddressResourceImpl
 	)
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public PlacedOrderAddress getPlacedOrderPlacedOrderBillingAddres(
+	public PlacedOrderAddress getPlacedOrderPlacedOrderBillingAddress(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.validation.constraints.NotNull
 			@javax.ws.rs.PathParam("placedOrderId")
@@ -182,7 +182,7 @@ public abstract class BasePlacedOrderAddressResourceImpl
 	)
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public PlacedOrderAddress getPlacedOrderPlacedOrderShippingAddres(
+	public PlacedOrderAddress getPlacedOrderPlacedOrderShippingAddress(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.validation.constraints.NotNull
 			@javax.ws.rs.PathParam("placedOrderId")

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -42,7 +42,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Headless Delivery Commerce Order API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.delivery.order.client', and version '1.0.25'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery Commerce Order API", version = "v1.0")
+	info = @Info(description = "Headless Delivery Commerce Order API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.delivery.order.client', and version '1.0.26'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery Commerce Order API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/PlacedOrderAddressResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/PlacedOrderAddressResourceImpl.java
@@ -49,7 +49,7 @@ public class PlacedOrderAddressResourceImpl
 					externalReferenceCode);
 		}
 
-		return getPlacedOrderPlacedOrderBillingAddres(
+		return getPlacedOrderPlacedOrderBillingAddress(
 			commerceOrder.getCommerceOrderId());
 	}
 
@@ -69,7 +69,7 @@ public class PlacedOrderAddressResourceImpl
 					externalReferenceCode);
 		}
 
-		return getPlacedOrderPlacedOrderShippingAddres(
+		return getPlacedOrderPlacedOrderShippingAddress(
 			commerceOrder.getCommerceOrderId());
 	}
 
@@ -77,7 +77,7 @@ public class PlacedOrderAddressResourceImpl
 		parentClass = PlacedOrder.class, value = "placedOrderBillingAddress"
 	)
 	@Override
-	public PlacedOrderAddress getPlacedOrderPlacedOrderBillingAddres(
+	public PlacedOrderAddress getPlacedOrderPlacedOrderBillingAddress(
 			Long placedOrderId)
 		throws Exception {
 
@@ -109,7 +109,7 @@ public class PlacedOrderAddressResourceImpl
 		parentClass = PlacedOrder.class, value = "placedOrderShippingAddress"
 	)
 	@Override
-	public PlacedOrderAddress getPlacedOrderPlacedOrderShippingAddres(
+	public PlacedOrderAddress getPlacedOrderPlacedOrderShippingAddress(
 			Long placedOrderId)
 		throws Exception {
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/order/resource/v1_0/test/BasePlacedOrderAddressResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/order/resource/v1_0/test/BasePlacedOrderAddressResourceTestCase.java
@@ -510,19 +510,20 @@ public abstract class BasePlacedOrderAddressResourceTestCase {
 	}
 
 	@Test
-	public void testGetPlacedOrderPlacedOrderBillingAddres() throws Exception {
+	public void testGetPlacedOrderPlacedOrderBillingAddress() throws Exception {
 		PlacedOrderAddress postPlacedOrderAddress =
-			testGetPlacedOrderPlacedOrderBillingAddres_addPlacedOrderAddress();
+			testGetPlacedOrderPlacedOrderBillingAddress_addPlacedOrderAddress();
 
 		PlacedOrderAddress getPlacedOrderAddress =
-			placedOrderAddressResource.getPlacedOrderPlacedOrderBillingAddres(
-				testGetPlacedOrderPlacedOrderBillingAddres_getPlacedOrderId());
+			placedOrderAddressResource.getPlacedOrderPlacedOrderBillingAddress(
+				testGetPlacedOrderPlacedOrderBillingAddress_getPlacedOrderId());
 
 		assertEquals(postPlacedOrderAddress, getPlacedOrderAddress);
 		assertValid(getPlacedOrderAddress);
 	}
 
-	protected Long testGetPlacedOrderPlacedOrderBillingAddres_getPlacedOrderId()
+	protected Long
+			testGetPlacedOrderPlacedOrderBillingAddress_getPlacedOrderId()
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -530,7 +531,7 @@ public abstract class BasePlacedOrderAddressResourceTestCase {
 	}
 
 	protected PlacedOrderAddress
-			testGetPlacedOrderPlacedOrderBillingAddres_addPlacedOrderAddress()
+			testGetPlacedOrderPlacedOrderBillingAddress_addPlacedOrderAddress()
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -538,11 +539,11 @@ public abstract class BasePlacedOrderAddressResourceTestCase {
 	}
 
 	@Test
-	public void testGraphQLGetPlacedOrderPlacedOrderBillingAddres()
+	public void testGraphQLGetPlacedOrderPlacedOrderBillingAddress()
 		throws Exception {
 
 		PlacedOrderAddress placedOrderAddress =
-			testGraphQLGetPlacedOrderPlacedOrderBillingAddres_addPlacedOrderAddress();
+			testGraphQLGetPlacedOrderPlacedOrderBillingAddress_addPlacedOrderAddress();
 
 		// No namespace
 
@@ -553,17 +554,17 @@ public abstract class BasePlacedOrderAddressResourceTestCase {
 					JSONUtil.getValueAsString(
 						invokeGraphQLQuery(
 							new GraphQLField(
-								"placedOrderPlacedOrderBillingAddres",
+								"placedOrderPlacedOrderBillingAddress",
 								new HashMap<String, Object>() {
 									{
 										put(
 											"placedOrderId",
-											testGraphQLGetPlacedOrderPlacedOrderBillingAddres_getPlacedOrderId());
+											testGraphQLGetPlacedOrderPlacedOrderBillingAddress_getPlacedOrderId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
-						"Object/placedOrderPlacedOrderBillingAddres"))));
+						"Object/placedOrderPlacedOrderBillingAddress"))));
 
 		// Using the namespace headlessCommerceDeliveryOrder_v1_0
 
@@ -576,22 +577,22 @@ public abstract class BasePlacedOrderAddressResourceTestCase {
 							new GraphQLField(
 								"headlessCommerceDeliveryOrder_v1_0",
 								new GraphQLField(
-									"placedOrderPlacedOrderBillingAddres",
+									"placedOrderPlacedOrderBillingAddress",
 									new HashMap<String, Object>() {
 										{
 											put(
 												"placedOrderId",
-												testGraphQLGetPlacedOrderPlacedOrderBillingAddres_getPlacedOrderId());
+												testGraphQLGetPlacedOrderPlacedOrderBillingAddress_getPlacedOrderId());
 										}
 									},
 									getGraphQLFields()))),
 						"JSONObject/data",
 						"JSONObject/headlessCommerceDeliveryOrder_v1_0",
-						"Object/placedOrderPlacedOrderBillingAddres"))));
+						"Object/placedOrderPlacedOrderBillingAddress"))));
 	}
 
 	protected Long
-			testGraphQLGetPlacedOrderPlacedOrderBillingAddres_getPlacedOrderId()
+			testGraphQLGetPlacedOrderPlacedOrderBillingAddress_getPlacedOrderId()
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -599,7 +600,7 @@ public abstract class BasePlacedOrderAddressResourceTestCase {
 	}
 
 	@Test
-	public void testGraphQLGetPlacedOrderPlacedOrderBillingAddresNotFound()
+	public void testGraphQLGetPlacedOrderPlacedOrderBillingAddressNotFound()
 		throws Exception {
 
 		Long irrelevantPlacedOrderId = RandomTestUtil.randomLong();
@@ -611,7 +612,7 @@ public abstract class BasePlacedOrderAddressResourceTestCase {
 			JSONUtil.getValueAsString(
 				invokeGraphQLQuery(
 					new GraphQLField(
-						"placedOrderPlacedOrderBillingAddres",
+						"placedOrderPlacedOrderBillingAddress",
 						new HashMap<String, Object>() {
 							{
 								put("placedOrderId", irrelevantPlacedOrderId);
@@ -630,7 +631,7 @@ public abstract class BasePlacedOrderAddressResourceTestCase {
 					new GraphQLField(
 						"headlessCommerceDeliveryOrder_v1_0",
 						new GraphQLField(
-							"placedOrderPlacedOrderBillingAddres",
+							"placedOrderPlacedOrderBillingAddress",
 							new HashMap<String, Object>() {
 								{
 									put(
@@ -644,27 +645,29 @@ public abstract class BasePlacedOrderAddressResourceTestCase {
 	}
 
 	protected PlacedOrderAddress
-			testGraphQLGetPlacedOrderPlacedOrderBillingAddres_addPlacedOrderAddress()
+			testGraphQLGetPlacedOrderPlacedOrderBillingAddress_addPlacedOrderAddress()
 		throws Exception {
 
 		return testGraphQLPlacedOrderAddress_addPlacedOrderAddress();
 	}
 
 	@Test
-	public void testGetPlacedOrderPlacedOrderShippingAddres() throws Exception {
+	public void testGetPlacedOrderPlacedOrderShippingAddress()
+		throws Exception {
+
 		PlacedOrderAddress postPlacedOrderAddress =
-			testGetPlacedOrderPlacedOrderShippingAddres_addPlacedOrderAddress();
+			testGetPlacedOrderPlacedOrderShippingAddress_addPlacedOrderAddress();
 
 		PlacedOrderAddress getPlacedOrderAddress =
-			placedOrderAddressResource.getPlacedOrderPlacedOrderShippingAddres(
-				testGetPlacedOrderPlacedOrderShippingAddres_getPlacedOrderId());
+			placedOrderAddressResource.getPlacedOrderPlacedOrderShippingAddress(
+				testGetPlacedOrderPlacedOrderShippingAddress_getPlacedOrderId());
 
 		assertEquals(postPlacedOrderAddress, getPlacedOrderAddress);
 		assertValid(getPlacedOrderAddress);
 	}
 
 	protected Long
-			testGetPlacedOrderPlacedOrderShippingAddres_getPlacedOrderId()
+			testGetPlacedOrderPlacedOrderShippingAddress_getPlacedOrderId()
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -672,7 +675,7 @@ public abstract class BasePlacedOrderAddressResourceTestCase {
 	}
 
 	protected PlacedOrderAddress
-			testGetPlacedOrderPlacedOrderShippingAddres_addPlacedOrderAddress()
+			testGetPlacedOrderPlacedOrderShippingAddress_addPlacedOrderAddress()
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -680,11 +683,11 @@ public abstract class BasePlacedOrderAddressResourceTestCase {
 	}
 
 	@Test
-	public void testGraphQLGetPlacedOrderPlacedOrderShippingAddres()
+	public void testGraphQLGetPlacedOrderPlacedOrderShippingAddress()
 		throws Exception {
 
 		PlacedOrderAddress placedOrderAddress =
-			testGraphQLGetPlacedOrderPlacedOrderShippingAddres_addPlacedOrderAddress();
+			testGraphQLGetPlacedOrderPlacedOrderShippingAddress_addPlacedOrderAddress();
 
 		// No namespace
 
@@ -695,17 +698,17 @@ public abstract class BasePlacedOrderAddressResourceTestCase {
 					JSONUtil.getValueAsString(
 						invokeGraphQLQuery(
 							new GraphQLField(
-								"placedOrderPlacedOrderShippingAddres",
+								"placedOrderPlacedOrderShippingAddress",
 								new HashMap<String, Object>() {
 									{
 										put(
 											"placedOrderId",
-											testGraphQLGetPlacedOrderPlacedOrderShippingAddres_getPlacedOrderId());
+											testGraphQLGetPlacedOrderPlacedOrderShippingAddress_getPlacedOrderId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
-						"Object/placedOrderPlacedOrderShippingAddres"))));
+						"Object/placedOrderPlacedOrderShippingAddress"))));
 
 		// Using the namespace headlessCommerceDeliveryOrder_v1_0
 
@@ -718,22 +721,22 @@ public abstract class BasePlacedOrderAddressResourceTestCase {
 							new GraphQLField(
 								"headlessCommerceDeliveryOrder_v1_0",
 								new GraphQLField(
-									"placedOrderPlacedOrderShippingAddres",
+									"placedOrderPlacedOrderShippingAddress",
 									new HashMap<String, Object>() {
 										{
 											put(
 												"placedOrderId",
-												testGraphQLGetPlacedOrderPlacedOrderShippingAddres_getPlacedOrderId());
+												testGraphQLGetPlacedOrderPlacedOrderShippingAddress_getPlacedOrderId());
 										}
 									},
 									getGraphQLFields()))),
 						"JSONObject/data",
 						"JSONObject/headlessCommerceDeliveryOrder_v1_0",
-						"Object/placedOrderPlacedOrderShippingAddres"))));
+						"Object/placedOrderPlacedOrderShippingAddress"))));
 	}
 
 	protected Long
-			testGraphQLGetPlacedOrderPlacedOrderShippingAddres_getPlacedOrderId()
+			testGraphQLGetPlacedOrderPlacedOrderShippingAddress_getPlacedOrderId()
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -741,7 +744,7 @@ public abstract class BasePlacedOrderAddressResourceTestCase {
 	}
 
 	@Test
-	public void testGraphQLGetPlacedOrderPlacedOrderShippingAddresNotFound()
+	public void testGraphQLGetPlacedOrderPlacedOrderShippingAddressNotFound()
 		throws Exception {
 
 		Long irrelevantPlacedOrderId = RandomTestUtil.randomLong();
@@ -753,7 +756,7 @@ public abstract class BasePlacedOrderAddressResourceTestCase {
 			JSONUtil.getValueAsString(
 				invokeGraphQLQuery(
 					new GraphQLField(
-						"placedOrderPlacedOrderShippingAddres",
+						"placedOrderPlacedOrderShippingAddress",
 						new HashMap<String, Object>() {
 							{
 								put("placedOrderId", irrelevantPlacedOrderId);
@@ -772,7 +775,7 @@ public abstract class BasePlacedOrderAddressResourceTestCase {
 					new GraphQLField(
 						"headlessCommerceDeliveryOrder_v1_0",
 						new GraphQLField(
-							"placedOrderPlacedOrderShippingAddres",
+							"placedOrderPlacedOrderShippingAddress",
 							new HashMap<String, Object>() {
 								{
 									put(
@@ -786,7 +789,7 @@ public abstract class BasePlacedOrderAddressResourceTestCase {
 	}
 
 	protected PlacedOrderAddress
-			testGraphQLGetPlacedOrderPlacedOrderShippingAddres_addPlacedOrderAddress()
+			testGraphQLGetPlacedOrderPlacedOrderShippingAddress_addPlacedOrderAddress()
 		throws Exception {
 
 		return testGraphQLPlacedOrderAddress_addPlacedOrderAddress();

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/order/resource/v1_0/test/PlacedOrderAddressResourceTest.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/order/resource/v1_0/test/PlacedOrderAddressResourceTest.java
@@ -193,7 +193,8 @@ public class PlacedOrderAddressResourceTest
 	}
 
 	@Override
-	protected Long testGetPlacedOrderPlacedOrderBillingAddress_getPlacedOrderId()
+	protected Long
+			testGetPlacedOrderPlacedOrderBillingAddress_getPlacedOrderId()
 		throws Exception {
 
 		return _commerceOrder.getCommerceOrderId();

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/order/resource/v1_0/test/PlacedOrderAddressResourceTest.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/order/resource/v1_0/test/PlacedOrderAddressResourceTest.java
@@ -186,14 +186,14 @@ public class PlacedOrderAddressResourceTest
 
 	@Override
 	protected PlacedOrderAddress
-			testGetPlacedOrderPlacedOrderBillingAddres_addPlacedOrderAddress()
+			testGetPlacedOrderPlacedOrderBillingAddress_addPlacedOrderAddress()
 		throws Exception {
 
 		return _updateBillingAndShippingAddresses();
 	}
 
 	@Override
-	protected Long testGetPlacedOrderPlacedOrderBillingAddres_getPlacedOrderId()
+	protected Long testGetPlacedOrderPlacedOrderBillingAddress_getPlacedOrderId()
 		throws Exception {
 
 		return _commerceOrder.getCommerceOrderId();
@@ -201,7 +201,7 @@ public class PlacedOrderAddressResourceTest
 
 	@Override
 	protected PlacedOrderAddress
-			testGetPlacedOrderPlacedOrderShippingAddres_addPlacedOrderAddress()
+			testGetPlacedOrderPlacedOrderShippingAddress_addPlacedOrderAddress()
 		throws Exception {
 
 		return _updateBillingAndShippingAddresses();
@@ -209,7 +209,7 @@ public class PlacedOrderAddressResourceTest
 
 	@Override
 	protected Long
-			testGetPlacedOrderPlacedOrderShippingAddres_getPlacedOrderId()
+			testGetPlacedOrderPlacedOrderShippingAddress_getPlacedOrderId()
 		throws Exception {
 
 		return _commerceOrder.getCommerceOrderId();
@@ -235,7 +235,7 @@ public class PlacedOrderAddressResourceTest
 
 	@Override
 	protected Long
-			testGraphQLGetPlacedOrderPlacedOrderBillingAddres_getPlacedOrderId()
+			testGraphQLGetPlacedOrderPlacedOrderBillingAddress_getPlacedOrderId()
 		throws Exception {
 
 		return _commerceOrder.getCommerceOrderId();
@@ -243,7 +243,7 @@ public class PlacedOrderAddressResourceTest
 
 	@Override
 	protected Long
-			testGraphQLGetPlacedOrderPlacedOrderShippingAddres_getPlacedOrderId()
+			testGraphQLGetPlacedOrderPlacedOrderShippingAddress_getPlacedOrderId()
 		throws Exception {
 
 		return _commerceOrder.getCommerceOrderId();

--- a/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/dto/v1_0/TestEntityAddress.java
+++ b/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/dto/v1_0/TestEntityAddress.java
@@ -1,0 +1,576 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.tools.rest.builder.test.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.io.Serializable;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+
+import java.util.Date;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import javax.annotation.Generated;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * @author Alejandro Tardín
+ * @generated
+ */
+@Generated("")
+@GraphQLName(
+	description = "https://www.schema.org/Document", value = "TestEntityAddress"
+)
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "TestEntityAddress")
+public class TestEntityAddress implements Serializable {
+
+	public static TestEntityAddress toDTO(String json) {
+		return ObjectMapperUtil.readValue(TestEntityAddress.class, json);
+	}
+
+	public static TestEntityAddress unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(TestEntityAddress.class, json);
+	}
+
+	@Schema
+	public Date getDateCreated() {
+		if (_dateCreatedSupplier != null) {
+			dateCreated = _dateCreatedSupplier.get();
+
+			_dateCreatedSupplier = null;
+		}
+
+		return dateCreated;
+	}
+
+	public void setDateCreated(Date dateCreated) {
+		this.dateCreated = dateCreated;
+
+		_dateCreatedSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setDateCreated(
+		UnsafeSupplier<Date, Exception> dateCreatedUnsafeSupplier) {
+
+		_dateCreatedSupplier = () -> {
+			try {
+				return dateCreatedUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Date dateCreated;
+
+	@JsonIgnore
+	private Supplier<Date> _dateCreatedSupplier;
+
+	@Schema
+	public Date getDateModified() {
+		if (_dateModifiedSupplier != null) {
+			dateModified = _dateModifiedSupplier.get();
+
+			_dateModifiedSupplier = null;
+		}
+
+		return dateModified;
+	}
+
+	public void setDateModified(Date dateModified) {
+		this.dateModified = dateModified;
+
+		_dateModifiedSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setDateModified(
+		UnsafeSupplier<Date, Exception> dateModifiedUnsafeSupplier) {
+
+		_dateModifiedSupplier = () -> {
+			try {
+				return dateModifiedUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Date dateModified;
+
+	@JsonIgnore
+	private Supplier<Date> _dateModifiedSupplier;
+
+	@Schema
+	public String getDescription() {
+		if (_descriptionSupplier != null) {
+			description = _descriptionSupplier.get();
+
+			_descriptionSupplier = null;
+		}
+
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+
+		_descriptionSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setDescription(
+		UnsafeSupplier<String, Exception> descriptionUnsafeSupplier) {
+
+		_descriptionSupplier = () -> {
+			try {
+				return descriptionUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String description;
+
+	@JsonIgnore
+	private Supplier<String> _descriptionSupplier;
+
+	@Schema
+	public Long getDocumentId() {
+		if (_documentIdSupplier != null) {
+			documentId = _documentIdSupplier.get();
+
+			_documentIdSupplier = null;
+		}
+
+		return documentId;
+	}
+
+	public void setDocumentId(Long documentId) {
+		this.documentId = documentId;
+
+		_documentIdSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setDocumentId(
+		UnsafeSupplier<Long, Exception> documentIdUnsafeSupplier) {
+
+		_documentIdSupplier = () -> {
+			try {
+				return documentIdUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Long documentId;
+
+	@JsonIgnore
+	private Supplier<Long> _documentIdSupplier;
+
+	@Schema
+	public Long getId() {
+		if (_idSupplier != null) {
+			id = _idSupplier.get();
+
+			_idSupplier = null;
+		}
+
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+
+		_idSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setId(UnsafeSupplier<Long, Exception> idUnsafeSupplier) {
+		_idSupplier = () -> {
+			try {
+				return idUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Long id;
+
+	@JsonIgnore
+	private Supplier<Long> _idSupplier;
+
+	@Schema
+	public String getJsonProperty() {
+		if (_jsonPropertySupplier != null) {
+			jsonProperty = _jsonPropertySupplier.get();
+
+			_jsonPropertySupplier = null;
+		}
+
+		return jsonProperty;
+	}
+
+	public void setJsonProperty(String jsonProperty) {
+		this.jsonProperty = jsonProperty;
+
+		_jsonPropertySupplier = null;
+	}
+
+	@JsonIgnore
+	public void setJsonProperty(
+		UnsafeSupplier<String, Exception> jsonPropertyUnsafeSupplier) {
+
+		_jsonPropertySupplier = () -> {
+			try {
+				return jsonPropertyUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@XmlElement(name = "xmlProperty")
+	protected String jsonProperty;
+
+	@JsonIgnore
+	private Supplier<String> _jsonPropertySupplier;
+
+	@Schema
+	public String getName() {
+		if (_nameSupplier != null) {
+			name = _nameSupplier.get();
+
+			_nameSupplier = null;
+		}
+
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+
+		_nameSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setName(UnsafeSupplier<String, Exception> nameUnsafeSupplier) {
+		_nameSupplier = () -> {
+			try {
+				return nameUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String name;
+
+	@JsonIgnore
+	private Supplier<String> _nameSupplier;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof TestEntityAddress)) {
+			return false;
+		}
+
+		TestEntityAddress testEntityAddress = (TestEntityAddress)object;
+
+		return Objects.equals(toString(), testEntityAddress.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		Date dateCreated = getDateCreated();
+
+		if (dateCreated != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"dateCreated\": ");
+
+			sb.append("\"");
+
+			sb.append(liferayToJSONDateFormat.format(dateCreated));
+
+			sb.append("\"");
+		}
+
+		Date dateModified = getDateModified();
+
+		if (dateModified != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"dateModified\": ");
+
+			sb.append("\"");
+
+			sb.append(liferayToJSONDateFormat.format(dateModified));
+
+			sb.append("\"");
+		}
+
+		String description = getDescription();
+
+		if (description != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"description\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(description));
+
+			sb.append("\"");
+		}
+
+		Long documentId = getDocumentId();
+
+		if (documentId != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"documentId\": ");
+
+			sb.append(documentId);
+		}
+
+		Long id = getId();
+
+		if (id != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"id\": ");
+
+			sb.append(id);
+		}
+
+		String jsonProperty = getJsonProperty();
+
+		if (jsonProperty != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"jsonProperty\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(jsonProperty));
+
+			sb.append("\"");
+		}
+
+		String name = getName();
+
+		if (name != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"name\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(name));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@Schema(
+		accessMode = Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.portal.tools.rest.builder.test.dto.v1_0.TestEntityAddress",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof Map) {
+						sb.append(_toJSON((Map<String, ?>)valueArray[i]));
+					}
+					else if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+	private Map<String, Serializable> _extendedProperties;
+
+}

--- a/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/TestEntityAddressResource.java
+++ b/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/TestEntityAddressResource.java
@@ -1,0 +1,133 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.tools.rest.builder.test.resource.v1_0;
+
+import com.liferay.portal.kernel.change.tracking.CTAware;
+import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.tools.rest.builder.test.dto.v1_0.TestEntityAddress;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * To access this resource, run:
+ *
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/test/v1.0
+ *
+ * @author Alejandro Tardín
+ * @generated
+ */
+@CTAware
+@Generated("")
+@ProviderType
+public interface TestEntityAddressResource {
+
+	public TestEntityAddress getTestEntityTestEntityAddress(Long testEntityId)
+		throws Exception;
+
+	public default void setContextAcceptLanguage(
+		AcceptLanguage contextAcceptLanguage) {
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser);
+
+	public void setExpressionConvert(
+		ExpressionConvert<Filter> expressionConvert);
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider);
+
+	public void setGroupLocalService(GroupLocalService groupLocalService);
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService);
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService);
+
+	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setSortParserProvider(SortParserProvider sortParserProvider);
+
+	public default Filter toFilter(String filterString) {
+		return toFilter(
+			filterString, Collections.<String, List<String>>emptyMap());
+	}
+
+	public default Filter toFilter(
+		String filterString, Map<String, List<String>> multivaluedMap) {
+
+		return null;
+	}
+
+	public default Sort[] toSorts(String sortsString) {
+		return new Sort[0];
+	}
+
+	@ProviderType
+	public interface Builder {
+
+		public TestEntityAddressResource build();
+
+		public Builder checkPermissions(boolean checkPermissions);
+
+		public Builder httpServletRequest(
+			HttpServletRequest httpServletRequest);
+
+		public Builder httpServletResponse(
+			HttpServletResponse httpServletResponse);
+
+		public Builder preferredLocale(Locale preferredLocale);
+
+		public Builder uriInfo(UriInfo uriInfo);
+
+		public Builder user(com.liferay.portal.kernel.model.User user);
+
+	}
+
+	@ProviderType
+	public interface Factory {
+
+		public Builder create();
+
+	}
+
+}

--- a/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/dto/v1_0/TestEntityAddress.java
+++ b/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/dto/v1_0/TestEntityAddress.java
@@ -1,0 +1,203 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.tools.rest.builder.test.client.dto.v1_0;
+
+import com.liferay.portal.tools.rest.builder.test.client.function.UnsafeSupplier;
+import com.liferay.portal.tools.rest.builder.test.client.serdes.v1_0.TestEntityAddressSerDes;
+
+import java.io.Serializable;
+
+import java.util.Date;
+import java.util.Objects;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Alejandro Tardín
+ * @generated
+ */
+@Generated("")
+public class TestEntityAddress implements Cloneable, Serializable {
+
+	public static TestEntityAddress toDTO(String json) {
+		return TestEntityAddressSerDes.toDTO(json);
+	}
+
+	public Date getDateCreated() {
+		return dateCreated;
+	}
+
+	public void setDateCreated(Date dateCreated) {
+		this.dateCreated = dateCreated;
+	}
+
+	public void setDateCreated(
+		UnsafeSupplier<Date, Exception> dateCreatedUnsafeSupplier) {
+
+		try {
+			dateCreated = dateCreatedUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Date dateCreated;
+
+	public Date getDateModified() {
+		return dateModified;
+	}
+
+	public void setDateModified(Date dateModified) {
+		this.dateModified = dateModified;
+	}
+
+	public void setDateModified(
+		UnsafeSupplier<Date, Exception> dateModifiedUnsafeSupplier) {
+
+		try {
+			dateModified = dateModifiedUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Date dateModified;
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	public void setDescription(
+		UnsafeSupplier<String, Exception> descriptionUnsafeSupplier) {
+
+		try {
+			description = descriptionUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String description;
+
+	public Long getDocumentId() {
+		return documentId;
+	}
+
+	public void setDocumentId(Long documentId) {
+		this.documentId = documentId;
+	}
+
+	public void setDocumentId(
+		UnsafeSupplier<Long, Exception> documentIdUnsafeSupplier) {
+
+		try {
+			documentId = documentIdUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long documentId;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public void setId(UnsafeSupplier<Long, Exception> idUnsafeSupplier) {
+		try {
+			id = idUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long id;
+
+	public String getJsonProperty() {
+		return jsonProperty;
+	}
+
+	public void setJsonProperty(String jsonProperty) {
+		this.jsonProperty = jsonProperty;
+	}
+
+	public void setJsonProperty(
+		UnsafeSupplier<String, Exception> jsonPropertyUnsafeSupplier) {
+
+		try {
+			jsonProperty = jsonPropertyUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String jsonProperty;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public void setName(UnsafeSupplier<String, Exception> nameUnsafeSupplier) {
+		try {
+			name = nameUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String name;
+
+	@Override
+	public TestEntityAddress clone() throws CloneNotSupportedException {
+		return (TestEntityAddress)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof TestEntityAddress)) {
+			return false;
+		}
+
+		TestEntityAddress testEntityAddress = (TestEntityAddress)object;
+
+		return Objects.equals(toString(), testEntityAddress.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return TestEntityAddressSerDes.toJSON(this);
+	}
+
+}

--- a/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/TestEntityAddressResource.java
+++ b/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/TestEntityAddressResource.java
@@ -1,0 +1,266 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.tools.rest.builder.test.client.resource.v1_0;
+
+import com.liferay.portal.tools.rest.builder.test.client.dto.v1_0.TestEntityAddress;
+import com.liferay.portal.tools.rest.builder.test.client.http.HttpInvoker;
+import com.liferay.portal.tools.rest.builder.test.client.problem.Problem;
+
+import java.net.URL;
+
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Alejandro Tardín
+ * @generated
+ */
+@Generated("")
+public interface TestEntityAddressResource {
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public TestEntityAddress getTestEntityTestEntityAddress(Long testEntityId)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse getTestEntityTestEntityAddressHttpResponse(
+			Long testEntityId)
+		throws Exception;
+
+	public static class Builder {
+
+		public Builder authentication(String login, String password) {
+			_login = login;
+			_password = password;
+
+			return this;
+		}
+
+		public Builder bearerToken(String token) {
+			return header("Authorization", "Bearer " + token);
+		}
+
+		public TestEntityAddressResource build() {
+			return new TestEntityAddressResourceImpl(this);
+		}
+
+		public Builder contextPath(String contextPath) {
+			_contextPath = contextPath;
+
+			return this;
+		}
+
+		public Builder endpoint(String address, String scheme) {
+			String[] addressParts = address.split(":");
+
+			String host = addressParts[0];
+
+			int port = 443;
+
+			if (addressParts.length > 1) {
+				String portString = addressParts[1];
+
+				try {
+					port = Integer.parseInt(portString);
+				}
+				catch (NumberFormatException numberFormatException) {
+					throw new IllegalArgumentException(
+						"Unable to parse port from " + portString);
+				}
+			}
+
+			return endpoint(host, port, scheme);
+		}
+
+		public Builder endpoint(String host, int port, String scheme) {
+			_host = host;
+			_port = port;
+			_scheme = scheme;
+
+			return this;
+		}
+
+		public Builder endpoint(URL url) {
+			return endpoint(url.getHost(), url.getPort(), url.getProtocol());
+		}
+
+		public Builder header(String key, String value) {
+			_headers.put(key, value);
+
+			return this;
+		}
+
+		public Builder locale(Locale locale) {
+			_locale = locale;
+
+			return this;
+		}
+
+		public Builder parameter(String key, String value) {
+			_parameters.put(key, value);
+
+			return this;
+		}
+
+		public Builder parameters(String... parameters) {
+			if ((parameters.length % 2) != 0) {
+				throw new IllegalArgumentException(
+					"Parameters length is not an even number");
+			}
+
+			for (int i = 0; i < parameters.length; i += 2) {
+				String parameterName = String.valueOf(parameters[i]);
+				String parameterValue = String.valueOf(parameters[i + 1]);
+
+				_parameters.put(parameterName, parameterValue);
+			}
+
+			return this;
+		}
+
+		private Builder() {
+		}
+
+		private String _contextPath = "";
+		private Map<String, String> _headers = new LinkedHashMap<>();
+		private String _host = "localhost";
+		private Locale _locale;
+		private String _login = "";
+		private String _password = "";
+		private Map<String, String> _parameters = new LinkedHashMap<>();
+		private int _port = 8080;
+		private String _scheme = "http";
+
+	}
+
+	public static class TestEntityAddressResourceImpl
+		implements TestEntityAddressResource {
+
+		public TestEntityAddress getTestEntityTestEntityAddress(
+				Long testEntityId)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getTestEntityTestEntityAddressHttpResponse(testEntityId);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return com.liferay.portal.tools.rest.builder.test.client.serdes.
+					v1_0.TestEntityAddressSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				getTestEntityTestEntityAddressHttpResponse(Long testEntityId)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/test/v1.0/test-entities/{testEntityId}/test-entity-address");
+
+			httpInvoker.path("testEntityId", testEntityId);
+
+			httpInvoker.userNameAndPassword(
+				_builder._login + ":" + _builder._password);
+
+			return httpInvoker.invoke();
+		}
+
+		private TestEntityAddressResourceImpl(Builder builder) {
+			_builder = builder;
+		}
+
+		private static final Logger _logger = Logger.getLogger(
+			TestEntityAddressResource.class.getName());
+
+		private Builder _builder;
+
+	}
+
+}

--- a/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/serdes/v1_0/TestEntityAddressSerDes.java
+++ b/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/serdes/v1_0/TestEntityAddressSerDes.java
@@ -1,0 +1,399 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.tools.rest.builder.test.client.serdes.v1_0;
+
+import com.liferay.portal.tools.rest.builder.test.client.dto.v1_0.TestEntityAddress;
+import com.liferay.portal.tools.rest.builder.test.client.json.BaseJSONParser;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Alejandro Tardín
+ * @generated
+ */
+@Generated("")
+public class TestEntityAddressSerDes {
+
+	public static TestEntityAddress toDTO(String json) {
+		TestEntityAddressJSONParser testEntityAddressJSONParser =
+			new TestEntityAddressJSONParser();
+
+		return testEntityAddressJSONParser.parseToDTO(json);
+	}
+
+	public static TestEntityAddress[] toDTOs(String json) {
+		TestEntityAddressJSONParser testEntityAddressJSONParser =
+			new TestEntityAddressJSONParser();
+
+		return testEntityAddressJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(TestEntityAddress testEntityAddress) {
+		if (testEntityAddress == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ssXX");
+
+		if (testEntityAddress.getDateCreated() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"dateCreated\": ");
+
+			sb.append("\"");
+
+			sb.append(
+				liferayToJSONDateFormat.format(
+					testEntityAddress.getDateCreated()));
+
+			sb.append("\"");
+		}
+
+		if (testEntityAddress.getDateModified() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"dateModified\": ");
+
+			sb.append("\"");
+
+			sb.append(
+				liferayToJSONDateFormat.format(
+					testEntityAddress.getDateModified()));
+
+			sb.append("\"");
+		}
+
+		if (testEntityAddress.getDescription() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"description\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(testEntityAddress.getDescription()));
+
+			sb.append("\"");
+		}
+
+		if (testEntityAddress.getDocumentId() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"documentId\": ");
+
+			sb.append(testEntityAddress.getDocumentId());
+		}
+
+		if (testEntityAddress.getId() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"id\": ");
+
+			sb.append(testEntityAddress.getId());
+		}
+
+		if (testEntityAddress.getJsonProperty() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"jsonProperty\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(testEntityAddress.getJsonProperty()));
+
+			sb.append("\"");
+		}
+
+		if (testEntityAddress.getName() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"name\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(testEntityAddress.getName()));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		TestEntityAddressJSONParser testEntityAddressJSONParser =
+			new TestEntityAddressJSONParser();
+
+		return testEntityAddressJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(
+		TestEntityAddress testEntityAddress) {
+
+		if (testEntityAddress == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ssXX");
+
+		if (testEntityAddress.getDateCreated() == null) {
+			map.put("dateCreated", null);
+		}
+		else {
+			map.put(
+				"dateCreated",
+				liferayToJSONDateFormat.format(
+					testEntityAddress.getDateCreated()));
+		}
+
+		if (testEntityAddress.getDateModified() == null) {
+			map.put("dateModified", null);
+		}
+		else {
+			map.put(
+				"dateModified",
+				liferayToJSONDateFormat.format(
+					testEntityAddress.getDateModified()));
+		}
+
+		if (testEntityAddress.getDescription() == null) {
+			map.put("description", null);
+		}
+		else {
+			map.put(
+				"description",
+				String.valueOf(testEntityAddress.getDescription()));
+		}
+
+		if (testEntityAddress.getDocumentId() == null) {
+			map.put("documentId", null);
+		}
+		else {
+			map.put(
+				"documentId",
+				String.valueOf(testEntityAddress.getDocumentId()));
+		}
+
+		if (testEntityAddress.getId() == null) {
+			map.put("id", null);
+		}
+		else {
+			map.put("id", String.valueOf(testEntityAddress.getId()));
+		}
+
+		if (testEntityAddress.getJsonProperty() == null) {
+			map.put("jsonProperty", null);
+		}
+		else {
+			map.put(
+				"jsonProperty",
+				String.valueOf(testEntityAddress.getJsonProperty()));
+		}
+
+		if (testEntityAddress.getName() == null) {
+			map.put("name", null);
+		}
+		else {
+			map.put("name", String.valueOf(testEntityAddress.getName()));
+		}
+
+		return map;
+	}
+
+	public static class TestEntityAddressJSONParser
+		extends BaseJSONParser<TestEntityAddress> {
+
+		@Override
+		protected TestEntityAddress createDTO() {
+			return new TestEntityAddress();
+		}
+
+		@Override
+		protected TestEntityAddress[] createDTOArray(int size) {
+			return new TestEntityAddress[size];
+		}
+
+		@Override
+		protected boolean parseMaps(String jsonParserFieldName) {
+			if (Objects.equals(jsonParserFieldName, "dateCreated")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "dateModified")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "description")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "documentId")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "id")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "jsonProperty")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "name")) {
+				return false;
+			}
+
+			return false;
+		}
+
+		@Override
+		protected void setField(
+			TestEntityAddress testEntityAddress, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "dateCreated")) {
+				if (jsonParserFieldValue != null) {
+					testEntityAddress.setDateCreated(
+						toDate((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "dateModified")) {
+				if (jsonParserFieldValue != null) {
+					testEntityAddress.setDateModified(
+						toDate((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "description")) {
+				if (jsonParserFieldValue != null) {
+					testEntityAddress.setDescription(
+						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "documentId")) {
+				if (jsonParserFieldValue != null) {
+					testEntityAddress.setDocumentId(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "id")) {
+				if (jsonParserFieldValue != null) {
+					testEntityAddress.setId(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "jsonProperty")) {
+				if (jsonParserFieldValue != null) {
+					testEntityAddress.setJsonProperty(
+						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "name")) {
+				if (jsonParserFieldValue != null) {
+					testEntityAddress.setName((String)jsonParserFieldValue);
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			sb.append(_toJSON(value));
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static String _toJSON(Object value) {
+		if (value instanceof Map) {
+			return _toJSON((Map)value);
+		}
+
+		Class<?> clazz = value.getClass();
+
+		if (clazz.isArray()) {
+			StringBuilder sb = new StringBuilder("[");
+
+			Object[] values = (Object[])value;
+
+			for (int i = 0; i < values.length; i++) {
+				sb.append(_toJSON(values[i]));
+
+				if ((i + 1) < values.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+
+			return sb.toString();
+		}
+
+		if (value instanceof String) {
+			return "\"" + _escape(value) + "\"";
+		}
+
+		return String.valueOf(value);
+	}
+
+}

--- a/modules/util/portal-tools-rest-builder-test-impl/rest-openapi.yaml
+++ b/modules/util/portal-tools-rest-builder-test-impl/rest-openapi.yaml
@@ -222,9 +222,9 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/TestEntity"
             tags: ["TestEntity"]
-    /test-entities-address/{testEntityId}/test-entities-address:
+    /test-entities/{testEntityId}/test-entity-address:
         get:
-            operationId: getTestEntitiesAddressTestEntityTestEntitiesAddressPage
+            operationId: getTestEntityTestEntityAddress
             parameters:
                 - in: path
                   explode: false
@@ -241,14 +241,10 @@ paths:
                     content:
                         "application/json":
                             schema:
-                                items:
-                                    $ref: "#/components/schemas/TestEntityAddress"
-                                type: array
+                                $ref: "#/components/schemas/TestEntityAddress"
                         "application/xml":
                             schema:
-                                items:
-                                    $ref: "#/components/schemas/TestEntityAddress"
-                                type: array
+                                $ref: "#/components/schemas/TestEntityAddress"
                     description:
                         "OK"
             tags: ["TestEntityAddress"]

--- a/modules/util/portal-tools-rest-builder-test-impl/rest-openapi.yaml
+++ b/modules/util/portal-tools-rest-builder-test-impl/rest-openapi.yaml
@@ -123,6 +123,32 @@ components:
                         - ChildTestEntity3
                     type: string
             type: object
+        TestEntityAddress:
+            description:
+                "https://www.schema.org/Document"
+            properties:
+                dateCreated:
+                    format: date-time
+                    type: string
+                dateModified:
+                    format: date-time
+                    type: string
+                description:
+                    type: string
+                documentId:
+                    format: int64
+                    type: integer
+                id:
+                    format: int64
+                    readOnly: true
+                    type: integer
+                jsonProperty:
+                    type: string
+                    xml:
+                        name: xmlProperty
+                name:
+                    type: string
+            type: object
         UnreferencedTestEntity:
             properties:
                 description:
@@ -196,6 +222,36 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/TestEntity"
             tags: ["TestEntity"]
+    /test-entities-address/{testEntityId}/test-entities-address:
+        get:
+            operationId: getTestEntitiesAddressTestEntityTestEntitiesAddressPage
+            parameters:
+                - in: path
+                  explode: false
+                  name: testEntityId
+                  required: true
+                  schema:
+                      description:
+                          Test Entity Id
+                      format: int64
+                      type: integer
+                  style: simple
+            responses:
+                200:
+                    content:
+                        "application/json":
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/TestEntityAddress"
+                                type: array
+                        "application/xml":
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/TestEntityAddress"
+                                type: array
+                    description:
+                        "OK"
+            tags: ["TestEntityAddress"]
     /test-entities/count:
         get:
             description:

--- a/modules/util/portal-tools-rest-builder-test-impl/rest-openapi.yaml
+++ b/modules/util/portal-tools-rest-builder-test-impl/rest-openapi.yaml
@@ -227,7 +227,6 @@ paths:
             operationId: getTestEntityTestEntityAddress
             parameters:
                 - in: path
-                  explode: false
                   name: testEntityId
                   required: true
                   schema:
@@ -235,7 +234,6 @@ paths:
                           Test Entity Id
                       format: int64
                       type: integer
-                  style: simple
             responses:
                 200:
                     content:

--- a/modules/util/portal-tools-rest-builder-test-impl/rest-openapi.yaml
+++ b/modules/util/portal-tools-rest-builder-test-impl/rest-openapi.yaml
@@ -222,30 +222,6 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/TestEntity"
             tags: ["TestEntity"]
-    /test-entities/{testEntityId}/test-entity-address:
-        get:
-            operationId: getTestEntityTestEntityAddress
-            parameters:
-                - in: path
-                  name: testEntityId
-                  required: true
-                  schema:
-                      description:
-                          Test Entity Id
-                      format: int64
-                      type: integer
-            responses:
-                200:
-                    content:
-                        "application/json":
-                            schema:
-                                $ref: "#/components/schemas/TestEntityAddress"
-                        "application/xml":
-                            schema:
-                                $ref: "#/components/schemas/TestEntityAddress"
-                    description:
-                        "OK"
-            tags: ["TestEntityAddress"]
     /test-entities/count:
         get:
             description:
@@ -354,3 +330,27 @@ paths:
                     description:
                         "OK"
             tags: ["TestEntity"]
+    /test-entities/{testEntityId}/test-entity-address:
+        get:
+            operationId: getTestEntityTestEntityAddress
+            parameters:
+                - in: path
+                  name: testEntityId
+                  required: true
+                  schema:
+                      description:
+                          Test Entity Id
+                      format: int64
+                      type: integer
+            responses:
+                200:
+                    content:
+                        "application/json":
+                            schema:
+                                $ref: "#/components/schemas/TestEntityAddress"
+                        "application/xml":
+                            schema:
+                                $ref: "#/components/schemas/TestEntityAddress"
+                    description:
+                        "OK"
+            tags: ["TestEntityAddress"]

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseTestEntityAddressResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseTestEntityAddressResourceImpl.java
@@ -1,0 +1,271 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.tools.rest.builder.test.internal.resource.v1_0;
+
+import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.tools.rest.builder.test.dto.v1_0.TestEntityAddress;
+import com.liferay.portal.tools.rest.builder.test.resource.v1_0.TestEntityAddressResource;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.util.ActionUtil;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
+/**
+ * @author Alejandro Tardín
+ * @generated
+ */
+@Generated("")
+@javax.ws.rs.Path("/v1.0")
+public abstract class BaseTestEntityAddressResourceImpl
+	implements TestEntityAddressResource {
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/test-entities/{testEntityId}/test-entity-address'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "testEntityId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(name = "TestEntityAddress")
+		}
+	)
+	@javax.ws.rs.GET
+	@javax.ws.rs.Path("/test-entities/{testEntityId}/test-entity-address")
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public TestEntityAddress getTestEntityTestEntityAddress(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("testEntityId")
+			Long testEntityId)
+		throws Exception {
+
+		return new TestEntityAddress();
+	}
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany) {
+
+		this.contextCompany = contextCompany;
+	}
+
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser) {
+
+		this.contextUser = contextUser;
+	}
+
+	public void setExpressionConvert(
+		ExpressionConvert<Filter> expressionConvert) {
+
+		this.expressionConvert = expressionConvert;
+	}
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider) {
+
+		this.filterParserProvider = filterParserProvider;
+	}
+
+	public void setGroupLocalService(GroupLocalService groupLocalService) {
+		this.groupLocalService = groupLocalService;
+	}
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService) {
+
+		this.resourceActionLocalService = resourceActionLocalService;
+	}
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService) {
+
+		this.resourcePermissionLocalService = resourcePermissionLocalService;
+	}
+
+	public void setRoleLocalService(RoleLocalService roleLocalService) {
+		this.roleLocalService = roleLocalService;
+	}
+
+	public void setSortParserProvider(SortParserProvider sortParserProvider) {
+		this.sortParserProvider = sortParserProvider;
+	}
+
+	protected Map<String, String> addAction(
+		String actionName,
+		com.liferay.portal.kernel.model.GroupedModel groupedModel,
+		String methodName) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), groupedModel, methodName,
+			contextScopeChecker, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName, Long ownerId,
+		String permissionName, Long siteId) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			ownerId, permissionName, siteId, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName,
+		ModelResourcePermission modelResourcePermission) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			modelResourcePermission, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, String methodName, String permissionName,
+		Long siteId) {
+
+		return addAction(
+			actionName, siteId, methodName, null, permissionName, siteId);
+	}
+
+	protected <T, R, E extends Throwable> List<R> transform(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transform(collection, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> R[] transform(
+		T[] array, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] transformToArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> List<R> transformToList(
+		T[] array, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> long[] transformToLongArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToLongArray(collection, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> unsafeTransform(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransform(collection, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> R[] unsafeTransform(
+			T[] array, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> List<R> unsafeTransformToList(
+			T[] array, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> long[] unsafeTransformToLongArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToLongArray(
+			collection, unsafeFunction);
+	}
+
+	protected AcceptLanguage contextAcceptLanguage;
+	protected com.liferay.portal.kernel.model.Company contextCompany;
+	protected HttpServletRequest contextHttpServletRequest;
+	protected HttpServletResponse contextHttpServletResponse;
+	protected Object contextScopeChecker;
+	protected UriInfo contextUriInfo;
+	protected com.liferay.portal.kernel.model.User contextUser;
+	protected ExpressionConvert<Filter> expressionConvert;
+	protected FilterParserProvider filterParserProvider;
+	protected GroupLocalService groupLocalService;
+	protected ResourceActionLocalService resourceActionLocalService;
+	protected ResourcePermissionLocalService resourcePermissionLocalService;
+	protected RoleLocalService roleLocalService;
+	protected SortParserProvider sortParserProvider;
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(BaseTestEntityAddressResourceImpl.class);
+
+}

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -87,6 +87,8 @@ public class OpenAPIResourceImpl {
 		{
 			add(TestEntityResourceImpl.class);
 
+			add(TestEntityAddressResourceImpl.class);
+
 			add(OpenAPIResourceImpl.class);
 		}
 	};

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/TestEntityAddressResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/TestEntityAddressResourceImpl.java
@@ -1,0 +1,22 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.tools.rest.builder.test.internal.resource.v1_0;
+
+import com.liferay.portal.tools.rest.builder.test.resource.v1_0.TestEntityAddressResource;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ServiceScope;
+
+/**
+ * @author Alejandro Tardín
+ */
+@Component(
+	properties = "OSGI-INF/liferay/rest/v1_0/test-entity-address.properties",
+	scope = ServiceScope.PROTOTYPE, service = TestEntityAddressResource.class
+)
+public class TestEntityAddressResourceImpl
+	extends BaseTestEntityAddressResourceImpl {
+}

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/factory/TestEntityAddressResourceFactoryImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/factory/TestEntityAddressResourceFactoryImpl.java
@@ -1,0 +1,335 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.tools.rest.builder.test.internal.resource.v1_0.factory;
+
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.tools.rest.builder.test.internal.security.permission.LiberalPermissionChecker;
+import com.liferay.portal.tools.rest.builder.test.resource.v1_0.TestEntityAddressResource;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+
+import javax.annotation.Generated;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
+import org.osgi.service.component.ComponentServiceObjects;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceScope;
+
+/**
+ * @author Alejandro Tardín
+ * @generated
+ */
+@Component(
+	property = "resource.locator.key=/test/v1.0/TestEntityAddress",
+	service = TestEntityAddressResource.Factory.class
+)
+@Generated("")
+public class TestEntityAddressResourceFactoryImpl
+	implements TestEntityAddressResource.Factory {
+
+	@Override
+	public TestEntityAddressResource.Builder create() {
+		return new TestEntityAddressResource.Builder() {
+
+			@Override
+			public TestEntityAddressResource build() {
+				if (_user == null) {
+					throw new IllegalArgumentException("User is not set");
+				}
+
+				Function<InvocationHandler, TestEntityAddressResource>
+					testEntityAddressResourceProxyProviderFunction =
+						ResourceProxyProviderFunctionHolder.
+							_testEntityAddressResourceProxyProviderFunction;
+
+				return testEntityAddressResourceProxyProviderFunction.apply(
+					(proxy, method, arguments) -> _invoke(
+						method, arguments, _checkPermissions,
+						_httpServletRequest, _httpServletResponse,
+						_preferredLocale, _uriInfo, _user));
+			}
+
+			@Override
+			public TestEntityAddressResource.Builder checkPermissions(
+				boolean checkPermissions) {
+
+				_checkPermissions = checkPermissions;
+
+				return this;
+			}
+
+			@Override
+			public TestEntityAddressResource.Builder httpServletRequest(
+				HttpServletRequest httpServletRequest) {
+
+				_httpServletRequest = httpServletRequest;
+
+				return this;
+			}
+
+			@Override
+			public TestEntityAddressResource.Builder httpServletResponse(
+				HttpServletResponse httpServletResponse) {
+
+				_httpServletResponse = httpServletResponse;
+
+				return this;
+			}
+
+			@Override
+			public TestEntityAddressResource.Builder preferredLocale(
+				Locale preferredLocale) {
+
+				_preferredLocale = preferredLocale;
+
+				return this;
+			}
+
+			@Override
+			public TestEntityAddressResource.Builder uriInfo(UriInfo uriInfo) {
+				_uriInfo = uriInfo;
+
+				return this;
+			}
+
+			@Override
+			public TestEntityAddressResource.Builder user(User user) {
+				_user = user;
+
+				return this;
+			}
+
+			private boolean _checkPermissions = true;
+			private HttpServletRequest _httpServletRequest;
+			private HttpServletResponse _httpServletResponse;
+			private Locale _preferredLocale;
+			private UriInfo _uriInfo;
+			private User _user;
+
+		};
+	}
+
+	private static Function<InvocationHandler, TestEntityAddressResource>
+		_getProxyProviderFunction() {
+
+		Class<?> proxyClass = ProxyUtil.getProxyClass(
+			TestEntityAddressResource.class.getClassLoader(),
+			TestEntityAddressResource.class);
+
+		try {
+			Constructor<TestEntityAddressResource> constructor =
+				(Constructor<TestEntityAddressResource>)
+					proxyClass.getConstructor(InvocationHandler.class);
+
+			return invocationHandler -> {
+				try {
+					return constructor.newInstance(invocationHandler);
+				}
+				catch (ReflectiveOperationException
+							reflectiveOperationException) {
+
+					throw new InternalError(reflectiveOperationException);
+				}
+			};
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			throw new InternalError(noSuchMethodException);
+		}
+	}
+
+	private Object _invoke(
+			Method method, Object[] arguments, boolean checkPermissions,
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, Locale preferredLocale,
+			UriInfo uriInfo, User user)
+		throws Throwable {
+
+		String name = PrincipalThreadLocal.getName();
+
+		PrincipalThreadLocal.setName(user.getUserId());
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if (checkPermissions) {
+			PermissionThreadLocal.setPermissionChecker(
+				_defaultPermissionCheckerFactory.create(user));
+		}
+		else {
+			PermissionThreadLocal.setPermissionChecker(
+				new LiberalPermissionChecker(user));
+		}
+
+		TestEntityAddressResource testEntityAddressResource =
+			_componentServiceObjects.getService();
+
+		testEntityAddressResource.setContextAcceptLanguage(
+			new AcceptLanguageImpl(httpServletRequest, preferredLocale, user));
+
+		Company company = _companyLocalService.getCompany(user.getCompanyId());
+
+		testEntityAddressResource.setContextCompany(company);
+
+		testEntityAddressResource.setContextHttpServletRequest(
+			httpServletRequest);
+		testEntityAddressResource.setContextHttpServletResponse(
+			httpServletResponse);
+		testEntityAddressResource.setContextUriInfo(uriInfo);
+		testEntityAddressResource.setContextUser(user);
+		testEntityAddressResource.setExpressionConvert(_expressionConvert);
+		testEntityAddressResource.setFilterParserProvider(
+			_filterParserProvider);
+		testEntityAddressResource.setGroupLocalService(_groupLocalService);
+		testEntityAddressResource.setResourceActionLocalService(
+			_resourceActionLocalService);
+		testEntityAddressResource.setResourcePermissionLocalService(
+			_resourcePermissionLocalService);
+		testEntityAddressResource.setRoleLocalService(_roleLocalService);
+		testEntityAddressResource.setSortParserProvider(_sortParserProvider);
+
+		try {
+			return method.invoke(testEntityAddressResource, arguments);
+		}
+		catch (InvocationTargetException invocationTargetException) {
+			throw invocationTargetException.getTargetException();
+		}
+		finally {
+			_componentServiceObjects.ungetService(testEntityAddressResource);
+
+			PrincipalThreadLocal.setName(name);
+
+			PermissionThreadLocal.setPermissionChecker(permissionChecker);
+		}
+	}
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
+	private ComponentServiceObjects<TestEntityAddressResource>
+		_componentServiceObjects;
+
+	@Reference
+	private PermissionCheckerFactory _defaultPermissionCheckerFactory;
+
+	@Reference(
+		target = "(result.class.name=com.liferay.portal.kernel.search.filter.Filter)"
+	)
+	private ExpressionConvert<Filter> _expressionConvert;
+
+	@Reference
+	private FilterParserProvider _filterParserProvider;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private ResourceActionLocalService _resourceActionLocalService;
+
+	@Reference
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Reference
+	private RoleLocalService _roleLocalService;
+
+	@Reference
+	private SortParserProvider _sortParserProvider;
+
+	@Reference
+	private UserLocalService _userLocalService;
+
+	private static class ResourceProxyProviderFunctionHolder {
+
+		private static final Function
+			<InvocationHandler, TestEntityAddressResource>
+				_testEntityAddressResourceProxyProviderFunction =
+					_getProxyProviderFunction();
+
+	}
+
+	private class AcceptLanguageImpl implements AcceptLanguage {
+
+		public AcceptLanguageImpl(
+			HttpServletRequest httpServletRequest, Locale preferredLocale,
+			User user) {
+
+			_httpServletRequest = httpServletRequest;
+			_preferredLocale = preferredLocale;
+			_user = user;
+		}
+
+		@Override
+		public List<Locale> getLocales() {
+			return Arrays.asList(getPreferredLocale());
+		}
+
+		@Override
+		public String getPreferredLanguageId() {
+			return LocaleUtil.toLanguageId(getPreferredLocale());
+		}
+
+		@Override
+		public Locale getPreferredLocale() {
+			if (_preferredLocale != null) {
+				return _preferredLocale;
+			}
+
+			if (_httpServletRequest != null) {
+				Locale locale = (Locale)_httpServletRequest.getAttribute(
+					WebKeys.LOCALE);
+
+				if (locale != null) {
+					return locale;
+				}
+			}
+
+			return _user.getLocale();
+		}
+
+		@Override
+		public boolean isAcceptAllLanguages() {
+			return false;
+		}
+
+		private final HttpServletRequest _httpServletRequest;
+		private final Locale _preferredLocale;
+		private final User _user;
+
+	}
+
+}

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/test-entity-address.properties
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/test-entity-address.properties
@@ -1,0 +1,8 @@
+#
+# This is a generated file.
+#
+
+api.version=v1.0
+entity.class.name=com.liferay.portal.tools.rest.builder.test.dto.v1_0.TestEntityAddress
+osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Tools.REST.Builder.Test)
+osgi.jaxrs.resource=true

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseTestEntityAddressResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseTestEntityAddressResourceTestCase.java
@@ -1,0 +1,1142 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.tools.rest.builder.test.resource.v1_0.test;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
+
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.odata.entity.EntityField;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.tools.rest.builder.test.client.dto.v1_0.TestEntityAddress;
+import com.liferay.portal.tools.rest.builder.test.client.http.HttpInvoker;
+import com.liferay.portal.tools.rest.builder.test.client.pagination.Page;
+import com.liferay.portal.tools.rest.builder.test.client.resource.v1_0.TestEntityAddressResource;
+import com.liferay.portal.tools.rest.builder.test.client.serdes.v1_0.TestEntityAddressSerDes;
+import com.liferay.portal.util.PropsValues;
+import com.liferay.portal.vulcan.resource.EntityModelResource;
+
+import java.lang.reflect.Method;
+
+import java.text.DateFormat;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import javax.annotation.Generated;
+
+import javax.ws.rs.core.MultivaluedHashMap;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Alejandro Tardín
+ * @generated
+ */
+@Generated("")
+public abstract class BaseTestEntityAddressResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		irrelevantGroup = GroupTestUtil.addGroup();
+		testGroup = GroupTestUtil.addGroup();
+
+		testCompany = CompanyLocalServiceUtil.getCompany(
+			testGroup.getCompanyId());
+
+		_testEntityAddressResource.setContextCompany(testCompany);
+
+		TestEntityAddressResource.Builder builder =
+			TestEntityAddressResource.builder();
+
+		testEntityAddressResource = builder.authentication(
+			"test@liferay.com", PropsValues.DEFAULT_ADMIN_PASSWORD
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		GroupTestUtil.deleteGroup(irrelevantGroup);
+		GroupTestUtil.deleteGroup(testGroup);
+	}
+
+	@Test
+	public void testClientSerDesToDTO() throws Exception {
+		ObjectMapper objectMapper = getClientSerDesObjectMapper();
+
+		TestEntityAddress testEntityAddress1 = randomTestEntityAddress();
+
+		String json = objectMapper.writeValueAsString(testEntityAddress1);
+
+		TestEntityAddress testEntityAddress2 = TestEntityAddressSerDes.toDTO(
+			json);
+
+		Assert.assertTrue(equals(testEntityAddress1, testEntityAddress2));
+	}
+
+	@Test
+	public void testClientSerDesToJSON() throws Exception {
+		ObjectMapper objectMapper = getClientSerDesObjectMapper();
+
+		TestEntityAddress testEntityAddress = randomTestEntityAddress();
+
+		String json1 = objectMapper.writeValueAsString(testEntityAddress);
+		String json2 = TestEntityAddressSerDes.toJSON(testEntityAddress);
+
+		Assert.assertEquals(
+			objectMapper.readTree(json1), objectMapper.readTree(json2));
+	}
+
+	protected ObjectMapper getClientSerDesObjectMapper() {
+		return new ObjectMapper() {
+			{
+				configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+				configure(
+					SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
+				enable(SerializationFeature.INDENT_OUTPUT);
+				setDateFormat(new ISO8601DateFormat());
+				setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+				setSerializationInclusion(JsonInclude.Include.NON_NULL);
+				setVisibility(
+					PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+				setVisibility(
+					PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
+			}
+		};
+	}
+
+	@Test
+	public void testEscapeRegexInStringFields() throws Exception {
+		String regex = "^[0-9]+(\\.[0-9]{1,2})\"?";
+
+		TestEntityAddress testEntityAddress = randomTestEntityAddress();
+
+		testEntityAddress.setDescription(regex);
+		testEntityAddress.setJsonProperty(regex);
+		testEntityAddress.setName(regex);
+
+		String json = TestEntityAddressSerDes.toJSON(testEntityAddress);
+
+		Assert.assertFalse(json.contains(regex));
+
+		testEntityAddress = TestEntityAddressSerDes.toDTO(json);
+
+		Assert.assertEquals(regex, testEntityAddress.getDescription());
+		Assert.assertEquals(regex, testEntityAddress.getJsonProperty());
+		Assert.assertEquals(regex, testEntityAddress.getName());
+	}
+
+	@Test
+	public void testGetTestEntityTestEntityAddress() throws Exception {
+		TestEntityAddress postTestEntityAddress =
+			testGetTestEntityTestEntityAddress_addTestEntityAddress();
+
+		TestEntityAddress getTestEntityAddress =
+			testEntityAddressResource.getTestEntityTestEntityAddress(
+				testGetTestEntityTestEntityAddress_getTestEntityId());
+
+		assertEquals(postTestEntityAddress, getTestEntityAddress);
+		assertValid(getTestEntityAddress);
+	}
+
+	protected Long testGetTestEntityTestEntityAddress_getTestEntityId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected TestEntityAddress
+			testGetTestEntityTestEntityAddress_addTestEntityAddress()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected TestEntityAddress
+			testGraphQLTestEntityAddress_addTestEntityAddress()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected void assertContains(
+		TestEntityAddress testEntityAddress,
+		List<TestEntityAddress> testEntityAddresses) {
+
+		boolean contains = false;
+
+		for (TestEntityAddress item : testEntityAddresses) {
+			if (equals(testEntityAddress, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			testEntityAddresses + " does not contain " + testEntityAddress,
+			contains);
+	}
+
+	protected void assertHttpResponseStatusCode(
+		int expectedHttpResponseStatusCode,
+		HttpInvoker.HttpResponse actualHttpResponse) {
+
+		Assert.assertEquals(
+			expectedHttpResponseStatusCode, actualHttpResponse.getStatusCode());
+	}
+
+	protected void assertEquals(
+		TestEntityAddress testEntityAddress1,
+		TestEntityAddress testEntityAddress2) {
+
+		Assert.assertTrue(
+			testEntityAddress1 + " does not equal " + testEntityAddress2,
+			equals(testEntityAddress1, testEntityAddress2));
+	}
+
+	protected void assertEquals(
+		List<TestEntityAddress> testEntityAddresses1,
+		List<TestEntityAddress> testEntityAddresses2) {
+
+		Assert.assertEquals(
+			testEntityAddresses1.size(), testEntityAddresses2.size());
+
+		for (int i = 0; i < testEntityAddresses1.size(); i++) {
+			TestEntityAddress testEntityAddress1 = testEntityAddresses1.get(i);
+			TestEntityAddress testEntityAddress2 = testEntityAddresses2.get(i);
+
+			assertEquals(testEntityAddress1, testEntityAddress2);
+		}
+	}
+
+	protected void assertEqualsIgnoringOrder(
+		List<TestEntityAddress> testEntityAddresses1,
+		List<TestEntityAddress> testEntityAddresses2) {
+
+		Assert.assertEquals(
+			testEntityAddresses1.size(), testEntityAddresses2.size());
+
+		for (TestEntityAddress testEntityAddress1 : testEntityAddresses1) {
+			boolean contains = false;
+
+			for (TestEntityAddress testEntityAddress2 : testEntityAddresses2) {
+				if (equals(testEntityAddress1, testEntityAddress2)) {
+					contains = true;
+
+					break;
+				}
+			}
+
+			Assert.assertTrue(
+				testEntityAddresses2 + " does not contain " +
+					testEntityAddress1,
+				contains);
+		}
+	}
+
+	protected void assertValid(TestEntityAddress testEntityAddress)
+		throws Exception {
+
+		boolean valid = true;
+
+		if (testEntityAddress.getDateCreated() == null) {
+			valid = false;
+		}
+
+		if (testEntityAddress.getDateModified() == null) {
+			valid = false;
+		}
+
+		if (testEntityAddress.getId() == null) {
+			valid = false;
+		}
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("description", additionalAssertFieldName)) {
+				if (testEntityAddress.getDescription() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("documentId", additionalAssertFieldName)) {
+				if (testEntityAddress.getDocumentId() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("jsonProperty", additionalAssertFieldName)) {
+				if (testEntityAddress.getJsonProperty() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("name", additionalAssertFieldName)) {
+				if (testEntityAddress.getName() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		Assert.assertTrue(valid);
+	}
+
+	protected void assertValid(Page<TestEntityAddress> page) {
+		assertValid(page, Collections.emptyMap());
+	}
+
+	protected void assertValid(
+		Page<TestEntityAddress> page,
+		Map<String, Map<String, String>> expectedActions) {
+
+		boolean valid = false;
+
+		java.util.Collection<TestEntityAddress> testEntityAddresses =
+			page.getItems();
+
+		int size = testEntityAddresses.size();
+
+		if ((page.getLastPage() > 0) && (page.getPage() > 0) &&
+			(page.getPageSize() > 0) && (page.getTotalCount() > 0) &&
+			(size > 0)) {
+
+			valid = true;
+		}
+
+		Assert.assertTrue(valid);
+
+		assertValid(page.getActions(), expectedActions);
+	}
+
+	protected void assertValid(
+		Map<String, Map<String, String>> actions1,
+		Map<String, Map<String, String>> actions2) {
+
+		for (String key : actions2.keySet()) {
+			Map action = actions1.get(key);
+
+			Assert.assertNotNull(key + " does not contain an action", action);
+
+			Map<String, String> expectedAction = actions2.get(key);
+
+			Assert.assertEquals(
+				expectedAction.get("method"), action.get("method"));
+			Assert.assertEquals(expectedAction.get("href"), action.get("href"));
+		}
+	}
+
+	protected String[] getAdditionalAssertFieldNames() {
+		return new String[0];
+	}
+
+	protected List<GraphQLField> getGraphQLFields() throws Exception {
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		for (java.lang.reflect.Field field :
+				getDeclaredFields(
+					com.liferay.portal.tools.rest.builder.test.dto.v1_0.
+						TestEntityAddress.class)) {
+
+			if (!ArrayUtil.contains(
+					getAdditionalAssertFieldNames(), field.getName())) {
+
+				continue;
+			}
+
+			graphQLFields.addAll(getGraphQLFields(field));
+		}
+
+		return graphQLFields;
+	}
+
+	protected List<GraphQLField> getGraphQLFields(
+			java.lang.reflect.Field... fields)
+		throws Exception {
+
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		for (java.lang.reflect.Field field : fields) {
+			com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+				vulcanGraphQLField = field.getAnnotation(
+					com.liferay.portal.vulcan.graphql.annotation.GraphQLField.
+						class);
+
+			if (vulcanGraphQLField != null) {
+				Class<?> clazz = field.getType();
+
+				if (clazz.isArray()) {
+					clazz = clazz.getComponentType();
+				}
+
+				List<GraphQLField> childrenGraphQLFields = getGraphQLFields(
+					getDeclaredFields(clazz));
+
+				graphQLFields.add(
+					new GraphQLField(field.getName(), childrenGraphQLFields));
+			}
+		}
+
+		return graphQLFields;
+	}
+
+	protected String[] getIgnoredEntityFieldNames() {
+		return new String[0];
+	}
+
+	protected boolean equals(
+		TestEntityAddress testEntityAddress1,
+		TestEntityAddress testEntityAddress2) {
+
+		if (testEntityAddress1 == testEntityAddress2) {
+			return true;
+		}
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("dateCreated", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						testEntityAddress1.getDateCreated(),
+						testEntityAddress2.getDateCreated())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("dateModified", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						testEntityAddress1.getDateModified(),
+						testEntityAddress2.getDateModified())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("description", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						testEntityAddress1.getDescription(),
+						testEntityAddress2.getDescription())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("documentId", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						testEntityAddress1.getDocumentId(),
+						testEntityAddress2.getDocumentId())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("id", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						testEntityAddress1.getId(),
+						testEntityAddress2.getId())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("jsonProperty", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						testEntityAddress1.getJsonProperty(),
+						testEntityAddress2.getJsonProperty())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("name", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						testEntityAddress1.getName(),
+						testEntityAddress2.getName())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		return true;
+	}
+
+	protected boolean equals(
+		Map<String, Object> map1, Map<String, Object> map2) {
+
+		if (Objects.equals(map1.keySet(), map2.keySet())) {
+			for (Map.Entry<String, Object> entry : map1.entrySet()) {
+				if (entry.getValue() instanceof Map) {
+					if (!equals(
+							(Map)entry.getValue(),
+							(Map)map2.get(entry.getKey()))) {
+
+						return false;
+					}
+				}
+				else if (!Objects.deepEquals(
+							entry.getValue(), map2.get(entry.getKey()))) {
+
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		return false;
+	}
+
+	protected java.lang.reflect.Field[] getDeclaredFields(Class clazz)
+		throws Exception {
+
+		if (clazz.getClassLoader() == null) {
+			return new java.lang.reflect.Field[0];
+		}
+
+		return TransformUtil.transform(
+			ReflectionUtil.getDeclaredFields(clazz),
+			field -> {
+				if (field.isSynthetic()) {
+					return null;
+				}
+
+				return field;
+			},
+			java.lang.reflect.Field.class);
+	}
+
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
+		if (!(_testEntityAddressResource instanceof EntityModelResource)) {
+			throw new UnsupportedOperationException(
+				"Resource is not an instance of EntityModelResource");
+		}
+
+		EntityModelResource entityModelResource =
+			(EntityModelResource)_testEntityAddressResource;
+
+		EntityModel entityModel = entityModelResource.getEntityModel(
+			new MultivaluedHashMap());
+
+		if (entityModel == null) {
+			return Collections.emptyList();
+		}
+
+		Map<String, EntityField> entityFieldsMap =
+			entityModel.getEntityFieldsMap();
+
+		return entityFieldsMap.values();
+	}
+
+	protected List<EntityField> getEntityFields(EntityField.Type type)
+		throws Exception {
+
+		return TransformUtil.transform(
+			getEntityFields(),
+			entityField -> {
+				if (!Objects.equals(entityField.getType(), type) ||
+					ArrayUtil.contains(
+						getIgnoredEntityFieldNames(), entityField.getName())) {
+
+					return null;
+				}
+
+				return entityField;
+			});
+	}
+
+	protected String getFilterString(
+		EntityField entityField, String operator,
+		TestEntityAddress testEntityAddress) {
+
+		StringBundler sb = new StringBundler();
+
+		String entityFieldName = entityField.getName();
+
+		sb.append(entityFieldName);
+
+		sb.append(" ");
+		sb.append(operator);
+		sb.append(" ");
+
+		if (entityFieldName.equals("dateCreated")) {
+			if (operator.equals("between")) {
+				Date date = testEntityAddress.getDateCreated();
+
+				sb = new StringBundler();
+
+				sb.append("(");
+				sb.append(entityFieldName);
+				sb.append(" gt ");
+				sb.append(
+					_dateFormat.format(date.getTime() - (2 * Time.SECOND)));
+				sb.append(" and ");
+				sb.append(entityFieldName);
+				sb.append(" lt ");
+				sb.append(
+					_dateFormat.format(date.getTime() + (2 * Time.SECOND)));
+				sb.append(")");
+			}
+			else {
+				sb.append(entityFieldName);
+
+				sb.append(" ");
+				sb.append(operator);
+				sb.append(" ");
+
+				sb.append(
+					_dateFormat.format(testEntityAddress.getDateCreated()));
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("dateModified")) {
+			if (operator.equals("between")) {
+				Date date = testEntityAddress.getDateModified();
+
+				sb = new StringBundler();
+
+				sb.append("(");
+				sb.append(entityFieldName);
+				sb.append(" gt ");
+				sb.append(
+					_dateFormat.format(date.getTime() - (2 * Time.SECOND)));
+				sb.append(" and ");
+				sb.append(entityFieldName);
+				sb.append(" lt ");
+				sb.append(
+					_dateFormat.format(date.getTime() + (2 * Time.SECOND)));
+				sb.append(")");
+			}
+			else {
+				sb.append(entityFieldName);
+
+				sb.append(" ");
+				sb.append(operator);
+				sb.append(" ");
+
+				sb.append(
+					_dateFormat.format(testEntityAddress.getDateModified()));
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("description")) {
+			Object object = testEntityAddress.getDescription();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("documentId")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("id")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("jsonProperty")) {
+			Object object = testEntityAddress.getJsonProperty();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("name")) {
+			Object object = testEntityAddress.getName();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		throw new IllegalArgumentException(
+			"Invalid entity field " + entityFieldName);
+	}
+
+	protected String invoke(String query) throws Exception {
+		HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+		httpInvoker.body(
+			JSONUtil.put(
+				"query", query
+			).toString(),
+			"application/json");
+		httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+		httpInvoker.path("http://localhost:8080/o/graphql");
+		httpInvoker.userNameAndPassword(
+			"test@liferay.com:" + PropsValues.DEFAULT_ADMIN_PASSWORD);
+
+		HttpInvoker.HttpResponse httpResponse = httpInvoker.invoke();
+
+		return httpResponse.getContent();
+	}
+
+	protected JSONObject invokeGraphQLMutation(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField mutationGraphQLField = new GraphQLField(
+			"mutation", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(mutationGraphQLField.toString()));
+	}
+
+	protected JSONObject invokeGraphQLQuery(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField queryGraphQLField = new GraphQLField(
+			"query", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(queryGraphQLField.toString()));
+	}
+
+	protected TestEntityAddress randomTestEntityAddress() throws Exception {
+		return new TestEntityAddress() {
+			{
+				dateCreated = RandomTestUtil.nextDate();
+				dateModified = RandomTestUtil.nextDate();
+				description = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				documentId = RandomTestUtil.randomLong();
+				id = RandomTestUtil.randomLong();
+				jsonProperty = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				name = StringUtil.toLowerCase(RandomTestUtil.randomString());
+			}
+		};
+	}
+
+	protected TestEntityAddress randomIrrelevantTestEntityAddress()
+		throws Exception {
+
+		TestEntityAddress randomIrrelevantTestEntityAddress =
+			randomTestEntityAddress();
+
+		return randomIrrelevantTestEntityAddress;
+	}
+
+	protected TestEntityAddress randomPatchTestEntityAddress()
+		throws Exception {
+
+		return randomTestEntityAddress();
+	}
+
+	protected TestEntityAddressResource testEntityAddressResource;
+	protected com.liferay.portal.kernel.model.Group irrelevantGroup;
+	protected com.liferay.portal.kernel.model.Company testCompany;
+	protected com.liferay.portal.kernel.model.Group testGroup;
+
+	protected static class BeanTestUtil {
+
+		public static void copyProperties(Object source, Object target)
+			throws Exception {
+
+			Class<?> sourceClass = source.getClass();
+
+			Class<?> targetClass = target.getClass();
+
+			for (java.lang.reflect.Field field :
+					_getAllDeclaredFields(sourceClass)) {
+
+				if (field.isSynthetic()) {
+					continue;
+				}
+
+				Method getMethod = _getMethod(
+					sourceClass, field.getName(), "get");
+
+				try {
+					Method setMethod = _getMethod(
+						targetClass, field.getName(), "set",
+						getMethod.getReturnType());
+
+					setMethod.invoke(target, getMethod.invoke(source));
+				}
+				catch (Exception e) {
+					continue;
+				}
+			}
+		}
+
+		public static boolean hasProperty(Object bean, String name) {
+			Method setMethod = _getMethod(
+				bean.getClass(), "set" + StringUtil.upperCaseFirstLetter(name));
+
+			if (setMethod != null) {
+				return true;
+			}
+
+			return false;
+		}
+
+		public static void setProperty(Object bean, String name, Object value)
+			throws Exception {
+
+			Class<?> clazz = bean.getClass();
+
+			Method setMethod = _getMethod(
+				clazz, "set" + StringUtil.upperCaseFirstLetter(name));
+
+			if (setMethod == null) {
+				throw new NoSuchMethodException();
+			}
+
+			Class<?>[] parameterTypes = setMethod.getParameterTypes();
+
+			setMethod.invoke(bean, _translateValue(parameterTypes[0], value));
+		}
+
+		private static List<java.lang.reflect.Field> _getAllDeclaredFields(
+			Class<?> clazz) {
+
+			List<java.lang.reflect.Field> fields = new ArrayList<>();
+
+			while ((clazz != null) && (clazz != Object.class)) {
+				for (java.lang.reflect.Field field :
+						clazz.getDeclaredFields()) {
+
+					fields.add(field);
+				}
+
+				clazz = clazz.getSuperclass();
+			}
+
+			return fields;
+		}
+
+		private static Method _getMethod(Class<?> clazz, String name) {
+			for (Method method : clazz.getMethods()) {
+				if (name.equals(method.getName()) &&
+					(method.getParameterCount() == 1) &&
+					_parameterTypes.contains(method.getParameterTypes()[0])) {
+
+					return method;
+				}
+			}
+
+			return null;
+		}
+
+		private static Method _getMethod(
+				Class<?> clazz, String fieldName, String prefix,
+				Class<?>... parameterTypes)
+			throws Exception {
+
+			return clazz.getMethod(
+				prefix + StringUtil.upperCaseFirstLetter(fieldName),
+				parameterTypes);
+		}
+
+		private static Object _translateValue(
+			Class<?> parameterType, Object value) {
+
+			if ((value instanceof Integer) &&
+				parameterType.equals(Long.class)) {
+
+				Integer intValue = (Integer)value;
+
+				return intValue.longValue();
+			}
+
+			return value;
+		}
+
+		private static final Set<Class<?>> _parameterTypes = new HashSet<>(
+			Arrays.asList(
+				Boolean.class, Date.class, Double.class, Integer.class,
+				Long.class, Map.class, String.class));
+
+	}
+
+	protected class GraphQLField {
+
+		public GraphQLField(String key, GraphQLField... graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(String key, List<GraphQLField> graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			GraphQLField... graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = Arrays.asList(graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			List<GraphQLField> graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = graphQLFields;
+		}
+
+		@Override
+		public String toString() {
+			StringBuilder sb = new StringBuilder(_key);
+
+			if (!_parameterMap.isEmpty()) {
+				sb.append("(");
+
+				for (Map.Entry<String, Object> entry :
+						_parameterMap.entrySet()) {
+
+					sb.append(entry.getKey());
+					sb.append(": ");
+					sb.append(entry.getValue());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append(")");
+			}
+
+			if (!_graphQLFields.isEmpty()) {
+				sb.append("{");
+
+				for (GraphQLField graphQLField : _graphQLFields) {
+					sb.append(graphQLField.toString());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append("}");
+			}
+
+			return sb.toString();
+		}
+
+		private final List<GraphQLField> _graphQLFields;
+		private final String _key;
+		private final Map<String, Object> _parameterMap;
+
+	}
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(BaseTestEntityAddressResourceTestCase.class);
+
+	private static DateFormat _dateFormat;
+
+	@Inject
+	private com.liferay.portal.tools.rest.builder.test.resource.v1_0.
+		TestEntityAddressResource _testEntityAddressResource;
+
+}

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/TestEntityAddressResourceTest.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/TestEntityAddressResourceTest.java
@@ -1,0 +1,20 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.tools.rest.builder.test.resource.v1_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+
+import org.junit.Ignore;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alejandro Tardín
+ */
+@Ignore
+@RunWith(Arquillian.class)
+public class TestEntityAddressResourceTest
+	extends BaseTestEntityAddressResourceTestCase {
+}

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/util/OpenAPIUtil.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/util/OpenAPIUtil.java
@@ -17,7 +17,6 @@ import com.liferay.portal.tools.rest.builder.internal.yaml.openapi.Schema;
 
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -52,7 +51,12 @@ public class OpenAPIUtil {
 	}
 
 	public static String formatSingular(String s) {
-		if (StringUtil.lowerCase(s).endsWith("address")){
+		if (StringUtil.lowerCase(
+				s
+			).endsWith(
+				"address"
+			)) {
+
 			return s;
 		}
 

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/util/OpenAPIUtil.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/util/OpenAPIUtil.java
@@ -17,6 +17,7 @@ import com.liferay.portal.tools.rest.builder.internal.yaml.openapi.Schema;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -51,6 +52,20 @@ public class OpenAPIUtil {
 	}
 
 	public static String formatSingular(String s) {
+		Set<String> wordsExceptionsToKeepFormat = new HashSet<>();
+
+		wordsExceptionsToKeepFormat.add("address");
+
+		String[] words = s.split("(?=[A-Z])");
+
+		String lastWord = words[words.length - 1];
+
+		if (wordsExceptionsToKeepFormat.contains(
+				StringUtil.lowerCase(lastWord))) {
+
+			return s;
+		}
+
 		if (s.endsWith("ases")) {
 
 			// bases to base

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/util/OpenAPIUtil.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/util/OpenAPIUtil.java
@@ -52,17 +52,7 @@ public class OpenAPIUtil {
 	}
 
 	public static String formatSingular(String s) {
-		Set<String> wordsExceptionsToKeepFormat = new HashSet<>();
-
-		wordsExceptionsToKeepFormat.add("address");
-
-		String[] words = s.split("(?=[A-Z])");
-
-		String lastWord = words[words.length - 1];
-
-		if (wordsExceptionsToKeepFormat.contains(
-				StringUtil.lowerCase(lastWord))) {
-
+		if (StringUtil.lowerCase(s).endsWith("address")){
 			return s;
 		}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-37815

I was thinking about possible solutions:

- A simple if only checking address
- A regex for words ending in "ss"
- Looking for a library

Then I looked how ruby on rails to see how the manage this task (https://github.com/rails/rails/blob/main/activesupport/lib/active_support/inflections.rb) and from that I concluded that just creating a structure to create exception words works fine.

I wanted to add to the set all the words ending with "ss" like "access", but Alberto suggested me to fix only address with the purpose to not create a very big breaking change.

Let me know what you think about the proposed solution