### PR TITLE
LPD-38293 Fix external $refs

### DIFF
--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/rest-openapi.yaml
@@ -34,7 +34,7 @@ components:
                     readOnly: true
                     type: array
                 creator:
-                    $ref: "../../headless-delivery/headless-delivery-impl/rest-openapi.yaml#Creator"
+                    $ref: "../../headless-delivery/headless-delivery-impl/rest-openapi.yaml#/components/schemas/Creator"
                     description:
                         The Display Page Template's creator.
                     readOnly: true
@@ -42,7 +42,7 @@ components:
                     description:
                         The custom fields associated to the page that renders the Display Page Template.
                     items:
-                        $ref: "../../headless-delivery/headless-delivery-impl/rest-openapi.yaml#CustomField"
+                        $ref: "../../headless-delivery/headless-delivery-impl/rest-openapi.yaml#/components/schemas/CustomField"
                     type: array
                 dateCreated:
                     description:
@@ -69,7 +69,7 @@ components:
                         Specifies if the Display Page Template is the default one for the content type.
                     type: boolean
                 pageDefinition:
-                    $ref: "../../headless-delivery/headless-delivery-impl/rest-openapi.yaml#PageDefinition"
+                    $ref: "../../headless-delivery/headless-delivery-impl/rest-openapi.yaml#/components/schemas/PageDefinition"
                 siteId:
                     description:
                         The ID of the site to which this Page Template is scoped.
@@ -304,10 +304,10 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: "../../headless-delivery/headless-delivery-impl/rest-openapi.yaml#PageDefinition"
+                            $ref: "../../headless-delivery/headless-delivery-impl/rest-openapi.yaml#/components/schemas/PageDefinition"
                     application/xml:
                         schema:
-                            $ref: "../../headless-delivery/headless-delivery-impl/rest-openapi.yaml#PageDefinition"
+                            $ref: "../../headless-delivery/headless-delivery-impl/rest-openapi.yaml#/components/schemas/PageDefinition"
             responses:
                 200:
                     content:
@@ -381,12 +381,12 @@ paths:
                         application/json:
                             schema:
                                 items:
-                                    $ref: "../../headless-delivery/headless-delivery-impl/rest-openapi.yaml#StructuredContent"
+                                    $ref: "../../headless-delivery/headless-delivery-impl/rest-openapi.yaml#/components/schemas/StructuredContent"
                                 type: array
                         application/xml:
                             schema:
                                 items:
-                                    $ref: "../../headless-delivery/headless-delivery-impl/rest-openapi.yaml#StructuredContent"
+                                    $ref: "../../headless-delivery/headless-delivery-impl/rest-openapi.yaml#/components/schemas/StructuredContent"
                                 type: array
             tags: ["StructuredContent"]
     "/sites/{siteId}/structured-contents/draft":
@@ -406,19 +406,19 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: "../../headless-delivery/headless-delivery-impl/rest-openapi.yaml#StructuredContent"
+                            $ref: "../../headless-delivery/headless-delivery-impl/rest-openapi.yaml#/components/schemas/StructuredContent"
                     application/xml:
                         schema:
-                            $ref: "../../headless-delivery/headless-delivery-impl/rest-openapi.yaml#StructuredContent"
+                            $ref: "../../headless-delivery/headless-delivery-impl/rest-openapi.yaml#/components/schemas/StructuredContent"
             responses:
                 200:
                     content:
                         application/json:
                             schema:
-                                $ref: "../../headless-delivery/headless-delivery-impl/rest-openapi.yaml#StructuredContent"
+                                $ref: "../../headless-delivery/headless-delivery-impl/rest-openapi.yaml#/components/schemas/StructuredContent"
                         application/xml:
                             schema:
-                                $ref: "../../headless-delivery/headless-delivery-impl/rest-openapi.yaml#StructuredContent"
+                                $ref: "../../headless-delivery/headless-delivery-impl/rest-openapi.yaml#/components/schemas/StructuredContent"
             tags: ["StructuredContent"]
     "/structured-contents/{structuredContentId}/by-version/{version}":
         delete:
@@ -480,10 +480,10 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: "../../headless-delivery/headless-delivery-impl/rest-openapi.yaml#StructuredContent"
+                                $ref: "../../headless-delivery/headless-delivery-impl/rest-openapi.yaml#/components/schemas/StructuredContent"
                         application/xml:
                             schema:
-                                $ref: "../../headless-delivery/headless-delivery-impl/rest-openapi.yaml#StructuredContent"
+                                $ref: "../../headless-delivery/headless-delivery-impl/rest-openapi.yaml#/components/schemas/StructuredContent"
             tags: ["StructuredContent"]
     "/structured-contents/{structuredContentId}/versions":
         get:
@@ -520,11 +520,11 @@ paths:
                         application/json:
                             schema:
                                 items:
-                                    $ref: "../../headless-delivery/headless-delivery-impl/rest-openapi.yaml#StructuredContent"
+                                    $ref: "../../headless-delivery/headless-delivery-impl/rest-openapi.yaml#/components/schemas/StructuredContent"
                                 type: array
                         application/xml:
                             schema:
                                 items:
-                                    $ref: "../../headless-delivery/headless-delivery-impl/rest-openapi.yaml#StructuredContent"
+                                    $ref: "../../headless-delivery/headless-delivery-impl/rest-openapi.yaml#/components/schemas/StructuredContent"
                                 type: array
             tags: ["StructuredContent"]

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -1885,7 +1885,7 @@ components:
                     description:
                         A list of segments the experience is used for.
                     items:
-                        $ref: "../../headless-admin-user/headless-admin-user-impl/rest-openapi.yaml#Segment"
+                        $ref: "../../headless-admin-user/headless-admin-user-impl/rest-openapi.yaml#/components/schemas/Segment"
                     type: array
             type: object
         Fragment:

--- a/modules/apps/object/object-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-rest-impl/rest-openapi.yaml
@@ -8,7 +8,7 @@ components:
                     readOnly: true
                     type: array
                 creator:
-                    $ref: "../../headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml#Creator"
+                    $ref: "../../headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml#/components/schemas/Creator"
                     readOnly: true
                 dateCreated:
                     format: date
@@ -91,7 +91,7 @@ components:
                     readOnly: true
                     type: array
                 creator:
-                    $ref: "../../headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml#Creator"
+                    $ref: "../../headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml#/components/schemas/Creator"
                     readOnly: true
                 dateCreated:
                     format: date

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/util/OpenAPIParserUtil.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/util/OpenAPIParserUtil.java
@@ -559,7 +559,7 @@ public class OpenAPIParserUtil {
 				String reference = _getReference(currentSchema);
 
 				if (reference != null) {
-					if (reference.contains("#/components/schemas/")) {
+					if (reference.startsWith("#/components/schemas/")) {
 						String referenceName = getReferenceName(reference);
 
 						Schema referenceSchema = schemas.get(referenceName);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-38293

These are issues we found in the original stubs PR that made our input openapi files not compatible with the spec. These are now not a problem because we are not generating the js clients for those modules yet, but I think we should fix them now.