### PR TITLE
LPD-37289 Fix ImportExport#GetImportFileAvailableEntityTypes and ImportExport#GetExportFileAvailableEntityTypes

### DIFF
--- a/modules/apps/batch-planner/batch-planner-test/src/testFunctional/macros/ImportExport.macro
+++ b/modules/apps/batch-planner/batch-planner-test/src/testFunctional/macros/ImportExport.macro
@@ -2,10 +2,9 @@ definition {
 
 	@summary = "Default summary"
 	macro assertAvailableEntityTypes(entityTypes = null) {
-		Click(locator1 = "ImportExport#ENTITY_TYPE");
-
 		for (var entityType : list ${entityTypes}) {
 			AssertTextEquals(
+				key_entityType = ${entityType},
 				locator1 = "ImportExport#ENTITY_TYPE",
 				value1 = ${entityType});
 		}

--- a/modules/apps/batch-planner/batch-planner-test/src/testFunctional/paths/ImportExport.path
+++ b/modules/apps/batch-planner/batch-planner-test/src/testFunctional/paths/ImportExport.path
@@ -12,7 +12,7 @@
 <tbody>
 <tr>
 	<td>ENTITY_TYPE</td>
-	<td>//div[not(contains(@class,'hide'))]/div[label[contains(.,'Entity Type')]]/select[not(@disabled)]</td>
+	<td>//div[not(contains(@class,'hide'))]/div[label[contains(.,'Entity Type')]]/select[not(@disabled)]/option[contains(.,'${key_entityType}')]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
**What's changed?**
The `assertAvailableEntityType` macro was not correctly verifying the presence of the queried option in the select. This update modifies the macro's path to ensure it accurately checks for the inclusion of the specified option.

See the following Jira Ticket: [LPD-37289](https://liferay.atlassian.net/browse/LPD-37289)
