### PR TITLE
LPD-37285 Adapt test to use the new language value

### DIFF
--- a/modules/test/playwright/tests/dispatch-web/pages/JobSchedulerPage.ts
+++ b/modules/test/playwright/tests/dispatch-web/pages/JobSchedulerPage.ts
@@ -17,7 +17,7 @@ export class JobSchedulerPage {
 	constructor(page: Page) {
 		this.applicationsMenuPage = new ApplicationsMenuPage(page);
 		this.exportAnalyticsDxpEntitiesItem = page.getByRole('menuitem', {
-			name: 'export-analytics-dxp-entities',
+			name: 'Export Analytics DXP Entities',
 		});
 		this.newJobSchedulerTriggerButton = page.getByRole('button', {
 			name: 'New',


### PR DESCRIPTION
Test was failing since the incorporation of the 'export-analytics-dxp-entities' language key-value. This PR fixes this issue.

See the following Jira ticket: [LPD-32697](https://liferay.atlassian.net/browse/LPD-32697)