### PR TITLE
LPD-37295 Fix failure in HideOptionsForEntitiesInImportAndExport#CanConfigImportWithOnlyAddImportStrategyAndUpdateChangedRecordFieldsStrategy

### DIFF
--- a/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/HideOptionsForEntitiesInImportAndExport.testcase
+++ b/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/HideOptionsForEntitiesInImportAndExport.testcase
@@ -113,8 +113,12 @@ definition {
 
 		task ("Then the available Import Strategy is Only Add New Records for CommerceAccount,Catalog") {
 			ImportExport.assertStrategiesForEntityTypes(
-				entityTypes = "Account (v1.0 - Liferay Headless Commerce Admin Account),Catalog (v1.0 - Liferay Headless Commerce Admin Catalog)",
+				entityTypes = "Account (v1.0 - Liferay Headless Commerce Admin Account)",
 				importStrategy = "Only Add New Records");
+
+			ImportExport.assertStrategiesForEntityTypes(
+				entityTypes = "Catalog (v1.0 - Liferay Headless Commerce Admin Catalog)",
+				importStrategy = "Only Add New Records Add or Update Records");
 		}
 
 		task ("And Then the available Update Strategy is empty for CommerceAccount,Catalog") {

--- a/modules/test/playwright/tests/batch-planner/import.spec.ts
+++ b/modules/test/playwright/tests/batch-planner/import.spec.ts
@@ -493,6 +493,54 @@ const siteObjectDefinition: ObjectDefinition = {
 	status: {code: 0},
 };
 
+test('can handle OnlyAddNewRecords and UpdateChangedRecordFields import strategies with duplicate ERCs', async ({
+	apiHelpers,
+	dataMigrationCenterPage,
+	page,
+}) => {
+	const objectAdminRestClient = await apiHelpers.buildRestClient(
+		ObjectAdminRestClient
+	);
+
+	const objectDefinition =
+		await objectAdminRestClient.objectDefinition.postObjectDefinition({
+			requestBody: companyObjectDefinition,
+		});
+
+	await dataMigrationCenterPage.goto();
+	await dataMigrationCenterPage.goToImportFile();
+
+	await dataMigrationCenterPage.importFile(
+		OBJECT_ENTRY_ENTITY_TYPE,
+		path.join(__dirname, '/dependencies/object_entries.csv'),
+		'INSERT',
+		'PARTIAL_UPDATE'
+	);
+
+	await expect(
+		page.getByText('The import process completed successfully.')
+	).toBeVisible();
+
+	await page.getByRole('button', {exact: true, name: 'Close'}).click();
+
+	await dataMigrationCenterPage.importFile(
+		OBJECT_ENTRY_ENTITY_TYPE,
+		path.join(__dirname, '/dependencies/object_entry_same_erc.csv'),
+		'INSERT',
+		'PARTIAL_UPDATE'
+	);
+
+	await expect(
+		page.getByText(
+			'com.liferay.object.exception.DuplicateObjectEntryExternalReferenceCodeException'
+		)
+	).toBeVisible();
+
+	await objectAdminRestClient.objectDefinition.deleteObjectDefinition({
+		objectDefinitionId: objectDefinition.id,
+	});
+});
+
 test('can import CSV file with an unexisting field', async ({
 	apiHelpers,
 	dataMigrationCenterPage,


### PR DESCRIPTION
**What's changed?**
- Fixed test due to change in Catalog that now accepts two different strategies
- The new added test verifies the system's behavior when handling imports with duplicate External Reference Codes (ERCs). 

See the following Jira Ticket: [LPD-37295](https://liferay.atlassian.net/browse/LPD-37295)
