### PR TITLE
LPD-37768 | Allow creating nested object entries with mandatory one to many relationships

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -1781,6 +1781,32 @@ public class DefaultObjectEntryManagerImpl
 				continue;
 			}
 
+			if (Objects.equals(
+					objectField.getBusinessType(),
+					ObjectFieldConstants.BUSINESS_TYPE_RELATIONSHIP) &&
+				objectField.isRequired()) {
+
+				Map<String, ObjectRelationship> objectRelationships =
+					_getObjectRelationships(objectDefinition, objectEntry);
+
+				for (Map.Entry<String, ObjectRelationship> objectRelationship :
+						objectRelationships.entrySet()) {
+
+					if (StringUtil.equals(
+							objectRelationship.getValue(
+							).getType(),
+							ObjectRelationshipConstants.TYPE_ONE_TO_MANY)) {
+
+						values.put(
+							objectField.getName(),
+							objectRelationship.getValue(
+							).getObjectRelationshipId());
+					}
+				}
+
+				continue;
+			}
+
 			values.put(objectField.getName(), (Serializable)value);
 		}
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
@@ -9,7 +9,9 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.headless.admin.user.dto.v1_0.UserAccount;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.constants.ObjectFieldSettingConstants;
 import com.liferay.object.constants.ObjectRelationshipConstants;
+import com.liferay.object.field.setting.util.ObjectFieldSettingUtil;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
@@ -913,6 +915,18 @@ public class ObjectEntryRelatedObjectsResourceTest {
 	}
 
 	@Test
+	public void testPostCustomObjectEntryWithNestedObjectEntry()
+		throws Exception {
+
+		// Mandatory One to many custom-custom
+
+		_testPostCustomObjectEntryWithNestedObjectEntryMandatoryRelationship(
+			_addObjectRelationship(
+				_objectDefinition1, _objectDefinition2,
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY));
+	}
+
+	@Test
 	public void testPostCustomObjectEntryWithNestedSystemObjectEntry()
 		throws Exception {
 
@@ -1678,6 +1692,75 @@ public class ObjectEntryRelatedObjectsResourceTest {
 			_objectDefinition1.getRESTContextPath(), Http.Method.POST);
 
 		Assert.assertEquals("BAD_REQUEST", jsonObject.get("status"));
+	}
+
+	private void
+			_testPostCustomObjectEntryWithNestedObjectEntryMandatoryRelationship(
+				ObjectRelationship objectRelationship)
+		throws Exception {
+
+		ObjectField objectField = _objectFieldLocalService.getObjectField(
+			objectRelationship.getObjectFieldId2());
+
+		objectField.setRequired(true);
+
+		objectField = _objectFieldLocalService.updateObjectField(objectField);
+
+		JSONAssert.assertEquals(
+			JSONUtil.put(
+				ObjectFieldSettingUtil.getValue(
+					ObjectFieldSettingConstants.
+						NAME_OBJECT_RELATIONSHIP_ERC_OBJECT_FIELD_NAME,
+					objectField),
+				_objectEntry1.getExternalReferenceCode()
+			).put(
+				objectRelationship.getName(),
+				JSONUtil.put(
+					_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1
+				).put(
+					"externalReferenceCode",
+					_objectEntry1.getExternalReferenceCode()
+				).put(
+					"status",
+					JSONUtil.put(
+						"code", 0
+					).put(
+						"label", "approved"
+					).put(
+						"label_i18n", "Approved"
+					)
+				)
+			).put(
+				_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2
+			).put(
+				"status",
+				JSONUtil.put(
+					"code", 0
+				).put(
+					"label", "approved"
+				).put(
+					"label_i18n", "Approved"
+				)
+			).toString(),
+			HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2
+				).put(
+					objectRelationship.getName(),
+					JSONUtil.put(
+						_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1
+					).put(
+						"externalReferenceCode",
+						_objectEntry1.getExternalReferenceCode()
+					)
+				).toString(),
+				_objectDefinition2.getRESTContextPath(
+				).substring(
+					1
+				),
+				Http.Method.POST
+			).toString(),
+			JSONCompareMode.LENIENT);
 	}
 
 	private void _testPostCustomObjectEntryWithNestedSystemObjectEntry(


### PR DESCRIPTION
**Description**: Fix error where we couldnt create a nested object entry on a mandatory one to many relationship as the curl:
```
curl -X POST \
     -u test@liferay.com:test \
     http://localhost:8080/o/c/students \
     -H 'Content-type: application/json' \
     -d '{"studentName": "student5", "universityStudents": {"universityName": "university", "externalReferenceCode": "entry1_erc"}}'
```
Gave us the error 
```
{
  "status" : "BAD_REQUEST",
  "title" : "No value was provided for required object field \"r_universityStudents_c_universityId\""
}
```

**Jira Ticket**: https://liferay.atlassian.net/browse/LPD-37768