### PR TITLE
LPD-37290 Access just the external reference code from the user to fix prevously failing test 

### DIFF
--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/OperateCustomObjectAndRelatedSystemObjectsWithinSingleRequest.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/OperateCustomObjectAndRelatedSystemObjectsWithinSingleRequest.testcase
@@ -125,7 +125,7 @@ definition {
 			var studentId = JSONPathUtil.getIdValue(response = ${response});
 			var user1ExternalReferenceCode = UserAccountAPI.getUserFieldWithFilter(
 				filter = "alternateName%20eq%20%27user1%27",
-				jsonPath = "$..externalReferenceCode");
+				jsonPath = "$.items[0].externalReferenceCode");
 
 			CustomObjectAPI.updateObjectEntryAndRelatedObjectsByPut(
 				alternateName = "user",
@@ -175,10 +175,10 @@ definition {
 			var studentId = JSONPathUtil.getIdValue(response = ${response});
 			var user1ExternalReferenceCode = UserAccountAPI.getUserFieldWithFilter(
 				filter = "alternateName%20eq%20%27user1%27",
-				jsonPath = "$..externalReferenceCode");
+				jsonPath = "$.items[0].externalReferenceCode");
 			var user2ExternalReferenceCode = UserAccountAPI.getUserFieldWithFilter(
 				filter = "alternateName%20eq%20%27user2%27",
-				jsonPath = "$..externalReferenceCode");
+				jsonPath = "$.items[0].externalReferenceCode");
 
 			CustomObjectAPI.updateObjectEntryAndRelatedObjectsByPatch(
 				alternateName = "user",
@@ -227,10 +227,10 @@ definition {
 			var studentId = JSONPathUtil.getIdValue(response = ${response});
 			var user1ExternalReferenceCode = UserAccountAPI.getUserFieldWithFilter(
 				filter = "alternateName%20eq%20%27user1%27",
-				jsonPath = "$..externalReferenceCode");
+				jsonPath = "$.items[0].externalReferenceCode");
 			var user2ExternalReferenceCode = UserAccountAPI.getUserFieldWithFilter(
 				filter = "alternateName%20eq%20%27user2%27",
-				jsonPath = "$..externalReferenceCode");
+				jsonPath = "$.items[0].externalReferenceCode");
 
 			CustomObjectAPI.updateObjectEntryAndRelatedObjectsByPatch(
 				alternateName = "user",
@@ -279,10 +279,10 @@ definition {
 			var studentId = JSONPathUtil.getIdValue(response = ${response});
 			var user1ExternalReferenceCode = UserAccountAPI.getUserFieldWithFilter(
 				filter = "alternateName%20eq%20%27user1%27",
-				jsonPath = "$..externalReferenceCode");
+				jsonPath = "$.items[0].externalReferenceCode");
 			var user2ExternalReferenceCode = UserAccountAPI.getUserFieldWithFilter(
 				filter = "alternateName%20eq%20%27user2%27",
-				jsonPath = "$..externalReferenceCode");
+				jsonPath = "$.items[0].externalReferenceCode");
 
 			CustomObjectAPI.updateObjectEntryAndRelatedObjectsByPut(
 				alternateName = "user",
@@ -331,10 +331,10 @@ definition {
 			var studentId = JSONPathUtil.getIdValue(response = ${response});
 			var user1ExternalReferenceCode = UserAccountAPI.getUserFieldWithFilter(
 				filter = "alternateName%20eq%20%27user1%27",
-				jsonPath = "$..externalReferenceCode");
+				jsonPath = "$.items[0].externalReferenceCode");
 			var user2ExternalReferenceCode = UserAccountAPI.getUserFieldWithFilter(
 				filter = "alternateName%20eq%20%27user2%27",
-				jsonPath = "$..externalReferenceCode");
+				jsonPath = "$.items[0].externalReferenceCode");
 
 			CustomObjectAPI.updateObjectEntryAndRelatedObjectsByPut(
 				alternateName = "user",


### PR DESCRIPTION
Test started failing since the [incorporation of new external reference codes in entities related to users](https://github.com/liferay/liferay-portal/compare/d548429213ad34626cdf90a0da189876dcfaa537...bf6b2caab2813f04907e10f9e0d36ce370b08595).

This PR purpose fixes the issue by making sure only the ERC from the user is used to create the put/patch requests.

See the following Jira ticket: [LPD-37290](https://liferay.atlassian.net/browse/LPD-37166)