### PR TITLE
LPD-37293 Adapt locator to fix test

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/paths/APIBuilder.path
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/paths/APIBuilder.path
@@ -77,7 +77,7 @@
 </tr>
 <tr>
 	<td>DND_TD_WITH_TEXT</td>
-	<td>//div[@class='dnd-td' and contains(.,'${key_text}')]</td>
+	<td>//div[@class='dnd-td cell-${cell_name}' and contains(.,'${key_text}')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationsInTheAPIBuilder/CreateAPIApplication.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationsInTheAPIBuilder/CreateAPIApplication.testcase
@@ -117,6 +117,7 @@ definition {
 				value1 = "/my-title-123/");
 
 			AssertTextEquals(
+				cell_name = "description",
 				key_text = "This is an application",
 				locator1 = "APIBuilder#DND_TD_WITH_TEXT",
 				value1 = "This is an application");


### PR DESCRIPTION
Test was failing because the locator didn't adapt to a new way of generating the classes of the table entries.

See the following Jira Ticket: [LPD-37293](https://liferay.atlassian.net/browse/LPD-37293)