### PR TITLE
LPD-37767 Fix SQLDSLTest failure "DSLFunctionFactoryUtil is not fully covered

### DIFF
--- a/modules/core/petra/petra-sql-dsl-spi/src/test/java/com/liferay/petra/sql/dsl/spi/SQLDSLTest.java
+++ b/modules/core/petra/petra-sql-dsl-spi/src/test/java/com/liferay/petra/sql/dsl/spi/SQLDSLTest.java
@@ -68,6 +68,7 @@ import java.sql.Types;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.function.Consumer;
@@ -568,6 +569,11 @@ public class SQLDSLTest {
 			String.valueOf(
 				DSLFunctionFactoryUtil.sum(
 					MainExampleTable.INSTANCE.mainExampleIdColumn)));
+		Assert.assertEquals(
+			"TRUNCATE_TO_SECONDS(MainExample.date)",
+			String.valueOf(
+				DSLFunctionFactoryUtil.truncateToSeconds(
+					MainExampleTable.INSTANCE.dateColumn)));
 		Assert.assertEquals(
 			"(MainExample.mainExampleId + ReferenceExample.referenceExampleId)",
 			String.valueOf(
@@ -1092,9 +1098,15 @@ public class SQLDSLTest {
 
 		columns = (Collection<Column<?, ?>>)table4.getColumns();
 
-		Assert.assertEquals(columns.toString(), 4, columns.size());
+		Assert.assertEquals(columns.toString(), 5, columns.size());
 
 		iterator = columns.iterator();
+
+		column = iterator.next();
+
+		Assert.assertSame(table4, column.getTable());
+		Assert.assertEquals(
+			MainExampleTable.INSTANCE.dateColumn.getName(), column.getName());
 
 		column = iterator.next();
 
@@ -1500,7 +1512,7 @@ public class SQLDSLTest {
 		Collection<Column<MainExampleTable, ?>> columns =
 			MainExampleTable.INSTANCE.getColumns();
 
-		Assert.assertEquals(columns.toString(), 4, columns.size());
+		Assert.assertEquals(columns.toString(), 5, columns.size());
 
 		Assert.assertTrue(
 			columns.contains(MainExampleTable.INSTANCE.mainExampleIdColumn));
@@ -1510,6 +1522,8 @@ public class SQLDSLTest {
 			columns.contains(MainExampleTable.INSTANCE.descriptionColumn));
 		Assert.assertTrue(
 			columns.contains(MainExampleTable.INSTANCE.flagColumn));
+		Assert.assertTrue(
+			columns.contains(MainExampleTable.INSTANCE.dateColumn));
 
 		try {
 			columns.remove(MainExampleTable.INSTANCE.mainExampleIdColumn);
@@ -1610,6 +1624,8 @@ public class SQLDSLTest {
 
 		public static final MainExampleTable INSTANCE = new MainExampleTable();
 
+		public final Column<MainExampleTable, Date> dateColumn = createColumn(
+			"date", Date.class, Types.TIMESTAMP, Column.FLAG_DEFAULT);
 		public final Column<MainExampleTable, Clob> descriptionColumn =
 			createColumn(
 				"description", Clob.class, Types.CLOB, Column.FLAG_DEFAULT);


### PR DESCRIPTION
**What's changed?**

When fixing [LPD-37767](https://liferay.atlassian.net/browse/LPD-37767), unit tets was not created for `DSLFunctionFactoryUtil.truncateToSeconds`. Causing the following failure at SQLDSLTest:

> classMethod: java.lang.AssertionError: com.liferay.petra.sql.dsl.DSLFunctionFactoryUtil is not fully covered

The test has been adapted for the new method.


