### PR TITLE
LPD-39011 Add expected externalReferenceCode for the creator to fix failing test

### DIFF
--- a/modules/test/playwright/tests/batch-planner/export.spec.ts
+++ b/modules/test/playwright/tests/batch-planner/export.spec.ts
@@ -344,6 +344,7 @@ test('can export as JSON with all field types mapped', async ({
 			creator: {
 				additionalName: '',
 				contentType: 'UserAccount',
+				externalReferenceCode: expect.any(String),
 				familyName: 'Test',
 				givenName: 'Test',
 				id: expect.any(Number),


### PR DESCRIPTION
Test is failing since the externalReferenceCode was incorporated to the creator entity in [LPD-32160](https://liferay.atlassian.net/browse/LPD-32160).

This PR adds the missing ERC to fix the test.

See the following Jira ticket: [LPD-39011](https://liferay.atlassian.net/browse/LPD-39011)