### PR TITLE
LPD-39238 Use field name instead of the localized one when creating API Builder schemas

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/baseComponents/BaseAPISchemaProperty.tsx
+++ b/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/baseComponents/BaseAPISchemaProperty.tsx
@@ -73,14 +73,11 @@ export default function BaseAPISchemaProperty({
 		});
 	};
 
-	const localizedPropertyName =
-		objectField.label[Liferay.ThemeDisplay.getDefaultLanguageId()]!;
-
 	return (
 		<ClayButton
 			aria-label={sub(
 				Liferay.Language.get('add-x-property'),
-				localizedPropertyName
+				objectField.label[Liferay.ThemeDisplay.getDefaultLanguageId()]!
 			)}
 			className="property-container"
 			displayType="unstyled"


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPD-39238