### PR TITLE
 LPD-37770  Modify export-import/staging infrastructure to support disable data handlers

### DIFF
--- a/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/data/handler/base/BaseStagedModelDataHandler.java
+++ b/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/data/handler/base/BaseStagedModelDataHandler.java
@@ -40,6 +40,10 @@ public abstract class BaseStagedModelDataHandler<T extends StagedModel>
 			String uuid, long groupId, String className, String extraData)
 		throws PortalException {
 
+		if (!isEnabled()) {
+			return;
+		}
+
 		StagedModelRepository<T> stagedModelRepository =
 			getStagedModelRepository();
 
@@ -53,6 +57,10 @@ public abstract class BaseStagedModelDataHandler<T extends StagedModel>
 
 	@Override
 	public void deleteStagedModel(T stagedModel) throws PortalException {
+		if (!isEnabled()) {
+			return;
+		}
+
 		StagedModelRepository<T> stagedModelRepository =
 			getStagedModelRepository();
 
@@ -67,6 +75,10 @@ public abstract class BaseStagedModelDataHandler<T extends StagedModel>
 	public void exportStagedModel(
 			PortletDataContext portletDataContext, T stagedModel)
 		throws PortletDataException {
+
+		if (!isEnabled()) {
+			return;
+		}
 
 		super.exportStagedModel(portletDataContext, stagedModel);
 
@@ -158,6 +170,10 @@ public abstract class BaseStagedModelDataHandler<T extends StagedModel>
 	public void restoreStagedModel(
 			PortletDataContext portletDataContext, T stagedModel)
 		throws PortletDataException {
+
+		if (!isEnabled()) {
+			return;
+		}
 
 		StagedModelRepository<T> stagedModelRepository =
 			getStagedModelRepository();

--- a/modules/apps/export-import/export-import-test-util/bnd.bnd
+++ b/modules/apps/export-import/export-import-test-util/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Export Import Test Utilities
 Bundle-SymbolicName: com.liferay.exportimport.test.util
-Bundle-Version: 6.1.1
+Bundle-Version: 6.2.0
 Export-Package:\
 	com.liferay.exportimport.test.util,\
 	com.liferay.exportimport.test.util.constants,\

--- a/modules/apps/export-import/export-import-test-util/src/main/java/com/liferay/exportimport/test/util/exportimport/data/handler/DummyFolderPortletDataHandler.java
+++ b/modules/apps/export-import/export-import-test-util/src/main/java/com/liferay/exportimport/test/util/exportimport/data/handler/DummyFolderPortletDataHandler.java
@@ -44,6 +44,15 @@ public class DummyFolderPortletDataHandler extends BasePortletDataHandler {
 	}
 
 	@Override
+	public boolean isEnabled() {
+		return _enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		_enabled = enabled;
+	}
+
+	@Override
 	public boolean validateSchemaVersion(String schemaVersion) {
 		return _portletDataHandlerHelper.validateSchemaVersion(
 			schemaVersion, getSchemaVersion());
@@ -139,6 +148,8 @@ public class DummyFolderPortletDataHandler extends BasePortletDataHandler {
 	)
 	private StagedModelRepository<DummyFolder>
 		_dummyFolderStagedModelRepository;
+
+	private boolean _enabled = true;
 
 	@Reference
 	private PortletDataHandlerHelper _portletDataHandlerHelper;

--- a/modules/apps/export-import/export-import-test-util/src/main/java/com/liferay/exportimport/test/util/exportimport/data/handler/DummyFolderStagedModelDataHandler.java
+++ b/modules/apps/export-import/export-import-test-util/src/main/java/com/liferay/exportimport/test/util/exportimport/data/handler/DummyFolderStagedModelDataHandler.java
@@ -36,6 +36,15 @@ public class DummyFolderStagedModelDataHandler
 	}
 
 	@Override
+	public boolean isEnabled() {
+		return _enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		_enabled = enabled;
+	}
+
+	@Override
 	protected void doExportStagedModel(
 			PortletDataContext portletDataContext, DummyFolder dummyFolder)
 		throws Exception {
@@ -103,5 +112,7 @@ public class DummyFolderStagedModelDataHandler
 		target = "(model.class.name=com.liferay.exportimport.test.util.model.Dummy)"
 	)
 	private StagedModelRepository<Dummy> _dummyStagedModelRepository;
+
+	private boolean _enabled = true;
 
 }

--- a/modules/apps/export-import/export-import-test-util/src/main/resources/com/liferay/exportimport/test/util/exportimport/data/handler/packageinfo
+++ b/modules/apps/export-import/export-import-test-util/src/main/resources/com/liferay/exportimport/test/util/exportimport/data/handler/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.2
+version 3.1.0

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/data/handler/test/DummyFolderStagedModelDataHandlerTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/data/handler/test/DummyFolderStagedModelDataHandlerTest.java
@@ -6,8 +6,12 @@
 package com.liferay.exportimport.data.handler.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.exportimport.kernel.lar.StagedModelDataHandler;
+import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerRegistryUtil;
+import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.exportimport.staged.model.repository.StagedModelRepository;
 import com.liferay.exportimport.staged.model.repository.StagedModelRepositoryRegistryUtil;
+import com.liferay.exportimport.test.util.exportimport.data.handler.DummyFolderStagedModelDataHandler;
 import com.liferay.exportimport.test.util.lar.BaseStagedModelDataHandlerTestCase;
 import com.liferay.exportimport.test.util.model.DummyFolder;
 import com.liferay.exportimport.test.util.model.util.DummyFolderTestUtil;
@@ -20,6 +24,7 @@ import com.liferay.portal.kernel.service.PersistedModelLocalService;
 import com.liferay.portal.kernel.service.persistence.BasePersistence;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.io.Serializable;
@@ -28,9 +33,12 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.osgi.framework.Bundle;
@@ -49,6 +57,14 @@ public class DummyFolderStagedModelDataHandlerTest
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() {
+		_dummyFolderStagedModelDataHandler =
+			(DummyFolderStagedModelDataHandler)
+				StagedModelDataHandlerRegistryUtil.getStagedModelDataHandler(
+					DummyFolder.class.getName());
+	}
 
 	@Before
 	@Override
@@ -114,6 +130,135 @@ public class DummyFolderStagedModelDataHandlerTest
 	}
 
 	@Override
+	@Test
+	public void testCleanStagedModelDataHandler() throws Exception {
+		try {
+			_dummyFolderStagedModelDataHandler.setEnabled(true);
+
+			super.testCleanStagedModelDataHandler();
+
+			_dummyFolderStagedModelDataHandler.setEnabled(false);
+
+			initExport();
+
+			Map<String, List<StagedModel>> dependentStagedModelsMap =
+				addDependentStagedModelsMap(stagingGroup);
+
+			StagedModel stagedModel = addStagedModel(
+				stagingGroup, dependentStagedModelsMap);
+
+			addComments(stagedModel);
+
+			addRatings(stagedModel);
+
+			StagedModelDataHandlerUtil.exportStagedModel(
+				portletDataContext, stagedModel);
+
+			validateExport(
+				portletDataContext, stagedModel, dependentStagedModelsMap);
+
+			initImport();
+
+			deleteStagedModel(
+				stagedModel, dependentStagedModelsMap, stagingGroup);
+
+			StagedModel exportedStagedModel = readExportedStagedModel(
+				stagedModel);
+
+			Assert.assertNull(exportedStagedModel);
+		}
+		finally {
+			_dummyFolderStagedModelDataHandler.setEnabled(false);
+		}
+	}
+
+	@Override
+	@Test
+	public void testExportImportWithDefaultData() throws Exception {
+		try {
+			_dummyFolderStagedModelDataHandler.setEnabled(true);
+
+			super.testExportImportWithDefaultData();
+
+			_dummyFolderStagedModelDataHandler.setEnabled(false);
+
+			initExport();
+
+			Map<String, List<StagedModel>> defaultDependentStagedModelsMap =
+				addDefaultDependentStagedModelsMap(stagingGroup);
+
+			StagedModel stagedModel = addDefaultStagedModel(
+				stagingGroup, defaultDependentStagedModelsMap);
+
+			if (stagedModel == null) {
+				return;
+			}
+
+			StagedModelDataHandlerUtil.exportStagedModel(
+				portletDataContext, stagedModel);
+
+			validateExport(
+				portletDataContext, stagedModel,
+				defaultDependentStagedModelsMap);
+
+			Map<String, List<StagedModel>> secondDependentStagedModelsMap =
+				addDefaultDependentStagedModelsMap(liveGroup);
+
+			addDefaultStagedModel(liveGroup, secondDependentStagedModelsMap);
+
+			initImport();
+
+			StagedModel exportedStagedModel = readExportedStagedModel(
+				stagedModel);
+
+			Assert.assertNull(exportedStagedModel);
+		}
+		finally {
+			_dummyFolderStagedModelDataHandler.setEnabled(false);
+		}
+	}
+
+	@Override
+	@Test
+	public void testStagedModelDataHandler() throws Exception {
+		try {
+			_dummyFolderStagedModelDataHandler.setEnabled(true);
+
+			super.testStagedModelDataHandler();
+
+			_dummyFolderStagedModelDataHandler.setEnabled(false);
+
+			initExport();
+
+			Map<String, List<StagedModel>> dependentStagedModelsMap =
+				addDependentStagedModelsMap(stagingGroup);
+
+			StagedModel stagedModel = addStagedModel(
+				stagingGroup, dependentStagedModelsMap);
+
+			addComments(stagedModel);
+
+			addRatings(stagedModel);
+
+			StagedModelDataHandlerUtil.exportStagedModel(
+				portletDataContext, stagedModel);
+
+			validateExport(
+				portletDataContext, stagedModel, dependentStagedModelsMap);
+
+			initImport();
+
+			StagedModel exportedStagedModel = readExportedStagedModel(
+				stagedModel);
+
+			Assert.assertNull(exportedStagedModel);
+		}
+		finally {
+			_dummyFolderStagedModelDataHandler.setEnabled(false);
+		}
+	}
+
+	@Override
 	protected StagedModel addStagedModel(
 			Group group,
 			Map<String, List<StagedModel>> dependentStagedModelsMap)
@@ -146,8 +291,14 @@ public class DummyFolderStagedModelDataHandlerTest
 		return DummyFolder.class;
 	}
 
+	private static DummyFolderStagedModelDataHandler
+		_dummyFolderStagedModelDataHandler;
+
 	private StagedModelRepository<DummyFolder>
 		_dummyFolderStagedModelRepository;
 	private ServiceRegistration<?> _serviceRegistration;
+
+	@Inject
+	private StagedModelDataHandler<DummyFolder> _stagedModelDataHandler;
 
 }

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/kernel/lar/test/DummyFolderPortletDataHandlerTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/kernel/lar/test/DummyFolderPortletDataHandlerTest.java
@@ -1,0 +1,104 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.exportimport.kernel.lar.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.exportimport.kernel.lar.DataLevel;
+import com.liferay.exportimport.test.util.constants.DummyFolderPortletKeys;
+import com.liferay.exportimport.test.util.exportimport.data.handler.DummyFolderPortletDataHandler;
+import com.liferay.exportimport.test.util.lar.BasePortletDataHandlerTestCase;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portlet.PortletPreferencesImpl;
+
+import javax.portlet.PortletPreferences;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Mikel Lorza
+ */
+@RunWith(Arquillian.class)
+public class DummyFolderPortletDataHandlerTest
+	extends BasePortletDataHandlerTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Override
+	@Test
+	public void testExportImportData() throws Exception {
+		DummyFolderPortletDataHandler dummyFolderPortletDataHandler =
+			(DummyFolderPortletDataHandler)portletDataHandler;
+
+		try {
+			dummyFolderPortletDataHandler.setEnabled(true);
+
+			super.testExportImportData();
+
+			PortletPreferences portletPreferences =
+				new PortletPreferencesImpl();
+
+			initContext();
+
+			portletDataContext.setEndDate(getEndDate());
+
+			dummyFolderPortletDataHandler.setEnabled(false);
+
+			Assert.assertNull(
+				portletDataHandler.exportData(
+					portletDataContext, portletId, portletPreferences));
+
+			Assert.assertNull(
+				portletDataHandler.importData(
+					portletDataContext, portletId, portletPreferences, null));
+		}
+		finally {
+			dummyFolderPortletDataHandler.setEnabled(true);
+		}
+	}
+
+	@Override
+	protected void addStagedModels() throws Exception {
+	}
+
+	@Override
+	protected DataLevel getDataLevel() {
+		return DataLevel.SITE;
+	}
+
+	@Override
+	protected String getPortletId() {
+		return DummyFolderPortletKeys.DUMMY_FOLDER;
+	}
+
+	@Override
+	protected boolean isDataPortalLevel() {
+		return false;
+	}
+
+	@Override
+	protected boolean isDataPortletInstanceLevel() {
+		return false;
+	}
+
+	@Override
+	protected boolean isDataSiteLevel() {
+		return true;
+	}
+
+	@Override
+	protected boolean isDisplayPortlet() {
+		return false;
+	}
+
+}

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/import/new_import/import_layouts_resources.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/import/new_import/import_layouts_resources.jsp
@@ -216,6 +216,10 @@ ManifestSummary manifestSummary = ExportImportHelperUtil.getManifestSummary(user
 											for (Portlet portlet : dataPortlets) {
 												PortletDataHandler portletDataHandler = portlet.getPortletDataHandlerInstance();
 
+												if (!portletDataHandler.isEnabled()) {
+													continue;
+												}
+
 												Class<?> portletDataHandlerClass = portletDataHandler.getClass();
 
 												String portletDataHandlerClassName = portletDataHandlerClass.getName();

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/process_summary/process_summary_portlets.jspf
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/process_summary/process_summary_portlets.jspf
@@ -57,6 +57,10 @@
 
 			PortletDataHandler portletDataHandler = portlet.getPortletDataHandlerInstance();
 
+			if (!portletDataHandler.isEnabled()) {
+				continue;
+			}
+
 			PortletDataHandlerControl[] exportControls = portletDataHandler.getExportControls();
 
 			PortletDataHandlerControl[] metadataControls = portletDataHandler.getExportMetadataControls();

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/publish/simple/publish_layouts_simple.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/publish/simple/publish_layouts_simple.jsp
@@ -133,6 +133,10 @@ Map<String, String[]> parameterMap = (Map<String, String[]>)settingsMap.get("par
 										for (Portlet portlet : dataSiteLevelPortlets) {
 											PortletDataHandler portletDataHandler = portlet.getPortletDataHandlerInstance();
 
+											if (!portletDataHandler.isEnabled()) {
+												continue;
+											}
+
 											Class<?> portletDataHandlerClass = portletDataHandler.getClass();
 
 											String portletDataHandlerClassName = portletDataHandlerClass.getName();

--- a/modules/apps/staging/staging-configuration-web/src/main/resources/META-INF/resources/staging_configuration_staged_portlets.jspf
+++ b/modules/apps/staging/staging-configuration-web/src/main/resources/META-INF/resources/staging_configuration_staged_portlets.jspf
@@ -107,7 +107,7 @@
 			for (Portlet curPortlet : dataSiteLevelPortlets) {
 				PortletDataHandler portletDataHandler = curPortlet.getPortletDataHandlerInstance();
 
-				if (!portletDataHandler.isConfigurationEnabled() || !GroupCapabilityUtil.isSupportsPortlet(liveGroup, curPortlet)) {
+				if (!portletDataHandler.isConfigurationEnabled() || !portletDataHandler.isEnabled() || !GroupCapabilityUtil.isSupportsPortlet(liveGroup, curPortlet)) {
 					continue;
 				}
 

--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/portlet_list/page.jsp
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/portlet_list/page.jsp
@@ -25,6 +25,10 @@
 
 		PortletDataHandler portletDataHandler = portlet.getPortletDataHandlerInstance();
 
+		if (!portletDataHandler.isEnabled()) {
+			continue;
+		}
+
 		Class<?> portletDataHandlerClass = portletDataHandler.getClass();
 
 		String portletDataHandlerClassName = portletDataHandlerClass.getName();

--- a/portal-kernel/src/com/liferay/exportimport/kernel/lar/BasePortletDataHandler.java
+++ b/portal-kernel/src/com/liferay/exportimport/kernel/lar/BasePortletDataHandler.java
@@ -46,6 +46,10 @@ public abstract class BasePortletDataHandler implements PortletDataHandler {
 			PortletPreferences portletPreferences)
 		throws PortletDataException {
 
+		if (!isEnabled()) {
+			return null;
+		}
+
 		long startTime = 0;
 
 		if (_log.isInfoEnabled()) {
@@ -81,6 +85,10 @@ public abstract class BasePortletDataHandler implements PortletDataHandler {
 			PortletPreferences portletPreferences)
 		throws PortletDataException {
 
+		if (!isEnabled()) {
+			return null;
+		}
+
 		long startTime = 0;
 
 		if (_log.isInfoEnabled()) {
@@ -111,6 +119,10 @@ public abstract class BasePortletDataHandler implements PortletDataHandler {
 			PortletDataContext portletDataContext, String portletId,
 			PortletPreferences portletPreferences)
 		throws PortletDataException {
+
+		if (!isEnabled()) {
+			return null;
+		}
 
 		long startTime = 0;
 
@@ -363,6 +375,10 @@ public abstract class BasePortletDataHandler implements PortletDataHandler {
 			PortletPreferences portletPreferences, String data)
 		throws PortletDataException {
 
+		if (!isEnabled()) {
+			return null;
+		}
+
 		long startTime = 0;
 
 		if (_log.isInfoEnabled()) {
@@ -470,6 +486,10 @@ public abstract class BasePortletDataHandler implements PortletDataHandler {
 			PortletPreferences portletPreferences)
 		throws PortletDataException {
 
+		if (!isEnabled()) {
+			return;
+		}
+
 		try {
 			doPrepareManifestSummary(portletDataContext, portletPreferences);
 		}
@@ -492,6 +512,10 @@ public abstract class BasePortletDataHandler implements PortletDataHandler {
 
 	@Override
 	public boolean validateSchemaVersion(String schemaVersion) {
+		if (!isEnabled()) {
+			return true;
+		}
+
 		try {
 			return doValidateSchemaVersion(schemaVersion);
 		}

--- a/portal-kernel/src/com/liferay/exportimport/kernel/lar/BaseStagedModelDataHandler.java
+++ b/portal-kernel/src/com/liferay/exportimport/kernel/lar/BaseStagedModelDataHandler.java
@@ -67,6 +67,10 @@ public abstract class BaseStagedModelDataHandler<T extends StagedModel>
 			PortletDataContext portletDataContext, T stagedModel)
 		throws PortletDataException {
 
+		if (!isEnabled()) {
+			return;
+		}
+
 		validateExport(portletDataContext, stagedModel);
 
 		String path = ExportImportPathUtil.getModelPath(stagedModel);
@@ -270,6 +274,10 @@ public abstract class BaseStagedModelDataHandler<T extends StagedModel>
 			PortletDataContext portletDataContext, Element referenceElement)
 		throws PortletDataException {
 
+		if (!isEnabled()) {
+			return;
+		}
+
 		try {
 			doImportMissingReference(portletDataContext, referenceElement);
 		}
@@ -289,6 +297,10 @@ public abstract class BaseStagedModelDataHandler<T extends StagedModel>
 			long classPK)
 		throws PortletDataException {
 
+		if (!isEnabled()) {
+			return;
+		}
+
 		try {
 			doImportMissingReference(
 				portletDataContext, uuid, groupId, classPK);
@@ -305,6 +317,10 @@ public abstract class BaseStagedModelDataHandler<T extends StagedModel>
 	public void importStagedModel(
 			PortletDataContext portletDataContext, T stagedModel)
 		throws PortletDataException {
+
+		if (!isEnabled()) {
+			return;
+		}
 
 		String path = ExportImportPathUtil.getModelPath(stagedModel);
 
@@ -422,6 +438,10 @@ public abstract class BaseStagedModelDataHandler<T extends StagedModel>
 	public void restoreStagedModel(
 			PortletDataContext portletDataContext, T stagedModel)
 		throws PortletDataException {
+
+		if (!isEnabled()) {
+			return;
+		}
 
 		try {
 			if (stagedModel instanceof TrashedModel) {

--- a/portal-kernel/src/com/liferay/exportimport/kernel/lar/PortletDataHandler.java
+++ b/portal-kernel/src/com/liferay/exportimport/kernel/lar/PortletDataHandler.java
@@ -276,6 +276,10 @@ public interface PortletDataHandler {
 
 	public boolean isDisplayPortlet();
 
+	public default boolean isEnabled() {
+		return true;
+	}
+
 	/**
 	 * Returns whether the data exported by this handler should be included by
 	 * default when publishing to live. This should only be <code>true</code>

--- a/portal-kernel/src/com/liferay/exportimport/kernel/lar/StagedModelDataHandler.java
+++ b/portal-kernel/src/com/liferay/exportimport/kernel/lar/StagedModelDataHandler.java
@@ -191,6 +191,10 @@ public interface StagedModelDataHandler<T extends StagedModel> {
 			PortletDataContext portletDataContext, T stagedModel)
 		throws PortletDataException;
 
+	public default boolean isEnabled() {
+		return true;
+	}
+
 	/**
 	 * Restores the staged model from the trash. This method is called during
 	 * the import process to ensure the imported staged model is not in the

--- a/portal-kernel/src/com/liferay/exportimport/kernel/lar/packageinfo
+++ b/portal-kernel/src/com/liferay/exportimport/kernel/lar/packageinfo
@@ -1,1 +1,1 @@
-version 5.5.0
+version 5.6.0


### PR DESCRIPTION
Hi @DaniSzimko ,

I am reseding the PR again in response to [Brian's comment](https://github.com/brianchandotcom/liferay-portal/pull/155037#issuecomment-2405555957). So, for that, I have created the tests in a different way. You can see these changes in the last 3 commits.

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-37770

Hi team,

Working on deprecating wiki from the portal, we have the need to hide wiki from the export-import/staging process. So, this PR include all necessary changes to support disable data handlers in order to do not import/export staged data models neither portlet data models

# How am I fixing it?

Adding isEnabled method to portlet and staged model data handlers interfaces and use it in base implementations in order to exclude wiki model and portlets from the export-import process.

# How can you verify that it works?

Run included tests.