### PR TITLE
LPD-37767 | Greater than filter for the dateModified fiels does not work properly with custom objects

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/odata/filter/expression/field/predicate/provider/FieldPredicateProvider.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/odata/filter/expression/field/predicate/provider/FieldPredicateProvider.java
@@ -8,6 +8,7 @@ package com.liferay.object.odata.filter.expression.field.predicate.provider;
 import com.liferay.petra.sql.dsl.Column;
 import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.portal.odata.filter.expression.BinaryExpression;
+import com.liferay.portal.odata.filter.expression.ExpressionVisitException;
 
 import java.util.List;
 import java.util.function.Function;
@@ -21,24 +22,29 @@ import org.osgi.annotation.versioning.ProviderType;
 public interface FieldPredicateProvider {
 
 	public Predicate getBinaryExpressionPredicate(
-		Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
-		Object left, long objectDefinitionId,
-		BinaryExpression.Operation operation, Object right);
+			Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
+			Object left, long objectDefinitionId,
+			BinaryExpression.Operation operation, Object right)
+		throws ExpressionVisitException;
 
 	public Predicate getContainsPredicate(
-		Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
-		String fieldName, Object fieldValue);
+			Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
+			String fieldName, Object fieldValue)
+		throws ExpressionVisitException;
 
 	public Predicate getInPredicate(
-		Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
-		Object left, List<Object> rights);
+			Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
+			Object left, List<Object> rights)
+		throws ExpressionVisitException;
 
 	public Predicate getIsNotEmptyPredicate(
-		String fieldName,
-		Function<String, Column<?, ?>> objectDefinitionColumnSupplier);
+			String fieldName,
+			Function<String, Column<?, ?>> objectDefinitionColumnSupplier)
+		throws ExpressionVisitException;
 
 	public Predicate getStartsWithPredicate(
-		Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
-		String fieldName, Object fieldValue);
+			Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
+			String fieldName, Object fieldValue)
+		throws ExpressionVisitException;
 
 }

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
@@ -464,15 +464,10 @@ public class PredicateExpressionVisitorImpl
 			_getFieldPredicateProvider(String.valueOf(left), objectDefinition);
 
 		if (fieldPredicateProvider != null) {
-			List<Object> adjustedRights = new ArrayList<>();
-
-			for (Object right : rights) {
-				adjustedRights.add(_getValue(left, objectDefinition, right));
-			}
-
 			return fieldPredicateProvider.getInPredicate(
 				name -> _getColumn(name, objectDefinition), left,
-				adjustedRights);
+				TransformUtil.transform(
+					rights, right -> _getValue(left, objectDefinition, right)));
 		}
 
 		return _getColumn(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
@@ -99,7 +99,8 @@ public class PredicateExpressionVisitorImpl
 
 	@Override
 	public Predicate visitBinaryExpressionOperation(
-		BinaryExpression.Operation operation, Object left, Object right) {
+			BinaryExpression.Operation operation, Object left, Object right)
+		throws ExpressionVisitException {
 
 		Predicate predicate = null;
 
@@ -262,7 +263,8 @@ public class PredicateExpressionVisitorImpl
 
 	@Override
 	public Object visitMethodExpression(
-		List<Object> expressions, MethodExpression.Type type) {
+			List<Object> expressions, MethodExpression.Type type)
+		throws ExpressionVisitException {
 
 		if (expressions.size() == 2) {
 			String left = (String)expressions.get(0);
@@ -372,8 +374,9 @@ public class PredicateExpressionVisitorImpl
 	}
 
 	private Predicate _contains(
-		Object fieldName, Object fieldValue,
-		ObjectDefinition objectDefinition) {
+			Object fieldName, Object fieldValue,
+			ObjectDefinition objectDefinition)
+		throws ExpressionVisitException {
 
 		FieldPredicateProvider fieldPredicateProvider =
 			_getFieldPredicateProvider(
@@ -458,7 +461,8 @@ public class PredicateExpressionVisitorImpl
 	}
 
 	private Predicate _getInPredicate(
-		Object left, ObjectDefinition objectDefinition, List<Object> rights) {
+			Object left, ObjectDefinition objectDefinition, List<Object> rights)
+		throws ExpressionVisitException {
 
 		FieldPredicateProvider fieldPredicateProvider =
 			_getFieldPredicateProvider(String.valueOf(left), objectDefinition);
@@ -600,8 +604,9 @@ public class PredicateExpressionVisitorImpl
 	}
 
 	private Predicate _getPredicate(
-		Object left, ObjectDefinition objectDefinition,
-		BinaryExpression.Operation operation, Object right) {
+			Object left, ObjectDefinition objectDefinition,
+			BinaryExpression.Operation operation, Object right)
+		throws ExpressionVisitException {
 
 		Predicate predicate = null;
 
@@ -780,8 +785,9 @@ public class PredicateExpressionVisitorImpl
 	}
 
 	private Predicate _startsWith(
-		Object fieldName, Object fieldValue,
-		ObjectDefinition objectDefinition) {
+			Object fieldName, Object fieldValue,
+			ObjectDefinition objectDefinition)
+		throws ExpressionVisitException {
 
 		FieldPredicateProvider fieldPredicateProvider =
 			_getFieldPredicateProvider(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
@@ -464,8 +464,15 @@ public class PredicateExpressionVisitorImpl
 			_getFieldPredicateProvider(String.valueOf(left), objectDefinition);
 
 		if (fieldPredicateProvider != null) {
+			List<Object> adjustedRights = new ArrayList<>();
+
+			for (Object right : rights) {
+				adjustedRights.add(_getValue(left, objectDefinition, right));
+			}
+
 			return fieldPredicateProvider.getInPredicate(
-				name -> _getColumn(name, objectDefinition), left, rights);
+				name -> _getColumn(name, objectDefinition), left,
+				adjustedRights);
 		}
 
 		return _getColumn(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/field/predicate/provider/SystemDateFieldPredicateProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/field/predicate/provider/SystemDateFieldPredicateProvider.java
@@ -45,8 +45,8 @@ public class SystemDateFieldPredicateProvider
 			BinaryExpression.Operation operation, Object right)
 		throws ExpressionVisitException {
 
-		Expression<String> expression =
-			(Expression<String>)objectDefinitionColumnSupplier.apply(
+		Expression<Object> expression =
+			(Expression<Object>)objectDefinitionColumnSupplier.apply(
 				String.valueOf(left));
 
 		if (right == null) {
@@ -60,7 +60,7 @@ public class SystemDateFieldPredicateProvider
 
 		if (right instanceof Date) {
 			return _getDateTimePredicate(
-				(Date)right, expression, String::valueOf, operation);
+				(Date)right, expression, date -> date, operation);
 		}
 
 		String valueString = (String)right;
@@ -111,7 +111,7 @@ public class SystemDateFieldPredicateProvider
 			predicate = predicate.or(binaryExpressionPredicate);
 		}
 
-		return predicate;
+		return predicate.withParentheses();
 	}
 
 	@Override
@@ -133,8 +133,8 @@ public class SystemDateFieldPredicateProvider
 	}
 
 	private Predicate _getDateTimePredicate(
-		Date date, Expression<String> expression,
-		Function<Object, String> function,
+		Date date, Expression<Object> expression,
+		Function<Object, Object> function,
 		BinaryExpression.Operation operation) {
 
 		if (operation == BinaryExpression.Operation.EQ) {
@@ -146,19 +146,19 @@ public class SystemDateFieldPredicateProvider
 				expression.lt(function.apply(_incrementSecond(truncatedDate)))
 			).withParentheses();
 		}
+		else if (operation == BinaryExpression.Operation.GE) {
+			return expression.gte(function.apply(_truncateMilliseconds(date)));
+		}
 		else if (operation == BinaryExpression.Operation.GT) {
 			return expression.gte(
 				function.apply(_incrementSecond(_truncateMilliseconds(date))));
 		}
-		else if (operation == BinaryExpression.Operation.GE) {
-			return expression.gte(function.apply(_truncateMilliseconds(date)));
-		}
-		else if (operation == BinaryExpression.Operation.LT) {
-			return expression.lt(function.apply(_truncateMilliseconds(date)));
-		}
 		else if (operation == BinaryExpression.Operation.LE) {
 			return expression.lt(
 				function.apply(_incrementSecond(_truncateMilliseconds(date))));
+		}
+		else if (operation == BinaryExpression.Operation.LT) {
+			return expression.lt(function.apply(_truncateMilliseconds(date)));
 		}
 		else if (operation == BinaryExpression.Operation.NE) {
 			Date truncatedDate = _truncateMilliseconds(date);

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/field/predicate/provider/SystemDateFieldPredicateProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/field/predicate/provider/SystemDateFieldPredicateProvider.java
@@ -5,17 +5,20 @@
 
 package com.liferay.object.rest.internal.odata.filter.expression.field.predicate.provider;
 
+import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.odata.filter.expression.field.predicate.provider.FieldPredicateProvider;
 import com.liferay.petra.sql.dsl.Column;
 import com.liferay.petra.sql.dsl.expression.Expression;
 import com.liferay.petra.sql.dsl.expression.Predicate;
+import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.filter.expression.BinaryExpression;
+import com.liferay.portal.odata.filter.expression.ExpressionVisitException;
 
 import java.text.DateFormat;
 import java.text.ParseException;
 
+import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.function.Function;
@@ -37,24 +40,43 @@ public class SystemDateFieldPredicateProvider
 
 	@Override
 	public Predicate getBinaryExpressionPredicate(
-		Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
-		Object left, long objectDefinitionId,
-		BinaryExpression.Operation operation, Object right) {
+			Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
+			Object left, long objectDefinitionId,
+			BinaryExpression.Operation operation, Object right)
+		throws ExpressionVisitException {
 
 		Expression<String> expression =
 			(Expression<String>)objectDefinitionColumnSupplier.apply(
 				String.valueOf(left));
 
-		if ((operation == BinaryExpression.Operation.NE) && (right == null)) {
-			return expression.isNotNull();
+		if (right == null) {
+			if (operation == BinaryExpression.Operation.EQ) {
+				return expression.isNull();
+			}
+			else if (operation == BinaryExpression.Operation.NE) {
+				return expression.isNotNull();
+			}
 		}
-		else if ((operation == BinaryExpression.Operation.EQ) &&
-				 (right == null)) {
 
-			return expression.isNull();
+		if (right instanceof Date) {
+			return _getDateTimePredicate(
+				(Date)right, expression, String::valueOf, operation);
 		}
 
-		return _getDateTimePredicate(expression, operation, (String)right);
+		String valueString = (String)right;
+
+		DateFormat dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
+			ObjectFieldUtil.getDateTimePattern(valueString));
+
+		try {
+			return _getDateTimePredicate(
+				dateFormat.parse(valueString), expression, dateFormat::format,
+				operation);
+		}
+		catch (ParseException parseException) {
+			throw new ExpressionVisitException(
+				"Error parsing date " + valueString, parseException);
+		}
 	}
 
 	@Override
@@ -69,25 +91,24 @@ public class SystemDateFieldPredicateProvider
 
 	@Override
 	public Predicate getInPredicate(
-		Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
-		Object left, List<Object> rights) {
-
-		Expression<String> expression =
-			(Expression<String>)objectDefinitionColumnSupplier.apply(
-				String.valueOf(left));
+			Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
+			Object left, List<Object> rights)
+		throws ExpressionVisitException {
 
 		Predicate predicate = null;
 
 		for (Object right : rights) {
-			Predicate eqPredicate = _getDateTimePredicate(
-				expression, BinaryExpression.Operation.EQ, (String)right);
+			Predicate binaryExpressionPredicate = getBinaryExpressionPredicate(
+				objectDefinitionColumnSupplier, left, 0L,
+				BinaryExpression.Operation.EQ, right);
 
 			if (predicate == null) {
-				predicate = eqPredicate;
+				predicate = binaryExpressionPredicate;
+
+				continue;
 			}
-			else {
-				predicate = predicate.or(eqPredicate);
-			}
+
+			predicate = predicate.or(binaryExpressionPredicate);
 		}
 
 		return predicate;
@@ -111,153 +132,61 @@ public class SystemDateFieldPredicateProvider
 				"dateCreated/dateModified fields");
 	}
 
-	private <T> T _adjustToEndOfMillis(T value) {
-		String dateString = (String)_adjustToStartOfMillis(value);
-
-		if (value instanceof String) {
-			try {
-				String pattern = _getDateTimePattern(dateString);
-
-				DateFormat dateFormat =
-					DateFormatFactoryUtil.getSimpleDateFormat(pattern);
-
-				Date date = dateFormat.parse((String)dateString);
-
-				date.setTime(date.getTime() + 1000);
-
-				return (T)dateFormat.format(date);
-			}
-			catch (ParseException parseException) {
-				throw new IllegalArgumentException(
-					"Unable to parse date from " + value, parseException);
-			}
-		}
-		else if (value instanceof Date) {
-			Date date = (Date)value;
-
-			date.setTime(date.getTime() + 1000);
-
-			return (T)date;
-		}
-
-		return value;
-	}
-
-	private <T> T _adjustToStartOfMillis(T value) {
-		if (value instanceof String) {
-			String dateString = (String)value;
-
-			try {
-				String pattern = _getDateTimePattern(dateString);
-
-				DateFormat dateFormat =
-					DateFormatFactoryUtil.getSimpleDateFormat(pattern);
-
-				if (pattern.equals("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")) {
-					if (dateString.matches(
-							"^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$")) {
-
-						dateString = StringUtil.replace(
-							dateString, 'Z', ".000Z");
-					}
-					else if (dateString.matches(
-								"^\\d{4}-\\d{2}-\\d{2}T\\d{2}:" +
-									"\\d{2}:\\d{2}\\.\\d{4,}Z$")) {
-
-						String truncatedDateString = dateString.substring(
-							0, dateString.indexOf('.') + 4);
-
-						dateString = truncatedDateString + "Z";
-					}
-				}
-
-				Date date = dateFormat.parse(dateString);
-
-				date.setTime((date.getTime() / 1000) * 1000);
-
-				if (dateString.length() == 20) {
-					return (T)DateFormatFactoryUtil.getSimpleDateFormat(
-						"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
-					).format(
-						date
-					);
-				}
-
-				return (T)dateFormat.format(date);
-			}
-			catch (ParseException parseException) {
-				throw new IllegalArgumentException(
-					"Unable to parse date from " + dateString, parseException);
-			}
-		}
-		else if (value instanceof Date) {
-			Date date = (Date)value;
-
-			date.setTime((date.getTime() / 1000) * 1000);
-
-			return (T)date;
-		}
-
-		return value;
-	}
-
-	private String _getDateTimePattern(String value) {
-		if (value.matches(
-				"^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$")) {
-
-			return "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"; // oData
-		}
-
-		if (value.length() == 23) {
-			return "yyyy-MM-dd HH:mm:ss.SSS"; // Hypersonic, DB2
-		}
-
-		if (value.length() == 27) {
-			return "dd-MMM-yyyy HH:mm:ss.SSS a"; // Oracle
-		}
-
-		throw new IllegalArgumentException(
-			"Unrecognized date format: " + value);
-	}
-
-	private <T> Predicate _getDateTimePredicate(
-		Expression<T> expression, BinaryExpression.Operation operation,
-		T value) {
+	private Predicate _getDateTimePredicate(
+		Date date, Expression<String> expression,
+		Function<Object, String> function,
+		BinaryExpression.Operation operation) {
 
 		if (operation == BinaryExpression.Operation.EQ) {
-			T startOfSecond = _adjustToStartOfMillis(value);
-			T endOfSecond = _adjustToEndOfMillis(value);
+			Date truncatedDate = _truncateMilliseconds(date);
 
 			return expression.gte(
-				startOfSecond
+				function.apply(truncatedDate)
 			).and(
-				expression.lt(endOfSecond)
-			);
-		}
-		else if (operation == BinaryExpression.Operation.NE) {
-			T startOfSecond = _adjustToStartOfMillis(value);
-			T endOfSecond = _adjustToEndOfMillis(value);
-
-			return expression.lt(
-				startOfSecond
-			).or(
-				expression.gte(endOfSecond)
-			);
+				expression.lt(function.apply(_incrementSecond(truncatedDate)))
+			).withParentheses();
 		}
 		else if (operation == BinaryExpression.Operation.GT) {
-			return expression.gte(_adjustToEndOfMillis(value));
+			return expression.gte(
+				function.apply(_incrementSecond(_truncateMilliseconds(date))));
 		}
 		else if (operation == BinaryExpression.Operation.GE) {
-			return expression.gte(_adjustToStartOfMillis(value));
+			return expression.gte(function.apply(_truncateMilliseconds(date)));
 		}
 		else if (operation == BinaryExpression.Operation.LT) {
-			return expression.lt(_adjustToStartOfMillis(value));
+			return expression.lt(function.apply(_truncateMilliseconds(date)));
 		}
 		else if (operation == BinaryExpression.Operation.LE) {
-			return expression.lt(_adjustToEndOfMillis(value));
+			return expression.lt(
+				function.apply(_incrementSecond(_truncateMilliseconds(date))));
+		}
+		else if (operation == BinaryExpression.Operation.NE) {
+			Date truncatedDate = _truncateMilliseconds(date);
+
+			return expression.lt(
+				function.apply(truncatedDate)
+			).or(
+				expression.gte(function.apply(_incrementSecond(truncatedDate)))
+			).withParentheses();
 		}
 
 		return null;
+	}
+
+	private Date _incrementSecond(Date date) {
+		Calendar calendar = CalendarFactoryUtil.getCalendar(date.getTime());
+
+		calendar.add(Calendar.SECOND, 1);
+
+		return calendar.getTime();
+	}
+
+	private Date _truncateMilliseconds(Date date) {
+		Calendar calendar = CalendarFactoryUtil.getCalendar(date.getTime());
+
+		calendar.set(Calendar.MILLISECOND, 0);
+
+		return calendar.getTime();
 	}
 
 }

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/field/predicate/provider/SystemDateFieldPredicateProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/field/predicate/provider/SystemDateFieldPredicateProvider.java
@@ -60,7 +60,7 @@ public class SystemDateFieldPredicateProvider
 
 		if (right instanceof Date) {
 			return _getDateTimePredicate(
-				(Date)right, expression, date -> date, operation);
+				(Date)right, expression, Function.identity(), operation);
 		}
 
 		String valueString = (String)right;

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/field/predicate/provider/SystemDateFieldPredicateProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/field/predicate/provider/SystemDateFieldPredicateProvider.java
@@ -111,11 +111,7 @@ public class SystemDateFieldPredicateProvider
 			predicate = predicate.or(binaryExpressionPredicate);
 		}
 
-		if (predicate != null) {
-			predicate = predicate.withParentheses();
-		}
-
-		return predicate;
+		return Predicate.withParentheses(predicate);
 	}
 
 	@Override

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/field/predicate/provider/SystemDateFieldPredicateProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/field/predicate/provider/SystemDateFieldPredicateProvider.java
@@ -41,22 +41,18 @@ public class SystemDateFieldPredicateProvider
 		Object left, long objectDefinitionId,
 		BinaryExpression.Operation operation, Object right) {
 
+		Expression<String> expression =
+			(Expression<String>)objectDefinitionColumnSupplier.apply(
+				String.valueOf(left));
+
 		if ((operation == BinaryExpression.Operation.NE) && (right == null)) {
-			return objectDefinitionColumnSupplier.apply(
-				String.valueOf(left)
-			).isNotNull();
+			return expression.isNotNull();
 		}
 		else if ((operation == BinaryExpression.Operation.EQ) &&
 				 (right == null)) {
 
-			return objectDefinitionColumnSupplier.apply(
-				String.valueOf(left)
-			).isNull();
+			return expression.isNull();
 		}
-
-		Expression<String> expression =
-			(Expression<String>)objectDefinitionColumnSupplier.apply(
-				String.valueOf(left));
 
 		return _getDateTimePredicate(expression, operation, (String)right);
 	}

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/field/predicate/provider/SystemDateFieldPredicateProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/field/predicate/provider/SystemDateFieldPredicateProvider.java
@@ -119,7 +119,9 @@ public class SystemDateFieldPredicateProvider
 		String fieldName,
 		Function<String, Column<?, ?>> objectDefinitionColumnSupplier) {
 
-		return null;
+		throw new UnsupportedOperationException(
+			"Unsupported method getIsNotEmptyPredicate for " +
+				"dateCreated/dateModified fields");
 	}
 
 	@Override

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/field/predicate/provider/SystemDateFieldPredicateProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/field/predicate/provider/SystemDateFieldPredicateProvider.java
@@ -1,0 +1,267 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.rest.internal.odata.filter.expression.field.predicate.provider;
+
+import com.liferay.object.odata.filter.expression.field.predicate.provider.FieldPredicateProvider;
+import com.liferay.petra.sql.dsl.Column;
+import com.liferay.petra.sql.dsl.expression.Expression;
+import com.liferay.petra.sql.dsl.expression.Predicate;
+import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.odata.filter.expression.BinaryExpression;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+
+import java.util.Date;
+import java.util.List;
+import java.util.function.Function;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Daniel Raposo
+ */
+@Component(
+	property = {
+		"field.predicate.provider.key=dateCreated",
+		"field.predicate.provider.key=dateModified"
+	},
+	service = FieldPredicateProvider.class
+)
+public class SystemDateFieldPredicateProvider
+	implements FieldPredicateProvider {
+
+	@Override
+	public Predicate getBinaryExpressionPredicate(
+		Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
+		Object left, long objectDefinitionId,
+		BinaryExpression.Operation operation, Object right) {
+
+		if ((operation == BinaryExpression.Operation.NE) && (right == null)) {
+			return objectDefinitionColumnSupplier.apply(
+				String.valueOf(left)
+			).isNotNull();
+		}
+		else if ((operation == BinaryExpression.Operation.EQ) &&
+				 (right == null)) {
+
+			return objectDefinitionColumnSupplier.apply(
+				String.valueOf(left)
+			).isNull();
+		}
+
+		Expression<String> expression =
+			(Expression<String>)objectDefinitionColumnSupplier.apply(
+				String.valueOf(left));
+
+		return _getDateTimePredicate(expression, operation, (String)right);
+	}
+
+	@Override
+	public Predicate getContainsPredicate(
+		Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
+		String fieldName, Object fieldValue) {
+
+		throw new UnsupportedOperationException(
+			"Unsupported method getContainsPredicate for " +
+				"dateCreated/dateModified fields");
+	}
+
+	@Override
+	public Predicate getInPredicate(
+		Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
+		Object left, List<Object> rights) {
+
+		Expression<String> expression =
+			(Expression<String>)objectDefinitionColumnSupplier.apply(
+				String.valueOf(left));
+
+		Predicate predicate = null;
+
+		for (Object right : rights) {
+			Predicate eqPredicate = _getDateTimePredicate(
+				expression, BinaryExpression.Operation.EQ, (String)right);
+
+			if (predicate == null) {
+				predicate = eqPredicate;
+			}
+			else {
+				predicate = predicate.or(eqPredicate);
+			}
+		}
+
+		return predicate;
+	}
+
+	@Override
+	public Predicate getIsNotEmptyPredicate(
+		String fieldName,
+		Function<String, Column<?, ?>> objectDefinitionColumnSupplier) {
+
+		return null;
+	}
+
+	@Override
+	public Predicate getStartsWithPredicate(
+		Function<String, Column<?, ?>> objectDefinitionColumnSupplier,
+		String fieldName, Object fieldValue) {
+
+		throw new UnsupportedOperationException(
+			"Unsupported method getStartsWithPredicate for " +
+				"dateCreated/dateModified fields");
+	}
+
+	private <T> T _adjustToEndOfMillis(T value) {
+		String dateString = (String)_adjustToStartOfMillis(value);
+
+		if (value instanceof String) {
+			try {
+				String pattern = _getDateTimePattern(dateString);
+
+				DateFormat dateFormat =
+					DateFormatFactoryUtil.getSimpleDateFormat(pattern);
+
+				Date date = dateFormat.parse((String)dateString);
+
+				date.setTime(date.getTime() + 1000);
+
+				return (T)dateFormat.format(date);
+			}
+			catch (ParseException parseException) {
+				throw new IllegalArgumentException(
+					"Unable to parse date from " + value, parseException);
+			}
+		}
+		else if (value instanceof Date) {
+			Date date = (Date)value;
+
+			date.setTime(date.getTime() + 1000);
+
+			return (T)date;
+		}
+
+		return value;
+	}
+
+	private <T> T _adjustToStartOfMillis(T value) {
+		if (value instanceof String) {
+			String dateString = (String)value;
+
+			try {
+				String pattern = _getDateTimePattern(dateString);
+
+				DateFormat dateFormat =
+					DateFormatFactoryUtil.getSimpleDateFormat(pattern);
+
+				if (pattern.equals("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")) {
+					if (dateString.matches(
+							"^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$")) {
+
+						dateString = StringUtil.replace(
+							dateString, 'Z', ".000Z");
+					}
+					else if (dateString.matches(
+								"^\\d{4}-\\d{2}-\\d{2}T\\d{2}:" +
+									"\\d{2}:\\d{2}\\.\\d{4,}Z$")) {
+
+						String truncatedDateString = dateString.substring(
+							0, dateString.indexOf('.') + 4);
+
+						dateString = truncatedDateString + "Z";
+					}
+				}
+
+				Date date = dateFormat.parse(dateString);
+
+				date.setTime((date.getTime() / 1000) * 1000);
+
+				if (dateString.length() == 20) {
+					return (T)DateFormatFactoryUtil.getSimpleDateFormat(
+						"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+					).format(
+						date
+					);
+				}
+
+				return (T)dateFormat.format(date);
+			}
+			catch (ParseException parseException) {
+				throw new IllegalArgumentException(
+					"Unable to parse date from " + dateString, parseException);
+			}
+		}
+		else if (value instanceof Date) {
+			Date date = (Date)value;
+
+			date.setTime((date.getTime() / 1000) * 1000);
+
+			return (T)date;
+		}
+
+		return value;
+	}
+
+	private String _getDateTimePattern(String value) {
+		if (value.matches(
+				"^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$")) {
+
+			return "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"; // oData
+		}
+
+		if (value.length() == 23) {
+			return "yyyy-MM-dd HH:mm:ss.SSS"; // Hypersonic, DB2
+		}
+
+		if (value.length() == 27) {
+			return "dd-MMM-yyyy HH:mm:ss.SSS a"; // Oracle (24-hour format)
+		}
+
+		throw new IllegalArgumentException(
+			"Unrecognized date format: " + value);
+	}
+
+	private <T> Predicate _getDateTimePredicate(
+		Expression<T> expression, BinaryExpression.Operation operation,
+		T value) {
+
+		if (operation == BinaryExpression.Operation.EQ) {
+			T startOfSecond = _adjustToStartOfMillis(value);
+			T endOfSecond = _adjustToEndOfMillis(value);
+
+			return expression.gte(
+				startOfSecond
+			).and(
+				expression.lt(endOfSecond)
+			);
+		}
+		else if (operation == BinaryExpression.Operation.NE) {
+			T startOfSecond = _adjustToStartOfMillis(value);
+			T endOfSecond = _adjustToEndOfMillis(value);
+
+			return expression.lt(
+				startOfSecond
+			).or(
+				expression.gte(endOfSecond)
+			);
+		}
+		else if (operation == BinaryExpression.Operation.GT) {
+			return expression.gte(_adjustToEndOfMillis(value));
+		}
+		else if (operation == BinaryExpression.Operation.GE) {
+			return expression.gte(_adjustToStartOfMillis(value));
+		}
+		else if (operation == BinaryExpression.Operation.LT) {
+			return expression.lt(_adjustToStartOfMillis(value));
+		}
+		else if (operation == BinaryExpression.Operation.LE) {
+			return expression.lt(_adjustToEndOfMillis(value));
+		}
+
+		return null;
+	}
+
+}

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/field/predicate/provider/SystemDateFieldPredicateProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/field/predicate/provider/SystemDateFieldPredicateProvider.java
@@ -111,7 +111,11 @@ public class SystemDateFieldPredicateProvider
 			predicate = predicate.or(binaryExpressionPredicate);
 		}
 
-		return predicate.withParentheses();
+		if (predicate != null) {
+			predicate = predicate.withParentheses();
+		}
+
+		return predicate;
 	}
 
 	@Override

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/field/predicate/provider/SystemDateFieldPredicateProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/field/predicate/provider/SystemDateFieldPredicateProvider.java
@@ -217,7 +217,7 @@ public class SystemDateFieldPredicateProvider
 		}
 
 		if (value.length() == 27) {
-			return "dd-MMM-yyyy HH:mm:ss.SSS a"; // Oracle (24-hour format)
+			return "dd-MMM-yyyy HH:mm:ss.SSS a"; // Oracle
 		}
 
 		throw new IllegalArgumentException(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -5269,21 +5269,27 @@ public class ObjectEntryResourceTest {
 			_objectDefinition1, _OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1);
 		_objectEntry2 = ObjectEntryTestUtil.addObjectEntry(
 			_objectDefinition1, _OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_2);
+		_objectEntry3 = ObjectEntryTestUtil.addObjectEntry(
+			_objectDefinition1, _OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_3);
 
 		_objectEntry1.setCreateDate(
 			_dateTimeDateFormat.parse("2023-09-20T10:00:00.150Z"));
 		_objectEntry2.setCreateDate(
 			_dateTimeDateFormat.parse("2023-09-20T10:05:00.450Z"));
+		_objectEntry3.setCreateDate(null);
 
 		_objectEntry1.setModifiedDate(
 			_dateTimeDateFormat.parse("2023-09-20T10:00:00.150Z"));
 		_objectEntry2.setModifiedDate(
 			_dateTimeDateFormat.parse("2023-09-20T10:05:00.450Z"));
+		_objectEntry3.setModifiedDate(null);
 
 		_objectEntry1 = _objectEntryLocalService.updateObjectEntry(
 			_objectEntry1);
 		_objectEntry2 = _objectEntryLocalService.updateObjectEntry(
 			_objectEntry2);
+		_objectEntry3 = _objectEntryLocalService.updateObjectEntry(
+			_objectEntry3);
 
 		for (String fieldName : new String[] {"dateCreated", "dateModified"}) {
 
@@ -5305,6 +5311,9 @@ public class ObjectEntryResourceTest {
 				_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_2,
 				URLCodec.encodeURL(fieldName + " eq 2023-09-20T10:05:00.999Z"),
 				_objectDefinition1);
+			_assertFilterString(
+				_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_3,
+				URLCodec.encodeURL(fieldName + " eq null"), _objectDefinition1);
 
 			// Test case for 'ge' (greater than or equal)
 
@@ -5333,10 +5342,6 @@ public class ObjectEntryResourceTest {
 			_assertFilteredObjectEntries(
 				2,
 				fieldName + " in (2023-09-20T10:05:00Z,2023-09-20T10:00:00Z)");
-
-			// Test case for 'isNotEmpty' (check that dateModified is not null)
-
-			_assertFilteredObjectEntries(2, fieldName + " ne null");
 
 			// Test case for 'le' (less than or equal)
 
@@ -5370,6 +5375,7 @@ public class ObjectEntryResourceTest {
 				_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_2,
 				URLCodec.encodeURL(fieldName + " ne 2023-09-20T10:00:00Z"),
 				_objectDefinition1);
+			_assertFilteredObjectEntries(2, fieldName + " ne null");
 		}
 	}
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -5264,12 +5264,17 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
-	public void testGetObjectEntriesFilteredByDateModified() throws Exception {
+	public void testGetObjectEntriesFilteredBySystemDate() throws Exception {
 		_objectEntry1 = ObjectEntryTestUtil.addObjectEntry(
 			_objectDefinition1, _OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1);
 
 		_objectEntry2 = ObjectEntryTestUtil.addObjectEntry(
 			_objectDefinition1, _OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_2);
+
+		_objectEntry1.setCreateDate(
+			_dateTimeDateFormat.parse("2023-09-20T10:00:00.150Z"));
+		_objectEntry2.setCreateDate(
+			_dateTimeDateFormat.parse("2023-09-20T10:05:00.450Z"));
 
 		_objectEntry1.setModifiedDate(
 			_dateTimeDateFormat.parse("2023-09-20T10:00:00.150Z"));
@@ -5281,79 +5286,92 @@ public class ObjectEntryResourceTest {
 		_objectEntry2 = _objectEntryLocalService.updateObjectEntry(
 			_objectEntry2);
 
-		// Test case for 'gt' (greater than)
+		String[] dateFields = {"dateModified", "dateCreated"};
 
-		_assertFilterString(
-			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_2,
-			URLCodec.encodeURL("dateModified gt 2023-09-20T10:00:00.150Z"),
-			_objectDefinition1);
-		_assertFilterString(
-			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_2,
-			URLCodec.encodeURL("dateModified gt 2023-09-20T10:00:00Z"),
-			_objectDefinition1);
+		for (String dateFieldName : dateFields) {
 
-		// Test case for 'ge' (greater than or equal)
+			// Test case for 'eq' (equal)
 
-		_assertFilteredObjectEntries(
-			2, "dateModified ge 2023-09-20T10:00:00.400Z");
-		_assertFilteredObjectEntries(2, "dateModified ge 2023-09-20T10:00:00Z");
+			_assertFilterString(
+				_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+				URLCodec.encodeURL(dateFieldName + " eq 2023-09-20T10:00:00Z"),
+				_objectDefinition1);
+			_assertFilterString(
+				_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+				URLCodec.encodeURL(dateFieldName + " eq 2023-09-20T10:00:00.999Z"),
+				_objectDefinition1);
 
-		// Test case for 'lt' (less than)
+			_assertFilterString(
+				_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_2,
+				URLCodec.encodeURL(dateFieldName + " eq 2023-09-20T10:05:00Z"),
+				_objectDefinition1);
+			_assertFilterString(
+				_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_2,
+				URLCodec.encodeURL(dateFieldName + " eq 2023-09-20T10:05:00.999Z"),
+				_objectDefinition1);
 
-		_assertFilterString(
-			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
-			URLCodec.encodeURL("dateModified lt 2023-09-20T10:05:00.450Z"),
-			_objectDefinition1);
-		_assertFilterString(
-			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
-			URLCodec.encodeURL("dateModified lt 2023-09-20T10:05:00Z"),
-			_objectDefinition1);
+			// Test case for 'ge' (greater than or equal)
 
-		// Test case for 'le' (less than or equal)
+			_assertFilteredObjectEntries(
+				2, dateFieldName + " ge 2023-09-20T10:00:00Z");
+			_assertFilteredObjectEntries(
+				2, dateFieldName + " ge 2023-09-20T10:00:00.999Z");
+			_assertFilteredObjectEntries(
+				1, dateFieldName + " ge 2023-09-20T10:00:01Z");
 
-		_assertFilteredObjectEntries(
-			2, "dateModified le 2023-09-20T10:05:00.700Z");
-		_assertFilteredObjectEntries(2, "dateModified le 2023-09-20T10:05:00Z");
+			// Test case for 'gt' (greater than)
 
-		// Test case for 'eq' (equal)
+			_assertFilterString(
+				_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_2,
+				URLCodec.encodeURL(dateFieldName + " gt 2023-09-20T10:00:00Z"),
+				_objectDefinition1);
+			_assertFilterString(
+				_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_2,
+				URLCodec.encodeURL(dateFieldName + " gt 2023-09-20T10:00:00.999Z"),
+				_objectDefinition1);
 
-		_assertFilterString(
-			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
-			URLCodec.encodeURL("dateModified eq 2023-09-20T10:00:00.300Z"),
-			_objectDefinition1);
-		_assertFilterString(
-			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
-			URLCodec.encodeURL("dateModified eq 2023-09-20T10:00:00Z"),
-			_objectDefinition1);
 
-		_assertFilterString(
-			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_2,
-			URLCodec.encodeURL("dateModified eq 2023-09-20T10:05:00.200Z"),
-			_objectDefinition1);
-		_assertFilterString(
-			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_2,
-			URLCodec.encodeURL("dateModified eq 2023-09-20T10:05:00Z"),
-			_objectDefinition1);
+			// Test case for 'in' (multiple values)
 
-		// Test case for 'ne' (not equal)
+			_assertFilteredObjectEntries(
+				2,
+				dateFieldName + " in (2023-09-20T10:05:00Z,2023-09-20T10:00:00Z)");
 
-		_assertFilterString(
-			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_2,
-			URLCodec.encodeURL("dateModified ne 2023-09-20T10:00:00Z"),
-			_objectDefinition1);
-		_assertFilterString(
-			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
-			URLCodec.encodeURL("dateModified ne 2023-09-20T10:05:00Z"),
-			_objectDefinition1);
+			// Test case for 'isNotEmpty' (check that dateModified is not null)
 
-		// Test case for 'in' (multiple values)
+			_assertFilteredObjectEntries(2, dateFieldName + " ne null");
 
-		_assertFilteredObjectEntries(
-			2, "dateModified in (2023-09-20T10:05:00Z,2023-09-20T10:00:00Z)");
+			// Test case for 'le' (less than or equal)
 
-		// Test case for 'isNotEmpty' (check that dateModified is not null)
+			_assertFilteredObjectEntries(
+				2, dateFieldName + " le 2023-09-20T10:05:00Z");
+			_assertFilteredObjectEntries(
+				2, dateFieldName + " le 2023-09-20T10:05:00.999Z");
+			_assertFilteredObjectEntries(
+				1, dateFieldName + " le 2023-09-20T10:04:00.999Z");
 
-		_assertFilteredObjectEntries(2, "dateModified ne null");
+			// Test case for 'lt' (less than)
+
+			_assertFilterString(
+				_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+				URLCodec.encodeURL(dateFieldName + " lt 2023-09-20T10:05:00Z"),
+				_objectDefinition1);
+			_assertFilterString(
+				_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+				URLCodec.encodeURL(dateFieldName + " lt 2023-09-20T10:05:00.999Z"),
+				_objectDefinition1);
+
+			// Test case for 'ne' (not equal)
+
+			_assertFilterString(
+				_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+				URLCodec.encodeURL(dateFieldName + " ne 2023-09-20T10:05:00Z"),
+				_objectDefinition1);
+			_assertFilterString(
+				_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_2,
+				URLCodec.encodeURL(dateFieldName + " ne 2023-09-20T10:00:00Z"),
+				_objectDefinition1);
+		}
 	}
 
 	@Test

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -5286,90 +5286,87 @@ public class ObjectEntryResourceTest {
 		_objectEntry2 = _objectEntryLocalService.updateObjectEntry(
 			_objectEntry2);
 
-		String[] dateFields = {"dateModified", "dateCreated"};
-
-		for (String dateFieldName : dateFields) {
+		for (String fieldName : new String[] {"dateCreated", "dateModified"}) {
 
 			// Test case for 'eq' (equal)
 
 			_assertFilterString(
 				_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
-				URLCodec.encodeURL(dateFieldName + " eq 2023-09-20T10:00:00Z"),
+				URLCodec.encodeURL(fieldName + " eq 2023-09-20T10:00:00Z"),
 				_objectDefinition1);
 			_assertFilterString(
 				_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
-				URLCodec.encodeURL(dateFieldName + " eq 2023-09-20T10:00:00.999Z"),
+				URLCodec.encodeURL(fieldName + " eq 2023-09-20T10:00:00.999Z"),
 				_objectDefinition1);
 
 			_assertFilterString(
 				_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_2,
-				URLCodec.encodeURL(dateFieldName + " eq 2023-09-20T10:05:00Z"),
+				URLCodec.encodeURL(fieldName + " eq 2023-09-20T10:05:00Z"),
 				_objectDefinition1);
 			_assertFilterString(
 				_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_2,
-				URLCodec.encodeURL(dateFieldName + " eq 2023-09-20T10:05:00.999Z"),
+				URLCodec.encodeURL(fieldName + " eq 2023-09-20T10:05:00.999Z"),
 				_objectDefinition1);
 
 			// Test case for 'ge' (greater than or equal)
 
 			_assertFilteredObjectEntries(
-				2, dateFieldName + " ge 2023-09-20T10:00:00Z");
+				2, fieldName + " ge 2023-09-20T10:00:00Z");
 			_assertFilteredObjectEntries(
-				2, dateFieldName + " ge 2023-09-20T10:00:00.999Z");
+				2, fieldName + " ge 2023-09-20T10:00:00.999Z");
 			_assertFilteredObjectEntries(
-				1, dateFieldName + " ge 2023-09-20T10:00:01Z");
+				1, fieldName + " ge 2023-09-20T10:00:01Z");
 
 			// Test case for 'gt' (greater than)
 
 			_assertFilterString(
 				_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_2,
-				URLCodec.encodeURL(dateFieldName + " gt 2023-09-20T10:00:00Z"),
+				URLCodec.encodeURL(fieldName + " gt 2023-09-20T10:00:00Z"),
 				_objectDefinition1);
 			_assertFilterString(
 				_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_2,
-				URLCodec.encodeURL(dateFieldName + " gt 2023-09-20T10:00:00.999Z"),
+				URLCodec.encodeURL(fieldName + " gt 2023-09-20T10:00:00.999Z"),
 				_objectDefinition1);
-
 
 			// Test case for 'in' (multiple values)
 
 			_assertFilteredObjectEntries(
 				2,
-				dateFieldName + " in (2023-09-20T10:05:00Z,2023-09-20T10:00:00Z)");
+				fieldName + " in (2023-09-20T10:05:00Z,2023-09-20T10:00:00Z)");
 
 			// Test case for 'isNotEmpty' (check that dateModified is not null)
 
-			_assertFilteredObjectEntries(2, dateFieldName + " ne null");
+			_assertFilteredObjectEntries(2, fieldName + " ne null");
 
 			// Test case for 'le' (less than or equal)
 
 			_assertFilteredObjectEntries(
-				2, dateFieldName + " le 2023-09-20T10:05:00Z");
+				2, fieldName + " le 2023-09-20T10:05:00Z");
 			_assertFilteredObjectEntries(
-				2, dateFieldName + " le 2023-09-20T10:05:00.999Z");
+				2, fieldName + " le 2023-09-20T10:05:00.999Z");
 			_assertFilteredObjectEntries(
-				1, dateFieldName + " le 2023-09-20T10:04:00.999Z");
+				1, fieldName + " le 2023-09-20T10:04:00.999Z");
 
 			// Test case for 'lt' (less than)
 
 			_assertFilterString(
 				_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
-				URLCodec.encodeURL(dateFieldName + " lt 2023-09-20T10:05:00Z"),
+				URLCodec.encodeURL(fieldName + " lt 2023-09-20T10:05:00Z"),
 				_objectDefinition1);
 			_assertFilterString(
 				_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
-				URLCodec.encodeURL(dateFieldName + " lt 2023-09-20T10:05:00.999Z"),
+				URLCodec.encodeURL(fieldName + " lt 2023-09-20T10:05:00.999Z"),
 				_objectDefinition1);
 
 			// Test case for 'ne' (not equal)
 
 			_assertFilterString(
 				_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
-				URLCodec.encodeURL(dateFieldName + " ne 2023-09-20T10:05:00Z"),
+				URLCodec.encodeURL(fieldName + " ne 2023-09-20T10:05:00Z"),
 				_objectDefinition1);
 			_assertFilterString(
 				_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_2,
-				URLCodec.encodeURL(dateFieldName + " ne 2023-09-20T10:00:00Z"),
+				URLCodec.encodeURL(fieldName + " ne 2023-09-20T10:00:00Z"),
 				_objectDefinition1);
 		}
 	}

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -5267,7 +5267,6 @@ public class ObjectEntryResourceTest {
 	public void testGetObjectEntriesFilteredBySystemDate() throws Exception {
 		_objectEntry1 = ObjectEntryTestUtil.addObjectEntry(
 			_objectDefinition1, _OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1);
-
 		_objectEntry2 = ObjectEntryTestUtil.addObjectEntry(
 			_objectDefinition1, _OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_2);
 
@@ -5298,7 +5297,6 @@ public class ObjectEntryResourceTest {
 				_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
 				URLCodec.encodeURL(fieldName + " eq 2023-09-20T10:00:00.999Z"),
 				_objectDefinition1);
-
 			_assertFilterString(
 				_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_2,
 				URLCodec.encodeURL(fieldName + " eq 2023-09-20T10:05:00Z"),
@@ -5314,8 +5312,10 @@ public class ObjectEntryResourceTest {
 				2, fieldName + " ge 2023-09-20T10:00:00Z");
 			_assertFilteredObjectEntries(
 				2, fieldName + " ge 2023-09-20T10:00:00.999Z");
-			_assertFilteredObjectEntries(
-				1, fieldName + " ge 2023-09-20T10:00:01Z");
+			_assertFilterString(
+				_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_2,
+				URLCodec.encodeURL(fieldName + " ge 2023-09-20T10:00:01Z"),
+				_objectDefinition1);
 
 			// Test case for 'gt' (greater than)
 
@@ -5344,8 +5344,10 @@ public class ObjectEntryResourceTest {
 				2, fieldName + " le 2023-09-20T10:05:00Z");
 			_assertFilteredObjectEntries(
 				2, fieldName + " le 2023-09-20T10:05:00.999Z");
-			_assertFilteredObjectEntries(
-				1, fieldName + " le 2023-09-20T10:04:00.999Z");
+			_assertFilterString(
+				_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+				URLCodec.encodeURL(fieldName + " le 2023-09-20T10:04:00.999Z"),
+				_objectDefinition1);
 
 			// Test case for 'lt' (less than)
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -5264,6 +5264,99 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
+	public void testGetObjectEntriesFilteredByDateModified() throws Exception {
+		_objectEntry1 = ObjectEntryTestUtil.addObjectEntry(
+			_objectDefinition1, _OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1);
+
+		_objectEntry2 = ObjectEntryTestUtil.addObjectEntry(
+			_objectDefinition1, _OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_2);
+
+		_objectEntry1.setModifiedDate(
+			_dateTimeDateFormat.parse("2023-09-20T10:00:00.150Z"));
+		_objectEntry2.setModifiedDate(
+			_dateTimeDateFormat.parse("2023-09-20T10:05:00.450Z"));
+
+		_objectEntry1 = _objectEntryLocalService.updateObjectEntry(
+			_objectEntry1);
+		_objectEntry2 = _objectEntryLocalService.updateObjectEntry(
+			_objectEntry2);
+
+		// Test case for 'gt' (greater than)
+
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_2,
+			URLCodec.encodeURL("dateModified gt 2023-09-20T10:00:00.150Z"),
+			_objectDefinition1);
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_2,
+			URLCodec.encodeURL("dateModified gt 2023-09-20T10:00:00Z"),
+			_objectDefinition1);
+
+		// Test case for 'ge' (greater than or equal)
+
+		_assertFilteredObjectEntries(
+			2, "dateModified ge 2023-09-20T10:00:00.400Z");
+		_assertFilteredObjectEntries(2, "dateModified ge 2023-09-20T10:00:00Z");
+
+		// Test case for 'lt' (less than)
+
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			URLCodec.encodeURL("dateModified lt 2023-09-20T10:05:00.450Z"),
+			_objectDefinition1);
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			URLCodec.encodeURL("dateModified lt 2023-09-20T10:05:00Z"),
+			_objectDefinition1);
+
+		// Test case for 'le' (less than or equal)
+
+		_assertFilteredObjectEntries(
+			2, "dateModified le 2023-09-20T10:05:00.700Z");
+		_assertFilteredObjectEntries(2, "dateModified le 2023-09-20T10:05:00Z");
+
+		// Test case for 'eq' (equal)
+
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			URLCodec.encodeURL("dateModified eq 2023-09-20T10:00:00.300Z"),
+			_objectDefinition1);
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			URLCodec.encodeURL("dateModified eq 2023-09-20T10:00:00Z"),
+			_objectDefinition1);
+
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_2,
+			URLCodec.encodeURL("dateModified eq 2023-09-20T10:05:00.200Z"),
+			_objectDefinition1);
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_2,
+			URLCodec.encodeURL("dateModified eq 2023-09-20T10:05:00Z"),
+			_objectDefinition1);
+
+		// Test case for 'ne' (not equal)
+
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_2,
+			URLCodec.encodeURL("dateModified ne 2023-09-20T10:00:00Z"),
+			_objectDefinition1);
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			URLCodec.encodeURL("dateModified ne 2023-09-20T10:05:00Z"),
+			_objectDefinition1);
+
+		// Test case for 'in' (multiple values)
+
+		_assertFilteredObjectEntries(
+			2, "dateModified in (2023-09-20T10:05:00Z,2023-09-20T10:00:00Z)");
+
+		// Test case for 'isNotEmpty' (check that dateModified is not null)
+
+		_assertFilteredObjectEntries(2, "dateModified ne null");
+	}
+
+	@Test
 	public void testGetObjectEntriesWithPagination() throws Exception {
 		ObjectEntryTestUtil.addObjectEntry(
 			_objectDefinition6, _OBJECT_FIELD_NAME_TEXT,


### PR DESCRIPTION
**What's changed?**
In this PR, two key changes have been made to address issues related to date filtering for system object fields of type `DATE_TIME`:

1. **Date Format Alignment**: The query logic has been updated to ensure the correct formatting of `DATE_TIME` values when filtering `dateCreated` and `dateModified`. The changes ensure:
   - Seconds are correctly accepted and the filters work as expected.
   - Milliseconds are ignored, addressing issues where inconsistent precision (such as milliseconds) caused mismatches.

2. **Fix in `PredicateExpressionVisitorImpl._getInPredicate`**: A bug in the `_getInPredicate` method has been fixed. Previously, the right-side values in filter comparisons were not being correctly formatted, especially for dates. Since date formats vary across different databases, this led to filter failures. The PR corrects this by ensuring that dates are formatted uniformly regardless of the database being used.

Additionally, an **integration test** has been added to ensure these fixes work as intended, particularly for date filtering scenarios.

See the following Jira Ticket: [LPD-37767](https://liferay.atlassian.net/browse/LPD-37767)