### PR TITLE
LPD 30463 | Can't sort by object nestedField of type boolean when using Oracle

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIEndpointRelevantObjectEntryModelListener.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIEndpointRelevantObjectEntryModelListener.java
@@ -197,12 +197,10 @@ public class APIEndpointRelevantObjectEntryModelListener
 			Predicate predicate = _filterFactory.create(
 				filterString, apiEndpointObjectDefinition);
 
-			List<Map<String, Serializable>> valuesList =
-				_objectEntryLocalService.getValuesList(
-					objectEntry.getGroupId(), objectEntry.getCompanyId(),
-					objectEntry.getUserId(),
-					objectEntry.getObjectDefinitionId(), null, predicate, null,
-					-1, -1, null);
+			List<Long> valuesList = _objectEntryLocalService.getPrimaryKeyList(
+				objectEntry.getGroupId(), objectEntry.getCompanyId(),
+				objectEntry.getUserId(), objectEntry.getObjectDefinitionId(),
+				null, predicate, null, -1, -1, null);
 
 			if (!valuesList.isEmpty()) {
 				throw new ObjectEntryValuesException.InvalidObjectField(

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIEndpointRelevantObjectEntryModelListener.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIEndpointRelevantObjectEntryModelListener.java
@@ -28,6 +28,7 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -197,12 +198,13 @@ public class APIEndpointRelevantObjectEntryModelListener
 			Predicate predicate = _filterFactory.create(
 				filterString, apiEndpointObjectDefinition);
 
-			List<Long> valuesList = _objectEntryLocalService.getPrimaryKeyList(
-				objectEntry.getGroupId(), objectEntry.getCompanyId(),
-				objectEntry.getUserId(), objectEntry.getObjectDefinitionId(),
-				predicate, null, -1, -1, null);
+			if (ListUtil.isNotEmpty(
+					_objectEntryLocalService.getPrimaryKeyList(
+						objectEntry.getGroupId(), objectEntry.getCompanyId(),
+						objectEntry.getUserId(),
+						objectEntry.getObjectDefinitionId(), predicate, null,
+						-1, -1, null))) {
 
-			if (!valuesList.isEmpty()) {
 				throw new ObjectEntryValuesException.InvalidObjectField(
 					null,
 					"There is an API endpoint with the same HTTP method and " +

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIEndpointRelevantObjectEntryModelListener.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIEndpointRelevantObjectEntryModelListener.java
@@ -200,7 +200,7 @@ public class APIEndpointRelevantObjectEntryModelListener
 			List<Long> valuesList = _objectEntryLocalService.getPrimaryKeyList(
 				objectEntry.getGroupId(), objectEntry.getCompanyId(),
 				objectEntry.getUserId(), objectEntry.getObjectDefinitionId(),
-				null, predicate, null, -1, -1, null);
+				predicate, null, -1, -1, null);
 
 			if (!valuesList.isEmpty()) {
 				throw new ObjectEntryValuesException.InvalidObjectField(

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIPropertyRelevantObjectEntryModelListener.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIPropertyRelevantObjectEntryModelListener.java
@@ -239,7 +239,7 @@ public class APIPropertyRelevantObjectEntryModelListener
 			}
 
 			if (ListUtil.isNotEmpty(
-					_objectEntryLocalService.getValuesList(
+					_objectEntryLocalService.getPrimaryKeyList(
 						objectEntry.getGroupId(), objectEntry.getCompanyId(),
 						objectEntry.getUserId(),
 						objectEntry.getObjectDefinitionId(), null,

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIPropertyRelevantObjectEntryModelListener.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIPropertyRelevantObjectEntryModelListener.java
@@ -242,7 +242,7 @@ public class APIPropertyRelevantObjectEntryModelListener
 					_objectEntryLocalService.getPrimaryKeyList(
 						objectEntry.getGroupId(), objectEntry.getCompanyId(),
 						objectEntry.getUserId(),
-						objectEntry.getObjectDefinitionId(), null,
+						objectEntry.getObjectDefinitionId(),
 						_filterFactory.create(
 							StringBundler.concat(
 								"id ne '", objectEntry.getObjectEntryId(),

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/object/deployer/APIPropertyObjectDefinitionDeployerImpl.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/object/deployer/APIPropertyObjectDefinitionDeployerImpl.java
@@ -20,6 +20,7 @@ import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.osgi.util.ServiceTrackerFactory;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
@@ -129,13 +130,14 @@ public class APIPropertyObjectDefinitionDeployerImpl
 			return;
 		}
 
-		List<Map<String, Serializable>> valuesList =
-			_objectEntryLocalService.getValuesList(
+		List<Map<String, Serializable>> valuesList = TransformUtil.transform(
+			_objectEntryLocalService.getPrimaryKeyList(
 				GroupThreadLocal.getGroupId(), objectDefinition.getCompanyId(),
 				objectDefinition.getUserId(),
 				objectDefinition.getObjectDefinitionId(), null,
 				_filterFactory.create("type eq null", objectDefinition), null,
-				QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS, null),
+			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
 
 		for (Map<String, Serializable> values : valuesList) {
 			Collection<Serializable> collection = values.values();

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/object/deployer/APIPropertyObjectDefinitionDeployerImpl.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/object/deployer/APIPropertyObjectDefinitionDeployerImpl.java
@@ -134,7 +134,7 @@ public class APIPropertyObjectDefinitionDeployerImpl
 			_objectEntryLocalService.getPrimaryKeyList(
 				GroupThreadLocal.getGroupId(), objectDefinition.getCompanyId(),
 				objectDefinition.getUserId(),
-				objectDefinition.getObjectDefinitionId(), null,
+				objectDefinition.getObjectDefinitionId(),
 				_filterFactory.create("type eq null", objectDefinition), null,
 				QueryUtil.ALL_POS, QueryUtil.ALL_POS, null),
 			primaryKey -> _objectEntryLocalService.getValues(primaryKey));

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalService.java
@@ -426,6 +426,13 @@ public interface ObjectEntryLocalService
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<Long> getPrimaryKeyList(
+			long groupId, long companyId, long userId, long objectDefinitionId,
+			String[] selectedObjectFieldNames, Predicate predicate,
+			String search, int start, int end, Sort[] sorts)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public Map<String, Object> getSystemModelAttributes(
 			ObjectDefinition objectDefinition, long primaryKey)
 		throws PortalException;
@@ -444,13 +451,6 @@ public interface ObjectEntryLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public Map<String, Serializable> getValues(ObjectEntry objectEntry)
-		throws PortalException;
-
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public List<Map<String, Serializable>> getValuesList(
-			long groupId, long companyId, long userId, long objectDefinitionId,
-			String[] selectedObjectFieldNames, Predicate predicate,
-			String search, int start, int end, Sort[] sorts)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalService.java
@@ -428,8 +428,8 @@ public interface ObjectEntryLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<Long> getPrimaryKeyList(
 			long groupId, long companyId, long userId, long objectDefinitionId,
-			Predicate predicate, String search,
-			int start, int end, Sort[] sorts)
+			Predicate predicate, String search, int start, int end,
+			Sort[] sorts)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalService.java
@@ -428,8 +428,8 @@ public interface ObjectEntryLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<Long> getPrimaryKeyList(
 			long groupId, long companyId, long userId, long objectDefinitionId,
-			String[] selectedObjectFieldNames, Predicate predicate,
-			String search, int start, int end, Sort[] sorts)
+			Predicate predicate, String search,
+			int start, int end, Sort[] sorts)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceUtil.java
@@ -538,6 +538,19 @@ public class ObjectEntryLocalServiceUtil {
 		return getService().getPersistedModel(primaryKeyObj);
 	}
 
+	public static List<Long> getPrimaryKeyList(
+			long groupId, long companyId, long userId, long objectDefinitionId,
+			String[] selectedObjectFieldNames,
+			com.liferay.petra.sql.dsl.expression.Predicate predicate,
+			String search, int start, int end,
+			com.liferay.portal.kernel.search.Sort[] sorts)
+		throws PortalException {
+
+		return getService().getPrimaryKeyList(
+			groupId, companyId, userId, objectDefinitionId,
+			selectedObjectFieldNames, predicate, search, start, end, sorts);
+	}
+
 	public static Map<String, Object> getSystemModelAttributes(
 			com.liferay.object.model.ObjectDefinition objectDefinition,
 			long primaryKey)
@@ -570,19 +583,6 @@ public class ObjectEntryLocalServiceUtil {
 		throws PortalException {
 
 		return getService().getValues(objectEntry);
-	}
-
-	public static List<Map<String, Serializable>> getValuesList(
-			long groupId, long companyId, long userId, long objectDefinitionId,
-			String[] selectedObjectFieldNames,
-			com.liferay.petra.sql.dsl.expression.Predicate predicate,
-			String search, int start, int end,
-			com.liferay.portal.kernel.search.Sort[] sorts)
-		throws PortalException {
-
-		return getService().getValuesList(
-			groupId, companyId, userId, objectDefinitionId,
-			selectedObjectFieldNames, predicate, search, start, end, sorts);
 	}
 
 	public static int getValuesListCount(

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceUtil.java
@@ -540,7 +540,6 @@ public class ObjectEntryLocalServiceUtil {
 
 	public static List<Long> getPrimaryKeyList(
 			long groupId, long companyId, long userId, long objectDefinitionId,
-			String[] selectedObjectFieldNames,
 			com.liferay.petra.sql.dsl.expression.Predicate predicate,
 			String search, int start, int end,
 			com.liferay.portal.kernel.search.Sort[] sorts)
@@ -548,7 +547,7 @@ public class ObjectEntryLocalServiceUtil {
 
 		return getService().getPrimaryKeyList(
 			groupId, companyId, userId, objectDefinitionId,
-			selectedObjectFieldNames, predicate, search, start, end, sorts);
+			predicate, search, start, end, sorts);
 	}
 
 	public static Map<String, Object> getSystemModelAttributes(

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceUtil.java
@@ -546,8 +546,8 @@ public class ObjectEntryLocalServiceUtil {
 		throws PortalException {
 
 		return getService().getPrimaryKeyList(
-			groupId, companyId, userId, objectDefinitionId,
-			predicate, search, start, end, sorts);
+			groupId, companyId, userId, objectDefinitionId, predicate, search,
+			start, end, sorts);
 	}
 
 	public static Map<String, Object> getSystemModelAttributes(

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceWrapper.java
@@ -617,6 +617,20 @@ public class ObjectEntryLocalServiceWrapper
 	}
 
 	@Override
+	public java.util.List<Long> getPrimaryKeyList(
+			long groupId, long companyId, long userId, long objectDefinitionId,
+			String[] selectedObjectFieldNames,
+			com.liferay.petra.sql.dsl.expression.Predicate predicate,
+			String search, int start, int end,
+			com.liferay.portal.kernel.search.Sort[] sorts)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _objectEntryLocalService.getPrimaryKeyList(
+			groupId, companyId, userId, objectDefinitionId,
+			selectedObjectFieldNames, predicate, search, start, end, sorts);
+	}
+
+	@Override
 	public java.util.Map<String, Object> getSystemModelAttributes(
 			com.liferay.object.model.ObjectDefinition objectDefinition,
 			long primaryKey)
@@ -656,21 +670,6 @@ public class ObjectEntryLocalServiceWrapper
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _objectEntryLocalService.getValues(objectEntry);
-	}
-
-	@Override
-	public java.util.List<java.util.Map<String, java.io.Serializable>>
-			getValuesList(
-				long groupId, long companyId, long userId,
-				long objectDefinitionId, String[] selectedObjectFieldNames,
-				com.liferay.petra.sql.dsl.expression.Predicate predicate,
-				String search, int start, int end,
-				com.liferay.portal.kernel.search.Sort[] sorts)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _objectEntryLocalService.getValuesList(
-			groupId, companyId, userId, objectDefinitionId,
-			selectedObjectFieldNames, predicate, search, start, end, sorts);
 	}
 
 	@Override

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceWrapper.java
@@ -619,7 +619,6 @@ public class ObjectEntryLocalServiceWrapper
 	@Override
 	public java.util.List<Long> getPrimaryKeyList(
 			long groupId, long companyId, long userId, long objectDefinitionId,
-			String[] selectedObjectFieldNames,
 			com.liferay.petra.sql.dsl.expression.Predicate predicate,
 			String search, int start, int end,
 			com.liferay.portal.kernel.search.Sort[] sorts)
@@ -627,7 +626,7 @@ public class ObjectEntryLocalServiceWrapper
 
 		return _objectEntryLocalService.getPrimaryKeyList(
 			groupId, companyId, userId, objectDefinitionId,
-			selectedObjectFieldNames, predicate, search, start, end, sorts);
+			predicate, search, start, end, sorts);
 	}
 
 	@Override

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceWrapper.java
@@ -625,8 +625,8 @@ public class ObjectEntryLocalServiceWrapper
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _objectEntryLocalService.getPrimaryKeyList(
-			groupId, companyId, userId, objectDefinitionId,
-			predicate, search, start, end, sorts);
+			groupId, companyId, userId, objectDefinitionId, predicate, search,
+			start, end, sorts);
 	}
 
 	@Override

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -400,22 +400,6 @@ public class DefaultObjectEntryManagerImpl
 			}
 		}
 
-		String[] selectedObjectFieldNames = null;
-
-		UriInfo uriInfo = dtoConverterContext.getUriInfo();
-
-		if (uriInfo != null) {
-			MultivaluedMap<String, String> queryParameters =
-				uriInfo.getQueryParameters();
-
-			String fields = queryParameters.getFirst("fields");
-
-			if (fields != null) {
-				selectedObjectFieldNames = StringUtil.split(
-					fields, StringPool.COMMA);
-			}
-		}
-
 		return Page.of(
 			HashMapBuilder.put(
 				"create",
@@ -458,9 +442,8 @@ public class DefaultObjectEntryManagerImpl
 			TransformUtil.transform(
 				objectEntryLocalService.getPrimaryKeyList(
 					groupId, companyId, dtoConverterContext.getUserId(),
-					objectDefinition.getObjectDefinitionId(),
-					selectedObjectFieldNames, predicate, search, start, end,
-					sorts),
+					objectDefinition.getObjectDefinitionId(), predicate, search,
+					start, end, sorts),
 				primaryKey -> _getObjectEntry(
 					dtoConverterContext, objectDefinition,
 					objectEntryLocalService.getValues(primaryKey))),

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -445,8 +445,7 @@ public class DefaultObjectEntryManagerImpl
 					objectDefinition.getObjectDefinitionId(), predicate, search,
 					start, end, sorts),
 				primaryKey -> _getObjectEntry(
-					dtoConverterContext, objectDefinition,
-					objectEntryLocalService.getValues(primaryKey))),
+					dtoConverterContext, objectDefinition, primaryKey)),
 			pagination,
 			objectEntryLocalService.getValuesListCount(
 				groupId, companyId, dtoConverterContext.getUserId(),
@@ -1162,13 +1161,11 @@ public class DefaultObjectEntryManagerImpl
 
 	private ObjectEntry _getObjectEntry(
 			DTOConverterContext dtoConverterContext,
-			ObjectDefinition objectDefinition, Map<String, Serializable> values)
+			ObjectDefinition objectDefinition, long objectEntryId)
 		throws Exception {
 
 		com.liferay.object.model.ObjectEntry serviceBuilderObjectEntry =
-			_objectEntryService.getObjectEntry(
-				GetterUtil.getLong(
-					values.get(objectDefinition.getPKObjectFieldName())));
+			_objectEntryService.getObjectEntry(objectEntryId);
 
 		_checkObjectEntryObjectDefinitionId(
 			objectDefinition, serviceBuilderObjectEntry);

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -456,13 +456,14 @@ public class DefaultObjectEntryManagerImpl
 			).build(),
 			facets,
 			TransformUtil.transform(
-				objectEntryLocalService.getValuesList(
+				objectEntryLocalService.getPrimaryKeyList(
 					groupId, companyId, dtoConverterContext.getUserId(),
 					objectDefinition.getObjectDefinitionId(),
 					selectedObjectFieldNames, predicate, search, start, end,
 					sorts),
-				values -> _getObjectEntry(
-					dtoConverterContext, objectDefinition, values)),
+				primaryKey -> _getObjectEntry(
+					dtoConverterContext, objectDefinition,
+					objectEntryLocalService.getValues(primaryKey))),
 			pagination,
 			objectEntryLocalService.getValuesListCount(
 				groupId, companyId, dtoConverterContext.getUserId(),

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -1030,8 +1030,8 @@ public class ObjectEntryLocalServiceImpl
 	@Override
 	public List<Long> getPrimaryKeyList(
 			long groupId, long companyId, long userId, long objectDefinitionId,
-			String[] selectedObjectFieldNames, Predicate predicate,
-			String search, int start, int end, Sort[] sorts)
+			Predicate predicate, String search, int start, int end,
+			Sort[] sorts)
 		throws PortalException {
 
 		DynamicObjectDefinitionLocalizationTable
@@ -1048,7 +1048,7 @@ public class ObjectEntryLocalServiceImpl
 			_getRootDynamicObjectDefinitionTable(objectDefinitionId);
 
 		DSLQuery dslQuery = DSLQueryFactoryUtil.select(
-			dynamicObjectDefinitionTable.getPrimaryKeyColumn()
+			ObjectEntryTable.INSTANCE.objectEntryId
 		).from(
 			dynamicObjectDefinitionTable
 		).innerJoinON(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -1028,6 +1028,93 @@ public class ObjectEntryLocalServiceImpl
 	}
 
 	@Override
+	public List<Long> getPrimaryKeyList(
+			long groupId, long companyId, long userId, long objectDefinitionId,
+			String[] selectedObjectFieldNames, Predicate predicate,
+			String search, int start, int end, Sort[] sorts)
+		throws PortalException {
+
+		DynamicObjectDefinitionLocalizationTable
+			dynamicObjectDefinitionLocalizationTable =
+				DynamicObjectDefinitionLocalizationTableFactory.create(
+					_objectDefinitionPersistence.findByPrimaryKey(
+						objectDefinitionId),
+					_objectFieldLocalService);
+		DynamicObjectDefinitionTable dynamicObjectDefinitionTable =
+			_getDynamicObjectDefinitionTable(objectDefinitionId);
+		DynamicObjectDefinitionTable extensionDynamicObjectDefinitionTable =
+			_getExtensionDynamicObjectDefinitionTable(objectDefinitionId);
+		DynamicObjectDefinitionTable rootDynamicObjectDefinitionTable =
+			_getRootDynamicObjectDefinitionTable(objectDefinitionId);
+
+		DSLQuery dslQuery = DSLQueryFactoryUtil.select(
+			dynamicObjectDefinitionTable.getPrimaryKeyColumn()
+		).from(
+			dynamicObjectDefinitionTable
+		).innerJoinON(
+			extensionDynamicObjectDefinitionTable,
+			extensionDynamicObjectDefinitionTable.getPrimaryKeyColumn(
+			).eq(
+				dynamicObjectDefinitionTable.getPrimaryKeyColumn()
+			)
+		).innerJoinON(
+			ObjectEntryTable.INSTANCE,
+			ObjectEntryTable.INSTANCE.objectEntryId.eq(
+				dynamicObjectDefinitionTable.getPrimaryKeyColumn())
+		).innerJoinON(
+			rootDynamicObjectDefinitionTable,
+			_getInnerJoinRootObjectDefinitionTablePredicate(
+				rootDynamicObjectDefinitionTable)
+		).leftJoinOn(
+			dynamicObjectDefinitionLocalizationTable,
+			ObjectEntrySearchUtil.getLeftJoinLocalizationTablePredicate(
+				dynamicObjectDefinitionLocalizationTable,
+				dynamicObjectDefinitionTable)
+		).where(
+			ObjectEntryTable.INSTANCE.objectDefinitionId.eq(
+				objectDefinitionId
+			).and(
+				() -> {
+					if (groupId == 0) {
+						return null;
+					}
+
+					return ObjectEntryTable.INSTANCE.groupId.eq(groupId);
+				}
+			).and(
+				Predicate.withParentheses(
+					_fillPredicate(objectDefinitionId, predicate, search))
+			).and(
+				_getPermissionWherePredicate(
+					dynamicObjectDefinitionTable, groupId)
+			)
+		).limit(
+			start, end
+		);
+
+		if (sorts != null) {
+			SortDSLQueryVisitor sortDSLQueryVisitor = new SortDSLQueryVisitor(
+				_objectFieldLocalService,
+				_objectRelationshipLocalServiceSnapshot.get());
+
+			for (Sort sort : sorts) {
+				dslQuery = sortDSLQueryVisitor.visit(
+					dslQuery,
+					new com.liferay.object.internal.sort.Sort(
+						_objectDefinitionPersistence.findByPrimaryKey(
+							objectDefinitionId),
+						sort));
+			}
+		}
+
+		return TransformUtil.transform(
+			objectEntryPersistence.dslQuery(dslQuery),
+			value -> (Long)_getResult(
+				value, objectDefinitionId,
+				dynamicObjectDefinitionTable.getPrimaryKeyColumn()));
+	}
+
+	@Override
 	public Map<String, Object> getSystemModelAttributes(
 			ObjectDefinition objectDefinition, long primaryKey)
 		throws PortalException {
@@ -1238,111 +1325,6 @@ public class ObjectEntryLocalServiceImpl
 			objectEntry.getObjectDefinitionId(), values);
 
 		return values;
-	}
-
-	@Override
-	public List<Map<String, Serializable>> getValuesList(
-			long groupId, long companyId, long userId, long objectDefinitionId,
-			String[] selectedObjectFieldNames, Predicate predicate,
-			String search, int start, int end, Sort[] sorts)
-		throws PortalException {
-
-		DynamicObjectDefinitionLocalizationTable
-			dynamicObjectDefinitionLocalizationTable =
-				DynamicObjectDefinitionLocalizationTableFactory.create(
-					_objectDefinitionPersistence.findByPrimaryKey(
-						objectDefinitionId),
-					_objectFieldLocalService);
-		DynamicObjectDefinitionTable dynamicObjectDefinitionTable =
-			_getDynamicObjectDefinitionTable(objectDefinitionId);
-		DynamicObjectDefinitionTable extensionDynamicObjectDefinitionTable =
-			_getExtensionDynamicObjectDefinitionTable(objectDefinitionId);
-		DynamicObjectDefinitionTable rootDynamicObjectDefinitionTable =
-			_getRootDynamicObjectDefinitionTable(objectDefinitionId);
-
-		Expression<?>[] selectExpressions = ArrayUtil.append(
-			_getSelectExpressions(dynamicObjectDefinitionLocalizationTable),
-			_getSelectExpressions(
-				dynamicObjectDefinitionTable, selectedObjectFieldNames),
-			ArrayUtil.remove(
-				_getSelectExpressions(
-					extensionDynamicObjectDefinitionTable,
-					selectedObjectFieldNames),
-				extensionDynamicObjectDefinitionTable.getPrimaryKeyColumn()),
-			_EXPRESSIONS);
-
-		DSLQuery dslQuery = DSLQueryFactoryUtil.select(
-			selectExpressions
-		).from(
-			dynamicObjectDefinitionTable
-		).innerJoinON(
-			extensionDynamicObjectDefinitionTable,
-			extensionDynamicObjectDefinitionTable.getPrimaryKeyColumn(
-			).eq(
-				dynamicObjectDefinitionTable.getPrimaryKeyColumn()
-			)
-		).innerJoinON(
-			ObjectEntryTable.INSTANCE,
-			ObjectEntryTable.INSTANCE.objectEntryId.eq(
-				dynamicObjectDefinitionTable.getPrimaryKeyColumn())
-		).innerJoinON(
-			rootDynamicObjectDefinitionTable,
-			_getInnerJoinRootObjectDefinitionTablePredicate(
-				rootDynamicObjectDefinitionTable)
-		).leftJoinOn(
-			dynamicObjectDefinitionLocalizationTable,
-			ObjectEntrySearchUtil.getLeftJoinLocalizationTablePredicate(
-				dynamicObjectDefinitionLocalizationTable,
-				dynamicObjectDefinitionTable)
-		).where(
-			ObjectEntryTable.INSTANCE.objectDefinitionId.eq(
-				objectDefinitionId
-			).and(
-				() -> {
-					if (groupId == 0) {
-						return null;
-					}
-
-					return ObjectEntryTable.INSTANCE.groupId.eq(groupId);
-				}
-			).and(
-				Predicate.withParentheses(
-					_fillPredicate(objectDefinitionId, predicate, search))
-			).and(
-				_getPermissionWherePredicate(
-					dynamicObjectDefinitionTable, groupId)
-			)
-		).limit(
-			start, end
-		);
-
-		if (sorts != null) {
-			SortDSLQueryVisitor sortDSLQueryVisitor = new SortDSLQueryVisitor(
-				_objectFieldLocalService,
-				_objectRelationshipLocalServiceSnapshot.get());
-
-			for (Sort sort : sorts) {
-				dslQuery = sortDSLQueryVisitor.visit(
-					dslQuery,
-					new com.liferay.object.internal.sort.Sort(
-						_objectDefinitionPersistence.findByPrimaryKey(
-							objectDefinitionId),
-						sort));
-			}
-		}
-
-		List<Object[]> rows = _list(
-			dslQuery, objectDefinitionId, selectExpressions);
-
-		List<Map<String, Serializable>> valuesList = new ArrayList<>(
-			rows.size());
-
-		for (Object[] objects : rows) {
-			valuesList.add(
-				_getValues(objectDefinitionId, objects, selectExpressions));
-		}
-
-		return valuesList;
 	}
 
 	@Override

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -2674,13 +2674,13 @@ public class ObjectEntryLocalServiceTest {
 	}
 
 	@Test
-	public void testGetValuesList() throws Exception {
+	public void testGetValues() throws Exception {
 		Sort[] sorts = {new Sort("id", false)};
 
 		List<Map<String, Serializable>> valuesList = TransformUtil.transform(
 			_objectEntryLocalService.getPrimaryKeyList(
 				0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-				_objectDefinition.getObjectDefinitionId(), null, null, null,
+				_objectDefinition.getObjectDefinitionId(), null, null,
 				QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts),
 			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
 
@@ -2704,7 +2704,7 @@ public class ObjectEntryLocalServiceTest {
 		valuesList = TransformUtil.transform(
 			_objectEntryLocalService.getPrimaryKeyList(
 				0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-				_objectDefinition.getObjectDefinitionId(), null, null, null,
+				_objectDefinition.getObjectDefinitionId(), null, null,
 				QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts),
 			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
 
@@ -2730,7 +2730,7 @@ public class ObjectEntryLocalServiceTest {
 		valuesList = TransformUtil.transform(
 			_objectEntryLocalService.getPrimaryKeyList(
 				0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-				_objectDefinition.getObjectDefinitionId(), null, null, null,
+				_objectDefinition.getObjectDefinitionId(), null, null,
 				QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts),
 			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
 
@@ -2757,7 +2757,7 @@ public class ObjectEntryLocalServiceTest {
 		valuesList = TransformUtil.transform(
 			_objectEntryLocalService.getPrimaryKeyList(
 				0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-				_objectDefinition.getObjectDefinitionId(), null, null, null,
+				_objectDefinition.getObjectDefinitionId(), null, null,
 				QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts),
 			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
 
@@ -2775,7 +2775,7 @@ public class ObjectEntryLocalServiceTest {
 			_objectEntryLocalService.getPrimaryKeyList(
 				0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
 				_irrelevantObjectDefinition.getObjectDefinitionId(), null, null,
-				null, QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts),
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts),
 			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
 
 		Assert.assertEquals(valuesList.toString(), 0, valuesList.size());
@@ -2805,7 +2805,7 @@ public class ObjectEntryLocalServiceTest {
 		valuesList = TransformUtil.transform(
 			_objectEntryLocalService.getPrimaryKeyList(
 				0, TestPropsValues.getCompanyId(), user.getUserId(),
-				_objectDefinition.getObjectDefinitionId(), null, null, null,
+				_objectDefinition.getObjectDefinitionId(), null, null,
 				QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts),
 			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
 
@@ -2831,8 +2831,8 @@ public class ObjectEntryLocalServiceTest {
 		valuesList = TransformUtil.transform(
 			_objectEntryLocalService.getPrimaryKeyList(
 				0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-				_objectDefinition.getObjectDefinitionId(), null, predicate,
-				null, QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts),
+				_objectDefinition.getObjectDefinitionId(), predicate, null,
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts),
 			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
 
 		Assert.assertEquals(valuesList.toString(), 2, valuesList.size());
@@ -2847,8 +2847,8 @@ public class ObjectEntryLocalServiceTest {
 		valuesList = TransformUtil.transform(
 			_objectEntryLocalService.getPrimaryKeyList(
 				0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-				_objectDefinition.getObjectDefinitionId(), null, predicate,
-				search, QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts),
+				_objectDefinition.getObjectDefinitionId(), predicate, search,
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts),
 			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
 
 		Assert.assertEquals(valuesList.toString(), 1, valuesList.size());
@@ -2858,7 +2858,7 @@ public class ObjectEntryLocalServiceTest {
 		valuesList = TransformUtil.transform(
 			_objectEntryLocalService.getPrimaryKeyList(
 				0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-				_objectDefinition.getObjectDefinitionId(), null, predicate,
+				_objectDefinition.getObjectDefinitionId(), predicate,
 				StringUtil.toLowerCase(search), QueryUtil.ALL_POS,
 				QueryUtil.ALL_POS, sorts),
 			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
@@ -2870,7 +2870,7 @@ public class ObjectEntryLocalServiceTest {
 		valuesList = TransformUtil.transform(
 			_objectEntryLocalService.getPrimaryKeyList(
 				0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-				_objectDefinition.getObjectDefinitionId(), null, predicate,
+				_objectDefinition.getObjectDefinitionId(), predicate,
 				StringUtil.toUpperCase(search), QueryUtil.ALL_POS,
 				QueryUtil.ALL_POS, sorts),
 			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
@@ -2882,7 +2882,7 @@ public class ObjectEntryLocalServiceTest {
 		valuesList = TransformUtil.transform(
 			_objectEntryLocalService.getPrimaryKeyList(
 				0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-				_objectDefinition.getObjectDefinitionId(), null, predicate,
+				_objectDefinition.getObjectDefinitionId(), predicate,
 				RandomTestUtil.randomString(), QueryUtil.ALL_POS,
 				QueryUtil.ALL_POS, sorts),
 			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
@@ -2898,8 +2898,8 @@ public class ObjectEntryLocalServiceTest {
 		valuesList = TransformUtil.transform(
 			_objectEntryLocalService.getPrimaryKeyList(
 				0, TestPropsValues.getCompanyId(), user.getUserId(),
-				_objectDefinition.getObjectDefinitionId(), null, predicate,
-				null, QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts),
+				_objectDefinition.getObjectDefinitionId(), predicate, null,
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts),
 			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
 
 		Assert.assertEquals(valuesList.toString(), 1, valuesList.size());
@@ -2918,9 +2918,8 @@ public class ObjectEntryLocalServiceTest {
 		valuesList = TransformUtil.transform(
 			_objectEntryLocalService.getPrimaryKeyList(
 				0, TestPropsValues.getCompanyId(), user.getUserId(),
-				_objectDefinition.getObjectDefinitionId(),
-				selectedObjectFieldNames, null, null, QueryUtil.ALL_POS,
-				QueryUtil.ALL_POS, sorts),
+				_objectDefinition.getObjectDefinitionId(), null, null,
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts),
 			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
 
 		Assert.assertEquals(valuesList.toString(), 3, valuesList.size());

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -83,6 +83,7 @@ import com.liferay.object.tree.Tree;
 import com.liferay.object.validation.rule.ObjectValidationRuleEngine;
 import com.liferay.object.validation.rule.ObjectValidationRuleResult;
 import com.liferay.object.validation.rule.setting.builder.ObjectValidationRuleSettingBuilder;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.sql.dsl.Column;
 import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.petra.string.StringBundler;
@@ -2676,11 +2677,12 @@ public class ObjectEntryLocalServiceTest {
 	public void testGetValuesList() throws Exception {
 		Sort[] sorts = {new Sort("id", false)};
 
-		List<Map<String, Serializable>> valuesList =
-			_objectEntryLocalService.getValuesList(
+		List<Map<String, Serializable>> valuesList = TransformUtil.transform(
+			_objectEntryLocalService.getPrimaryKeyList(
 				0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
 				_objectDefinition.getObjectDefinitionId(), null, null, null,
-				QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts);
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts),
+			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
 
 		Assert.assertEquals(valuesList.toString(), 0, valuesList.size());
 
@@ -2699,16 +2701,18 @@ public class ObjectEntryLocalServiceTest {
 
 		_addObjectEntry(values1);
 
-		valuesList = _objectEntryLocalService.getValuesList(
-			0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			_objectDefinition.getObjectDefinitionId(), null, null, null,
-			QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts);
+		valuesList = TransformUtil.transform(
+			_objectEntryLocalService.getPrimaryKeyList(
+				0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+				_objectDefinition.getObjectDefinitionId(), null, null, null,
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts),
+			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
 
 		Assert.assertEquals(valuesList.toString(), 1, valuesList.size());
 
 		_assertCount(1);
 
-		_assertObjectEntryValues(29, values1, valuesList.get(0));
+		_assertObjectEntryValues(23, values1, valuesList.get(0));
 
 		// Add second object entry
 
@@ -2723,17 +2727,19 @@ public class ObjectEntryLocalServiceTest {
 
 		_addObjectEntry(values2);
 
-		valuesList = _objectEntryLocalService.getValuesList(
-			0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			_objectDefinition.getObjectDefinitionId(), null, null, null,
-			QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts);
+		valuesList = TransformUtil.transform(
+			_objectEntryLocalService.getPrimaryKeyList(
+				0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+				_objectDefinition.getObjectDefinitionId(), null, null, null,
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts),
+			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
 
 		Assert.assertEquals(valuesList.toString(), 2, valuesList.size());
 
 		_assertCount(2);
 
-		_assertObjectEntryValues(29, values1, valuesList.get(0));
-		_assertObjectEntryValues(29, values2, valuesList.get(1));
+		_assertObjectEntryValues(23, values1, valuesList.get(0));
+		_assertObjectEntryValues(23, values2, valuesList.get(1));
 
 		// Add third object entry
 
@@ -2748,25 +2754,29 @@ public class ObjectEntryLocalServiceTest {
 
 		ObjectEntry objectEntry = _addObjectEntry(values3);
 
-		valuesList = _objectEntryLocalService.getValuesList(
-			0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			_objectDefinition.getObjectDefinitionId(), null, null, null,
-			QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts);
+		valuesList = TransformUtil.transform(
+			_objectEntryLocalService.getPrimaryKeyList(
+				0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+				_objectDefinition.getObjectDefinitionId(), null, null, null,
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts),
+			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
 
 		Assert.assertEquals(valuesList.toString(), 3, valuesList.size());
 
 		_assertCount(3);
 
-		_assertObjectEntryValues(29, values1, valuesList.get(0));
-		_assertObjectEntryValues(29, values2, valuesList.get(1));
-		_assertObjectEntryValues(29, values3, valuesList.get(2));
+		_assertObjectEntryValues(23, values1, valuesList.get(0));
+		_assertObjectEntryValues(23, values2, valuesList.get(1));
+		_assertObjectEntryValues(23, values3, valuesList.get(2));
 
 		// Irrelevant object definition
 
-		valuesList = _objectEntryLocalService.getValuesList(
-			0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			_irrelevantObjectDefinition.getObjectDefinitionId(), null, null,
-			null, QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts);
+		valuesList = TransformUtil.transform(
+			_objectEntryLocalService.getPrimaryKeyList(
+				0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+				_irrelevantObjectDefinition.getObjectDefinitionId(), null, null,
+				null, QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts),
+			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
 
 		Assert.assertEquals(valuesList.toString(), 0, valuesList.size());
 
@@ -2792,14 +2802,16 @@ public class ObjectEntryLocalServiceTest {
 
 		_userLocalService.addRoleUser(role.getRoleId(), user);
 
-		valuesList = _objectEntryLocalService.getValuesList(
-			0, TestPropsValues.getCompanyId(), user.getUserId(),
-			_objectDefinition.getObjectDefinitionId(), null, null, null,
-			QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts);
+		valuesList = TransformUtil.transform(
+			_objectEntryLocalService.getPrimaryKeyList(
+				0, TestPropsValues.getCompanyId(), user.getUserId(),
+				_objectDefinition.getObjectDefinitionId(), null, null, null,
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts),
+			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
 
 		Assert.assertEquals(valuesList.toString(), 1, valuesList.size());
 
-		_assertObjectEntryValues(29, values3, valuesList.get(0));
+		_assertObjectEntryValues(23, values3, valuesList.get(0));
 
 		PermissionThreadLocal.setPermissionChecker(originalPermissionChecker);
 		PrincipalThreadLocal.setName(originalName);
@@ -2816,54 +2828,64 @@ public class ObjectEntryLocalServiceTest {
 			firstNameColumn.eq("John")
 		);
 
-		valuesList = _objectEntryLocalService.getValuesList(
-			0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			_objectDefinition.getObjectDefinitionId(), null, predicate, null,
-			QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts);
+		valuesList = TransformUtil.transform(
+			_objectEntryLocalService.getPrimaryKeyList(
+				0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+				_objectDefinition.getObjectDefinitionId(), null, predicate,
+				null, QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts),
+			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
 
 		Assert.assertEquals(valuesList.toString(), 2, valuesList.size());
 
-		_assertObjectEntryValues(29, values1, valuesList.get(0));
-		_assertObjectEntryValues(29, values3, valuesList.get(1));
+		_assertObjectEntryValues(23, values1, valuesList.get(0));
+		_assertObjectEntryValues(23, values3, valuesList.get(1));
 
 		// Predicate and search
 
 		String search = "John";
 
-		valuesList = _objectEntryLocalService.getValuesList(
-			0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			_objectDefinition.getObjectDefinitionId(), null, predicate, search,
-			QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts);
+		valuesList = TransformUtil.transform(
+			_objectEntryLocalService.getPrimaryKeyList(
+				0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+				_objectDefinition.getObjectDefinitionId(), null, predicate,
+				search, QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts),
+			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
 
 		Assert.assertEquals(valuesList.toString(), 1, valuesList.size());
 
-		_assertObjectEntryValues(29, values3, valuesList.get(0));
+		_assertObjectEntryValues(23, values3, valuesList.get(0));
 
-		valuesList = _objectEntryLocalService.getValuesList(
-			0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			_objectDefinition.getObjectDefinitionId(), null, predicate,
-			StringUtil.toLowerCase(search), QueryUtil.ALL_POS,
-			QueryUtil.ALL_POS, sorts);
-
-		Assert.assertEquals(valuesList.toString(), 1, valuesList.size());
-
-		_assertObjectEntryValues(29, values3, valuesList.get(0));
-
-		valuesList = _objectEntryLocalService.getValuesList(
-			0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			_objectDefinition.getObjectDefinitionId(), null, predicate,
-			StringUtil.toUpperCase(search), QueryUtil.ALL_POS,
-			QueryUtil.ALL_POS, sorts);
+		valuesList = TransformUtil.transform(
+			_objectEntryLocalService.getPrimaryKeyList(
+				0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+				_objectDefinition.getObjectDefinitionId(), null, predicate,
+				StringUtil.toLowerCase(search), QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS, sorts),
+			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
 
 		Assert.assertEquals(valuesList.toString(), 1, valuesList.size());
 
-		_assertObjectEntryValues(29, values3, valuesList.get(0));
+		_assertObjectEntryValues(23, values3, valuesList.get(0));
 
-		valuesList = _objectEntryLocalService.getValuesList(
-			0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			_objectDefinition.getObjectDefinitionId(), null, predicate,
-			RandomTestUtil.randomString(), QueryUtil.ALL_POS, QueryUtil.ALL_POS,
-			sorts);
+		valuesList = TransformUtil.transform(
+			_objectEntryLocalService.getPrimaryKeyList(
+				0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+				_objectDefinition.getObjectDefinitionId(), null, predicate,
+				StringUtil.toUpperCase(search), QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS, sorts),
+			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
+
+		Assert.assertEquals(valuesList.toString(), 1, valuesList.size());
+
+		_assertObjectEntryValues(23, values3, valuesList.get(0));
+
+		valuesList = TransformUtil.transform(
+			_objectEntryLocalService.getPrimaryKeyList(
+				0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+				_objectDefinition.getObjectDefinitionId(), null, predicate,
+				RandomTestUtil.randomString(), QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS, sorts),
+			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
 
 		Assert.assertEquals(valuesList.toString(), 0, valuesList.size());
 
@@ -2873,14 +2895,16 @@ public class ObjectEntryLocalServiceTest {
 			PermissionCheckerFactoryUtil.create(user));
 		PrincipalThreadLocal.setName(user.getUserId());
 
-		valuesList = _objectEntryLocalService.getValuesList(
-			0, TestPropsValues.getCompanyId(), user.getUserId(),
-			_objectDefinition.getObjectDefinitionId(), null, predicate, null,
-			QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts);
+		valuesList = TransformUtil.transform(
+			_objectEntryLocalService.getPrimaryKeyList(
+				0, TestPropsValues.getCompanyId(), user.getUserId(),
+				_objectDefinition.getObjectDefinitionId(), null, predicate,
+				null, QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts),
+			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
 
 		Assert.assertEquals(valuesList.toString(), 1, valuesList.size());
 
-		_assertObjectEntryValues(29, values3, valuesList.get(0));
+		_assertObjectEntryValues(23, values3, valuesList.get(0));
 
 		PermissionThreadLocal.setPermissionChecker(originalPermissionChecker);
 		PrincipalThreadLocal.setName(originalName);
@@ -2891,19 +2915,22 @@ public class ObjectEntryLocalServiceTest {
 			"emailAddressRequired", "firstName"
 		};
 
-		valuesList = _objectEntryLocalService.getValuesList(
-			0, TestPropsValues.getCompanyId(), user.getUserId(),
-			_objectDefinition.getObjectDefinitionId(), selectedObjectFieldNames,
-			null, null, QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts);
+		valuesList = TransformUtil.transform(
+			_objectEntryLocalService.getPrimaryKeyList(
+				0, TestPropsValues.getCompanyId(), user.getUserId(),
+				_objectDefinition.getObjectDefinitionId(),
+				selectedObjectFieldNames, null, null, QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS, sorts),
+			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
 
 		Assert.assertEquals(valuesList.toString(), 3, valuesList.size());
 
 		_assertObjectEntryValues(
-			9, values1, valuesList.get(0), selectedObjectFieldNames);
+			23, values1, valuesList.get(0), selectedObjectFieldNames);
 		_assertObjectEntryValues(
-			9, values2, valuesList.get(1), selectedObjectFieldNames);
+			23, values2, valuesList.get(1), selectedObjectFieldNames);
 		_assertObjectEntryValues(
-			9, values3, valuesList.get(2), selectedObjectFieldNames);
+			23, values3, valuesList.get(2), selectedObjectFieldNames);
 	}
 
 	@Test

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -2674,7 +2674,7 @@ public class ObjectEntryLocalServiceTest {
 	}
 
 	@Test
-	public void testGetValues() throws Exception {
+	public void testGetPrimaryKeyList() throws Exception {
 		Sort[] sorts = {new Sort("id", false)};
 
 		List<Map<String, Serializable>> valuesList = TransformUtil.transform(


### PR DESCRIPTION
**What's changed?**

The method `getValuesList` has been replaced with `getPrimaryKeyList` to improve query construction when sorting is applied. Previously, dslQuery grouped by all fields in the object, causing SQL errors in Oracle when any field was of type CLOB, even if that field was not part of the sorting criteria. Since Oracle does not support grouping by CLOB fields, the updated approach **retrieves only the primary key** (PK) column in the initial query. A subsequent query is then executed to retrieve the remaining fields.

This two-step approach does not reduce efficiency, as the second query was already present, meaning it was unnecessary to retrieve all fields in the initial query when only the PK was ultimately used.

See the following Jira Ticket: [LPD-30463](https://liferay.atlassian.net/browse/LPD-30463)
