### PR TITLE
LPD-39365 Merge PathItems for the same path instead of using just one when building the OpenAPI from Headless Builder

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/vulcan/openapi/contributor/APIApplicationOpenApiContributor.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/vulcan/openapi/contributor/APIApplicationOpenApiContributor.java
@@ -137,7 +137,37 @@ public class APIApplicationOpenApiContributor implements OpenAPIContributor {
 				continue;
 			}
 
-			paths.put(_formatPath(endpoint), _toOpenAPIPathItem(endpoint));
+			paths.compute(
+				_formatPath(endpoint),
+				(key, pathItem) -> {
+					PathItem openAPIPathItem = _toOpenAPIPathItem(endpoint);
+
+					if (pathItem == null) {
+						return openAPIPathItem;
+					}
+
+					if (openAPIPathItem.getDelete() != null) {
+						pathItem.setDelete(openAPIPathItem.getDelete());
+					}
+
+					if (openAPIPathItem.getGet() != null) {
+						pathItem.setGet(openAPIPathItem.getGet());
+					}
+
+					if (openAPIPathItem.getPatch() != null) {
+						pathItem.setPatch(openAPIPathItem.getPatch());
+					}
+
+					if (openAPIPathItem.getPost() != null) {
+						pathItem.setPost(openAPIPathItem.getPost());
+					}
+
+					if (openAPIPathItem.getPut() != null) {
+						pathItem.setPut(openAPIPathItem.getPut());
+					}
+
+					return pathItem;
+				});
 
 			APIApplication.Schema requestSchema = endpoint.getRequestSchema();
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderOpenAPIResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderOpenAPIResourceTest.java
@@ -875,7 +875,7 @@ public class HeadlessBuilderOpenAPIResourceTest extends BaseTestCase {
 					).put(
 						"name", "post endpoint"
 					).put(
-						"path", "/post-path"
+						"path", "/path"
 					).put(
 						"r_requestAPISchemaToAPIEndpoints_l_apiSchemaERC",
 						_API_SCHEMA_ERC
@@ -897,7 +897,7 @@ public class HeadlessBuilderOpenAPIResourceTest extends BaseTestCase {
 					).put(
 						"name", "site scoped post endpoint"
 					).put(
-						"path", "/site-scoped-post-path"
+						"path", "/site-scoped-path"
 					).put(
 						"r_requestAPISchemaToAPIEndpoints_l_apiSchemaERC",
 						_API_SITE_SCOPED_SCHEMA_ERC

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/resources/com/liferay/headless/builder/resource/test/dependencies/expected_openapi.json
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/resources/com/liferay/headless/builder/resource/test/dependencies/expected_openapi.json
@@ -467,11 +467,9 @@
 				"tags": [
 					"SchemaName"
 				]
-			}
-		},
-		"/post-path": {
+			},
 			"post": {
-				"operationId": "postPostPath",
+				"operationId": "postPath",
 				"requestBody": {
 					"content": {
 						"application/json": {
@@ -649,11 +647,9 @@
 				"tags": [
 					"SiteScopedSchemaName"
 				]
-			}
-		},
-		"/scopes/{scopeKey}/site-scoped-post-path": {
+			},
 			"post": {
-				"operationId": "postScopeScopeKeySiteScopedPostPath",
+				"operationId": "postScopeScopeKeySiteScopedPath",
 				"parameters": [
 					{
 						"in": "path",


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPD-39365