### PR TITLE
Help request LPD-33603 Create document metadata sets via headless API

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-api/bnd.bnd
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Delivery API
 Bundle-SymbolicName: com.liferay.headless.delivery.api
-Bundle-Version: 49.17.1
+Bundle-Version: 49.18.0
 Export-Package:\
 	com.liferay.headless.delivery.dto.v1_0,\
 	com.liferay.headless.delivery.dto.v1_0.util,\

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/DocumentMetadataSet.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/DocumentMetadataSet.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.data.engine.rest.dto.v2_0.DataDefinitionField;
+import com.liferay.data.engine.rest.dto.v2_0.DataLayout;
 import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -244,6 +245,52 @@ public class DocumentMetadataSet implements Serializable {
 
 	@JsonIgnore
 	private Supplier<DataDefinitionField[]> _dataDefinitionFieldsSupplier;
+
+	@Schema(
+		description = "The layout of the document data definition type fields."
+	)
+	@Valid
+	public DataLayout getDataLayout() {
+		if (_dataLayoutSupplier != null) {
+			dataLayout = _dataLayoutSupplier.get();
+
+			_dataLayoutSupplier = null;
+		}
+
+		return dataLayout;
+	}
+
+	public void setDataLayout(DataLayout dataLayout) {
+		this.dataLayout = dataLayout;
+
+		_dataLayoutSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setDataLayout(
+		UnsafeSupplier<DataLayout, Exception> dataLayoutUnsafeSupplier) {
+
+		_dataLayoutSupplier = () -> {
+			try {
+				return dataLayoutUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "The layout of the document data definition type fields."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected DataLayout dataLayout;
+
+	@JsonIgnore
+	private Supplier<DataLayout> _dataLayoutSupplier;
 
 	@Schema(description = "The Document Metadata Set's creation date.")
 	public Date getDateCreated() {
@@ -687,6 +734,18 @@ public class DocumentMetadataSet implements Serializable {
 			}
 
 			sb.append("]");
+		}
+
+		DataLayout dataLayout = getDataLayout();
+
+		if (dataLayout != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"dataLayout\": ");
+
+			sb.append(dataLayout);
 		}
 
 		Date dateCreated = getDateCreated();

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/DocumentMetadataSet.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/DocumentMetadataSet.java
@@ -35,6 +35,8 @@ import java.util.function.Supplier;
 import javax.annotation.Generated;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -48,6 +50,12 @@ import javax.xml.bind.annotation.XmlRootElement;
 	value = "DocumentMetadataSet"
 )
 @JsonFilter("Liferay.Vulcan")
+@Schema(
+	description = "Represents a Document Metadata Set.",
+	requiredProperties = {
+		"availableLanguages", "dataDefinitionFields", "dataLayout", "name"
+	}
+)
 @XmlRootElement(name = "DocumentMetadataSet")
 public class DocumentMetadataSet implements Serializable {
 
@@ -192,6 +200,7 @@ public class DocumentMetadataSet implements Serializable {
 		description = "The list of languages the navigation menu item has a translation for."
 	)
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	@NotNull
 	protected String[] availableLanguages;
 
 	@JsonIgnore
@@ -241,6 +250,7 @@ public class DocumentMetadataSet implements Serializable {
 		description = "The list of fields that store the structured content's information."
 	)
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	@NotNull
 	protected DataDefinitionField[] dataDefinitionFields;
 
 	@JsonIgnore
@@ -287,6 +297,7 @@ public class DocumentMetadataSet implements Serializable {
 		description = "The layout of the document data definition type fields."
 	)
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@NotNull
 	protected DataLayout dataLayout;
 
 	@JsonIgnore
@@ -537,6 +548,7 @@ public class DocumentMetadataSet implements Serializable {
 
 	@GraphQLField(description = "The Document Metadata Set's name.")
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@NotEmpty
 	protected String name;
 
 	@JsonIgnore

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/DocumentMetadataSetResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/DocumentMetadataSetResource.java
@@ -59,6 +59,14 @@ public interface DocumentMetadataSetResource {
 			String fieldNames)
 		throws Exception;
 
+	public DocumentMetadataSet postAssetLibraryDocumentMetadataSet(
+			Long assetLibraryId, DocumentMetadataSet documentMetadataSet)
+		throws Exception;
+
+	public Response postAssetLibraryDocumentMetadataSetBatch(
+			Long assetLibraryId, String callbackURL, Object object)
+		throws Exception;
+
 	public void deleteDocumentMetadataSet(Long documentMetadataSetId)
 		throws Exception;
 
@@ -77,6 +85,14 @@ public interface DocumentMetadataSetResource {
 	public Response postSiteDocumentMetadataSetsPageExportBatch(
 			Long siteId, String callbackURL, String contentType,
 			String fieldNames)
+		throws Exception;
+
+	public DocumentMetadataSet postSiteDocumentMetadataSet(
+			Long siteId, DocumentMetadataSet documentMetadataSet)
+		throws Exception;
+
+	public Response postSiteDocumentMetadataSetBatch(
+			Long siteId, String callbackURL, Object object)
 		throws Exception;
 
 	public default void setContextAcceptLanguage(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 31.35.0
+version 31.36.0

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 18.8.0
+version 18.9.0

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/DocumentMetadataSet.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/DocumentMetadataSet.java
@@ -115,6 +115,27 @@ public class DocumentMetadataSet implements Cloneable, Serializable {
 
 	protected DataDefinitionField[] dataDefinitionFields;
 
+	public DataLayout getDataLayout() {
+		return dataLayout;
+	}
+
+	public void setDataLayout(DataLayout dataLayout) {
+		this.dataLayout = dataLayout;
+	}
+
+	public void setDataLayout(
+		UnsafeSupplier<DataLayout, Exception> dataLayoutUnsafeSupplier) {
+
+		try {
+			dataLayout = dataLayoutUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected DataLayout dataLayout;
+
 	public Date getDateCreated() {
 		return dateCreated;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/DocumentMetadataSetResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/DocumentMetadataSetResource.java
@@ -54,6 +54,24 @@ public interface DocumentMetadataSetResource {
 				String fieldNames)
 		throws Exception;
 
+	public DocumentMetadataSet postAssetLibraryDocumentMetadataSet(
+			Long assetLibraryId, DocumentMetadataSet documentMetadataSet)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			postAssetLibraryDocumentMetadataSetHttpResponse(
+				Long assetLibraryId, DocumentMetadataSet documentMetadataSet)
+		throws Exception;
+
+	public void postAssetLibraryDocumentMetadataSetBatch(
+			Long assetLibraryId, String callbackURL, Object object)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			postAssetLibraryDocumentMetadataSetBatchHttpResponse(
+				Long assetLibraryId, String callbackURL, Object object)
+		throws Exception;
+
 	public void deleteDocumentMetadataSet(Long documentMetadataSetId)
 		throws Exception;
 
@@ -94,6 +112,23 @@ public interface DocumentMetadataSetResource {
 			postSiteDocumentMetadataSetsPageExportBatchHttpResponse(
 				Long siteId, String callbackURL, String contentType,
 				String fieldNames)
+		throws Exception;
+
+	public DocumentMetadataSet postSiteDocumentMetadataSet(
+			Long siteId, DocumentMetadataSet documentMetadataSet)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse postSiteDocumentMetadataSetHttpResponse(
+			Long siteId, DocumentMetadataSet documentMetadataSet)
+		throws Exception;
+
+	public void postSiteDocumentMetadataSetBatch(
+			Long siteId, String callbackURL, Object object)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			postSiteDocumentMetadataSetBatchHttpResponse(
+				Long siteId, String callbackURL, Object object)
 		throws Exception;
 
 	public static class Builder {
@@ -423,6 +458,218 @@ public interface DocumentMetadataSetResource {
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
 						"/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/document-metadata-sets/export-batch");
+
+			httpInvoker.path("assetLibraryId", assetLibraryId);
+
+			httpInvoker.userNameAndPassword(
+				_builder._login + ":" + _builder._password);
+
+			return httpInvoker.invoke();
+		}
+
+		public DocumentMetadataSet postAssetLibraryDocumentMetadataSet(
+				Long assetLibraryId, DocumentMetadataSet documentMetadataSet)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postAssetLibraryDocumentMetadataSetHttpResponse(
+					assetLibraryId, documentMetadataSet);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return DocumentMetadataSetSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				postAssetLibraryDocumentMetadataSetHttpResponse(
+					Long assetLibraryId,
+					DocumentMetadataSet documentMetadataSet)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(
+				documentMetadataSet.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/document-metadata-sets");
+
+			httpInvoker.path("assetLibraryId", assetLibraryId);
+
+			httpInvoker.userNameAndPassword(
+				_builder._login + ":" + _builder._password);
+
+			return httpInvoker.invoke();
+		}
+
+		public void postAssetLibraryDocumentMetadataSetBatch(
+				Long assetLibraryId, String callbackURL, Object object)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postAssetLibraryDocumentMetadataSetBatchHttpResponse(
+					assetLibraryId, callbackURL, object);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				postAssetLibraryDocumentMetadataSetBatchHttpResponse(
+					Long assetLibraryId, String callbackURL, Object object)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(object.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			if (callbackURL != null) {
+				httpInvoker.parameter(
+					"callbackURL", String.valueOf(callbackURL));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/document-metadata-sets/batch");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
 
@@ -954,6 +1201,216 @@ public interface DocumentMetadataSetResource {
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
 						"/o/headless-delivery/v1.0/sites/{siteId}/document-metadata-sets/export-batch");
+
+			httpInvoker.path("siteId", siteId);
+
+			httpInvoker.userNameAndPassword(
+				_builder._login + ":" + _builder._password);
+
+			return httpInvoker.invoke();
+		}
+
+		public DocumentMetadataSet postSiteDocumentMetadataSet(
+				Long siteId, DocumentMetadataSet documentMetadataSet)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postSiteDocumentMetadataSetHttpResponse(
+					siteId, documentMetadataSet);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return DocumentMetadataSetSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse postSiteDocumentMetadataSetHttpResponse(
+				Long siteId, DocumentMetadataSet documentMetadataSet)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(
+				documentMetadataSet.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-delivery/v1.0/sites/{siteId}/document-metadata-sets");
+
+			httpInvoker.path("siteId", siteId);
+
+			httpInvoker.userNameAndPassword(
+				_builder._login + ":" + _builder._password);
+
+			return httpInvoker.invoke();
+		}
+
+		public void postSiteDocumentMetadataSetBatch(
+				Long siteId, String callbackURL, Object object)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postSiteDocumentMetadataSetBatchHttpResponse(
+					siteId, callbackURL, object);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				postSiteDocumentMetadataSetBatchHttpResponse(
+					Long siteId, String callbackURL, Object object)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(object.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			if (callbackURL != null) {
+				httpInvoker.parameter(
+					"callbackURL", String.valueOf(callbackURL));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-delivery/v1.0/sites/{siteId}/document-metadata-sets/batch");
 
 			httpInvoker.path("siteId", siteId);
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/DocumentMetadataSetSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/DocumentMetadataSetSerDes.java
@@ -127,6 +127,16 @@ public class DocumentMetadataSetSerDes {
 			sb.append("]");
 		}
 
+		if (documentMetadataSet.getDataLayout() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"dataLayout\": ");
+
+			sb.append(documentMetadataSet.getDataLayout());
+		}
+
 		if (documentMetadataSet.getDateCreated() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -286,6 +296,15 @@ public class DocumentMetadataSetSerDes {
 				String.valueOf(documentMetadataSet.getDataDefinitionFields()));
 		}
 
+		if (documentMetadataSet.getDataLayout() == null) {
+			map.put("dataLayout", null);
+		}
+		else {
+			map.put(
+				"dataLayout",
+				String.valueOf(documentMetadataSet.getDataLayout()));
+		}
+
 		if (documentMetadataSet.getDateCreated() == null) {
 			map.put("dateCreated", null);
 		}
@@ -388,6 +407,9 @@ public class DocumentMetadataSetSerDes {
 
 				return false;
 			}
+			else if (Objects.equals(jsonParserFieldName, "dataLayout")) {
+				return false;
+			}
 			else if (Objects.equals(jsonParserFieldName, "dateCreated")) {
 				return false;
 			}
@@ -459,6 +481,12 @@ public class DocumentMetadataSetSerDes {
 
 					documentMetadataSet.setDataDefinitionFields(
 						dataDefinitionFieldsArray);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "dataLayout")) {
+				if (jsonParserFieldValue != null) {
+					documentMetadataSet.setDataLayout(
+						DataLayoutSerDes.toDTO((String)jsonParserFieldValue));
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "dateCreated")) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -1745,6 +1745,10 @@ components:
                         $ref: "../../../data-engine/data-engine-rest-impl/rest-openapi.yaml#DataDefinitionField"
                     readOnly: true
                     type: array
+                dataLayout:
+                    $ref: "../../../data-engine/data-engine-rest-impl/rest-openapi.yaml#DataLayout"
+                    description:
+                        The layout of the document data definition type fields.
                 dateCreated:
                     description:
                         The Document Metadata Set's creation date.

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -6778,6 +6778,32 @@ paths:
                                     $ref: "#/components/schemas/DocumentMetadataSet"
                                 type: array
             tags: ["DocumentMetadataSet"]
+        post:
+            parameters:
+                - in: path
+                  name: assetLibraryId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/DocumentMetadataSet"
+                    application/xml:
+                        schema:
+                            $ref: "#/components/schemas/DocumentMetadataSet"
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/DocumentMetadataSet"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/DocumentMetadataSet"
+            tags: ["DocumentMetadataSet"]
     "/asset-libraries/{assetLibraryId}/document-shortcuts":
         get:
             operationId: getAssetLibraryDocumentShortcutsPage
@@ -13413,6 +13439,32 @@ paths:
                                 items:
                                     $ref: "#/components/schemas/DocumentMetadataSet"
                                 type: array
+            tags: ["DocumentMetadataSet"]
+        post:
+            parameters:
+                - in: path
+                  name: siteId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/DocumentMetadataSet"
+                    application/xml:
+                        schema:
+                            $ref: "#/components/schemas/DocumentMetadataSet"
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/DocumentMetadataSet"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/DocumentMetadataSet"
             tags: ["DocumentMetadataSet"]
     "/sites/{siteId}/document-shortcuts":
         get:

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -6138,7 +6138,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.delivery.client', and version '4.0.87'."
+        'com.liferay.headless.delivery.client', and version '4.0.88'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"
@@ -6779,6 +6779,7 @@ paths:
                                 type: array
             tags: ["DocumentMetadataSet"]
         post:
+            operationId: postAssetLibraryDocumentMetadataSet
             parameters:
                 - in: path
                   name: assetLibraryId
@@ -13441,6 +13442,7 @@ paths:
                                 type: array
             tags: ["DocumentMetadataSet"]
         post:
+            operationId: postSiteDocumentMetadataSet
             parameters:
                 - in: path
                   name: siteId

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -1796,6 +1796,11 @@ components:
                     format: int64
                     readOnly: true
                     type: integer
+            required:
+                - availableLanguages
+                - dataDefinitionFields
+                - dataLayout
+                - name
             type: object
         DocumentShortcut:
             description:

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/mutation/v1_0/Mutation.java
@@ -11,6 +11,7 @@ import com.liferay.headless.delivery.dto.v1_0.Comment;
 import com.liferay.headless.delivery.dto.v1_0.Document;
 import com.liferay.headless.delivery.dto.v1_0.DocumentDataDefinitionType;
 import com.liferay.headless.delivery.dto.v1_0.DocumentFolder;
+import com.liferay.headless.delivery.dto.v1_0.DocumentMetadataSet;
 import com.liferay.headless.delivery.dto.v1_0.DocumentShortcut;
 import com.liferay.headless.delivery.dto.v1_0.KnowledgeBaseArticle;
 import com.liferay.headless.delivery.dto.v1_0.KnowledgeBaseAttachment;
@@ -2287,6 +2288,37 @@ public class Mutation {
 						fieldNames));
 	}
 
+	@GraphQLField
+	public DocumentMetadataSet createAssetLibraryDocumentMetadataSet(
+			@GraphQLName("assetLibraryId") @NotEmpty String assetLibraryId,
+			@GraphQLName("documentMetadataSet") DocumentMetadataSet
+				documentMetadataSet)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_documentMetadataSetResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			documentMetadataSetResource ->
+				documentMetadataSetResource.postAssetLibraryDocumentMetadataSet(
+					Long.valueOf(assetLibraryId), documentMetadataSet));
+	}
+
+	@GraphQLField
+	public Response createAssetLibraryDocumentMetadataSetBatch(
+			@GraphQLName("assetLibraryId") @NotEmpty String assetLibraryId,
+			@GraphQLName("callbackURL") String callbackURL,
+			@GraphQLName("object") Object object)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_documentMetadataSetResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			documentMetadataSetResource ->
+				documentMetadataSetResource.
+					postAssetLibraryDocumentMetadataSetBatch(
+						Long.valueOf(assetLibraryId), callbackURL, object));
+	}
+
 	@GraphQLField(
 		description = "Deletes the document metadata set and returns a 204 if the operation succeeds."
 	)
@@ -2334,6 +2366,36 @@ public class Mutation {
 					postSiteDocumentMetadataSetsPageExportBatch(
 						Long.valueOf(siteKey), callbackURL, contentType,
 						fieldNames));
+	}
+
+	@GraphQLField
+	public DocumentMetadataSet createSiteDocumentMetadataSet(
+			@GraphQLName("siteKey") @NotEmpty String siteKey,
+			@GraphQLName("documentMetadataSet") DocumentMetadataSet
+				documentMetadataSet)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_documentMetadataSetResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			documentMetadataSetResource ->
+				documentMetadataSetResource.postSiteDocumentMetadataSet(
+					Long.valueOf(siteKey), documentMetadataSet));
+	}
+
+	@GraphQLField
+	public Response createSiteDocumentMetadataSetBatch(
+			@GraphQLName("siteKey") @NotEmpty String siteKey,
+			@GraphQLName("callbackURL") String callbackURL,
+			@GraphQLName("object") Object object)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_documentMetadataSetResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			documentMetadataSetResource ->
+				documentMetadataSetResource.postSiteDocumentMetadataSetBatch(
+					Long.valueOf(siteKey), callbackURL, object));
 	}
 
 	@GraphQLField

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/query/v1_0/Query.java
@@ -1876,7 +1876,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {documentMetadataSet(documentMetadataSetId: ___){actions, assetLibraryKey, availableLanguages, dataDefinitionFields, dateCreated, dateModified, description, description_i18n, id, name, name_i18n, siteId}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {documentMetadataSet(documentMetadataSetId: ___){actions, assetLibraryKey, availableLanguages, dataDefinitionFields, dataLayout, dateCreated, dateModified, description, description_i18n, id, name, name_i18n, siteId}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(description = "Retrieves the document metadata set.")
 	public DocumentMetadataSet documentMetadataSet(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -760,6 +760,16 @@ public class ServletDataImpl implements ServletData {
 							DocumentMetadataSetResourceImpl.class,
 							"postAssetLibraryDocumentMetadataSetsPageExportBatch"));
 					put(
+						"mutation#createAssetLibraryDocumentMetadataSet",
+						new ObjectValuePair<>(
+							DocumentMetadataSetResourceImpl.class,
+							"postAssetLibraryDocumentMetadataSet"));
+					put(
+						"mutation#createAssetLibraryDocumentMetadataSetBatch",
+						new ObjectValuePair<>(
+							DocumentMetadataSetResourceImpl.class,
+							"postAssetLibraryDocumentMetadataSetBatch"));
+					put(
 						"mutation#deleteDocumentMetadataSet",
 						new ObjectValuePair<>(
 							DocumentMetadataSetResourceImpl.class,
@@ -774,6 +784,16 @@ public class ServletDataImpl implements ServletData {
 						new ObjectValuePair<>(
 							DocumentMetadataSetResourceImpl.class,
 							"postSiteDocumentMetadataSetsPageExportBatch"));
+					put(
+						"mutation#createSiteDocumentMetadataSet",
+						new ObjectValuePair<>(
+							DocumentMetadataSetResourceImpl.class,
+							"postSiteDocumentMetadataSet"));
+					put(
+						"mutation#createSiteDocumentMetadataSetBatch",
+						new ObjectValuePair<>(
+							DocumentMetadataSetResourceImpl.class,
+							"postSiteDocumentMetadataSetBatch"));
 					put(
 						"mutation#createAssetLibraryDocumentShortcutsPageExportBatch",
 						new ObjectValuePair<>(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentMetadataSetResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentMetadataSetResourceImpl.java
@@ -201,7 +201,7 @@ public abstract class BaseDocumentMetadataSetResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/document-metadata-sets' -d $'{"description": ___, "description_i18n": ___, "name": ___, "name_i18n": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/document-metadata-sets' -d $'{"dataLayout": ___, "description": ___, "description_i18n": ___, "name": ___, "name_i18n": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -553,7 +553,7 @@ public abstract class BaseDocumentMetadataSetResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-delivery/v1.0/sites/{siteId}/document-metadata-sets' -d $'{"description": ___, "description_i18n": ___, "name": ___, "name_i18n": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-delivery/v1.0/sites/{siteId}/document-metadata-sets' -d $'{"dataLayout": ___, "description": ___, "description_i18n": ___, "name": ___, "name_i18n": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentMetadataSetResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentMetadataSetResourceImpl.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
@@ -194,6 +195,102 @@ public abstract class BaseDocumentMetadataSetResourceImpl
 			vulcanBatchEngineExportTaskResource.postExportTask(
 				DocumentMetadataSet.class.getName(), callbackURL, contentType,
 				fieldNames)
+		).build();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/document-metadata-sets' -d $'{"description": ___, "description_i18n": ___, "name": ___, "name_i18n": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "assetLibraryId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(
+				name = "DocumentMetadataSet"
+			)
+		}
+	)
+	@javax.ws.rs.Consumes({"application/json", "application/xml"})
+	@javax.ws.rs.Path(
+		"/asset-libraries/{assetLibraryId}/document-metadata-sets"
+	)
+	@javax.ws.rs.POST
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public DocumentMetadataSet postAssetLibraryDocumentMetadataSet(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("assetLibraryId")
+			Long assetLibraryId,
+			DocumentMetadataSet documentMetadataSet)
+		throws Exception {
+
+		return new DocumentMetadataSet();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/document-metadata-sets/batch'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "assetLibraryId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "callbackURL"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(
+				name = "DocumentMetadataSet"
+			)
+		}
+	)
+	@javax.ws.rs.Consumes("application/json")
+	@javax.ws.rs.Path(
+		"/asset-libraries/{assetLibraryId}/document-metadata-sets/batch"
+	)
+	@javax.ws.rs.POST
+	@javax.ws.rs.Produces("application/json")
+	@Override
+	public Response postAssetLibraryDocumentMetadataSetBatch(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("assetLibraryId")
+			Long assetLibraryId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("callbackURL")
+			String callbackURL,
+			Object object)
+		throws Exception {
+
+		vulcanBatchEngineImportTaskResource.setContextAcceptLanguage(
+			contextAcceptLanguage);
+		vulcanBatchEngineImportTaskResource.setContextCompany(contextCompany);
+		vulcanBatchEngineImportTaskResource.setContextHttpServletRequest(
+			contextHttpServletRequest);
+		vulcanBatchEngineImportTaskResource.setContextUriInfo(contextUriInfo);
+		vulcanBatchEngineImportTaskResource.setContextUser(contextUser);
+
+		Response.ResponseBuilder responseBuilder = Response.accepted();
+
+		return responseBuilder.entity(
+			vulcanBatchEngineImportTaskResource.postImportTask(
+				DocumentMetadataSet.class.getName(), callbackURL, null, object)
 		).build();
 	}
 
@@ -453,6 +550,98 @@ public abstract class BaseDocumentMetadataSetResourceImpl
 		).build();
 	}
 
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-delivery/v1.0/sites/{siteId}/document-metadata-sets' -d $'{"description": ___, "description_i18n": ___, "name": ___, "name_i18n": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "siteId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(
+				name = "DocumentMetadataSet"
+			)
+		}
+	)
+	@javax.ws.rs.Consumes({"application/json", "application/xml"})
+	@javax.ws.rs.Path("/sites/{siteId}/document-metadata-sets")
+	@javax.ws.rs.POST
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public DocumentMetadataSet postSiteDocumentMetadataSet(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("siteId")
+			Long siteId,
+			DocumentMetadataSet documentMetadataSet)
+		throws Exception {
+
+		return new DocumentMetadataSet();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-delivery/v1.0/sites/{siteId}/document-metadata-sets/batch'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "siteId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "callbackURL"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(
+				name = "DocumentMetadataSet"
+			)
+		}
+	)
+	@javax.ws.rs.Consumes("application/json")
+	@javax.ws.rs.Path("/sites/{siteId}/document-metadata-sets/batch")
+	@javax.ws.rs.POST
+	@javax.ws.rs.Produces("application/json")
+	@Override
+	public Response postSiteDocumentMetadataSetBatch(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("siteId")
+			Long siteId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("callbackURL")
+			String callbackURL,
+			Object object)
+		throws Exception {
+
+		vulcanBatchEngineImportTaskResource.setContextAcceptLanguage(
+			contextAcceptLanguage);
+		vulcanBatchEngineImportTaskResource.setContextCompany(contextCompany);
+		vulcanBatchEngineImportTaskResource.setContextHttpServletRequest(
+			contextHttpServletRequest);
+		vulcanBatchEngineImportTaskResource.setContextUriInfo(contextUriInfo);
+		vulcanBatchEngineImportTaskResource.setContextUser(contextUser);
+
+		Response.ResponseBuilder responseBuilder = Response.accepted();
+
+		return responseBuilder.entity(
+			vulcanBatchEngineImportTaskResource.postImportTask(
+				DocumentMetadataSet.class.getName(), callbackURL, null, object)
+		).build();
+	}
+
 	@Override
 	@SuppressWarnings("PMD.UnusedLocalVariable")
 	public void create(
@@ -460,8 +649,51 @@ public abstract class BaseDocumentMetadataSetResourceImpl
 			Map<String, Serializable> parameters)
 		throws Exception {
 
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
+		UnsafeFunction<DocumentMetadataSet, DocumentMetadataSet, Exception>
+			documentMetadataSetUnsafeFunction = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if (StringUtil.equalsIgnoreCase(createStrategy, "INSERT")) {
+			if (parameters.containsKey("assetLibraryId")) {
+				documentMetadataSetUnsafeFunction =
+					documentMetadataSet -> postAssetLibraryDocumentMetadataSet(
+						(Long)parameters.get("assetLibraryId"),
+						documentMetadataSet);
+			}
+			else if (parameters.containsKey("siteId")) {
+				documentMetadataSetUnsafeFunction =
+					documentMetadataSet -> postSiteDocumentMetadataSet(
+						(Long)parameters.get("siteId"), documentMetadataSet);
+			}
+			else {
+				throw new NotSupportedException(
+					"One of the following parameters must be specified: [assetLibraryId, siteId]");
+			}
+		}
+
+		if (documentMetadataSetUnsafeFunction == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" is not supported for DocumentMetadataSet");
+		}
+
+		if (contextBatchUnsafeBiConsumer != null) {
+			contextBatchUnsafeBiConsumer.accept(
+				documentMetadataSets, documentMetadataSetUnsafeFunction);
+		}
+		else if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				documentMetadataSets, documentMetadataSetUnsafeFunction::apply);
+		}
+		else {
+			for (DocumentMetadataSet documentMetadataSet :
+					documentMetadataSets) {
+
+				documentMetadataSetUnsafeFunction.apply(documentMetadataSet);
+			}
+		}
 	}
 
 	@Override
@@ -476,7 +708,7 @@ public abstract class BaseDocumentMetadataSetResourceImpl
 	}
 
 	public Set<String> getAvailableCreateStrategies() {
-		return SetUtil.fromArray();
+		return SetUtil.fromArray("INSERT");
 	}
 
 	public Set<String> getAvailableUpdateStrategies() {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentMetadataSetResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentMetadataSetResourceImpl.java
@@ -5,6 +5,8 @@
 
 package com.liferay.headless.delivery.internal.resource.v1_0;
 
+import com.liferay.data.engine.field.type.util.LocalizedValueUtil;
+import com.liferay.data.engine.rest.dto.v2_0.DataDefinition;
 import com.liferay.data.engine.rest.resource.v2_0.DataDefinitionResource;
 import com.liferay.document.library.kernel.model.DLFileEntryMetadata;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
@@ -23,8 +25,10 @@ import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 import com.liferay.portlet.documentlibrary.constants.DLConstants;
 
+import java.util.Locale;
 import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
@@ -108,6 +112,68 @@ public class DocumentMetadataSetResourceImpl
 					DLConstants.RESOURCE_NAME, siteId)
 			).build(),
 			siteId, pagination);
+	}
+
+	@Override
+	public DocumentMetadataSet postAssetLibraryDocumentMetadataSet(
+			Long assetLibraryId, DocumentMetadataSet documentMetadataSet)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-32247")) {
+			throw new UnsupportedOperationException();
+		}
+
+		return postSiteDocumentMetadataSet(assetLibraryId, documentMetadataSet);
+	}
+
+	@Override
+	public DocumentMetadataSet postSiteDocumentMetadataSet(
+			Long siteId, DocumentMetadataSet documentMetadataSet)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-32247")) {
+			throw new UnsupportedOperationException();
+		}
+
+		DataDefinitionResource.Builder builder =
+			_dataDefinitionResourceFactory.create();
+
+		DataDefinitionResource dataDefinitionResource = builder.user(
+			contextUser
+		).build();
+
+		Map<Locale, String> descriptionMap = LocalizedMapUtil.getLocalizedMap(
+			contextAcceptLanguage.getPreferredLocale(),
+			documentMetadataSet.getDescription(),
+			documentMetadataSet.getDescription_i18n());
+		Map<Locale, String> nameMap = LocalizedMapUtil.getLocalizedMap(
+			contextAcceptLanguage.getPreferredLocale(),
+			documentMetadataSet.getName(), documentMetadataSet.getName_i18n());
+
+		DataDefinition dataDefinition =
+			dataDefinitionResource.postSiteDataDefinitionByContentType(
+				siteId, "document-library",
+				new DataDefinition() {
+					{
+						setAvailableLanguageIds(
+							documentMetadataSet::getAvailableLanguages);
+						setDataDefinitionFields(
+							documentMetadataSet::getDataDefinitionFields);
+						setDefaultDataLayout(
+							documentMetadataSet::getDataLayout);
+						setDescription(
+							() -> LocalizedValueUtil.toStringObjectMap(
+								descriptionMap));
+						setName(
+							() -> LocalizedValueUtil.toStringObjectMap(
+								nameMap));
+						setSiteId(() -> siteId);
+						setUserId(contextUser::getUserId);
+					}
+				});
+
+		return _toDocumentMetadataSet(
+			_ddmStructureService.getStructure(dataDefinition.getId()));
 	}
 
 	private Page<DocumentMetadataSet> _getPage(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -42,7 +42,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.delivery.client', and version '4.0.87'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.delivery.client', and version '4.0.88'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/document-metadata-set.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/document-metadata-set.properties
@@ -6,7 +6,7 @@ api.version=v1.0
 batch.engine.entity.class.name=com.liferay.headless.delivery.dto.v1_0.DocumentMetadataSet
 batch.engine.task.item.delegate=true
 batch.planner.export.enabled=true
-batch.planner.import.enabled=false
+batch.planner.import.enabled=true
 entity.class.name=com.liferay.headless.delivery.dto.v1_0.DocumentMetadataSet
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)
 osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentMetadataSetResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentMetadataSetResourceTestCase.java
@@ -1252,6 +1252,14 @@ public abstract class BaseDocumentMetadataSetResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("dataLayout", additionalAssertFieldName)) {
+				if (documentMetadataSet.getDataLayout() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("description", additionalAssertFieldName)) {
 				if (documentMetadataSet.getDescription() == null) {
 					valid = false;
@@ -1437,6 +1445,17 @@ public abstract class BaseDocumentMetadataSetResourceTestCase {
 				if (!Objects.deepEquals(
 						documentMetadataSet1.getDataDefinitionFields(),
 						documentMetadataSet2.getDataDefinitionFields())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("dataLayout", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						documentMetadataSet1.getDataLayout(),
+						documentMetadataSet2.getDataLayout())) {
 
 					return false;
 				}
@@ -1686,6 +1705,11 @@ public abstract class BaseDocumentMetadataSetResourceTestCase {
 		}
 
 		if (entityFieldName.equals("dataDefinitionFields")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("dataLayout")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
 		}

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentMetadataSetResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentMetadataSetResourceTestCase.java
@@ -26,6 +26,7 @@ import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONDeserializer;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -269,6 +270,15 @@ public abstract class BaseDocumentMetadataSetResourceTestCase {
 
 		Map<String, Map<String, String>> expectedActions = new HashMap<>();
 
+		Map createBatchAction = new HashMap<>();
+		createBatchAction.put("method", "POST");
+		createBatchAction.put(
+			"href",
+			"http://localhost:8080/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/document-metadata-sets/batch".
+				replace("{assetLibraryId}", String.valueOf(assetLibraryId)));
+
+		expectedActions.put("createBatch", createBatchAction);
+
 		return expectedActions;
 	}
 
@@ -390,8 +400,8 @@ public abstract class BaseDocumentMetadataSetResourceTestCase {
 				Long assetLibraryId, DocumentMetadataSet documentMetadataSet)
 		throws Exception {
 
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
+		return documentMetadataSetResource.postAssetLibraryDocumentMetadataSet(
+			assetLibraryId, documentMetadataSet);
 	}
 
 	protected Long
@@ -406,6 +416,29 @@ public abstract class BaseDocumentMetadataSetResourceTestCase {
 		throws Exception {
 
 		return null;
+	}
+
+	@Test
+	public void testPostAssetLibraryDocumentMetadataSet() throws Exception {
+		DocumentMetadataSet randomDocumentMetadataSet =
+			randomDocumentMetadataSet();
+
+		DocumentMetadataSet postDocumentMetadataSet =
+			testPostAssetLibraryDocumentMetadataSet_addDocumentMetadataSet(
+				randomDocumentMetadataSet);
+
+		assertEquals(randomDocumentMetadataSet, postDocumentMetadataSet);
+		assertValid(postDocumentMetadataSet);
+	}
+
+	protected DocumentMetadataSet
+			testPostAssetLibraryDocumentMetadataSet_addDocumentMetadataSet(
+				DocumentMetadataSet documentMetadataSet)
+		throws Exception {
+
+		return documentMetadataSetResource.postAssetLibraryDocumentMetadataSet(
+			testGetAssetLibraryDocumentMetadataSetsPage_getAssetLibraryId(),
+			documentMetadataSet);
 	}
 
 	@Test
@@ -433,8 +466,8 @@ public abstract class BaseDocumentMetadataSetResourceTestCase {
 			testDeleteDocumentMetadataSet_addDocumentMetadataSet()
 		throws Exception {
 
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
+		return documentMetadataSetResource.postSiteDocumentMetadataSet(
+			testGroup.getGroupId(), randomDocumentMetadataSet());
 	}
 
 	@Test
@@ -540,8 +573,8 @@ public abstract class BaseDocumentMetadataSetResourceTestCase {
 			testGetDocumentMetadataSet_addDocumentMetadataSet()
 		throws Exception {
 
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
+		return documentMetadataSetResource.postSiteDocumentMetadataSet(
+			testGroup.getGroupId(), randomDocumentMetadataSet());
 	}
 
 	@Test
@@ -710,6 +743,15 @@ public abstract class BaseDocumentMetadataSetResourceTestCase {
 
 		Map<String, Map<String, String>> expectedActions = new HashMap<>();
 
+		Map createBatchAction = new HashMap<>();
+		createBatchAction.put("method", "POST");
+		createBatchAction.put(
+			"href",
+			"http://localhost:8080/o/headless-delivery/v1.0/sites/{siteId}/document-metadata-sets/batch".
+				replace("{siteId}", String.valueOf(siteId)));
+
+		expectedActions.put("createBatch", createBatchAction);
+
 		return expectedActions;
 	}
 
@@ -824,8 +866,8 @@ public abstract class BaseDocumentMetadataSetResourceTestCase {
 				Long siteId, DocumentMetadataSet documentMetadataSet)
 		throws Exception {
 
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
+		return documentMetadataSetResource.postSiteDocumentMetadataSet(
+			siteId, documentMetadataSet);
 	}
 
 	protected Long testGetSiteDocumentMetadataSetsPage_getSiteId()
@@ -921,12 +963,146 @@ public abstract class BaseDocumentMetadataSetResourceTestCase {
 		return testGraphQLDocumentMetadataSet_addDocumentMetadataSet();
 	}
 
+	@Test
+	public void testPostSiteDocumentMetadataSet() throws Exception {
+		DocumentMetadataSet randomDocumentMetadataSet =
+			randomDocumentMetadataSet();
+
+		DocumentMetadataSet postDocumentMetadataSet =
+			testPostSiteDocumentMetadataSet_addDocumentMetadataSet(
+				randomDocumentMetadataSet);
+
+		assertEquals(randomDocumentMetadataSet, postDocumentMetadataSet);
+		assertValid(postDocumentMetadataSet);
+	}
+
+	protected DocumentMetadataSet
+			testPostSiteDocumentMetadataSet_addDocumentMetadataSet(
+				DocumentMetadataSet documentMetadataSet)
+		throws Exception {
+
+		return documentMetadataSetResource.postSiteDocumentMetadataSet(
+			testGetSiteDocumentMetadataSetsPage_getSiteId(),
+			documentMetadataSet);
+	}
+
+	@Test
+	public void testGraphQLPostSiteDocumentMetadataSet() throws Exception {
+		DocumentMetadataSet randomDocumentMetadataSet =
+			randomDocumentMetadataSet();
+
+		DocumentMetadataSet documentMetadataSet =
+			testGraphQLDocumentMetadataSet_addDocumentMetadataSet(
+				randomDocumentMetadataSet);
+
+		Assert.assertTrue(
+			equals(randomDocumentMetadataSet, documentMetadataSet));
+	}
+
+	protected void appendGraphQLFieldValue(StringBuilder sb, Object value)
+		throws Exception {
+
+		if (value instanceof Object[]) {
+			StringBuilder arraySB = new StringBuilder("[");
+
+			for (Object object : (Object[])value) {
+				if (arraySB.length() > 1) {
+					arraySB.append(", ");
+				}
+
+				arraySB.append("{");
+
+				Class<?> clazz = object.getClass();
+
+				for (java.lang.reflect.Field field :
+						getDeclaredFields(clazz.getSuperclass())) {
+
+					arraySB.append(field.getName());
+					arraySB.append(": ");
+
+					appendGraphQLFieldValue(arraySB, field.get(object));
+
+					arraySB.append(", ");
+				}
+
+				arraySB.setLength(arraySB.length() - 2);
+
+				arraySB.append("}");
+			}
+
+			arraySB.append("]");
+
+			sb.append(arraySB.toString());
+		}
+		else if (value instanceof String) {
+			sb.append("\"");
+			sb.append(value);
+			sb.append("\"");
+		}
+		else {
+			sb.append(value);
+		}
+	}
+
 	protected DocumentMetadataSet
 			testGraphQLDocumentMetadataSet_addDocumentMetadataSet()
 		throws Exception {
 
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
+		return testGraphQLDocumentMetadataSet_addDocumentMetadataSet(
+			randomDocumentMetadataSet());
+	}
+
+	protected DocumentMetadataSet
+			testGraphQLDocumentMetadataSet_addDocumentMetadataSet(
+				DocumentMetadataSet documentMetadataSet)
+		throws Exception {
+
+		JSONDeserializer<DocumentMetadataSet> jsonDeserializer =
+			JSONFactoryUtil.createJSONDeserializer();
+
+		StringBuilder sb = new StringBuilder("{");
+
+		for (java.lang.reflect.Field field :
+				getDeclaredFields(DocumentMetadataSet.class)) {
+
+			if (!ArrayUtil.contains(
+					getAdditionalAssertFieldNames(), field.getName())) {
+
+				continue;
+			}
+
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append(field.getName());
+			sb.append(": ");
+
+			appendGraphQLFieldValue(sb, field.get(documentMetadataSet));
+		}
+
+		sb.append("}");
+
+		List<GraphQLField> graphQLFields = getGraphQLFields();
+
+		graphQLFields.add(new GraphQLField("id"));
+
+		return jsonDeserializer.deserialize(
+			JSONUtil.getValueAsString(
+				invokeGraphQLMutation(
+					new GraphQLField(
+						"createSiteDocumentMetadataSet",
+						new HashMap<String, Object>() {
+							{
+								put(
+									"siteKey",
+									"\"" + testGroup.getGroupId() + "\"");
+								put("documentMetadataSet", sb.toString());
+							}
+						},
+						graphQLFields)),
+				"JSONObject/data", "JSONObject/createSiteDocumentMetadataSet"),
+			DocumentMetadataSet.class);
 	}
 
 	protected void assertContains(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/DocumentMetadataSetResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/DocumentMetadataSetResourceTest.java
@@ -9,18 +9,29 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.data.engine.rest.resource.v2_0.DataDefinitionResource;
 import com.liferay.document.library.kernel.model.DLFileEntryMetadata;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.model.DDMStructureLayout;
+import com.liferay.dynamic.data.mapping.service.DDMStructureLayoutLocalService;
 import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestUtil;
 import com.liferay.headless.delivery.client.dto.v1_0.DataDefinitionField;
 import com.liferay.headless.delivery.client.dto.v1_0.DocumentMetadataSet;
+import com.liferay.headless.delivery.client.serdes.v1_0.DataLayoutSerDes;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.vulcan.util.GroupUtil;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
+
+import java.util.Locale;
 
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -63,6 +74,69 @@ public class DocumentMetadataSetResourceTest
 	@Override
 	protected String[] getAdditionalAssertFieldNames() {
 		return new String[] {"availableLanguages", "description", "name"};
+	}
+
+	@Override
+	protected DocumentMetadataSet randomDocumentMetadataSet() throws Exception {
+		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
+			testGroup.getGroupId(), DLFileEntryMetadata.class.getName());
+
+		DDMStructureLayout ddmStructureLayout =
+			_ddmStructureLayoutLocalService.getDDMStructureLayout(
+				ddmStructure.getDefaultDDMStructureLayoutId());
+
+		String randomDescription = StringUtil.toLowerCase(
+			RandomTestUtil.randomString());
+
+		String randomName = StringUtil.toLowerCase(
+			RandomTestUtil.randomString());
+
+		return new DocumentMetadataSet() {
+			{
+				setActions(() -> null);
+				setAssetLibraryKey(
+					() -> GroupUtil.getAssetLibraryKey(testGroup));
+				setAvailableLanguages(
+					() -> LocaleUtil.toW3cLanguageIds(
+						new Locale[] {LocaleUtil.getSiteDefault()}));
+				setDataDefinitionFields(
+					() -> {
+						JSONObject jsonObject =
+							JSONFactoryUtil.createJSONObject(
+								ddmStructure.getDefinition());
+
+						JSONArray fieldsJSONArray = jsonObject.getJSONArray(
+							"fields");
+
+						DataDefinitionField[] dataDefinitionFields =
+							new DataDefinitionField[fieldsJSONArray.length()];
+
+						for (int i = 0; i < fieldsJSONArray.length(); i++) {
+							dataDefinitionFields[i] = DataDefinitionField.toDTO(
+								fieldsJSONArray.getString(i));
+						}
+
+						return dataDefinitionFields;
+					});
+				setDataLayout(
+					DataLayoutSerDes.toDTO(ddmStructureLayout.getDefinition()));
+				setDateCreated(RandomTestUtil.nextDate());
+				setDateModified(RandomTestUtil.nextDate());
+				setDescription(() -> randomDescription);
+				setDescription_i18n(
+					() -> LocalizedMapUtil.getI18nMap(
+						HashMapBuilder.put(
+							LocaleUtil.getSiteDefault(), randomDescription
+						).build()));
+				setId(RandomTestUtil.randomLong());
+				setName(() -> randomName);
+				setName_i18n(
+					() -> LocalizedMapUtil.getI18nMap(
+						HashMapBuilder.put(
+							LocaleUtil.getSiteDefault(), randomName
+						).build()));
+			}
+		};
 	}
 
 	@Override
@@ -157,5 +231,8 @@ public class DocumentMetadataSetResourceTest
 
 	@Inject
 	private DataDefinitionResource.Factory _dataDefinitionResourceFactory;
+
+	@Inject
+	private DDMStructureLayoutLocalService _ddmStructureLayoutLocalService;
 
 }


### PR DESCRIPTION
Hi Team,
I'm trying to introduce a post method for DocumentMetadataSets but when running 
```
cd modules/apps/headless/headless-delivery/headless-delivery-test
gw testIntegration --tests DocumentMetadataSetResourceTest.testPostSiteDocumentMetadataSet
```

I'm getting
```
com.liferay.headless.delivery.resource.v1_0.test.DocumentMetadataSetResourceTest > testPostSiteDocumentMetadataSet FAILED
    com.liferay.headless.delivery.client.problem.Problem$ProblemException: availableLanguages must not be null
    dataDefinitionFields must not be null
        at com.liferay.headless.delivery.client.resource.v1_0.DocumentMetadataSetResource$DocumentMetadataSetResourceImpl.postSiteDocumentMetadataSet(DocumentMetadataSetResource.java:1241)
        at com.liferay.headless.delivery.resource.v1_0.test.BaseDocumentMetadataSetResourceTestCase.testPostSiteDocumentMetadataSet_addDocumentMetadataSet(BaseDocumentMetadataSetResourceTestCase.java:984)
        at com.liferay.headless.delivery.resource.v1_0.test.BaseDocumentMetadataSetResourceTestCase.testPostSiteDocumentMetadataSet(BaseDocumentMetadataSetResourceTestCase.java:972)
```
Can you please help me identify why the deserialisation fails to extract these fields?

Cheers,
Balázs
