### PR TITLE
LPD-39238 | Show object field name on API Schema

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/PropertiesTreeView.tsx
+++ b/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/PropertiesTreeView.tsx
@@ -170,7 +170,7 @@ export default function PropertiesTreeView({
 						>
 							<ClayIcon symbol={getIconName(businessType)} />
 
-							<span className="treeview-item-label">{name}</span>
+							<span className="treeview-item-label">{objectFieldName}</span>
 
 							<span className="text-truncate treeview-item-path">
 								&nbsp;

--- a/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/PropertiesTreeView.tsx
+++ b/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/PropertiesTreeView.tsx
@@ -170,7 +170,9 @@ export default function PropertiesTreeView({
 						>
 							<ClayIcon symbol={getIconName(businessType)} />
 
-							<span className="treeview-item-label">{objectFieldName}</span>
+							<span className="treeview-item-label">
+								{objectFieldName ? objectFieldName : name}
+							</span>
 
 							<span className="text-truncate treeview-item-path">
 								&nbsp;

--- a/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/baseComponents/BaseAPISchemaProperty.tsx
+++ b/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/baseComponents/BaseAPISchemaProperty.tsx
@@ -46,15 +46,12 @@ export default function BaseAPISchemaProperty({
 				objectDefinition.externalReferenceCode
 			));
 
-	const localizedPropertyName =
-		objectField.label[Liferay.ThemeDisplay.getDefaultLanguageId()]!;
-
 	const handleClick = () => {
 		setSchemaUIData((previous) => {
 			if (previous.schemaProperties) {
 				previous.schemaProperties.unshift({
 					businessType: objectField.businessType,
-					name: localizedPropertyName,
+					name: objectField.name,
 					objectDefinitionName: objectDefinition.name,
 					objectFieldERC: objectField.externalReferenceCode,
 					objectFieldId: objectField.id,
@@ -75,6 +72,9 @@ export default function BaseAPISchemaProperty({
 			return previous;
 		});
 	};
+
+	const localizedPropertyName =
+		objectField.label[Liferay.ThemeDisplay.getDefaultLanguageId()]!;
 
 	return (
 		<ClayButton

--- a/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/baseComponents/BaseAPISchemaProperty.tsx
+++ b/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/baseComponents/BaseAPISchemaProperty.tsx
@@ -73,14 +73,11 @@ export default function BaseAPISchemaProperty({
 		});
 	};
 
-	const localizedPropertyName =
-		objectField.label[Liferay.ThemeDisplay.getDefaultLanguageId()]!;
-
 	return (
 		<ClayButton
 			aria-label={sub(
 				Liferay.Language.get('add-x-property'),
-				localizedPropertyName
+				objectField.label[Liferay.ThemeDisplay.getDefaultLanguageId()]!
 			)}
 			className="property-container"
 			displayType="unstyled"


### PR DESCRIPTION
**Description:** Now we show the object field name on the properties
![image](https://github.com/user-attachments/assets/e40bda2d-2ad0-496d-9dbc-41162b420314)

Also, this is the response for the curl
`$ curl -X GET -u test@liferay.com:test http://localhost:8080/o/c/api-app/students
`
```
{
  "actions" : { },
  "facets" : [ ],
  "items" : [ {
    "creator" : {
      "additionalName" : "",
      "contentType" : "UserAccount",
      "externalReferenceCode" : "8b948656-bda7-3d3b-16d0-b06e52f368ff",
      "familyName" : "Test",
      "givenName" : "Test",
      "id" : 20123,
      "name" : "Test Test"
    },
    "stName" : "juan",
    "modifiedDate" : "2024-10-29T15:13:26Z",
    "id" : 35305,
    "externalReferenceCode" : "56015aa7-7e6b-9aa4-8f3c-1c885976c16f",
    "createDate" : "2024-10-29T15:13:26Z"
  } ],
  "lastPage" : 1,
  "page" : 1,
  "pageSize" : 20,
  "totalCount" : 1
}

```

**Jira Ticket**: https://liferay.atlassian.net/browse/LPD-39238