### PR TITLE
LPD-37787 Filtering using r_<relationshipName>_c_<objectName>ERC is not working properly

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/v1_0/ObjectEntryEntityModel.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/v1_0/ObjectEntryEntityModel.java
@@ -278,7 +278,7 @@ public class ObjectEntryEntityModel implements EntityModel {
 				objectRelationshipERCObjectFieldName,
 				new StringEntityField(
 					objectRelationshipERCObjectFieldName,
-					locale -> objectFieldName));
+					locale -> "externalReferenceCode"));
 
 			String relationshipIdName = objectFieldName.substring(
 				objectFieldName.lastIndexOf(StringPool.UNDERLINE) + 1);

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntry1toMObjectRelatedModelsPredicateProviderImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntry1toMObjectRelatedModelsPredicateProviderImpl.java
@@ -17,6 +17,7 @@ import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.petra.sql.dsl.Column;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
+import com.liferay.petra.sql.dsl.expression.Expression;
 import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.petra.sql.dsl.query.FromStep;
 import com.liferay.petra.string.StringBundler;
@@ -79,8 +80,8 @@ public class ObjectEntry1toMObjectRelatedModelsPredicateProviderImpl
 					objectDefinition2, objectFieldLocalService),
 				objectDefinition2DynamicObjectDefinitionTable,
 				objectDefinition2ExtensionDynamicObjectDefinitionTable,
-				DSLQueryFactoryUtil.select(objectRelationshipColumn),
-				predicate);
+				DSLQueryFactoryUtil.select(objectRelationshipColumn), predicate,
+				objectRelationshipColumn);
 		}
 
 		DynamicObjectDefinitionTable dynamicObjectDefinitionTable =
@@ -104,7 +105,7 @@ public class ObjectEntry1toMObjectRelatedModelsPredicateProviderImpl
 					DSLQueryFactoryUtil.select(
 						objectDefinition1DynamicObjectDefinitionTable.
 							getPrimaryKeyColumn()),
-					predicate)
+					predicate, objectRelationshipColumn)
 			));
 	}
 
@@ -163,15 +164,20 @@ public class ObjectEntry1toMObjectRelatedModelsPredicateProviderImpl
 				dynamicObjectDefinitionLocalizationTable,
 			DynamicObjectDefinitionTable dynamicObjectDefinitionTable,
 			DynamicObjectDefinitionTable extensionDynamicObjectDefinitionTable,
-			FromStep fromStep, Predicate predicate)
+			FromStep fromStep, Predicate predicate,
+			Column<?, ?> relationshipColumn)
 		throws PortalException {
+
+		ObjectEntryTable objectEntryTable1 = ObjectEntryTable.INSTANCE;
+		ObjectEntryTable objectEntryTable2 = ObjectEntryTable.INSTANCE.as(
+			"Object2");
 
 		return column.in(
 			fromStep.from(
 				dynamicObjectDefinitionTable
 			).innerJoinON(
-				ObjectEntryTable.INSTANCE,
-				ObjectEntryTable.INSTANCE.objectEntryId.eq(
+				objectEntryTable2,
+				objectEntryTable2.objectEntryId.eq(
 					dynamicObjectDefinitionTable.getPrimaryKeyColumn())
 			).innerJoinON(
 				extensionDynamicObjectDefinitionTable,
@@ -179,6 +185,10 @@ public class ObjectEntry1toMObjectRelatedModelsPredicateProviderImpl
 				).eq(
 					extensionDynamicObjectDefinitionTable.getPrimaryKeyColumn()
 				)
+			).innerJoinON(
+				objectEntryTable1,
+				objectEntryTable1.objectEntryId.eq(
+					(Expression<Long>)relationshipColumn)
 			).leftJoinOn(
 				dynamicObjectDefinitionLocalizationTable,
 				ObjectEntrySearchUtil.getLeftJoinLocalizationTablePredicate(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-37787

The bug was happening because the built query was having a bad parsing to sql.

```sql
SELECT o_82008147278367_student.r_universitystudents_c_universityid
FROM   o_82008147278367_student
       INNER JOIN objectentry
               ON objectentry.objectentryid =
                  o_82008147278367_student.c_studentid_
       INNER JOIN o_82008147278367_student_x
               ON o_82008147278367_student.c_studentid_ =
                  o_82008147278367_student_x.c_studentid_
WHERE  o_82008147278367_student.r_universitystudents_c_universityid =
       "university-erc-test" 
```

That is why sending the request with the id was working. 

With the changes now the query is like this

```sql
SELECT o_82008147278367_student.r_universitystudents_c_universityid
FROM   o_82008147278367_student
       INNER JOIN objectentry Object2
               ON Object2.objectentryid = o_82008147278367_student.c_studentid_
       INNER JOIN o_82008147278367_student_x
               ON o_82008147278367_student.c_studentid_ =
                  o_82008147278367_student_x.c_studentid_
       INNER JOIN objectentry
               ON objectentry.objectentryid =
                  o_82008147278367_student.r_universitystudents_c_universityid
WHERE  objectentry.externalreferencecode = "university-erc-test" 
```

## TODO

- Check if this implementation breaks something 
- Create the corresponding test
