### PR TITLE
LPD-40988 Export includes unselected portlets if a widget page template with a web content display portlet is exported

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/controller/PortletExportControllerImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/controller/PortletExportControllerImpl.java
@@ -1001,6 +1001,12 @@ public class PortletExportControllerImpl implements PortletExportController {
 			Set<String> oldScopedPrimaryKeys = new HashSet<>(
 				portletDataContext.getScopedPrimaryKeys());
 
+			Map<String, String[]> parameterMap =
+				portletDataContext.getParameterMap();
+
+			boolean portletDataAll = MapUtil.getBoolean(
+				parameterMap, PortletDataHandlerKeys.PORTLET_DATA_ALL);
+
 			try {
 				portletDataContext.clearScopedPrimaryKeys();
 
@@ -1034,6 +1040,9 @@ public class PortletExportControllerImpl implements PortletExportController {
 				}
 			}
 			finally {
+				parameterMap.put(
+					PortletDataHandlerKeys.PORTLET_DATA_ALL,
+					new String[] {String.valueOf(portletDataAll)});
 				portletDataContext.addScopedPrimaryKeys(oldScopedPrimaryKeys);
 				portletDataContext.setExportDataRootElement(
 					exportDataRootElement);

--- a/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
+++ b/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
@@ -172,6 +172,27 @@ export class PageEditorPage {
 			.press('Enter');
 	}
 
+	async addWidgetToWidgetPageTemplate(category: string, name: string) {
+		await this.goToSidebarTab('Widgets');
+
+		await this.page
+			.getByRole('tab', {exact: true, name: 'Widgets'})
+			.click();
+
+		const header = this.page.getByRole('button', {
+			exact: true,
+			name: category,
+		});
+
+		await expandSection(header);
+
+		await this.page
+			.locator('li', {hasText: name})
+			.getByLabel('Add Content')
+			.first()
+			.click();
+	}
+
 	async addWidget(category: string, name: string, dropTarget?: Locator) {
 		await this.goToSidebarTab('Fragments and Widgets');
 

--- a/modules/test/playwright/tests/export-import-web/import.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/import.spec.ts
@@ -13,8 +13,13 @@ import {applicationsMenuPageTest} from '../../fixtures/applicationsMenuPageTest'
 import {dataApiHelpersTest} from '../../fixtures/dataApiHelpersTest';
 import {depotAdminPageTest} from '../../fixtures/depotAdminPageTest';
 import {documentLibraryPagesTest} from '../../fixtures/documentLibraryPages.fixtures';
+import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../fixtures/pageEditorPagesTest';
+import {pageTemplatesPagesTest} from '../../fixtures/pageTemplatesPagesTest';
+import {pagesAdminPagesTest} from '../../fixtures/pagesAdminPagesTest';
 import {productMenuPageTest} from '../../fixtures/productMenuPageTest';
+import {wikiPagesTest} from '../../fixtures/wikiPagesTest';
 import {depotsPagesTest} from '../../tests/depot-web/fixtures/depotsPagesTest';
 import getRandomString from '../../utils/getRandomString';
 import {getTempDir} from '../../utils/temp';
@@ -31,7 +36,12 @@ export const test = mergeTests(
 	stagingPageTest,
 	depotsPagesTest,
 	depotAdminPageTest,
-	loginTest()
+	pagesAdminPagesTest,
+	pageEditorPagesTest,
+	pageTemplatesPagesTest,
+	wikiPagesTest,
+	loginTest(),
+	isolatedSiteTest
 );
 
 async function getSiteHomePageScreenshot(
@@ -60,6 +70,78 @@ async function getSiteHomePageScreenshot(
 
 	return screenshot;
 }
+
+test(
+	'make sure we do not export-import wikiNodes if they are not selected in the export configuration screen',
+	{tag: '@LPS-195766'},
+	async ({
+		exportImportPage,
+		page,
+		pageEditorPage,
+		pageTemplatesPage,
+		site,
+		wikiPage,
+	}) => {
+		await wikiPage.goto(site.friendlyUrlPath);
+
+		await wikiPage.createNewWikiNode('Wiki Node Title');
+
+		await pageTemplatesPage.goto(site.friendlyUrlPath);
+
+		// Create page template collection
+
+		const pageTemplateCollectionName = getRandomString();
+
+		await pageTemplatesPage.addPageTemplateCollection(
+			pageTemplateCollectionName
+		);
+
+		await expect(
+			page.getByRole('menuitem', {
+				exact: true,
+				name: pageTemplateCollectionName,
+			})
+		).toBeVisible();
+
+		// Create widget page template
+
+		const pageTemplateName = getRandomString();
+
+		await pageTemplatesPage.addWidgetPageTemplate(pageTemplateName);
+
+		await pageTemplatesPage.page.getByLabel('Add', {exact: true}).click();
+
+		await pageEditorPage.addWidgetToWidgetPageTemplate(
+			'Content Management',
+			'Web Content Display'
+		);
+
+		await wikiPage.goto(site.friendlyUrlPath);
+
+		await exportImportPage.goToExport();
+
+		const exportName = 'MyExport-' + getRandomString();
+
+		await exportImportPage.createNewExportProcess(exportName);
+
+		await expect(
+			exportImportPage.page
+				.getByText(exportName)
+				.locator('../..')
+				.getByText('Successful')
+		).toBeVisible();
+
+		const exportFilePath =
+			await exportImportPage.downloadExportProcess(exportName);
+
+		await exportImportPage.goToImport();
+
+		await exportImportPage.checkItemInNewlyCreatedImportProcess(
+			exportFilePath,
+			'Wiki'
+		);
+	}
+);
 
 test(
 	'can XSS with `searchContainerId` in Asset Libraries import',

--- a/modules/test/playwright/tests/export-import-web/import.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/import.spec.ts
@@ -72,8 +72,8 @@ async function getSiteHomePageScreenshot(
 }
 
 test(
-	'make sure we do not export-import wikiNodes if they are not selected in the export configuration screen',
-	{tag: '@LPS-195766'},
+	'Make sure we do not export-import wikiNodes if they are not selected in the export configuration screen',
+	{tag: '@LPD-40988'},
 	async ({
 		exportImportPage,
 		page,

--- a/modules/test/playwright/tests/export-import-web/pages/ExportImportPage.ts
+++ b/modules/test/playwright/tests/export-import-web/pages/ExportImportPage.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {Locator, Page} from '@playwright/test';
+import {Locator, Page, expect} from '@playwright/test';
 
 import {ProductMenuPage} from '../../../pages/product-navigation-control-menu-web/ProductMenuPage';
 import {getTempDir} from '../../../utils/temp';
@@ -43,6 +43,29 @@ export class ExportImportPage {
 		await this.title.fill(title);
 
 		await this.exportButton.click();
+	}
+
+	async checkItemInNewlyCreatedImportProcess(
+		folderPath: string,
+		itemToCheck: string
+	) {
+		await this.newImportButton.click();
+
+		const fileChooserPromise = this.page.waitForEvent('filechooser');
+
+		await this.fileSelector.click();
+
+		const fileChooser = await fileChooserPromise;
+
+		await fileChooser.setFiles(folderPath);
+
+		await this.continueButton.click();
+
+		await this.page.waitForLoadState('domcontentloaded');
+		await this.page.waitForTimeout(1000);
+
+		const wikiLabelCount = await this.page.getByLabel(itemToCheck).count();
+		expect(wikiLabelCount).toBe(0);
 	}
 
 	async createNewImportProcess(folderPath: string) {

--- a/modules/test/playwright/tests/layout-content-page-editor-web/types/page-editor.d.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/types/page-editor.d.ts
@@ -25,6 +25,7 @@ type SidebarTab =
 	| 'Fragments and Widgets'
 	| 'Page Content'
 	| 'Page Design Options'
-	| 'Page Rules';
+	| 'Page Rules'
+	| 'Widgets';
 
 type Viewport = 'Desktop' | 'Landscape Phone' | 'Portrait Phone' | 'Tablet';

--- a/modules/test/playwright/tsconfig.json
+++ b/modules/test/playwright/tsconfig.json
@@ -11,6 +11,7 @@
 	},
 	"include": [
 		"../../global.d.ts",
-		"**/*.ts"
+		"**/*.ts",
+		"../../node_modules/@types/jest/index.d.ts"
 	]
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-40988

reset PORTLET_DATA_ALL after exporting metadata