### PR TITLE
LPD-35830 Enable object filtering in batch engine export processes

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
@@ -543,6 +543,13 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 
 	private String _getFilterString() {
 		if (contextHttpServletRequest == null) {
+			if (contextUriInfo != null) {
+				MultivaluedMap<String, String> queryParameters =
+					contextUriInfo.getQueryParameters();
+
+				return queryParameters.getFirst("filter");
+			}
+
 			return null;
 		}
 

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
@@ -542,18 +542,18 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 	}
 
 	private String _getFilterString() {
-		if (contextHttpServletRequest == null) {
-			if (contextUriInfo != null) {
-				MultivaluedMap<String, String> queryParameters =
-					contextUriInfo.getQueryParameters();
-
-				return queryParameters.getFirst("filter");
-			}
-
-			return null;
+		if (contextHttpServletRequest != null) {
+			return ParamUtil.getString(contextHttpServletRequest, "filter");
 		}
 
-		return ParamUtil.getString(contextHttpServletRequest, "filter");
+		if (contextUriInfo != null) {
+			MultivaluedMap<String, String> queryParameters =
+				contextUriInfo.getQueryParameters();
+
+			return queryParameters.getFirst("filter");
+		}
+
+		return null;
 	}
 
 	private long _getPrimaryKey(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
@@ -10,6 +10,7 @@ import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.rest.test.util.ObjectEntryTestUtil;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
@@ -49,9 +50,6 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import org.skyscreamer.jsonassert.JSONAssert;
-import org.skyscreamer.jsonassert.JSONCompareMode;
 
 /**
  * @author Carolina Barbosa
@@ -164,13 +162,12 @@ public class ExportTaskResourceTest {
 					"BatchEngineExportTaskExecutorImpl",
 				LoggerTestUtil.ERROR)) {
 
-			String objectDefinitionRESTContextPath =
-				_objectDefinition1.getRESTContextPath();
-
-			ObjectEntryTestUtil.addObjectEntry(
+			ObjectEntry objectEntry1 = ObjectEntryTestUtil.addObjectEntry(
 				_objectDefinition1, _OBJECT_FIELD_NAME_TEXT, "TestObject1");
-			ObjectEntryTestUtil.addObjectEntry(
+
+			ObjectEntry objectEntry2 = ObjectEntryTestUtil.addObjectEntry(
 				_objectDefinition1, _OBJECT_FIELD_NAME_TEXT, "TestObject2");
+
 			ObjectEntryTestUtil.addObjectEntry(
 				_objectDefinition1, _OBJECT_FIELD_NAME_TEXT, "Object3");
 
@@ -178,11 +175,12 @@ public class ExportTaskResourceTest {
 				StringBundler.concat(
 					"contains(", _OBJECT_FIELD_NAME_TEXT, ", 'Test')"));
 
-			String queryParametersString =
-				"restrictFields=actions&filter=" + encodedFilterString;
+			String queryParametersString = "filter=" + encodedFilterString;
 
 			JSONObject jsonObject = _testPostExportTask(
 				_objectDefinition1, queryParametersString);
+
+			Assert.assertEquals(2, jsonObject.getInt("processedItemsCount"));
 
 			InputStream inputStream = HTTPTestUtil.invokeToInputStream(
 				null,
@@ -196,21 +194,22 @@ public class ExportTaskResourceTest {
 
 			zipInputStream.getNextEntry();
 
-			String responseString = StringUtil.read(zipInputStream);
+			JSONArray responseJSONArray = _jsonFactory.createJSONArray(
+				StringUtil.read(zipInputStream));
 
-			JSONObject filteredPageJSONObject = HTTPTestUtil.invokeToJSONObject(
-				null,
-				StringBundler.concat(
-					objectDefinitionRESTContextPath, "/?",
-					queryParametersString),
-				Http.Method.GET);
+			JSONObject objectEntry1JSONObject =
+				(JSONObject)responseJSONArray.get(0);
 
-			JSONArray itemsJSONArray = filteredPageJSONObject.getJSONArray(
-				"items");
+			Assert.assertEquals(
+				objectEntry1.getExternalReferenceCode(),
+				objectEntry1JSONObject.get("externalReferenceCode"));
 
-			JSONAssert.assertEquals(
-				itemsJSONArray.toString(), responseString,
-				JSONCompareMode.LENIENT);
+			JSONObject objectEntry2JSONObject =
+				(JSONObject)responseJSONArray.get(1);
+
+			Assert.assertEquals(
+				objectEntry2.getExternalReferenceCode(),
+				objectEntry2JSONObject.get("externalReferenceCode"));
 		}
 	}
 
@@ -260,10 +259,10 @@ public class ExportTaskResourceTest {
 	@Inject
 	private CompanyLocalService _companyLocalService;
 
-	private ObjectDefinition _objectDefinition1;
-
 	@Inject
 	private JSONFactory _jsonFactory;
+
+	private ObjectDefinition _objectDefinition1;
 
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.URLCodec;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
@@ -94,9 +95,13 @@ public class ExportTaskResourceTest {
 					"BatchEngineExportTaskExecutorImpl",
 				LoggerTestUtil.ERROR)) {
 
-			_testPostExportTask("COMPLETED", _objectDefinition1);
+			JSONObject exportTaskJSONObject1 = _testPostExportTask(
+				_objectDefinition1, null);
 
-			JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+			Assert.assertEquals(
+				"COMPLETED", exportTaskJSONObject1.get("executeStatus"));
+
+			JSONObject companyJSONObject = HTTPTestUtil.invokeToJSONObject(
 				JSONUtil.put(
 					"domain", "able.com"
 				).put(
@@ -108,7 +113,7 @@ public class ExportTaskResourceTest {
 				Http.Method.POST);
 
 			User user = UserTestUtil.getAdminUser(
-				jsonObject.getLong("companyId"));
+				companyJSONObject.getLong("companyId"));
 
 			ObjectDefinition objectDefinition2 =
 				ObjectDefinitionTestUtil.publishObjectDefinition(
@@ -119,7 +124,11 @@ public class ExportTaskResourceTest {
 							_OBJECT_FIELD_NAME_TEXT)),
 					ObjectDefinitionConstants.SCOPE_COMPANY, user.getUserId());
 
-			_testPostExportTask("FAILED", objectDefinition2);
+			exportTaskJSONObject1 = _testPostExportTask(
+				objectDefinition2, null);
+
+			Assert.assertEquals(
+				"FAILED", exportTaskJSONObject1.get("executeStatus"));
 
 			HTTPTestUtil.customize(
 			).withBaseURL(
@@ -128,12 +137,23 @@ public class ExportTaskResourceTest {
 				"test@able.com", PropsValues.DEFAULT_ADMIN_PASSWORD
 			).apply(
 				() -> {
-					_testPostExportTask("COMPLETED", objectDefinition2);
-					_testPostExportTask("FAILED", _objectDefinition1);
+					JSONObject exportTaskJSONObject2 = _testPostExportTask(
+						objectDefinition2, null);
+
+					Assert.assertEquals(
+						"COMPLETED",
+						exportTaskJSONObject2.get("executeStatus"));
+
+					exportTaskJSONObject2 = _testPostExportTask(
+						_objectDefinition1, null);
+
+					Assert.assertEquals(
+						"FAILED", exportTaskJSONObject2.get("executeStatus"));
 				}
 			);
 
-			_companyLocalService.deleteCompany(jsonObject.getLong("companyId"));
+			_companyLocalService.deleteCompany(
+				companyJSONObject.getLong("companyId"));
 		}
 	}
 
@@ -154,38 +174,15 @@ public class ExportTaskResourceTest {
 			ObjectEntryTestUtil.addObjectEntry(
 				_objectDefinition1, _OBJECT_FIELD_NAME_TEXT, "Object3");
 
-			String queryParametersString = StringBundler.concat(
-				"restrictFields=actions&filter=contains%28",
-				_OBJECT_FIELD_NAME_TEXT, "%2C%20%27Test%27%29");
-
-			JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
-				null,
+			String encodedFilterString = URLCodec.encodeURL(
 				StringBundler.concat(
-					"headless-batch-engine/v1.0/export-task",
-					"/com.liferay.object.rest.dto.v1_0.ObjectEntry/JSON?",
-					"taskItemDelegateName=", _objectDefinition1.getName(), "&",
-					queryParametersString),
-				Http.Method.POST);
+					"contains(", _OBJECT_FIELD_NAME_TEXT, ", 'Test')"));
 
-			String actualExecuteStatus = null;
+			String queryParametersString =
+				"restrictFields=actions&filter=" + encodedFilterString;
 
-			while (true) {
-				jsonObject = HTTPTestUtil.invokeToJSONObject(
-					null,
-					StringBundler.concat(
-						"headless-batch-engine/v1.0/export-task",
-						"/by-external-reference-code/",
-						jsonObject.getString("externalReferenceCode")),
-					Http.Method.GET);
-
-				actualExecuteStatus = jsonObject.getString("executeStatus");
-
-				if (StringUtil.equals(actualExecuteStatus, "COMPLETED") ||
-					StringUtil.equals(actualExecuteStatus, "FAILED")) {
-
-					break;
-				}
-			}
+			JSONObject jsonObject = _testPostExportTask(
+				_objectDefinition1, queryParametersString);
 
 			InputStream inputStream = HTTPTestUtil.invokeToInputStream(
 				null,
@@ -217,17 +214,22 @@ public class ExportTaskResourceTest {
 		}
 	}
 
-	private void _testPostExportTask(
-			String expectedExecuteStatus, ObjectDefinition objectDefinition)
+	private JSONObject _testPostExportTask(
+			ObjectDefinition objectDefinition, String queryParameters)
 		throws Exception {
 
+		String endpointString = StringBundler.concat(
+			"headless-batch-engine/v1.0/export-task",
+			"/com.liferay.object.rest.dto.v1_0.ObjectEntry/json?",
+			"taskItemDelegateName=", objectDefinition.getName());
+
+		if (queryParameters != null) {
+			endpointString = StringBundler.concat(
+				endpointString, "&", queryParameters);
+		}
+
 		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
-			null,
-			StringBundler.concat(
-				"headless-batch-engine/v1.0/export-task",
-				"/com.liferay.object.rest.dto.v1_0.ObjectEntry/json?",
-				"taskItemDelegateName=", objectDefinition.getName()),
-			Http.Method.POST);
+			null, endpointString, Http.Method.POST);
 
 		String actualExecuteStatus = null;
 
@@ -249,7 +251,7 @@ public class ExportTaskResourceTest {
 			}
 		}
 
-		Assert.assertEquals(expectedExecuteStatus, actualExecuteStatus);
+		return jsonObject;
 	}
 
 	private static final String _OBJECT_FIELD_NAME_TEXT =

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
@@ -66,7 +66,7 @@ public class ExportTaskResourceTest {
 
 	@Before
 	public void setUp() throws Exception {
-		_objectDefinition1 = ObjectDefinitionTestUtil.publishObjectDefinition(
+		_objectDefinition = ObjectDefinitionTestUtil.publishObjectDefinition(
 			Collections.singletonList(
 				ObjectFieldUtil.createObjectField(
 					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
@@ -75,7 +75,7 @@ public class ExportTaskResourceTest {
 			ObjectDefinitionConstants.SCOPE_COMPANY,
 			TestPropsValues.getUserId());
 
-		_objectDefinitions.add(_objectDefinition1);
+		_objectDefinitions.add(_objectDefinition);
 	}
 
 	@After
@@ -96,7 +96,7 @@ public class ExportTaskResourceTest {
 				LoggerTestUtil.ERROR)) {
 
 			JSONObject exportTaskJSONObject1 = _postExportTask(
-				_objectDefinition1, null);
+				_objectDefinition, null);
 
 			Assert.assertEquals(
 				"COMPLETED", exportTaskJSONObject1.get("executeStatus"));
@@ -145,7 +145,7 @@ public class ExportTaskResourceTest {
 						exportTaskJSONObject2.get("executeStatus"));
 
 					exportTaskJSONObject2 = _postExportTask(
-						_objectDefinition1, null);
+						_objectDefinition, null);
 
 					Assert.assertEquals(
 						"FAILED", exportTaskJSONObject2.get("executeStatus"));
@@ -162,13 +162,13 @@ public class ExportTaskResourceTest {
 	@Test
 	public void testPostExportTaskWithFiltering() throws Exception {
 		ObjectEntry objectEntry1 = ObjectEntryTestUtil.addObjectEntry(
-			_objectDefinition1, _OBJECT_FIELD_NAME_TEXT, "TestObject1");
+			_objectDefinition, _OBJECT_FIELD_NAME_TEXT, "TestObject1");
 
 		ObjectEntry objectEntry2 = ObjectEntryTestUtil.addObjectEntry(
-			_objectDefinition1, _OBJECT_FIELD_NAME_TEXT, "TestObject2");
+			_objectDefinition, _OBJECT_FIELD_NAME_TEXT, "TestObject2");
 
 		ObjectEntryTestUtil.addObjectEntry(
-			_objectDefinition1, _OBJECT_FIELD_NAME_TEXT, "Object3");
+			_objectDefinition, _OBJECT_FIELD_NAME_TEXT, "Object3");
 
 		String encodedFilterString = URLCodec.encodeURL(
 			StringBundler.concat(
@@ -177,7 +177,7 @@ public class ExportTaskResourceTest {
 		String queryParametersString = "filter=" + encodedFilterString;
 
 		JSONObject jsonObject = _postExportTask(
-			_objectDefinition1, queryParametersString);
+			_objectDefinition, queryParametersString);
 
 		Assert.assertEquals(2, jsonObject.getInt("processedItemsCount"));
 
@@ -260,7 +260,7 @@ public class ExportTaskResourceTest {
 	@Inject
 	private JSONFactory _jsonFactory;
 
-	private ObjectDefinition _objectDefinition1;
+	private ObjectDefinition _objectDefinition;
 
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
@@ -38,9 +38,7 @@ import com.liferay.portal.util.PropsValues;
 
 import java.io.InputStream;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 import java.util.zip.ZipInputStream;
 
 import org.junit.After;
@@ -74,16 +72,11 @@ public class ExportTaskResourceTest {
 					_OBJECT_FIELD_NAME_TEXT)),
 			ObjectDefinitionConstants.SCOPE_COMPANY,
 			TestPropsValues.getUserId());
-
-		_objectDefinitions.add(_objectDefinition);
 	}
 
 	@After
 	public void tearDown() throws Exception {
-		for (ObjectDefinition objectDefinition : _objectDefinitions) {
-			_objectDefinitionLocalService.deleteObjectDefinition(
-				objectDefinition);
-		}
+		_objectDefinitionLocalService.deleteObjectDefinition(_objectDefinition);
 	}
 
 	@Test
@@ -264,7 +257,5 @@ public class ExportTaskResourceTest {
 
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
-
-	private final List<ObjectDefinition> _objectDefinitions = new ArrayList<>();
 
 }

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
@@ -49,6 +49,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
 /**
  * @author Carolina Barbosa
  */
@@ -168,22 +171,19 @@ public class ExportTaskResourceTest {
 
 		zipInputStream.getNextEntry();
 
-		JSONArray responseJSONArray = _jsonFactory.createJSONArray(
-			StringUtil.read(zipInputStream));
+		String responseJSONArrayString = StringUtil.read(zipInputStream);
 
-		JSONObject objectEntry1JSONObject = (JSONObject)responseJSONArray.get(
-			0);
+		JSONArray expectedJSONArray = JSONUtil.putAll(
+			JSONUtil.put(
+				"externalReferenceCode",
+				objectEntry1.getExternalReferenceCode()),
+			JSONUtil.put(
+				"externalReferenceCode",
+				objectEntry2.getExternalReferenceCode()));
 
-		Assert.assertEquals(
-			objectEntry1.getExternalReferenceCode(),
-			objectEntry1JSONObject.get("externalReferenceCode"));
-
-		JSONObject objectEntry2JSONObject = (JSONObject)responseJSONArray.get(
-			1);
-
-		Assert.assertEquals(
-			objectEntry2.getExternalReferenceCode(),
-			objectEntry2JSONObject.get("externalReferenceCode"));
+		JSONAssert.assertEquals(
+			expectedJSONArray.toString(), responseJSONArrayString,
+			JSONCompareMode.LENIENT);
 	}
 
 	private JSONObject _postExportTask(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
@@ -88,6 +88,8 @@ public class ExportTaskResourceTest {
 
 	@Test
 	public void testPostExportTask() throws Exception {
+		long companyId = 0;
+
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				"com.liferay.batch.engine.internal." +
 					"BatchEngineExportTaskExecutorImpl",
@@ -110,8 +112,9 @@ public class ExportTaskResourceTest {
 				"headless-portal-instances/v1.0/portal-instances",
 				Http.Method.POST);
 
-			User user = UserTestUtil.getAdminUser(
-				companyJSONObject.getLong("companyId"));
+			companyId = companyJSONObject.getLong("companyId");
+
+			User user = UserTestUtil.getAdminUser(companyId);
 
 			ObjectDefinition objectDefinition2 =
 				ObjectDefinitionTestUtil.publishObjectDefinition(
@@ -149,9 +152,11 @@ public class ExportTaskResourceTest {
 						"FAILED", exportTaskJSONObject2.get("executeStatus"));
 				}
 			);
-
-			_companyLocalService.deleteCompany(
-				companyJSONObject.getLong("companyId"));
+		}
+		finally {
+			if (companyId != 0) {
+				_companyLocalService.deleteCompany(companyId);
+			}
 		}
 	}
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
@@ -10,13 +10,17 @@ import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.rest.test.util.ObjectEntryTestUtil;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -27,15 +31,22 @@ import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.util.PropsValues;
 
+import java.io.InputStream;
+
 import java.util.Collections;
+import java.util.zip.ZipInputStream;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 
 /**
  * @author Carolina Barbosa
@@ -45,8 +56,10 @@ public class ExportTaskResourceTest {
 
 	@ClassRule
 	@Rule
-	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
-		new LiferayIntegrationTestRule();
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
 
 	@Test
 	public void testPostExportTask() throws Exception {
@@ -113,6 +126,99 @@ public class ExportTaskResourceTest {
 		}
 	}
 
+	@Test
+	public void testPostExportTaskWithFiltering() throws Exception {
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.batch.engine.internal." +
+					"BatchEngineExportTaskExecutorImpl",
+				LoggerTestUtil.ERROR)) {
+
+			ObjectDefinition objectDefinition =
+				ObjectDefinitionTestUtil.publishObjectDefinition(
+					Collections.singletonList(
+						ObjectFieldUtil.createObjectField(
+							ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+							ObjectFieldConstants.DB_TYPE_STRING,
+							_OBJECT_FIELD_NAME_TEXT)),
+					ObjectDefinitionConstants.SCOPE_COMPANY,
+					TestPropsValues.getUserId());
+
+			String objectDefinitionRESTContextPath =
+				objectDefinition.getRESTContextPath();
+
+			ObjectEntryTestUtil.addObjectEntry(
+				objectDefinition, _OBJECT_FIELD_NAME_TEXT, "TestObject1");
+			ObjectEntryTestUtil.addObjectEntry(
+				objectDefinition, _OBJECT_FIELD_NAME_TEXT, "TestObject2");
+			ObjectEntryTestUtil.addObjectEntry(
+				objectDefinition, _OBJECT_FIELD_NAME_TEXT, "Object3");
+
+			String queryParametersString = StringBundler.concat(
+				"restrictFields=actions&filter=contains%28",
+				_OBJECT_FIELD_NAME_TEXT, "%2C%20%27Test%27%29");
+
+			JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+				null,
+				StringBundler.concat(
+					"headless-batch-engine/v1.0/export-task",
+					"/com.liferay.object.rest.dto.v1_0.ObjectEntry/JSON?",
+					"taskItemDelegateName=", objectDefinition.getName(), "&",
+					queryParametersString),
+				Http.Method.POST);
+
+			String actualExecuteStatus = null;
+
+			while (true) {
+				jsonObject = HTTPTestUtil.invokeToJSONObject(
+					null,
+					StringBundler.concat(
+						"headless-batch-engine/v1.0/export-task",
+						"/by-external-reference-code/",
+						jsonObject.getString("externalReferenceCode")),
+					Http.Method.GET);
+
+				actualExecuteStatus = jsonObject.getString("executeStatus");
+
+				if (StringUtil.equals(actualExecuteStatus, "COMPLETED") ||
+					StringUtil.equals(actualExecuteStatus, "FAILED")) {
+
+					break;
+				}
+			}
+
+			InputStream inputStream = HTTPTestUtil.invokeToInputStream(
+				null,
+				StringBundler.concat(
+					"headless-batch-engine/v1.0/export-task",
+					"/by-external-reference-code/",
+					jsonObject.getString("externalReferenceCode"), "/content"),
+				Http.Method.GET);
+
+			ZipInputStream zipInputStream = new ZipInputStream(inputStream);
+
+			zipInputStream.getNextEntry();
+
+			String responseString = StringUtil.read(zipInputStream);
+
+			JSONObject filteredPageJSONObject = HTTPTestUtil.invokeToJSONObject(
+				null,
+				StringBundler.concat(
+					objectDefinitionRESTContextPath, "/?",
+					queryParametersString),
+				Http.Method.GET);
+
+			JSONArray itemsJSONArray = filteredPageJSONObject.getJSONArray(
+				"items");
+
+			JSONAssert.assertEquals(
+				itemsJSONArray.toString(), responseString,
+				JSONCompareMode.LENIENT);
+
+			_objectDefinitionLocalService.deleteObjectDefinition(
+				objectDefinition);
+		}
+	}
+
 	private void _testPostExportTask(
 			String expectedExecuteStatus, ObjectDefinition objectDefinition)
 		throws Exception {
@@ -153,6 +259,9 @@ public class ExportTaskResourceTest {
 
 	@Inject
 	private CompanyLocalService _companyLocalService;
+
+	@Inject
+	private JSONFactory _jsonFactory;
 
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
@@ -88,11 +88,7 @@ public class ExportTaskResourceTest {
 					"BatchEngineExportTaskExecutorImpl",
 				LoggerTestUtil.ERROR)) {
 
-			JSONObject exportTaskJSONObject1 = _postExportTask(
-				_objectDefinition, null);
-
-			Assert.assertEquals(
-				"COMPLETED", exportTaskJSONObject1.get("executeStatus"));
+			_postExportTask("COMPLETED", null, _objectDefinition);
 
 			JSONObject companyJSONObject = HTTPTestUtil.invokeToJSONObject(
 				JSONUtil.put(
@@ -118,10 +114,7 @@ public class ExportTaskResourceTest {
 							_OBJECT_FIELD_NAME_TEXT)),
 					ObjectDefinitionConstants.SCOPE_COMPANY, user.getUserId());
 
-			exportTaskJSONObject1 = _postExportTask(objectDefinition2, null);
-
-			Assert.assertEquals(
-				"FAILED", exportTaskJSONObject1.get("executeStatus"));
+			_postExportTask("FAILED", null, objectDefinition2);
 
 			HTTPTestUtil.customize(
 			).withBaseURL(
@@ -130,18 +123,9 @@ public class ExportTaskResourceTest {
 				"test@able.com", PropsValues.DEFAULT_ADMIN_PASSWORD
 			).apply(
 				() -> {
-					JSONObject exportTaskJSONObject2 = _postExportTask(
-						objectDefinition2, null);
+					_postExportTask("COMPLETED", null, objectDefinition2);
 
-					Assert.assertEquals(
-						"COMPLETED",
-						exportTaskJSONObject2.get("executeStatus"));
-
-					exportTaskJSONObject2 = _postExportTask(
-						_objectDefinition, null);
-
-					Assert.assertEquals(
-						"FAILED", exportTaskJSONObject2.get("executeStatus"));
+					_postExportTask("FAILED", null, _objectDefinition);
 				}
 			);
 		}
@@ -168,7 +152,7 @@ public class ExportTaskResourceTest {
 				"contains(", _OBJECT_FIELD_NAME_TEXT, ", 'Test')"));
 
 		JSONObject jsonObject = _postExportTask(
-			_objectDefinition, "filter=" + encodedFilterString);
+			"COMPLETED", "filter=" + encodedFilterString, _objectDefinition);
 
 		Assert.assertEquals(2, jsonObject.getInt("processedItemsCount"));
 
@@ -203,7 +187,8 @@ public class ExportTaskResourceTest {
 	}
 
 	private JSONObject _postExportTask(
-			ObjectDefinition objectDefinition, String queryParameters)
+			String expectedExecuteStatus, String queryParameters,
+			ObjectDefinition objectDefinition)
 		throws Exception {
 
 		String endpointString = StringBundler.concat(
@@ -238,6 +223,8 @@ public class ExportTaskResourceTest {
 				break;
 			}
 		}
+
+		Assert.assertEquals(expectedExecuteStatus, actualExecuteStatus);
 
 		return jsonObject;
 	}

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
@@ -167,10 +167,8 @@ public class ExportTaskResourceTest {
 			StringBundler.concat(
 				"contains(", _OBJECT_FIELD_NAME_TEXT, ", 'Test')"));
 
-		String queryParametersString = "filter=" + encodedFilterString;
-
 		JSONObject jsonObject = _postExportTask(
-			_objectDefinition, queryParametersString);
+			_objectDefinition, "filter=" + encodedFilterString);
 
 		Assert.assertEquals(2, jsonObject.getInt("processedItemsCount"));
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
@@ -162,60 +162,54 @@ public class ExportTaskResourceTest {
 
 	@Test
 	public void testPostExportTaskWithFiltering() throws Exception {
-		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				"com.liferay.batch.engine.internal." +
-					"BatchEngineExportTaskExecutorImpl",
-				LoggerTestUtil.ERROR)) {
+		ObjectEntry objectEntry1 = ObjectEntryTestUtil.addObjectEntry(
+			_objectDefinition1, _OBJECT_FIELD_NAME_TEXT, "TestObject1");
 
-			ObjectEntry objectEntry1 = ObjectEntryTestUtil.addObjectEntry(
-				_objectDefinition1, _OBJECT_FIELD_NAME_TEXT, "TestObject1");
+		ObjectEntry objectEntry2 = ObjectEntryTestUtil.addObjectEntry(
+			_objectDefinition1, _OBJECT_FIELD_NAME_TEXT, "TestObject2");
 
-			ObjectEntry objectEntry2 = ObjectEntryTestUtil.addObjectEntry(
-				_objectDefinition1, _OBJECT_FIELD_NAME_TEXT, "TestObject2");
+		ObjectEntryTestUtil.addObjectEntry(
+			_objectDefinition1, _OBJECT_FIELD_NAME_TEXT, "Object3");
 
-			ObjectEntryTestUtil.addObjectEntry(
-				_objectDefinition1, _OBJECT_FIELD_NAME_TEXT, "Object3");
+		String encodedFilterString = URLCodec.encodeURL(
+			StringBundler.concat(
+				"contains(", _OBJECT_FIELD_NAME_TEXT, ", 'Test')"));
 
-			String encodedFilterString = URLCodec.encodeURL(
-				StringBundler.concat(
-					"contains(", _OBJECT_FIELD_NAME_TEXT, ", 'Test')"));
+		String queryParametersString = "filter=" + encodedFilterString;
 
-			String queryParametersString = "filter=" + encodedFilterString;
+		JSONObject jsonObject = _testPostExportTask(
+			_objectDefinition1, queryParametersString);
 
-			JSONObject jsonObject = _testPostExportTask(
-				_objectDefinition1, queryParametersString);
+		Assert.assertEquals(2, jsonObject.getInt("processedItemsCount"));
 
-			Assert.assertEquals(2, jsonObject.getInt("processedItemsCount"));
+		InputStream inputStream = HTTPTestUtil.invokeToInputStream(
+			null,
+			StringBundler.concat(
+				"headless-batch-engine/v1.0/export-task",
+				"/by-external-reference-code/",
+				jsonObject.getString("externalReferenceCode"), "/content"),
+			Http.Method.GET);
 
-			InputStream inputStream = HTTPTestUtil.invokeToInputStream(
-				null,
-				StringBundler.concat(
-					"headless-batch-engine/v1.0/export-task",
-					"/by-external-reference-code/",
-					jsonObject.getString("externalReferenceCode"), "/content"),
-				Http.Method.GET);
+		ZipInputStream zipInputStream = new ZipInputStream(inputStream);
 
-			ZipInputStream zipInputStream = new ZipInputStream(inputStream);
+		zipInputStream.getNextEntry();
 
-			zipInputStream.getNextEntry();
+		JSONArray responseJSONArray = _jsonFactory.createJSONArray(
+			StringUtil.read(zipInputStream));
 
-			JSONArray responseJSONArray = _jsonFactory.createJSONArray(
-				StringUtil.read(zipInputStream));
+		JSONObject objectEntry1JSONObject = (JSONObject)responseJSONArray.get(
+			0);
 
-			JSONObject objectEntry1JSONObject =
-				(JSONObject)responseJSONArray.get(0);
+		Assert.assertEquals(
+			objectEntry1.getExternalReferenceCode(),
+			objectEntry1JSONObject.get("externalReferenceCode"));
 
-			Assert.assertEquals(
-				objectEntry1.getExternalReferenceCode(),
-				objectEntry1JSONObject.get("externalReferenceCode"));
+		JSONObject objectEntry2JSONObject = (JSONObject)responseJSONArray.get(
+			1);
 
-			JSONObject objectEntry2JSONObject =
-				(JSONObject)responseJSONArray.get(1);
-
-			Assert.assertEquals(
-				objectEntry2.getExternalReferenceCode(),
-				objectEntry2JSONObject.get("externalReferenceCode"));
-		}
+		Assert.assertEquals(
+			objectEntry2.getExternalReferenceCode(),
+			objectEntry2JSONObject.get("externalReferenceCode"));
 	}
 
 	private JSONObject _testPostExportTask(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
@@ -95,7 +95,7 @@ public class ExportTaskResourceTest {
 					"BatchEngineExportTaskExecutorImpl",
 				LoggerTestUtil.ERROR)) {
 
-			JSONObject exportTaskJSONObject1 = _testPostExportTask(
+			JSONObject exportTaskJSONObject1 = _postExportTask(
 				_objectDefinition1, null);
 
 			Assert.assertEquals(
@@ -125,8 +125,7 @@ public class ExportTaskResourceTest {
 							_OBJECT_FIELD_NAME_TEXT)),
 					ObjectDefinitionConstants.SCOPE_COMPANY, user.getUserId());
 
-			exportTaskJSONObject1 = _testPostExportTask(
-				objectDefinition2, null);
+			exportTaskJSONObject1 = _postExportTask(objectDefinition2, null);
 
 			Assert.assertEquals(
 				"FAILED", exportTaskJSONObject1.get("executeStatus"));
@@ -138,14 +137,14 @@ public class ExportTaskResourceTest {
 				"test@able.com", PropsValues.DEFAULT_ADMIN_PASSWORD
 			).apply(
 				() -> {
-					JSONObject exportTaskJSONObject2 = _testPostExportTask(
+					JSONObject exportTaskJSONObject2 = _postExportTask(
 						objectDefinition2, null);
 
 					Assert.assertEquals(
 						"COMPLETED",
 						exportTaskJSONObject2.get("executeStatus"));
 
-					exportTaskJSONObject2 = _testPostExportTask(
+					exportTaskJSONObject2 = _postExportTask(
 						_objectDefinition1, null);
 
 					Assert.assertEquals(
@@ -177,7 +176,7 @@ public class ExportTaskResourceTest {
 
 		String queryParametersString = "filter=" + encodedFilterString;
 
-		JSONObject jsonObject = _testPostExportTask(
+		JSONObject jsonObject = _postExportTask(
 			_objectDefinition1, queryParametersString);
 
 		Assert.assertEquals(2, jsonObject.getInt("processedItemsCount"));
@@ -212,7 +211,7 @@ public class ExportTaskResourceTest {
 			objectEntry2JSONObject.get("externalReferenceCode"));
 	}
 
-	private JSONObject _testPostExportTask(
+	private JSONObject _postExportTask(
 			ObjectDefinition objectDefinition, String queryParameters)
 		throws Exception {
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
@@ -36,10 +36,14 @@ import com.liferay.portal.util.PropsValues;
 
 import java.io.InputStream;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.zip.ZipInputStream;
 
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -61,6 +65,28 @@ public class ExportTaskResourceTest {
 			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
 
+	@Before
+	public void setUp() throws Exception {
+		_objectDefinition1 = ObjectDefinitionTestUtil.publishObjectDefinition(
+			Collections.singletonList(
+				ObjectFieldUtil.createObjectField(
+					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+					ObjectFieldConstants.DB_TYPE_STRING,
+					_OBJECT_FIELD_NAME_TEXT)),
+			ObjectDefinitionConstants.SCOPE_COMPANY,
+			TestPropsValues.getUserId());
+
+		_objectDefinitions.add(_objectDefinition1);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		for (ObjectDefinition objectDefinition : _objectDefinitions) {
+			_objectDefinitionLocalService.deleteObjectDefinition(
+				objectDefinition);
+		}
+	}
+
 	@Test
 	public void testPostExportTask() throws Exception {
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
@@ -68,17 +94,7 @@ public class ExportTaskResourceTest {
 					"BatchEngineExportTaskExecutorImpl",
 				LoggerTestUtil.ERROR)) {
 
-			ObjectDefinition objectDefinition1 =
-				ObjectDefinitionTestUtil.publishObjectDefinition(
-					Collections.singletonList(
-						ObjectFieldUtil.createObjectField(
-							ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-							ObjectFieldConstants.DB_TYPE_STRING,
-							_OBJECT_FIELD_NAME_TEXT)),
-					ObjectDefinitionConstants.SCOPE_COMPANY,
-					TestPropsValues.getUserId());
-
-			_testPostExportTask("COMPLETED", objectDefinition1);
+			_testPostExportTask("COMPLETED", _objectDefinition1);
 
 			JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
 				JSONUtil.put(
@@ -113,14 +129,9 @@ public class ExportTaskResourceTest {
 			).apply(
 				() -> {
 					_testPostExportTask("COMPLETED", objectDefinition2);
-					_testPostExportTask("FAILED", objectDefinition1);
+					_testPostExportTask("FAILED", _objectDefinition1);
 				}
 			);
-
-			_objectDefinitionLocalService.deleteObjectDefinition(
-				objectDefinition1);
-			_objectDefinitionLocalService.deleteObjectDefinition(
-				objectDefinition2);
 
 			_companyLocalService.deleteCompany(jsonObject.getLong("companyId"));
 		}
@@ -133,25 +144,15 @@ public class ExportTaskResourceTest {
 					"BatchEngineExportTaskExecutorImpl",
 				LoggerTestUtil.ERROR)) {
 
-			ObjectDefinition objectDefinition =
-				ObjectDefinitionTestUtil.publishObjectDefinition(
-					Collections.singletonList(
-						ObjectFieldUtil.createObjectField(
-							ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-							ObjectFieldConstants.DB_TYPE_STRING,
-							_OBJECT_FIELD_NAME_TEXT)),
-					ObjectDefinitionConstants.SCOPE_COMPANY,
-					TestPropsValues.getUserId());
-
 			String objectDefinitionRESTContextPath =
-				objectDefinition.getRESTContextPath();
+				_objectDefinition1.getRESTContextPath();
 
 			ObjectEntryTestUtil.addObjectEntry(
-				objectDefinition, _OBJECT_FIELD_NAME_TEXT, "TestObject1");
+				_objectDefinition1, _OBJECT_FIELD_NAME_TEXT, "TestObject1");
 			ObjectEntryTestUtil.addObjectEntry(
-				objectDefinition, _OBJECT_FIELD_NAME_TEXT, "TestObject2");
+				_objectDefinition1, _OBJECT_FIELD_NAME_TEXT, "TestObject2");
 			ObjectEntryTestUtil.addObjectEntry(
-				objectDefinition, _OBJECT_FIELD_NAME_TEXT, "Object3");
+				_objectDefinition1, _OBJECT_FIELD_NAME_TEXT, "Object3");
 
 			String queryParametersString = StringBundler.concat(
 				"restrictFields=actions&filter=contains%28",
@@ -162,7 +163,7 @@ public class ExportTaskResourceTest {
 				StringBundler.concat(
 					"headless-batch-engine/v1.0/export-task",
 					"/com.liferay.object.rest.dto.v1_0.ObjectEntry/JSON?",
-					"taskItemDelegateName=", objectDefinition.getName(), "&",
+					"taskItemDelegateName=", _objectDefinition1.getName(), "&",
 					queryParametersString),
 				Http.Method.POST);
 
@@ -213,9 +214,6 @@ public class ExportTaskResourceTest {
 			JSONAssert.assertEquals(
 				itemsJSONArray.toString(), responseString,
 				JSONCompareMode.LENIENT);
-
-			_objectDefinitionLocalService.deleteObjectDefinition(
-				objectDefinition);
 		}
 	}
 
@@ -260,10 +258,14 @@ public class ExportTaskResourceTest {
 	@Inject
 	private CompanyLocalService _companyLocalService;
 
+	private ObjectDefinition _objectDefinition1;
+
 	@Inject
 	private JSONFactory _jsonFactory;
 
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	private final List<ObjectDefinition> _objectDefinitions = new ArrayList<>();
 
 }

--- a/portal-test/src/com/liferay/portal/kernel/test/util/HTTPTestUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/HTTPTestUtil.java
@@ -17,6 +17,8 @@ import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.util.PropsValues;
 
+import java.io.InputStream;
+
 import java.nio.charset.StandardCharsets;
 
 import java.util.Map;
@@ -43,6 +45,16 @@ public class HTTPTestUtil {
 		Http.Response response = options.getResponse();
 
 		return response.getResponseCode();
+	}
+
+	public static InputStream invokeToInputStream(
+			String body, String endpoint, Http.Method httpMethod)
+		throws Exception {
+
+		Http.Options options = _getHttpOptions(
+			body, endpoint, null, httpMethod);
+
+		return HttpUtil.URLtoInputStream(options);
 	}
 
 	public static JSONObject invokeToJSONObject(

--- a/portal-test/src/com/liferay/portal/kernel/test/util/packageinfo
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 8.4.0
+version 8.5.0


### PR DESCRIPTION
**What's new?:**
- Now filters work as expected while generating a batch-engine export task so that only the wanted object entries are exported.
- A new test for export tasks of object entries has been created.

**What's changed?:**
- Now the ObjectEntryResourceImpl takes into account the `contextUriInfo` when the `contextHttpServletRequest` is empty for those aforementioned batch-engine cases.

See the following **Jira ticket**: [LPD-35254](https://liferay.atlassian.net/browse/LPD-35254)