### PR TITLE
LPD-40178 Show warning also to the fields that belongs to the single container in the UI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -438,6 +438,13 @@ modules/sdk/gradle-plugins-xsd-builder/    @liferay-devtools
 modules/sdk/gradle-plugins/    @liferay-devtools
 modules/sdk/gradle-util/    @liferay-devtools
 modules/sdk/project-templates/    @liferay-devtools
+modules/test/playwright/tests/batch-planner    @liferay-headless
+modules/test/playwright/tests/dispatch-web    @liferay-headless
+modules/test/playwright/tests/export-import-web    @liferay-headless
+modules/test/playwright/tests/headless-builder-impl    @liferay-headless
+modules/test/playwright/tests/headless-builder-web    @liferay-headless
+modules/test/playwright/tests/portal-tools-rest-builder-test-impl    @liferay-headless
+modules/test/playwright/tests/staging-configuration-web    @liferay-headless
 modules/third-party/
 modules/util/pmd/    @liferay-core-infra
 modules/util/portal-tools-benchmarks/    @liferay-core-infra

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -443,6 +443,7 @@ modules/test/playwright/tests/dispatch-web    @liferay-headless
 modules/test/playwright/tests/export-import-web    @liferay-headless
 modules/test/playwright/tests/headless-builder-impl    @liferay-headless
 modules/test/playwright/tests/headless-builder-web    @liferay-headless
+modules/test/playwright/tests/layout-set-prototype-web    @liferay-headless
 modules/test/playwright/tests/portal-tools-rest-builder-test-impl    @liferay-headless
 modules/test/playwright/tests/staging-configuration-web    @liferay-headless
 modules/third-party/

--- a/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/index.d.ts
+++ b/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/index.d.ts
@@ -68,6 +68,7 @@ interface APISchemaPropertyItem {
 	objectFieldERC: string;
 	objectFieldId: number;
 	objectRelationshipNames: string;
+	r_apiPropertyToAPIProperties_l_apiPropertyId: number;
 	r_apiSchemaToAPIProperties_l_apiSchemaERC: string;
 	r_apiSchemaToAPIProperties_l_apiSchemaId: number;
 	type: schemaPropertyItem;
@@ -271,6 +272,7 @@ interface TreeViewItemData {
 	objectFieldId: number;
 	objectFieldName: string;
 	objectRelationshipNames?: string;
+	r_apiPropertyToAPIProperties_l_apiPropertyId: number;
 	r_apiSchemaToAPIProperties_l_apiSchemaId: number;
 	type: string;
 }

--- a/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/EditAPISchema.tsx
+++ b/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/EditAPISchema.tsx
@@ -257,6 +257,8 @@ export default function EditAPISchema({
 											property.externalReferenceCode,
 										name: property.name,
 										objectFieldERC: property.objectFieldERC,
+										r_apiPropertyToAPIProperties_l_apiPropertyId:
+											property.r_apiPropertyToAPIProperties_l_apiPropertyId,
 										r_apiSchemaToAPIProperties_l_apiSchemaId:
 											property.r_apiSchemaToAPIProperties_l_apiSchemaId,
 										...(property.objectRelationshipNames && {

--- a/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/PropertiesTreeView.tsx
+++ b/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/PropertiesTreeView.tsx
@@ -177,9 +177,7 @@ export default function PropertiesTreeView({
 						>
 							<ClayIcon symbol={getIconName(businessType)} />
 
-							<span className="treeview-item-label">
-								{objectFieldName ? objectFieldName : name}
-							</span>
+							<span className="treeview-item-label">{objectFieldName}</span>
 
 							{!ALLOWED_BUSINESS_TYPES.includes(businessType) && (
 								<ClayTooltipProvider>

--- a/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/PropertiesTreeView.tsx
+++ b/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/PropertiesTreeView.tsx
@@ -132,6 +132,7 @@ export default function PropertiesTreeView({
 						objectDefinitionName,
 						objectFieldId,
 						objectFieldName,
+						r_apiPropertyToAPIProperties_l_apiPropertyId,
 					}) => (
 						<TreeView.Item
 							actions={
@@ -179,7 +180,9 @@ export default function PropertiesTreeView({
 
 							<span className="treeview-item-label">{name}</span>
 
-							{!ALLOWED_BUSINESS_TYPES.includes(businessType) && (
+							{(!ALLOWED_BUSINESS_TYPES.includes(businessType) ||
+								r_apiPropertyToAPIProperties_l_apiPropertyId !==
+									0) && (
 								<ClayTooltipProvider>
 									<span
 										className="inline-item-after"

--- a/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/PropertiesTreeView.tsx
+++ b/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/PropertiesTreeView.tsx
@@ -177,7 +177,7 @@ export default function PropertiesTreeView({
 						>
 							<ClayIcon symbol={getIconName(businessType)} />
 
-							<span className="treeview-item-label">{objectFieldName}</span>
+							<span className="treeview-item-label">{name}</span>
 
 							{!ALLOWED_BUSINESS_TYPES.includes(businessType) && (
 								<ClayTooltipProvider>

--- a/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/baseComponents/BaseAPISchemaProperty.tsx
+++ b/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/baseComponents/BaseAPISchemaProperty.tsx
@@ -57,6 +57,7 @@ export default function BaseAPISchemaProperty({
 					objectFieldERC: objectField.externalReferenceCode,
 					objectFieldId: objectField.id,
 					objectFieldName: objectField.name,
+					r_apiPropertyToAPIProperties_l_apiPropertyId: 0,
 					r_apiSchemaToAPIProperties_l_apiSchemaId: apiSchemaId,
 					type: 'treeViewItem',
 					...(objectRelationshipName && {

--- a/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/utils/dataUtils.ts
+++ b/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/utils/dataUtils.ts
@@ -26,6 +26,7 @@ export function AddObjectFieldsDataToProperties({
 			name,
 			objectFieldERC,
 			objectRelationshipNames,
+			r_apiPropertyToAPIProperties_l_apiPropertyId,
 			type,
 		}) => {
 			if (type.key === 'record') {
@@ -95,6 +96,7 @@ export function AddObjectFieldsDataToProperties({
 					...(objectRelationshipNames && {
 						objectRelationshipNames,
 					}),
+					r_apiPropertyToAPIProperties_l_apiPropertyId,
 					r_apiSchemaToAPIProperties_l_apiSchemaId: apiSchema.id,
 					type: 'trewViewItem',
 				};


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPD-40178

Given the following API Builder schema instance:

```json
{
  "sender" : {
    "avatar_url" : "https://avatars.githubusercontent.com/u/32699538?v=4",
    "login" : "ccorreagg"
  },
  "action" : "created",
  "starred_at" : "2024-10-16T14:48:59.000Z"
}
```

Before the PR:
![image](https://github.com/user-attachments/assets/4a0dadfc-8a68-4fe0-bf2e-aec55e4f8996)


After the PR:
![image](https://github.com/user-attachments/assets/6cc78de5-faac-4376-b40b-c753005c5695)


NOTE: The first commits are already in brianchandotom/master. I have included them because otherwise, we should fix the conflicts once this PR is sent to Brian. Please, consider reviewing just the last commit of this PR