### PR TITLE
LPD-41477 Technical Task | Investigate failures in API Builder - LocalFile.AllowUsersToEditSchemaProperties#FieldsOfRelatedObjectsAreAccessibleFromPropertiesSidebar

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]DefineAPISchemasWithinAnAPIGroup/AllowUsersToEditSchemaProperties.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]DefineAPISchemasWithinAnAPIGroup/AllowUsersToEditSchemaProperties.testcase
@@ -238,7 +238,7 @@ definition {
 		}
 
 		task ("Then all fields of APISort object definition are present") {
-			var fieldNameList = "Author,Create Date,External Reference Code,ID,Modified Date,Status,OData Sort,UniversityAPISorts";
+			var fieldNameList = "Author,Create Date,External Reference Code,ID,Modified Date,Status,OData Sort";
 
 			for (var fieldName : list ${fieldNameList}) {
 				AssertElementPresent(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPD-41477

---

This PR removes the many to one field from the University --> View related elements (API Sort) --> API Sort fields, so the field should not appear