### PR TITLE
LPD-42480 Fix DispatcherType and path handling for JBoss

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/template/RESTClientTemplateContextContributor.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/template/RESTClientTemplateContextContributor.java
@@ -90,7 +90,7 @@ public class RESTClientTemplateContextContributor
 
 				requestDispatcher.forward(
 					new RESTClientHttpRequest(
-						_contextObjects, _httpServletRequest),
+						_contextObjects, _httpServletRequest, path),
 					httpServletResponse);
 			}
 			finally {

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/template/servlet/RESTClientHttpRequest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/template/servlet/RESTClientHttpRequest.java
@@ -49,7 +49,7 @@ public class RESTClientHttpRequest implements HttpServletRequest {
 
 	public RESTClientHttpRequest(
 		Map<String, Object> contextObjects,
-		HttpServletRequest httpServletRequest) {
+		HttpServletRequest httpServletRequest, String pathInfo) {
 
 		_attributes = HashMapBuilder.<String, Object>put(
 			RESTClientHttpRequest.class.getName(), true
@@ -100,6 +100,7 @@ public class RESTClientHttpRequest implements HttpServletRequest {
 			}
 		).build();
 		_httpServletRequest = httpServletRequest;
+		_pathInfo = pathInfo;
 	}
 
 	@Override
@@ -181,7 +182,7 @@ public class RESTClientHttpRequest implements HttpServletRequest {
 	}
 
 	public DispatcherType getDispatcherType() {
-		return _httpServletRequest.getDispatcherType();
+		return DispatcherType.FORWARD;
 	}
 
 	@Override
@@ -277,7 +278,7 @@ public class RESTClientHttpRequest implements HttpServletRequest {
 
 	@Override
 	public String getPathInfo() {
-		return _httpServletRequest.getPathInfo();
+		return _pathInfo;
 	}
 
 	@Override
@@ -474,5 +475,6 @@ public class RESTClientHttpRequest implements HttpServletRequest {
 	private final Map<String, Object> _attributes;
 	private final Map<String, String> _headers;
 	private final HttpServletRequest _httpServletRequest;
+	private final String _pathInfo;
 
 }


### PR DESCRIPTION
- **Problem?**

There is a bug in `RESTClientTemplateContextContributor` that affects the creation of `RESTClientHttpRequest` objects on JBoss servers. When wrapping the original HTTP request, the `getDispatcherType` method does not correctly retrieve the dispatcher type from the `RequestDispatcher`, causing it to default to `INCLUDE` instead of the intended `FORWARD`. Additionally, the request path is not properly obtained from the `RequestDispatcher`, resulting in a missing path. These issues prevent the HTTP request from reaching the intended REST endpoint correctly.

- **Changes?**

The `DispatcherType` has been defaulted to `FORWARD`, and the request path is now passed as a parameter when creating the `RESTClientHttpRequest`.

See the following Jira Ticket: [LPD-42480](https://liferay.atlassian.net/browse/LPD-42480)