### PR TITLE
LPD-30463 | Can't sort by object nestedField of type boolean when using Oracle

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIEndpointRelevantObjectEntryModelListener.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIEndpointRelevantObjectEntryModelListener.java
@@ -28,6 +28,7 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -197,14 +198,13 @@ public class APIEndpointRelevantObjectEntryModelListener
 			Predicate predicate = _filterFactory.create(
 				filterString, apiEndpointObjectDefinition);
 
-			List<Map<String, Serializable>> valuesList =
-				_objectEntryLocalService.getValuesList(
-					objectEntry.getGroupId(), objectEntry.getCompanyId(),
-					objectEntry.getUserId(),
-					objectEntry.getObjectDefinitionId(), null, predicate, null,
-					-1, -1, null);
+			if (ListUtil.isNotEmpty(
+					_objectEntryLocalService.getPrimaryKeys(
+						objectEntry.getGroupId(), objectEntry.getCompanyId(),
+						objectEntry.getUserId(),
+						objectEntry.getObjectDefinitionId(), predicate, null,
+						-1, -1, null))) {
 
-			if (!valuesList.isEmpty()) {
 				throw new ObjectEntryValuesException.InvalidObjectField(
 					null,
 					"There is an API endpoint with the same HTTP method and " +

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIEndpointRelevantObjectEntryModelListener.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIEndpointRelevantObjectEntryModelListener.java
@@ -28,7 +28,6 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Http;
-import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -195,16 +194,14 @@ public class APIEndpointRelevantObjectEntryModelListener
 				_objectDefinitionLocalService.getObjectDefinition(
 					objectEntry.getObjectDefinitionId());
 
-			Predicate predicate = _filterFactory.create(
-				filterString, apiEndpointObjectDefinition);
+			int count = _objectEntryLocalService.getValuesListCount(
+				objectEntry.getGroupId(), objectEntry.getCompanyId(),
+				objectEntry.getUserId(), objectEntry.getObjectDefinitionId(),
+				_filterFactory.create(
+					filterString, apiEndpointObjectDefinition),
+				null);
 
-			if (ListUtil.isNotEmpty(
-					_objectEntryLocalService.getPrimaryKeys(
-						objectEntry.getGroupId(), objectEntry.getCompanyId(),
-						objectEntry.getUserId(),
-						objectEntry.getObjectDefinitionId(), predicate, null,
-						-1, -1, null))) {
-
+			if (count > 0) {
 				throw new ObjectEntryValuesException.InvalidObjectField(
 					null,
 					"There is an API endpoint with the same HTTP method and " +

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIPropertyRelevantObjectEntryModelListener.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIPropertyRelevantObjectEntryModelListener.java
@@ -238,23 +238,22 @@ public class APIPropertyRelevantObjectEntryModelListener
 				}
 			}
 
-			if (ListUtil.isNotEmpty(
-					_objectEntryLocalService.getPrimaryKeys(
-						objectEntry.getGroupId(), objectEntry.getCompanyId(),
-						objectEntry.getUserId(),
-						objectEntry.getObjectDefinitionId(),
-						_filterFactory.create(
-							StringBundler.concat(
-								"id ne '", objectEntry.getObjectEntryId(),
-								"' and name eq '", values.get("name"), "' and ",
-								"r_apiPropertyToAPIProperties_l_apiPropertyId ",
-								"eq '", parentAPIPropertyId, "' and ",
-								"r_apiSchemaToAPIProperties_l_apiSchemaId eq '",
-								apiSchemaId, "'"),
-							_objectDefinitionLocalService.getObjectDefinition(
-								objectEntry.getObjectDefinitionId())),
-						null, 0, 1, null))) {
+			int count = _objectEntryLocalService.getValuesListCount(
+				objectEntry.getGroupId(), objectEntry.getCompanyId(),
+				objectEntry.getUserId(), objectEntry.getObjectDefinitionId(),
+				_filterFactory.create(
+					StringBundler.concat(
+						"id ne '", objectEntry.getObjectEntryId(),
+						"' and name eq '", values.get("name"), "' and ",
+						"r_apiPropertyToAPIProperties_l_apiPropertyId eq '",
+						parentAPIPropertyId, "' and ",
+						"r_apiSchemaToAPIProperties_l_apiSchemaId eq '",
+						apiSchemaId, "'"),
+					_objectDefinitionLocalService.getObjectDefinition(
+						objectEntry.getObjectDefinitionId())),
+				null);
 
+			if (count > 0) {
 				throw new ObjectEntryValuesException.InvalidObjectField(
 					null, "API property name must be unique",
 					"api-property-name-must-be-unique");

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIPropertyRelevantObjectEntryModelListener.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/model/listener/APIPropertyRelevantObjectEntryModelListener.java
@@ -239,10 +239,10 @@ public class APIPropertyRelevantObjectEntryModelListener
 			}
 
 			if (ListUtil.isNotEmpty(
-					_objectEntryLocalService.getValuesList(
+					_objectEntryLocalService.getPrimaryKeys(
 						objectEntry.getGroupId(), objectEntry.getCompanyId(),
 						objectEntry.getUserId(),
-						objectEntry.getObjectDefinitionId(), null,
+						objectEntry.getObjectDefinitionId(),
 						_filterFactory.create(
 							StringBundler.concat(
 								"id ne '", objectEntry.getObjectEntryId(),

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/object/deployer/APIPropertyObjectDefinitionDeployerImpl.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/object/deployer/APIPropertyObjectDefinitionDeployerImpl.java
@@ -20,7 +20,6 @@ import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.osgi.util.ServiceTrackerFactory;
-import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
@@ -130,14 +129,13 @@ public class APIPropertyObjectDefinitionDeployerImpl
 			return;
 		}
 
-		List<Map<String, Serializable>> valuesList = TransformUtil.transform(
-			_objectEntryLocalService.getPrimaryKeys(
+		List<Map<String, Serializable>> valuesList =
+			_objectEntryLocalService.getValuesList(
 				GroupThreadLocal.getGroupId(), objectDefinition.getCompanyId(),
 				objectDefinition.getUserId(),
 				objectDefinition.getObjectDefinitionId(),
 				_filterFactory.create("type eq null", objectDefinition), null,
-				QueryUtil.ALL_POS, QueryUtil.ALL_POS, null),
-			_objectEntryLocalService::getValues);
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
 
 		for (Map<String, Serializable> values : valuesList) {
 			Collection<Serializable> collection = values.values();

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/object/deployer/APIPropertyObjectDefinitionDeployerImpl.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/object/deployer/APIPropertyObjectDefinitionDeployerImpl.java
@@ -20,6 +20,7 @@ import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.osgi.util.ServiceTrackerFactory;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
@@ -129,13 +130,14 @@ public class APIPropertyObjectDefinitionDeployerImpl
 			return;
 		}
 
-		List<Map<String, Serializable>> valuesList =
-			_objectEntryLocalService.getValuesList(
+		List<Map<String, Serializable>> valuesList = TransformUtil.transform(
+			_objectEntryLocalService.getPrimaryKeys(
 				GroupThreadLocal.getGroupId(), objectDefinition.getCompanyId(),
 				objectDefinition.getUserId(),
-				objectDefinition.getObjectDefinitionId(), null,
+				objectDefinition.getObjectDefinitionId(),
 				_filterFactory.create("type eq null", objectDefinition), null,
-				QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS, null),
+			_objectEntryLocalService::getValues);
 
 		for (Map<String, Serializable> values : valuesList) {
 			Collection<Serializable> collection = values.values();

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalService.java
@@ -426,6 +426,13 @@ public interface ObjectEntryLocalService
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<Long> getPrimaryKeys(
+			long groupId, long companyId, long userId, long objectDefinitionId,
+			Predicate predicate, String search, int start, int end,
+			Sort[] sorts)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public Map<String, Object> getSystemModelAttributes(
 			ObjectDefinition objectDefinition, long primaryKey)
 		throws PortalException;
@@ -449,8 +456,8 @@ public interface ObjectEntryLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<Map<String, Serializable>> getValuesList(
 			long groupId, long companyId, long userId, long objectDefinitionId,
-			String[] selectedObjectFieldNames, Predicate predicate,
-			String search, int start, int end, Sort[] sorts)
+			Predicate predicate, String search, int start, int end,
+			Sort[] sorts)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceUtil.java
@@ -538,6 +538,18 @@ public class ObjectEntryLocalServiceUtil {
 		return getService().getPersistedModel(primaryKeyObj);
 	}
 
+	public static List<Long> getPrimaryKeys(
+			long groupId, long companyId, long userId, long objectDefinitionId,
+			com.liferay.petra.sql.dsl.expression.Predicate predicate,
+			String search, int start, int end,
+			com.liferay.portal.kernel.search.Sort[] sorts)
+		throws PortalException {
+
+		return getService().getPrimaryKeys(
+			groupId, companyId, userId, objectDefinitionId, predicate, search,
+			start, end, sorts);
+	}
+
 	public static Map<String, Object> getSystemModelAttributes(
 			com.liferay.object.model.ObjectDefinition objectDefinition,
 			long primaryKey)
@@ -574,15 +586,14 @@ public class ObjectEntryLocalServiceUtil {
 
 	public static List<Map<String, Serializable>> getValuesList(
 			long groupId, long companyId, long userId, long objectDefinitionId,
-			String[] selectedObjectFieldNames,
 			com.liferay.petra.sql.dsl.expression.Predicate predicate,
 			String search, int start, int end,
 			com.liferay.portal.kernel.search.Sort[] sorts)
 		throws PortalException {
 
 		return getService().getValuesList(
-			groupId, companyId, userId, objectDefinitionId,
-			selectedObjectFieldNames, predicate, search, start, end, sorts);
+			groupId, companyId, userId, objectDefinitionId, predicate, search,
+			start, end, sorts);
 	}
 
 	public static int getValuesListCount(

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceWrapper.java
@@ -617,6 +617,19 @@ public class ObjectEntryLocalServiceWrapper
 	}
 
 	@Override
+	public java.util.List<Long> getPrimaryKeys(
+			long groupId, long companyId, long userId, long objectDefinitionId,
+			com.liferay.petra.sql.dsl.expression.Predicate predicate,
+			String search, int start, int end,
+			com.liferay.portal.kernel.search.Sort[] sorts)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _objectEntryLocalService.getPrimaryKeys(
+			groupId, companyId, userId, objectDefinitionId, predicate, search,
+			start, end, sorts);
+	}
+
+	@Override
 	public java.util.Map<String, Object> getSystemModelAttributes(
 			com.liferay.object.model.ObjectDefinition objectDefinition,
 			long primaryKey)
@@ -662,15 +675,15 @@ public class ObjectEntryLocalServiceWrapper
 	public java.util.List<java.util.Map<String, java.io.Serializable>>
 			getValuesList(
 				long groupId, long companyId, long userId,
-				long objectDefinitionId, String[] selectedObjectFieldNames,
+				long objectDefinitionId,
 				com.liferay.petra.sql.dsl.expression.Predicate predicate,
 				String search, int start, int end,
 				com.liferay.portal.kernel.search.Sort[] sorts)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _objectEntryLocalService.getValuesList(
-			groupId, companyId, userId, objectDefinitionId,
-			selectedObjectFieldNames, predicate, search, start, end, sorts);
+			groupId, companyId, userId, objectDefinitionId, predicate, search,
+			start, end, sorts);
 	}
 
 	@Override

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -400,22 +400,6 @@ public class DefaultObjectEntryManagerImpl
 			}
 		}
 
-		String[] selectedObjectFieldNames = null;
-
-		UriInfo uriInfo = dtoConverterContext.getUriInfo();
-
-		if (uriInfo != null) {
-			MultivaluedMap<String, String> queryParameters =
-				uriInfo.getQueryParameters();
-
-			String fields = queryParameters.getFirst("fields");
-
-			if (fields != null) {
-				selectedObjectFieldNames = StringUtil.split(
-					fields, StringPool.COMMA);
-			}
-		}
-
 		return Page.of(
 			HashMapBuilder.put(
 				"create",
@@ -456,13 +440,13 @@ public class DefaultObjectEntryManagerImpl
 			).build(),
 			facets,
 			TransformUtil.transform(
-				objectEntryLocalService.getValuesList(
+				objectEntryLocalService.getPrimaryKeys(
 					groupId, companyId, dtoConverterContext.getUserId(),
-					objectDefinition.getObjectDefinitionId(),
-					selectedObjectFieldNames, predicate, search, start, end,
-					sorts),
-				values -> _getObjectEntry(
-					dtoConverterContext, objectDefinition, values)),
+					objectDefinition.getObjectDefinitionId(), predicate, search,
+					start, end, sorts),
+				primaryKey -> _getObjectEntry(
+					dtoConverterContext, objectDefinition,
+					objectEntryLocalService.getValues(primaryKey))),
 			pagination,
 			objectEntryLocalService.getValuesListCount(
 				groupId, companyId, dtoConverterContext.getUserId(),

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -445,8 +445,7 @@ public class DefaultObjectEntryManagerImpl
 					objectDefinition.getObjectDefinitionId(), predicate, search,
 					start, end, sorts),
 				primaryKey -> _getObjectEntry(
-					dtoConverterContext, objectDefinition,
-					objectEntryLocalService.getValues(primaryKey))),
+					dtoConverterContext, objectDefinition, primaryKey)),
 			pagination,
 			objectEntryLocalService.getValuesListCount(
 				groupId, companyId, dtoConverterContext.getUserId(),
@@ -1162,13 +1161,11 @@ public class DefaultObjectEntryManagerImpl
 
 	private ObjectEntry _getObjectEntry(
 			DTOConverterContext dtoConverterContext,
-			ObjectDefinition objectDefinition, Map<String, Serializable> values)
+			ObjectDefinition objectDefinition, long objectEntryId)
 		throws Exception {
 
 		com.liferay.object.model.ObjectEntry serviceBuilderObjectEntry =
-			_objectEntryService.getObjectEntry(
-				GetterUtil.getLong(
-					values.get(objectDefinition.getPKObjectFieldName())));
+			_objectEntryService.getObjectEntry(objectEntryId);
 
 		_checkObjectEntryObjectDefinitionId(
 			objectDefinition, serviceBuilderObjectEntry);

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -1027,11 +1027,10 @@ public class ObjectEntryLocalServiceImpl
 		return objectEntryPersistence.dslQueryCount(dslQuery);
 	}
 
-	@Override
-	public List<Long> getPrimaryKeyList(
+	public List<Long> getPrimaryKeys(
 			long groupId, long companyId, long userId, long objectDefinitionId,
-			String[] selectedObjectFieldNames, Predicate predicate,
-			String search, int start, int end, Sort[] sorts)
+			Predicate predicate, String search, int start, int end,
+			Sort[] sorts)
 		throws PortalException {
 
 		DynamicObjectDefinitionLocalizationTable
@@ -1048,7 +1047,7 @@ public class ObjectEntryLocalServiceImpl
 			_getRootDynamicObjectDefinitionTable(objectDefinitionId);
 
 		DSLQuery dslQuery = DSLQueryFactoryUtil.select(
-			dynamicObjectDefinitionTable.getPrimaryKeyColumn()
+			ObjectEntryTable.INSTANCE.objectEntryId
 		).from(
 			dynamicObjectDefinitionTable
 		).innerJoinON(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -1028,6 +1028,93 @@ public class ObjectEntryLocalServiceImpl
 	}
 
 	@Override
+	public List<Long> getPrimaryKeyList(
+			long groupId, long companyId, long userId, long objectDefinitionId,
+			String[] selectedObjectFieldNames, Predicate predicate,
+			String search, int start, int end, Sort[] sorts)
+		throws PortalException {
+
+		DynamicObjectDefinitionLocalizationTable
+			dynamicObjectDefinitionLocalizationTable =
+				DynamicObjectDefinitionLocalizationTableFactory.create(
+					_objectDefinitionPersistence.findByPrimaryKey(
+						objectDefinitionId),
+					_objectFieldLocalService);
+		DynamicObjectDefinitionTable dynamicObjectDefinitionTable =
+			_getDynamicObjectDefinitionTable(objectDefinitionId);
+		DynamicObjectDefinitionTable extensionDynamicObjectDefinitionTable =
+			_getExtensionDynamicObjectDefinitionTable(objectDefinitionId);
+		DynamicObjectDefinitionTable rootDynamicObjectDefinitionTable =
+			_getRootDynamicObjectDefinitionTable(objectDefinitionId);
+
+		DSLQuery dslQuery = DSLQueryFactoryUtil.select(
+			dynamicObjectDefinitionTable.getPrimaryKeyColumn()
+		).from(
+			dynamicObjectDefinitionTable
+		).innerJoinON(
+			extensionDynamicObjectDefinitionTable,
+			extensionDynamicObjectDefinitionTable.getPrimaryKeyColumn(
+			).eq(
+				dynamicObjectDefinitionTable.getPrimaryKeyColumn()
+			)
+		).innerJoinON(
+			ObjectEntryTable.INSTANCE,
+			ObjectEntryTable.INSTANCE.objectEntryId.eq(
+				dynamicObjectDefinitionTable.getPrimaryKeyColumn())
+		).innerJoinON(
+			rootDynamicObjectDefinitionTable,
+			_getInnerJoinRootObjectDefinitionTablePredicate(
+				rootDynamicObjectDefinitionTable)
+		).leftJoinOn(
+			dynamicObjectDefinitionLocalizationTable,
+			ObjectEntrySearchUtil.getLeftJoinLocalizationTablePredicate(
+				dynamicObjectDefinitionLocalizationTable,
+				dynamicObjectDefinitionTable)
+		).where(
+			ObjectEntryTable.INSTANCE.objectDefinitionId.eq(
+				objectDefinitionId
+			).and(
+				() -> {
+					if (groupId == 0) {
+						return null;
+					}
+
+					return ObjectEntryTable.INSTANCE.groupId.eq(groupId);
+				}
+			).and(
+				Predicate.withParentheses(
+					_fillPredicate(objectDefinitionId, predicate, search))
+			).and(
+				_getPermissionWherePredicate(
+					dynamicObjectDefinitionTable, groupId)
+			)
+		).limit(
+			start, end
+		);
+
+		if (sorts != null) {
+			SortDSLQueryVisitor sortDSLQueryVisitor = new SortDSLQueryVisitor(
+				_objectFieldLocalService,
+				_objectRelationshipLocalServiceSnapshot.get());
+
+			for (Sort sort : sorts) {
+				dslQuery = sortDSLQueryVisitor.visit(
+					dslQuery,
+					new com.liferay.object.internal.sort.Sort(
+						_objectDefinitionPersistence.findByPrimaryKey(
+							objectDefinitionId),
+						sort));
+			}
+		}
+
+		return TransformUtil.transform(
+			objectEntryPersistence.dslQuery(dslQuery),
+			value -> (Long)_getResult(
+				value, objectDefinitionId,
+				dynamicObjectDefinitionTable.getPrimaryKeyColumn()));
+	}
+
+	@Override
 	public Map<String, Object> getSystemModelAttributes(
 			ObjectDefinition objectDefinition, long primaryKey)
 		throws PortalException {
@@ -1243,106 +1330,15 @@ public class ObjectEntryLocalServiceImpl
 	@Override
 	public List<Map<String, Serializable>> getValuesList(
 			long groupId, long companyId, long userId, long objectDefinitionId,
-			String[] selectedObjectFieldNames, Predicate predicate,
-			String search, int start, int end, Sort[] sorts)
+			Predicate predicate, String search, int start, int end,
+			Sort[] sorts)
 		throws PortalException {
 
-		DynamicObjectDefinitionLocalizationTable
-			dynamicObjectDefinitionLocalizationTable =
-				DynamicObjectDefinitionLocalizationTableFactory.create(
-					_objectDefinitionPersistence.findByPrimaryKey(
-						objectDefinitionId),
-					_objectFieldLocalService);
-		DynamicObjectDefinitionTable dynamicObjectDefinitionTable =
-			_getDynamicObjectDefinitionTable(objectDefinitionId);
-		DynamicObjectDefinitionTable extensionDynamicObjectDefinitionTable =
-			_getExtensionDynamicObjectDefinitionTable(objectDefinitionId);
-		DynamicObjectDefinitionTable rootDynamicObjectDefinitionTable =
-			_getRootDynamicObjectDefinitionTable(objectDefinitionId);
-
-		Expression<?>[] selectExpressions = ArrayUtil.append(
-			_getSelectExpressions(dynamicObjectDefinitionLocalizationTable),
-			_getSelectExpressions(
-				dynamicObjectDefinitionTable, selectedObjectFieldNames),
-			ArrayUtil.remove(
-				_getSelectExpressions(
-					extensionDynamicObjectDefinitionTable,
-					selectedObjectFieldNames),
-				extensionDynamicObjectDefinitionTable.getPrimaryKeyColumn()),
-			_EXPRESSIONS);
-
-		DSLQuery dslQuery = DSLQueryFactoryUtil.select(
-			selectExpressions
-		).from(
-			dynamicObjectDefinitionTable
-		).innerJoinON(
-			extensionDynamicObjectDefinitionTable,
-			extensionDynamicObjectDefinitionTable.getPrimaryKeyColumn(
-			).eq(
-				dynamicObjectDefinitionTable.getPrimaryKeyColumn()
-			)
-		).innerJoinON(
-			ObjectEntryTable.INSTANCE,
-			ObjectEntryTable.INSTANCE.objectEntryId.eq(
-				dynamicObjectDefinitionTable.getPrimaryKeyColumn())
-		).innerJoinON(
-			rootDynamicObjectDefinitionTable,
-			_getInnerJoinRootObjectDefinitionTablePredicate(
-				rootDynamicObjectDefinitionTable)
-		).leftJoinOn(
-			dynamicObjectDefinitionLocalizationTable,
-			ObjectEntrySearchUtil.getLeftJoinLocalizationTablePredicate(
-				dynamicObjectDefinitionLocalizationTable,
-				dynamicObjectDefinitionTable)
-		).where(
-			ObjectEntryTable.INSTANCE.objectDefinitionId.eq(
-				objectDefinitionId
-			).and(
-				() -> {
-					if (groupId == 0) {
-						return null;
-					}
-
-					return ObjectEntryTable.INSTANCE.groupId.eq(groupId);
-				}
-			).and(
-				Predicate.withParentheses(
-					_fillPredicate(objectDefinitionId, predicate, search))
-			).and(
-				_getPermissionWherePredicate(
-					dynamicObjectDefinitionTable, groupId)
-			)
-		).limit(
-			start, end
-		);
-
-		if (sorts != null) {
-			SortDSLQueryVisitor sortDSLQueryVisitor = new SortDSLQueryVisitor(
-				_objectFieldLocalService,
-				_objectRelationshipLocalServiceSnapshot.get());
-
-			for (Sort sort : sorts) {
-				dslQuery = sortDSLQueryVisitor.visit(
-					dslQuery,
-					new com.liferay.object.internal.sort.Sort(
-						_objectDefinitionPersistence.findByPrimaryKey(
-							objectDefinitionId),
-						sort));
-			}
-		}
-
-		List<Object[]> rows = _list(
-			dslQuery, objectDefinitionId, selectExpressions);
-
-		List<Map<String, Serializable>> valuesList = new ArrayList<>(
-			rows.size());
-
-		for (Object[] objects : rows) {
-			valuesList.add(
-				_getValues(objectDefinitionId, objects, selectExpressions));
-		}
-
-		return valuesList;
+		return TransformUtil.transform(
+			getPrimaryKeys(
+				groupId, companyId, userId, objectDefinitionId, predicate,
+				search, start, end, sorts),
+			this::getValues);
 	}
 
 	@Override

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryServiceImpl.java
@@ -68,6 +68,7 @@ import com.liferay.portal.kernel.service.UserNotificationEventLocalService;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
+import com.liferay.portal.kernel.transaction.Transactional;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
@@ -149,6 +150,7 @@ public class ObjectEntryServiceImpl extends ObjectEntryServiceBaseImpl {
 	}
 
 	@Override
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public void checkModelResourcePermission(
 			long objectDefinitionId, long objectEntryId, String actionId)
 		throws PortalException {

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -83,6 +83,7 @@ import com.liferay.object.tree.Tree;
 import com.liferay.object.validation.rule.ObjectValidationRuleEngine;
 import com.liferay.object.validation.rule.ObjectValidationRuleResult;
 import com.liferay.object.validation.rule.setting.builder.ObjectValidationRuleSettingBuilder;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.sql.dsl.Column;
 import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.petra.string.StringBundler;
@@ -2673,14 +2674,15 @@ public class ObjectEntryLocalServiceTest {
 	}
 
 	@Test
-	public void testGetValuesList() throws Exception {
+	public void testGetPrimaryKeys() throws Exception {
 		Sort[] sorts = {new Sort("id", false)};
 
-		List<Map<String, Serializable>> valuesList =
-			_objectEntryLocalService.getValuesList(
+		List<Map<String, Serializable>> valuesList = TransformUtil.transform(
+			_objectEntryLocalService.getPrimaryKeys(
 				0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-				_objectDefinition.getObjectDefinitionId(), null, null, null,
-				QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts);
+				_objectDefinition.getObjectDefinitionId(), null, null,
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts),
+			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
 
 		Assert.assertEquals(valuesList.toString(), 0, valuesList.size());
 
@@ -2699,16 +2701,18 @@ public class ObjectEntryLocalServiceTest {
 
 		_addObjectEntry(values1);
 
-		valuesList = _objectEntryLocalService.getValuesList(
-			0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			_objectDefinition.getObjectDefinitionId(), null, null, null,
-			QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts);
+		valuesList = TransformUtil.transform(
+			_objectEntryLocalService.getPrimaryKeys(
+				0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+				_objectDefinition.getObjectDefinitionId(), null, null,
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts),
+			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
 
 		Assert.assertEquals(valuesList.toString(), 1, valuesList.size());
 
 		_assertCount(1);
 
-		_assertObjectEntryValues(29, values1, valuesList.get(0));
+		_assertObjectEntryValues(23, values1, valuesList.get(0));
 
 		// Add second object entry
 
@@ -2723,17 +2727,19 @@ public class ObjectEntryLocalServiceTest {
 
 		_addObjectEntry(values2);
 
-		valuesList = _objectEntryLocalService.getValuesList(
-			0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			_objectDefinition.getObjectDefinitionId(), null, null, null,
-			QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts);
+		valuesList = TransformUtil.transform(
+			_objectEntryLocalService.getPrimaryKeys(
+				0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+				_objectDefinition.getObjectDefinitionId(), null, null,
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts),
+			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
 
 		Assert.assertEquals(valuesList.toString(), 2, valuesList.size());
 
 		_assertCount(2);
 
-		_assertObjectEntryValues(29, values1, valuesList.get(0));
-		_assertObjectEntryValues(29, values2, valuesList.get(1));
+		_assertObjectEntryValues(23, values1, valuesList.get(0));
+		_assertObjectEntryValues(23, values2, valuesList.get(1));
 
 		// Add third object entry
 
@@ -2748,25 +2754,29 @@ public class ObjectEntryLocalServiceTest {
 
 		ObjectEntry objectEntry = _addObjectEntry(values3);
 
-		valuesList = _objectEntryLocalService.getValuesList(
-			0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			_objectDefinition.getObjectDefinitionId(), null, null, null,
-			QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts);
+		valuesList = TransformUtil.transform(
+			_objectEntryLocalService.getPrimaryKeys(
+				0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+				_objectDefinition.getObjectDefinitionId(), null, null,
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts),
+			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
 
 		Assert.assertEquals(valuesList.toString(), 3, valuesList.size());
 
 		_assertCount(3);
 
-		_assertObjectEntryValues(29, values1, valuesList.get(0));
-		_assertObjectEntryValues(29, values2, valuesList.get(1));
-		_assertObjectEntryValues(29, values3, valuesList.get(2));
+		_assertObjectEntryValues(23, values1, valuesList.get(0));
+		_assertObjectEntryValues(23, values2, valuesList.get(1));
+		_assertObjectEntryValues(23, values3, valuesList.get(2));
 
 		// Irrelevant object definition
 
-		valuesList = _objectEntryLocalService.getValuesList(
-			0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			_irrelevantObjectDefinition.getObjectDefinitionId(), null, null,
-			null, QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts);
+		valuesList = TransformUtil.transform(
+			_objectEntryLocalService.getPrimaryKeys(
+				0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+				_irrelevantObjectDefinition.getObjectDefinitionId(), null, null,
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts),
+			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
 
 		Assert.assertEquals(valuesList.toString(), 0, valuesList.size());
 
@@ -2792,14 +2802,16 @@ public class ObjectEntryLocalServiceTest {
 
 		_userLocalService.addRoleUser(role.getRoleId(), user);
 
-		valuesList = _objectEntryLocalService.getValuesList(
-			0, TestPropsValues.getCompanyId(), user.getUserId(),
-			_objectDefinition.getObjectDefinitionId(), null, null, null,
-			QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts);
+		valuesList = TransformUtil.transform(
+			_objectEntryLocalService.getPrimaryKeys(
+				0, TestPropsValues.getCompanyId(), user.getUserId(),
+				_objectDefinition.getObjectDefinitionId(), null, null,
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts),
+			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
 
 		Assert.assertEquals(valuesList.toString(), 1, valuesList.size());
 
-		_assertObjectEntryValues(29, values3, valuesList.get(0));
+		_assertObjectEntryValues(23, values3, valuesList.get(0));
 
 		PermissionThreadLocal.setPermissionChecker(originalPermissionChecker);
 		PrincipalThreadLocal.setName(originalName);
@@ -2816,54 +2828,64 @@ public class ObjectEntryLocalServiceTest {
 			firstNameColumn.eq("John")
 		);
 
-		valuesList = _objectEntryLocalService.getValuesList(
-			0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			_objectDefinition.getObjectDefinitionId(), null, predicate, null,
-			QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts);
+		valuesList = TransformUtil.transform(
+			_objectEntryLocalService.getPrimaryKeys(
+				0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+				_objectDefinition.getObjectDefinitionId(), predicate, null,
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts),
+			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
 
 		Assert.assertEquals(valuesList.toString(), 2, valuesList.size());
 
-		_assertObjectEntryValues(29, values1, valuesList.get(0));
-		_assertObjectEntryValues(29, values3, valuesList.get(1));
+		_assertObjectEntryValues(23, values1, valuesList.get(0));
+		_assertObjectEntryValues(23, values3, valuesList.get(1));
 
 		// Predicate and search
 
 		String search = "John";
 
-		valuesList = _objectEntryLocalService.getValuesList(
-			0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			_objectDefinition.getObjectDefinitionId(), null, predicate, search,
-			QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts);
+		valuesList = TransformUtil.transform(
+			_objectEntryLocalService.getPrimaryKeys(
+				0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+				_objectDefinition.getObjectDefinitionId(), predicate, search,
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts),
+			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
 
 		Assert.assertEquals(valuesList.toString(), 1, valuesList.size());
 
-		_assertObjectEntryValues(29, values3, valuesList.get(0));
+		_assertObjectEntryValues(23, values3, valuesList.get(0));
 
-		valuesList = _objectEntryLocalService.getValuesList(
-			0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			_objectDefinition.getObjectDefinitionId(), null, predicate,
-			StringUtil.toLowerCase(search), QueryUtil.ALL_POS,
-			QueryUtil.ALL_POS, sorts);
-
-		Assert.assertEquals(valuesList.toString(), 1, valuesList.size());
-
-		_assertObjectEntryValues(29, values3, valuesList.get(0));
-
-		valuesList = _objectEntryLocalService.getValuesList(
-			0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			_objectDefinition.getObjectDefinitionId(), null, predicate,
-			StringUtil.toUpperCase(search), QueryUtil.ALL_POS,
-			QueryUtil.ALL_POS, sorts);
+		valuesList = TransformUtil.transform(
+			_objectEntryLocalService.getPrimaryKeys(
+				0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+				_objectDefinition.getObjectDefinitionId(), predicate,
+				StringUtil.toLowerCase(search), QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS, sorts),
+			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
 
 		Assert.assertEquals(valuesList.toString(), 1, valuesList.size());
 
-		_assertObjectEntryValues(29, values3, valuesList.get(0));
+		_assertObjectEntryValues(23, values3, valuesList.get(0));
 
-		valuesList = _objectEntryLocalService.getValuesList(
-			0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			_objectDefinition.getObjectDefinitionId(), null, predicate,
-			RandomTestUtil.randomString(), QueryUtil.ALL_POS, QueryUtil.ALL_POS,
-			sorts);
+		valuesList = TransformUtil.transform(
+			_objectEntryLocalService.getPrimaryKeys(
+				0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+				_objectDefinition.getObjectDefinitionId(), predicate,
+				StringUtil.toUpperCase(search), QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS, sorts),
+			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
+
+		Assert.assertEquals(valuesList.toString(), 1, valuesList.size());
+
+		_assertObjectEntryValues(23, values3, valuesList.get(0));
+
+		valuesList = TransformUtil.transform(
+			_objectEntryLocalService.getPrimaryKeys(
+				0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+				_objectDefinition.getObjectDefinitionId(), predicate,
+				RandomTestUtil.randomString(), QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS, sorts),
+			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
 
 		Assert.assertEquals(valuesList.toString(), 0, valuesList.size());
 
@@ -2873,14 +2895,16 @@ public class ObjectEntryLocalServiceTest {
 			PermissionCheckerFactoryUtil.create(user));
 		PrincipalThreadLocal.setName(user.getUserId());
 
-		valuesList = _objectEntryLocalService.getValuesList(
-			0, TestPropsValues.getCompanyId(), user.getUserId(),
-			_objectDefinition.getObjectDefinitionId(), null, predicate, null,
-			QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts);
+		valuesList = TransformUtil.transform(
+			_objectEntryLocalService.getPrimaryKeys(
+				0, TestPropsValues.getCompanyId(), user.getUserId(),
+				_objectDefinition.getObjectDefinitionId(), predicate, null,
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts),
+			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
 
 		Assert.assertEquals(valuesList.toString(), 1, valuesList.size());
 
-		_assertObjectEntryValues(29, values3, valuesList.get(0));
+		_assertObjectEntryValues(23, values3, valuesList.get(0));
 
 		PermissionThreadLocal.setPermissionChecker(originalPermissionChecker);
 		PrincipalThreadLocal.setName(originalName);
@@ -2891,19 +2915,21 @@ public class ObjectEntryLocalServiceTest {
 			"emailAddressRequired", "firstName"
 		};
 
-		valuesList = _objectEntryLocalService.getValuesList(
-			0, TestPropsValues.getCompanyId(), user.getUserId(),
-			_objectDefinition.getObjectDefinitionId(), selectedObjectFieldNames,
-			null, null, QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts);
+		valuesList = TransformUtil.transform(
+			_objectEntryLocalService.getPrimaryKeys(
+				0, TestPropsValues.getCompanyId(), user.getUserId(),
+				_objectDefinition.getObjectDefinitionId(), null, null,
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts),
+			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
 
 		Assert.assertEquals(valuesList.toString(), 3, valuesList.size());
 
 		_assertObjectEntryValues(
-			9, values1, valuesList.get(0), selectedObjectFieldNames);
+			23, values1, valuesList.get(0), selectedObjectFieldNames);
 		_assertObjectEntryValues(
-			9, values2, valuesList.get(1), selectedObjectFieldNames);
+			23, values2, valuesList.get(1), selectedObjectFieldNames);
 		_assertObjectEntryValues(
-			9, values3, valuesList.get(2), selectedObjectFieldNames);
+			23, values3, valuesList.get(2), selectedObjectFieldNames);
 	}
 
 	@Test

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -83,7 +83,6 @@ import com.liferay.object.tree.Tree;
 import com.liferay.object.validation.rule.ObjectValidationRuleEngine;
 import com.liferay.object.validation.rule.ObjectValidationRuleResult;
 import com.liferay.object.validation.rule.setting.builder.ObjectValidationRuleSettingBuilder;
-import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.sql.dsl.Column;
 import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.petra.string.StringBundler;
@@ -2677,12 +2676,11 @@ public class ObjectEntryLocalServiceTest {
 	public void testGetPrimaryKeys() throws Exception {
 		Sort[] sorts = {new Sort("id", false)};
 
-		List<Map<String, Serializable>> valuesList = TransformUtil.transform(
-			_objectEntryLocalService.getPrimaryKeys(
+		List<Map<String, Serializable>> valuesList =
+			_objectEntryLocalService.getValuesList(
 				0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
 				_objectDefinition.getObjectDefinitionId(), null, null,
-				QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts),
-			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts);
 
 		Assert.assertEquals(valuesList.toString(), 0, valuesList.size());
 
@@ -2701,12 +2699,10 @@ public class ObjectEntryLocalServiceTest {
 
 		_addObjectEntry(values1);
 
-		valuesList = TransformUtil.transform(
-			_objectEntryLocalService.getPrimaryKeys(
-				0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-				_objectDefinition.getObjectDefinitionId(), null, null,
-				QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts),
-			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
+		valuesList = _objectEntryLocalService.getValuesList(
+			0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			_objectDefinition.getObjectDefinitionId(), null, null,
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts);
 
 		Assert.assertEquals(valuesList.toString(), 1, valuesList.size());
 
@@ -2727,12 +2723,10 @@ public class ObjectEntryLocalServiceTest {
 
 		_addObjectEntry(values2);
 
-		valuesList = TransformUtil.transform(
-			_objectEntryLocalService.getPrimaryKeys(
-				0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-				_objectDefinition.getObjectDefinitionId(), null, null,
-				QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts),
-			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
+		valuesList = _objectEntryLocalService.getValuesList(
+			0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			_objectDefinition.getObjectDefinitionId(), null, null,
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts);
 
 		Assert.assertEquals(valuesList.toString(), 2, valuesList.size());
 
@@ -2754,12 +2748,10 @@ public class ObjectEntryLocalServiceTest {
 
 		ObjectEntry objectEntry = _addObjectEntry(values3);
 
-		valuesList = TransformUtil.transform(
-			_objectEntryLocalService.getPrimaryKeys(
-				0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-				_objectDefinition.getObjectDefinitionId(), null, null,
-				QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts),
-			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
+		valuesList = _objectEntryLocalService.getValuesList(
+			0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			_objectDefinition.getObjectDefinitionId(), null, null,
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts);
 
 		Assert.assertEquals(valuesList.toString(), 3, valuesList.size());
 
@@ -2771,12 +2763,10 @@ public class ObjectEntryLocalServiceTest {
 
 		// Irrelevant object definition
 
-		valuesList = TransformUtil.transform(
-			_objectEntryLocalService.getPrimaryKeys(
-				0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-				_irrelevantObjectDefinition.getObjectDefinitionId(), null, null,
-				QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts),
-			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
+		valuesList = _objectEntryLocalService.getValuesList(
+			0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			_irrelevantObjectDefinition.getObjectDefinitionId(), null, null,
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts);
 
 		Assert.assertEquals(valuesList.toString(), 0, valuesList.size());
 
@@ -2802,12 +2792,10 @@ public class ObjectEntryLocalServiceTest {
 
 		_userLocalService.addRoleUser(role.getRoleId(), user);
 
-		valuesList = TransformUtil.transform(
-			_objectEntryLocalService.getPrimaryKeys(
-				0, TestPropsValues.getCompanyId(), user.getUserId(),
-				_objectDefinition.getObjectDefinitionId(), null, null,
-				QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts),
-			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
+		valuesList = _objectEntryLocalService.getValuesList(
+			0, TestPropsValues.getCompanyId(), user.getUserId(),
+			_objectDefinition.getObjectDefinitionId(), null, null,
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts);
 
 		Assert.assertEquals(valuesList.toString(), 1, valuesList.size());
 
@@ -2828,12 +2816,10 @@ public class ObjectEntryLocalServiceTest {
 			firstNameColumn.eq("John")
 		);
 
-		valuesList = TransformUtil.transform(
-			_objectEntryLocalService.getPrimaryKeys(
-				0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-				_objectDefinition.getObjectDefinitionId(), predicate, null,
-				QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts),
-			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
+		valuesList = _objectEntryLocalService.getValuesList(
+			0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			_objectDefinition.getObjectDefinitionId(), predicate, null,
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts);
 
 		Assert.assertEquals(valuesList.toString(), 2, valuesList.size());
 
@@ -2844,48 +2830,40 @@ public class ObjectEntryLocalServiceTest {
 
 		String search = "John";
 
-		valuesList = TransformUtil.transform(
-			_objectEntryLocalService.getPrimaryKeys(
-				0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-				_objectDefinition.getObjectDefinitionId(), predicate, search,
-				QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts),
-			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
+		valuesList = _objectEntryLocalService.getValuesList(
+			0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			_objectDefinition.getObjectDefinitionId(), predicate, search,
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts);
 
 		Assert.assertEquals(valuesList.toString(), 1, valuesList.size());
 
 		_assertObjectEntryValues(23, values3, valuesList.get(0));
 
-		valuesList = TransformUtil.transform(
-			_objectEntryLocalService.getPrimaryKeys(
-				0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-				_objectDefinition.getObjectDefinitionId(), predicate,
-				StringUtil.toLowerCase(search), QueryUtil.ALL_POS,
-				QueryUtil.ALL_POS, sorts),
-			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
+		valuesList = _objectEntryLocalService.getValuesList(
+			0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			_objectDefinition.getObjectDefinitionId(), predicate,
+			StringUtil.toLowerCase(search), QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, sorts);
 
 		Assert.assertEquals(valuesList.toString(), 1, valuesList.size());
 
 		_assertObjectEntryValues(23, values3, valuesList.get(0));
 
-		valuesList = TransformUtil.transform(
-			_objectEntryLocalService.getPrimaryKeys(
-				0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-				_objectDefinition.getObjectDefinitionId(), predicate,
-				StringUtil.toUpperCase(search), QueryUtil.ALL_POS,
-				QueryUtil.ALL_POS, sorts),
-			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
+		valuesList = _objectEntryLocalService.getValuesList(
+			0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			_objectDefinition.getObjectDefinitionId(), predicate,
+			StringUtil.toUpperCase(search), QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, sorts);
 
 		Assert.assertEquals(valuesList.toString(), 1, valuesList.size());
 
 		_assertObjectEntryValues(23, values3, valuesList.get(0));
 
-		valuesList = TransformUtil.transform(
-			_objectEntryLocalService.getPrimaryKeys(
-				0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-				_objectDefinition.getObjectDefinitionId(), predicate,
-				RandomTestUtil.randomString(), QueryUtil.ALL_POS,
-				QueryUtil.ALL_POS, sorts),
-			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
+		valuesList = _objectEntryLocalService.getValuesList(
+			0, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			_objectDefinition.getObjectDefinitionId(), predicate,
+			RandomTestUtil.randomString(), QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+			sorts);
 
 		Assert.assertEquals(valuesList.toString(), 0, valuesList.size());
 
@@ -2895,12 +2873,10 @@ public class ObjectEntryLocalServiceTest {
 			PermissionCheckerFactoryUtil.create(user));
 		PrincipalThreadLocal.setName(user.getUserId());
 
-		valuesList = TransformUtil.transform(
-			_objectEntryLocalService.getPrimaryKeys(
-				0, TestPropsValues.getCompanyId(), user.getUserId(),
-				_objectDefinition.getObjectDefinitionId(), predicate, null,
-				QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts),
-			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
+		valuesList = _objectEntryLocalService.getValuesList(
+			0, TestPropsValues.getCompanyId(), user.getUserId(),
+			_objectDefinition.getObjectDefinitionId(), predicate, null,
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts);
 
 		Assert.assertEquals(valuesList.toString(), 1, valuesList.size());
 
@@ -2915,12 +2891,10 @@ public class ObjectEntryLocalServiceTest {
 			"emailAddressRequired", "firstName"
 		};
 
-		valuesList = TransformUtil.transform(
-			_objectEntryLocalService.getPrimaryKeys(
-				0, TestPropsValues.getCompanyId(), user.getUserId(),
-				_objectDefinition.getObjectDefinitionId(), null, null,
-				QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts),
-			primaryKey -> _objectEntryLocalService.getValues(primaryKey));
+		valuesList = _objectEntryLocalService.getValuesList(
+			0, TestPropsValues.getCompanyId(), user.getUserId(),
+			_objectDefinition.getObjectDefinitionId(), null, null,
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS, sorts);
 
 		Assert.assertEquals(valuesList.toString(), 3, valuesList.size());
 


### PR DESCRIPTION
From: https://github.com/brianchandotcom/liferay-portal/pull/156371

---

**What's changed?**

The method `getValuesList` has been replaced with `getPrimaryKeys` to improve query construction when sorting is applied. Previously, dslQuery grouped by all fields in the object, causing SQL errors in Oracle when any field was of type CLOB, even if that field was not part of the sorting criteria. Since Oracle does not support grouping by CLOB fields, the updated approach **retrieves only the primary key** (PK) column in the initial query. A subsequent query is then executed to retrieve the remaining fields.

This two-step approach does not reduce efficiency, as the second query was already present, meaning it was unnecessary to retrieve all fields in the initial query when only the PK was ultimately used.

See the following Jira Ticket: [LPD-30463](https://liferay.atlassian.net/browse/LPD-30463)

cc/ @dannielraposo 

TODO: https://github.com/brianchandotcom/liferay-portal/pull/156371#issuecomment-2493705284 keep the initial method
