### PR TITLE
LPD-42808 Unable to export/import a WidetPage using batch engine

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/SitePageDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/SitePageDTOConverter.java
@@ -102,7 +102,6 @@ public class SitePageDTOConverter implements DTOConverter<Layout, SitePage> {
 				setLayoutTemplateId(
 					() -> layout.getTypeSettingsProperty(
 						LayoutTypePortletConstants.LAYOUT_TEMPLATE_ID));
-				setType(Type.WIDGET_PAGE_SETTINGS);
 			}
 		};
 	}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/SitePageDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/SitePageDTOConverter.java
@@ -102,6 +102,7 @@ public class SitePageDTOConverter implements DTOConverter<Layout, SitePage> {
 				setLayoutTemplateId(
 					() -> layout.getTypeSettingsProperty(
 						LayoutTypePortletConstants.LAYOUT_TEMPLATE_ID));
+				setType(Type.WIDGET_PAGE_SETTINGS);
 			}
 		};
 	}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SitePageResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SitePageResourceImpl.java
@@ -11,19 +11,37 @@ import com.liferay.headless.admin.site.internal.resource.util.GroupUtil;
 import com.liferay.headless.admin.site.resource.v1_0.SitePageResource;
 import com.liferay.headless.common.spi.service.context.ServiceContextBuilder;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.LayoutTypePortletConstants;
+import com.liferay.portal.kernel.search.BooleanClauseOccur;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.search.filter.BooleanFilter;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.search.filter.TermFilter;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
+import com.liferay.portal.vulcan.aggregation.Aggregation;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
+import com.liferay.portal.vulcan.util.SearchUtil;
 
+import java.io.Serializable;
+
+import java.util.Map;
 import java.util.Objects;
+
+import javax.ws.rs.NotSupportedException;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -72,6 +90,54 @@ public class SitePageResourceImpl extends BaseSitePageResourceImpl {
 				siteExternalReferenceCode));
 
 		return _toSitePage(layout);
+	}
+
+	@Override
+	public Page<SitePage> getSiteSiteByExternalReferenceCodeSitePagesPage(
+			String siteExternalReferenceCode, String search,
+			Aggregation aggregation, Filter filter, Pagination pagination,
+			Sort[] sorts)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-35443")) {
+			throw new UnsupportedOperationException();
+		}
+
+		Group group = _groupLocalService.getGroupByExternalReferenceCode(
+			siteExternalReferenceCode, contextCompany.getCompanyId());
+
+		return SearchUtil.search(
+			null,
+			booleanQuery -> {
+				BooleanFilter booleanFilter =
+					booleanQuery.getPreBooleanFilter();
+
+				booleanFilter.add(
+					new TermFilter(
+						Field.GROUP_ID, String.valueOf(group.getGroupId())),
+					BooleanClauseOccur.MUST);
+			},
+			filter, Layout.class.getName(), search, pagination,
+			queryConfig -> queryConfig.setSelectedFieldNames(
+				Field.ENTRY_CLASS_PK),
+			searchContext -> {
+				searchContext.addVulcanAggregation(aggregation);
+				searchContext.setAttribute(Field.TITLE, search);
+				searchContext.setAttribute(
+					Field.TYPE, new String[] {LayoutConstants.TYPE_PORTLET});
+				searchContext.setAttribute(
+					"privateLayout", Boolean.FALSE.toString());
+				searchContext.setCompanyId(contextCompany.getCompanyId());
+				searchContext.setGroupIds(new long[] {group.getGroupId()});
+				searchContext.setKeywords(search);
+			},
+			sorts,
+			document -> {
+				long plid = GetterUtil.getLong(
+					document.get(Field.ENTRY_CLASS_PK));
+
+				return _toSitePage(_layoutLocalService.getLayout(plid));
+			});
 	}
 
 	@Override
@@ -142,6 +208,12 @@ public class SitePageResourceImpl extends BaseSitePageResourceImpl {
 
 	@Reference
 	private DTOConverterRegistry _dtoConverterRegistry;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private LayoutLocalService _layoutLocalService;
 
 	@Reference
 	private LayoutService _layoutService;

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SitePageResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SitePageResourceImpl.java
@@ -182,6 +182,29 @@ public class SitePageResourceImpl extends BaseSitePageResourceImpl {
 				0, serviceContext));
 	}
 
+	@Override
+	public Page<SitePage> read(
+			Filter filter, Pagination pagination, Sort[] sorts,
+			Map<String, Serializable> parameters, String search)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-35443")) {
+			throw new UnsupportedOperationException();
+		}
+
+		if (parameters.containsKey("siteId")) {
+			Group group = _groupLocalService.getGroup(
+				(Long)parameters.get("siteId"));
+
+			return getSiteSiteByExternalReferenceCodeSitePagesPage(
+				group.getExternalReferenceCode(), search, null, filter,
+				pagination, sorts);
+		}
+
+		throw new NotSupportedException(
+			"One of the following parameters must be specified: [siteId]");
+	}
+
 	private SitePage _toSitePage(Layout layout) throws Exception {
 		return _sitePageDTOConverter.toDTO(
 			new DefaultDTOConverterContext(

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-test/src/testIntegration/java/com/liferay/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-test/src/testIntegration/java/com/liferay/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
@@ -39,6 +39,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -311,10 +312,9 @@ public class ExportTaskResourceTest {
 	/**
 	 * Modify the value of _testableClassNames to test specific class names.
 	 */
-	private static Collection<String> _testableClassNames = Arrays.asList(
-		//"com.liferay.data.engine.rest.dto.v2_0.DataDefinition",
-		//"com.liferay.data.engine.rest.dto.v2_0.DataDefinitionFieldLink"
-	);
+	private static Collection<String> _testableClassNames =
+		Collections.singleton(
+			"com.liferay.headless.admin.site.dto.v1_0.SitePage");
 
 	private static final List<String> _untestableDTOClassNames = Arrays.asList(
 		"com.liferay.headless.admin.user.dto.v1_0.PostalAddress",

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-test/src/testIntegration/java/com/liferay/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-test/src/testIntegration/java/com/liferay/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
@@ -278,7 +278,7 @@ public class ExportTaskResourceTest {
 		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
 
 		ImportTask importTask = _importTaskResource.postImportTask(
-			classNamePartsMap.get("className"), null, "UPSERT", null, null,
+			classNamePartsMap.get("className"), null, "INSERT", null, null,
 			null, classNamePartsMap.get("taskItemDelegateName"),
 			itemsJSONArray);
 

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-test/src/testIntegration/java/com/liferay/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-test/src/testIntegration/java/com/liferay/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
@@ -28,6 +28,7 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.util.PropsValues;
@@ -62,6 +63,7 @@ import org.junit.runner.RunWith;
  * @author Raymond Augé
  * @author Brian Wing Shun Chan
  */
+@FeatureFlags("LPS-35443")
 @RunWith(Arquillian.class)
 public class ExportTaskResourceTest {
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-42808 - Unable to export/import a WidetPage using batch engine 

- **LPD-42539 Implement getSiteSiteByExternalReferenceCodeSitePagesPage returning widget pages**
- **LPD-42539 Implement read method**
- **LPD-42539 DON'T COMMIT - Temporarily set _testableClassNames to SitePage**
- **LPD-42539 DON'T COMMIT - Temporarily set importStrategy to INSERT until put (with upsert) is implemented for SitePages**
- **LPD-42539 Enable feature flag for batch export tests**
- **LPD-42539 Don't set type when creating WidgetPageSettings in SitePageDTOConverter**
- **Revert "LPD-42539 Don't set type when creating WidgetPageSettings in SitePageDTOConverter"**
