### PR TITLE
LPD-41479 fix flakiness in com.liferay.object.rest.internal.resource.v1_0.test.OpenAPIResourceTest

### DIFF
--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/internal/object/contributor/test/CommerceReturnItemObjectEntryValuesContributorTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/internal/object/contributor/test/CommerceReturnItemObjectEntryValuesContributorTest.java
@@ -27,6 +27,7 @@ import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -118,7 +119,7 @@ public class CommerceReturnItemObjectEntryValuesContributorTest {
 
 		ObjectDefinition objectDefinition =
 			_objectDefinitionLocalService.fetchSystemObjectDefinition(
-				"CommerceReturn");
+				CompanyThreadLocal.getCompanyId(), "CommerceReturn");
 
 		_objectEntry = _objectEntryLocalService.addObjectEntry(
 			_user.getUserId(), 0, objectDefinition.getObjectDefinitionId(),
@@ -162,7 +163,7 @@ public class CommerceReturnItemObjectEntryValuesContributorTest {
 
 		ObjectDefinition objectDefinition =
 			_objectDefinitionLocalService.fetchSystemObjectDefinition(
-				"CommerceReturnItem");
+				CompanyThreadLocal.getCompanyId(), "CommerceReturnItem");
 
 		ObjectEntry objectEntry = _objectEntryLocalService.addObjectEntry(
 			_user.getUserId(), 0, objectDefinition.getObjectDefinitionId(),

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/internal/object/contributor/test/CommerceReturnObjectEntryValuesContributorTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/internal/object/contributor/test/CommerceReturnObjectEntryValuesContributorTest.java
@@ -27,6 +27,7 @@ import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -141,7 +142,7 @@ public class CommerceReturnObjectEntryValuesContributorTest {
 
 		ObjectDefinition objectDefinition =
 			_objectDefinitionLocalService.fetchSystemObjectDefinition(
-				"CommerceReturn");
+				CompanyThreadLocal.getCompanyId(), "CommerceReturn");
 
 		ObjectEntry objectEntry = _objectEntryLocalService.addObjectEntry(
 			_user.getUserId(), 0, objectDefinition.getObjectDefinitionId(),

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APIPropertyRelevantObjectEntryModelListenerTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APIPropertyRelevantObjectEntryModelListenerTest.java
@@ -20,6 +20,7 @@ import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -126,7 +127,8 @@ public class APIPropertyRelevantObjectEntryModelListenerTest
 			jsonObject.get("title"));
 
 		ObjectDefinition userSystemObjectDefinition =
-			_objectDefinitionLocalService.fetchSystemObjectDefinition("User");
+			_objectDefinitionLocalService.fetchSystemObjectDefinition(
+				CompanyThreadLocal.getCompanyId(), "User");
 
 		ObjectRelationship objectRelationship =
 			ObjectRelationshipTestUtil.addObjectRelationship(

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
@@ -42,6 +42,7 @@ import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -459,6 +460,7 @@ public class ObjectDefinitionResourceTest
 		com.liferay.object.model.ObjectDefinition
 			serviceBuilderAccountEntryObjectDefinition =
 				_objectDefinitionLocalService.fetchSystemObjectDefinition(
+					CompanyThreadLocal.getCompanyId(),
 					AccountEntry.class.getSimpleName());
 
 		_objectDefinitionLocalService.enableAccountEntryRestricted(

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalService.java
@@ -283,7 +283,8 @@ public interface ObjectDefinitionLocalService
 		String uuid, long companyId);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public ObjectDefinition fetchSystemObjectDefinition(String name);
+	public ObjectDefinition fetchSystemObjectDefinition(
+		long companyId, String name);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ActionableDynamicQuery getActionableDynamicQuery();

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalServiceUtil.java
@@ -344,8 +344,10 @@ public class ObjectDefinitionLocalServiceUtil {
 			uuid, companyId);
 	}
 
-	public static ObjectDefinition fetchSystemObjectDefinition(String name) {
-		return getService().fetchSystemObjectDefinition(name);
+	public static ObjectDefinition fetchSystemObjectDefinition(
+		long companyId, String name) {
+
+		return getService().fetchSystemObjectDefinition(companyId, name);
 	}
 
 	public static com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalServiceWrapper.java
@@ -394,9 +394,10 @@ public class ObjectDefinitionLocalServiceWrapper
 
 	@Override
 	public com.liferay.object.model.ObjectDefinition
-		fetchSystemObjectDefinition(String name) {
+		fetchSystemObjectDefinition(long companyId, String name) {
 
-		return _objectDefinitionLocalService.fetchSystemObjectDefinition(name);
+		return _objectDefinitionLocalService.fetchSystemObjectDefinition(
+			companyId, name);
 	}
 
 	@Override

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryService.java
@@ -58,7 +58,6 @@ public interface ObjectEntryService extends BaseService {
 			Map<String, Serializable> values, ServiceContext serviceContext)
 		throws PortalException;
 
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public void checkModelResourcePermission(
 			long objectDefinitionId, long objectEntryId, String actionId)
 		throws PortalException;

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
@@ -37,6 +37,7 @@ import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
@@ -129,6 +130,7 @@ public class ObjectEntryRelatedObjectsResourceTest {
 
 		_userSystemObjectDefinition =
 			_objectDefinitionLocalService.fetchSystemObjectDefinition(
+				CompanyThreadLocal.getCompanyId(),
 				_userSystemObjectDefinitionManager.getName());
 	}
 
@@ -767,6 +769,7 @@ public class ObjectEntryRelatedObjectsResourceTest {
 
 		ObjectDefinition relatedObjectDefinition =
 			_objectDefinitionLocalService.fetchSystemObjectDefinition(
+				CompanyThreadLocal.getCompanyId(),
 				_userSystemObjectDefinitionManager.getName());
 
 		// Many to many relationships
@@ -839,6 +842,7 @@ public class ObjectEntryRelatedObjectsResourceTest {
 
 		ObjectDefinition relatedObjectDefinition =
 			_objectDefinitionLocalService.fetchSystemObjectDefinition(
+				CompanyThreadLocal.getCompanyId(),
 				_userSystemObjectDefinitionManager.getName());
 
 		ObjectRelationship objectRelationship = _addObjectRelationship(
@@ -1311,6 +1315,7 @@ public class ObjectEntryRelatedObjectsResourceTest {
 
 		ObjectDefinition relatedObjectDefinition =
 			_objectDefinitionLocalService.fetchSystemObjectDefinition(
+				CompanyThreadLocal.getCompanyId(),
 				_userSystemObjectDefinitionManager.getName());
 
 		// Many to many relationship

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -808,6 +808,7 @@ public class ObjectEntryResourceTest {
 
 		_userSystemObjectDefinition =
 			_objectDefinitionLocalService.fetchSystemObjectDefinition(
+				CompanyThreadLocal.getCompanyId(),
 				_systemObjectDefinitionManager.getName());
 
 		_userSystemObjectField = ObjectFieldTestUtil.addCustomObjectField(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/OpenAPIResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/OpenAPIResourceTest.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -293,6 +294,7 @@ public class OpenAPIResourceTest {
 
 		_userSystemObjectDefinition =
 			_objectDefinitionLocalService.fetchSystemObjectDefinition(
+				CompanyThreadLocal.getCompanyId(),
 				userSystemObjectDefinitionManager.getName());
 
 		JaxRsApplicationDescriptor jaxRsApplicationDescriptor =

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/OpenAPIResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/OpenAPIResourceTest.java
@@ -193,59 +193,70 @@ public class OpenAPIResourceTest {
 
 	@Test
 	public void testGetOpenAPIInDifferentCompany() throws Exception {
-		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
-			JSONUtil.put(
-				"domain", "able.com"
-			).put(
-				"portalInstanceId", "able.com"
-			).put(
-				"virtualHost", "www.able.com"
-			).toString(),
-			"headless-portal-instances/v1.0/portal-instances",
-			Http.Method.POST);
+		long companyId = 0;
 
-		HTTPTestUtil.customize(
-		).withBaseURL(
-			"http://www.able.com:8080"
-		).withCredentials(
-			"test@able.com", PropsValues.DEFAULT_ADMIN_PASSWORD
-		).apply(
-			() -> {
-				User user = UserTestUtil.addUser(
-					_companyLocalService.getCompany(
-						jsonObject.getLong("companyId")));
+		try {
+			JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					"domain", "able.com"
+				).put(
+					"portalInstanceId", "able.com"
+				).put(
+					"virtualHost", "www.able.com"
+				).toString(),
+				"headless-portal-instances/v1.0/portal-instances",
+				Http.Method.POST);
 
-				ObjectDefinition companyObjectDefinition =
-					ObjectDefinitionTestUtil.publishObjectDefinition(
-						"Object1",
-						Collections.singletonList(
-							ObjectFieldUtil.createObjectField(
-								ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-								ObjectFieldConstants.DB_TYPE_STRING, true, true,
-								null, "field", "field", false)),
-						ObjectDefinitionConstants.SCOPE_COMPANY,
-						user.getUserId());
+			companyId = jsonObject.getLong("companyId");
+			HTTPTestUtil.customize(
+			).withBaseURL(
+				"http://www.able.com:8080"
+			).withCredentials(
+				"test@able.com", PropsValues.DEFAULT_ADMIN_PASSWORD
+			).apply(
+				() -> {
+					User user = UserTestUtil.addUser(
+						_companyLocalService.getCompany(
+							jsonObject.getLong("companyId")));
 
-				Assert.assertEquals(
-					200,
-					HTTPTestUtil.invokeToHttpCode(
-						null, companyObjectDefinition.getRESTContextPath(),
-						Http.Method.GET));
+					ObjectDefinition companyObjectDefinition =
+						ObjectDefinitionTestUtil.publishObjectDefinition(
+							"Object1",
+							Collections.singletonList(
+								ObjectFieldUtil.createObjectField(
+									ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+									ObjectFieldConstants.DB_TYPE_STRING, true,
+									true, null, "field", "field", false)),
+							ObjectDefinitionConstants.SCOPE_COMPANY,
+							user.getUserId());
 
-				JSONObject openAPIJSONObject = HTTPTestUtil.invokeToJSONObject(
-					null, "/openapi", Http.Method.GET);
+					Assert.assertEquals(
+						200,
+						HTTPTestUtil.invokeToHttpCode(
+							null, companyObjectDefinition.getRESTContextPath(),
+							Http.Method.GET));
 
-				JSONArray jsonArray = openAPIJSONObject.getJSONArray(
-					companyObjectDefinition.getRESTContextPath());
+					JSONObject openAPIJSONObject =
+						HTTPTestUtil.invokeToJSONObject(
+							null, "/openapi", Http.Method.GET);
 
-				Assert.assertEquals(1, jsonArray.length());
-				Assert.assertEquals(
-					"http://www.able.com:8080/o" +
+					JSONArray jsonArray = openAPIJSONObject.getJSONArray(
+						companyObjectDefinition.getRESTContextPath());
+
+					Assert.assertEquals(1, jsonArray.length());
+					Assert.assertEquals(
+						"http://www.able.com:8080/o" +
 						companyObjectDefinition.getRESTContextPath() +
-							"/openapi.yaml",
-					jsonArray.get(0));
+						"/openapi.yaml",
+						jsonArray.get(0));
+				}
+			);
+		}
+		finally {
+			if (companyId != 0) {
+				_companyLocalService.deleteCompany(companyId);
 			}
-		);
+		}
 	}
 
 	@FeatureFlags("LPS-180090")
@@ -311,25 +322,29 @@ public class OpenAPIResourceTest {
 			"relationMToM", false,
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY, null);
 
+		String jsonObject = HTTPTestUtil.invokeToJSONObject(
+			null,
+			StringBundler.concat(
+				jaxRsApplicationDescriptor.getApplicationPath(),
+				StringPool.SLASH, jaxRsApplicationDescriptor.getVersion(),
+				"/openapi.json"),
+			Http.Method.GET
+		).toString();
+
+		String relationshipString = new String(
+			FileUtil.getBytes(
+				getClass(),
+				"dependencies" +
+				"/expected_openapi_system_object_relationship.json"));
+
 		JSONAssert.assertEquals(
-			new String(
-				FileUtil.getBytes(
-					getClass(),
-					"dependencies" +
-						"/expected_openapi_system_object_relationship.json")),
-			HTTPTestUtil.invokeToJSONObject(
-				null,
-				StringBundler.concat(
-					jaxRsApplicationDescriptor.getApplicationPath(),
-					StringPool.SLASH, jaxRsApplicationDescriptor.getVersion(),
-					"/openapi.json"),
-				Http.Method.GET
-			).toString(),
+			relationshipString,
+			jsonObject,
 			JSONCompareMode.LENIENT);
 	}
 
 	private void _assertOpenAPI(
-			String fileName, ObjectDefinition objectDefinition)
+		String fileName, ObjectDefinition objectDefinition)
 		throws Exception {
 
 		JSONAssert.assertEquals(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/OpenAPIResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/OpenAPIResourceTest.java
@@ -246,8 +246,8 @@ public class OpenAPIResourceTest {
 					Assert.assertEquals(1, jsonArray.length());
 					Assert.assertEquals(
 						"http://www.able.com:8080/o" +
-						companyObjectDefinition.getRESTContextPath() +
-						"/openapi.yaml",
+							companyObjectDefinition.getRESTContextPath() +
+								"/openapi.yaml",
 						jsonArray.get(0));
 				}
 			);
@@ -322,7 +322,7 @@ public class OpenAPIResourceTest {
 			"relationMToM", false,
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY, null);
 
-		String jsonObject = HTTPTestUtil.invokeToJSONObject(
+		String jsonObjectString = HTTPTestUtil.invokeToJSONObject(
 			null,
 			StringBundler.concat(
 				jaxRsApplicationDescriptor.getApplicationPath(),
@@ -335,16 +335,14 @@ public class OpenAPIResourceTest {
 			FileUtil.getBytes(
 				getClass(),
 				"dependencies" +
-				"/expected_openapi_system_object_relationship.json"));
+					"/expected_openapi_system_object_relationship.json"));
 
 		JSONAssert.assertEquals(
-			relationshipString,
-			jsonObject,
-			JSONCompareMode.LENIENT);
+			relationshipString, jsonObjectString, JSONCompareMode.LENIENT);
 	}
 
 	private void _assertOpenAPI(
-		String fileName, ObjectDefinition objectDefinition)
+			String fileName, ObjectDefinition objectDefinition)
 		throws Exception {
 
 		JSONAssert.assertEquals(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/RelatedObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/RelatedObjectEntryResourceTest.java
@@ -24,6 +24,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
@@ -74,6 +75,7 @@ public class RelatedObjectEntryResourceTest {
 
 		_userSystemObjectDefinition =
 			_objectDefinitionLocalService.fetchSystemObjectDefinition(
+				CompanyThreadLocal.getCompanyId(),
 				_userSystemObjectDefinitionManager.getName());
 	}
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/SystemObjectRelatedObjectEntriesTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/SystemObjectRelatedObjectEntriesTest.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
@@ -104,6 +105,7 @@ public class SystemObjectRelatedObjectEntriesTest {
 
 		_userSystemObjectDefinition =
 			_objectDefinitionLocalService.fetchSystemObjectDefinition(
+				CompanyThreadLocal.getCompanyId(),
 				_userSystemObjectDefinitionManager.getName());
 
 		_userSystemObjectField = ObjectFieldTestUtil.addCustomObjectField(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/test/ObjectRelationshipExtensionProviderTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/test/ObjectRelationshipExtensionProviderTest.java
@@ -22,6 +22,7 @@ import com.liferay.object.system.SystemObjectDefinitionManager;
 import com.liferay.object.system.SystemObjectDefinitionManagerRegistry;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -80,6 +81,7 @@ public class ObjectRelationshipExtensionProviderTest {
 
 		ObjectDefinition userSystemObjectDefinition =
 			_objectDefinitionLocalService.fetchSystemObjectDefinition(
+				CompanyThreadLocal.getCompanyId(),
 				_userSystemObjectDefinitionManager.getName());
 
 		_user = TestPropsValues.getUser();

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -809,11 +809,16 @@ public class ObjectDefinitionLocalServiceImpl
 	}
 
 	@Override
-	public ObjectDefinition fetchSystemObjectDefinition(long companyId, String name) {
+	public ObjectDefinition fetchSystemObjectDefinition(
+		long companyId, String name) {
+
 		for (ObjectDefinition systemObjectDefinition :
 				getSystemObjectDefinitions()) {
 
-			if (Objects.equals(systemObjectDefinition.getName(), name)) {
+			if (Objects.equals(systemObjectDefinition.getName(), name) &&
+				Objects.equals(
+					systemObjectDefinition.getCompanyId(), companyId)) {
+
 				return systemObjectDefinition;
 			}
 		}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -809,7 +809,7 @@ public class ObjectDefinitionLocalServiceImpl
 	}
 
 	@Override
-	public ObjectDefinition fetchSystemObjectDefinition(String name) {
+	public ObjectDefinition fetchSystemObjectDefinition(long companyId, String name) {
 		for (ObjectDefinition systemObjectDefinition :
 				getSystemObjectDefinitions()) {
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/model/listener/test/AccountEntryOrganizationRelModelListenerTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/model/listener/test/AccountEntryOrganizationRelModelListenerTest.java
@@ -23,6 +23,7 @@ import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.model.Organization;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.OrganizationTestUtil;
@@ -69,7 +70,7 @@ public class AccountEntryOrganizationRelModelListenerTest {
 				_objectRelationshipLocalService.addObjectRelationship(
 					null, TestPropsValues.getUserId(),
 					_objectDefinitionLocalService.fetchSystemObjectDefinition(
-						"AccountEntry"
+						CompanyThreadLocal.getCompanyId(), "AccountEntry"
 					).getObjectDefinitionId(),
 					objectDefinition.getObjectDefinitionId(), 0,
 					ObjectRelationshipConstants.DELETION_TYPE_PREVENT, false,

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
@@ -1796,7 +1796,7 @@ public class ObjectDefinitionLocalServiceTest {
 				_objectRelationshipLocalService.addObjectRelationship(
 					null, TestPropsValues.getUserId(),
 					_objectDefinitionLocalService.fetchSystemObjectDefinition(
-						"AccountEntry"
+						CompanyThreadLocal.getCompanyId(), "AccountEntry"
 					).getObjectDefinitionId(),
 					objectDefinition.getObjectDefinitionId(), 0,
 					ObjectRelationshipConstants.DELETION_TYPE_PREVENT, false,

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -3659,7 +3659,7 @@ public class ObjectEntryLocalServiceTest {
 
 			ObjectDefinition objectDefinition =
 				_objectDefinitionLocalService.fetchSystemObjectDefinition(
-					"User");
+					CompanyThreadLocal.getCompanyId(), "User");
 
 			User user = UserTestUtil.addUser(
 				TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test/src/testIntegration/java/com/liferay/site/initializer/extender/internal/test/BundleSiteInitializerTest.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test/src/testIntegration/java/com/liferay/site/initializer/extender/internal/test/BundleSiteInitializerTest.java
@@ -2673,7 +2673,8 @@ public class BundleSiteInitializerTest {
 			).build();
 
 		ObjectDefinition objectDefinition1 =
-			_objectDefinitionLocalService.fetchSystemObjectDefinition("User");
+			_objectDefinitionLocalService.fetchSystemObjectDefinition(
+				CompanyThreadLocal.getCompanyId(), "User");
 
 		Page<ObjectRelationship> page1 =
 			objectRelationshipResource.
@@ -2719,7 +2720,7 @@ public class BundleSiteInitializerTest {
 
 		objectDefinition =
 			_objectDefinitionLocalService.fetchSystemObjectDefinition(
-				"AccountEntry");
+				CompanyThreadLocal.getCompanyId(), "AccountEntry");
 
 		Page<ObjectRelationship> page3 =
 			objectRelationshipResource.
@@ -2754,7 +2755,8 @@ public class BundleSiteInitializerTest {
 			).build();
 
 		ObjectDefinition objectDefinition1 =
-			_objectDefinitionLocalService.fetchSystemObjectDefinition("User");
+			_objectDefinitionLocalService.fetchSystemObjectDefinition(
+				CompanyThreadLocal.getCompanyId(), "User");
 
 		Page<ObjectRelationship> page1 =
 			objectRelationshipResource.
@@ -2800,7 +2802,7 @@ public class BundleSiteInitializerTest {
 
 		objectDefinition =
 			_objectDefinitionLocalService.fetchSystemObjectDefinition(
-				"AccountEntry");
+				CompanyThreadLocal.getCompanyId(), "AccountEntry");
 
 		Page<ObjectRelationship> page3 =
 			objectRelationshipResource.


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-41479

The test failed (_testGetOpenAPIWithSystemObjectRelationship_) because, as you can see in the picture, there were two system object definitions called 'User'.

![object-definition](https://github.com/user-attachments/assets/4c49907f-57b2-4cd4-b198-c50004beb2ed)

The second 'User' was created in the previous test, `testGetOpenAPIInDifferentCompany`. To remove this second object definition, I added a final step of removing the company created in that test.

**WARNING**: This wouldn't have happened if the system definition had been fetched by ID here

`		_userSystemObjectDefinition =
			_objectDefinitionLocalService.fetchSystemObjectDefinition(
				userSystemObjectDefinitionManager.getName());`

But I couldn't find a method to do that. This method smells dangerous, and we should implement the fetch by ID or add the company name. What do you think @ccorreagg 

CC: We were talking about this @dannielraposo, @albertojml 