### PR TITLE
LPD-42640 Add file to launch the relevant tests if there is any change

### DIFF
--- a/modules/apps/portal-vulcan/test.properties
+++ b/modules/apps/portal-vulcan/test.properties
@@ -4,9 +4,9 @@
 
     modified.files.includes[relevant][portal-vulcan-java-rule]=\
         **/*.java,\
-        **/build.gradle,\
         **/test/**,\
-        **/testIntegration/**
+        **/testIntegration/**,\
+        /apps/portal-vulcan/**/build.gradle
 
     relevant.rule.names=portal-vulcan-java-rule
 

--- a/modules/apps/portal-vulcan/test.properties
+++ b/modules/apps/portal-vulcan/test.properties
@@ -4,6 +4,7 @@
 
     modified.files.includes[relevant][portal-vulcan-java-rule]=\
         **/*.java,\
+        **/build.gradle,\
         **/test/**,\
         **/testIntegration/**
 


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPD-42640

The purpose of this PR is to add the `build.gradle` file as one of the files that, if it is changed, the `portal-vulcan` tests will be launched inside the relevant suite. For example, we did some changes in [this other PR](https://github.com/liferay-headless/liferay-portal/pull/2346) and the portal-vulcan tests were not launched the first execution of the relevant suite

---

cc/ @GaborKomaromi 