### PR TITLE
LPD-43999 | Fix headless-builder-web/schemas.spec.ts > can see all available object definitions on schema creation

### DIFF
--- a/modules/test/playwright/tests/headless-builder-web/schemas.spec.ts
+++ b/modules/test/playwright/tests/headless-builder-web/schemas.spec.ts
@@ -195,7 +195,7 @@ testFeatureFlagsDisabled(
 			await apiHelpers.buildRestClient(ObjectDefinitionApi);
 
 		for (let i = 0; i <= 21; i++) {
-			objectDefinitions.push(
+			const objectDefinition = (
 				await objectDefinitionAPIClient.postObjectDefinition({
 					active: true,
 					externalReferenceCode: `objectDefinition${i}`,
@@ -231,7 +231,9 @@ testFeatureFlagsDisabled(
 						code: 0,
 					},
 				})
-			);
+			).body;
+
+			objectDefinitions.push(objectDefinition);
 		}
 
 		objectDefinitions.forEach((objectDefinition) => {

--- a/modules/test/playwright/tests/headless-builder-web/schemas.spec.ts
+++ b/modules/test/playwright/tests/headless-builder-web/schemas.spec.ts
@@ -234,14 +234,12 @@ testFeatureFlagsDisabled(
 			).body;
 
 			objectDefinitions.push(objectDefinition);
-		}
 
-		objectDefinitions.forEach((objectDefinition) => {
 			apiHelpers.data.push({
 				id: objectDefinition.id,
 				type: 'objectDefinition',
 			});
-		});
+		}
 
 		const application = await apiHelpers.objectEntry.postObjectEntry(
 			applicationData,


### PR DESCRIPTION
**Description**: Fill array with object definition and not with promises

**Jira Ticket**: https://liferay.atlassian.net/browse/LPD-43999