### PR TITLE
LPD-44872 Ensuring node is downloaded before running buildREST

### DIFF
--- a/modules/util/portal-tools-rest-builder/build.gradle
+++ b/modules/util/portal-tools-rest-builder/build.gradle
@@ -39,6 +39,10 @@ dependencies {
 	compileOnly group: "org.apache.maven", name: "maven-plugin-api", transitive: false, version: "3.0.4"
 }
 
+deploy {
+	dependsOn downloadNode
+}
+
 deployDependencies {
 	from (configurations.compileClasspath) {
 		include "checkstyle-*.jar"


### PR DESCRIPTION
See https://liferay.atlassian.net/browse/LPD-44872.