### PR TITLE
LPD-45725 Fix tests that were using HTTPTestUtilCustomizer without modulePath value declared

### DIFF
--- a/portal-test/src/com/liferay/portal/kernel/test/util/HTTPTestUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/HTTPTestUtil.java
@@ -147,7 +147,7 @@ public class HTTPTestUtil {
 
 		private String _newBaseURL = _baseURL;
 		private String _newCredentials = _credentials;
-		private boolean _newModulePath;
+		private boolean _newModulePath = _modulePath;
 
 	}
 


### PR DESCRIPTION
**What's changed?:**
- Now the `_newModulePath` variable value is initialized with the same value as `_modulePath`

See the following Jira Ticket: [LPD-45725](https://liferay.atlassian.net/browse/LPD-45725)