### PR TITLE
LPD-47114 Rest Builder fails on Java 8

### DIFF
--- a/modules/util/portal-tools-rest-builder/build.gradle
+++ b/modules/util/portal-tools-rest-builder/build.gradle
@@ -22,8 +22,8 @@ dependencies {
 	api group: "com.puppycrawl.tools", name: "checkstyle", version: "8.29"
 	api group: "commons-io", name: "commons-io", version: "2.15.1"
 	compileInclude group: "com.beust", name: "jcommander", version: "1.82"
+	compileInclude group: "com.liferay", name: "com.liferay.portal.vulcan.api", version: "44.1.0"
 	compileInclude group: "org.yaml", name: "snakeyaml", version: "2.3"
-	compileInclude project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly group: "com.liferay", name: "com.liferay.petra.io", version: "5.0.5"
 	compileOnly group: "com.liferay", name: "com.liferay.petra.lang", version: "1.0.0"
 	compileOnly group: "com.liferay", name: "com.liferay.petra.string", version: "5.0.1"

--- a/modules/util/portal-tools-rest-builder/build.gradle
+++ b/modules/util/portal-tools-rest-builder/build.gradle
@@ -28,13 +28,22 @@ dependencies {
 	compileOnly group: "com.liferay", name: "com.liferay.petra.lang", version: "1.0.0"
 	compileOnly group: "com.liferay", name: "com.liferay.petra.string", version: "5.0.1"
 	compileOnly group: "com.liferay", name: "com.liferay.portal.tools.java.parser", version: "1.0.41"
-	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
-	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel"
 	compileOnly group: "javax.annotation", name: "javax.annotation-api", version: "1.3.2"
 	compileOnly group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"
 	compileOnly group: "javax.xml.bind", name: "jaxb-api", version: "2.3.0"
 	compileOnly group: "org.apache.ant", name: "ant", transitive: false, version: "1.10.14"
 	compileOnly group: "org.apache.maven", name: "maven-plugin-api", transitive: false, version: "3.0.4"
+
+	constraints {
+		compileOnly(group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "109.0.0") {
+			because "Java 8 runtime support is required"
+		}
+		compileOnly(group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "154.0.0") {
+			because "Java 8 runtime support is required"
+		}
+	}
 }
 
 deploy {


### PR DESCRIPTION
This is an update for [LPD-47114](https://liferay.atlassian.net/browse/LPD-47114).

Hi all, this is just an update that maintains compatibility with the Java 8 runtime. This is needed since the tool is invoked on older branches (e.g. `7.3.x`).

Please let me know if you have any questions or concerns. Thanks!

/cc @petershin @brianwulbern