### PR TITLE
LPD-37787 Filtering using r_<relationshipName>_c_<objectName>ERC is not working properly

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/ReferenceStringEntityField.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/ReferenceStringEntityField.java
@@ -1,0 +1,33 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.rest.internal.odata.entity;
+
+import com.liferay.portal.odata.entity.StringEntityField;
+
+import java.util.Locale;
+import java.util.function.Function;
+
+/**
+ * @author Carlos Correa
+ */
+public class ReferenceStringEntityField extends StringEntityField {
+
+	public ReferenceStringEntityField(
+		String fieldName, Function<Locale, String> filterableFunction,
+		String referencedFieldName) {
+
+		super(fieldName, locale -> referencedFieldName, filterableFunction);
+
+		_referencedFieldName = referencedFieldName;
+	}
+
+	public String getReferencedFieldName() {
+		return _referencedFieldName;
+	}
+
+	private final String _referencedFieldName;
+
+}

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/v1_0/ObjectEntryEntityModel.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/v1_0/ObjectEntryEntityModel.java
@@ -277,11 +277,15 @@ public class ObjectEntryEntityModel implements EntityModel {
 						NAME_OBJECT_RELATIONSHIP_ERC_OBJECT_FIELD_NAME,
 					objectField);
 
+			String relationshipName =
+				objectRelationshipERCObjectFieldName.split("_c_")[0].substring(
+					2);
+
 			entityFieldsMap.put(
 				objectRelationshipERCObjectFieldName,
 				new StringEntityField(
 					objectRelationshipERCObjectFieldName,
-					locale -> objectFieldName));
+					locale -> relationshipName + "/externalReferenceCode"));
 
 			String relationshipIdName = objectFieldName.substring(
 				objectFieldName.lastIndexOf(StringPool.UNDERLINE) + 1);

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/v1_0/ObjectEntryEntityModel.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/v1_0/ObjectEntryEntityModel.java
@@ -283,9 +283,11 @@ public class ObjectEntryEntityModel implements EntityModel {
 
 			entityFieldsMap.put(
 				objectRelationshipERCObjectFieldName,
-				new StringEntityField(
+				new EntityField(
 					objectRelationshipERCObjectFieldName,
-					locale -> relationshipName + "/externalReferenceCode"));
+					EntityField.Type.STRING, locale -> "externalReferenceCode",
+					locale -> relationshipName + "/externalReferenceCode",
+					String::valueOf));
 
 			String relationshipIdName = objectFieldName.substring(
 				objectFieldName.lastIndexOf(StringPool.UNDERLINE) + 1);

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/v1_0/ObjectEntryEntityModel.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/v1_0/ObjectEntryEntityModel.java
@@ -277,16 +277,14 @@ public class ObjectEntryEntityModel implements EntityModel {
 						NAME_OBJECT_RELATIONSHIP_ERC_OBJECT_FIELD_NAME,
 					objectField);
 
-			String relationshipName =
-				objectRelationshipERCObjectFieldName.split("_c_")[0].substring(
-					2);
-
 			entityFieldsMap.put(
 				objectRelationshipERCObjectFieldName,
 				new EntityField(
 					objectRelationshipERCObjectFieldName,
 					EntityField.Type.STRING, locale -> "externalReferenceCode",
-					locale -> relationshipName + "/externalReferenceCode",
+					locale ->
+						objectFieldName.split(StringPool.UNDERLINE)[1] +
+							"/externalReferenceCode",
 					String::valueOf));
 
 			String relationshipIdName = objectFieldName.substring(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/v1_0/ObjectEntryEntityModel.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/v1_0/ObjectEntryEntityModel.java
@@ -13,6 +13,7 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.relationship.util.ObjectRelationshipUtil;
+import com.liferay.object.rest.internal.odata.entity.ReferenceStringEntityField;
 import com.liferay.object.service.ObjectFieldLocalServiceUtil;
 import com.liferay.object.service.ObjectRelationshipLocalServiceUtil;
 import com.liferay.petra.string.StringPool;
@@ -33,9 +34,11 @@ import com.liferay.portal.odata.entity.StringEntityField;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
 
 import javax.ws.rs.BadRequestException;
 
@@ -157,6 +160,10 @@ public class ObjectEntryEntityModel implements EntityModel {
 			"Unable to get entity field for object field " + objectField);
 	}
 
+	private Function<Locale, String> _getExternalReferenceCodeFunction() {
+		return locale -> "externalReferenceCode";
+	}
+
 	private Map<String, EntityField> _getObjectDefinitionEntityFieldsMap(
 		ObjectDefinition objectDefinition) {
 
@@ -211,7 +218,8 @@ public class ObjectEntryEntityModel implements EntityModel {
 			).put(
 				"externalReferenceCode",
 				() -> new StringEntityField(
-					"externalReferenceCode", locale -> "externalReferenceCode")
+					"externalReferenceCode",
+					_getExternalReferenceCodeFunction())
 			).put(
 				"id", new IdEntityField("id", locale -> "id", String::valueOf)
 			).put(
@@ -279,13 +287,11 @@ public class ObjectEntryEntityModel implements EntityModel {
 
 			entityFieldsMap.put(
 				objectRelationshipERCObjectFieldName,
-				new EntityField(
+				new ReferenceStringEntityField(
 					objectRelationshipERCObjectFieldName,
-					EntityField.Type.STRING, locale -> "externalReferenceCode",
-					locale ->
-						objectFieldName.split(StringPool.UNDERLINE)[1] +
-							"/externalReferenceCode",
-					String::valueOf));
+					_getExternalReferenceCodeFunction(),
+					objectFieldName.split(StringPool.UNDERLINE)[1] +
+						"/externalReferenceCode"));
 
 			String relationshipIdName = objectFieldName.substring(
 				objectFieldName.lastIndexOf(StringPool.UNDERLINE) + 1);

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
@@ -161,6 +161,28 @@ public class PredicateExpressionVisitorImpl
 				});
 		}
 
+		EntityModel entityModel = _getObjectDefinitionEntityModel(
+			ObjectRelationshipUtil.getRelatedObjectDefinition(
+				_objectDefinition,
+				_fetchObjectRelationship(
+					_objectDefinition, complexPropertyExpression.getName())));
+
+		Map<String, EntityField> entityFieldsMap =
+			entityModel.getEntityFieldsMap();
+
+		EntityField entityField = entityFieldsMap.get(
+			propertyExpression.getName());
+
+		if (entityField.getFilterableName(
+				null
+			).contains(
+				"/"
+			)) {
+
+			return complexPropertyExpression.getName() + "/" +
+				entityField.getFilterableName(null);
+		}
+
 		return complexPropertyExpression.toString();
 	}
 
@@ -317,6 +339,24 @@ public class PredicateExpressionVisitorImpl
 	@Override
 	public Object visitPrimitivePropertyExpression(
 		PrimitivePropertyExpression primitivePropertyExpression) {
+
+		EntityModel entityModel = _entityModels.get(
+			_objectDefinition.getObjectDefinitionId());
+
+		Map<String, EntityField> entityFieldsMap =
+			entityModel.getEntityFieldsMap();
+
+		EntityField entityField = entityFieldsMap.get(
+			primitivePropertyExpression.getName());
+
+		if (entityField.getFilterableName(
+				null
+			).contains(
+				"/"
+			)) {
+
+			return entityField.getFilterableName(null);
+		}
 
 		return primitivePropertyExpression.getName();
 	}

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
@@ -696,7 +696,7 @@ public class PredicateExpressionVisitorImpl
 
 		try {
 			ObjectField objectField = _objectFieldLocalService.getObjectField(
-				_objectDefinition.getObjectDefinitionId(),
+				objectDefinition.getObjectDefinitionId(),
 				entityFieldFilterableName);
 
 			ObjectFieldBusinessType objectFieldBusinessType =

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
@@ -16,6 +16,7 @@ import com.liferay.object.odata.filter.expression.field.predicate.provider.Field
 import com.liferay.object.related.models.ObjectRelatedModelsPredicateProvider;
 import com.liferay.object.related.models.ObjectRelatedModelsPredicateProviderRegistry;
 import com.liferay.object.relationship.util.ObjectRelationshipUtil;
+import com.liferay.object.rest.internal.odata.entity.ReferenceStringEntityField;
 import com.liferay.object.rest.internal.util.BinaryExpressionConverterUtil;
 import com.liferay.object.rest.odata.entity.v1_0.provider.EntityModelProvider;
 import com.liferay.object.service.ObjectFieldLocalService;
@@ -161,27 +162,19 @@ public class PredicateExpressionVisitorImpl
 				});
 		}
 
-		EntityModel entityModel = _getObjectDefinitionEntityModel(
-			ObjectRelationshipUtil.getRelatedObjectDefinition(
-				_objectDefinition,
-				_fetchObjectRelationship(
-					_objectDefinition, complexPropertyExpression.getName())));
+		if (propertyExpression instanceof PrimitivePropertyExpression) {
+			PrimitivePropertyExpression primitivePropertyExpression =
+				(PrimitivePropertyExpression)propertyExpression;
 
-		Map<String, EntityField> entityFieldsMap =
-			entityModel.getEntityFieldsMap();
+			Object value = _visitPrimitivePropertyExpression(
+				_getEntityField(
+					complexPropertyExpression.getName() + StringPool.SLASH +
+						primitivePropertyExpression.getName(),
+					_objectDefinition),
+				primitivePropertyExpression);
 
-		EntityField entityField = entityFieldsMap.get(
-			propertyExpression.getName());
-
-		if (entityField.getFilterableName(
-				null
-			).contains(
-				StringPool.SLASH
-			)) {
-
-			return StringBundler.concat(
-				complexPropertyExpression.getName(), StringPool.SLASH,
-				entityField.getFilterableName(null));
+			return complexPropertyExpression.getName() + StringPool.SLASH +
+				value;
 		}
 
 		return complexPropertyExpression.toString();
@@ -341,25 +334,10 @@ public class PredicateExpressionVisitorImpl
 	public Object visitPrimitivePropertyExpression(
 		PrimitivePropertyExpression primitivePropertyExpression) {
 
-		EntityModel entityModel = _entityModels.get(
-			_objectDefinition.getObjectDefinitionId());
-
-		Map<String, EntityField> entityFieldsMap =
-			entityModel.getEntityFieldsMap();
-
-		EntityField entityField = entityFieldsMap.get(
-			primitivePropertyExpression.getName());
-
-		if (entityField.getFilterableName(
-				null
-			).contains(
-				StringPool.SLASH
-			)) {
-
-			return entityField.getFilterableName(null);
-		}
-
-		return primitivePropertyExpression.getName();
+		return _visitPrimitivePropertyExpression(
+			_getEntityField(
+				primitivePropertyExpression.getName(), _objectDefinition),
+			primitivePropertyExpression);
 	}
 
 	@Override
@@ -456,7 +434,8 @@ public class PredicateExpressionVisitorImpl
 	private Column<?, Object> _getColumn(
 		Object fieldName, ObjectDefinition objectDefinition) {
 
-		EntityField entityField = _getEntityField(fieldName, objectDefinition);
+		EntityField entityField = _getEntityField(
+			(String)fieldName, objectDefinition);
 
 		return (Column<?, Object>)_objectFieldLocalService.getColumn(
 			objectDefinition.getObjectDefinitionId(),
@@ -464,12 +443,23 @@ public class PredicateExpressionVisitorImpl
 	}
 
 	private EntityField _getEntityField(
-		Object fieldName, ObjectDefinition objectDefinition) {
+		String fieldName, ObjectDefinition objectDefinition) {
 
 		Map<String, EntityField> entityFieldsMap = _getEntityFieldsMap(
 			objectDefinition);
 
-		return entityFieldsMap.get(GetterUtil.getString(fieldName));
+		int index = fieldName.indexOf(StringPool.SLASH);
+
+		if (index != -1) {
+			return _getEntityField(
+				fieldName.substring(index + 1),
+				ObjectRelationshipUtil.getRelatedObjectDefinition(
+					objectDefinition,
+					_fetchObjectRelationship(
+						objectDefinition, fieldName.substring(0, index))));
+		}
+
+		return entityFieldsMap.get(fieldName);
 	}
 
 	private Map<String, EntityField> _getEntityFieldsMap(
@@ -686,7 +676,8 @@ public class PredicateExpressionVisitorImpl
 	private Object _getValue(
 		Object left, ObjectDefinition objectDefinition, Object right) {
 
-		EntityField entityField = _getEntityField(left, objectDefinition);
+		EntityField entityField = _getEntityField(
+			(String)left, objectDefinition);
 
 		EntityField.Type entityType = entityField.getType();
 
@@ -801,6 +792,22 @@ public class PredicateExpressionVisitorImpl
 				complexPropertyExpression.getPropertyExpression(),
 				relationshipsNames);
 		}
+		else if (propertyExpression instanceof PrimitivePropertyExpression) {
+			PrimitivePropertyExpression primitivePropertyExpression =
+				(PrimitivePropertyExpression)propertyExpression;
+
+			String relationshipsNamesValue = StringUtil.merge(
+				relationshipsNames, StringPool.SLASH);
+
+			Object value = _visitPrimitivePropertyExpression(
+				_getEntityField(
+					relationshipsNamesValue + StringPool.SLASH +
+						primitivePropertyExpression.getName(),
+					_objectDefinition),
+				primitivePropertyExpression);
+
+			return relationshipsNamesValue + StringPool.SLASH + value;
+		}
 
 		relationshipsNames.add(propertyExpression.toString());
 
@@ -874,6 +881,20 @@ public class PredicateExpressionVisitorImpl
 				_objectFieldLocalService,
 				_objectRelatedModelsPredicateProviderRegistry,
 				_serviceTrackerMap));
+	}
+
+	private Object _visitPrimitivePropertyExpression(
+		EntityField entityField,
+		PrimitivePropertyExpression primitivePropertyExpression) {
+
+		if (entityField instanceof ReferenceStringEntityField) {
+			ReferenceStringEntityField referenceStringEntityField =
+				(ReferenceStringEntityField)entityField;
+
+			return referenceStringEntityField.getReferencedFieldName();
+		}
+
+		return primitivePropertyExpression.getName();
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
@@ -176,11 +176,12 @@ public class PredicateExpressionVisitorImpl
 		if (entityField.getFilterableName(
 				null
 			).contains(
-				"/"
+				StringPool.SLASH
 			)) {
 
-			return complexPropertyExpression.getName() + "/" +
-				entityField.getFilterableName(null);
+			return StringBundler.concat(
+				complexPropertyExpression.getName(), StringPool.SLASH,
+				entityField.getFilterableName(null));
 		}
 
 		return complexPropertyExpression.toString();
@@ -352,7 +353,7 @@ public class PredicateExpressionVisitorImpl
 		if (entityField.getFilterableName(
 				null
 			).contains(
-				"/"
+				StringPool.SLASH
 			)) {
 
 			return entityField.getFilterableName(null);

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -2919,6 +2919,22 @@ public class DefaultObjectEntryManagerImplTest
 				_buildContainsExpressionFilterString("textObjectFieldName", "b")
 			).build(),
 			childObjectEntry2);
+		testGetObjectEntries(
+			HashMapBuilder.put(
+				"filter",
+				_buildContainsExpressionFilterString(
+					_objectRelationshipERCObjectFieldName,
+					parentObjectEntry1.getExternalReferenceCode())
+			).build(),
+			childObjectEntry1);
+		testGetObjectEntries(
+			HashMapBuilder.put(
+				"filter",
+				_buildContainsExpressionFilterString(
+					_objectRelationshipERCObjectFieldName,
+					parentObjectEntry2.getExternalReferenceCode())
+			).build(),
+			childObjectEntry2);
 
 		// Equals expression
 
@@ -3429,6 +3445,22 @@ public class DefaultObjectEntryManagerImplTest
 				_buildStartsWithExpressionFilterString(
 					"textObjectFieldName", "b")
 			).build());
+		testGetObjectEntries(
+			HashMapBuilder.put(
+				"filter",
+				_buildStartsWithExpressionFilterString(
+					_objectRelationshipERCObjectFieldName,
+					parentObjectEntry1.getExternalReferenceCode())
+			).build(),
+			childObjectEntry1);
+		testGetObjectEntries(
+			HashMapBuilder.put(
+				"filter",
+				_buildStartsWithExpressionFilterString(
+					_objectRelationshipERCObjectFieldName,
+					parentObjectEntry2.getExternalReferenceCode())
+			).build(),
+			childObjectEntry2);
 	}
 
 	@Test

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/odata/entity/v1_0/test/ObjectEntryEntityModelTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/odata/entity/v1_0/test/ObjectEntryEntityModelTest.java
@@ -105,8 +105,18 @@ public class ObjectEntryEntityModelTest {
 		ObjectDefinition relatedObjectDefinition = _publishObjectDefinition(
 			ObjectDefinitionTestUtil.getRandomName(), customObjectFields);
 
-		ObjectRelationship objectRelationship = _addObjectRelationship(
-			objectDefinition, relatedObjectDefinition);
+		ObjectRelationship manyToManyObjectRelationship =
+			_addObjectRelationship(
+				objectDefinition, relatedObjectDefinition,
+				ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		ObjectRelationship manyToOneObjectRelationship = _addObjectRelationship(
+			relatedObjectDefinition, objectDefinition,
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		ObjectRelationship oneToManyObjectRelationship = _addObjectRelationship(
+			objectDefinition, relatedObjectDefinition,
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		_assertEquals(
 			HashMapBuilder.<String, EntityField>put(
@@ -147,16 +157,23 @@ public class ObjectEntryEntityModelTest {
 				"userId",
 				new IntegerEntityField("userId", locale -> Field.USER_ID)
 			).putAll(
-				_getExpectedEntityFieldsMap(
-					customObjectFields, objectRelationship,
-					relatedObjectDefinition)
+				_getExpectedObjectFieldsEntityFieldsMap(customObjectFields)
+			).putAll(
+				_getExpectedRelationshipFieldsEntityFieldsMap(
+					manyToManyObjectRelationship, relatedObjectDefinition)
+			).putAll(
+				_getExpectedRelationshipFieldsEntityFieldsMap(
+					manyToOneObjectRelationship, relatedObjectDefinition)
+			).putAll(
+				_getExpectedRelationshipFieldsEntityFieldsMap(
+					oneToManyObjectRelationship, relatedObjectDefinition)
 			).build(),
 			_getObjectDefinitionEntityFieldsMap(objectDefinition));
 	}
 
 	private ObjectRelationship _addObjectRelationship(
 			ObjectDefinition objectDefinition,
-			ObjectDefinition relatedObjectDefinition)
+			ObjectDefinition relatedObjectDefinition, String type)
 		throws Exception {
 
 		ObjectRelationship objectRelationship =
@@ -166,8 +183,7 @@ public class ObjectEntryEntityModelTest {
 				objectDefinition.getObjectDefinitionId(), 0,
 				ObjectRelationshipConstants.DELETION_TYPE_PREVENT, false,
 				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-				StringUtil.randomId(), false,
-				ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
+				StringUtil.randomId(), false, type, null);
 
 		_objectRelationships.add(objectRelationship);
 
@@ -209,10 +225,8 @@ public class ObjectEntryEntityModelTest {
 		).build();
 	}
 
-	private Map<String, EntityField> _getExpectedEntityFieldsMap(
-		List<ObjectField> customObjectFields,
-		ObjectRelationship objectRelationship,
-		ObjectDefinition relatedObjectDefinition) {
+	private Map<String, EntityField> _getExpectedObjectFieldsEntityFieldsMap(
+		List<ObjectField> customObjectFields) {
 
 		Map<String, EntityField> expectedEntityFieldsMap = new HashMap<>();
 
@@ -222,43 +236,80 @@ public class ObjectEntryEntityModelTest {
 			expectedEntityFieldsMap.put(entityField.getName(), entityField);
 		}
 
-		String pkObjectFieldName =
-			relatedObjectDefinition.getPKObjectFieldName();
-		String relationshipEntityFieldPrefix = StringBundler.concat(
-			"r_", objectRelationship.getName(), "_");
+		return expectedEntityFieldsMap;
+	}
 
-		String expectedObjectFieldName =
-			relationshipEntityFieldPrefix + pkObjectFieldName;
+	private Map<String, EntityField>
+		_getExpectedRelationshipFieldsEntityFieldsMap(
+			ObjectRelationship objectRelationship,
+			ObjectDefinition relatedObjectDefinition) {
 
-		expectedEntityFieldsMap.put(
-			expectedObjectFieldName,
-			new IdEntityField(
-				expectedObjectFieldName, locale -> expectedObjectFieldName,
-				String::valueOf));
+		Map<String, EntityField> expectedEntityFieldsMap = new HashMap<>();
 
-		String expectedObjectRelationshipERCObjectFieldName =
-			relationshipEntityFieldPrefix +
-				StringUtil.replaceLast(pkObjectFieldName, "Id", "ERC");
+		if (StringUtil.equals(
+				objectRelationship.getType(),
+				ObjectRelationshipConstants.TYPE_MANY_TO_MANY)) {
 
-		expectedEntityFieldsMap.put(
-			expectedObjectRelationshipERCObjectFieldName,
-			new StringEntityField(
-				expectedObjectRelationshipERCObjectFieldName,
-				locale -> expectedObjectFieldName));
+			expectedEntityFieldsMap.put(
+				objectRelationship.getName(),
+				new ComplexEntityField(
+					objectRelationship.getName(), Collections.emptyList()));
+		}
+		else if (StringUtil.equals(
+					objectRelationship.getType(),
+					ObjectRelationshipConstants.TYPE_ONE_TO_MANY)) {
 
-		String expectedRelatedObjectDefinitionIdObjectFieldName =
-			pkObjectFieldName.replaceFirst("c_", "");
+			if (objectRelationship.getObjectDefinitionId1() ==
+					relatedObjectDefinition.getObjectDefinitionId()) {
 
-		expectedEntityFieldsMap.put(
-			expectedRelatedObjectDefinitionIdObjectFieldName,
-			new IdEntityField(
-				expectedRelatedObjectDefinitionIdObjectFieldName,
-				locale -> expectedObjectFieldName, String::valueOf));
+				String pkObjectFieldName =
+					relatedObjectDefinition.getPKObjectFieldName();
+				String relationshipEntityFieldPrefix = StringBundler.concat(
+					"r_", objectRelationship.getName(), "_");
 
-		expectedEntityFieldsMap.put(
-			objectRelationship.getName(),
-			new ComplexEntityField(
-				objectRelationship.getName(), Collections.emptyList()));
+				String expectedObjectFieldName =
+					relationshipEntityFieldPrefix + pkObjectFieldName;
+
+				expectedEntityFieldsMap.put(
+					expectedObjectFieldName,
+					new IdEntityField(
+						expectedObjectFieldName,
+						locale -> expectedObjectFieldName, String::valueOf));
+
+				String expectedObjectRelationshipERCObjectFieldName =
+					relationshipEntityFieldPrefix +
+						StringUtil.replaceLast(pkObjectFieldName, "Id", "ERC");
+
+				expectedEntityFieldsMap.put(
+					expectedObjectRelationshipERCObjectFieldName,
+					new StringEntityField(
+						expectedObjectRelationshipERCObjectFieldName,
+						locale -> expectedObjectFieldName));
+
+				String expectedRelatedObjectDefinitionIdObjectFieldName =
+					pkObjectFieldName.replaceFirst("c_", "");
+
+				expectedEntityFieldsMap.put(
+					expectedRelatedObjectDefinitionIdObjectFieldName,
+					new IdEntityField(
+						expectedRelatedObjectDefinitionIdObjectFieldName,
+						locale -> expectedObjectFieldName, String::valueOf));
+
+				expectedEntityFieldsMap.put(
+					objectRelationship.getName(),
+					new ComplexEntityField(
+						objectRelationship.getName(), Collections.emptyList()));
+			}
+			else {
+				expectedEntityFieldsMap.put(
+					objectRelationship.getName(),
+					new ComplexEntityField(
+						objectRelationship.getName(), Collections.emptyList()));
+			}
+		}
+		else {
+			throw new IllegalStateException();
+		}
 
 		return expectedEntityFieldsMap;
 	}

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -9954,8 +9954,12 @@ public class ObjectEntryResourceTest {
 				() -> {
 					ObjectEntry relatedObjectEntry =
 						ObjectEntryTestUtil.addObjectEntry(
-							_objectDefinition2, _OBJECT_FIELD_NAME_2,
-							_OBJECT_FIELD_VALUE_2);
+							_objectDefinition2,
+							HashMapBuilder.<String, Serializable>put(
+								_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2
+							).put(
+								"externalReferenceCode", _ERC_VALUE_1
+							).build());
 
 					return relatedObjectEntry.getObjectEntryId();
 				}
@@ -9998,8 +10002,12 @@ public class ObjectEntryResourceTest {
 				() -> {
 					ObjectEntry relatedObjectEntry =
 						ObjectEntryTestUtil.addObjectEntry(
-							_objectDefinition2, _OBJECT_FIELD_NAME_2,
-							_OBJECT_FIELD_VALUE_2);
+							_objectDefinition2,
+							HashMapBuilder.<String, Serializable>put(
+								_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2
+							).put(
+								"externalReferenceCode", _ERC_VALUE_2
+							).build());
 
 					return relatedObjectEntry.getObjectEntryId();
 				}
@@ -16133,9 +16141,11 @@ public class ObjectEntryResourceTest {
 
 	private static final String _ERC_VALUE_1 = RandomTestUtil.randomString();
 
-	private static final String _ERC_VALUE_2 = RandomTestUtil.randomString();
+	private static final String _ERC_VALUE_2 =
+		_ERC_VALUE_1 + RandomTestUtil.randomString();
 
-	private static final String _ERC_VALUE_3 = RandomTestUtil.randomString();
+	private static final String _ERC_VALUE_3 =
+		_ERC_VALUE_2 + RandomTestUtil.randomString();
 
 	private static final String _LIST_TYPE_ENTRY_KEY_1 =
 		"a" + RandomTestUtil.randomString();

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -9923,6 +9923,7 @@ public class ObjectEntryResourceTest {
 			ObjectFieldValidationConstants.BUSINESS_TYPE_LONG_VALUE_MAX);
 		String randomString1 = RandomTestUtil.randomString();
 		String randomString2 = RandomTestUtil.randomString();
+		String randomString3 = RandomTestUtil.randomString();
 
 		JSONObject jsonObject1 = HTTPTestUtil.invokeToJSONObject(
 			JSONUtil.put(
@@ -9950,6 +9951,8 @@ public class ObjectEntryResourceTest {
 			).put(
 				_OBJECT_FIELD_NAME_TEXT, "a" + randomString2
 			).put(
+				"externalReferenceCode", _ERC_VALUE_2
+			).put(
 				objectField.getName(),
 				() -> {
 					ObjectEntry relatedObjectEntry =
@@ -9958,7 +9961,7 @@ public class ObjectEntryResourceTest {
 							HashMapBuilder.<String, Serializable>put(
 								_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2
 							).put(
-								"externalReferenceCode", _ERC_VALUE_1
+								"externalReferenceCode", "a" + randomString3
 							).build());
 
 					return relatedObjectEntry.getObjectEntryId();
@@ -9998,6 +10001,8 @@ public class ObjectEntryResourceTest {
 			).put(
 				_OBJECT_FIELD_NAME_TEXT, "b" + randomString2
 			).put(
+				"externalReferenceCode", _ERC_VALUE_1
+			).put(
 				objectField.getName(),
 				() -> {
 					ObjectEntry relatedObjectEntry =
@@ -10006,7 +10011,7 @@ public class ObjectEntryResourceTest {
 							HashMapBuilder.<String, Serializable>put(
 								_OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2
 							).put(
-								"externalReferenceCode", _ERC_VALUE_2
+								"externalReferenceCode", "b" + randomString3
 							).build());
 
 					return relatedObjectEntry.getObjectEntryId();
@@ -16139,13 +16144,14 @@ public class ObjectEntryResourceTest {
 		return JSONFactoryUtil.createJSONObject(fileEntry.toString());
 	}
 
-	private static final String _ERC_VALUE_1 = RandomTestUtil.randomString();
+	private static final String _ERC_VALUE_1 =
+		"a" + RandomTestUtil.randomString();
 
 	private static final String _ERC_VALUE_2 =
-		_ERC_VALUE_1 + RandomTestUtil.randomString();
+		"b" + RandomTestUtil.randomString();
 
 	private static final String _ERC_VALUE_3 =
-		_ERC_VALUE_2 + RandomTestUtil.randomString();
+		"c" + RandomTestUtil.randomString();
 
 	private static final String _LIST_TYPE_ENTRY_KEY_1 =
 		"a" + RandomTestUtil.randomString();

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -4161,6 +4161,137 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
+	public void testFilterByRelationshipERCFieldNameInOneToManyRelationship()
+		throws Exception {
+
+		_objectEntry1 = ObjectEntryTestUtil.addObjectEntry(
+			_objectDefinition1, _OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1);
+
+		_objectEntry2 = ObjectEntryTestUtil.addObjectEntry(
+			_objectDefinition2, _OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2);
+
+		_objectRelationship1 = _addObjectRelationshipAndRelateObjectEntries(
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		String relationshipERCFieldName = String.format(
+			"r_%s_%s", _objectRelationship1.getName(),
+			_objectDefinition1.getPKObjectFieldName()
+		).replace(
+			"Id", "ERC"
+		);
+
+		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+			null, _objectDefinition2.getRESTContextPath(), Http.Method.GET);
+
+		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
+
+		Assert.assertEquals(1, itemsJSONArray.length());
+
+		JSONObject itemJSONObject = itemsJSONArray.getJSONObject(0);
+
+		Assert.assertEquals(
+			itemJSONObject.getString(relationshipERCFieldName),
+			_objectEntry1.getExternalReferenceCode());
+
+		// Comparison operators
+
+		String relationshipERCSubstring =
+			_objectEntry1.getExternalReferenceCode(
+			).substring(
+				0, 3
+			);
+
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s eq '%s'", _objectRelationship1.getName(),
+					relationshipERCFieldName,
+					_objectEntry1.getExternalReferenceCode())),
+			_objectDefinition1);
+
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s ge '%s'", _objectRelationship1.getName(),
+					relationshipERCFieldName,
+					_objectEntry1.getExternalReferenceCode())),
+			_objectDefinition1);
+
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s gt '%s'", _objectRelationship1.getName(),
+					relationshipERCFieldName,
+					relationshipERCSubstring + "0000")),
+			_objectDefinition1);
+
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s le '%s'", _objectRelationship1.getName(),
+					relationshipERCFieldName,
+					_objectEntry1.getExternalReferenceCode())),
+			_objectDefinition1);
+
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s lt '%s'", _objectRelationship1.getName(),
+					relationshipERCFieldName,
+					relationshipERCSubstring + "ZZZZ")),
+			_objectDefinition1);
+
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s ne '%s'", _objectRelationship1.getName(),
+					relationshipERCFieldName, RandomTestUtil.randomInt())),
+			_objectDefinition1);
+
+		// List operators
+
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			_escape(
+				String.format(
+					"%s/%s in ('%s', '%s')", _objectRelationship1.getName(),
+					relationshipERCFieldName,
+					_objectEntry1.getExternalReferenceCode(),
+					RandomTestUtil.randomInt())),
+			_objectDefinition1);
+
+		// String operators
+
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			String.format(
+				"contains(%s/%s,'%s')", _objectRelationship1.getName(),
+				relationshipERCFieldName,
+				_objectEntry1.getExternalReferenceCode(
+				).substring(
+					0, 2
+				)),
+			_objectDefinition1);
+
+		_assertFilterString(
+			_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1,
+			String.format(
+				"startswith(%s/%s,'%s')", _objectRelationship1.getName(),
+				relationshipERCFieldName,
+				_objectEntry1.getExternalReferenceCode(
+				).substring(
+					0, 2
+				)),
+			_objectDefinition1);
+	}
+
+	@Test
 	public void testFilterByStringOperatorsObjectEntriesByRelatedObjectEntriesFields()
 		throws Exception {
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/sort/ObjectEntryFieldSortDSLQueryVisitor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/sort/ObjectEntryFieldSortDSLQueryVisitor.java
@@ -47,8 +47,10 @@ public class ObjectEntryFieldSortDSLQueryVisitor
 	public DSLQuery visit(DSLQuery dslQuery, Sort sort) throws PortalException {
 		ObjectDefinition objectDefinition = sort.getObjectDefinition();
 
+		String fieldName = _getSortFieldName(sort);
+
 		ObjectField objectField = objectFieldLocalService.fetchObjectField(
-			objectDefinition.getObjectDefinitionId(), sort.getFieldName());
+			objectDefinition.getObjectDefinitionId(), fieldName);
 
 		Expression<?> columnExpression = null;
 		Table fieldTable = null;
@@ -57,12 +59,11 @@ public class ObjectEntryFieldSortDSLQueryVisitor
 		if (objectField == null) {
 			Column<?, Object> column =
 				(Column<?, Object>)objectFieldLocalService.getColumn(
-					objectDefinition.getObjectDefinitionId(),
-					sort.getFieldName());
+					objectDefinition.getObjectDefinitionId(), fieldName);
 
 			fieldTable = getAliasedTable(_getSuffix(sort), column.getTable());
 
-			columnExpression = fieldTable.getColumn(sort.getFieldName());
+			columnExpression = fieldTable.getColumn(fieldName);
 		}
 		else {
 			fieldTable = getAliasedTable(
@@ -152,6 +153,16 @@ public class ObjectEntryFieldSortDSLQueryVisitor
 		return expression.ascending();
 	}
 
+	private String _getSortFieldName(Sort sort) {
+		String fieldName = sort.getFieldName();
+
+		if (!fieldName.contains(StringPool.SLASH)) {
+			return fieldName;
+		}
+
+		return StringUtil.extractLast(fieldName, StringPool.SLASH);
+	}
+
 	private String _getSuffix(Sort sort) {
 		if (!_isParentComplexField(sort)) {
 			return null;
@@ -160,12 +171,12 @@ public class ObjectEntryFieldSortDSLQueryVisitor
 		return StringUtil.replace(
 			StringUtil.removeLast(
 				sort.getFieldPath(),
-				CharPool.FORWARD_SLASH + sort.getFieldName()),
+				CharPool.FORWARD_SLASH + _getSortFieldName(sort)),
 			CharPool.FORWARD_SLASH, CharPool.UNDERLINE);
 	}
 
 	private boolean _isParentComplexField(Sort sort) {
-		return !StringUtil.equals(sort.getFieldName(), sort.getFieldPath());
+		return !StringUtil.equals(_getSortFieldName(sort), sort.getFieldPath());
 	}
 
 }

--- a/modules/apps/portal-odata/portal-odata-api/src/main/java/com/liferay/portal/odata/sort/SortField.java
+++ b/modules/apps/portal-odata/portal-odata-api/src/main/java/com/liferay/portal/odata/sort/SortField.java
@@ -82,6 +82,10 @@ public class SortField implements Serializable {
 	public String getSortableFieldPath(Locale locale) {
 		String sortableFieldName = getSortableFieldName(locale);
 
+		if (sortableFieldName.equals("externalReferenceCode")) {
+			sortableFieldName = _entityField.getFilterableName(locale);
+		}
+
 		if (ListUtil.isEmpty(_parentEntityFields)) {
 			return sortableFieldName;
 		}

--- a/modules/apps/portal-odata/portal-odata-api/src/main/java/com/liferay/portal/odata/sort/SortField.java
+++ b/modules/apps/portal-odata/portal-odata-api/src/main/java/com/liferay/portal/odata/sort/SortField.java
@@ -82,10 +82,6 @@ public class SortField implements Serializable {
 	public String getSortableFieldPath(Locale locale) {
 		String sortableFieldName = getSortableFieldName(locale);
 
-		if (sortableFieldName.equals("externalReferenceCode")) {
-			sortableFieldName = _entityField.getFilterableName(locale);
-		}
-
 		if (ListUtil.isEmpty(_parentEntityFields)) {
 			return sortableFieldName;
 		}


### PR DESCRIPTION
**Initial Approach** https://github.com/liferay-headless/liferay-portal/pull/2460
The first attempt to fix this involved modifying the query by adding a new inner join for this case. While technically feasible, this approach was quite complex.

**Solution in this PR**
The new solution leverages the fact that for a many-to-one relationship, the field r_<relationshipName>_c_<objectName>ERC is always equivalent to <relationshipName>/externalReferenceCode, which is already implemented and functional.

By modifying the filterableAndSortableFieldNameFunction of the entity field to utilize this existing workaround, the filter now works as intended without the need for additional joins or complex query adjustments.

See the following Jira Ticket: [LPD-37787](https://liferay.atlassian.net/browse/LPD-37787)