### PR TITLE
LPD-47903 NPE in HttpInvoker due to httpURLConnection.getErrorStream returning null

### DIFF
--- a/modules/apps/analytics/analytics-settings-rest-client/src/main/java/com/liferay/analytics/settings/rest/client/http/HttpInvoker.java
+++ b/modules/apps/analytics/analytics-settings-rest-client/src/main/java/com/liferay/analytics/settings/rest/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/apps/batch-planner/batch-planner-rest-client/src/main/java/com/liferay/batch/planner/rest/client/http/HttpInvoker.java
+++ b/modules/apps/batch-planner/batch-planner-rest-client/src/main/java/com/liferay/batch/planner/rest/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/apps/bulk/bulk-rest-client/src/main/java/com/liferay/bulk/rest/client/http/HttpInvoker.java
+++ b/modules/apps/bulk/bulk-rest-client/src/main/java/com/liferay/bulk/rest/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/apps/captcha/captcha-rest-client/src/main/java/com/liferay/captcha/rest/client/http/HttpInvoker.java
+++ b/modules/apps/captcha/captcha-rest-client/src/main/java/com/liferay/captcha/rest/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/apps/change-tracking/change-tracking-rest-client/src/main/java/com/liferay/change/tracking/rest/client/http/HttpInvoker.java
+++ b/modules/apps/change-tracking/change-tracking-rest-client/src/main/java/com/liferay/change/tracking/rest/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-client/src/main/java/com/liferay/headless/commerce/admin/account/client/http/HttpInvoker.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-client/src/main/java/com/liferay/headless/commerce/admin/account/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/http/HttpInvoker.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-client/src/main/java/com/liferay/headless/commerce/admin/channel/client/http/HttpInvoker.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-client/src/main/java/com/liferay/headless/commerce/admin/channel/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-client/src/main/java/com/liferay/headless/commerce/admin/inventory/client/http/HttpInvoker.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-client/src/main/java/com/liferay/headless/commerce/admin/inventory/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/http/HttpInvoker.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-payment-client/src/main/java/com/liferay/headless/commerce/admin/payment/client/http/HttpInvoker.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-payment-client/src/main/java/com/liferay/headless/commerce/admin/payment/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/http/HttpInvoker.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-client/src/main/java/com/liferay/headless/commerce/admin/shipment/client/http/HttpInvoker.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-client/src/main/java/com/liferay/headless/commerce/admin/shipment/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-client/src/main/java/com/liferay/headless/commerce/admin/site/setting/client/http/HttpInvoker.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-client/src/main/java/com/liferay/headless/commerce/admin/site/setting/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-client/src/main/java/com/liferay/headless/commerce/delivery/cart/client/http/HttpInvoker.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-client/src/main/java/com/liferay/headless/commerce/delivery/cart/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-client/src/main/java/com/liferay/headless/commerce/delivery/catalog/client/http/HttpInvoker.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-client/src/main/java/com/liferay/headless/commerce/delivery/catalog/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-client/src/main/java/com/liferay/headless/commerce/delivery/order/client/http/HttpInvoker.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-client/src/main/java/com/liferay/headless/commerce/delivery/order/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/http/HttpInvoker.java
+++ b/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/apps/digital-signature/digital-signature-rest-client/src/main/java/com/liferay/digital/signature/rest/client/http/HttpInvoker.java
+++ b/modules/apps/digital-signature/digital-signature-rest-client/src/main/java/com/liferay/digital/signature/rest/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/apps/dispatch/dispatch-rest-client/src/main/java/com/liferay/dispatch/rest/client/http/HttpInvoker.java
+++ b/modules/apps/dispatch/dispatch-rest-client/src/main/java/com/liferay/dispatch/rest/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-client/src/main/java/com/liferay/headless/admin/address/client/http/HttpInvoker.java
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-client/src/main/java/com/liferay/headless/admin/address/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-client/src/main/java/com/liferay/headless/admin/content/client/http/HttpInvoker.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-client/src/main/java/com/liferay/headless/admin/content/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-client/src/main/java/com/liferay/headless/admin/list/type/client/http/HttpInvoker.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-client/src/main/java/com/liferay/headless/admin/list/type/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/http/HttpInvoker.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/http/HttpInvoker.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/http/HttpInvoker.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/http/HttpInvoker.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-client/src/main/java/com/liferay/headless/batch/engine/client/http/HttpInvoker.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-client/src/main/java/com/liferay/headless/batch/engine/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/http/HttpInvoker.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/http/HttpInvoker.java
+++ b/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-client/src/main/java/com/liferay/headless/portal/instances/client/http/HttpInvoker.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-client/src/main/java/com/liferay/headless/portal/instances/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/apps/headless/headless-site/headless-site-client/src/main/java/com/liferay/headless/site/client/http/HttpInvoker.java
+++ b/modules/apps/headless/headless-site/headless-site-client/src/main/java/com/liferay/headless/site/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/apps/headless/headless-site/headless-site-test/src/testIntegration/java/com/liferay/headless/site/resource/v1_0/test/SiteResourceTest.java
+++ b/modules/apps/headless/headless-site/headless-site-test/src/testIntegration/java/com/liferay/headless/site/resource/v1_0/test/SiteResourceTest.java
@@ -594,7 +594,7 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		catch (Problem.ProblemException problemException) {
 			Problem problem = problemException.getProblem();
 
-			Assert.assertEquals("403", problem.getStatus());
+			Assert.assertEquals("401", problem.getStatus());
 		}
 	}
 

--- a/modules/apps/headless/headless-user-notification/headless-user-notification-client/src/main/java/com/liferay/headless/user/notification/client/http/HttpInvoker.java
+++ b/modules/apps/headless/headless-user-notification/headless-user-notification-client/src/main/java/com/liferay/headless/user/notification/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/apps/notification/notification-rest-client/src/main/java/com/liferay/notification/rest/client/http/HttpInvoker.java
+++ b/modules/apps/notification/notification-rest-client/src/main/java/com/liferay/notification/rest/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/http/HttpInvoker.java
+++ b/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/apps/portal-language/portal-language-rest-client/src/main/java/com/liferay/portal/language/rest/client/http/HttpInvoker.java
+++ b/modules/apps/portal-language/portal-language-rest-client/src/main/java/com/liferay/portal/language/rest/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/apps/portal-search/portal-search-rest-client/src/main/java/com/liferay/portal/search/rest/client/http/HttpInvoker.java
+++ b/modules/apps/portal-search/portal-search-rest-client/src/main/java/com/liferay/portal/search/rest/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/dxp/apps/analytics/analytics-reports-rest-client/src/main/java/com/liferay/analytics/reports/rest/client/http/HttpInvoker.java
+++ b/modules/dxp/apps/analytics/analytics-reports-rest-client/src/main/java/com/liferay/analytics/reports/rest/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-client/src/main/java/com/liferay/headless/commerce/machine/learning/client/http/HttpInvoker.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-client/src/main/java/com/liferay/headless/commerce/machine/learning/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/dxp/apps/osb/osb-testray/osb-testray-rest-client/src/main/java/com/liferay/osb/testray/rest/client/http/HttpInvoker.java
+++ b/modules/dxp/apps/osb/osb-testray/osb-testray-rest-client/src/main/java/com/liferay/osb/testray/rest/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/http/HttpInvoker.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/dxp/apps/saml/saml-admin-rest-client/src/main/java/com/liferay/saml/admin/rest/client/http/HttpInvoker.java
+++ b/modules/dxp/apps/saml/saml-admin-rest-client/src/main/java/com/liferay/saml/admin/rest/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/dxp/apps/scim/scim-rest-client/src/main/java/com/liferay/scim/rest/client/http/HttpInvoker.java
+++ b/modules/dxp/apps/scim/scim-rest-client/src/main/java/com/liferay/scim/rest/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/http/HttpInvoker.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/dxp/apps/segments/segments-asah-rest-client/src/main/java/com/liferay/segments/asah/rest/client/http/HttpInvoker.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-client/src/main/java/com/liferay/segments/asah/rest/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/http/HttpInvoker.java
+++ b/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/http/HttpInvoker.java
@@ -379,16 +379,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/client_http_invoker.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/client_http_invoker.ftl
@@ -354,16 +354,18 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		byte[] bytes = new byte[8192];
+		if (inputStream != null) {
+			byte[] bytes = new byte[8192];
 
-		while (true) {
-			int read = inputStream.read(bytes, 0, bytes.length);
+			while (true) {
+				int read = inputStream.read(bytes, 0, bytes.length);
 
-			if (read == -1) {
-				break;
+				if (read == -1) {
+					break;
+				}
+
+				byteArrayOutputStream.write(bytes, 0, read);
 			}
-
-			byteArrayOutputStream.write(bytes, 0, read);
 		}
 
 		byteArrayOutputStream.flush();


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-47903

# How am I fixing it?

In certain cases `httpURLConnection.getErrorStream()` can return `null` as defined in the spec - https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/net/HttpURLConnection.html#getErrorStream()

This was caught in one of Site Management's tests where we expect the action to fail and confirm it fails with the correct status code.

I updated the template to only process the `inputStream` if it exists. Please let me know your thoughts on the change and if you see an alternative approach that you would prefer instead. Thank you.

# How can you verify that it works?

In `headless-site-test` run `gw testIntegration --tests *.SiteResourceTest`