### PR TITLE
LPD-46741 fix test HeadlessBuilderOpenAPIResourceTest

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/resources/com/liferay/headless/builder/resource/test/dependencies/expected_openapi.json
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/resources/com/liferay/headless/builder/resource/test/dependencies/expected_openapi.json
@@ -101,7 +101,6 @@
 						"type": "string"
 					}
 				},
-				"readOnly": true,
 				"type": "object",
 				"xml": {
 					"name": "Link"
@@ -401,6 +400,7 @@
 						"name": "type",
 						"required": true,
 						"schema": {
+							"pattern": "json|yaml",
 							"type": "string"
 						}
 					}

--- a/modules/apps/object/object-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-rest-impl/rest-openapi.yaml
@@ -49,6 +49,7 @@ components:
                     type: integer
                 link:
                     $ref: "#/components/schemas/Link"
+                    readOnly: true
                 name:
                     type: string
                 scope:

--- a/modules/apps/object/object-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-rest-impl/rest-openapi.yaml
@@ -49,7 +49,6 @@ components:
                     type: integer
                 link:
                     $ref: "#/components/schemas/Link"
-                    readOnly: true
                 name:
                     type: string
                 scope:


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-46741

Needed to fix the test because the error was triggered with the upgrade of the packages.

1.) Removed the readOnly from the Link (in the expected json) because the schema doesn't have it.

![image](https://github.com/user-attachments/assets/07e0adc1-89a2-4d8f-9610-ebca41c41508)


2.) I wanted to understand what means the code from rest-openapi, and doing it I found that the code is not valid, at least in openapi 3.0.1

```
link:
        $ref: "#/components/schemas/Link"
        readOnly: true
```

As you can see in the picture the readOnly would be ignored.

![image](https://github.com/user-attachments/assets/1dd00a5c-c22d-438d-92b7-77e7df165083)

With the current changes the test `HeadlessBuilderOpenAPIResourceTest` is passing. But not sure if it the expected behavior. 

Maybe the expected behavior would be something like this.
```
        link:
          readOnly: true
          allOf:
            - $ref: "#/components/schemas/Link"
 ```
But at least in the swagger ui editor I don't see any difference. Should I go deeper on this?

3.) I added the `"pattern": "json|yaml",` because is being generated now and makes sense. 

![image](https://github.com/user-attachments/assets/4e0473b1-5eb0-4a85-8ec3-7eb6de6dbf64)

Helps with the UX. As you see in the image is giving feedback about the value that should be the parameter json or yaml.

What you you think? @4lejandrito @ccorreagg 
