### PR TITLE
LPD-47252 | Hide UI element from the Import screen: Entity Technical Name

### DIFF
--- a/modules/apps/export-import/export-import-web/build.gradle
+++ b/modules/apps/export-import/export-import-web/build.gradle
@@ -15,6 +15,7 @@ dependencies {
 	compileOnly project(":apps:export-import:export-import-changeset-api")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
+	compileOnly project(":apps:object:object-api")
 	compileOnly project(":apps:portal-background-task:portal-background-task-api")
 	compileOnly project(":apps:portal-configuration:portal-configuration-module-configuration-api")
 	compileOnly project(":apps:site-navigation:site-navigation-taglib")

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/import/new_import/import_layouts_resources.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/import/new_import/import_layouts_resources.jsp
@@ -258,31 +258,33 @@ ManifestSummary manifestSummary = ExportImportHelperUtil.getManifestSummary(user
 														PortletDataHandlerControl[] importMetadataControls = portletDataHandler.getImportMetadataControls();
 														%>
 
-														<ul class="hide" id="<portlet:namespace />showChangeContent_<%= portlet.getRootPortletId() %>">
-															<li>
-																<span class="selected-labels" id="<portlet:namespace />selectedContent_<%= portlet.getRootPortletId() %>"></span>
+														<c:if test="<%= !portlet.getRootPortletId().startsWith(ObjectPortletKeys.OBJECT_DEFINITIONS) %>">
+															<ul class="hide" id="<portlet:namespace />showChangeContent_<%= portlet.getRootPortletId() %>">
+																<li>
+																	<span class="selected-labels" id="<portlet:namespace />selectedContent_<%= portlet.getRootPortletId() %>"></span>
 
-																<clay:button
-																	cssClass="content-link modify-link pr-1"
-																	data-portletid="<%= portlet.getRootPortletId() %>"
-																	data-portlettitle="<%= portletTitle %>"
-																	displayType="link"
-																	id='<%= liferayPortletResponse.getNamespace() + "contentLink_" + portlet.getRootPortletId() %>'
-																	label="change"
-																/>
+																	<clay:button
+																		cssClass="content-link modify-link pr-1"
+																		data-portletid="<%= portlet.getRootPortletId() %>"
+																		data-portlettitle="<%= portletTitle %>"
+																		displayType="link"
+																		id='<%= liferayPortletResponse.getNamespace() + "contentLink_" + portlet.getRootPortletId() %>'
+																		label="change"
+																	/>
 
-																<span id="<portlet:namespace />rightContentArrow_<%= portlet.getRootPortletId() %>">
-																	<clay:icon
-																		symbol="angle-right-small"
-																	/>
-																</span>
-																<span class="hide" id="<portlet:namespace />downContentArrow_<%= portlet.getRootPortletId() %>">
-																	<clay:icon
-																		symbol="angle-down-small"
-																	/>
-																</span>
-															</li>
-														</ul>
+																	<span id="<portlet:namespace />rightContentArrow_<%= portlet.getRootPortletId() %>">
+																		<clay:icon
+																			symbol="angle-right-small"
+																		/>
+																	</span>
+																	<span class="hide" id="<portlet:namespace />downContentArrow_<%= portlet.getRootPortletId() %>">
+																		<clay:icon
+																			symbol="angle-down-small"
+																		/>
+																	</span>
+																</li>
+															</ul>
+														</c:if>
 
 														<c:if test="<%= ArrayUtil.isNotEmpty(importControls) || ArrayUtil.isNotEmpty(importMetadataControls) %>">
 															<div class="hide" id="<portlet:namespace />content_<%= portlet.getRootPortletId() %>">

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/init.jsp
@@ -58,6 +58,7 @@ page import="com.liferay.exportimport.web.internal.display.context.ExportLayouts
 page import="com.liferay.exportimport.web.internal.display.context.ExportTemplatesToolbarDisplayContext" %><%@
 page import="com.liferay.exportimport.web.internal.portlet.action.ExportImportMVCActionCommand" %><%@
 page import="com.liferay.frontend.taglib.clay.servlet.taglib.util.JSPNavigationItemList" %><%@
+page import="com.liferay.object.constants.ObjectPortletKeys" %><%@
 page import="com.liferay.petra.string.StringBundler" %><%@
 page import="com.liferay.petra.string.StringPool" %><%@
 page import="com.liferay.portal.background.task.util.comparator.BackgroundTaskComparatorFactoryUtil" %><%@

--- a/modules/test/playwright/tests/export-import-web/instance.export.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/instance.export.spec.ts
@@ -212,4 +212,8 @@ test('can see corresponding elements at instance level', async ({
 	await expect(
 		companyExportImportPage.page.getByText('Comments, Ratings')
 	).not.toBeVisible();
+
+	await expect(
+		companyExportImportPage.page.getByText('C_Test Change')
+	).not.toBeVisible();
 });

--- a/modules/test/playwright/tests/export-import-web/instance.import.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/instance.import.spec.ts
@@ -290,4 +290,8 @@ test('can see corresponding elements at instance level', async ({
 	await expect(
 		companyExportImportPage.page.getByText('Comments, Ratings')
 	).not.toBeVisible();
+
+	await expect(
+		companyExportImportPage.page.getByText('C_Test Change')
+	).not.toBeVisible();
 });


### PR DESCRIPTION
**Description**: Hide entity technical name from objects in both instance and site level. The main idea behind this is hiding the entity technical name in the portlets where the rootPortletId is the one of objects.

**Jira Ticket**: https://liferay.atlassian.net/browse/LPD-47252
This pull has the commits from https://github.com/liferay-headless/liferay-portal/pull/2542