### PR TITLE
LPD-49400 Restrict access to edit mode for Pages created from SiteTemplates that does not allow modifications

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
@@ -457,6 +457,7 @@ public class LayoutsAdminDisplayContext {
 
 	public String getEditOrViewLayoutURL(Layout layout) throws Exception {
 		if ((isConversionDraft(layout) || layout.isTypeContent()) &&
+			layout.isLayoutUpdateable() &&
 			_layoutActionsHelper.isShowConfigureAction(layout)) {
 
 			return getEditLayoutURL(layout);

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/util/LayoutActionDropdownItemsProvider.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/util/LayoutActionDropdownItemsProvider.java
@@ -76,6 +76,7 @@ public class LayoutActionDropdownItemsProvider {
 					DropdownItemListBuilder.add(
 						() ->
 							_isEditable(layout) &&
+							layout.isLayoutUpdateable() &&
 							_layoutActionsHelper.isShowConfigureAction(layout),
 						_getEditLayoutActionUnsafeConsumer(layout)
 					).add(

--- a/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContextTest.java
+++ b/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContextTest.java
@@ -82,7 +82,7 @@ public class LayoutsAdminDisplayContextTest {
 
 	@Test
 	public void testGetEditOrViewLayoutURLEditURL() throws Exception {
-		Layout layout = _getContentLayout();
+		Layout layout = _getContentLayout(true);
 
 		Mockito.when(
 			_layoutActionsHelper.isShowConfigureAction(layout)
@@ -95,7 +95,28 @@ public class LayoutsAdminDisplayContextTest {
 
 	@Test
 	public void testGetEditOrViewLayoutURLViewURL() throws Exception {
-		Layout layout = _getContentLayout();
+		Layout layout = _getContentLayout(true);
+
+		Mockito.when(
+			_layoutActionsHelper.isShowViewLayoutAction(layout)
+		).thenReturn(
+			true
+		);
+
+		_assertGetEditOrViewLayoutURL(layout, StringPool.BLANK);
+	}
+
+	@Test
+	public void testGetEditOrViewLayoutURLViewURLWithLayoutUpdateableFalse()
+		throws Exception {
+
+		Layout layout = _getContentLayout(false);
+
+		Mockito.when(
+			_layoutActionsHelper.isShowConfigureAction(layout)
+		).thenReturn(
+			true
+		);
 
 		Mockito.when(
 			_layoutActionsHelper.isShowViewLayoutAction(layout)
@@ -149,7 +170,7 @@ public class LayoutsAdminDisplayContextTest {
 			HttpComponentsUtil.getParameter(url, "p_l_back_url_title", false));
 	}
 
-	private Layout _getContentLayout() {
+	private Layout _getContentLayout(boolean layoutUpdateable) {
 		Layout layout = Mockito.mock(Layout.class);
 
 		Layout draftLayout = Mockito.mock(Layout.class);
@@ -164,6 +185,12 @@ public class LayoutsAdminDisplayContextTest {
 			layout.getPlid()
 		).thenReturn(
 			RandomTestUtil.randomLong()
+		);
+
+		Mockito.when(
+			layout.isLayoutUpdateable()
+		).thenReturn(
+			layoutUpdateable
 		);
 
 		Mockito.when(

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-content/src/main/java/com/liferay/layout/type/controller/content/internal/layout/type/controller/ContentLayoutTypeController.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-content/src/main/java/com/liferay/layout/type/controller/content/internal/layout/type/controller/ContentLayoutTypeController.java
@@ -135,6 +135,17 @@ public class ContentLayoutTypeController extends BaseLayoutTypeControllerImpl {
 				redirect = _layoutLockManager.getLockedLayoutURL(
 					httpServletRequest);
 			}
+			else if (!layout.isLayoutUpdateable()) {
+				Layout redirectLayout = layout;
+
+				if (layout.isDraftLayout()) {
+					redirectLayout = _layoutLocalService.fetchLayout(
+						layout.getClassPK());
+				}
+
+				redirect = _portal.getLayoutFullURL(
+					redirectLayout, themeDisplay);
+			}
 			else {
 				redirect = _getDraftLayoutFullURL(
 					httpServletRequest, layout, themeDisplay);

--- a/modules/test/playwright/helpers/HeadlessDeliveryApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessDeliveryApiHelper.ts
@@ -114,6 +114,12 @@ export class HeadlessDeliveryApiHelper {
 		);
 	}
 
+	async getSitePage(friendlyUrlPath: string, siteId: string) {
+		return this.apiHelpers.get(
+			`${this.apiHelpers.baseUrl}${this.basePath}/sites/${siteId}/site-pages/${friendlyUrlPath}`
+		);
+	}
+
 	async getSitePages(siteId: string) {
 		return this.apiHelpers.get(
 			`${this.apiHelpers.baseUrl}${this.basePath}/sites/${siteId}/site-pages`

--- a/modules/test/playwright/helpers/json-web-services/JSONWebServicesLayoutSetPrototypeApiHelper.ts
+++ b/modules/test/playwright/helpers/json-web-services/JSONWebServicesLayoutSetPrototypeApiHelper.ts
@@ -58,7 +58,13 @@ export class JSONWebServicesLayoutSetPrototypeApiHelper {
 		);
 	}
 
-	async addLayoutSetPrototypes(name: string): Promise<LayoutSetPrototype> {
+	async addLayoutSetPrototypes({
+		layoutsUpdateable = true,
+		name,
+	}: {
+		layoutsUpdateable?: boolean;
+		name: string;
+	}): Promise<LayoutSetPrototype> {
 		const urlSearchParams = new URLSearchParams();
 
 		const booleanTrue: boolean = true;
@@ -66,7 +72,10 @@ export class JSONWebServicesLayoutSetPrototypeApiHelper {
 		urlSearchParams.append('name', name);
 		urlSearchParams.append('description', '');
 		urlSearchParams.append('active', booleanTrue.toString());
-		urlSearchParams.append('layoutsUpdateable', booleanTrue.toString());
+		urlSearchParams.append(
+			'layoutsUpdateable',
+			layoutsUpdateable.toString()
+		);
 		urlSearchParams.append('readyForPropagation', booleanTrue.toString());
 
 		return this.apiHelpers.post(

--- a/modules/test/playwright/pages/site-admin-web/SitesPage.ts
+++ b/modules/test/playwright/pages/site-admin-web/SitesPage.ts
@@ -41,17 +41,26 @@ export class SitesPage {
 		this.uiElementsPage = new UIElementsPage(page);
 	}
 
-	async createSiteFromTemplate(
-		templateName: string,
-		siteName: string
-	): Promise<string> {
+	async createSiteFromTemplate({
+		defaultPagesAsPrivate = false,
+		siteName,
+		templateName,
+	}: {
+		defaultPagesAsPrivate?: boolean;
+		siteName: string;
+		templateName: string;
+	}): Promise<string> {
 		await this.addSiteButton.click();
 		await this.customSiteTemplatesItem.click();
 		await this.page
 			.getByRole('button', {name: `Select Template: ${templateName}`})
 			.click();
 		await this.nameBox.fill(siteName);
-		await this.defaultPagesAsPrivateCheck.check();
+
+		if (defaultPagesAsPrivate) {
+			await this.defaultPagesAsPrivateCheck.check();
+		}
+
 		await this.addButton.click();
 		await this.page.waitForURL(/(.)settings(.)/);
 		await this.page.getByRole('link', {name: 'Site Configuration'}).click();

--- a/modules/test/playwright/tests/layout-set-prototype-web/siteTemplatesWithPage.spec.ts
+++ b/modules/test/playwright/tests/layout-set-prototype-web/siteTemplatesWithPage.spec.ts
@@ -1,0 +1,149 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {applicationsMenuPageTest} from '../../fixtures/applicationsMenuPageTest';
+import {dataApiHelpersTest} from '../../fixtures/dataApiHelpersTest';
+import {loginTest} from '../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../fixtures/pageEditorPagesTest';
+import {pagesAdminPagesTest} from '../../fixtures/pagesAdminPagesTest';
+import {productMenuPageTest} from '../../fixtures/productMenuPageTest';
+import {sitesPageTest} from '../../fixtures/sitesPageTest';
+import {uiElementsPageTest} from '../../fixtures/uiElementsTest';
+import getRandomString from '../../utils/getRandomString';
+import createSiteTemplate from './utils/createSiteTemplate';
+
+export const test = mergeTests(
+	applicationsMenuPageTest,
+	dataApiHelpersTest,
+	loginTest(),
+	pageEditorPagesTest,
+	pagesAdminPagesTest,
+	productMenuPageTest,
+	sitesPageTest,
+	uiElementsPageTest
+);
+
+test(
+	'Can not edit Pages created with Site Templates if the checkbox of allowing edition is disabled',
+	{tag: ['@LPD-49053', '@LPS-131903', '@LPS-132256']},
+	async ({
+		apiHelpers,
+		applicationsMenuPage,
+		page,
+		pageEditorPage,
+		pagesAdminPage,
+		productMenuPage,
+		sitesPage,
+		uiElementsPage,
+	}) => {
+
+		// Create a site template with the checkbox of allowing edition (layoutsUpdateable) disabled
+
+		const siteTemplateName: string = 'SiteTemplate-' + getRandomString();
+
+		const layoutSetPrototype = await createSiteTemplate({
+			apiHelpers,
+			layoutsUpdateable: false,
+			page,
+			productMenuPage,
+			templateName: siteTemplateName,
+		});
+
+		apiHelpers.data.push({
+			id: layoutSetPrototype.layoutSetPrototypeId,
+			type: 'layoutSetPrototype',
+		});
+
+		// Create and publish a page in the site template
+
+		const pageName: string = 'Page-' + getRandomString();
+
+		await productMenuPage.goToPages();
+		await pagesAdminPage.newButton.click();
+		await pagesAdminPage.addPage({
+			name: pageName,
+		});
+
+		await uiElementsPage.publishButton.click();
+
+		// Create a site using the site template
+
+		await applicationsMenuPage.goToSites();
+
+		const siteName: string = 'Site-' + getRandomString();
+
+		const siteId = await sitesPage.createSiteFromTemplate({
+			siteName,
+			templateName: siteTemplateName,
+		});
+
+		apiHelpers.data.push({id: siteId, type: 'site'});
+
+		// Check the Edit button of the dropdown is not visible
+
+		await productMenuPage.goToPages();
+
+		await page.reload();
+
+		const dropdown = page
+			.locator('.miller-columns-item', {
+				hasText: pageName,
+			})
+			.locator('button.dropdown-toggle');
+
+		await dropdown.click();
+
+		await expect(page.getByRole('menuitem', {name: 'Edit'})).toBeHidden();
+
+		// Check the Page link opens the view mode
+
+		const href = await page
+			.getByLabel(pageName, {exact: true})
+			.getAttribute('href');
+
+		await page.goto(href);
+
+		expect(await page.title()).toBe(
+			`${pageName} - ${siteName} - Liferay DXP`
+		);
+
+		await page
+			.locator('.control-menu-nav-item')
+			.getByRole('button', {name: 'Additional Information'})
+			.click();
+
+		await expect(
+			page
+				.locator('.popover-body')
+				.getByText(
+					'This page is linked to a site template which does not allow modifications to it.',
+					{exact: true}
+				)
+		).toBeVisible();
+
+		// Check the Edit button is not visible in the view mode
+
+		await expect(
+			page
+				.locator('.control-menu-nav-item')
+				.getByLabel('Edit', {exact: true})
+		).toBeHidden();
+
+		// Check going to the edit mode redirects to the view mode
+
+		const layout = await apiHelpers.headlessDelivery.getSitePage(
+			pageName,
+			siteId
+		);
+
+		await pageEditorPage.goto(layout, `/${siteName.toLowerCase()}`);
+
+		expect(await page.title()).toBe(
+			`${pageName} - ${siteName} - Liferay DXP`
+		);
+	}
+);

--- a/modules/test/playwright/tests/layout-set-prototype-web/siteTemplatesWithPage.spec.ts
+++ b/modules/test/playwright/tests/layout-set-prototype-web/siteTemplatesWithPage.spec.ts
@@ -14,6 +14,7 @@ import {productMenuPageTest} from '../../fixtures/productMenuPageTest';
 import {sitesPageTest} from '../../fixtures/sitesPageTest';
 import {uiElementsPageTest} from '../../fixtures/uiElementsTest';
 import getRandomString from '../../utils/getRandomString';
+import {reloadUntilVisible} from '../../utils/reloadUntilVisible';
 import createSiteTemplate from './utils/createSiteTemplate';
 
 export const test = mergeTests(
@@ -87,13 +88,16 @@ test(
 
 		await productMenuPage.goToPages();
 
-		await page.reload();
-
 		const dropdown = page
 			.locator('.miller-columns-item', {
 				hasText: pageName,
 			})
 			.locator('button.dropdown-toggle');
+
+		await reloadUntilVisible({
+			myLocator: dropdown,
+			page,
+		});
 
 		await dropdown.click();
 

--- a/modules/test/playwright/tests/layout-set-prototype-web/siteTemplatesWithWebContent.spec.ts
+++ b/modules/test/playwright/tests/layout-set-prototype-web/siteTemplatesWithWebContent.spec.ts
@@ -119,18 +119,20 @@ testWithPrivatePages(
 
 		await applicationsMenuPage.goToSites();
 
-		const site1Id = await sitesPage.createSiteFromTemplate(
-			siteTemplateName,
-			getRandomString()
-		);
+		const site1Id = await sitesPage.createSiteFromTemplate({
+			defaultPagesAsPrivate: true,
+			siteName: getRandomString(),
+			templateName: siteTemplateName,
+		});
 
 		apiHelpers.data.push({id: site1Id, type: 'site'});
 
 		await applicationsMenuPage.goToSites();
-		const site2Id = await sitesPage.createSiteFromTemplate(
-			siteTemplateName,
-			getRandomString()
-		);
+		const site2Id = await sitesPage.createSiteFromTemplate({
+			defaultPagesAsPrivate: true,
+			siteName: getRandomString(),
+			templateName: siteTemplateName,
+		});
 
 		apiHelpers.data.push({id: site2Id, type: 'site'});
 

--- a/modules/test/playwright/tests/layout-set-prototype-web/utils/createSiteTemplate.ts
+++ b/modules/test/playwright/tests/layout-set-prototype-web/utils/createSiteTemplate.ts
@@ -12,6 +12,7 @@ import getBasicWebContentStructureId from '../../../utils/structured-content/get
 
 export default async function createSiteTemplate({
 	apiHelpers,
+	layoutsUpdateable = true,
 	page,
 	productMenuPage,
 	templateName,
@@ -19,6 +20,7 @@ export default async function createSiteTemplate({
 	webContentName,
 }: {
 	apiHelpers: ApiHelpers;
+	layoutsUpdateable?: boolean;
 	page: Page;
 	productMenuPage: ProductMenuPage;
 	templateName: string;
@@ -28,6 +30,7 @@ export default async function createSiteTemplate({
 	const layoutSetPrototype: LayoutSetPrototype =
 		await apiHelpers.jsonWebServicesLayoutSetPrototype.addLayoutSetPrototypes(
 			{
+				layoutsUpdateable,
 				name: templateName,
 			}
 		);

--- a/modules/test/playwright/tests/layout-set-prototype-web/utils/createSiteTemplate.ts
+++ b/modules/test/playwright/tests/layout-set-prototype-web/utils/createSiteTemplate.ts
@@ -27,7 +27,9 @@ export default async function createSiteTemplate({
 }): Promise<LayoutSetPrototype> {
 	const layoutSetPrototype: LayoutSetPrototype =
 		await apiHelpers.jsonWebServicesLayoutSetPrototype.addLayoutSetPrototypes(
-			templateName
+			{
+				name: templateName,
+			}
 		);
 
 	await page.goto(

--- a/modules/test/playwright/tests/site-admin-web/siteInitializerSelection.spec.ts
+++ b/modules/test/playwright/tests/site-admin-web/siteInitializerSelection.spec.ts
@@ -56,7 +56,9 @@ test(
 		for (let i = 0; i < 5; i++) {
 			const layoutSetPrototype: LayoutSetPrototype =
 				await apiHelpers.jsonWebServicesLayoutSetPrototype.addLayoutSetPrototypes(
-					getRandomString()
+					{
+						name: getRandomString(),
+					}
 				);
 
 			layoutSetPrototypes.push(layoutSetPrototype);

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/sitetemplates/cpsitetemplates/CPSitetemplates.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/sitetemplates/cpsitetemplates/CPSitetemplates.testcase
@@ -706,44 +706,6 @@ definition {
 		}
 	}
 
-	@description = "This is a use case for LPS-131903 and LPS-132256. Verify that users can not attempt to edit pages when disable changes."
-	@priority = 3
-	test CannotEditSiteLinkedToDisabledPageModificationSiteTemplate {
-		property portal.acceptance = "true";
-
-		task ("Given: User adds new site template with disallowing site admin's right to modificate pages") {
-			SiteTemplates.addCP(
-				disableChanges = "true",
-				siteTemplateName = "Site Template Name");
-		}
-
-		task ("When: Adds a site based on this site template") {
-			Site.openSitesAdmin();
-
-			Site.addCP(
-				siteName = "Site Template Site Name",
-				siteTemplateName = "Site Template Name",
-				siteTemplateTab = "Custom Site Templates",
-				siteType = "Site Template");
-		}
-
-		task ("Then: User is not able to edit the site or to view Permissions menu") {
-			Navigator.openSiteURL(siteName = "Site Template Site Name");
-
-			Page.viewPageLockCheck();
-
-			AssertElementNotPresent(locator1 = "Icon#EDIT_PENCIL");
-
-			MouseOver(
-				key_pageName = "Home",
-				locator1 = "Home#PAGE");
-
-			AssertElementNotPresent(locator1 = "Portlet#OPTIONS_ICON");
-
-			MenuItem.viewNotPresent(menuItem = "Permissions");
-		}
-	}
-
 	@description = "This is a use case for LPS-161817. Child content page of a Site created from a Site Template cannot be viewed or edited."
 	@priority = 3
 	test CanViewAndEditChildContentPageInSiteCreatedBySiteTemplate {


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPD-49400

---

The purpose of this PR is to restrict the access to `edit` mode for all the Pages created from Site Template that does not allow modifications. That is by unchecking the checkbox: 

`Allow site administrators to modify pages associated with this site template, even when propagation of changes is enabled.`

In addition, any access to the edit mode for those pages is redirected to the view mode.

---

Before the PR:

![image](https://github.com/user-attachments/assets/ac500b7a-58b9-4915-beb0-03c1e0c4b25d)

![Captura desde 2025-02-20 17-28-03](https://github.com/user-attachments/assets/f5cf2721-4cb2-46a7-b5e9-d01a5318f61e)

After the PR:

![Captura desde 2025-02-20 17-25-21](https://github.com/user-attachments/assets/39c90737-5e38-44dc-96b1-7340d9669900)

![image](https://github.com/user-attachments/assets/3720818d-7f07-4b10-8704-dd4c477f122f)
