### PR TITLE
LPD-49328 headless part of LPD-47718

### DIFF
--- a/modules/apps/batch-planner/batch-planner-web/package.json
+++ b/modules/apps/batch-planner/batch-planner-web/package.json
@@ -13,6 +13,7 @@
 		"@liferay/frontend-js-react-web": "*",
 		"classnames": "2.3.1",
 		"fetch-mock": "5.13.1",
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*",
 		"prop-types": "15.7.2",
 		"react": "18.2.0",

--- a/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/BatchPlannerPlanTemplateManagementToolbarPropsTransformer.js
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/BatchPlannerPlanTemplateManagementToolbarPropsTransformer.js
@@ -3,11 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {
-	getCheckedCheckboxes,
-	openConfirmModal,
-	postForm,
-} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
+import {getCheckedCheckboxes, postForm} from 'frontend-js-web';
 
 export default function propsTransformer({portletNamespace, ...otherProps}) {
 	const deleteBatchPlannerPlanTemplates = (itemData) => {

--- a/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/SaveTemplateModal.js
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/SaveTemplateModal.js
@@ -8,7 +8,8 @@ import ClayForm, {ClayInput} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayModal from '@clayui/modal';
 import {useIsMounted} from '@liferay/frontend-js-react-web';
-import {fetch, openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
+import {fetch} from 'frontend-js-web';
 import React, {useState} from 'react';
 
 import {HEADERS, TEMPLATE_CREATED_EVENT} from './constants';

--- a/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/editBatchPlannerPlan.js
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/editBatchPlannerPlan.js
@@ -4,7 +4,8 @@
  */
 
 import {render} from '@liferay/frontend-js-react-web';
-import {fetch, openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
+import {fetch} from 'frontend-js-web';
 
 import TemplateSelect from './TemplateSelect';
 import {

--- a/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/export/Export.js
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/export/Export.js
@@ -5,7 +5,7 @@
 
 import ClayButton from '@clayui/button';
 import {useModal} from '@clayui/modal';
-import {openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
 import PropTypes from 'prop-types';
 import React, {useCallback, useEffect, useState} from 'react';
 

--- a/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/import/ImportForm.js
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/import/ImportForm.js
@@ -4,7 +4,7 @@
  */
 
 import ClayTable from '@clayui/table';
-import {openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
 import PropTypes from 'prop-types';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 

--- a/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/utilities/dataFetch.js
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/utilities/dataFetch.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {fetch, openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
+import {fetch} from 'frontend-js-web';
 
 import {
 	HEADLESS_BATCH_PLANNER_URL,

--- a/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "d5e6b72410e4c20e9c3e89568a793ff4579d2e20",
+	"@generated": "2d3bddf02a8b54afbae7de53c445211773c9469f",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -14,6 +14,9 @@
 		"paths": {
 			"@liferay/frontend-js-react-web": [
 				"../../../../../../../frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/index.ts"
+			],
+			"frontend-js-components-web": [
+				"../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
 			],
 			"frontend-js-web": [
 				"../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
@@ -37,6 +40,9 @@
 	"references": [
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
 		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"

--- a/modules/apps/batch-planner/batch-planner-web/test/components/Export/Export.js
+++ b/modules/apps/batch-planner/batch-planner-web/test/components/Export/Export.js
@@ -26,12 +26,12 @@ import {
 } from '../../../src/main/resources/META-INF/resources/js/constants';
 import Export from '../../../src/main/resources/META-INF/resources/js/export/Export';
 
-const INPUT_VALUE_TEST = 'test';
 const BASE_PROPS = {
 	formExportDataQuerySelector: 'form',
 	formExportURL: 'https://formUrl.test',
 	portletNamespace: 'test',
 };
+const INPUT_VALUE_TEST = 'test';
 
 const externalReferenceCode = '1234';
 let mockApi;
@@ -41,6 +41,10 @@ window.URL.createObjectURL = mockCreateObjectUrl;
 window.URL.revokeObjectURL = jest.fn();
 
 configure({asyncUtilTimeout: 5000});
+
+jest.mock('frontend-js-components-web', () => {
+	jest.fn();
+});
 
 jest.mock(
 	'../../../src/main/resources/META-INF/resources/js/BatchPlannerExport',

--- a/modules/apps/batch-planner/batch-planner-web/test/components/Import/ImportForm.js
+++ b/modules/apps/batch-planner/batch-planner-web/test/components/Import/ImportForm.js
@@ -51,6 +51,10 @@ const fileContent = [
 	['EUR', 'truck', 'default'],
 ];
 
+jest.mock('frontend-js-components-web', () => {
+	jest.fn();
+});
+
 describe('ImportForm', () => {
 	beforeEach(() => {
 		const mockDiv = document.createElement('div');

--- a/modules/apps/batch-planner/batch-planner-web/test/components/SaveTemplate/SaveTemplate.js
+++ b/modules/apps/batch-planner/batch-planner-web/test/components/SaveTemplate/SaveTemplate.js
@@ -11,6 +11,11 @@ import React from 'react';
 import SaveTemplate from '../../../src/main/resources/META-INF/resources/js/SaveTemplate';
 import {SCHEMA_SELECTED_EVENT} from '../../../src/main/resources/META-INF/resources/js/constants';
 
+jest.mock('frontend-js-components-web', () => ({
+	openModal: jest.fn(),
+	openToast: jest.fn(),
+}));
+
 const BASE_PROPS = {
 	evaluateForm: () => {},
 	formIsValid: true,

--- a/modules/apps/batch-planner/batch-planner-web/test/components/TemplateSelect/TemplateSelect.js
+++ b/modules/apps/batch-planner/batch-planner-web/test/components/TemplateSelect/TemplateSelect.js
@@ -41,6 +41,10 @@ const mockPlanId = 106902;
 
 const getPlanInfoURL = `${HEADLESS_BATCH_PLANNER_URL}/plans/${mockPlanId}`;
 
+jest.mock('frontend-js-components-web', () => {
+	jest.fn();
+});
+
 describe('TemplateSelect', () => {
 	beforeEach(() => {
 		fetchMock.mock(getPlanInfoURL, mockGetPlan);

--- a/modules/apps/dispatch/dispatch-web/package.json
+++ b/modules/apps/dispatch/dispatch-web/package.json
@@ -1,5 +1,6 @@
 {
 	"dependencies": {
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*"
 	},
 	"main": "js/index.js",

--- a/modules/apps/dispatch/dispatch-web/src/main/resources/META-INF/resources/js/DispatchTriggerManagementToolbarPropsTransformer.js
+++ b/modules/apps/dispatch/dispatch-web/src/main/resources/META-INF/resources/js/DispatchTriggerManagementToolbarPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openConfirmModal} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
 
 export default function propsTransformer({
 	additionalProps: {deleteEntriesURL, inputId, inputValue},

--- a/modules/apps/dispatch/dispatch-web/src/main/resources/META-INF/resources/js/trigger/DispatchLogManagementToolbarPropsTransformer.js
+++ b/modules/apps/dispatch/dispatch-web/src/main/resources/META-INF/resources/js/trigger/DispatchLogManagementToolbarPropsTransformer.js
@@ -3,11 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {
-	getCheckedCheckboxes,
-	openConfirmModal,
-	postForm,
-} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
+import {getCheckedCheckboxes, postForm} from 'frontend-js-web';
 
 export default function propsTransformer({portletNamespace, ...otherProps}) {
 	return {

--- a/modules/apps/dispatch/dispatch-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/dispatch/dispatch-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "903f71d3f920edc3fb2a885bd1c40248b3018aa8",
+	"@generated": "540504d70d2efe083efbdaee5c062d9f22efa1c7",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -12,6 +12,9 @@
 		"module": "es6",
 		"moduleResolution": "node",
 		"paths": {
+			"frontend-js-components-web": [
+				"../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
+			],
 			"frontend-js-web": [
 				"../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
 			]
@@ -32,6 +35,9 @@
 		"../../../../../../../../global.d.ts"
 	],
 	"references": [
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"
 		}

--- a/modules/apps/export-import/export-import-web/package.json
+++ b/modules/apps/export-import/export-import-web/package.json
@@ -1,5 +1,6 @@
 {
 	"dependencies": {
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*"
 	},
 	"main": "js/index.js",

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/js/index.js
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/js/index.js
@@ -3,11 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {
-	getCheckedCheckboxes,
-	openConfirmModal,
-	postForm,
-} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
+import {getCheckedCheckboxes, postForm} from 'frontend-js-web';
 
 export function ExportImportManagementToolbarPropsTransformer({
 	portletNamespace,

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "1f4a82e038dfcf1e718bb21480869dee49cc1521",
+	"@generated": "5fda4f50c41d8c38f0f7ee63e8e6acd472a855be",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -12,6 +12,9 @@
 		"module": "es6",
 		"moduleResolution": "node",
 		"paths": {
+			"frontend-js-components-web": [
+				"../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
+			],
 			"frontend-js-web": [
 				"../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
 			]
@@ -32,6 +35,9 @@
 		"../../../../../../../../global.d.ts"
 	],
 	"references": [
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"
 		}

--- a/modules/apps/headless/headless-builder/headless-builder-web/package.json
+++ b/modules/apps/headless/headless-builder/headless-builder-web/package.json
@@ -19,6 +19,7 @@
 		"@clayui/tooltip": "3.119.0",
 		"@liferay/frontend-data-set-web": "*",
 		"classnames": "2.3.1",
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*",
 		"react": "18.2.0"
 	},

--- a/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/EditAPIApplication.tsx
+++ b/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/EditAPIApplication.tsx
@@ -9,7 +9,8 @@ import {Heading} from '@clayui/core';
 import ClayLayout from '@clayui/layout';
 import ClayModal from '@clayui/modal';
 import ClayNavigationBar from '@clayui/navigation-bar';
-import {localStorage, openModal, openToast} from 'frontend-js-web';
+import {openModal, openToast} from 'frontend-js-components-web';
+import {localStorage} from 'frontend-js-web';
 import React, {useCallback, useEffect, useState} from 'react';
 
 import EndpointsContent from '../components/EndpointsContent';

--- a/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/EditAPIEndpoint.tsx
+++ b/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/EditAPIEndpoint.tsx
@@ -6,7 +6,7 @@
 import ClayBreadcrumb from '@clayui/breadcrumb';
 import ClayCard from '@clayui/card';
 import ClayTabs from '@clayui/tabs';
-import {openModal, openToast} from 'frontend-js-web';
+import {openModal, openToast} from 'frontend-js-components-web';
 import React, {
 	Dispatch,
 	SetStateAction,

--- a/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/EditAPISchema.tsx
+++ b/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/EditAPISchema.tsx
@@ -6,7 +6,7 @@
 import ClayBreadcrumb from '@clayui/breadcrumb';
 import ClayCard from '@clayui/card';
 import ClayTabs from '@clayui/tabs';
-import {openModal, openToast} from 'frontend-js-web';
+import {openModal, openToast} from 'frontend-js-components-web';
 import React, {
 	Dispatch,
 	SetStateAction,

--- a/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/FDS/APIApplicationsTable.tsx
+++ b/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/FDS/APIApplicationsTable.tsx
@@ -4,7 +4,7 @@
  */
 
 import {FrontendDataSet} from '@liferay/frontend-data-set-web';
-import {openModal, openToast} from 'frontend-js-web';
+import {openModal, openToast} from 'frontend-js-components-web';
 import React from 'react';
 
 import {ConfirmUnpublishAPIApplicationModalContent} from '../modals/ConfirmUnpublishAPIApplicationModalContent';

--- a/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/FDS/APIEndpointsTable.tsx
+++ b/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/FDS/APIEndpointsTable.tsx
@@ -4,7 +4,7 @@
  */
 
 import {FrontendDataSet} from '@liferay/frontend-data-set-web';
-import {openModal} from 'frontend-js-web';
+import {openModal} from 'frontend-js-components-web';
 import React, {Dispatch, SetStateAction, useContext, useEffect} from 'react';
 
 import {EditAPIApplicationContext} from '../EditAPIApplicationContext';

--- a/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/FDS/APISchemasTable.tsx
+++ b/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/FDS/APISchemasTable.tsx
@@ -4,7 +4,7 @@
  */
 
 import {FrontendDataSet} from '@liferay/frontend-data-set-web';
-import {openModal} from 'frontend-js-web';
+import {openModal} from 'frontend-js-components-web';
 import React, {Dispatch, SetStateAction, useContext, useEffect} from 'react';
 
 import {EditAPIApplicationContext} from '../EditAPIApplicationContext';

--- a/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/PropertiesTreeView.tsx
+++ b/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/PropertiesTreeView.tsx
@@ -7,7 +7,8 @@ import ClayButton from '@clayui/button';
 import {TreeView} from '@clayui/core';
 import ClayIcon from '@clayui/icon';
 import {ClayTooltipProvider} from '@clayui/tooltip';
-import {openModal, openToast, sub} from 'frontend-js-web';
+import {openModal, openToast} from 'frontend-js-components-web';
+import {sub} from 'frontend-js-web';
 import React, {Dispatch, SetStateAction} from 'react';
 
 import EditAPIPropertyModalContent from './modals/EditAPIPropertyModalContent';

--- a/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/baseComponents/BaseAPIEndpointFields.tsx
+++ b/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/baseComponents/BaseAPIEndpointFields.tsx
@@ -8,7 +8,8 @@ import {Text} from '@clayui/core';
 import ClayForm, {ClayInput} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import classNames from 'classnames';
-import {openToast, sub} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
+import {sub} from 'frontend-js-web';
 import React, {Dispatch, SetStateAction, useEffect, useState} from 'react';
 
 import {Select} from '../fieldComponents/Select';

--- a/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/modals/CreateAPIApplicationModalContent.tsx
+++ b/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/modals/CreateAPIApplicationModalContent.tsx
@@ -5,7 +5,8 @@
 
 import ClayButton from '@clayui/button';
 import ClayModal from '@clayui/modal';
-import {fetch, localStorage, openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
+import {fetch, localStorage} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
 import BaseAPIApplicationField from '../baseComponents/BaseAPIApplicationFields';

--- a/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/modals/CreateAPIEndpointModalContent.tsx
+++ b/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/modals/CreateAPIEndpointModalContent.tsx
@@ -5,7 +5,8 @@
 
 import ClayButton from '@clayui/button';
 import ClayModal from '@clayui/modal';
-import {fetch, openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
+import {fetch} from 'frontend-js-web';
 import React, {Dispatch, SetStateAction, useEffect, useState} from 'react';
 
 import BaseAPIEndpointFields from '../baseComponents/BaseAPIEndpointFields';

--- a/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/modals/CreateAPISchemaModalContent.tsx
+++ b/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/modals/CreateAPISchemaModalContent.tsx
@@ -5,7 +5,8 @@
 
 import ClayButton from '@clayui/button';
 import ClayModal from '@clayui/modal';
-import {fetch, openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
+import {fetch} from 'frontend-js-web';
 import React, {Dispatch, SetStateAction, useEffect, useState} from 'react';
 
 import BaseAPISchemaFields from '../baseComponents/BaseAPISchemaFields';

--- a/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/modals/DeleteAPIApplicationModalContent.tsx
+++ b/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/modals/DeleteAPIApplicationModalContent.tsx
@@ -7,7 +7,8 @@ import ClayButton from '@clayui/button';
 import ClayForm, {ClayInput} from '@clayui/form';
 import ClayModal from '@clayui/modal';
 import classNames from 'classnames';
-import {fetch, openToast, sub} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
+import {fetch, sub} from 'frontend-js-web';
 import React, {useState} from 'react';
 
 interface DeleteAPIApplicationModal {

--- a/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/modals/DeleteAPIEndpointModalContent.tsx
+++ b/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/modals/DeleteAPIEndpointModalContent.tsx
@@ -5,7 +5,8 @@
 
 import ClayButton from '@clayui/button';
 import ClayModal from '@clayui/modal';
-import {fetch, openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
+import {fetch} from 'frontend-js-web';
 import React from 'react';
 
 interface DeleteAPIEndpointModalProps {

--- a/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/modals/DeleteAPISchemaModalContent.tsx
+++ b/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/modals/DeleteAPISchemaModalContent.tsx
@@ -5,7 +5,8 @@
 
 import ClayButton from '@clayui/button';
 import ClayModal from '@clayui/modal';
-import {fetch, openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
+import {fetch} from 'frontend-js-web';
 import React from 'react';
 
 interface DeleteAPISchemaModal {

--- a/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/modals/EditAPIPropertyModalContent.tsx
+++ b/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/js/components/modals/EditAPIPropertyModalContent.tsx
@@ -8,7 +8,7 @@ import ClayForm, {ClayInput} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayModal from '@clayui/modal';
 import classNames from 'classnames';
-import {openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
 import React, {Dispatch, SetStateAction, useEffect, useState} from 'react';
 
 import {Select} from '../fieldComponents/Select';

--- a/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/headless/headless-builder/headless-builder-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "38c99c69c27269dbf930f569de8bdd21a34aa1cd",
+	"@generated": "928d55c996269c1980647d06f2faec06ee55b4ba",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -14,6 +14,9 @@
 		"paths": {
 			"@liferay/frontend-data-set-web": [
 				"../../../../../../../../frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/index.ts"
+			],
+			"frontend-js-components-web": [
+				"../../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
 			],
 			"frontend-js-web": [
 				"../../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
@@ -37,6 +40,9 @@
 	"references": [
 		{
 			"path": "../../../../../../../../frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
+		{
+			"path": "../../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
 		},
 		{
 			"path": "../../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"

--- a/modules/apps/layout/layout-set-prototype-web/package.json
+++ b/modules/apps/layout/layout-set-prototype-web/package.json
@@ -4,6 +4,7 @@
 		"@clayui/link": "3.111.0",
 		"@clayui/popover": "3.119.0",
 		"@liferay/frontend-js-react-web": "*",
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*",
 		"react": "18.2.0"
 	},

--- a/modules/apps/layout/layout-set-prototype-web/src/main/resources/META-INF/resources/js/LayoutSetPrototypeDropdownDefaultPropsTransformer.js
+++ b/modules/apps/layout/layout-set-prototype-web/src/main/resources/META-INF/resources/js/LayoutSetPrototypeDropdownDefaultPropsTransformer.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openConfirmModal, openWindow} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
+import {openWindow} from 'frontend-js-web';
 
 const ACTIONS = {
 	activate(itemData) {

--- a/modules/apps/layout/layout-set-prototype-web/src/main/resources/META-INF/resources/js/LayoutSetPrototypeManagementToolbarPropsTransformer.js
+++ b/modules/apps/layout/layout-set-prototype-web/src/main/resources/META-INF/resources/js/LayoutSetPrototypeManagementToolbarPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openConfirmModal} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
 
 export default function propsTransformer({portletNamespace, ...otherProps}) {
 	return {

--- a/modules/apps/layout/layout-set-prototype-web/src/main/resources/META-INF/resources/js/dynamic_include/PropagationMessage.js
+++ b/modules/apps/layout/layout-set-prototype-web/src/main/resources/META-INF/resources/js/dynamic_include/PropagationMessage.js
@@ -7,7 +7,7 @@ import {ClayButtonWithIcon} from '@clayui/button';
 import ClayLink from '@clayui/link';
 import ClayPopover from '@clayui/popover';
 import {useEventListener} from '@liferay/frontend-js-react-web';
-import {openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
 import React, {useRef, useState} from 'react';
 
 export default function ({

--- a/modules/apps/layout/layout-set-prototype-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/layout/layout-set-prototype-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "54711851e89cd407e9dd9087c4a6c85ae679da2c",
+	"@generated": "d6c106eb9f7a59bd301cdc32fd5cc3aa10dc4160",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -14,6 +14,9 @@
 		"paths": {
 			"@liferay/frontend-js-react-web": [
 				"../../../../../../../frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/index.ts"
+			],
+			"frontend-js-components-web": [
+				"../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
 			],
 			"frontend-js-web": [
 				"../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
@@ -37,6 +40,9 @@
 	"references": [
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
 		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"

--- a/modules/apps/staging/staging-bar-web/package.json
+++ b/modules/apps/staging/staging-bar-web/package.json
@@ -1,5 +1,6 @@
 {
 	"dependencies": {
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*"
 	},
 	"main": "js/index.js",

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/js/StagingVersionPropsTransformer.js
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/js/StagingVersionPropsTransformer.js
@@ -4,13 +4,11 @@
  */
 
 import {
-	fetch,
-	objectToFormData,
 	openConfirmModal,
 	openModal,
 	openToast,
-	runScriptsInElement,
-} from 'frontend-js-web';
+} from 'frontend-js-components-web';
+import {fetch, objectToFormData, runScriptsInElement} from 'frontend-js-web';
 
 const MAP_CMD_REVISION = {
 	redo: 'redo_layout_revision',

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "1bbcdaf6a00ff69f53f6ba429bd61feda36fac44",
+	"@generated": "fd9f7d2b0d28f197a1216b44b6698d85be95a6f2",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -12,6 +12,9 @@
 		"module": "es6",
 		"moduleResolution": "node",
 		"paths": {
+			"frontend-js-components-web": [
+				"../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
+			],
 			"frontend-js-web": [
 				"../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
 			]
@@ -32,6 +35,9 @@
 		"../../../../../../../../global.d.ts"
 	],
 	"references": [
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"
 		}

--- a/modules/apps/staging/staging-processes-web/package.json
+++ b/modules/apps/staging/staging-processes-web/package.json
@@ -1,5 +1,6 @@
 {
 	"dependencies": {
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*"
 	},
 	"main": "js/index.js",

--- a/modules/apps/staging/staging-processes-web/src/main/resources/META-INF/resources/js/index.js
+++ b/modules/apps/staging/staging-processes-web/src/main/resources/META-INF/resources/js/index.js
@@ -3,11 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {
-	getCheckedCheckboxes,
-	openConfirmModal,
-	postForm,
-} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
+import {getCheckedCheckboxes, postForm} from 'frontend-js-web';
 
 export function StagingProcessesWebToolbarPropsTransformer({
 	portletNamespace,

--- a/modules/apps/staging/staging-processes-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/staging/staging-processes-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "f33915efaa4fad790b9d0ee43118ec41ba0109da",
+	"@generated": "c4f3a5984ec02271429e4a5dd38ac28229858021",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -12,6 +12,9 @@
 		"module": "es6",
 		"moduleResolution": "node",
 		"paths": {
+			"frontend-js-components-web": [
+				"../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
+			],
 			"frontend-js-web": [
 				"../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
 			]
@@ -32,6 +35,9 @@
 		"../../../../../../../../global.d.ts"
 	],
 	"references": [
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"
 		}

--- a/modules/apps/staging/staging-taglib/package.json
+++ b/modules/apps/staging/staging-taglib/package.json
@@ -5,6 +5,7 @@
 		"@clayui/form": "3.125.0",
 		"@clayui/icon": "3.111.0",
 		"classnames": "2.3.1",
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*",
 		"prop-types": "15.7.2",
 		"react": "18.2.0"

--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/js/index.js
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/js/index.js
@@ -8,7 +8,8 @@ import {TreeView as ClayTreeView} from '@clayui/core';
 import {ClayCheckbox} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import classNames from 'classnames';
-import {fetch, openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
+import {fetch} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useCallback, useState} from 'react';
 

--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "cc8f714f179e0f6424c24d38bf90ead51477a61e",
+	"@generated": "5fe211ef7cb217770dccb79045a926689a4be652",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -12,6 +12,9 @@
 		"module": "es6",
 		"moduleResolution": "node",
 		"paths": {
+			"frontend-js-components-web": [
+				"../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
+			],
 			"frontend-js-web": [
 				"../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
 			]
@@ -32,6 +35,9 @@
 		"../../../../../../../../global.d.ts"
 	],
 	"references": [
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"
 		}


### PR DESCRIPTION
Hi team :wave: 

This PR is part of [LPD-47718](https://liferay.atlassian.net/browse/LPD-47718).

It refactors your code to import `openModal`, `openToast`, etc. from `frontend-js-components-web` instead of `frontend-js-web`.

The final goal is to remove those methods from `frontend-js-web` so that whenever that module is imported the browser doesn't need to pull React and Clay simply because those methods existed there. This will enhance the performance of sites that don't need React or Clay.

Internally, for now, we are only [re-exporting those methods](https://github.com/brianchandotcom/liferay-portal/pull/159020/commits/3c4231e573b72d8775583af87224810fe42de532) from `frontend-js-components-web`, but once all PRs like this one sent to teams are merged, we (Frontend Infra) will send another final PR to move the methods and remove them completely from `frontend-js-web`.

The code in this PR (as well as the one we will send to other teams) has been thoroughly tested in [this PR](https://github.com/liferay-frontend/liferay-portal/pull/4720#) but we want to make sure that it doesn't break anything and that's why we send it to you for review.

The expectations are that you run the tests suites you think apply and if nothing breaks you just simply forward the PR to Brian. 

Also, it would be great if any new code you write that uses those methods imports them from `frontend-js-components-web` instead of `frontend-js-web` so that we don't have to repeat this process again :grimacing: .

For reference, here is the list of moved methods:

1. openAlertModal
2. openCategorySelectionModal
3. openConfirmModal
4. openModal
5. openPortletModal
6. openPortletWindow
7. openSelectionModal
8. openSimpleInputModal
9. openTagSelectionModal
10. openToast