### PR TITLE
LPD-49752 Command to reset API Builder

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-impl/build.gradle
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly project(":apps:batch-engine:batch-engine-api")
 	compileOnly project(":apps:headless:headless-builder:headless-builder-api")
 	compileOnly project(":apps:headless:headless-delivery:headless-delivery-api")
 	compileOnly project(":apps:info:info-api")
@@ -22,6 +23,7 @@ dependencies {
 	compileOnly project(":apps:static:portal:portal-upgrade-api")
 	compileOnly project(":core:osgi-service-tracker-collections")
 	compileOnly project(":core:petra:petra-function")
+	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")
 	testImplementation group: "org.skyscreamer", name: "jsonassert", version: "1.2.3"

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/osgi/commands/HeadlessBuilderOSGiCommands.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/osgi/commands/HeadlessBuilderOSGiCommands.java
@@ -65,16 +65,14 @@ public class HeadlessBuilderOSGiCommands implements OSGiCommands {
 			}
 		}
 
-		for (String processedFileName :
-				Arrays.asList(
-					"00.list.type.definition", "01.object.definition")) {
+		File dataFolder = bundle.getDataFile("");
 
-			File processedFile = bundle.getDataFile(
-				".com.liferay.headless.builder.internal.batch." +
-					processedFileName + ".batch.engine.data.json.0.processed");
+		File[] files = dataFolder.listFiles(
+			(dir, name) -> name.endsWith(".processed"));
 
-			if ((processedFile != null) && processedFile.exists()) {
-				processedFile.delete();
+		if (files != null) {
+			for (File file : files) {
+				file.delete();
 			}
 		}
 

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/osgi/commands/HeadlessBuilderOSGiCommands.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/osgi/commands/HeadlessBuilderOSGiCommands.java
@@ -1,0 +1,108 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.builder.internal.osgi.commands;
+
+import com.liferay.batch.engine.unit.BatchEngineUnitProcessor;
+import com.liferay.batch.engine.unit.BatchEngineUnitReader;
+import com.liferay.batch.engine.unit.BatchEngineUnitThreadLocal;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.osgi.util.osgi.commands.OSGiCommands;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+
+import java.io.File;
+
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Alejandro Tardín
+ */
+@Component(
+	property = {
+		"osgi.command.function=reset", "osgi.command.scope=headlessBuilder"
+	},
+	service = OSGiCommands.class
+)
+public class HeadlessBuilderOSGiCommands implements OSGiCommands {
+
+	public void reset(long companyId) throws Exception {
+		Bundle bundle = _bundleContext.getBundle();
+
+		for (String externalReferenceCode :
+				Arrays.asList(
+					"L_API_APPLICATION", "L_API_ENDPOINT", "L_API_FILTER",
+					"L_API_PROPERTY", "L_API_SCHEMA", "L_API_SORT")) {
+
+			ObjectDefinition objectDefinition =
+				_objectDefinitionLocalService.
+					fetchObjectDefinitionByExternalReferenceCode(
+						externalReferenceCode, companyId);
+
+			if (objectDefinition == null) {
+				continue;
+			}
+
+			BatchEngineUnitThreadLocal.setFileName(bundle.toString());
+
+			try {
+				_objectDefinitionLocalService.deleteObjectDefinition(
+					objectDefinition);
+			}
+			finally {
+				BatchEngineUnitThreadLocal.setFileName(StringPool.BLANK);
+			}
+		}
+
+		for (String processedFileName :
+				Arrays.asList(
+					"00.list.type.definition", "01.object.definition")) {
+
+			File processedFile = bundle.getDataFile(
+				".com.liferay.headless.builder.internal.batch." +
+					processedFileName + ".batch.engine.data.json.0.processed");
+
+			if ((processedFile != null) && processedFile.exists()) {
+				processedFile.delete();
+			}
+		}
+
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(companyId)) {
+
+			CompletableFuture<Void> completableFuture =
+				_batchEngineUnitProcessor.processBatchEngineUnits(
+					_batchEngineUnitReader.getBatchEngineUnits(bundle));
+
+			completableFuture.join();
+		}
+	}
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_bundleContext = bundleContext;
+	}
+
+	@Reference
+	private BatchEngineUnitProcessor _batchEngineUnitProcessor;
+
+	@Reference
+	private BatchEngineUnitReader _batchEngineUnitReader;
+
+	private BundleContext _bundleContext;
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+}

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/internal/osgi/commands/test/HeadlessBuilderOSGiCommandsTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/internal/osgi/commands/test/HeadlessBuilderOSGiCommandsTest.java
@@ -7,12 +7,11 @@ package com.liferay.headless.builder.internal.osgi.commands.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.headless.builder.test.BaseTestCase;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
-
-import java.lang.reflect.Method;
 
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -33,12 +32,9 @@ public class HeadlessBuilderOSGiCommandsTest extends BaseTestCase {
 
 	@Test
 	public void testReset() throws Exception {
-		Class<?> clazz = _headlessBuilderOSGiCommands.getClass();
-
-		Method method = clazz.getMethod("reset", long.class);
-
-		method.invoke(
-			_headlessBuilderOSGiCommands, TestPropsValues.getCompanyId());
+		ReflectionTestUtil.invoke(
+			_headlessBuilderOSGiCommands, "reset", new Class<?>[] {long.class},
+			TestPropsValues.getCompanyId());
 	}
 
 	@Inject(

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/internal/osgi/commands/test/HeadlessBuilderOSGiCommandsTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/internal/osgi/commands/test/HeadlessBuilderOSGiCommandsTest.java
@@ -1,0 +1,50 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.builder.internal.osgi.commands.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.headless.builder.test.BaseTestCase;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.lang.reflect.Method;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alejandro Tardín
+ */
+@FeatureFlags("LPS-178642")
+@RunWith(Arquillian.class)
+public class HeadlessBuilderOSGiCommandsTest extends BaseTestCase {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testReset() throws Exception {
+		Class<?> clazz = _headlessBuilderOSGiCommands.getClass();
+
+		Method method = clazz.getMethod("reset", long.class);
+
+		method.invoke(
+			_headlessBuilderOSGiCommands, TestPropsValues.getCompanyId());
+	}
+
+	@Inject(
+		filter = "osgi.command.scope=headlessBuilder",
+		type = Inject.NoType.class
+	)
+	private static Object _headlessBuilderOSGiCommands;
+
+}


### PR DESCRIPTION
1. Make sure the FF `LPS-178642` is enabled.
2. Go to `Control Panel / System / Virtual Instances`.
3. Copy the `Instance ID` value.
4. Go to `Control Panel / System / Gogo Shell`.
5. Type `headlessBuilder:reset <companyId>`. In the example: `headlessBuilder:reset 91102545556063`.