### PR TITLE
LPD-48895 Operations

### DIFF
--- a/modules/dxp/apps/scim/scim-rest-api/bnd.bnd
+++ b/modules/dxp/apps/scim/scim-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay SCIM REST API
 Bundle-SymbolicName: com.liferay.scim.rest.api
-Bundle-Version: 3.1.1
+Bundle-Version: 4.0.0
 Export-Package:\
 	com.liferay.scim.rest.dto.v1_0,\
 	com.liferay.scim.rest.resource.v1_0,\

--- a/modules/dxp/apps/scim/scim-rest-api/src/main/java/com/liferay/scim/rest/dto/v1_0/Operation.java
+++ b/modules/dxp/apps/scim/scim-rest-api/src/main/java/com/liferay/scim/rest/dto/v1_0/Operation.java
@@ -1,0 +1,363 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.scim.rest.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.io.Serializable;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import javax.annotation.Generated;
+
+import javax.validation.Valid;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * @author Olivér Kecskeméty
+ * @generated
+ */
+@Generated("")
+@GraphQLName("Operation")
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "Operation")
+public class Operation implements Serializable {
+
+	public static Operation toDTO(String json) {
+		return ObjectMapperUtil.readValue(Operation.class, json);
+	}
+
+	public static Operation unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(Operation.class, json);
+	}
+
+	@Schema(
+		description = "The method that should be used in the operation. Possible values add remove replace"
+	)
+	public String getOp() {
+		if (_opSupplier != null) {
+			op = _opSupplier.get();
+
+			_opSupplier = null;
+		}
+
+		return op;
+	}
+
+	public void setOp(String op) {
+		this.op = op;
+
+		_opSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setOp(UnsafeSupplier<String, Exception> opUnsafeSupplier) {
+		_opSupplier = () -> {
+			try {
+				return opUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "The method that should be used in the operation. Possible values add remove replace"
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String op;
+
+	@JsonIgnore
+	private Supplier<String> _opSupplier;
+
+	@Schema(
+		description = "Add the path to specify the attribute/sub-attribute that should be updated."
+	)
+	public String getPath() {
+		if (_pathSupplier != null) {
+			path = _pathSupplier.get();
+
+			_pathSupplier = null;
+		}
+
+		return path;
+	}
+
+	public void setPath(String path) {
+		this.path = path;
+
+		_pathSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setPath(UnsafeSupplier<String, Exception> pathUnsafeSupplier) {
+		_pathSupplier = () -> {
+			try {
+				return pathUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "Add the path to specify the attribute/sub-attribute that should be updated."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String path;
+
+	@JsonIgnore
+	private Supplier<String> _pathSupplier;
+
+	@Schema(description = "The value that should be updated.")
+	@Valid
+	public Object getValue() {
+		if (_valueSupplier != null) {
+			value = _valueSupplier.get();
+
+			_valueSupplier = null;
+		}
+
+		return value;
+	}
+
+	public void setValue(Object value) {
+		this.value = value;
+
+		_valueSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setValue(
+		UnsafeSupplier<Object, Exception> valueUnsafeSupplier) {
+
+		_valueSupplier = () -> {
+			try {
+				return valueUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(description = "The value that should be updated.")
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Object value;
+
+	@JsonIgnore
+	private Supplier<Object> _valueSupplier;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof Operation)) {
+			return false;
+		}
+
+		Operation operation = (Operation)object;
+
+		return Objects.equals(toString(), operation.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		String op = getOp();
+
+		if (op != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"op\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(op));
+
+			sb.append("\"");
+		}
+
+		String path = getPath();
+
+		if (path != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"path\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(path));
+
+			sb.append("\"");
+		}
+
+		Object value = getValue();
+
+		if (value != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"value\": ");
+
+			if (value instanceof Map) {
+				sb.append(JSONFactoryUtil.createJSONObject((Map<?, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape((String)value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@Schema(
+		accessMode = Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.scim.rest.dto.v1_0.Operation",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof Map) {
+						sb.append(_toJSON((Map<String, ?>)valueArray[i]));
+					}
+					else if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+	private Map<String, Serializable> _extendedProperties;
+
+}

--- a/modules/dxp/apps/scim/scim-rest-api/src/main/java/com/liferay/scim/rest/dto/v1_0/PatchOp.java
+++ b/modules/dxp/apps/scim/scim-rest-api/src/main/java/com/liferay/scim/rest/dto/v1_0/PatchOp.java
@@ -1,0 +1,311 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.scim.rest.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.io.Serializable;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import javax.annotation.Generated;
+
+import javax.validation.Valid;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * @author Olivér Kecskeméty
+ * @generated
+ */
+@Generated("")
+@GraphQLName("PatchOp")
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "PatchOp")
+public class PatchOp implements Serializable {
+
+	public static PatchOp toDTO(String json) {
+		return ObjectMapperUtil.readValue(PatchOp.class, json);
+	}
+
+	public static PatchOp unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(PatchOp.class, json);
+	}
+
+	@Schema
+	@Valid
+	public Operation[] getOperations() {
+		if (_OperationsSupplier != null) {
+			Operations = _OperationsSupplier.get();
+
+			_OperationsSupplier = null;
+		}
+
+		return Operations;
+	}
+
+	public void setOperations(Operation[] Operations) {
+		this.Operations = Operations;
+
+		_OperationsSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setOperations(
+		UnsafeSupplier<Operation[], Exception> OperationsUnsafeSupplier) {
+
+		_OperationsSupplier = () -> {
+			try {
+				return OperationsUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Operation[] Operations;
+
+	@JsonIgnore
+	private Supplier<Operation[]> _OperationsSupplier;
+
+	@Schema(description = "the schema associated to this operation")
+	public String[] getSchemas() {
+		if (_schemasSupplier != null) {
+			schemas = _schemasSupplier.get();
+
+			_schemasSupplier = null;
+		}
+
+		return schemas;
+	}
+
+	public void setSchemas(String[] schemas) {
+		this.schemas = schemas;
+
+		_schemasSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setSchemas(
+		UnsafeSupplier<String[], Exception> schemasUnsafeSupplier) {
+
+		_schemasSupplier = () -> {
+			try {
+				return schemasUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(description = "the schema associated to this operation")
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String[] schemas;
+
+	@JsonIgnore
+	private Supplier<String[]> _schemasSupplier;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof PatchOp)) {
+			return false;
+		}
+
+		PatchOp patchOp = (PatchOp)object;
+
+		return Objects.equals(toString(), patchOp.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		Operation[] Operations = getOperations();
+
+		if (Operations != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"Operations\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < Operations.length; i++) {
+				sb.append(String.valueOf(Operations[i]));
+
+				if ((i + 1) < Operations.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		String[] schemas = getSchemas();
+
+		if (schemas != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"schemas\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < schemas.length; i++) {
+				sb.append("\"");
+
+				sb.append(_escape(schemas[i]));
+
+				sb.append("\"");
+
+				if ((i + 1) < schemas.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@Schema(
+		accessMode = Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.scim.rest.dto.v1_0.PatchOp",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof Map) {
+						sb.append(_toJSON((Map<String, ?>)valueArray[i]));
+					}
+					else if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+	private Map<String, Serializable> _extendedProperties;
+
+}

--- a/modules/dxp/apps/scim/scim-rest-api/src/main/java/com/liferay/scim/rest/resource/v1_0/GroupResource.java
+++ b/modules/dxp/apps/scim/scim-rest-api/src/main/java/com/liferay/scim/rest/resource/v1_0/GroupResource.java
@@ -46,7 +46,7 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface GroupResource {
 
-	public Object getV2Groups(Integer count, Integer startIndex)
+	public Object getV2Groups(Integer count, Integer startIndex, Filter filter)
 		throws Exception;
 
 	public Response postV2Group(Group group) throws Exception;

--- a/modules/dxp/apps/scim/scim-rest-api/src/main/java/com/liferay/scim/rest/resource/v1_0/UserResource.java
+++ b/modules/dxp/apps/scim/scim-rest-api/src/main/java/com/liferay/scim/rest/resource/v1_0/UserResource.java
@@ -45,7 +45,7 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface UserResource {
 
-	public Object getV2Users(Integer count, Integer startIndex)
+	public Object getV2Users(Integer count, Integer startIndex, Filter filter)
 		throws Exception;
 
 	public Response postV2User(User user) throws Exception;

--- a/modules/dxp/apps/scim/scim-rest-api/src/main/java/com/liferay/scim/rest/resource/v1_0/UserResource.java
+++ b/modules/dxp/apps/scim/scim-rest-api/src/main/java/com/liferay/scim/rest/resource/v1_0/UserResource.java
@@ -15,6 +15,7 @@ import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.scim.rest.dto.v1_0.PatchOp;
 import com.liferay.scim.rest.dto.v1_0.QueryAttributes;
 import com.liferay.scim.rest.dto.v1_0.User;
 
@@ -56,6 +57,8 @@ public interface UserResource {
 	public Response deleteV2User(String id) throws Exception;
 
 	public Object getV2UserById(String id) throws Exception;
+
+	public Response patchV2User(String id, PatchOp patchOp) throws Exception;
 
 	public Response putV2User(String id, User user) throws Exception;
 

--- a/modules/dxp/apps/scim/scim-rest-api/src/main/resources/com/liferay/scim/rest/dto/v1_0/packageinfo
+++ b/modules/dxp/apps/scim/scim-rest-api/src/main/resources/com/liferay/scim/rest/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 2.3.0
+version 2.4.0

--- a/modules/dxp/apps/scim/scim-rest-api/src/main/resources/com/liferay/scim/rest/resource/v1_0/packageinfo
+++ b/modules/dxp/apps/scim/scim-rest-api/src/main/resources/com/liferay/scim/rest/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 3.0.0

--- a/modules/dxp/apps/scim/scim-rest-client/src/main/java/com/liferay/scim/rest/client/dto/v1_0/Operation.java
+++ b/modules/dxp/apps/scim/scim-rest-client/src/main/java/com/liferay/scim/rest/client/dto/v1_0/Operation.java
@@ -1,0 +1,118 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.scim.rest.client.dto.v1_0;
+
+import com.liferay.scim.rest.client.function.UnsafeSupplier;
+import com.liferay.scim.rest.client.serdes.v1_0.OperationSerDes;
+
+import java.io.Serializable;
+
+import java.util.Objects;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Olivér Kecskeméty
+ * @generated
+ */
+@Generated("")
+public class Operation implements Cloneable, Serializable {
+
+	public static Operation toDTO(String json) {
+		return OperationSerDes.toDTO(json);
+	}
+
+	public String getOp() {
+		return op;
+	}
+
+	public void setOp(String op) {
+		this.op = op;
+	}
+
+	public void setOp(UnsafeSupplier<String, Exception> opUnsafeSupplier) {
+		try {
+			op = opUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String op;
+
+	public String getPath() {
+		return path;
+	}
+
+	public void setPath(String path) {
+		this.path = path;
+	}
+
+	public void setPath(UnsafeSupplier<String, Exception> pathUnsafeSupplier) {
+		try {
+			path = pathUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String path;
+
+	public Object getValue() {
+		return value;
+	}
+
+	public void setValue(Object value) {
+		this.value = value;
+	}
+
+	public void setValue(
+		UnsafeSupplier<Object, Exception> valueUnsafeSupplier) {
+
+		try {
+			value = valueUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Object value;
+
+	@Override
+	public Operation clone() throws CloneNotSupportedException {
+		return (Operation)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof Operation)) {
+			return false;
+		}
+
+		Operation operation = (Operation)object;
+
+		return Objects.equals(toString(), operation.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return OperationSerDes.toJSON(this);
+	}
+
+}

--- a/modules/dxp/apps/scim/scim-rest-client/src/main/java/com/liferay/scim/rest/client/dto/v1_0/PatchOp.java
+++ b/modules/dxp/apps/scim/scim-rest-client/src/main/java/com/liferay/scim/rest/client/dto/v1_0/PatchOp.java
@@ -1,0 +1,101 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.scim.rest.client.dto.v1_0;
+
+import com.liferay.scim.rest.client.function.UnsafeSupplier;
+import com.liferay.scim.rest.client.serdes.v1_0.PatchOpSerDes;
+
+import java.io.Serializable;
+
+import java.util.Objects;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Olivér Kecskeméty
+ * @generated
+ */
+@Generated("")
+public class PatchOp implements Cloneable, Serializable {
+
+	public static PatchOp toDTO(String json) {
+		return PatchOpSerDes.toDTO(json);
+	}
+
+	public Operation[] getOperations() {
+		return Operations;
+	}
+
+	public void setOperations(Operation[] Operations) {
+		this.Operations = Operations;
+	}
+
+	public void setOperations(
+		UnsafeSupplier<Operation[], Exception> OperationsUnsafeSupplier) {
+
+		try {
+			Operations = OperationsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Operation[] Operations;
+
+	public String[] getSchemas() {
+		return schemas;
+	}
+
+	public void setSchemas(String[] schemas) {
+		this.schemas = schemas;
+	}
+
+	public void setSchemas(
+		UnsafeSupplier<String[], Exception> schemasUnsafeSupplier) {
+
+		try {
+			schemas = schemasUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String[] schemas;
+
+	@Override
+	public PatchOp clone() throws CloneNotSupportedException {
+		return (PatchOp)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof PatchOp)) {
+			return false;
+		}
+
+		PatchOp patchOp = (PatchOp)object;
+
+		return Objects.equals(toString(), patchOp.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return PatchOpSerDes.toJSON(this);
+	}
+
+}

--- a/modules/dxp/apps/scim/scim-rest-client/src/main/java/com/liferay/scim/rest/client/resource/v1_0/GroupResource.java
+++ b/modules/dxp/apps/scim/scim-rest-client/src/main/java/com/liferay/scim/rest/client/resource/v1_0/GroupResource.java
@@ -32,11 +32,12 @@ public interface GroupResource {
 		return new Builder();
 	}
 
-	public Object getV2Groups(Integer count, Integer startIndex)
+	public Object getV2Groups(
+			Integer count, Integer startIndex, String filterString)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse getV2GroupsHttpResponse(
-			Integer count, Integer startIndex)
+			Integer count, Integer startIndex, String filterString)
 		throws Exception;
 
 	public void postV2Group(Group group) throws Exception;
@@ -175,11 +176,12 @@ public interface GroupResource {
 
 	public static class GroupResourceImpl implements GroupResource {
 
-		public Object getV2Groups(Integer count, Integer startIndex)
+		public Object getV2Groups(
+				Integer count, Integer startIndex, String filterString)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse = getV2GroupsHttpResponse(
-				count, startIndex);
+				count, startIndex, filterString);
 
 			String content = httpResponse.getContent();
 
@@ -241,7 +243,7 @@ public interface GroupResource {
 		}
 
 		public HttpInvoker.HttpResponse getV2GroupsHttpResponse(
-				Integer count, Integer startIndex)
+				Integer count, Integer startIndex, String filterString)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -271,6 +273,10 @@ public interface GroupResource {
 
 			if (startIndex != null) {
 				httpInvoker.parameter("startIndex", String.valueOf(startIndex));
+			}
+
+			if (filterString != null) {
+				httpInvoker.parameter("filter", filterString);
 			}
 
 			httpInvoker.path(

--- a/modules/dxp/apps/scim/scim-rest-client/src/main/java/com/liferay/scim/rest/client/resource/v1_0/UserResource.java
+++ b/modules/dxp/apps/scim/scim-rest-client/src/main/java/com/liferay/scim/rest/client/resource/v1_0/UserResource.java
@@ -32,11 +32,12 @@ public interface UserResource {
 		return new Builder();
 	}
 
-	public Object getV2Users(Integer count, Integer startIndex)
+	public Object getV2Users(
+			Integer count, Integer startIndex, String filterString)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse getV2UsersHttpResponse(
-			Integer count, Integer startIndex)
+			Integer count, Integer startIndex, String filterString)
 		throws Exception;
 
 	public void postV2User(User user) throws Exception;
@@ -174,11 +175,12 @@ public interface UserResource {
 
 	public static class UserResourceImpl implements UserResource {
 
-		public Object getV2Users(Integer count, Integer startIndex)
+		public Object getV2Users(
+				Integer count, Integer startIndex, String filterString)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse = getV2UsersHttpResponse(
-				count, startIndex);
+				count, startIndex, filterString);
 
 			String content = httpResponse.getContent();
 
@@ -240,7 +242,7 @@ public interface UserResource {
 		}
 
 		public HttpInvoker.HttpResponse getV2UsersHttpResponse(
-				Integer count, Integer startIndex)
+				Integer count, Integer startIndex, String filterString)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -270,6 +272,10 @@ public interface UserResource {
 
 			if (startIndex != null) {
 				httpInvoker.parameter("startIndex", String.valueOf(startIndex));
+			}
+
+			if (filterString != null) {
+				httpInvoker.parameter("filter", filterString);
 			}
 
 			httpInvoker.path(

--- a/modules/dxp/apps/scim/scim-rest-client/src/main/java/com/liferay/scim/rest/client/resource/v1_0/UserResource.java
+++ b/modules/dxp/apps/scim/scim-rest-client/src/main/java/com/liferay/scim/rest/client/resource/v1_0/UserResource.java
@@ -5,6 +5,7 @@
 
 package com.liferay.scim.rest.client.resource.v1_0;
 
+import com.liferay.scim.rest.client.dto.v1_0.PatchOp;
 import com.liferay.scim.rest.client.dto.v1_0.QueryAttributes;
 import com.liferay.scim.rest.client.dto.v1_0.User;
 import com.liferay.scim.rest.client.http.HttpInvoker;
@@ -60,6 +61,12 @@ public interface UserResource {
 	public Object getV2UserById(String id) throws Exception;
 
 	public HttpInvoker.HttpResponse getV2UserByIdHttpResponse(String id)
+		throws Exception;
+
+	public void patchV2User(String id, PatchOp patchOp) throws Exception;
+
+	public HttpInvoker.HttpResponse patchV2UserHttpResponse(
+			String id, PatchOp patchOp)
 		throws Exception;
 
 	public void putV2User(String id, User user) throws Exception;
@@ -654,6 +661,100 @@ public interface UserResource {
 			}
 
 			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/scim/v1.0/v2/Users/{id}");
+
+			httpInvoker.path("id", id);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public void patchV2User(String id, PatchOp patchOp) throws Exception {
+			HttpInvoker.HttpResponse httpResponse = patchV2UserHttpResponse(
+				id, patchOp);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+		}
+
+		public HttpInvoker.HttpResponse patchV2UserHttpResponse(
+				String id, PatchOp patchOp)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(patchOp.toString(), "application/scim+json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.PATCH);
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +

--- a/modules/dxp/apps/scim/scim-rest-client/src/main/java/com/liferay/scim/rest/client/serdes/v1_0/OperationSerDes.java
+++ b/modules/dxp/apps/scim/scim-rest-client/src/main/java/com/liferay/scim/rest/client/serdes/v1_0/OperationSerDes.java
@@ -1,0 +1,257 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.scim.rest.client.serdes.v1_0;
+
+import com.liferay.scim.rest.client.dto.v1_0.Operation;
+import com.liferay.scim.rest.client.json.BaseJSONParser;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Olivér Kecskeméty
+ * @generated
+ */
+@Generated("")
+public class OperationSerDes {
+
+	public static Operation toDTO(String json) {
+		OperationJSONParser operationJSONParser = new OperationJSONParser();
+
+		return operationJSONParser.parseToDTO(json);
+	}
+
+	public static Operation[] toDTOs(String json) {
+		OperationJSONParser operationJSONParser = new OperationJSONParser();
+
+		return operationJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(Operation operation) {
+		if (operation == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		if (operation.getOp() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"op\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(operation.getOp()));
+
+			sb.append("\"");
+		}
+
+		if (operation.getPath() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"path\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(operation.getPath()));
+
+			sb.append("\"");
+		}
+
+		if (operation.getValue() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"value\": ");
+
+			if (operation.getValue() instanceof String) {
+				sb.append("\"");
+				sb.append((String)operation.getValue());
+				sb.append("\"");
+			}
+			else {
+				sb.append(operation.getValue());
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		OperationJSONParser operationJSONParser = new OperationJSONParser();
+
+		return operationJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(Operation operation) {
+		if (operation == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		if (operation.getOp() == null) {
+			map.put("op", null);
+		}
+		else {
+			map.put("op", String.valueOf(operation.getOp()));
+		}
+
+		if (operation.getPath() == null) {
+			map.put("path", null);
+		}
+		else {
+			map.put("path", String.valueOf(operation.getPath()));
+		}
+
+		if (operation.getValue() == null) {
+			map.put("value", null);
+		}
+		else {
+			map.put("value", String.valueOf(operation.getValue()));
+		}
+
+		return map;
+	}
+
+	public static class OperationJSONParser extends BaseJSONParser<Operation> {
+
+		@Override
+		protected Operation createDTO() {
+			return new Operation();
+		}
+
+		@Override
+		protected Operation[] createDTOArray(int size) {
+			return new Operation[size];
+		}
+
+		@Override
+		protected boolean parseMaps(String jsonParserFieldName) {
+			if (Objects.equals(jsonParserFieldName, "op")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "path")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "value")) {
+				return false;
+			}
+
+			return false;
+		}
+
+		@Override
+		protected void setField(
+			Operation operation, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "op")) {
+				if (jsonParserFieldValue != null) {
+					operation.setOp((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "path")) {
+				if (jsonParserFieldValue != null) {
+					operation.setPath((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "value")) {
+				if (jsonParserFieldValue != null) {
+					operation.setValue((Object)jsonParserFieldValue);
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			sb.append(_toJSON(value));
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static String _toJSON(Object value) {
+		if (value instanceof Map) {
+			return _toJSON((Map)value);
+		}
+
+		Class<?> clazz = value.getClass();
+
+		if (clazz.isArray()) {
+			StringBuilder sb = new StringBuilder("[");
+
+			Object[] values = (Object[])value;
+
+			for (int i = 0; i < values.length; i++) {
+				sb.append(_toJSON(values[i]));
+
+				if ((i + 1) < values.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+
+			return sb.toString();
+		}
+
+		if (value instanceof String) {
+			return "\"" + _escape(value) + "\"";
+		}
+
+		return String.valueOf(value);
+	}
+
+}

--- a/modules/dxp/apps/scim/scim-rest-client/src/main/java/com/liferay/scim/rest/client/serdes/v1_0/PatchOpSerDes.java
+++ b/modules/dxp/apps/scim/scim-rest-client/src/main/java/com/liferay/scim/rest/client/serdes/v1_0/PatchOpSerDes.java
@@ -1,0 +1,250 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.scim.rest.client.serdes.v1_0;
+
+import com.liferay.scim.rest.client.dto.v1_0.Operation;
+import com.liferay.scim.rest.client.dto.v1_0.PatchOp;
+import com.liferay.scim.rest.client.json.BaseJSONParser;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Olivér Kecskeméty
+ * @generated
+ */
+@Generated("")
+public class PatchOpSerDes {
+
+	public static PatchOp toDTO(String json) {
+		PatchOpJSONParser patchOpJSONParser = new PatchOpJSONParser();
+
+		return patchOpJSONParser.parseToDTO(json);
+	}
+
+	public static PatchOp[] toDTOs(String json) {
+		PatchOpJSONParser patchOpJSONParser = new PatchOpJSONParser();
+
+		return patchOpJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(PatchOp patchOp) {
+		if (patchOp == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		if (patchOp.getOperations() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"Operations\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < patchOp.getOperations().length; i++) {
+				sb.append(String.valueOf(patchOp.getOperations()[i]));
+
+				if ((i + 1) < patchOp.getOperations().length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		if (patchOp.getSchemas() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"schemas\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < patchOp.getSchemas().length; i++) {
+				sb.append(_toJSON(patchOp.getSchemas()[i]));
+
+				if ((i + 1) < patchOp.getSchemas().length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		PatchOpJSONParser patchOpJSONParser = new PatchOpJSONParser();
+
+		return patchOpJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(PatchOp patchOp) {
+		if (patchOp == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		if (patchOp.getOperations() == null) {
+			map.put("Operations", null);
+		}
+		else {
+			map.put("Operations", String.valueOf(patchOp.getOperations()));
+		}
+
+		if (patchOp.getSchemas() == null) {
+			map.put("schemas", null);
+		}
+		else {
+			map.put("schemas", String.valueOf(patchOp.getSchemas()));
+		}
+
+		return map;
+	}
+
+	public static class PatchOpJSONParser extends BaseJSONParser<PatchOp> {
+
+		@Override
+		protected PatchOp createDTO() {
+			return new PatchOp();
+		}
+
+		@Override
+		protected PatchOp[] createDTOArray(int size) {
+			return new PatchOp[size];
+		}
+
+		@Override
+		protected boolean parseMaps(String jsonParserFieldName) {
+			if (Objects.equals(jsonParserFieldName, "Operations")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "schemas")) {
+				return false;
+			}
+
+			return false;
+		}
+
+		@Override
+		protected void setField(
+			PatchOp patchOp, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "Operations")) {
+				if (jsonParserFieldValue != null) {
+					Object[] jsonParserFieldValues =
+						(Object[])jsonParserFieldValue;
+
+					Operation[] OperationsArray =
+						new Operation[jsonParserFieldValues.length];
+
+					for (int i = 0; i < OperationsArray.length; i++) {
+						OperationsArray[i] = OperationSerDes.toDTO(
+							(String)jsonParserFieldValues[i]);
+					}
+
+					patchOp.setOperations(OperationsArray);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "schemas")) {
+				if (jsonParserFieldValue != null) {
+					patchOp.setSchemas(
+						toStrings((Object[])jsonParserFieldValue));
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			sb.append(_toJSON(value));
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static String _toJSON(Object value) {
+		if (value instanceof Map) {
+			return _toJSON((Map)value);
+		}
+
+		Class<?> clazz = value.getClass();
+
+		if (clazz.isArray()) {
+			StringBuilder sb = new StringBuilder("[");
+
+			Object[] values = (Object[])value;
+
+			for (int i = 0; i < values.length; i++) {
+				sb.append(_toJSON(values[i]));
+
+				if ((i + 1) < values.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+
+			return sb.toString();
+		}
+
+		if (value instanceof String) {
+			return "\"" + _escape(value) + "\"";
+		}
+
+		return String.valueOf(value);
+	}
+
+}

--- a/modules/dxp/apps/scim/scim-rest-impl/rest-openapi.yaml
+++ b/modules/dxp/apps/scim/scim-rest-impl/rest-openapi.yaml
@@ -487,6 +487,10 @@ paths:
                   schema:
                       type: integer
                 - in: query
+                  name: filter
+                  schema:
+                      type: string
+                - in: query
                   name: startIndex
                   schema:
                       type: integer

--- a/modules/dxp/apps/scim/scim-rest-impl/rest-openapi.yaml
+++ b/modules/dxp/apps/scim/scim-rest-impl/rest-openapi.yaml
@@ -93,6 +93,40 @@ components:
                         The attribute's significant value, e.g., email address, phone number.
                     type: string
             type: object
+        Operation:
+            properties:
+                op:
+                    description:
+                        The method that should be used in the operation. Possible values add remove replace
+                    pattern: "^[Aa][dd]|[Rr][emove]|[Rr][eplace]$"
+                    type: string
+                path:
+                    description:
+                        Add the path to specify the attribute/sub-attribute that should be updated.
+                    type: string
+                value:
+                    description:
+                        The value that should be updated.
+                    oneOf:
+                        - type: boolean
+                        - type: integer
+                        - type: number
+                        - type: string
+            type: object
+        PatchOp:
+            properties:
+                Operations:
+                    items:
+                        $ref: "#/components/schemas/Operation"
+                    type: array
+                schemas:
+                    description:
+                        the schema associated to this operation
+                    items:
+                        enum: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"]
+                        type: string
+                    type: array
+            type: object
         QueryAttributes:
             properties:
                 attributes:
@@ -592,6 +626,33 @@ paths:
                     description:
                         If the resource exists, the server responds with HTTP status code 200 (OK) and includes the
                         result in the body of the response.
+            tags: ["User"]
+        patch:
+            description:
+                Updates a user.
+            operationId: patchV2User
+            parameters:
+                - in: path
+                  name: id
+                  required: true
+                  schema:
+                      type: string
+            requestBody:
+                content:
+                    application/scim+json:
+                        schema:
+                            $ref: "#/components/schemas/PatchOp"
+            responses:
+                200:
+                    content:
+                        application/scim+json:
+                            schema:
+                                oneOf:
+                                    - format: binary
+                                      type: string
+                                    - $ref: "#/components/schemas/User"
+                    description:
+                        The User was successfully updated.
             tags: ["User"]
         put:
             description:

--- a/modules/dxp/apps/scim/scim-rest-impl/rest-openapi.yaml
+++ b/modules/dxp/apps/scim/scim-rest-impl/rest-openapi.yaml
@@ -351,6 +351,10 @@ paths:
                   schema:
                       type: integer
                 - in: query
+                  name: filter
+                  schema:
+                      type: string
+                - in: query
                   name: startIndex
                   schema:
                       type: integer

--- a/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/manager/UserManagerImpl.java
+++ b/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/manager/UserManagerImpl.java
@@ -983,9 +983,14 @@ public class UserManagerImpl implements UserManager {
 			portalUser = _userLocalService.updateUser(portalUser);
 		}
 
-		if (!portalUser.isActive()) {
+		if (!portalUser.isActive() && scimUser.isActive()) {
 			portalUser = _userLocalService.updateStatus(
 				portalUser, WorkflowConstants.STATUS_APPROVED,
+				new ServiceContext());
+		}
+		else if (!scimUser.isActive() && portalUser.isActive()) {
+			portalUser = _userLocalService.updateStatus(
+				portalUser, WorkflowConstants.STATUS_INACTIVE,
 				new ServiceContext());
 		}
 

--- a/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/manager/UserManagerImpl.java
+++ b/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/manager/UserManagerImpl.java
@@ -25,7 +25,6 @@ import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Contact;
 import com.liferay.portal.kernel.model.UserGroup;
 import com.liferay.portal.kernel.search.Field;
-import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
@@ -295,12 +294,16 @@ public class UserManagerImpl implements UserManager {
 
 					ExpressionNode expressionNode = (ExpressionNode)node;
 
-					if (expressionNode != null) {
-						if (expressionNode.getAttributeValue().contains("displayName")) {
-							searchContext.setAttribute(
-								"name", expressionNode.getValue());
-						}
+					if ((expressionNode != null) &&
+						expressionNode.getAttributeValue(
+						).contains(
+							"displayName"
+						)) {
+
+						searchContext.setAttribute(
+							"name", expressionNode.getValue());
 					}
+
 					searchContext.setUserId(serviceContext.getUserId());
 				}
 			).build();
@@ -386,11 +389,21 @@ public class UserManagerImpl implements UserManager {
 					ExpressionNode expressionNode = (ExpressionNode)node;
 
 					if (expressionNode != null) {
-						if (expressionNode.getAttributeValue().contains("externalId")) {
+						if (expressionNode.getAttributeValue(
+							).contains(
+								"externalId"
+							)) {
+
 							searchContext.setAttribute(
-								"externalReferenceCode", expressionNode.getValue());
+								"externalReferenceCode",
+								expressionNode.getValue());
 						}
-						if (expressionNode.getAttributeValue().contains("userName")) {
+
+						if (expressionNode.getAttributeValue(
+							).contains(
+								"userName"
+							)) {
+
 							searchContext.setAttribute(
 								"screenName", expressionNode.getValue());
 						}

--- a/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/manager/UserManagerImpl.java
+++ b/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/manager/UserManagerImpl.java
@@ -287,10 +287,20 @@ public class UserManagerImpl implements UserManager {
 				count
 			).withSearchContext(
 				searchContext -> {
+					searchContext.setAndSearch(true);
 					searchContext.setAttribute(Field.GROUP_ID, 0L);
 					searchContext.setAttribute(
 						"expando__keyword__custom_fields__scimClientId",
 						scimClientId);
+
+					ExpressionNode expressionNode = (ExpressionNode)node;
+
+					if (expressionNode != null) {
+						if (expressionNode.getAttributeValue().contains("displayName")) {
+							searchContext.setAttribute(
+								"name", expressionNode.getValue());
+						}
+					}
 					searchContext.setUserId(serviceContext.getUserId());
 				}
 			).build();

--- a/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/manager/UserManagerImpl.java
+++ b/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/manager/UserManagerImpl.java
@@ -41,6 +41,7 @@ import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -295,10 +296,9 @@ public class UserManagerImpl implements UserManager {
 					ExpressionNode expressionNode = (ExpressionNode)node;
 
 					if ((expressionNode != null) &&
-						expressionNode.getAttributeValue(
-						).contains(
-							"displayName"
-						)) {
+						StringUtil.contains(
+							expressionNode.getAttributeValue(), "displayName",
+							StringPool.COLON)) {
 
 						searchContext.setAttribute(
 							"name", expressionNode.getValue());
@@ -389,20 +389,17 @@ public class UserManagerImpl implements UserManager {
 					ExpressionNode expressionNode = (ExpressionNode)node;
 
 					if (expressionNode != null) {
-						if (expressionNode.getAttributeValue(
-							).contains(
-								"externalId"
-							)) {
+						String value = expressionNode.getAttributeValue();
+
+						if (StringUtil.contains(
+								value, "externalId", StringPool.COLON)) {
 
 							searchContext.setAttribute(
 								"externalReferenceCode",
 								expressionNode.getValue());
 						}
-
-						if (expressionNode.getAttributeValue(
-							).contains(
-								"userName"
-							)) {
+						else if (StringUtil.contains(
+									value, "userName", StringPool.COLON)) {
 
 							searchContext.setAttribute(
 								"screenName", expressionNode.getValue());

--- a/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/manager/UserManagerImpl.java
+++ b/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/manager/UserManagerImpl.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Contact;
 import com.liferay.portal.kernel.model.UserGroup;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
@@ -73,6 +74,7 @@ import org.wso2.charon3.core.objects.Group;
 import org.wso2.charon3.core.objects.User;
 import org.wso2.charon3.core.objects.plainobjects.GroupsGetResponse;
 import org.wso2.charon3.core.objects.plainobjects.UsersGetResponse;
+import org.wso2.charon3.core.utils.codeutils.ExpressionNode;
 import org.wso2.charon3.core.utils.codeutils.Node;
 import org.wso2.charon3.core.utils.codeutils.SearchRequest;
 
@@ -363,12 +365,27 @@ public class UserManagerImpl implements UserManager {
 				count
 			).withSearchContext(
 				searchContext -> {
+					searchContext.setAndSearch(true);
 					searchContext.setAttribute(Field.GROUP_ID, 0L);
 					searchContext.setAttribute(
 						Field.STATUS, WorkflowConstants.STATUS_APPROVED);
 					searchContext.setAttribute(
 						"expando__keyword__custom_fields__scimClientId",
 						scimClientId);
+
+					ExpressionNode expressionNode = (ExpressionNode)node;
+
+					if (expressionNode != null) {
+						if (expressionNode.getAttributeValue().contains("externalId")) {
+							searchContext.setAttribute(
+								"externalReferenceCode", expressionNode.getValue());
+						}
+						if (expressionNode.getAttributeValue().contains("userName")) {
+							searchContext.setAttribute(
+								"screenName", expressionNode.getValue());
+						}
+					}
+
 					searchContext.setUserId(serviceContext.getUserId());
 				}
 			).build();

--- a/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/manager/UserResourceManagerImpl.java
+++ b/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/manager/UserResourceManagerImpl.java
@@ -50,6 +50,26 @@ public class UserResourceManagerImpl extends UserResourceManager {
 	}
 
 	@Override
+	public SCIMResponse updateWithPATCH(
+		String existingId, String scimObjectString, UserManager userManager,
+		String attributes, String excludeAttributes) {
+
+		try {
+			return super.updateWithPATCH(
+				existingId, scimObjectString, userManager, attributes,
+				excludeAttributes);
+		}
+		catch (Exception exception) {
+			if (exception instanceof ConflictException) {
+				return AbstractResourceManager.encodeSCIMException(
+					(ConflictException)exception);
+			}
+
+			throw exception;
+		}
+	}
+
+	@Override
 	public SCIMResponse updateWithPUT(
 		String existingId, String scimObjectString, UserManager userManager,
 		String attributes, String excludeAttributes) {

--- a/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/resource/v1_0/BaseGroupResourceImpl.java
+++ b/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/resource/v1_0/BaseGroupResourceImpl.java
@@ -58,6 +58,10 @@ public abstract class BaseGroupResourceImpl implements GroupResource {
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "filter"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "startIndex"
 			)
 		}
@@ -75,7 +79,8 @@ public abstract class BaseGroupResourceImpl implements GroupResource {
 			Integer count,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.ws.rs.QueryParam("startIndex")
-			Integer startIndex)
+			Integer startIndex,
+			@javax.ws.rs.core.Context Filter filter)
 		throws Exception {
 
 		return null;

--- a/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/resource/v1_0/BaseGroupResourceImpl.java
+++ b/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/resource/v1_0/BaseGroupResourceImpl.java
@@ -20,6 +20,7 @@ import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.scim.rest.dto.v1_0.Group;
+import com.liferay.scim.rest.dto.v1_0.Operation;
 import com.liferay.scim.rest.dto.v1_0.QueryAttributes;
 import com.liferay.scim.rest.dto.v1_0.User;
 import com.liferay.scim.rest.resource.v1_0.GroupResource;

--- a/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/resource/v1_0/BaseUserResourceImpl.java
+++ b/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/resource/v1_0/BaseUserResourceImpl.java
@@ -57,6 +57,10 @@ public abstract class BaseUserResourceImpl implements UserResource {
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "filter"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "startIndex"
 			)
 		}
@@ -74,7 +78,8 @@ public abstract class BaseUserResourceImpl implements UserResource {
 			Integer count,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@javax.ws.rs.QueryParam("startIndex")
-			Integer startIndex)
+			Integer startIndex,
+			@javax.ws.rs.core.Context Filter filter)
 		throws Exception {
 
 		return null;

--- a/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/resource/v1_0/BaseUserResourceImpl.java
+++ b/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/resource/v1_0/BaseUserResourceImpl.java
@@ -19,6 +19,8 @@ import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.util.ActionUtil;
+import com.liferay.scim.rest.dto.v1_0.Operation;
+import com.liferay.scim.rest.dto.v1_0.PatchOp;
 import com.liferay.scim.rest.dto.v1_0.QueryAttributes;
 import com.liferay.scim.rest.dto.v1_0.User;
 import com.liferay.scim.rest.resource.v1_0.UserResource;
@@ -186,6 +188,40 @@ public abstract class BaseUserResourceImpl implements UserResource {
 		throws Exception {
 
 		return null;
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'PATCH' 'http://localhost:8080/o/scim/v1.0/v2/Users/{id}' -d $'{"Operations": ___, "schemas": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(description = "Updates a user.")
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "id"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "User")}
+	)
+	@javax.ws.rs.Consumes("application/scim+json")
+	@javax.ws.rs.PATCH
+	@javax.ws.rs.Path("/v2/Users/{id}")
+	@javax.ws.rs.Produces("application/scim+json")
+	@Override
+	public Response patchV2User(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull @javax.ws.rs.PathParam("id")
+			String id,
+			PatchOp patchOp)
+		throws Exception {
+
+		Response.ResponseBuilder responseBuilder = Response.ok();
+
+		return responseBuilder.build();
 	}
 
 	/**

--- a/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/resource/v1_0/GroupResourceImpl.java
+++ b/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/resource/v1_0/GroupResourceImpl.java
@@ -60,10 +60,11 @@ public class GroupResourceImpl extends BaseGroupResourceImpl {
 	@Override
 	public Object getV2Groups(Integer count, Integer startIndex, Filter filter)
 		throws Exception {
+
 		return _buildResponse(
 			_groupResourceManager.listWithGET(
-				_userManager, contextHttpServletRequest.getParameter("filter"), startIndex, count, null, null, null, null,
-				null));
+				_userManager, contextHttpServletRequest.getParameter("filter"),
+				startIndex, count, null, null, null, null, null));
 	}
 
 	@Override

--- a/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/resource/v1_0/GroupResourceImpl.java
+++ b/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/resource/v1_0/GroupResourceImpl.java
@@ -8,6 +8,7 @@ package com.liferay.scim.rest.internal.resource.v1_0;
 import com.liferay.expando.kernel.service.ExpandoColumnLocalService;
 import com.liferay.expando.kernel.service.ExpandoTableLocalService;
 import com.liferay.expando.kernel.service.ExpandoValueLocalService;
+import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.UserGroupLocalService;
@@ -57,12 +58,11 @@ public class GroupResourceImpl extends BaseGroupResourceImpl {
 	}
 
 	@Override
-	public Object getV2Groups(Integer count, Integer startIndex)
+	public Object getV2Groups(Integer count, Integer startIndex, Filter filter)
 		throws Exception {
-
 		return _buildResponse(
 			_groupResourceManager.listWithGET(
-				_userManager, null, startIndex, count, null, null, null, null,
+				_userManager, contextHttpServletRequest.getParameter("filter"), startIndex, count, null, null, null, null,
 				null));
 	}
 

--- a/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/resource/v1_0/GroupResourceImpl.java
+++ b/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/resource/v1_0/GroupResourceImpl.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.service.UserGroupService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.UserService;
 import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.searcher.Searcher;
 import com.liferay.scim.rest.dto.v1_0.Group;
@@ -63,7 +64,8 @@ public class GroupResourceImpl extends BaseGroupResourceImpl {
 
 		return _buildResponse(
 			_groupResourceManager.listWithGET(
-				_userManager, contextHttpServletRequest.getParameter("filter"),
+				_userManager,
+				ParamUtil.getString(contextHttpServletRequest, "filter", null),
 				startIndex, count, null, null, null, null, null));
 	}
 

--- a/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/resource/v1_0/UserResourceImpl.java
+++ b/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/resource/v1_0/UserResourceImpl.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.searcher.Searcher;
+import com.liferay.scim.rest.dto.v1_0.PatchOp;
 import com.liferay.scim.rest.dto.v1_0.User;
 import com.liferay.scim.rest.internal.manager.UserManagerImpl;
 import com.liferay.scim.rest.internal.manager.UserResourceManagerImpl;
@@ -67,6 +68,15 @@ public class UserResourceImpl extends BaseUserResourceImpl {
 				_userManager,
 				ParamUtil.getString(contextHttpServletRequest, "filter", null),
 				startIndex, count, null, null, null, null, null));
+	}
+
+	@Override
+	public Response patchV2User(String id, PatchOp operations)
+		throws Exception {
+
+		return _buildResponse(
+			_userResourceManager.updateWithPATCH(
+				id, operations.toString(), _userManager, null, null));
 	}
 
 	@Override

--- a/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/resource/v1_0/UserResourceImpl.java
+++ b/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/resource/v1_0/UserResourceImpl.java
@@ -8,6 +8,7 @@ package com.liferay.scim.rest.internal.resource.v1_0;
 import com.liferay.expando.kernel.service.ExpandoColumnLocalService;
 import com.liferay.expando.kernel.service.ExpandoTableLocalService;
 import com.liferay.expando.kernel.service.ExpandoValueLocalService;
+import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.UserGroupLocalService;
@@ -57,13 +58,13 @@ public class UserResourceImpl extends BaseUserResourceImpl {
 	}
 
 	@Override
-	public Object getV2Users(Integer count, Integer startIndex)
+	public Object getV2Users(Integer count, Integer startIndex, Filter filter)
 		throws Exception {
 
 		return _buildResponse(
 			_userResourceManager.listWithGET(
-				_userManager, null, startIndex, count, null, null, null, null,
-				null));
+				_userManager, contextHttpServletRequest.getParameter("filter"),
+				startIndex, count, null, null, null, null, null));
 	}
 
 	@Override

--- a/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/resource/v1_0/UserResourceImpl.java
+++ b/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/resource/v1_0/UserResourceImpl.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.service.UserGroupService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.UserService;
 import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.searcher.Searcher;
 import com.liferay.scim.rest.dto.v1_0.User;
@@ -63,7 +64,8 @@ public class UserResourceImpl extends BaseUserResourceImpl {
 
 		return _buildResponse(
 			_userResourceManager.listWithGET(
-				_userManager, contextHttpServletRequest.getParameter("filter"),
+				_userManager,
+				ParamUtil.getString(contextHttpServletRequest, "filter", null),
 				startIndex, count, null, null, null, null, null));
 	}
 

--- a/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/search/spi/model/query/contributor/ScimClientIdKeywordQueryContributor.java
+++ b/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/search/spi/model/query/contributor/ScimClientIdKeywordQueryContributor.java
@@ -34,6 +34,9 @@ public class ScimClientIdKeywordQueryContributor
 		queryHelper.addSearchTerm(
 			booleanQuery, keywordQueryContributorHelper.getSearchContext(),
 			"expando__keyword__custom_fields__scimClientId", false);
+		queryHelper.addSearchTerm(
+			booleanQuery, keywordQueryContributorHelper.getSearchContext(),
+			"externalReferenceCode", false);
 	}
 
 	@Reference

--- a/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/search/spi/model/query/contributor/ScimClientIdKeywordQueryContributor.java
+++ b/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/search/spi/model/query/contributor/ScimClientIdKeywordQueryContributor.java
@@ -37,6 +37,9 @@ public class ScimClientIdKeywordQueryContributor
 		queryHelper.addSearchTerm(
 			booleanQuery, keywordQueryContributorHelper.getSearchContext(),
 			"externalReferenceCode", false);
+		queryHelper.addSearchTerm(
+			booleanQuery, keywordQueryContributorHelper.getSearchContext(),
+			"name", false);
 	}
 
 	@Reference

--- a/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/util/ScimUtil.java
+++ b/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/util/ScimUtil.java
@@ -101,7 +101,7 @@ public class ScimUtil {
 
 		ScimUser scimUser = new ScimUser();
 
-		scimUser.setActive(user.getActive());
+		scimUser.setActive(_calculateActive(user));
 		scimUser.setAutoScreenName(
 			PrefsPropsUtil.getBoolean(
 				companyId, PropsKeys.USERS_SCREEN_NAME_ALWAYS_AUTOGENERATE));
@@ -175,7 +175,7 @@ public class ScimUtil {
 		user.replaceEmails(
 			Collections.singletonList(
 				new MultiValuedComplexType(
-					"default", true, null, scimUser.getEmailAddress(), null)));
+					"work", true, null, scimUser.getEmailAddress(), null)));
 
 		ScimName scimName = new ScimName();
 
@@ -220,6 +220,22 @@ public class ScimUtil {
 		user.setUserName(scimUser.getScreenName());
 
 		return user;
+	}
+
+	private static boolean _calculateActive(User user) {
+		try {
+			return user.getActive();
+		}
+		catch (ClassCastException classCastException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(classCastException);
+			}
+
+			SimpleAttribute attribute = (SimpleAttribute)user.getAttribute(
+				"active");
+
+			return Boolean.parseBoolean((String)attribute.getValue());
+		}
 	}
 
 	private static AttributeSchema _createAttributeSchema() {

--- a/modules/dxp/apps/scim/scim-rest-test/src/testIntegration/java/com/liferay/scim/rest/resource/v1_0/test/BaseUserResourceTestCase.java
+++ b/modules/dxp/apps/scim/scim-rest-test/src/testIntegration/java/com/liferay/scim/rest/resource/v1_0/test/BaseUserResourceTestCase.java
@@ -234,6 +234,11 @@ public abstract class BaseUserResourceTestCase {
 	}
 
 	@Test
+	public void testPatchV2User() throws Exception {
+		Assert.assertTrue(false);
+	}
+
+	@Test
 	public void testPutV2User() throws Exception {
 		Assert.assertTrue(false);
 	}

--- a/modules/dxp/apps/scim/scim-rest-test/src/testIntegration/java/com/liferay/scim/rest/resource/v1_0/test/GroupResourceTest.java
+++ b/modules/dxp/apps/scim/scim-rest-test/src/testIntegration/java/com/liferay/scim/rest/resource/v1_0/test/GroupResourceTest.java
@@ -167,7 +167,7 @@ public class GroupResourceTest extends BaseGroupResourceTestCase {
 			TestPropsValues.getUserId(), TestPropsValues.getCompanyId(),
 			RandomTestUtil.randomString(), null, new ServiceContext());
 
-		_assertListResponse(groupResource.getV2Groups(5, 0,null), 0, 0);
+		_assertListResponse(groupResource.getV2Groups(5, 0, null), 0, 0);
 
 		Group group1 = testDeleteV2Group_addGroup();
 		Group group2 = testDeleteV2Group_addGroup();
@@ -177,17 +177,24 @@ public class GroupResourceTest extends BaseGroupResourceTestCase {
 
 		Group group3 = testDeleteV2Group_addGroup();
 
-		_assertListResponse(groupResource.getV2Groups(5, 3, null), 3, 1, group3);
+		_assertListResponse(
+			groupResource.getV2Groups(5, 3, null), 3, 1, group3);
 
 		_assertListResponse(
-			groupResource.getV2Groups(5, 0, "displayName eq \""+ group1.getDisplayName()+"\""), 1, 1, group1);
+			groupResource.getV2Groups(
+				5, 0, "displayName eq \"" + group1.getDisplayName() + "\""),
+			1, 1, group1);
 
-		_assertListResponse(groupResource.getV2Groups(5, 0,"displayName eq +\""+RandomTestUtil.randomString()+"\""), 0, 0);
+		_assertListResponse(
+			groupResource.getV2Groups(
+				5, 0,
+				"displayName eq +\"" + RandomTestUtil.randomString() + "\""),
+			0, 0);
 
 		ConfigurationTestUtil.deleteConfiguration(_pid);
 
 		assertHttpResponseStatusCode(
-			404, groupResource.getV2GroupsHttpResponse(5, 0,null));
+			404, groupResource.getV2GroupsHttpResponse(5, 0, null));
 	}
 
 	@Override

--- a/modules/dxp/apps/scim/scim-rest-test/src/testIntegration/java/com/liferay/scim/rest/resource/v1_0/test/GroupResourceTest.java
+++ b/modules/dxp/apps/scim/scim-rest-test/src/testIntegration/java/com/liferay/scim/rest/resource/v1_0/test/GroupResourceTest.java
@@ -167,22 +167,27 @@ public class GroupResourceTest extends BaseGroupResourceTestCase {
 			TestPropsValues.getUserId(), TestPropsValues.getCompanyId(),
 			RandomTestUtil.randomString(), null, new ServiceContext());
 
-		_assertListResponse(groupResource.getV2Groups(5, 0), 0, 0);
+		_assertListResponse(groupResource.getV2Groups(5, 0,null), 0, 0);
 
 		Group group1 = testDeleteV2Group_addGroup();
 		Group group2 = testDeleteV2Group_addGroup();
 
 		_assertListResponse(
-			groupResource.getV2Groups(5, 0), 2, 2, group1, group2);
+			groupResource.getV2Groups(5, 0, null), 2, 2, group1, group2);
 
 		Group group3 = testDeleteV2Group_addGroup();
 
-		_assertListResponse(groupResource.getV2Groups(5, 3), 3, 1, group3);
+		_assertListResponse(groupResource.getV2Groups(5, 3, null), 3, 1, group3);
+
+		_assertListResponse(
+			groupResource.getV2Groups(5, 0, "displayName eq \""+ group1.getDisplayName()+"\""), 1, 1, group1);
+
+		_assertListResponse(groupResource.getV2Groups(5, 0,"displayName eq +\""+RandomTestUtil.randomString()+"\""), 0, 0);
 
 		ConfigurationTestUtil.deleteConfiguration(_pid);
 
 		assertHttpResponseStatusCode(
-			404, groupResource.getV2GroupsHttpResponse(5, 0));
+			404, groupResource.getV2GroupsHttpResponse(5, 0,null));
 	}
 
 	@Override

--- a/modules/dxp/apps/scim/scim-rest-test/src/testIntegration/java/com/liferay/scim/rest/resource/v1_0/test/UserResourceTest.java
+++ b/modules/dxp/apps/scim/scim-rest-test/src/testIntegration/java/com/liferay/scim/rest/resource/v1_0/test/UserResourceTest.java
@@ -169,17 +169,18 @@ public class UserResourceTest extends BaseUserResourceTestCase {
 	public void testGetV2Users() throws Exception {
 		UserTestUtil.addUser();
 
-		_assertListResponse(userResource.getV2Users(5, 0), 0, 0);
+		_assertListResponse(userResource.getV2Users(5, 0, null), 0, 0);
 
 		User user1 = testDeleteV2User_addUser();
 		User user2 = testDeleteV2User_addUser();
 
-		_assertListResponse(userResource.getV2Users(5, 0), 2, 2, user1, user2);
+		_assertListResponse(
+			userResource.getV2Users(5, 0, null), 2, 2, user1, user2);
 
 		User user3 = testDeleteV2User_addUser();
 
 		_assertListResponse(
-			userResource.getV2Users(5, 3), 3, 1, user1, user2, user3);
+			userResource.getV2Users(5, 3, null), 3, 1, user1, user2, user3);
 
 		long userId = GetterUtil.getLong(user3.getId());
 
@@ -191,12 +192,34 @@ public class UserResourceTest extends BaseUserResourceTestCase {
 
 		_reindexUser(userId);
 
-		_assertListResponse(userResource.getV2Users(5, 0), 2, 2, user1, user2);
+		_assertListResponse(
+			userResource.getV2Users(5, 0, null), 2, 2, user1, user2);
+
+		_assertListResponse(
+			userResource.getV2Users(
+				5, 0, "externalId eq \"" + user1.getExternalId() + "\""),
+			1, 1, user1);
+
+		_assertListResponse(
+			userResource.getV2Users(
+				5, 0,
+				"externalId eq \"" + RandomTestUtil.randomString() + "\""),
+			0, 0);
+
+		_assertListResponse(
+			userResource.getV2Users(
+				5, 0, "userName eq \"" + user1.getUserName() + "\""),
+			1, 1, user1);
+
+		_assertListResponse(
+			userResource.getV2Users(
+				5, 0, "userName eq \"" + RandomTestUtil.randomString() + "\""),
+			0, 0);
 
 		ConfigurationTestUtil.deleteConfiguration(_pid);
 
 		assertHttpResponseStatusCode(
-			404, userResource.getV2UsersHttpResponse(5, 0));
+			404, userResource.getV2UsersHttpResponse(5, 0, null));
 	}
 
 	@Override

--- a/modules/dxp/apps/scim/scim-rest-test/src/testIntegration/java/com/liferay/scim/rest/resource/v1_0/test/UserResourceTest.java
+++ b/modules/dxp/apps/scim/scim-rest-test/src/testIntegration/java/com/liferay/scim/rest/resource/v1_0/test/UserResourceTest.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -37,6 +38,8 @@ import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.scim.rest.client.dto.v1_0.MultiValuedAttribute;
 import com.liferay.scim.rest.client.dto.v1_0.Name;
+import com.liferay.scim.rest.client.dto.v1_0.Operation;
+import com.liferay.scim.rest.client.dto.v1_0.PatchOp;
 import com.liferay.scim.rest.client.dto.v1_0.User;
 import com.liferay.scim.rest.client.dto.v1_0.UserSchemaExtension;
 import com.liferay.scim.rest.client.http.HttpInvoker;
@@ -224,6 +227,62 @@ public class UserResourceTest extends BaseUserResourceTestCase {
 
 	@Override
 	@Test
+	@TestInfo("LPD-48895")
+	public void testPatchV2User() throws Exception {
+		User user1 = testDeleteV2User_addUser();
+
+		String newTitle = StringUtil.toLowerCase(RandomTestUtil.randomString());
+
+		Operation operation = new Operation();
+
+		operation.setOp("replace");
+		operation.setPath("title");
+		operation.setValue(newTitle);
+
+		PatchOp patchOperation = new PatchOp();
+
+		patchOperation.setOperations(new Operation[] {operation});
+		patchOperation.setSchemas(
+			new String[] {"\"urn:ietf:params:scim:api:messages:2.0:PatchOp\""});
+
+		HttpInvoker.HttpResponse httpResponse1 =
+			userResource.patchV2UserHttpResponse(user1.getId(), patchOperation);
+
+		assertHttpResponseStatusCode(200, httpResponse1);
+
+		User patchedUser1 = User.toDTO(httpResponse1.getContent());
+
+		assertValid(patchedUser1);
+
+		Assert.assertEquals(patchedUser1.getTitle(), newTitle);
+
+		operation.setOp("replace");
+		operation.setPath("active");
+		operation.setValue(false);
+
+		patchOperation.setOperations(new Operation[] {operation});
+
+		HttpInvoker.HttpResponse httpResponse2 =
+			userResource.patchV2UserHttpResponse(user1.getId(), patchOperation);
+
+		assertHttpResponseStatusCode(200, httpResponse2);
+
+		User patchedUser2 = User.toDTO(httpResponse2.getContent());
+
+		assertValid(patchedUser2);
+
+		Assert.assertEquals(patchedUser2.getActive(), false);
+
+		ConfigurationTestUtil.deleteConfiguration(_pid);
+
+		assertHttpResponseStatusCode(
+			404,
+			userResource.patchV2UserHttpResponse(
+				randomUser().getId(), patchOperation));
+	}
+
+	@Override
+	@Test
 	public void testPostV2User() throws Exception {
 		User postUser1 = randomUser();
 
@@ -397,7 +456,7 @@ public class UserResourceTest extends BaseUserResourceTestCase {
 				new MultiValuedAttribute() {
 					{
 						primary = true;
-						type = "default";
+						type = "work";
 						value = user.getUserName() + "@liferay.com";
 					}
 				}


### PR DESCRIPTION
- LPD-49009 [SCIM Users] enable filtering to getUsers endpoint
- LPD-49009 [SCIM Users] gw buildRest
- LPD-49009 [SCIM Users] retrieve filter param and perform search by externalId or userName
- LPD-49009 [SCIM User] add new test cases when retrieving users in getv2Users endpoint. Added filtering with null, by externalId or by userName values.
- LPD-49010 [SCIM Groups] enable filtering to getGroups endpoint
- LPD-49010 [SCIM Groups] gw buildRest
- LPD-49010 [SCIM Groups] retrieve filter param and perform search by displayName
- LPD-49010 [SCIM Groups] add new test cases when retrieving groups in getv2Groups endpoint. Added filtering with null or by displayName values
- LPD-49010 SF
- LPD-49009 use util classes and avoid chaining
- LPD-48995 [SCIM Users] add patch to Users endpoint
- LPD-48995 [SCIM Users] gw buildRest
- LPD-48895 [SCIM Users] add patch operations to *ResourceImpl
- LPD-48895 [SCIM Users] set mail as work instead of default, check active in two ways, because charon throws a ClassCast if the patch operation sends a string
- LPD-48995 [SCIM Users] deactivate portal user if the scim user is not active. This allow patch operations to disable users
- LPD-48895 [SCIM User] create test for patchV2User method
