### PR TITLE
LPD-47247 | Hide UI element from the Import screen: Delete Application Data Before Importing checkbox

### DIFF
--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/deletions/page.jsp
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/deletions/page.jsp
@@ -7,6 +7,10 @@
 
 <%@ include file="/deletions/init.jsp" %>
 
+<%
+StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHelper();
+%>
+
 <c:if test="<%= cmd.equals(Constants.EXPORT) || cmd.equals(Constants.IMPORT) || cmd.equals(Constants.PUBLISH) %>">
 	<div aria-labelledby="<portlet:namespace />deletions" class="options-group" role="group">
 		<clay:sheet-section>
@@ -14,7 +18,7 @@
 				<liferay-ui:message key="deletions" />
 			</span>
 
-			<c:if test="<%= !cmd.equals(Constants.EXPORT) %>">
+			<c:if test="<%= !cmd.equals(Constants.EXPORT) && !stagingGroupHelper.isCompanyGroup(group) %>">
 				<liferay-staging:checkbox
 					checked="<%= MapUtil.getBoolean(parameterMap, PortletDataHandlerKeys.DELETE_PORTLET_DATA, false) %>"
 					disabled="<%= disableInputs %>"

--- a/modules/test/playwright/tests/export-import-web/instance.import.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/instance.import.spec.ts
@@ -294,6 +294,10 @@ test('can see corresponding elements at instance level', async ({
 	await expect(
 		companyExportImportPage.page.getByText('Comments, Ratings')
 	).not.toBeVisible();
+
+	await expect(
+		companyExportImportPage.page.getByLabel('Delete Application Data')
+	).not.toBeVisible();
 });
 
 test('Can/not view Import menu item in Application menu depending on permissions', async ({

--- a/modules/test/playwright/tests/export-import-web/site.import.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/site.import.spec.ts
@@ -355,4 +355,8 @@ test('can see corresponding elements at site level', async ({
 	await expect(
 		exportImportPage.page.getByRole('group', {name: 'Pages'})
 	).toBeVisible();
+
+	await expect(
+		exportImportPage.page.getByLabel('Delete Application Data')
+	).toBeVisible();
 });


### PR DESCRIPTION
**Description:** We want to hide the Delete Application Data Before Importing checkbox for Instance level
**Jira Ticket:** https://liferay.atlassian.net/browse/LPD-47247
___
Instance Level:
![image](https://github.com/user-attachments/assets/1d4776ea-4cad-4766-aa45-5bdcbe64b2b7)

Site Level:
![image](https://github.com/user-attachments/assets/e165a284-ba54-4098-9035-b9cb1c6cabe2)