### PR TITLE
LPD-47250 | Hide UI element from the Import screen: Unused Import Strategies

### DIFF
--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/import/new_import/import_layouts_resources.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/import/new_import/import_layouts_resources.jsp
@@ -414,26 +414,44 @@ ManifestSummary manifestSummary = ExportImportHelperUtil.getManifestSummary(user
 					labelCSSClass="permissions-label"
 				/>
 
-				<aui:fieldset collapsed="<%= true %>" collapsible="<%= true %>" cssClass="options-group" label="update-data">
+				<c:choose>
+					<c:when test="<%= stagingGroupHelper.isCompanyGroup(group) %>">
+						<clay:sheet-section>
+							<span class="sheet-subtitle" id="<portlet:namespace />updateData">
+								<liferay-ui:message key="update-data" />
+							</span>
+							<span cssClass="mr-1">
+								<strong>
+									<liferay-ui:message key="mirror" />:
+								</strong>
+							</span>
 
-					<%
-					String taglibMirrorLabel = LanguageUtil.get(request, "mirror") + ": <span style='font-weight: normal'>" + LanguageUtil.get(request, "import-data-strategy-mirror-help") + "</span>";
-					%>
+							<liferay-ui:message key="import-data-strategy-mirror-help" />
+						</clay:sheet-section>
+					</c:when>
+					<c:otherwise>
+						<aui:fieldset collapsed="<%= true %>" collapsible="<%= true %>" cssClass="options-group" label="update-data">
 
-					<aui:input checked="<%= true %>" id="mirror" label="<%= taglibMirrorLabel %>" name="<%= PortletDataHandlerKeys.DATA_STRATEGY %>" type="radio" value="<%= PortletDataHandlerKeys.DATA_STRATEGY_MIRROR %>" />
+							<%
+							String taglibMirrorLabel = LanguageUtil.get(request, "mirror") + ": <span style='font-weight: normal'>" + LanguageUtil.get(request, "import-data-strategy-mirror-help") + "</span>";
+							%>
 
-					<%
-					String taglibMirrorWithOverwritingLabel = LanguageUtil.get(request, "mirror-with-overwriting") + ": <span style='font-weight: normal'>" + LanguageUtil.get(request, "import-data-strategy-mirror-with-overwriting-help") + "</span>";
-					%>
+							<aui:input checked="<%= true %>" id="mirror" label="<%= taglibMirrorLabel %>" name="<%= PortletDataHandlerKeys.DATA_STRATEGY %>" type="radio" value="<%= PortletDataHandlerKeys.DATA_STRATEGY_MIRROR %>" />
 
-					<aui:input id="mirrorWithOverwriting" label="<%= taglibMirrorWithOverwritingLabel %>" name="<%= PortletDataHandlerKeys.DATA_STRATEGY %>" type="radio" value="<%= PortletDataHandlerKeys.DATA_STRATEGY_MIRROR_OVERWRITE %>" />
+							<%
+							String taglibMirrorWithOverwritingLabel = LanguageUtil.get(request, "mirror-with-overwriting") + ": <span style='font-weight: normal'>" + LanguageUtil.get(request, "import-data-strategy-mirror-with-overwriting-help") + "</span>";
+							%>
 
-					<%
-					String taglibCopyAsNewLabel = LanguageUtil.get(request, "copy-as-new") + ": <span style='font-weight: normal'>" + LanguageUtil.get(request, "import-data-strategy-copy-as-new-help") + "</span>";
-					%>
+							<aui:input id="mirrorWithOverwriting" label="<%= taglibMirrorWithOverwritingLabel %>" name="<%= PortletDataHandlerKeys.DATA_STRATEGY %>" type="radio" value="<%= PortletDataHandlerKeys.DATA_STRATEGY_MIRROR_OVERWRITE %>" />
 
-					<aui:input id="copyAsNew" label="<%= taglibCopyAsNewLabel %>" name="<%= PortletDataHandlerKeys.DATA_STRATEGY %>" type="radio" value="<%= PortletDataHandlerKeys.DATA_STRATEGY_COPY_AS_NEW %>" />
-				</aui:fieldset>
+							<%
+							String taglibCopyAsNewLabel = LanguageUtil.get(request, "copy-as-new") + ": <span style='font-weight: normal'>" + LanguageUtil.get(request, "import-data-strategy-copy-as-new-help") + "</span>";
+							%>
+
+							<aui:input id="copyAsNew" label="<%= taglibCopyAsNewLabel %>" name="<%= PortletDataHandlerKeys.DATA_STRATEGY %>" type="radio" value="<%= PortletDataHandlerKeys.DATA_STRATEGY_COPY_AS_NEW %>" />
+						</aui:fieldset>
+					</c:otherwise>
+				</c:choose>
 
 				<aui:fieldset collapsed="<%= true %>" collapsible="<%= true %>" cssClass="options-group" label="authorship-of-the-content">
 

--- a/modules/test/playwright/tests/export-import-web/instance.import.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/instance.import.spec.ts
@@ -381,6 +381,20 @@ test('can see corresponding elements at instance level', async ({
 	await expect(
 		companyExportImportPage.page.getByLabel('Delete Application Data')
 	).not.toBeVisible();
+
+	await expect(
+		companyExportImportPage.page.getByText(
+			'Mirror: All data and content inside the imported LAR is created as new the first time while maintaining a reference to the source. Subsequent imports from the same source update the entries instead of creating new entries.'
+		)
+	).toBeVisible();
+
+	await expect(
+		companyExportImportPage.page.getByText('Mirror with overwriting:')
+	).not.toBeVisible();
+
+	await expect(
+		companyExportImportPage.page.getByText('Copy as New:')
+	).not.toBeVisible();
 });
 
 test('Can/not view Import menu item in Application menu depending on permissions', async ({

--- a/modules/test/playwright/tests/export-import-web/pages/CompanyExportImportPage.ts
+++ b/modules/test/playwright/tests/export-import-web/pages/CompanyExportImportPage.ts
@@ -125,7 +125,7 @@ export class CompanyExportImportPage {
 
 		await this.page.locator('input[type="file"]').setInputFiles(filePath);
 
-		if (expectedErrorMessage !== null) {
+		if (expectedErrorMessage) {
 			await expect(
 				this.page.getByText(expectedErrorMessage)
 			).toBeVisible();

--- a/modules/test/playwright/tests/export-import-web/site.import.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/site.import.spec.ts
@@ -356,4 +356,16 @@ test('can see corresponding elements at site level', async ({
 	await expect(
 		exportImportPage.page.getByLabel('Delete Application Data')
 	).toBeVisible();
+
+	await expect(
+		exportImportPage.page.getByText(
+			'Mirror: All data and content inside the imported LAR is created as new the first time while maintaining a reference to the source. Subsequent imports from the same source update the entries instead of creating new entries.'
+		)
+	).toBeVisible();
+
+	await expect(
+		exportImportPage.page.getByText('Mirror with overwriting:')
+	).toBeVisible();
+
+	await expect(exportImportPage.page.getByText('Copy as New:')).toBeVisible();
 });

--- a/modules/test/playwright/tests/export-import-web/site.import.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/site.import.spec.ts
@@ -19,6 +19,7 @@ import {pageEditorPagesTest} from '../../fixtures/pageEditorPagesTest';
 import {pageTemplatesPagesTest} from '../../fixtures/pageTemplatesPagesTest';
 import {productMenuPageTest} from '../../fixtures/productMenuPageTest';
 import {wikiPagesTest} from '../../fixtures/wikiPagesTest';
+import {expandSection} from '../../utils/expandSection';
 import getRandomString from '../../utils/getRandomString';
 import {getTempDir} from '../../utils/temp';
 import {companyExportImportPageTest} from './fixtures/companyExportImportPagesTest';
@@ -356,6 +357,10 @@ test('can see corresponding elements at site level', async ({
 	await expect(
 		exportImportPage.page.getByLabel('Delete Application Data')
 	).toBeVisible();
+
+	await expandSection(
+		exportImportPage.page.getByRole('button', {name: 'Update Data'})
+	);
 
 	await expect(
 		exportImportPage.page.getByText(


### PR DESCRIPTION
Description: At instance level, only show mirror strategy, and show it as text instead of a radio button chooser.
Jira Ticket: https://liferay.atlassian.net/browse/LPD-47250
___
Site Level:
![image](https://github.com/user-attachments/assets/406d4cd9-9f70-4169-918c-85497a2437f9)
Instance Level:
![image](https://github.com/user-attachments/assets/5fc10526-734c-4267-9a43-51c892c7aed0)
