### PR TITLE
LPD-50558 Add 'defaultLanguageId' fields to expected OpenAPIs

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions.json
@@ -337,6 +337,9 @@
 						"readOnly": true,
 						"type": "string"
 					},
+					"defaultLanguageId": {
+						"type": "string"
+					},
 					"externalReferenceCode": {
 						"readOnly": false,
 						"type": "string",

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions_object_action.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions_object_action.json
@@ -349,6 +349,9 @@
 						"readOnly": true,
 						"type": "string"
 					},
+					"defaultLanguageId": {
+						"type": "string"
+					},
 					"externalReferenceCode": {
 						"readOnly": false,
 						"type": "string",


### PR DESCRIPTION
This fixes the OpenAPIResourceTest.testGetOpenAPIWithActions by adding the `defaultLanguageId` in the expected OpenAPIs.

See the following **Jira Ticket**: [LPD-50558](https://liferay.atlassian.net/browse/LPD-50558)