### PR TITLE
LPD-50786 LPD-50822 | Fix objects not visible at import time 

### DIFF
--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/import/new_import/import_layouts_resources.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/import/new_import/import_layouts_resources.jsp
@@ -238,7 +238,7 @@ ManifestSummary manifestSummary = ExportImportHelperUtil.getManifestSummary(user
 												long modelDeletionCount = manifestSummary.getModelDeletionCount(portletDataHandler.getDeletionSystemEventStagedModelTypes());
 											%>
 
-												<c:if test="<%= (importModelCount != 0) || (modelDeletionCount != 0) %>">
+												<c:if test="<%= (importModelCount != 0) || (modelDeletionCount != 0) || !portletDataHandler.isModelCountSupported() %>">
 													<li class="tree-item">
 														<liferay-util:buffer
 															var="badgeHTML"

--- a/modules/test/playwright/tests/export-import-web/instance.export.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/instance.export.spec.ts
@@ -81,7 +81,7 @@ test('cannot export site scoped custom object entries at instance level', async 
 
 	await page.getByTestId('creationMenuNewButton').nth(1).click();
 
-	await expect(page.getByLabel('Tests 1 Items')).toBeHidden();
+	await expect(page.getByLabel('Tests')).toBeHidden();
 });
 
 test('can export custom object entries at instance level with date filter', async ({
@@ -130,7 +130,7 @@ test('can export custom object entries at instance level with date filter', asyn
 	);
 
 	const exportFilePath1 = await companyExportImportPage.export(
-		'Tests 1 Items',
+		'Tests',
 		false
 	);
 
@@ -149,7 +149,7 @@ test('can export custom object entries at instance level with date filter', asyn
 	startDate.setDate(startDate.getDate() - 2);
 
 	const exportFilePath2 = await companyExportImportPage.export(
-		'Tests 1 Items',
+		'Tests',
 		false,
 		{
 			endDate: toDateRangeDate(endDate),
@@ -166,7 +166,7 @@ test('can export custom object entries at instance level with date filter', asyn
 	expect(json2.length).toBe(0);
 
 	const exportFilePath3 = await companyExportImportPage.export(
-		'Tests 1 Items',
+		'Tests',
 		false,
 		{
 			rangeLast: '12 Hours',
@@ -220,8 +220,7 @@ test('can export new default and custom task name', async ({
 
 	apiHelpers.data.push({id: objectDefinition.id, type: 'objectDefinition'});
 
-	const defaultExportFilePath =
-		await companyExportImportPage.export('Tests 1 Items');
+	const defaultExportFilePath = await companyExportImportPage.export('Tests');
 
 	expect(defaultExportFilePath).toMatch(
 		new RegExp(`^${getTempDir()}Export-`)
@@ -230,7 +229,7 @@ test('can export new default and custom task name', async ({
 	const taskName = 'CustomTaskName';
 
 	const customExportFilePath = await companyExportImportPage.export(
-		'Tests 1 Items',
+		'Tests',
 		false,
 		undefined,
 		taskName
@@ -286,10 +285,7 @@ test('can export custom object entries at instance level with permissions', asyn
 		'c/tests'
 	);
 
-	const exportFilePath = await companyExportImportPage.export(
-		'Tests 1 Items',
-		true
-	);
+	const exportFilePath = await companyExportImportPage.export('Tests', true);
 
 	const content = await readFileFromZip('C_Test.json', exportFilePath);
 

--- a/modules/test/playwright/tests/export-import-web/instance.import.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/instance.import.spec.ts
@@ -375,8 +375,8 @@ test('can see corresponding elements at instance level', async ({
 	).not.toBeVisible();
 
 	await expect(
-		companyExportImportPage.page.getByText('C_Tests Change')
-	).not.toBeVisible();
+		companyExportImportPage.page.getByText('Tests')
+	).toBeVisible();
 
 	await expect(
 		companyExportImportPage.page.getByLabel('Delete Application Data')

--- a/modules/test/playwright/tests/export-import-web/instance.import.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/instance.import.spec.ts
@@ -90,8 +90,7 @@ test('can export and import custom object entries at instance level', async ({
 		'c/tests'
 	);
 
-	const exportFilePath =
-		await companyExportImportPage.export('Tests 1 Items');
+	const exportFilePath = await companyExportImportPage.export('Tests');
 
 	const content = await readFileFromZip('C_Test.json', exportFilePath);
 
@@ -170,8 +169,7 @@ test('can only import custom object entries when their definitions are already i
 		'c/tests'
 	);
 
-	const exportFilePath =
-		await companyExportImportPage.export('Tests 1 Items');
+	const exportFilePath = await companyExportImportPage.export('Tests');
 
 	objectActionApiClient.deleteObjectDefinition(objectDefinition.id);
 
@@ -258,10 +256,7 @@ test('can import custom object entries at instance level with or without permiss
 
 	// Export with permissions
 
-	const exportFilePath = await companyExportImportPage.export(
-		'Tests 1 Items',
-		true
-	);
+	const exportFilePath = await companyExportImportPage.export('Tests', true);
 
 	// Import with permissions
 
@@ -374,9 +369,7 @@ test('can see corresponding elements at instance level', async ({
 		companyExportImportPage.page.getByText('Comments, Ratings')
 	).not.toBeVisible();
 
-	await expect(
-		companyExportImportPage.page.getByText('Tests')
-	).toBeVisible();
+	await expect(companyExportImportPage.page.getByText('Tests')).toBeVisible();
 
 	await expect(
 		companyExportImportPage.page.getByLabel('Delete Application Data')

--- a/modules/test/playwright/tests/export-import-web/site.import.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/site.import.spec.ts
@@ -24,7 +24,7 @@ import {getTempDir} from '../../utils/temp';
 import {companyExportImportPageTest} from './fixtures/companyExportImportPagesTest';
 import {exportImportPagesTest} from './fixtures/exportImportPagesTest';
 import {stagingPageTest} from './fixtures/stagingPageTest';
-import {reloadImportUntilFieldsetOpened} from './utils/reloadImportUntilFieldsetOpened';
+import {openImportFieldset} from './utils/openImportFieldset';
 
 export const test = mergeTests(
 	companyExportImportPageTest,
@@ -358,7 +358,7 @@ test('can see corresponding elements at site level', async ({
 		exportImportPage.page.getByLabel('Delete Application Data')
 	).toBeVisible();
 
-	await reloadImportUntilFieldsetOpened({
+	await openImportFieldset({
 		name: 'Update Data',
 		page: exportImportPage.page,
 	});

--- a/modules/test/playwright/tests/export-import-web/site.import.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/site.import.spec.ts
@@ -19,12 +19,12 @@ import {pageEditorPagesTest} from '../../fixtures/pageEditorPagesTest';
 import {pageTemplatesPagesTest} from '../../fixtures/pageTemplatesPagesTest';
 import {productMenuPageTest} from '../../fixtures/productMenuPageTest';
 import {wikiPagesTest} from '../../fixtures/wikiPagesTest';
-import {expandSection} from '../../utils/expandSection';
 import getRandomString from '../../utils/getRandomString';
 import {getTempDir} from '../../utils/temp';
 import {companyExportImportPageTest} from './fixtures/companyExportImportPagesTest';
 import {exportImportPagesTest} from './fixtures/exportImportPagesTest';
 import {stagingPageTest} from './fixtures/stagingPageTest';
+import {reloadImportUntilFieldsetOpened} from './utils/reloadImportUntilFieldsetOpened';
 
 export const test = mergeTests(
 	companyExportImportPageTest,
@@ -358,9 +358,10 @@ test('can see corresponding elements at site level', async ({
 		exportImportPage.page.getByLabel('Delete Application Data')
 	).toBeVisible();
 
-	await expandSection(
-		exportImportPage.page.getByRole('button', {name: 'Update Data'})
-	);
+	await reloadImportUntilFieldsetOpened({
+		name: 'Update Data',
+		page: exportImportPage.page,
+	});
 
 	await expect(
 		exportImportPage.page.getByText(

--- a/modules/test/playwright/tests/export-import-web/utils/openImportFieldset.ts
+++ b/modules/test/playwright/tests/export-import-web/utils/openImportFieldset.ts
@@ -5,7 +5,9 @@
 
 import {Locator, Page} from '@playwright/test';
 
-export async function reloadImportUntilFieldsetOpened({
+import {reloadImportPage} from './reloadImportPage';
+
+export async function openImportFieldset({
 	maxAttempts = 5,
 	name,
 	page,
@@ -31,8 +33,7 @@ export async function reloadImportUntilFieldsetOpened({
 		}
 
 		if (!(await _isExpanded(fieldset))) {
-			await page.reload();
-			await page.getByRole('button', {name: 'Continue'}).click();
+			reloadImportPage(page);
 		}
 
 		attempts++;

--- a/modules/test/playwright/tests/export-import-web/utils/reloadImportPage.ts
+++ b/modules/test/playwright/tests/export-import-web/utils/reloadImportPage.ts
@@ -1,0 +1,11 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Page} from '@playwright/test';
+
+export async function reloadImportPage(page: Page) {
+	await page.reload();
+	await page.getByRole('button', {name: 'Continue'}).click();
+}

--- a/modules/test/playwright/tests/export-import-web/utils/reloadImportUntilFieldsetOpened.ts
+++ b/modules/test/playwright/tests/export-import-web/utils/reloadImportUntilFieldsetOpened.ts
@@ -1,0 +1,46 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page} from '@playwright/test';
+
+export async function reloadImportUntilFieldsetOpened({
+	maxAttempts = 5,
+	name,
+	page,
+}: {
+	maxAttempts?: number;
+	name: string;
+	page: Page;
+}) {
+	let attempts = 0;
+
+	while (attempts < maxAttempts) {
+		const fieldset = page
+			.getByRole('group', {
+				name,
+			})
+			.getByRole('button', {name});
+
+		if (!(await _isExpanded(fieldset))) {
+			await fieldset.click();
+		}
+		else {
+			break;
+		}
+
+		if (!(await _isExpanded(fieldset))) {
+			await page.reload();
+			await page.getByRole('button', {name: 'Continue'}).click();
+		}
+
+		attempts++;
+	}
+}
+
+async function _isExpanded(fieldset: Locator) {
+	return await fieldset.evaluate(
+		(element) => element.getAttribute('aria-expanded') === 'true'
+	);
+}


### PR DESCRIPTION
**Description**: Adapt the code to the new `BatchEnginePortletDataHandler` as we did for export in https://github.com/liferay-headless/liferay-portal/pull/2598. This failed as we return 0 in `getExportModelCount()`, so we had to handle this logic also in import. Also, we fix some failing tests of export-import-web.

**Jira Ticket**: 
- https://liferay.atlassian.net/browse/LPD-50786 
- https://liferay.atlassian.net/browse/LPD-50822