### PR TITLE
LPD-51187 | Fix failure in DefaultObjectEntryManagerImplTest.testAddObjectEntryWithDynamicObjectFieldValues

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/business/type/DateTimeObjectFieldBusinessType.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/business/type/DateTimeObjectFieldBusinessType.java
@@ -31,6 +31,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -173,21 +174,26 @@ public class DateTimeObjectFieldBusinessType
 	}
 
 	@Override
-	public Object getValue(
+	public Timestamp getValue(
 			ObjectField objectField, long userId, Map<String, Object> values)
 		throws PortalException {
 
-		String value = String.valueOf(
-			ObjectFieldBusinessType.super.getValue(
-				objectField, userId, values));
+		Object value = ObjectFieldBusinessType.super.getValue(
+			objectField, userId, values);
 
 		if (Validator.isNull(value)) {
 			return null;
 		}
 
+		if (value instanceof Date) {
+			Date date = (Date)value;
+
+			return new Timestamp(date.getTime());
+		}
+
 		return _getTimestamp(
 			objectField.getObjectFieldSettings(),
-			_userLocalService.getUser(userId), value);
+			_userLocalService.getUser(userId), String.valueOf(value));
 	}
 
 	@Override


### PR DESCRIPTION
With [LPD-49623](https://liferay.atlassian.net/browse/LPD-49623) we simplified a lot and when forming the predicate, DATE_TIME fields are now always converted to a DATE type. Before they were a string and the milliseconds were preserved, but now, as a DATE, when converting to string, the milliseconds were lost.

This PR fixes the issue by modifying the getValue method in DateTimeObjectFieldBusinessType to preserve milliseconds precision when dealing with Date objects. Instead of converting Date objects to strings (which loses millisecond precision) and then back to Timestamps, we now directly convert Date objects to Timestamps, maintaining the full temporal precision including milliseconds. This ensures that filtering and other operations on DateTime fields work correctly when millisecond precision is important.

This case is "rare" as ussually we do not create DATE_TIME fields with milliseconds precision, but the test does.
Do not confuse it with the case of systemDates that do have milliseconds depending on the DDBB used, but do not retrieve them when calling the API. That is why those fields use a custom FieldPredicateProvider to workaround it. 

**Related Jira Ticket:** [LPD-51187](https://liferay.atlassian.net/browse/LPD-51187)
