### PR TITLE
LPD-49223 Provide endpoints to retrieve snapshots of an object entry

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/entry/util/ObjectEntryDTOConverterUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/entry/util/ObjectEntryDTOConverterUtil.java
@@ -102,6 +102,7 @@ public class ObjectEntryDTOConverterUtil {
 		dtoJSONObject.remove("dateModified");
 		dtoJSONObject.remove("id");
 		dtoJSONObject.remove("status");
+		dtoJSONObject.remove("version");
 
 		return dtoJSONObject.toString();
 	}

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryVersionLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryVersionLocalService.java
@@ -263,6 +263,10 @@ public interface ObjectEntryVersionLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<ObjectEntryVersion> getObjectEntryVersions(long objectEntryId);
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<ObjectEntryVersion> getObjectEntryVersions(
+		long objectEntryId, int start, int end);
+
 	/**
 	 * Returns the number of object entry versions.
 	 *
@@ -270,6 +274,9 @@ public interface ObjectEntryVersionLocalService
 	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getObjectEntryVersionsCount();
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int getObjectEntryVersionsCount(long objectEntryId);
 
 	/**
 	 * Returns the OSGi service identifier.

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryVersionLocalServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryVersionLocalServiceUtil.java
@@ -304,6 +304,12 @@ public class ObjectEntryVersionLocalServiceUtil {
 		return getService().getObjectEntryVersions(objectEntryId);
 	}
 
+	public static List<ObjectEntryVersion> getObjectEntryVersions(
+		long objectEntryId, int start, int end) {
+
+		return getService().getObjectEntryVersions(objectEntryId, start, end);
+	}
+
 	/**
 	 * Returns the number of object entry versions.
 	 *
@@ -311,6 +317,10 @@ public class ObjectEntryVersionLocalServiceUtil {
 	 */
 	public static int getObjectEntryVersionsCount() {
 		return getService().getObjectEntryVersionsCount();
+	}
+
+	public static int getObjectEntryVersionsCount(long objectEntryId) {
+		return getService().getObjectEntryVersionsCount(objectEntryId);
 	}
 
 	/**

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryVersionLocalServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryVersionLocalServiceWrapper.java
@@ -343,6 +343,14 @@ public class ObjectEntryVersionLocalServiceWrapper
 			objectEntryId);
 	}
 
+	@Override
+	public java.util.List<com.liferay.object.model.ObjectEntryVersion>
+		getObjectEntryVersions(long objectEntryId, int start, int end) {
+
+		return _objectEntryVersionLocalService.getObjectEntryVersions(
+			objectEntryId, start, end);
+	}
+
 	/**
 	 * Returns the number of object entry versions.
 	 *
@@ -351,6 +359,12 @@ public class ObjectEntryVersionLocalServiceWrapper
 	@Override
 	public int getObjectEntryVersionsCount() {
 		return _objectEntryVersionLocalService.getObjectEntryVersionsCount();
+	}
+
+	@Override
+	public int getObjectEntryVersionsCount(long objectEntryId) {
+		return _objectEntryVersionLocalService.getObjectEntryVersionsCount(
+			objectEntryId);
 	}
 
 	/**

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryVersionService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryVersionService.java
@@ -5,13 +5,17 @@
 
 package com.liferay.object.service;
 
+import com.liferay.object.model.ObjectEntryVersion;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.jsonwebservice.JSONWebService;
 import com.liferay.portal.kernel.security.access.control.AccessControlled;
 import com.liferay.portal.kernel.service.BaseService;
 import com.liferay.portal.kernel.transaction.Isolation;
+import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.Transactional;
+
+import java.util.List;
 
 import org.osgi.annotation.versioning.ProviderType;
 
@@ -38,6 +42,14 @@ public interface ObjectEntryVersionService extends BaseService {
 	 *
 	 * Never modify this interface directly. Add custom service methods to <code>com.liferay.object.service.impl.ObjectEntryVersionServiceImpl</code> and rerun ServiceBuilder to automatically copy the method declarations to this interface. Consume the object entry version remote service via injection or a <code>org.osgi.util.tracker.ServiceTracker</code>. Use {@link ObjectEntryVersionServiceUtil} if injection and service tracking are not available.
 	 */
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<ObjectEntryVersion> getObjectEntryVersions(
+			long objectEntryId, int start, int end)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int getObjectEntryVersionsCount(long objectEntryId)
+		throws PortalException;
 
 	/**
 	 * Returns the OSGi service identifier.

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryVersionServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryVersionServiceUtil.java
@@ -5,7 +5,11 @@
 
 package com.liferay.object.service;
 
+import com.liferay.object.model.ObjectEntryVersion;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.module.service.Snapshot;
+
+import java.util.List;
 
 /**
  * Provides the remote service utility for ObjectEntryVersion. This utility wraps
@@ -26,6 +30,18 @@ public class ObjectEntryVersionServiceUtil {
 	 *
 	 * Never modify this class directly. Add custom service methods to <code>com.liferay.object.service.impl.ObjectEntryVersionServiceImpl</code> and rerun ServiceBuilder to regenerate this class.
 	 */
+	public static List<ObjectEntryVersion> getObjectEntryVersions(
+			long objectEntryId, int start, int end)
+		throws PortalException {
+
+		return getService().getObjectEntryVersions(objectEntryId, start, end);
+	}
+
+	public static int getObjectEntryVersionsCount(long objectEntryId)
+		throws PortalException {
+
+		return getService().getObjectEntryVersionsCount(objectEntryId);
+	}
 
 	/**
 	 * Returns the OSGi service identifier.

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryVersionServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryVersionServiceWrapper.java
@@ -28,6 +28,23 @@ public class ObjectEntryVersionServiceWrapper
 		_objectEntryVersionService = objectEntryVersionService;
 	}
 
+	@Override
+	public java.util.List<com.liferay.object.model.ObjectEntryVersion>
+			getObjectEntryVersions(long objectEntryId, int start, int end)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _objectEntryVersionService.getObjectEntryVersions(
+			objectEntryId, start, end);
+	}
+
+	@Override
+	public int getObjectEntryVersionsCount(long objectEntryId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _objectEntryVersionService.getObjectEntryVersionsCount(
+			objectEntryId);
+	}
+
 	/**
 	 * Returns the OSGi service identifier.
 	 *

--- a/modules/apps/object/object-rest-api/bnd.bnd
+++ b/modules/apps/object/object-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object REST API
 Bundle-SymbolicName: com.liferay.object.rest.api
-Bundle-Version: 19.10.2
+Bundle-Version: 19.11.0
 Export-Package:\
 	com.liferay.object.rest.dto.v1_0,\
 	com.liferay.object.rest.dto.v1_0.util,\

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/ObjectEntry.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/ObjectEntry.java
@@ -831,6 +831,48 @@ public class ObjectEntry implements Serializable {
 	@JsonIgnore
 	private Supplier<Long[]> _taxonomyCategoryIdsSupplier;
 
+	@io.swagger.v3.oas.annotations.media.Schema
+	@Valid
+	public Version getVersion() {
+		if (_versionSupplier != null) {
+			version = _versionSupplier.get();
+
+			_versionSupplier = null;
+		}
+
+		return version;
+	}
+
+	public void setVersion(Version version) {
+		this.version = version;
+
+		_versionSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setVersion(
+		UnsafeSupplier<Version, Exception> versionUnsafeSupplier) {
+
+		_versionSupplier = () -> {
+			try {
+				return versionUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Version version;
+
+	@JsonIgnore
+	private Supplier<Version> _versionSupplier;
+
 	@Override
 	public boolean equals(Object object) {
 		if (this == object) {
@@ -894,6 +936,9 @@ public class ObjectEntry implements Serializable {
 		}
 		else if (Objects.equals(propertyName, "taxonomyCategoryIds")) {
 			return getTaxonomyCategoryIds();
+		}
+		else if (Objects.equals(propertyName, "version")) {
+			return getVersion();
 		}
 		else {
 			if (properties.containsKey(propertyName)) {
@@ -1242,6 +1287,18 @@ public class ObjectEntry implements Serializable {
 			}
 
 			sb.append("]");
+		}
+
+		Version version = getVersion();
+
+		if (version != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"version\": ");
+
+			sb.append(String.valueOf(version));
 		}
 
 		sb.append("}");

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/Version.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/Version.java
@@ -1,0 +1,229 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.rest.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import java.io.Serializable;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import javax.annotation.Generated;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+@GraphQLName("Version")
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "Version")
+public class Version implements Serializable {
+
+	public static Version toDTO(String json) {
+		return ObjectMapperUtil.readValue(Version.class, json);
+	}
+
+	public static Version unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(Version.class, json);
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Integer getNumber() {
+		if (_numberSupplier != null) {
+			number = _numberSupplier.get();
+
+			_numberSupplier = null;
+		}
+
+		return number;
+	}
+
+	public void setNumber(Integer number) {
+		this.number = number;
+
+		_numberSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setNumber(
+		UnsafeSupplier<Integer, Exception> numberUnsafeSupplier) {
+
+		_numberSupplier = () -> {
+			try {
+				return numberUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Integer number;
+
+	@JsonIgnore
+	private Supplier<Integer> _numberSupplier;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof Version)) {
+			return false;
+		}
+
+		Version version = (Version)object;
+
+		return Objects.equals(toString(), version.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		Integer number = getNumber();
+
+		if (number != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"number\": ");
+
+			sb.append(number);
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		accessMode = io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.object.rest.dto.v1_0.Version",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof Map) {
+						sb.append(_toJSON((Map<String, ?>)valueArray[i]));
+					}
+					else if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+	private Map<String, Serializable> _extendedProperties;
+
+}

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/DefaultObjectEntryManager.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/DefaultObjectEntryManager.java
@@ -93,6 +93,17 @@ public interface DefaultObjectEntryManager extends ObjectEntryManager {
 			String objectRelationshipName, Pagination pagination)
 		throws Exception;
 
+	public Page<ObjectEntry> getObjectEntryVersions(
+			DTOConverterContext dtoConverterContext, long objectEntryId,
+			Pagination pagination)
+		throws Exception;
+
+	public Page<ObjectEntry> getObjectEntryVersions(
+			DTOConverterContext dtoConverterContext,
+			String externalReferenceCode, ObjectDefinition objectDefinition,
+			Pagination pagination)
+		throws Exception;
+
 	public Page<Object> getRelatedSystemObjectEntries(
 			ObjectDefinition objectDefinition, Long objectEntryId,
 			String objectRelationshipName, Pagination pagination)

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/resource/v1_0/ObjectEntryResource.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/resource/v1_0/ObjectEntryResource.java
@@ -82,6 +82,10 @@ public interface ObjectEntryResource {
 			String externalReferenceCode, ObjectEntry objectEntry)
 		throws Exception;
 
+	public Page<ObjectEntry> getByExternalReferenceCodeVersionsPage(
+			String externalReferenceCode, Pagination pagination)
+		throws Exception;
+
 	public void
 			putByExternalReferenceCodeObjectEntryExternalReferenceCodeObjectActionObjectActionName(
 				String objectEntryExternalReferenceCode,
@@ -142,6 +146,10 @@ public interface ObjectEntryResource {
 			putObjectEntryPermissionsPage(
 				Long objectEntryId,
 				com.liferay.portal.vulcan.permission.Permission[] permissions)
+		throws Exception;
+
+	public Page<ObjectEntry> getObjectEntriesVersionsPage(
+			Long objectEntryId, Pagination pagination)
 		throws Exception;
 
 	public Page<ObjectEntry> getScopeScopeKeyPage(

--- a/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/dto/v1_0/packageinfo
+++ b/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.11.0
+version 1.12.0

--- a/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/manager/v1_0/packageinfo
+++ b/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/manager/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 12.4.0
+version 12.5.0

--- a/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/resource/v1_0/packageinfo
+++ b/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 3.5.0
+version 3.6.0

--- a/modules/apps/object/object-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-rest-impl/rest-openapi.yaml
@@ -159,6 +159,8 @@ components:
                         type: integer
                     type: array
                     writeOnly: true
+                version:
+                    $ref: "#/components/schemas/Version"
             type: object
         Scope:
             properties:
@@ -207,6 +209,13 @@ components:
                         The localized category's names.
                     readOnly: true
                     type: object
+            type: object
+        Version:
+            properties:
+                number:
+                    format: int32
+                    readOnly: true
+                    type: integer
             type: object
 info:
     license:
@@ -425,6 +434,37 @@ paths:
                         application/xml:
                             schema:
                                 $ref: "#/components/schemas/ObjectEntry"
+            tags: ["ObjectEntry"]
+    "/by-external-reference-code/{externalReferenceCode}/versions":
+        get:
+            operationId: getByExternalReferenceCodeVersionsPage
+            parameters:
+                - in: path
+                  name: externalReferenceCode
+                  required: true
+                  schema:
+                      type: string
+                - in: query
+                  name: page
+                  schema:
+                      type: integer
+                - in: query
+                  name: pageSize
+                  schema:
+                      type: integer
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/ObjectEntry"
+                                type: array
+                        application/xml:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/ObjectEntry"
+                                type: array
             tags: ["ObjectEntry"]
     "/by-external-reference-code/{objectEntryExternalReferenceCode}/object-actions/{objectActionName}":
         put:
@@ -759,6 +799,38 @@ paths:
                     content:
                         application/json: {}
                         application/xml: {}
+            tags: ["ObjectEntry"]
+    "/{objectEntryId}/versions":
+        get:
+            operationId: getObjectEntriesVersionsPage
+            parameters:
+                - in: path
+                  name: objectEntryId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+                - in: query
+                  name: page
+                  schema:
+                      type: integer
+                - in: query
+                  name: pageSize
+                  schema:
+                      type: integer
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/ObjectEntry"
+                                type: array
+                        application/xml:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/ObjectEntry"
+                                type: array
             tags: ["ObjectEntry"]
     /scopes/{scopeKey}:
         get:

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -24,6 +24,7 @@ import com.liferay.object.entry.util.ObjectEntryDTOConverterUtil;
 import com.liferay.object.entry.util.ObjectEntryValuesUtil;
 import com.liferay.object.field.setting.util.ObjectFieldSettingUtil;
 import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntryVersion;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.related.models.ObjectRelatedModelsProvider;
@@ -37,6 +38,7 @@ import com.liferay.object.rest.dto.v1_0.ObjectEntry;
 import com.liferay.object.rest.dto.v1_0.Scope;
 import com.liferay.object.rest.dto.v1_0.Status;
 import com.liferay.object.rest.dto.v1_0.TaxonomyCategoryBrief;
+import com.liferay.object.rest.dto.v1_0.Version;
 import com.liferay.object.rest.dto.v1_0.util.CreatorUtil;
 import com.liferay.object.rest.dto.v1_0.util.LinkUtil;
 import com.liferay.object.rest.internal.dto.v1_0.util.TaxonomyCategoryBriefUtil;
@@ -106,6 +108,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
@@ -172,21 +175,15 @@ public class ObjectEntryDTOConverter
 		ObjectEntry objectEntry = ObjectEntry.unsafeToDTO(
 			(String)dtoConverterContext.getAttribute("payload"));
 
-		User user = dtoConverterContext.getUser();
-
 		objectEntry.setActions(dtoConverterContext::getActions);
 
 		if (objectEntry.getStatus() == null) {
 			objectEntry.setStatus(
-				() -> new Status() {
-					{
-						setCode(() -> WorkflowConstants.STATUS_APPROVED);
-						setLabel(() -> WorkflowConstants.LABEL_APPROVED);
-						setLabel_i18n(
-							() -> _language.get(
-								user.getLocale(),
-								WorkflowConstants.LABEL_APPROVED));
-					}
+				() -> {
+					User user = dtoConverterContext.getUser();
+
+					return _toStatus(
+						user.getLocale(), WorkflowConstants.STATUS_APPROVED);
 				});
 		}
 
@@ -222,40 +219,45 @@ public class ObjectEntryDTOConverter
 	@Override
 	public ObjectEntry toDTO(
 			DTOConverterContext dtoConverterContext,
-			com.liferay.object.model.ObjectEntry objectEntry)
+			com.liferay.object.model.ObjectEntry serviceBuilderObjectEntry)
 		throws Exception {
 
 		ObjectDefinition objectDefinition = _getObjectDefinition(
-			dtoConverterContext, objectEntry);
+			dtoConverterContext, serviceBuilderObjectEntry);
 
-		return new ObjectEntry() {
+		ObjectEntry objectEntry = new ObjectEntry() {
 			{
 				setActions(dtoConverterContext::getActions);
 				setAuditEvents(
 					() -> _toAuditEvents(
-						dtoConverterContext, objectDefinition, objectEntry));
+						dtoConverterContext, objectDefinition,
+						serviceBuilderObjectEntry));
 				setCreator(
 					() -> CreatorUtil.toCreator(
 						_portal, dtoConverterContext.getUriInfo(),
-						_userLocalService.fetchUser(objectEntry.getUserId())));
-				setDateCreated(objectEntry::getCreateDate);
-				setDateModified(objectEntry::getModifiedDate);
+						_userLocalService.fetchUser(
+							serviceBuilderObjectEntry.getUserId())));
+				setDateCreated(serviceBuilderObjectEntry::getCreateDate);
+				setDateModified(serviceBuilderObjectEntry::getModifiedDate);
 				setDefaultLanguageId(
 					() -> {
 						if (FeatureFlagManagerUtil.isEnabled(
 								objectDefinition.getCompanyId(), "LPD-32050")) {
 
-							return objectEntry.getDefaultLanguageId();
+							return serviceBuilderObjectEntry.
+								getDefaultLanguageId();
 						}
 
 						return null;
 					});
-				setExternalReferenceCode(objectEntry::getExternalReferenceCode);
+				setExternalReferenceCode(
+					serviceBuilderObjectEntry::getExternalReferenceCode);
 				setFriendlyUrlPath(
-					() -> objectEntry.getURLTitle(
+					() -> serviceBuilderObjectEntry.getURLTitle(
 						dtoConverterContext.getLocale()));
-				setFriendlyUrlPath_i18n(objectEntry::getURLTitleMap);
-				setId(objectEntry::getObjectEntryId);
+				setFriendlyUrlPath_i18n(
+					serviceBuilderObjectEntry::getURLTitleMap);
+				setId(serviceBuilderObjectEntry::getObjectEntryId);
 				setKeywords(
 					() -> {
 						if (!objectDefinition.isEnableCategorization()) {
@@ -265,30 +267,23 @@ public class ObjectEntryDTOConverter
 						return ListUtil.toArray(
 							_assetTagLocalService.getTags(
 								objectDefinition.getClassName(),
-								objectEntry.getObjectEntryId()),
+								serviceBuilderObjectEntry.getObjectEntryId()),
 							AssetTag.NAME_ACCESSOR);
 					});
 				setPermissions(
-					() -> _toPermissions(objectDefinition, objectEntry));
+					() -> _toPermissions(
+						objectDefinition, serviceBuilderObjectEntry));
 				setProperties(
 					() -> _toProperties(
-						dtoConverterContext, objectDefinition, objectEntry));
-				setScopeKey(() -> _getScopeKey(objectDefinition, objectEntry));
+						dtoConverterContext, objectDefinition,
+						serviceBuilderObjectEntry));
+				setScopeKey(
+					() -> _getScopeKey(
+						objectDefinition, serviceBuilderObjectEntry));
 				setStatus(
-					() -> new Status() {
-						{
-							setCode(objectEntry::getStatus);
-							setLabel(
-								() -> WorkflowConstants.getStatusLabel(
-									objectEntry.getStatus()));
-							setLabel_i18n(
-								() -> _language.get(
-									LanguageResources.getResourceBundle(
-										dtoConverterContext.getLocale()),
-									WorkflowConstants.getStatusLabel(
-										objectEntry.getStatus())));
-						}
-					});
+					() -> _toStatus(
+						dtoConverterContext.getLocale(),
+						serviceBuilderObjectEntry.getStatus()));
 				setTaxonomyCategoryBriefs(
 					() -> {
 						if (!objectDefinition.isEnableCategorization()) {
@@ -298,15 +293,67 @@ public class ObjectEntryDTOConverter
 						return TransformUtil.transformToArray(
 							_assetCategoryLocalService.getCategories(
 								objectDefinition.getClassName(),
-								objectEntry.getObjectEntryId()),
+								serviceBuilderObjectEntry.getObjectEntryId()),
 							assetCategory ->
 								TaxonomyCategoryBriefUtil.
 									toTaxonomyCategoryBrief(
 										assetCategory, dtoConverterContext),
 							TaxonomyCategoryBrief.class);
 					});
+				setVersion(
+					() -> _toVersion(serviceBuilderObjectEntry.getVersion()));
 			}
 		};
+
+		ObjectEntryVersion objectEntryVersion =
+			(ObjectEntryVersion)dtoConverterContext.getAttribute(
+				"objectEntryVersion");
+
+		if (objectEntryVersion == null) {
+			return objectEntry;
+		}
+
+		ObjectEntry contentObjectEntry = ObjectEntry.unsafeToDTO(
+			objectEntryVersion.getContent());
+
+		objectEntry.setCreator(
+			() -> CreatorUtil.toCreator(
+				_portal, dtoConverterContext.getUriInfo(),
+				_userLocalService.fetchUser(objectEntryVersion.getUserId())));
+		objectEntry.setDateCreated(objectEntryVersion::getCreateDate);
+		objectEntry.setDateModified(objectEntryVersion::getModifiedDate);
+		objectEntry.setExternalReferenceCode(
+			contentObjectEntry::getExternalReferenceCode);
+		objectEntry.setKeywords(contentObjectEntry::getKeywords);
+		objectEntry.setProperties(
+			() -> {
+				Map<String, Object> properties =
+					contentObjectEntry.getProperties();
+
+				com.liferay.object.model.ObjectEntry
+					serviceBuilderObjectEntryClone =
+						(com.liferay.object.model.ObjectEntry)
+							serviceBuilderObjectEntry.clone();
+
+				serviceBuilderObjectEntryClone.setValues(
+					(Map<String, Serializable>)properties.get("properties"));
+
+				return _toProperties(
+					dtoConverterContext,
+					_objectDefinitionLocalService.getObjectDefinition(
+						serviceBuilderObjectEntryClone.getObjectDefinitionId()),
+					serviceBuilderObjectEntryClone);
+			});
+		objectEntry.setStatus(
+			() -> _toStatus(
+				dtoConverterContext.getLocale(),
+				objectEntryVersion.getStatus()));
+		objectEntry.setTaxonomyCategoryBriefs(
+			contentObjectEntry::getTaxonomyCategoryBriefs);
+		objectEntry.setVersion(
+			() -> _toVersion(objectEntryVersion.getVersion()));
+
+		return objectEntry;
 	}
 
 	private void _addManyToOneObjectRelationshipNames(
@@ -1113,6 +1160,31 @@ public class ObjectEntryDTOConverter
 		}
 
 		return (Map<String, Object>)(Map)unsafeSuppliers;
+	}
+
+	private Status _toStatus(Locale locale, int statusInt) {
+		return new Status() {
+			{
+				setCode(() -> statusInt);
+				setLabel(() -> WorkflowConstants.getStatusLabel(statusInt));
+				setLabel_i18n(
+					() -> _language.get(
+						LanguageResources.getResourceBundle(locale),
+						WorkflowConstants.getStatusLabel(statusInt)));
+			}
+		};
+	}
+
+	private Version _toVersion(int version) {
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+			return null;
+		}
+
+		return new Version() {
+			{
+				setNumber(() -> version);
+			}
+		};
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -48,6 +48,7 @@ import com.liferay.object.rest.manager.v1_0.util.ObjectEntryManagerUtil;
 import com.liferay.object.service.ObjectActionLocalService;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryService;
+import com.liferay.object.service.ObjectEntryVersionService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.service.ObjectRelationshipService;
 import com.liferay.object.system.SystemObjectDefinitionManager;
@@ -648,6 +649,48 @@ public class DefaultObjectEntryManagerImpl
 			objectRelatedModelsProvider.getRelatedModelsCount(
 				groupId, objectRelationship.getObjectRelationshipId(),
 				serviceBuilderObjectEntry.getPrimaryKey(), null));
+	}
+
+	@Override
+	public Page<ObjectEntry> getObjectEntryVersions(
+			DTOConverterContext dtoConverterContext, long objectEntryId,
+			Pagination pagination)
+		throws Exception {
+
+		com.liferay.object.model.ObjectEntry objectEntry =
+			objectEntryLocalService.getObjectEntry(objectEntryId);
+
+		return Page.of(
+			TransformUtil.transform(
+				_objectEntryVersionService.getObjectEntryVersions(
+					objectEntryId, _getStartPosition(pagination),
+					_getEndPosition(pagination)),
+				objectEntryVersion -> {
+					dtoConverterContext.setAttribute(
+						"objectEntryVersion", objectEntryVersion);
+
+					return _objectEntryDTOConverter.toDTO(
+						dtoConverterContext, objectEntry);
+				}),
+			pagination,
+			_objectEntryVersionService.getObjectEntryVersionsCount(
+				objectEntryId));
+	}
+
+	@Override
+	public Page<ObjectEntry> getObjectEntryVersions(
+			DTOConverterContext dtoConverterContext,
+			String externalReferenceCode, ObjectDefinition objectDefinition,
+			Pagination pagination)
+		throws Exception {
+
+		com.liferay.object.model.ObjectEntry objectEntry =
+			objectEntryLocalService.getObjectEntry(
+				externalReferenceCode,
+				objectDefinition.getObjectDefinitionId());
+
+		return getObjectEntryVersions(
+			dtoConverterContext, objectEntry.getObjectEntryId(), pagination);
 	}
 
 	@Override
@@ -1923,6 +1966,9 @@ public class DefaultObjectEntryManagerImpl
 
 	@Reference
 	private ObjectEntryService _objectEntryService;
+
+	@Reference
+	private ObjectEntryVersionService _objectEntryVersionService;
 
 	@Reference
 	private ObjectFieldBusinessTypeRegistry _objectFieldBusinessTypeRegistry;

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryResourceImpl.java
@@ -498,6 +498,42 @@ public abstract class BaseObjectEntryResourceImpl
 		value = {
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "externalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "page"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "pageSize"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "ObjectEntry")}
+	)
+	@javax.ws.rs.GET
+	@javax.ws.rs.Path(
+		"/by-external-reference-code/{externalReferenceCode}/versions"
+	)
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Page<ObjectEntry> getByExternalReferenceCodeVersionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("externalReferenceCode")
+			String externalReferenceCode,
+			@javax.ws.rs.core.Context Pagination pagination)
+		throws Exception {
+
+		return Page.of(Collections.emptyList());
+	}
+
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
 				name = "objectEntryExternalReferenceCode"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
@@ -1202,6 +1238,40 @@ public abstract class BaseObjectEntryResourceImpl
 					resourceName, resourceId)
 			).build(),
 			resourceId, resourceName, null);
+	}
+
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "objectEntryId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "page"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "pageSize"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "ObjectEntry")}
+	)
+	@javax.ws.rs.GET
+	@javax.ws.rs.Path("/{objectEntryId}/versions")
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Page<ObjectEntry> getObjectEntriesVersionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("objectEntryId")
+			Long objectEntryId,
+			@javax.ws.rs.core.Context Pagination pagination)
+		throws Exception {
+
+		return Page.of(Collections.emptyList());
 	}
 
 	@io.swagger.v3.oas.annotations.Parameters(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
@@ -22,6 +22,7 @@ import com.liferay.object.service.ObjectRelationshipService;
 import com.liferay.object.system.SystemObjectDefinitionManager;
 import com.liferay.object.system.SystemObjectDefinitionManagerRegistry;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
@@ -183,6 +184,25 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 	}
 
 	@Override
+	public Page<ObjectEntry> getByExternalReferenceCodeVersionsPage(
+			String externalReferenceCode, Pagination pagination)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+			throw new UnsupportedOperationException();
+		}
+
+		DefaultObjectEntryManager defaultObjectEntryManager =
+			DefaultObjectEntryManagerProvider.provide(
+				_objectEntryManagerRegistry.getObjectEntryManager(
+					_objectDefinition.getStorageType()));
+
+		return defaultObjectEntryManager.getObjectEntryVersions(
+			_getDTOConverterContext(null), externalReferenceCode,
+			_objectDefinition, pagination);
+	}
+
+	@Override
 	public EntityModel getEntityModel(MultivaluedMap multivaluedMap)
 		throws Exception {
 
@@ -208,6 +228,24 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 			contextCompany.getCompanyId(), _objectDefinition, null, aggregation,
 			_getDTOConverterContext(null), _getFilterString(), pagination,
 			search, sorts);
+	}
+
+	@Override
+	public Page<ObjectEntry> getObjectEntriesVersionsPage(
+			Long objectEntryId, Pagination pagination)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-17564")) {
+			throw new UnsupportedOperationException();
+		}
+
+		DefaultObjectEntryManager defaultObjectEntryManager =
+			DefaultObjectEntryManagerProvider.provide(
+				_objectEntryManagerRegistry.getObjectEntryManager(
+					_objectDefinition.getStorageType()));
+
+		return defaultObjectEntryManager.getObjectEntryVersions(
+			_getDTOConverterContext(objectEntryId), objectEntryId, pagination);
 	}
 
 	@Override

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -4238,6 +4238,56 @@ public class DefaultObjectEntryManagerImplTest
 		Assert.assertEquals(objectEntries.toString(), 1, objectEntries.size());
 	}
 
+	@FeatureFlags("LPD-17564")
+	@Test
+	public void testGetObjectEntryVersions() throws Exception {
+		ObjectEntry objectEntry1 = new ObjectEntry() {
+			{
+				externalReferenceCode = RandomTestUtil.randomString();
+				keywords = new String[] {RandomTestUtil.randomString()};
+				properties = HashMapBuilder.<String, Object>put(
+					"textObjectFieldName", RandomTestUtil.randomString()
+				).build();
+			}
+		};
+
+		_defaultObjectEntryManager.addObjectEntry(
+			dtoConverterContext, _objectDefinition1, objectEntry1,
+			ObjectDefinitionConstants.SCOPE_COMPANY);
+
+		Page<ObjectEntry> page =
+			_defaultObjectEntryManager.getObjectEntryVersions(
+				dtoConverterContext, objectEntry1.getExternalReferenceCode(),
+				_objectDefinition1, null);
+
+		assertEquals(
+			(List<ObjectEntry>)page.getItems(),
+			ListUtil.fromArray(objectEntry1));
+
+		ObjectEntry objectEntry2 = new ObjectEntry() {
+			{
+				externalReferenceCode = RandomTestUtil.randomString();
+				keywords = new String[] {RandomTestUtil.randomString()};
+				properties = HashMapBuilder.<String, Object>put(
+					"textObjectFieldName", RandomTestUtil.randomString()
+				).build();
+			}
+		};
+
+		_defaultObjectEntryManager.updateObjectEntry(
+			TestPropsValues.getCompanyId(), dtoConverterContext,
+			objectEntry1.getExternalReferenceCode(), _objectDefinition1,
+			objectEntry2, ObjectDefinitionConstants.SCOPE_COMPANY);
+
+		page = _defaultObjectEntryManager.getObjectEntryVersions(
+			dtoConverterContext, objectEntry2.getExternalReferenceCode(),
+			_objectDefinition1, null);
+
+		assertEquals(
+			(List<ObjectEntry>)page.getItems(),
+			ListUtil.fromArray(objectEntry1, objectEntry2));
+	}
+
 	@Test
 	public void testPartialUpdateObjectEntry() throws Exception {
 		LocalDateTime nowLocalDateTime = LocalDateTime.now();

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/http/ObjectEntryVersionServiceHttp.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/http/ObjectEntryVersionServiceHttp.java
@@ -5,13 +5,21 @@
 
 package com.liferay.object.service.http;
 
+import com.liferay.object.service.ObjectEntryVersionServiceUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.auth.HttpPrincipal;
+import com.liferay.portal.kernel.service.http.TunnelUtil;
+import com.liferay.portal.kernel.util.MethodHandler;
+import com.liferay.portal.kernel.util.MethodKey;
+
 /**
  * Provides the HTTP utility for the
- * <code>com.liferay.object.service.ObjectEntryVersionServiceUtil</code> service
+ * <code>ObjectEntryVersionServiceUtil</code> service
  * utility. The
  * static methods of this class calls the same methods of the service utility.
  * However, the signatures are different because it requires an additional
- * <code>com.liferay.portal.kernel.security.auth.HttpPrincipal</code> parameter.
+ * <code>HttpPrincipal</code> parameter.
  *
  * <p>
  * The benefits of using the HTTP utility is that it is fast and allows for
@@ -32,4 +40,97 @@ package com.liferay.object.service.http;
  * @generated
  */
 public class ObjectEntryVersionServiceHttp {
+
+	public static java.util.List<com.liferay.object.model.ObjectEntryVersion>
+			getObjectEntryVersions(
+				HttpPrincipal httpPrincipal, long objectEntryId, int start,
+				int end)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				ObjectEntryVersionServiceUtil.class, "getObjectEntryVersions",
+				_getObjectEntryVersionsParameterTypes0);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, objectEntryId, start, end);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (java.util.List<com.liferay.object.model.ObjectEntryVersion>)
+				returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static int getObjectEntryVersionsCount(
+			HttpPrincipal httpPrincipal, long objectEntryId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				ObjectEntryVersionServiceUtil.class,
+				"getObjectEntryVersionsCount",
+				_getObjectEntryVersionsCountParameterTypes1);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, objectEntryId);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return ((Integer)returnObj).intValue();
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	private static Log _log = LogFactoryUtil.getLog(
+		ObjectEntryVersionServiceHttp.class);
+
+	private static final Class<?>[] _getObjectEntryVersionsParameterTypes0 =
+		new Class[] {long.class, int.class, int.class};
+	private static final Class<?>[]
+		_getObjectEntryVersionsCountParameterTypes1 = new Class[] {long.class};
+
 }

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryVersionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryVersionLocalServiceImpl.java
@@ -49,6 +49,20 @@ public class ObjectEntryVersionLocalServiceImpl
 	}
 
 	@Override
+	public List<ObjectEntryVersion> getObjectEntryVersions(
+		long objectEntryId, int start, int end) {
+
+		return objectEntryVersionPersistence.findByObjectEntryId(
+			objectEntryId, start, end);
+	}
+
+	@Override
+	public int getObjectEntryVersionsCount(long objectEntryId) {
+		return objectEntryVersionPersistence.countByObjectEntryId(
+			objectEntryId);
+	}
+
+	@Override
 	public ObjectEntryVersion updateLatestObjectEntryVersion(
 			ObjectEntry objectEntry)
 		throws PortalException {

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryVersionServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryVersionServiceImpl.java
@@ -5,13 +5,22 @@
 
 package com.liferay.object.service.impl;
 
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectEntryVersion;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectEntryService;
 import com.liferay.object.service.base.ObjectEntryVersionServiceBaseImpl;
 import com.liferay.portal.aop.AopService;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+
+import java.util.List;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
- * @author Marco Leo
+ * @author Feliphe Marinho
  */
 @Component(
 	property = {
@@ -22,4 +31,43 @@ import org.osgi.service.component.annotations.Component;
 )
 public class ObjectEntryVersionServiceImpl
 	extends ObjectEntryVersionServiceBaseImpl {
+
+	@Override
+	public List<ObjectEntryVersion> getObjectEntryVersions(
+			long objectEntryId, int start, int end)
+		throws PortalException {
+
+		_checkModelResourcePermission(objectEntryId);
+
+		return objectEntryVersionLocalService.getObjectEntryVersions(
+			objectEntryId, start, end);
+	}
+
+	@Override
+	public int getObjectEntryVersionsCount(long objectEntryId)
+		throws PortalException {
+
+		_checkModelResourcePermission(objectEntryId);
+
+		return objectEntryVersionLocalService.getObjectEntryVersionsCount(
+			objectEntryId);
+	}
+
+	private void _checkModelResourcePermission(long objectEntryId)
+		throws PortalException {
+
+		ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
+			objectEntryId);
+
+		_objectEntryService.checkModelResourcePermission(
+			objectEntry.getObjectDefinitionId(), objectEntryId,
+			ActionKeys.UPDATE);
+	}
+
+	@Reference
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Reference
+	private ObjectEntryService _objectEntryService;
+
 }


### PR DESCRIPTION
Related: 

1. [LPD-49223](https://liferay.atlassian.net/browse/LPD-49223)
2. [[Object Entry Version API] Slack thread](https://liferay.slack.com/archives/C03S91MJG6L/p1740774603819079)

[LPD-49223]: https://liferay.atlassian.net/browse/LPD-49223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary

Object entries now support versioning, whenever an object entry is created or updated a snapshot of it is stored, the goal of these changes is to retrieve those snapshots via REST API.

## Solution

GET -> `/by-external-reference-code/{externalReferenceCode}/versions`
GET -> `/{objectEntryId}/versions`

### Response

[ObjectEntry DTO](https://github.com/liferay-bpm/liferay-portal/blob/17d3c7463a42fd12d740fbe51e167964c2ff177b/modules/apps/object/object-rest-impl/rest-openapi.yaml#L83)