### PR TITLE
LPD-51050 Update default response in REST APIs for Custom Fields of some Array types

### DIFF
--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/util/CustomFieldsUtil.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/util/CustomFieldsUtil.java
@@ -30,7 +30,6 @@ import java.text.DateFormat;
 import java.text.ParseException;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Locale;
@@ -76,15 +75,66 @@ public class CustomFieldsUtil {
 		Locale locale) {
 
 		if (customFields == null) {
-			return Collections.emptyMap();
+			return null;
 		}
 
 		Map<String, Serializable> map = new HashMap<>();
 
+		ExpandoBridge expandoBridge = ExpandoBridgeFactoryUtil.getExpandoBridge(
+			companyId, className);
+
 		for (CustomField customField : customFields) {
-			map.put(
-				customField.getName(),
-				_getValue(className, companyId, locale, customField));
+			String fieldName = customField.getName();
+
+			int attributeType = expandoBridge.getAttributeType(fieldName);
+
+			CustomValue customValue = customField.getCustomValue();
+
+			Object data = customValue.getData();
+
+			if (ExpandoColumnConstants.DATE == attributeType) {
+				map.put(fieldName, _parseDate(String.valueOf(data)));
+			}
+			else if (ExpandoColumnConstants.DOUBLE_ARRAY == attributeType) {
+				map.put(fieldName, _toArray(data, ArrayUtil::toDoubleArray));
+			}
+			else if (ExpandoColumnConstants.FLOAT_ARRAY == attributeType) {
+				map.put(fieldName, _toArray(data, ArrayUtil::toFloatArray));
+			}
+			else if (ExpandoColumnConstants.GEOLOCATION == attributeType) {
+				Geo geo = customValue.getGeo();
+
+				map.put(
+					fieldName,
+					JSONUtil.put(
+						"latitude", geo.getLatitude()
+					).put(
+						"longitude", geo.getLongitude()
+					).toString());
+			}
+			else if (ExpandoColumnConstants.INTEGER_ARRAY == attributeType) {
+				map.put(fieldName, _toArray(data, ArrayUtil::toIntArray));
+			}
+			else if (ExpandoColumnConstants.LONG_ARRAY == attributeType) {
+				map.put(
+					fieldName,
+					_toArray(
+						data,
+						(Function<Collection<Number>, Serializable>)
+							ArrayUtil::toLongArray));
+			}
+			else if (ExpandoColumnConstants.STRING_ARRAY == attributeType) {
+				map.put(fieldName, _toArray(data, ArrayUtil::toStringArray));
+			}
+			else if (ExpandoColumnConstants.STRING_LOCALIZED == attributeType) {
+				map.put(
+					fieldName,
+					(Serializable)LocalizedMapUtil.getLocalizedMap(
+						locale, (String)data, customValue.getData_i18n()));
+			}
+			else {
+				map.put(fieldName, (Serializable)data);
+			}
 		}
 
 		return map;
@@ -126,62 +176,10 @@ public class CustomFieldsUtil {
 		Object value = entry.getValue();
 
 		if (_isEmpty(value)) {
-			return expandoBridge.getAttributeDefault(key);
+			value = expandoBridge.getAttributeDefault(key);
 		}
 
 		return value;
-	}
-
-	private static Serializable _getValue(
-		String className, long companyId, Locale locale,
-		CustomField customField) {
-
-		ExpandoBridge expandoBridge = ExpandoBridgeFactoryUtil.getExpandoBridge(
-			companyId, className);
-
-		int attributeType = expandoBridge.getAttributeType(
-			customField.getName());
-
-		CustomValue customValue = customField.getCustomValue();
-
-		Object data = customValue.getData();
-
-		if (ExpandoColumnConstants.DATE == attributeType) {
-			return _parseDate(String.valueOf(data));
-		}
-		else if (ExpandoColumnConstants.DOUBLE_ARRAY == attributeType) {
-			return _toArray(data, ArrayUtil::toDoubleArray);
-		}
-		else if (ExpandoColumnConstants.FLOAT_ARRAY == attributeType) {
-			return _toArray(data, ArrayUtil::toFloatArray);
-		}
-		else if (ExpandoColumnConstants.GEOLOCATION == attributeType) {
-			Geo geo = customValue.getGeo();
-
-			return JSONUtil.put(
-				"latitude", geo.getLatitude()
-			).put(
-				"longitude", geo.getLongitude()
-			).toString();
-		}
-		else if (ExpandoColumnConstants.INTEGER_ARRAY == attributeType) {
-			return _toArray(data, ArrayUtil::toIntArray);
-		}
-		else if (ExpandoColumnConstants.LONG_ARRAY == attributeType) {
-			return _toArray(
-				data,
-				(Function<Collection<Number>, Serializable>)
-					ArrayUtil::toLongArray);
-		}
-		else if (ExpandoColumnConstants.STRING_ARRAY == attributeType) {
-			return _toArray(data, ArrayUtil::toStringArray);
-		}
-		else if (ExpandoColumnConstants.STRING_LOCALIZED == attributeType) {
-			return (Serializable)LocalizedMapUtil.getLocalizedMap(
-				locale, (String)data, customValue.getData_i18n());
-		}
-
-		return (Serializable)data;
 	}
 
 	private static boolean _isEmpty(Object value) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/util/CustomFieldsUtil.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/util/CustomFieldsUtil.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
@@ -65,7 +66,10 @@ public class CustomFieldsUtil {
 				}
 
 				return _toCustomField(
-					acceptAllLanguages, entry, expandoBridge, locale);
+					acceptAllLanguages,
+					unicodeProperties.getProperty(
+						ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE),
+					entry, expandoBridge, locale);
 			},
 			CustomField.class);
 	}
@@ -169,13 +173,53 @@ public class CustomFieldsUtil {
 	}
 
 	private static Object _getValue(
+		int attributeType, String displayType,
 		Map.Entry<String, Serializable> entry, ExpandoBridge expandoBridge,
 		String key) {
 
 		Object value = entry.getValue();
 
-		if (_isEmpty(value)) {
-			value = expandoBridge.getAttributeDefault(key);
+		if (!_isEmpty(value)) {
+			return value;
+		}
+
+		if (!ExpandoColumnConstants.isArray(attributeType)) {
+			return expandoBridge.getAttributeDefault(key);
+		}
+
+		boolean selectionList = StringUtil.equals(
+			displayType,
+			ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE_SELECTION_LIST);
+
+		if (ExpandoColumnConstants.DOUBLE_ARRAY == attributeType) {
+			if (selectionList) {
+				return ArrayUtil.subset(
+					GetterUtil.getDoubleValues(
+						expandoBridge.getAttributeDefault(key)),
+					0, 1);
+			}
+
+			return new double[] {GetterUtil.DEFAULT_DOUBLE};
+		}
+		else if (ExpandoColumnConstants.LONG_ARRAY == attributeType) {
+			if (selectionList) {
+				return ArrayUtil.subset(
+					GetterUtil.getLongValues(
+						expandoBridge.getAttributeDefault(key)),
+					0, 1);
+			}
+
+			return new long[] {GetterUtil.DEFAULT_INTEGER};
+		}
+		else if (ExpandoColumnConstants.STRING_ARRAY == attributeType) {
+			if (selectionList) {
+				return ArrayUtil.subset(
+					GetterUtil.getStringValues(
+						expandoBridge.getAttributeDefault(key)),
+					0, 1);
+			}
+
+			return new String[] {String.valueOf(GetterUtil.DEFAULT_BOOLEAN)};
 		}
 
 		return value;
@@ -227,8 +271,9 @@ public class CustomFieldsUtil {
 	}
 
 	private static CustomField _toCustomField(
-		boolean acceptAllLanguages, Map.Entry<String, Serializable> entry,
-		ExpandoBridge expandoBridge, Locale locale) {
+		boolean acceptAllLanguages, String displayType,
+		Map.Entry<String, Serializable> entry, ExpandoBridge expandoBridge,
+		Locale locale) {
 
 		String key = entry.getKey();
 
@@ -273,11 +318,15 @@ public class CustomFieldsUtil {
 							setData(
 								() -> _getValue(
 									attributeType, locale,
-									_getValue(entry, expandoBridge, key)));
+									_getValue(
+										attributeType, displayType, entry,
+										expandoBridge, key)));
 							setData_i18n(
 								() -> _getLocalizedValues(
 									acceptAllLanguages, attributeType,
-									_getValue(entry, expandoBridge, key)));
+									_getValue(
+										attributeType, displayType, entry,
+										expandoBridge, key)));
 						}
 					});
 				setDataType(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/util/CustomFieldsUtil.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/util/CustomFieldsUtil.java
@@ -147,9 +147,8 @@ public class CustomFieldsUtil {
 			return null;
 		}
 
-		Map<Locale, String> map = (Map<Locale, String>)value;
-
-		return LocalizedMapUtil.getI18nMap(acceptAllLanguages, map);
+		return LocalizedMapUtil.getI18nMap(
+			acceptAllLanguages, (Map<Locale, String>)value);
 	}
 
 	private static Object _getValue(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/AttachmentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/AttachmentResourceImpl.java
@@ -20,6 +20,7 @@ import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.headless.commerce.admin.catalog.dto.v1_0.Attachment;
 import com.liferay.headless.commerce.admin.catalog.dto.v1_0.AttachmentBase64;
 import com.liferay.headless.commerce.admin.catalog.dto.v1_0.AttachmentUrl;
+import com.liferay.headless.commerce.admin.catalog.dto.v1_0.CustomField;
 import com.liferay.headless.commerce.admin.catalog.dto.v1_0.Product;
 import com.liferay.headless.commerce.admin.catalog.internal.dto.v1_0.util.CustomFieldsUtil;
 import com.liferay.headless.commerce.admin.catalog.internal.util.v1_0.AttachmentUtil;
@@ -44,6 +45,7 @@ import com.liferay.upload.UniqueFileNameProvider;
 import java.io.Serializable;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -476,15 +478,10 @@ public class AttachmentResourceImpl extends BaseAttachmentResourceImpl {
 			serviceContext.setAssetTagNames(attachment.getTags());
 		}
 
-		Map<String, Serializable> expandoBridgeAttributes =
-			CustomFieldsUtil.toMap(
+		serviceContext.setExpandoBridgeAttributes(
+			_getExpandoBridgeAttributes(
 				CPAttachmentFileEntry.class.getName(),
-				contextCompany.getCompanyId(), attachment.getCustomFields(),
-				contextAcceptLanguage.getPreferredLocale());
-
-		if (expandoBridgeAttributes != null) {
-			serviceContext.setExpandoBridgeAttributes(expandoBridgeAttributes);
-		}
+				attachment.getCustomFields()));
 
 		CPAttachmentFileEntry cpAttachmentFileEntry =
 			AttachmentUtil.addOrUpdateCPAttachmentFileEntry(
@@ -513,16 +510,10 @@ public class AttachmentResourceImpl extends BaseAttachmentResourceImpl {
 			serviceContext.setAssetTagNames(attachmentBase64.getTags());
 		}
 
-		Map<String, Serializable> expandoBridgeAttributes =
-			CustomFieldsUtil.toMap(
+		serviceContext.setExpandoBridgeAttributes(
+			_getExpandoBridgeAttributes(
 				CPAttachmentFileEntry.class.getName(),
-				contextCompany.getCompanyId(),
-				attachmentBase64.getCustomFields(),
-				contextAcceptLanguage.getPreferredLocale());
-
-		if (expandoBridgeAttributes != null) {
-			serviceContext.setExpandoBridgeAttributes(expandoBridgeAttributes);
-		}
+				attachmentBase64.getCustomFields()));
 
 		CPAttachmentFileEntry cpAttachmentFileEntry =
 			AttachmentUtil.addOrUpdateCPAttachmentFileEntry(
@@ -548,15 +539,10 @@ public class AttachmentResourceImpl extends BaseAttachmentResourceImpl {
 			serviceContext.setAssetTagNames(attachmentUrl.getTags());
 		}
 
-		Map<String, Serializable> expandoBridgeAttributes =
-			CustomFieldsUtil.toMap(
+		serviceContext.setExpandoBridgeAttributes(
+			_getExpandoBridgeAttributes(
 				CPAttachmentFileEntry.class.getName(),
-				contextCompany.getCompanyId(), attachmentUrl.getCustomFields(),
-				contextAcceptLanguage.getPreferredLocale());
-
-		if (expandoBridgeAttributes != null) {
-			serviceContext.setExpandoBridgeAttributes(expandoBridgeAttributes);
-		}
+				attachmentUrl.getCustomFields()));
 
 		CPAttachmentFileEntry cpAttachmentFileEntry =
 			AttachmentUtil.addOrUpdateCPAttachmentFileEntry(
@@ -648,6 +634,21 @@ public class AttachmentResourceImpl extends BaseAttachmentResourceImpl {
 			_toAttachments(cpAttachmentFileEntries), pagination, totalCount);
 	}
 
+	private Map<String, Serializable> _getExpandoBridgeAttributes(
+		String className, CustomField[] customFields) {
+
+		Map<String, Serializable> expandoBridgeAttributes =
+			CustomFieldsUtil.toMap(
+				className, contextCompany.getCompanyId(), customFields,
+				contextAcceptLanguage.getPreferredLocale());
+
+		if (expandoBridgeAttributes == null) {
+			expandoBridgeAttributes = new HashMap<>();
+		}
+
+		return expandoBridgeAttributes;
+	}
+
 	private Attachment _toAttachment(Long cpAttachmentFileEntryId)
 		throws Exception {
 
@@ -679,15 +680,10 @@ public class AttachmentResourceImpl extends BaseAttachmentResourceImpl {
 			serviceContext.setAssetTagNames(attachment.getTags());
 		}
 
-		Map<String, Serializable> expandoBridgeAttributes =
-			CustomFieldsUtil.toMap(
+		serviceContext.setExpandoBridgeAttributes(
+			_getExpandoBridgeAttributes(
 				CPAttachmentFileEntry.class.getName(),
-				contextCompany.getCompanyId(), attachment.getCustomFields(),
-				contextAcceptLanguage.getPreferredLocale());
-
-		if (expandoBridgeAttributes != null) {
-			serviceContext.setExpandoBridgeAttributes(expandoBridgeAttributes);
-		}
+				attachment.getCustomFields()));
 
 		cpAttachmentFileEntry = AttachmentUtil.updateCPAttachmentFileEntry(
 			cpAttachmentFileEntry, _cpAttachmentFileEntryService,

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/OptionResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/OptionResourceImpl.java
@@ -37,6 +37,7 @@ import com.liferay.portal.vulcan.util.SearchUtil;
 import java.io.Serializable;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import javax.ws.rs.core.MultivaluedMap;
@@ -240,10 +241,17 @@ public class OptionResourceImpl extends BaseOptionResourceImpl {
 	private Map<String, Serializable> _getExpandoBridgeAttributes(
 		Option option) {
 
-		return CustomFieldsUtil.toMap(
-			CPOption.class.getName(), contextCompany.getCompanyId(),
-			option.getCustomFields(),
-			contextAcceptLanguage.getPreferredLocale());
+		Map<String, Serializable> expandoBridgeAttributes =
+			CustomFieldsUtil.toMap(
+				CPOption.class.getName(), contextCompany.getCompanyId(),
+				option.getCustomFields(),
+				contextAcceptLanguage.getPreferredLocale());
+
+		if (expandoBridgeAttributes == null) {
+			expandoBridgeAttributes = new HashMap<>();
+		}
+
+		return expandoBridgeAttributes;
 	}
 
 	private Option _toOption(Long cpOptionId) throws Exception {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/OptionValueResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/OptionValueResourceImpl.java
@@ -37,6 +37,7 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.io.Serializable;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -307,10 +308,17 @@ public class OptionValueResourceImpl extends BaseOptionValueResourceImpl {
 	private Map<String, Serializable> _getExpandoBridgeAttributes(
 		OptionValue optionValue) {
 
-		return CustomFieldsUtil.toMap(
-			CPOptionValue.class.getName(), contextCompany.getCompanyId(),
-			optionValue.getCustomFields(),
-			contextAcceptLanguage.getPreferredLocale());
+		Map<String, Serializable> expandoBridgeAttributes =
+			CustomFieldsUtil.toMap(
+				CPOptionValue.class.getName(), contextCompany.getCompanyId(),
+				optionValue.getCustomFields(),
+				contextAcceptLanguage.getPreferredLocale());
+
+		if (expandoBridgeAttributes == null) {
+			expandoBridgeAttributes = new HashMap<>();
+		}
+
+		return expandoBridgeAttributes;
 	}
 
 	private OptionValue _toOptionValue(Long cpOptionValueId) throws Exception {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/ProductOptionResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/ProductOptionResourceImpl.java
@@ -36,6 +36,9 @@ import com.liferay.portal.vulcan.fields.NestedFieldId;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
+import java.io.Serializable;
+
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -171,10 +174,7 @@ public class ProductOptionResourceImpl extends BaseProductOptionResourceImpl {
 			cpDefinitionOptionRel.getGroupId());
 
 		serviceContext.setExpandoBridgeAttributes(
-			CustomFieldsUtil.toMap(
-				CPDefinitionOptionRel.class.getName(),
-				contextCompany.getCompanyId(), productOption.getCustomFields(),
-				contextAcceptLanguage.getPreferredLocale()));
+			_getExpandoBridgeAttributes(productOption));
 
 		_cpDefinitionOptionRelService.updateCPDefinitionOptionRel(
 			cpDefinitionOptionRel.getCPDefinitionOptionRelId(),
@@ -277,11 +277,7 @@ public class ProductOptionResourceImpl extends BaseProductOptionResourceImpl {
 					cpDefinition.getGroupId());
 
 			serviceContext.setExpandoBridgeAttributes(
-				CustomFieldsUtil.toMap(
-					CPDefinitionOptionRel.class.getName(),
-					contextCompany.getCompanyId(),
-					productOption.getCustomFields(),
-					contextAcceptLanguage.getPreferredLocale()));
+				_getExpandoBridgeAttributes(productOption));
 
 			CPDefinitionOptionRel cpDefinitionOptionRel =
 				ProductOptionUtil.addOrUpdateCPDefinitionOptionRel(
@@ -314,6 +310,22 @@ public class ProductOptionResourceImpl extends BaseProductOptionResourceImpl {
 				QueryUtil.ALL_POS),
 			cpDefinitionOptionRel -> _toProductOption(
 				cpDefinitionOptionRel.getCPDefinitionOptionRelId()));
+	}
+
+	private Map<String, Serializable> _getExpandoBridgeAttributes(
+		ProductOption productOption) {
+
+		Map<String, Serializable> expandoBridgeAttributes =
+			CustomFieldsUtil.toMap(
+				CPDefinitionOptionRel.class.getName(),
+				contextCompany.getCompanyId(), productOption.getCustomFields(),
+				contextAcceptLanguage.getPreferredLocale());
+
+		if (expandoBridgeAttributes == null) {
+			expandoBridgeAttributes = new HashMap<>();
+		}
+
+		return expandoBridgeAttributes;
 	}
 
 	private long _getOptionId(long defaultOptionId, ProductOption productOption)

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/ProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/ProductResourceImpl.java
@@ -63,6 +63,7 @@ import com.liferay.expando.kernel.service.ExpandoColumnLocalService;
 import com.liferay.expando.kernel.service.ExpandoTableLocalService;
 import com.liferay.headless.commerce.admin.catalog.dto.v1_0.Attachment;
 import com.liferay.headless.commerce.admin.catalog.dto.v1_0.Category;
+import com.liferay.headless.commerce.admin.catalog.dto.v1_0.CustomField;
 import com.liferay.headless.commerce.admin.catalog.dto.v1_0.Diagram;
 import com.liferay.headless.commerce.admin.catalog.dto.v1_0.MappedProduct;
 import com.liferay.headless.commerce.admin.catalog.dto.v1_0.Pin;
@@ -510,7 +511,8 @@ public class ProductResourceImpl extends BaseProductResourceImpl {
 		serviceContext.setAssetTagNames(assetTagNames);
 
 		serviceContext.setExpandoBridgeAttributes(
-			_getExpandoBridgeAttributes(product));
+			_getExpandoBridgeAttributes(
+				CPDefinition.class.getName(), product.getCustomFields()));
 
 		DateConfig displayDateConfig = DateConfig.toDisplayDateConfig(
 			product.getDisplayDate(), serviceContext.getTimeZone());
@@ -876,21 +878,18 @@ public class ProductResourceImpl extends BaseProductResourceImpl {
 	}
 
 	private Map<String, Serializable> _getExpandoBridgeAttributes(
-		Attachment attachment) {
+		String className, CustomField[] customFields) {
 
-		return CustomFieldsUtil.toMap(
-			CPAttachmentFileEntry.class.getName(),
-			contextCompany.getCompanyId(), attachment.getCustomFields(),
-			contextAcceptLanguage.getPreferredLocale());
-	}
+		Map<String, Serializable> expandoBridgeAttributes =
+			CustomFieldsUtil.toMap(
+				className, contextCompany.getCompanyId(), customFields,
+				contextAcceptLanguage.getPreferredLocale());
 
-	private Map<String, Serializable> _getExpandoBridgeAttributes(
-		Product product) {
+		if (expandoBridgeAttributes == null) {
+			expandoBridgeAttributes = new HashMap<>();
+		}
 
-		return CustomFieldsUtil.toMap(
-			CPDefinition.class.getName(), contextCompany.getCompanyId(),
-			product.getCustomFields(),
-			contextAcceptLanguage.getPreferredLocale());
+		return expandoBridgeAttributes;
 	}
 
 	private ProductShippingConfiguration _getProductShippingConfiguration(
@@ -1181,11 +1180,9 @@ public class ProductResourceImpl extends BaseProductResourceImpl {
 		if (productOptions != null) {
 			for (ProductOption productOption : productOptions) {
 				serviceContext.setExpandoBridgeAttributes(
-					CustomFieldsUtil.toMap(
+					_getExpandoBridgeAttributes(
 						CPDefinitionOptionRel.class.getName(),
-						contextCompany.getCompanyId(),
-						productOption.getCustomFields(),
-						contextAcceptLanguage.getPreferredLocale()));
+						productOption.getCustomFields()));
 
 				CPDefinitionOptionRel cpDefinitionOptionRel =
 					ProductOptionUtil.addOrUpdateCPDefinitionOptionRel(
@@ -1235,10 +1232,8 @@ public class ProductResourceImpl extends BaseProductResourceImpl {
 		if (skus != null) {
 			for (Sku sku : skus) {
 				serviceContext.setExpandoBridgeAttributes(
-					CustomFieldsUtil.toMap(
-						CPInstance.class.getName(),
-						contextCompany.getCompanyId(), sku.getCustomFields(),
-						contextAcceptLanguage.getPreferredLocale()));
+					_getExpandoBridgeAttributes(
+						CPInstance.class.getName(), sku.getCustomFields()));
 
 				CPInstance cpInstance = SkuUtil.addOrUpdateCPInstance(
 					_cpInstanceService, sku, cpDefinition,
@@ -1280,7 +1275,9 @@ public class ProductResourceImpl extends BaseProductResourceImpl {
 			for (Attachment attachment : images) {
 				serviceContext.setAssetTagNames(attachment.getTags());
 				serviceContext.setExpandoBridgeAttributes(
-					_getExpandoBridgeAttributes(attachment));
+					_getExpandoBridgeAttributes(
+						CPAttachmentFileEntry.class.getName(),
+						attachment.getCustomFields()));
 
 				AttachmentUtil.addOrUpdateCPAttachmentFileEntry(
 					cpDefinition.getGroupId(), _cpAttachmentFileEntryService,
@@ -1303,7 +1300,9 @@ public class ProductResourceImpl extends BaseProductResourceImpl {
 			for (Attachment attachment : attachments) {
 				serviceContext.setAssetTagNames(attachment.getTags());
 				serviceContext.setExpandoBridgeAttributes(
-					_getExpandoBridgeAttributes(attachment));
+					_getExpandoBridgeAttributes(
+						CPAttachmentFileEntry.class.getName(),
+						attachment.getCustomFields()));
 
 				AttachmentUtil.addOrUpdateCPAttachmentFileEntry(
 					cpDefinition.getGroupId(), _cpAttachmentFileEntryService,
@@ -1510,7 +1509,8 @@ public class ProductResourceImpl extends BaseProductResourceImpl {
 		serviceContext.setAssetTagNames(assetTagNames);
 
 		serviceContext.setExpandoBridgeAttributes(
-			_getExpandoBridgeAttributes(product));
+			_getExpandoBridgeAttributes(
+				CPDefinition.class.getName(), product.getCustomFields()));
 
 		Category[] categories = product.getCategories();
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/util/v1_0/DiagramUtil.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/util/v1_0/DiagramUtil.java
@@ -25,6 +25,7 @@ import com.liferay.upload.UniqueFileNameProvider;
 
 import java.io.Serializable;
 
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
@@ -179,9 +180,11 @@ public class DiagramUtil {
 				CPAttachmentFileEntry.class.getName(), companyId,
 				attachmentBase64.getCustomFields(), locale);
 
-		if (expandoBridgeAttributes != null) {
-			serviceContext.setExpandoBridgeAttributes(expandoBridgeAttributes);
+		if (expandoBridgeAttributes == null) {
+			expandoBridgeAttributes = new HashMap<>();
 		}
+
+		serviceContext.setExpandoBridgeAttributes(expandoBridgeAttributes);
 
 		return serviceContext;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/util/v1_0/MappedProductUtil.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/util/v1_0/MappedProductUtil.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 
 import java.io.Serializable;
 
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -62,12 +63,8 @@ public class MappedProductUtil {
 		ServiceContext serviceContext = serviceContextHelper.getServiceContext(
 			groupId);
 
-		Map<String, Serializable> expandoBridgeAttributes =
-			getExpandoBridgeAttributes(companyId, locale, mappedProduct);
-
-		if (expandoBridgeAttributes != null) {
-			serviceContext.setExpandoBridgeAttributes(expandoBridgeAttributes);
-		}
+		serviceContext.setExpandoBridgeAttributes(
+			getExpandoBridgeAttributes(companyId, locale, mappedProduct));
 
 		return csDiagramEntryService.addCSDiagramEntry(
 			cpDefinitionId, skuId, productId, isDiagram(null, mappedProduct),
@@ -104,9 +101,16 @@ public class MappedProductUtil {
 	public static Map<String, Serializable> getExpandoBridgeAttributes(
 		long companyId, Locale locale, MappedProduct mappedProduct) {
 
-		return CustomFieldsUtil.toMap(
-			CSDiagramEntry.class.getName(), companyId,
-			mappedProduct.getCustomFields(), locale);
+		Map<String, Serializable> expandoBridgeAttributes =
+			CustomFieldsUtil.toMap(
+				CSDiagramEntry.class.getName(), companyId,
+				mappedProduct.getCustomFields(), locale);
+
+		if (expandoBridgeAttributes == null) {
+			expandoBridgeAttributes = new HashMap<>();
+		}
+
+		return expandoBridgeAttributes;
 	}
 
 	public static boolean isDiagram(
@@ -135,12 +139,8 @@ public class MappedProductUtil {
 		ServiceContext serviceContext = serviceContextHelper.getServiceContext(
 			groupId);
 
-		Map<String, Serializable> expandoBridgeAttributes =
-			getExpandoBridgeAttributes(companyId, locale, mappedProduct);
-
-		if (expandoBridgeAttributes != null) {
-			serviceContext.setExpandoBridgeAttributes(expandoBridgeAttributes);
-		}
+		serviceContext.setExpandoBridgeAttributes(
+			getExpandoBridgeAttributes(companyId, locale, mappedProduct));
 
 		return csDiagramEntryService.updateCSDiagramEntry(
 			csDiagramEntry.getCSDiagramEntryId(),

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/util/v1_0/ProductOptionUtil.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/util/v1_0/ProductOptionUtil.java
@@ -19,6 +19,9 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 
+import java.io.Serializable;
+
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -67,11 +70,17 @@ public class ProductOptionUtil {
 				cpDefinitionOptionRel.getDescriptionMap());
 		}
 
-		serviceContext.setExpandoBridgeAttributes(
+		Map<String, Serializable> expandoBridgeAttributes =
 			CustomFieldsUtil.toMap(
 				CPDefinitionOptionRel.class.getName(),
 				serviceContext.getCompanyId(), productOption.getCustomFields(),
-				serviceContext.getLocale()));
+				serviceContext.getLocale());
+
+		if (expandoBridgeAttributes == null) {
+			expandoBridgeAttributes = new HashMap<>();
+		}
+
+		serviceContext.setExpandoBridgeAttributes(expandoBridgeAttributes);
 
 		if (cpDefinitionOptionRel == null) {
 			cpDefinitionOptionRel =

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/dto/v1_0/util/CustomFieldsUtil.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/dto/v1_0/util/CustomFieldsUtil.java
@@ -84,9 +84,57 @@ public class CustomFieldsUtil {
 			companyId, className);
 
 		for (CustomField customField : customFields) {
-			map.put(
-				customField.getName(),
-				_getValue(customField, locale, expandoBridge));
+			String fieldName = customField.getName();
+
+			int attributeType = expandoBridge.getAttributeType(fieldName);
+
+			CustomValue customValue = customField.getCustomValue();
+
+			Object data = customValue.getData();
+
+			if (ExpandoColumnConstants.DATE == attributeType) {
+				map.put(fieldName, _parseDate(String.valueOf(data)));
+			}
+			else if (ExpandoColumnConstants.DOUBLE_ARRAY == attributeType) {
+				map.put(fieldName, _toArray(data, ArrayUtil::toDoubleArray));
+			}
+			else if (ExpandoColumnConstants.FLOAT_ARRAY == attributeType) {
+				map.put(fieldName, _toArray(data, ArrayUtil::toFloatArray));
+			}
+			else if (ExpandoColumnConstants.GEOLOCATION == attributeType) {
+				Geo geo = customValue.getGeo();
+
+				map.put(
+					fieldName,
+					JSONUtil.put(
+						"latitude", geo.getLatitude()
+					).put(
+						"longitude", geo.getLongitude()
+					).toString());
+			}
+			else if (ExpandoColumnConstants.INTEGER_ARRAY == attributeType) {
+				map.put(fieldName, _toArray(data, ArrayUtil::toIntArray));
+			}
+			else if (ExpandoColumnConstants.LONG_ARRAY == attributeType) {
+				map.put(
+					fieldName,
+					_toArray(
+						data,
+						(Function<Collection<Number>, Serializable>)
+							ArrayUtil::toLongArray));
+			}
+			else if (ExpandoColumnConstants.STRING_ARRAY == attributeType) {
+				map.put(fieldName, _toArray(data, ArrayUtil::toStringArray));
+			}
+			else if (ExpandoColumnConstants.STRING_LOCALIZED == attributeType) {
+				map.put(
+					fieldName,
+					(Serializable)LocalizedMapUtil.getLocalizedMap(
+						locale, (String)data, customValue.getData_i18n()));
+			}
+			else {
+				map.put(fieldName, (Serializable)data);
+			}
 		}
 
 		return map;
@@ -101,54 +149,6 @@ public class CustomFieldsUtil {
 
 		return LocalizedMapUtil.getI18nMap(
 			acceptAllLanguages, (Map<Locale, String>)value);
-	}
-
-	private static Serializable _getValue(
-		CustomField customField, Locale locale, ExpandoBridge expandoBridge) {
-
-		int attributeType = expandoBridge.getAttributeType(
-			customField.getName());
-
-		CustomValue customValue = customField.getCustomValue();
-
-		Object data = customValue.getData();
-
-		if (ExpandoColumnConstants.DATE == attributeType) {
-			return _parseDate(String.valueOf(data));
-		}
-		else if (ExpandoColumnConstants.DOUBLE_ARRAY == attributeType) {
-			return _toArray(data, ArrayUtil::toDoubleArray);
-		}
-		else if (ExpandoColumnConstants.FLOAT_ARRAY == attributeType) {
-			return _toArray(data, ArrayUtil::toFloatArray);
-		}
-		else if (ExpandoColumnConstants.GEOLOCATION == attributeType) {
-			Geo geo = customValue.getGeo();
-
-			return JSONUtil.put(
-				"latitude", geo.getLatitude()
-			).put(
-				"longitude", geo.getLongitude()
-			).toString();
-		}
-		else if (ExpandoColumnConstants.INTEGER_ARRAY == attributeType) {
-			return _toArray(data, ArrayUtil::toIntArray);
-		}
-		else if (ExpandoColumnConstants.LONG_ARRAY == attributeType) {
-			return _toArray(
-				data,
-				(Function<Collection<Number>, Serializable>)
-					ArrayUtil::toLongArray);
-		}
-		else if (ExpandoColumnConstants.STRING_ARRAY == attributeType) {
-			return _toArray(data, ArrayUtil::toStringArray);
-		}
-		else if (ExpandoColumnConstants.STRING_LOCALIZED == attributeType) {
-			return (Serializable)LocalizedMapUtil.getLocalizedMap(
-				locale, (String)data, customValue.getData_i18n());
-		}
-
-		return (Serializable)data;
 	}
 
 	private static Object _getValue(
@@ -174,7 +174,7 @@ public class CustomFieldsUtil {
 
 		Object value = entry.getValue();
 
-		if (_isEmpty(entry.getValue())) {
+		if (_isEmpty(value)) {
 			value = expandoBridge.getAttributeDefault(key);
 		}
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/dto/v1_0/util/CustomFieldsUtil.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/dto/v1_0/util/CustomFieldsUtil.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
@@ -65,7 +66,10 @@ public class CustomFieldsUtil {
 				}
 
 				return _toCustomField(
-					acceptAllLanguages, entry, expandoBridge, locale);
+					acceptAllLanguages,
+					unicodeProperties.getProperty(
+						ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE),
+					entry, expandoBridge, locale);
 			},
 			CustomField.class);
 	}
@@ -169,13 +173,53 @@ public class CustomFieldsUtil {
 	}
 
 	private static Object _getValue(
+		int attributeType, String displayType,
 		Map.Entry<String, Serializable> entry, ExpandoBridge expandoBridge,
 		String key) {
 
 		Object value = entry.getValue();
 
-		if (_isEmpty(value)) {
-			value = expandoBridge.getAttributeDefault(key);
+		if (!_isEmpty(value)) {
+			return value;
+		}
+
+		if (!ExpandoColumnConstants.isArray(attributeType)) {
+			return expandoBridge.getAttributeDefault(key);
+		}
+
+		boolean selectionList = StringUtil.equals(
+			displayType,
+			ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE_SELECTION_LIST);
+
+		if (ExpandoColumnConstants.DOUBLE_ARRAY == attributeType) {
+			if (selectionList) {
+				return ArrayUtil.subset(
+					GetterUtil.getDoubleValues(
+						expandoBridge.getAttributeDefault(key)),
+					0, 1);
+			}
+
+			return new double[] {GetterUtil.DEFAULT_DOUBLE};
+		}
+		else if (ExpandoColumnConstants.LONG_ARRAY == attributeType) {
+			if (selectionList) {
+				return ArrayUtil.subset(
+					GetterUtil.getLongValues(
+						expandoBridge.getAttributeDefault(key)),
+					0, 1);
+			}
+
+			return new long[] {GetterUtil.DEFAULT_INTEGER};
+		}
+		else if (ExpandoColumnConstants.STRING_ARRAY == attributeType) {
+			if (selectionList) {
+				return ArrayUtil.subset(
+					GetterUtil.getStringValues(
+						expandoBridge.getAttributeDefault(key)),
+					0, 1);
+			}
+
+			return new String[] {String.valueOf(GetterUtil.DEFAULT_BOOLEAN)};
 		}
 
 		return value;
@@ -227,8 +271,9 @@ public class CustomFieldsUtil {
 	}
 
 	private static CustomField _toCustomField(
-		boolean acceptAllLanguages, Map.Entry<String, Serializable> entry,
-		ExpandoBridge expandoBridge, Locale locale) {
+		boolean acceptAllLanguages, String displayType,
+		Map.Entry<String, Serializable> entry, ExpandoBridge expandoBridge,
+		Locale locale) {
 
 		String key = entry.getKey();
 
@@ -273,11 +318,15 @@ public class CustomFieldsUtil {
 							setData(
 								() -> _getValue(
 									attributeType, locale,
-									_getValue(entry, expandoBridge, key)));
+									_getValue(
+										attributeType, displayType, entry,
+										expandoBridge, key)));
 							setData_i18n(
 								() -> _getLocalizedValues(
 									acceptAllLanguages, attributeType,
-									_getValue(entry, expandoBridge, key)));
+									_getValue(
+										attributeType, displayType, entry,
+										expandoBridge, key)));
 						}
 					});
 				setDataType(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/dto/v1_0/util/CustomFieldsUtil.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/dto/v1_0/util/CustomFieldsUtil.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
@@ -65,7 +66,10 @@ public class CustomFieldsUtil {
 				}
 
 				return _toCustomField(
-					acceptAllLanguages, entry, expandoBridge, locale);
+					acceptAllLanguages,
+					unicodeProperties.getProperty(
+						ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE),
+					entry, expandoBridge, locale);
 			},
 			CustomField.class);
 	}
@@ -169,13 +173,53 @@ public class CustomFieldsUtil {
 	}
 
 	private static Object _getValue(
+		int attributeType, String displayType,
 		Map.Entry<String, Serializable> entry, ExpandoBridge expandoBridge,
 		String key) {
 
 		Object value = entry.getValue();
 
-		if (_isEmpty(value)) {
-			value = expandoBridge.getAttributeDefault(key);
+		if (!_isEmpty(value)) {
+			return value;
+		}
+
+		if (!ExpandoColumnConstants.isArray(attributeType)) {
+			return expandoBridge.getAttributeDefault(key);
+		}
+
+		boolean selectionList = StringUtil.equals(
+			displayType,
+			ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE_SELECTION_LIST);
+
+		if (ExpandoColumnConstants.DOUBLE_ARRAY == attributeType) {
+			if (selectionList) {
+				return ArrayUtil.subset(
+					GetterUtil.getDoubleValues(
+						expandoBridge.getAttributeDefault(key)),
+					0, 1);
+			}
+
+			return new double[] {GetterUtil.DEFAULT_DOUBLE};
+		}
+		else if (ExpandoColumnConstants.LONG_ARRAY == attributeType) {
+			if (selectionList) {
+				return ArrayUtil.subset(
+					GetterUtil.getLongValues(
+						expandoBridge.getAttributeDefault(key)),
+					0, 1);
+			}
+
+			return new long[] {GetterUtil.DEFAULT_INTEGER};
+		}
+		else if (ExpandoColumnConstants.STRING_ARRAY == attributeType) {
+			if (selectionList) {
+				return ArrayUtil.subset(
+					GetterUtil.getStringValues(
+						expandoBridge.getAttributeDefault(key)),
+					0, 1);
+			}
+
+			return new String[] {String.valueOf(GetterUtil.DEFAULT_BOOLEAN)};
 		}
 
 		return value;
@@ -227,8 +271,9 @@ public class CustomFieldsUtil {
 	}
 
 	private static CustomField _toCustomField(
-		boolean acceptAllLanguages, Map.Entry<String, Serializable> entry,
-		ExpandoBridge expandoBridge, Locale locale) {
+		boolean acceptAllLanguages, String displayType,
+		Map.Entry<String, Serializable> entry, ExpandoBridge expandoBridge,
+		Locale locale) {
 
 		String key = entry.getKey();
 
@@ -273,11 +318,15 @@ public class CustomFieldsUtil {
 							setData(
 								() -> _getValue(
 									attributeType, locale,
-									_getValue(entry, expandoBridge, key)));
+									_getValue(
+										attributeType, displayType, entry,
+										expandoBridge, key)));
 							setData_i18n(
 								() -> _getLocalizedValues(
 									acceptAllLanguages, attributeType,
-									_getValue(entry, expandoBridge, key)));
+									_getValue(
+										attributeType, displayType, entry,
+										expandoBridge, key)));
 						}
 					});
 				setDataType(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/dto/v1_0/util/CustomFieldsUtil.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/dto/v1_0/util/CustomFieldsUtil.java
@@ -30,7 +30,6 @@ import java.text.DateFormat;
 import java.text.ParseException;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Locale;
@@ -76,7 +75,7 @@ public class CustomFieldsUtil {
 		Locale locale) {
 
 		if (customFields == null) {
-			return Collections.emptyMap();
+			return null;
 		}
 
 		Map<String, Serializable> map = new HashMap<>();
@@ -85,60 +84,60 @@ public class CustomFieldsUtil {
 			companyId, className);
 
 		for (CustomField customField : customFields) {
-			map.put(
-				customField.getName(),
-				_getCustomField(customField, expandoBridge, locale));
+			String fieldName = customField.getName();
+
+			int attributeType = expandoBridge.getAttributeType(fieldName);
+
+			CustomValue customValue = customField.getCustomValue();
+
+			Object data = customValue.getData();
+
+			if (ExpandoColumnConstants.DATE == attributeType) {
+				map.put(fieldName, _parseDate(String.valueOf(data)));
+			}
+			else if (ExpandoColumnConstants.DOUBLE_ARRAY == attributeType) {
+				map.put(fieldName, _toArray(data, ArrayUtil::toDoubleArray));
+			}
+			else if (ExpandoColumnConstants.FLOAT_ARRAY == attributeType) {
+				map.put(fieldName, _toArray(data, ArrayUtil::toFloatArray));
+			}
+			else if (ExpandoColumnConstants.GEOLOCATION == attributeType) {
+				Geo geo = customValue.getGeo();
+
+				map.put(
+					fieldName,
+					JSONUtil.put(
+						"latitude", geo.getLatitude()
+					).put(
+						"longitude", geo.getLongitude()
+					).toString());
+			}
+			else if (ExpandoColumnConstants.INTEGER_ARRAY == attributeType) {
+				map.put(fieldName, _toArray(data, ArrayUtil::toIntArray));
+			}
+			else if (ExpandoColumnConstants.LONG_ARRAY == attributeType) {
+				map.put(
+					fieldName,
+					_toArray(
+						data,
+						(Function<Collection<Number>, Serializable>)
+							ArrayUtil::toLongArray));
+			}
+			else if (ExpandoColumnConstants.STRING_ARRAY == attributeType) {
+				map.put(fieldName, _toArray(data, ArrayUtil::toStringArray));
+			}
+			else if (ExpandoColumnConstants.STRING_LOCALIZED == attributeType) {
+				map.put(
+					fieldName,
+					(Serializable)LocalizedMapUtil.getLocalizedMap(
+						locale, (String)data, customValue.getData_i18n()));
+			}
+			else {
+				map.put(fieldName, (Serializable)data);
+			}
 		}
 
 		return map;
-	}
-
-	private static Serializable _getCustomField(
-		CustomField customField, ExpandoBridge expandoBridge, Locale locale) {
-
-		int attributeType = expandoBridge.getAttributeType(
-			customField.getName());
-
-		CustomValue customValue = customField.getCustomValue();
-
-		Object data = customValue.getData();
-
-		if (ExpandoColumnConstants.DATE == attributeType) {
-			return _parseDate(String.valueOf(data));
-		}
-		else if (ExpandoColumnConstants.DOUBLE_ARRAY == attributeType) {
-			return _toArray(data, ArrayUtil::toDoubleArray);
-		}
-		else if (ExpandoColumnConstants.FLOAT_ARRAY == attributeType) {
-			return _toArray(data, ArrayUtil::toFloatArray);
-		}
-		else if (ExpandoColumnConstants.GEOLOCATION == attributeType) {
-			Geo geo = customValue.getGeo();
-
-			return JSONUtil.put(
-				"latitude", geo.getLatitude()
-			).put(
-				"longitude", geo.getLongitude()
-			).toString();
-		}
-		else if (ExpandoColumnConstants.INTEGER_ARRAY == attributeType) {
-			return _toArray(data, ArrayUtil::toIntArray);
-		}
-		else if (ExpandoColumnConstants.LONG_ARRAY == attributeType) {
-			return _toArray(
-				data,
-				(Function<Collection<Number>, Serializable>)
-					ArrayUtil::toLongArray);
-		}
-		else if (ExpandoColumnConstants.STRING_ARRAY == attributeType) {
-			return _toArray(data, ArrayUtil::toStringArray);
-		}
-		else if (ExpandoColumnConstants.STRING_LOCALIZED == attributeType) {
-			return (Serializable)LocalizedMapUtil.getLocalizedMap(
-				locale, (String)data, customValue.getData_i18n());
-		}
-
-		return (Serializable)data;
 	}
 
 	private static Map<String, String> _getLocalizedValues(
@@ -148,9 +147,8 @@ public class CustomFieldsUtil {
 			return null;
 		}
 
-		Map<Locale, String> map = (Map<Locale, String>)value;
-
-		return LocalizedMapUtil.getI18nMap(acceptAllLanguages, map);
+		return LocalizedMapUtil.getI18nMap(
+			acceptAllLanguages, (Map<Locale, String>)value);
 	}
 
 	private static Object _getValue(
@@ -176,7 +174,7 @@ public class CustomFieldsUtil {
 
 		Object value = entry.getValue();
 
-		if (_isEmpty(entry.getValue())) {
+		if (_isEmpty(value)) {
 			value = expandoBridge.getAttributeDefault(key);
 		}
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/ShipmentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/ShipmentResourceImpl.java
@@ -46,6 +46,7 @@ import java.io.Serializable;
 
 import java.util.Calendar;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
@@ -434,9 +435,11 @@ public class ShipmentResourceImpl extends BaseShipmentResourceImpl {
 				shipment.getCustomFields(),
 				contextAcceptLanguage.getPreferredLocale());
 
-		if (expandoBridgeAttributes != null) {
-			serviceContext.setExpandoBridgeAttributes(expandoBridgeAttributes);
+		if (expandoBridgeAttributes == null) {
+			expandoBridgeAttributes = new HashMap<>();
 		}
+
+		serviceContext.setExpandoBridgeAttributes(expandoBridgeAttributes);
 
 		_commerceShipmentService.updateCommerceShipment(
 			commerceShipment.getCommerceShipmentId(),

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/dto/v1_0/util/CustomFieldsUtil.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/dto/v1_0/util/CustomFieldsUtil.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
@@ -65,7 +66,10 @@ public class CustomFieldsUtil {
 				}
 
 				return _toCustomField(
-					acceptAllLanguages, entry, expandoBridge, locale);
+					acceptAllLanguages,
+					unicodeProperties.getProperty(
+						ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE),
+					entry, expandoBridge, locale);
 			},
 			CustomField.class);
 	}
@@ -169,13 +173,53 @@ public class CustomFieldsUtil {
 	}
 
 	private static Object _getValue(
+		int attributeType, String displayType,
 		Map.Entry<String, Serializable> entry, ExpandoBridge expandoBridge,
 		String key) {
 
 		Object value = entry.getValue();
 
-		if (_isEmpty(value)) {
-			value = expandoBridge.getAttributeDefault(key);
+		if (!_isEmpty(value)) {
+			return value;
+		}
+
+		if (!ExpandoColumnConstants.isArray(attributeType)) {
+			return expandoBridge.getAttributeDefault(key);
+		}
+
+		boolean selectionList = StringUtil.equals(
+			displayType,
+			ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE_SELECTION_LIST);
+
+		if (ExpandoColumnConstants.DOUBLE_ARRAY == attributeType) {
+			if (selectionList) {
+				return ArrayUtil.subset(
+					GetterUtil.getDoubleValues(
+						expandoBridge.getAttributeDefault(key)),
+					0, 1);
+			}
+
+			return new double[] {GetterUtil.DEFAULT_DOUBLE};
+		}
+		else if (ExpandoColumnConstants.LONG_ARRAY == attributeType) {
+			if (selectionList) {
+				return ArrayUtil.subset(
+					GetterUtil.getLongValues(
+						expandoBridge.getAttributeDefault(key)),
+					0, 1);
+			}
+
+			return new long[] {GetterUtil.DEFAULT_INTEGER};
+		}
+		else if (ExpandoColumnConstants.STRING_ARRAY == attributeType) {
+			if (selectionList) {
+				return ArrayUtil.subset(
+					GetterUtil.getStringValues(
+						expandoBridge.getAttributeDefault(key)),
+					0, 1);
+			}
+
+			return new String[] {String.valueOf(GetterUtil.DEFAULT_BOOLEAN)};
 		}
 
 		return value;
@@ -227,8 +271,9 @@ public class CustomFieldsUtil {
 	}
 
 	private static CustomField _toCustomField(
-		boolean acceptAllLanguages, Map.Entry<String, Serializable> entry,
-		ExpandoBridge expandoBridge, Locale locale) {
+		boolean acceptAllLanguages, String displayType,
+		Map.Entry<String, Serializable> entry, ExpandoBridge expandoBridge,
+		Locale locale) {
 
 		String key = entry.getKey();
 
@@ -273,11 +318,15 @@ public class CustomFieldsUtil {
 							setData(
 								() -> _getValue(
 									attributeType, locale,
-									_getValue(entry, expandoBridge, key)));
+									_getValue(
+										attributeType, displayType, entry,
+										expandoBridge, key)));
 							setData_i18n(
 								() -> _getLocalizedValues(
 									acceptAllLanguages, attributeType,
-									_getValue(entry, expandoBridge, key)));
+									_getValue(
+										attributeType, displayType, entry,
+										expandoBridge, key)));
 						}
 					});
 				setDataType(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/dto/v1_0/util/CustomFieldsUtil.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/dto/v1_0/util/CustomFieldsUtil.java
@@ -30,7 +30,6 @@ import java.text.DateFormat;
 import java.text.ParseException;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Locale;
@@ -76,15 +75,66 @@ public class CustomFieldsUtil {
 		Locale locale) {
 
 		if (customFields == null) {
-			return Collections.emptyMap();
+			return null;
 		}
 
 		Map<String, Serializable> map = new HashMap<>();
 
+		ExpandoBridge expandoBridge = ExpandoBridgeFactoryUtil.getExpandoBridge(
+			companyId, className);
+
 		for (CustomField customField : customFields) {
-			map.put(
-				customField.getName(),
-				_getValue(className, companyId, locale, customField));
+			String fieldName = customField.getName();
+
+			int attributeType = expandoBridge.getAttributeType(fieldName);
+
+			CustomValue customValue = customField.getCustomValue();
+
+			Object data = customValue.getData();
+
+			if (ExpandoColumnConstants.DATE == attributeType) {
+				map.put(fieldName, _parseDate(String.valueOf(data)));
+			}
+			else if (ExpandoColumnConstants.DOUBLE_ARRAY == attributeType) {
+				map.put(fieldName, _toArray(data, ArrayUtil::toDoubleArray));
+			}
+			else if (ExpandoColumnConstants.FLOAT_ARRAY == attributeType) {
+				map.put(fieldName, _toArray(data, ArrayUtil::toFloatArray));
+			}
+			else if (ExpandoColumnConstants.GEOLOCATION == attributeType) {
+				Geo geo = customValue.getGeo();
+
+				map.put(
+					fieldName,
+					JSONUtil.put(
+						"latitude", geo.getLatitude()
+					).put(
+						"longitude", geo.getLongitude()
+					).toString());
+			}
+			else if (ExpandoColumnConstants.INTEGER_ARRAY == attributeType) {
+				map.put(fieldName, _toArray(data, ArrayUtil::toIntArray));
+			}
+			else if (ExpandoColumnConstants.LONG_ARRAY == attributeType) {
+				map.put(
+					fieldName,
+					_toArray(
+						data,
+						(Function<Collection<Number>, Serializable>)
+							ArrayUtil::toLongArray));
+			}
+			else if (ExpandoColumnConstants.STRING_ARRAY == attributeType) {
+				map.put(fieldName, _toArray(data, ArrayUtil::toStringArray));
+			}
+			else if (ExpandoColumnConstants.STRING_LOCALIZED == attributeType) {
+				map.put(
+					fieldName,
+					(Serializable)LocalizedMapUtil.getLocalizedMap(
+						locale, (String)data, customValue.getData_i18n()));
+			}
+			else {
+				map.put(fieldName, (Serializable)data);
+			}
 		}
 
 		return map;
@@ -97,9 +147,8 @@ public class CustomFieldsUtil {
 			return null;
 		}
 
-		Map<Locale, String> map = (Map<Locale, String>)value;
-
-		return LocalizedMapUtil.getI18nMap(acceptAllLanguages, map);
+		return LocalizedMapUtil.getI18nMap(
+			acceptAllLanguages, (Map<Locale, String>)value);
 	}
 
 	private static Object _getValue(
@@ -126,62 +175,10 @@ public class CustomFieldsUtil {
 		Object value = entry.getValue();
 
 		if (_isEmpty(value)) {
-			return expandoBridge.getAttributeDefault(key);
+			value = expandoBridge.getAttributeDefault(key);
 		}
 
 		return value;
-	}
-
-	private static Serializable _getValue(
-		String className, long companyId, Locale locale,
-		CustomField customField) {
-
-		ExpandoBridge expandoBridge = ExpandoBridgeFactoryUtil.getExpandoBridge(
-			companyId, className);
-
-		int attributeType = expandoBridge.getAttributeType(
-			customField.getName());
-
-		CustomValue customValue = customField.getCustomValue();
-
-		Object data = customValue.getData();
-
-		if (ExpandoColumnConstants.DATE == attributeType) {
-			return _parseDate(String.valueOf(data));
-		}
-		else if (ExpandoColumnConstants.DOUBLE_ARRAY == attributeType) {
-			return _toArray(data, ArrayUtil::toDoubleArray);
-		}
-		else if (ExpandoColumnConstants.FLOAT_ARRAY == attributeType) {
-			return _toArray(data, ArrayUtil::toFloatArray);
-		}
-		else if (ExpandoColumnConstants.GEOLOCATION == attributeType) {
-			Geo geo = customValue.getGeo();
-
-			return JSONUtil.put(
-				"latitude", geo.getLatitude()
-			).put(
-				"longitude", geo.getLongitude()
-			).toString();
-		}
-		else if (ExpandoColumnConstants.INTEGER_ARRAY == attributeType) {
-			return _toArray(data, ArrayUtil::toIntArray);
-		}
-		else if (ExpandoColumnConstants.LONG_ARRAY == attributeType) {
-			return _toArray(
-				data,
-				(Function<Collection<Number>, Serializable>)
-					ArrayUtil::toLongArray);
-		}
-		else if (ExpandoColumnConstants.STRING_ARRAY == attributeType) {
-			return _toArray(data, ArrayUtil::toStringArray);
-		}
-		else if (ExpandoColumnConstants.STRING_LOCALIZED == attributeType) {
-			return (Serializable)LocalizedMapUtil.getLocalizedMap(
-				locale, (String)data, customValue.getData_i18n());
-		}
-
-		return (Serializable)data;
 	}
 
 	private static boolean _isEmpty(Object value) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/AccountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/AccountResourceImpl.java
@@ -42,6 +42,9 @@ import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.util.SearchUtil;
 
+import java.io.Serializable;
+
+import java.util.HashMap;
 import java.util.Map;
 
 import javax.ws.rs.core.MultivaluedMap;
@@ -169,13 +172,20 @@ public class AccountResourceImpl extends BaseAccountResourceImpl {
 	private ServiceContext _createServiceContext(Account account)
 		throws Exception {
 
-		ServiceContext serviceContext = ServiceContextBuilder.create(
-			contextCompany.getGroupId(), contextHttpServletRequest, null
-		).expandoBridgeAttributes(
+		Map<String, Serializable> expandoBridgeAttributes =
 			CustomFieldsUtil.toMap(
 				AccountEntry.class.getName(), contextCompany.getCompanyId(),
 				account.getCustomFields(),
-				contextAcceptLanguage.getPreferredLocale())
+				contextAcceptLanguage.getPreferredLocale());
+
+		if (expandoBridgeAttributes == null) {
+			expandoBridgeAttributes = new HashMap<>();
+		}
+
+		ServiceContext serviceContext = ServiceContextBuilder.create(
+			contextCompany.getGroupId(), contextHttpServletRequest, null
+		).expandoBridgeAttributes(
+			expandoBridgeAttributes
 		).build();
 
 		serviceContext.setCompanyId(contextCompany.getCompanyId());

--- a/modules/apps/expando/expando-test-util/bnd.bnd
+++ b/modules/apps/expando/expando-test-util/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Expando Test Utilities
 Bundle-SymbolicName: com.liferay.expando.test.util
-Bundle-Version: 1.0.2
+Bundle-Version: 1.1.0
 Export-Package: com.liferay.expando.test.util

--- a/modules/apps/expando/expando-test-util/src/main/java/com/liferay/expando/test/util/ExpandoTestUtil.java
+++ b/modules/apps/expando/expando-test-util/src/main/java/com/liferay/expando/test/util/ExpandoTestUtil.java
@@ -44,6 +44,14 @@ public class ExpandoTestUtil {
 			table.getTableId(), columnName, type, defaultData);
 	}
 
+	public static ExpandoColumn addColumn(
+			ExpandoTable table, String columnName, int type, Object defaultData)
+		throws Exception {
+
+		return ExpandoColumnLocalServiceUtil.addColumn(
+			table.getTableId(), columnName, type, defaultData);
+	}
+
 	public static ExpandoTable addTable(long classNameId, String tableName)
 		throws Exception {
 

--- a/modules/apps/expando/expando-test-util/src/main/resources/com/liferay/expando/test/util/packageinfo
+++ b/modules/apps/expando/expando-test-util/src/main/resources/com/liferay/expando/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/dto/v1_0/util/CustomFieldsUtil.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/dto/v1_0/util/CustomFieldsUtil.java
@@ -14,8 +14,10 @@ import com.liferay.headless.delivery.dto.v1_0.Geo;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
@@ -56,7 +58,10 @@ public class CustomFieldsUtil {
 				}
 
 				return _toCustomField(
-					acceptAllLanguages, entry, expandoBridge, locale);
+					acceptAllLanguages,
+					unicodeProperties.getProperty(
+						ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE),
+					entry, expandoBridge, locale);
 			},
 			CustomField.class);
 	}
@@ -90,13 +95,53 @@ public class CustomFieldsUtil {
 	}
 
 	private static Object _getValue(
+		int attributeType, String displayType,
 		Map.Entry<String, Serializable> entry, ExpandoBridge expandoBridge,
 		String key) {
 
 		Object value = entry.getValue();
 
-		if (_isEmpty(value)) {
-			value = expandoBridge.getAttributeDefault(key);
+		if (!_isEmpty(value)) {
+			return value;
+		}
+
+		if (!ExpandoColumnConstants.isArray(attributeType)) {
+			return expandoBridge.getAttributeDefault(key);
+		}
+
+		boolean selectionList = StringUtil.equals(
+			displayType,
+			ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE_SELECTION_LIST);
+
+		if (ExpandoColumnConstants.DOUBLE_ARRAY == attributeType) {
+			if (selectionList) {
+				return ArrayUtil.subset(
+					GetterUtil.getDoubleValues(
+						expandoBridge.getAttributeDefault(key)),
+					0, 1);
+			}
+
+			return new double[] {GetterUtil.DEFAULT_DOUBLE};
+		}
+		else if (ExpandoColumnConstants.LONG_ARRAY == attributeType) {
+			if (selectionList) {
+				return ArrayUtil.subset(
+					GetterUtil.getLongValues(
+						expandoBridge.getAttributeDefault(key)),
+					0, 1);
+			}
+
+			return new long[] {GetterUtil.DEFAULT_INTEGER};
+		}
+		else if (ExpandoColumnConstants.STRING_ARRAY == attributeType) {
+			if (selectionList) {
+				return ArrayUtil.subset(
+					GetterUtil.getStringValues(
+						expandoBridge.getAttributeDefault(key)),
+					0, 1);
+			}
+
+			return new String[] {String.valueOf(GetterUtil.DEFAULT_BOOLEAN)};
 		}
 
 		return value;
@@ -125,8 +170,9 @@ public class CustomFieldsUtil {
 	}
 
 	private static CustomField _toCustomField(
-		boolean acceptAllLanguages, Map.Entry<String, Serializable> entry,
-		ExpandoBridge expandoBridge, Locale locale) {
+		boolean acceptAllLanguages, String displayType,
+		Map.Entry<String, Serializable> entry, ExpandoBridge expandoBridge,
+		Locale locale) {
 
 		String key = entry.getKey();
 
@@ -171,11 +217,15 @@ public class CustomFieldsUtil {
 							setData(
 								() -> _getValue(
 									attributeType, locale,
-									_getValue(entry, expandoBridge, key)));
+									_getValue(
+										attributeType, displayType, entry,
+										expandoBridge, key)));
 							setData_i18n(
 								() -> _getLocalizedValues(
 									acceptAllLanguages, attributeType,
-									_getValue(entry, expandoBridge, key)));
+									_getValue(
+										attributeType, displayType, entry,
+										expandoBridge, key)));
 						}
 					});
 				setDataType(

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/dto/v1_0/util/CustomFieldsUtil.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/dto/v1_0/util/CustomFieldsUtil.java
@@ -68,9 +68,8 @@ public class CustomFieldsUtil {
 			return null;
 		}
 
-		Map<Locale, String> map = (Map<Locale, String>)value;
-
-		return LocalizedMapUtil.getI18nMap(acceptAllLanguages, map);
+		return LocalizedMapUtil.getI18nMap(
+			acceptAllLanguages, (Map<Locale, String>)value);
 	}
 
 	private static Object _getValue(

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/dto/v1_0/util/CustomFieldsUtil.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/dto/v1_0/util/CustomFieldsUtil.java
@@ -96,7 +96,7 @@ public class CustomFieldsUtil {
 
 		Object value = entry.getValue();
 
-		if (_isEmpty(entry.getValue())) {
+		if (_isEmpty(value)) {
 			value = expandoBridge.getAttributeDefault(key);
 		}
 

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/dto/v1_0/util/CustomFieldsUtil.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/dto/v1_0/util/CustomFieldsUtil.java
@@ -11,6 +11,7 @@ import com.liferay.expando.kernel.util.ExpandoBridgeFactoryUtil;
 import com.liferay.headless.delivery.dto.v1_0.CustomField;
 import com.liferay.headless.delivery.dto.v1_0.CustomValue;
 import com.liferay.headless.delivery.dto.v1_0.Geo;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.util.DateUtil;
@@ -22,9 +23,7 @@ import java.io.Serializable;
 
 import java.lang.reflect.Array;
 
-import java.util.ArrayList;
 import java.util.Date;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
@@ -38,30 +37,28 @@ public class CustomFieldsUtil {
 		boolean acceptAllLanguages, String className, long classPK,
 		long companyId, Locale locale) {
 
-		List<CustomField> customFields = new ArrayList<>();
-
 		ExpandoBridge expandoBridge = ExpandoBridgeFactoryUtil.getExpandoBridge(
 			companyId, className, classPK);
 
 		Map<String, Serializable> attributes = expandoBridge.getAttributes();
 
-		for (Map.Entry<String, Serializable> entry : attributes.entrySet()) {
-			UnicodeProperties unicodeProperties =
-				expandoBridge.getAttributeProperties(entry.getKey());
+		return TransformUtil.transformToArray(
+			attributes.entrySet(),
+			entry -> {
+				UnicodeProperties unicodeProperties =
+					expandoBridge.getAttributeProperties(entry.getKey());
 
-			if (GetterUtil.getBoolean(
-					unicodeProperties.getProperty(
-						ExpandoColumnConstants.PROPERTY_HIDDEN))) {
+				if (GetterUtil.getBoolean(
+						unicodeProperties.getProperty(
+							ExpandoColumnConstants.PROPERTY_HIDDEN))) {
 
-				continue;
-			}
+					return null;
+				}
 
-			customFields.add(
-				_toCustomField(
-					acceptAllLanguages, entry, expandoBridge, locale));
-		}
-
-		return customFields.toArray(new CustomField[0]);
+				return _toCustomField(
+					acceptAllLanguages, entry, expandoBridge, locale);
+			},
+			CustomField.class);
 	}
 
 	private static Map<String, String> _getLocalizedValues(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/util/CustomFieldsUtil.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/util/CustomFieldsUtil.java
@@ -84,80 +84,57 @@ public class CustomFieldsUtil {
 			companyId, className);
 
 		for (CustomField customField : customFields) {
-			String name = customField.getName();
+			String fieldName = customField.getName();
 
-			int attributeType = expandoBridge.getAttributeType(
-				customField.getName());
+			int attributeType = expandoBridge.getAttributeType(fieldName);
 
 			CustomValue customValue = customField.getCustomValue();
 
 			Object data = customValue.getData();
 
 			if (ExpandoColumnConstants.DATE == attributeType) {
-				map.put(name, _parseDate(String.valueOf(data)));
-
-				continue;
+				map.put(fieldName, _parseDate(String.valueOf(data)));
 			}
-
-			if (ExpandoColumnConstants.DOUBLE_ARRAY == attributeType) {
-				map.put(name, _toArray(data, ArrayUtil::toDoubleArray));
-
-				continue;
+			else if (ExpandoColumnConstants.DOUBLE_ARRAY == attributeType) {
+				map.put(fieldName, _toArray(data, ArrayUtil::toDoubleArray));
 			}
-
-			if (ExpandoColumnConstants.FLOAT_ARRAY == attributeType) {
-				map.put(name, _toArray(data, ArrayUtil::toFloatArray));
-
-				continue;
+			else if (ExpandoColumnConstants.FLOAT_ARRAY == attributeType) {
+				map.put(fieldName, _toArray(data, ArrayUtil::toFloatArray));
 			}
-
-			if (ExpandoColumnConstants.GEOLOCATION == attributeType) {
+			else if (ExpandoColumnConstants.GEOLOCATION == attributeType) {
 				Geo geo = customValue.getGeo();
 
 				map.put(
-					name,
+					fieldName,
 					JSONUtil.put(
 						"latitude", geo.getLatitude()
 					).put(
 						"longitude", geo.getLongitude()
 					).toString());
-
-				continue;
 			}
-
-			if (ExpandoColumnConstants.INTEGER_ARRAY == attributeType) {
-				map.put(name, _toArray(data, ArrayUtil::toIntArray));
-
-				continue;
+			else if (ExpandoColumnConstants.INTEGER_ARRAY == attributeType) {
+				map.put(fieldName, _toArray(data, ArrayUtil::toIntArray));
 			}
-
-			if (ExpandoColumnConstants.LONG_ARRAY == attributeType) {
+			else if (ExpandoColumnConstants.LONG_ARRAY == attributeType) {
 				map.put(
-					name,
+					fieldName,
 					_toArray(
 						data,
 						(Function<Collection<Number>, Serializable>)
 							ArrayUtil::toLongArray));
-
-				continue;
 			}
-
-			if (ExpandoColumnConstants.STRING_ARRAY == attributeType) {
-				map.put(name, _toArray(data, ArrayUtil::toStringArray));
-
-				continue;
+			else if (ExpandoColumnConstants.STRING_ARRAY == attributeType) {
+				map.put(fieldName, _toArray(data, ArrayUtil::toStringArray));
 			}
-
-			if (ExpandoColumnConstants.STRING_LOCALIZED == attributeType) {
+			else if (ExpandoColumnConstants.STRING_LOCALIZED == attributeType) {
 				map.put(
-					name,
+					fieldName,
 					(Serializable)LocalizedMapUtil.getLocalizedMap(
 						locale, (String)data, customValue.getData_i18n()));
-
-				continue;
 			}
-
-			map.put(name, (Serializable)data);
+			else {
+				map.put(fieldName, (Serializable)data);
+			}
 		}
 
 		return map;

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/util/CustomFieldsUtil.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/util/CustomFieldsUtil.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
@@ -65,7 +66,10 @@ public class CustomFieldsUtil {
 				}
 
 				return _toCustomField(
-					acceptAllLanguages, entry, expandoBridge, locale);
+					acceptAllLanguages,
+					unicodeProperties.getProperty(
+						ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE),
+					entry, expandoBridge, locale);
 			},
 			CustomField.class);
 	}
@@ -169,8 +173,9 @@ public class CustomFieldsUtil {
 	}
 
 	private static Object _getValue(
-		int attributeType, Map.Entry<String, Serializable> entry,
-		ExpandoBridge expandoBridge, String key) {
+		int attributeType, String displayType,
+		Map.Entry<String, Serializable> entry, ExpandoBridge expandoBridge,
+		String key) {
 
 		Object value = entry.getValue();
 
@@ -180,6 +185,41 @@ public class CustomFieldsUtil {
 
 		if (!ExpandoColumnConstants.isArray(attributeType)) {
 			return expandoBridge.getAttributeDefault(key);
+		}
+
+		boolean selectionList = StringUtil.equals(
+			displayType,
+			ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE_SELECTION_LIST);
+
+		if (ExpandoColumnConstants.DOUBLE_ARRAY == attributeType) {
+			if (selectionList) {
+				return ArrayUtil.subset(
+					GetterUtil.getDoubleValues(
+						expandoBridge.getAttributeDefault(key)),
+					0, 1);
+			}
+
+			return new double[] {GetterUtil.DEFAULT_DOUBLE};
+		}
+		else if (ExpandoColumnConstants.LONG_ARRAY == attributeType) {
+			if (selectionList) {
+				return ArrayUtil.subset(
+					GetterUtil.getLongValues(
+						expandoBridge.getAttributeDefault(key)),
+					0, 1);
+			}
+
+			return new long[] {GetterUtil.DEFAULT_INTEGER};
+		}
+		else if (ExpandoColumnConstants.STRING_ARRAY == attributeType) {
+			if (selectionList) {
+				return ArrayUtil.subset(
+					GetterUtil.getStringValues(
+						expandoBridge.getAttributeDefault(key)),
+					0, 1);
+			}
+
+			return new String[] {String.valueOf(GetterUtil.DEFAULT_BOOLEAN)};
 		}
 
 		return value;
@@ -231,8 +271,9 @@ public class CustomFieldsUtil {
 	}
 
 	private static CustomField _toCustomField(
-		boolean acceptAllLanguages, Map.Entry<String, Serializable> entry,
-		ExpandoBridge expandoBridge, Locale locale) {
+		boolean acceptAllLanguages, String displayType,
+		Map.Entry<String, Serializable> entry, ExpandoBridge expandoBridge,
+		Locale locale) {
 
 		String key = entry.getKey();
 
@@ -278,14 +319,14 @@ public class CustomFieldsUtil {
 								() -> _getValue(
 									attributeType, locale,
 									_getValue(
-										attributeType, entry, expandoBridge,
-										key)));
+										attributeType, displayType, entry,
+										expandoBridge, key)));
 							setData_i18n(
 								() -> _getLocalizedValues(
 									acceptAllLanguages, attributeType,
 									_getValue(
-										attributeType, entry, expandoBridge,
-										key)));
+										attributeType, displayType, entry,
+										expandoBridge, key)));
 						}
 					});
 				setDataType(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/util/CustomFieldsUtil.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/util/CustomFieldsUtil.java
@@ -169,13 +169,17 @@ public class CustomFieldsUtil {
 	}
 
 	private static Object _getValue(
-		Map.Entry<String, Serializable> entry, ExpandoBridge expandoBridge,
-		String key) {
+		int attributeType, Map.Entry<String, Serializable> entry,
+		ExpandoBridge expandoBridge, String key) {
 
 		Object value = entry.getValue();
 
-		if (_isEmpty(value)) {
-			value = expandoBridge.getAttributeDefault(key);
+		if (!_isEmpty(value)) {
+			return value;
+		}
+
+		if (!ExpandoColumnConstants.isArray(attributeType)) {
+			return expandoBridge.getAttributeDefault(key);
 		}
 
 		return value;
@@ -273,11 +277,15 @@ public class CustomFieldsUtil {
 							setData(
 								() -> _getValue(
 									attributeType, locale,
-									_getValue(entry, expandoBridge, key)));
+									_getValue(
+										attributeType, entry, expandoBridge,
+										key)));
 							setData_i18n(
 								() -> _getLocalizedValues(
 									acceptAllLanguages, attributeType,
-									_getValue(entry, expandoBridge, key)));
+									_getValue(
+										attributeType, entry, expandoBridge,
+										key)));
 						}
 					});
 				setDataType(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/util/CustomFieldsUtil.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/util/CustomFieldsUtil.java
@@ -147,9 +147,8 @@ public class CustomFieldsUtil {
 			return null;
 		}
 
-		Map<Locale, String> map = (Map<Locale, String>)value;
-
-		return LocalizedMapUtil.getI18nMap(acceptAllLanguages, map);
+		return LocalizedMapUtil.getI18nMap(
+			acceptAllLanguages, (Map<Locale, String>)value);
 	}
 
 	private static Object _getValue(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/util/CustomFieldsUtil.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/util/CustomFieldsUtil.java
@@ -175,7 +175,7 @@ public class CustomFieldsUtil {
 
 		Object value = entry.getValue();
 
-		if (_isEmpty(entry.getValue())) {
+		if (_isEmpty(value)) {
 			value = expandoBridge.getAttributeDefault(key);
 		}
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/build.gradle
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/build.gradle
@@ -12,6 +12,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:captcha:captcha-api")
 	testIntegrationImplementation project(":apps:depot:depot-api")
 	testIntegrationImplementation project(":apps:document-library:document-library-api")
+	testIntegrationImplementation project(":apps:expando:expando-test-util")
 	testIntegrationImplementation project(":apps:headless:headless-admin-user:headless-admin-user-api")
 	testIntegrationImplementation project(":apps:headless:headless-admin-user:headless-admin-user-client")
 	testIntegrationImplementation project(":apps:oauth-client:oauth-client-api")

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/AccountResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/AccountResourceTest.java
@@ -25,11 +25,13 @@ import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.asset.kernel.service.AssetTagLocalService;
 import com.liferay.asset.test.util.AssetTestUtil;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.expando.kernel.exception.NoSuchValueException;
 import com.liferay.expando.kernel.model.ExpandoColumn;
 import com.liferay.expando.kernel.model.ExpandoColumnConstants;
 import com.liferay.expando.kernel.model.ExpandoTable;
 import com.liferay.expando.kernel.service.ExpandoColumnLocalService;
 import com.liferay.expando.kernel.service.ExpandoTableLocalService;
+import com.liferay.expando.test.util.ExpandoTestUtil;
 import com.liferay.headless.admin.user.client.dto.v1_0.Account;
 import com.liferay.headless.admin.user.client.dto.v1_0.AccountContactInformation;
 import com.liferay.headless.admin.user.client.dto.v1_0.Creator;
@@ -1045,6 +1047,20 @@ public class AccountResourceTest extends BaseAccountResourceTestCase {
 		return true;
 	}
 
+	private Object _getCustomFieldValueData(Account account, String name)
+		throws Exception {
+
+		for (CustomField customField : account.getCustomFields()) {
+			if (StringUtil.equals(customField.getName(), name)) {
+				CustomValue customValue = customField.getCustomValue();
+
+				return customValue.getData();
+			}
+		}
+
+		throw new NoSuchValueException();
+	}
+
 	private Account _postAccount() throws Exception {
 		return _postAccount(randomAccount());
 	}
@@ -1150,25 +1166,54 @@ public class AccountResourceTest extends BaseAccountResourceTestCase {
 	}
 
 	private void _testGetAccountsPageWithCustomFields() throws Exception {
-		ExpandoTable expandoTable = _expandoTableLocalService.addTable(
-			testGroup.getCompanyId(),
+		ExpandoTable expandoTable = ExpandoTestUtil.addTable(
 			_classNameLocalService.getClassNameId(AccountEntry.class),
 			"CUSTOM_FIELDS");
 
-		ExpandoColumn expandoColumn = _expandoColumnLocalService.addColumn(
-			expandoTable.getTableId(), "A" + RandomTestUtil.randomString(),
+		ExpandoColumn textExpandoColumn = ExpandoTestUtil.addColumn(
+			expandoTable, "A" + RandomTestUtil.randomString(),
 			ExpandoColumnConstants.STRING);
 
 		UnicodeProperties unicodeProperties =
-			expandoColumn.getTypeSettingsProperties();
+			textExpandoColumn.getTypeSettingsProperties();
 
 		unicodeProperties.setProperty(
 			ExpandoColumnConstants.INDEX_TYPE,
 			String.valueOf(ExpandoColumnConstants.INDEX_TYPE_KEYWORD));
 
-		expandoColumn.setTypeSettingsProperties(unicodeProperties);
+		textExpandoColumn.setTypeSettingsProperties(unicodeProperties);
 
-		_expandoColumnLocalService.updateExpandoColumn(expandoColumn);
+		_expandoColumnLocalService.updateExpandoColumn(textExpandoColumn);
+
+		double randomDouble = RandomTestUtil.randomDouble();
+
+		ExpandoColumn doubleArrayExpandoColumn = ExpandoTestUtil.addColumn(
+			expandoTable, "A" + RandomTestUtil.randomString(),
+			ExpandoColumnConstants.DOUBLE_ARRAY,
+			new double[] {
+				randomDouble, RandomTestUtil.randomDouble(),
+				RandomTestUtil.randomDouble()
+			});
+
+		long randomLong = RandomTestUtil.randomLong();
+
+		ExpandoColumn longArrayExpandoColumn = ExpandoTestUtil.addColumn(
+			expandoTable, "A" + RandomTestUtil.randomString(),
+			ExpandoColumnConstants.LONG_ARRAY,
+			new long[] {
+				randomLong, RandomTestUtil.randomLong(),
+				RandomTestUtil.randomLong()
+			});
+
+		String randomString = RandomTestUtil.randomString();
+
+		ExpandoColumn stringArrayExpandoColumn = ExpandoTestUtil.addColumn(
+			expandoTable, "A" + RandomTestUtil.randomString(),
+			ExpandoColumnConstants.STRING_ARRAY,
+			new String[] {
+				randomString, RandomTestUtil.randomString(),
+				RandomTestUtil.randomString()
+			});
 
 		Account account = randomAccount();
 
@@ -1184,7 +1229,7 @@ public class AccountResourceTest extends BaseAccountResourceTestCase {
 							}
 						};
 						dataType = "Text";
-						name = expandoColumn.getName();
+						name = textExpandoColumn.getName();
 					}
 				}
 			});
@@ -1194,7 +1239,7 @@ public class AccountResourceTest extends BaseAccountResourceTestCase {
 		Page<Account> page = accountResource.getAccountsPage(
 			null,
 			StringBundler.concat(
-				"(customFields/", expandoColumn.getName(), " eq '",
+				"(customFields/", textExpandoColumn.getName(), " eq '",
 				RandomTestUtil.randomString(), "')"),
 			Pagination.of(1, 2), null);
 
@@ -1203,14 +1248,35 @@ public class AccountResourceTest extends BaseAccountResourceTestCase {
 		page = accountResource.getAccountsPage(
 			null,
 			StringBundler.concat(
-				"(customFields/", expandoColumn.getName(), " eq '", value,
+				"(customFields/", textExpandoColumn.getName(), " eq '", value,
 				"')"),
 			Pagination.of(1, 2), null);
 
 		Assert.assertEquals(1, page.getTotalCount());
 
-		assertEquals(
-			Collections.singletonList(account), (List<Account>)page.getItems());
+		List<Account> accounts = (List<Account>)page.getItems();
+
+		assertEquals(Collections.singletonList(account), accounts);
+
+		Account actualAccount = accounts.get(0);
+
+		Assert.assertEquals(
+			Arrays.toString(new double[] {0.0}),
+			Arrays.toString(
+				(Object[])_getCustomFieldValueData(
+					actualAccount, doubleArrayExpandoColumn.getName())));
+
+		Assert.assertEquals(
+			Arrays.toString(new long[] {0}),
+			Arrays.toString(
+				(Object[])_getCustomFieldValueData(
+					actualAccount, longArrayExpandoColumn.getName())));
+
+		Assert.assertEquals(
+			Arrays.toString(new String[] {"false"}),
+			Arrays.toString(
+				(Object[])_getCustomFieldValueData(
+					actualAccount, stringArrayExpandoColumn.getName())));
 	}
 
 	private void _testGetAccountWithNestedFields() throws Exception {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/AccountResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/AccountResourceTest.java
@@ -72,6 +72,7 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -86,6 +87,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import org.junit.After;
@@ -838,6 +840,25 @@ public class AccountResourceTest extends BaseAccountResourceTestCase {
 		return _accountEntryLocalService.updateAccountEntry(accountEntry);
 	}
 
+	private ExpandoColumn _addExpandoColumn(
+			Object defaultData, ExpandoTable expandoTable, int type,
+			Map<String, String> typeSettingsProperties)
+		throws Exception {
+
+		ExpandoColumn expandoColumn = ExpandoTestUtil.addColumn(
+			expandoTable, "A" + RandomTestUtil.randomString(), type,
+			defaultData);
+
+		UnicodeProperties unicodeProperties =
+			expandoColumn.getTypeSettingsProperties();
+
+		unicodeProperties.putAll(typeSettingsProperties);
+
+		expandoColumn.setTypeSettingsProperties(unicodeProperties);
+
+		return _expandoColumnLocalService.updateExpandoColumn(expandoColumn);
+	}
+
 	private FileEntry _addImageFileEntry() throws Exception {
 		Group group = _groupLocalService.getCompanyGroup(
 			_accountGroup.getCompanyId());
@@ -1170,50 +1191,84 @@ public class AccountResourceTest extends BaseAccountResourceTestCase {
 			_classNameLocalService.getClassNameId(AccountEntry.class),
 			"CUSTOM_FIELDS");
 
-		ExpandoColumn textExpandoColumn = ExpandoTestUtil.addColumn(
-			expandoTable, "A" + RandomTestUtil.randomString(),
-			ExpandoColumnConstants.STRING);
-
-		UnicodeProperties unicodeProperties =
-			textExpandoColumn.getTypeSettingsProperties();
-
-		unicodeProperties.setProperty(
-			ExpandoColumnConstants.INDEX_TYPE,
-			String.valueOf(ExpandoColumnConstants.INDEX_TYPE_KEYWORD));
-
-		textExpandoColumn.setTypeSettingsProperties(unicodeProperties);
-
-		_expandoColumnLocalService.updateExpandoColumn(textExpandoColumn);
+		ExpandoColumn textExpandoColumn = _addExpandoColumn(
+			null, expandoTable, ExpandoColumnConstants.STRING,
+			HashMapBuilder.put(
+				ExpandoColumnConstants.INDEX_TYPE,
+				String.valueOf(ExpandoColumnConstants.INDEX_TYPE_KEYWORD)
+			).build());
 
 		double randomDouble = RandomTestUtil.randomDouble();
 
-		ExpandoColumn doubleArrayExpandoColumn = ExpandoTestUtil.addColumn(
-			expandoTable, "A" + RandomTestUtil.randomString(),
-			ExpandoColumnConstants.DOUBLE_ARRAY,
+		ExpandoColumn doubleArrayExpandoColumn1 = _addExpandoColumn(
 			new double[] {
 				randomDouble, RandomTestUtil.randomDouble(),
 				RandomTestUtil.randomDouble()
-			});
+			},
+			expandoTable, ExpandoColumnConstants.DOUBLE_ARRAY,
+			HashMapBuilder.put(
+				ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE,
+				ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE_RADIO
+			).build());
+
+		ExpandoColumn doubleArrayExpandoColumn2 = _addExpandoColumn(
+			new double[] {
+				randomDouble, RandomTestUtil.randomDouble(),
+				RandomTestUtil.randomDouble()
+			},
+			expandoTable, ExpandoColumnConstants.DOUBLE_ARRAY,
+			HashMapBuilder.put(
+				ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE,
+				ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE_SELECTION_LIST
+			).build());
 
 		long randomLong = RandomTestUtil.randomLong();
 
-		ExpandoColumn longArrayExpandoColumn = ExpandoTestUtil.addColumn(
-			expandoTable, "A" + RandomTestUtil.randomString(),
-			ExpandoColumnConstants.LONG_ARRAY,
+		ExpandoColumn longArrayExpandoColumn1 = _addExpandoColumn(
 			new long[] {
 				randomLong, RandomTestUtil.randomLong(),
 				RandomTestUtil.randomLong()
-			});
+			},
+			expandoTable, ExpandoColumnConstants.LONG_ARRAY,
+			HashMapBuilder.put(
+				ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE,
+				ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE_RADIO
+			).build());
+
+		ExpandoColumn longArrayExpandoColumn2 = _addExpandoColumn(
+			new long[] {
+				randomLong, RandomTestUtil.randomLong(),
+				RandomTestUtil.randomLong()
+			},
+			expandoTable, ExpandoColumnConstants.LONG_ARRAY,
+			HashMapBuilder.put(
+				ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE,
+				ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE_SELECTION_LIST
+			).build());
 
 		String randomString = RandomTestUtil.randomString();
 
-		ExpandoColumn stringArrayExpandoColumn = ExpandoTestUtil.addColumn(
-			expandoTable, "A" + RandomTestUtil.randomString(),
-			ExpandoColumnConstants.STRING_ARRAY,
+		ExpandoColumn stringArrayExpandoColumn1 = _addExpandoColumn(
 			new String[] {
 				randomString, RandomTestUtil.randomString(),
 				RandomTestUtil.randomString()
-			});
+			},
+			expandoTable, ExpandoColumnConstants.STRING_ARRAY,
+			HashMapBuilder.put(
+				ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE,
+				ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE_RADIO
+			).build());
+
+		ExpandoColumn stringArrayExpandoColumn2 = _addExpandoColumn(
+			new String[] {
+				randomString, RandomTestUtil.randomString(),
+				RandomTestUtil.randomString()
+			},
+			expandoTable, ExpandoColumnConstants.STRING_ARRAY,
+			HashMapBuilder.put(
+				ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE,
+				ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE_SELECTION_LIST
+			).build());
 
 		Account account = randomAccount();
 
@@ -1264,19 +1319,37 @@ public class AccountResourceTest extends BaseAccountResourceTestCase {
 			Arrays.toString(new double[] {0.0}),
 			Arrays.toString(
 				(Object[])_getCustomFieldValueData(
-					actualAccount, doubleArrayExpandoColumn.getName())));
+					actualAccount, doubleArrayExpandoColumn1.getName())));
+
+		Assert.assertEquals(
+			Arrays.toString(new double[] {randomDouble}),
+			Arrays.toString(
+				(Object[])_getCustomFieldValueData(
+					actualAccount, doubleArrayExpandoColumn2.getName())));
 
 		Assert.assertEquals(
 			Arrays.toString(new long[] {0}),
 			Arrays.toString(
 				(Object[])_getCustomFieldValueData(
-					actualAccount, longArrayExpandoColumn.getName())));
+					actualAccount, longArrayExpandoColumn1.getName())));
+
+		Assert.assertEquals(
+			Arrays.toString(new long[] {randomLong}),
+			Arrays.toString(
+				(Object[])_getCustomFieldValueData(
+					actualAccount, longArrayExpandoColumn2.getName())));
 
 		Assert.assertEquals(
 			Arrays.toString(new String[] {"false"}),
 			Arrays.toString(
 				(Object[])_getCustomFieldValueData(
-					actualAccount, stringArrayExpandoColumn.getName())));
+					actualAccount, stringArrayExpandoColumn1.getName())));
+
+		Assert.assertEquals(
+			Arrays.toString(new String[] {randomString}),
+			Arrays.toString(
+				(Object[])_getCustomFieldValueData(
+					actualAccount, stringArrayExpandoColumn2.getName())));
 	}
 
 	private void _testGetAccountWithNestedFields() throws Exception {

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/CustomFieldsUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/CustomFieldsUtil.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
@@ -65,7 +66,10 @@ public class CustomFieldsUtil {
 				}
 
 				return _toCustomField(
-					acceptAllLanguages, entry, expandoBridge, locale);
+					acceptAllLanguages,
+					unicodeProperties.getProperty(
+						ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE),
+					entry, expandoBridge, locale);
 			},
 			CustomField.class);
 	}
@@ -169,13 +173,53 @@ public class CustomFieldsUtil {
 	}
 
 	private static Object _getValue(
+		int attributeType, String displayType,
 		Map.Entry<String, Serializable> entry, ExpandoBridge expandoBridge,
 		String key) {
 
 		Object value = entry.getValue();
 
-		if (_isEmpty(value)) {
-			value = expandoBridge.getAttributeDefault(key);
+		if (!_isEmpty(value)) {
+			return value;
+		}
+
+		if (!ExpandoColumnConstants.isArray(attributeType)) {
+			return expandoBridge.getAttributeDefault(key);
+		}
+
+		boolean selectionList = StringUtil.equals(
+			displayType,
+			ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE_SELECTION_LIST);
+
+		if (ExpandoColumnConstants.DOUBLE_ARRAY == attributeType) {
+			if (selectionList) {
+				return ArrayUtil.subset(
+					GetterUtil.getDoubleValues(
+						expandoBridge.getAttributeDefault(key)),
+					0, 1);
+			}
+
+			return new double[] {GetterUtil.DEFAULT_DOUBLE};
+		}
+		else if (ExpandoColumnConstants.LONG_ARRAY == attributeType) {
+			if (selectionList) {
+				return ArrayUtil.subset(
+					GetterUtil.getLongValues(
+						expandoBridge.getAttributeDefault(key)),
+					0, 1);
+			}
+
+			return new long[] {GetterUtil.DEFAULT_INTEGER};
+		}
+		else if (ExpandoColumnConstants.STRING_ARRAY == attributeType) {
+			if (selectionList) {
+				return ArrayUtil.subset(
+					GetterUtil.getStringValues(
+						expandoBridge.getAttributeDefault(key)),
+					0, 1);
+			}
+
+			return new String[] {String.valueOf(GetterUtil.DEFAULT_BOOLEAN)};
 		}
 
 		return value;
@@ -227,8 +271,9 @@ public class CustomFieldsUtil {
 	}
 
 	private static CustomField _toCustomField(
-		boolean acceptAllLanguages, Map.Entry<String, Serializable> entry,
-		ExpandoBridge expandoBridge, Locale locale) {
+		boolean acceptAllLanguages, String displayType,
+		Map.Entry<String, Serializable> entry, ExpandoBridge expandoBridge,
+		Locale locale) {
 
 		String key = entry.getKey();
 
@@ -273,11 +318,15 @@ public class CustomFieldsUtil {
 							setData(
 								() -> _getValue(
 									attributeType, locale,
-									_getValue(entry, expandoBridge, key)));
+									_getValue(
+										attributeType, displayType, entry,
+										expandoBridge, key)));
 							setData_i18n(
 								() -> _getLocalizedValues(
 									acceptAllLanguages, attributeType,
-									_getValue(entry, expandoBridge, key)));
+									_getValue(
+										attributeType, displayType, entry,
+										expandoBridge, key)));
 						}
 					});
 				setDataType(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/CustomFieldsUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/CustomFieldsUtil.java
@@ -147,9 +147,8 @@ public class CustomFieldsUtil {
 			return null;
 		}
 
-		Map<Locale, String> map = (Map<Locale, String>)value;
-
-		return LocalizedMapUtil.getI18nMap(acceptAllLanguages, map);
+		return LocalizedMapUtil.getI18nMap(
+			acceptAllLanguages, (Map<Locale, String>)value);
 	}
 
 	private static Object _getValue(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/CustomFieldsUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/CustomFieldsUtil.java
@@ -175,7 +175,7 @@ public class CustomFieldsUtil {
 
 		Object value = entry.getValue();
 
-		if (_isEmpty(entry.getValue())) {
+		if (_isEmpty(value)) {
 			value = expandoBridge.getAttributeDefault(key);
 		}
 

--- a/portal-kernel/src/com/liferay/expando/kernel/model/ExpandoColumnConstants.java
+++ b/portal-kernel/src/com/liferay/expando/kernel/model/ExpandoColumnConstants.java
@@ -208,12 +208,7 @@ public class ExpandoColumnConstants {
 		if (type == BOOLEAN) {
 			return PROPERTY_DISPLAY_TYPE_BOOLEAN;
 		}
-		else if ((type == BOOLEAN_ARRAY) || (type == DATE_ARRAY) ||
-				 (type == DOUBLE_ARRAY) || (type == FLOAT_ARRAY) ||
-				 (type == INTEGER_ARRAY) || (type == LONG_ARRAY) ||
-				 (type == NUMBER_ARRAY) || (type == SHORT_ARRAY) ||
-				 (type == STRING_ARRAY) || (type == STRING_ARRAY_LOCALIZED)) {
-
+		else if (isArray(type)) {
 			return PROPERTY_DISPLAY_TYPE_SELECTION_LIST;
 		}
 		else if (type == DATE) {
@@ -390,6 +385,19 @@ public class ExpandoColumnConstants {
 		}
 
 		return UNKNOWN_LABEL;
+	}
+
+	public static boolean isArray(int type) {
+		if ((type == BOOLEAN_ARRAY) || (type == DATE_ARRAY) ||
+			(type == DOUBLE_ARRAY) || (type == FLOAT_ARRAY) ||
+			(type == INTEGER_ARRAY) || (type == LONG_ARRAY) ||
+			(type == NUMBER_ARRAY) || (type == SHORT_ARRAY) ||
+			(type == STRING_ARRAY) || (type == STRING_ARRAY_LOCALIZED)) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/portal-kernel/src/com/liferay/expando/kernel/model/packageinfo
+++ b/portal-kernel/src/com/liferay/expando/kernel/model/packageinfo
@@ -1,1 +1,1 @@
-version 6.1.0
+version 6.2.0


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPD-51050

---

The purpose of this ticket is to:

- Unify all the `CustomFieldsUtil` with the same code. In a following up task (https://liferay.atlassian.net/browse/LPD-51598), we will unify them in Vulcan
- Update the default response for some cases:
  - For checkboxs:
    - If TEXT: return [ "false" ]
    - If DOUBLE: return [ 0.0 ]
    - If LONG: return [ 0 ]
  - For radiobuttons:
    - If TEXT: return [ "false" ]
    - If DOUBLE: return [ 0.0 ]
    - If LONG: return [ 0 ]
  - For dropdowns:
    - If TEXT: return [ first element ]
    - If DOUBLE: return [ first element ]
    - If LONG: return [ first element ]