### PR TITLE
LPD-52158 Keep lookup order in GroupUtil backwards compatible

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/GroupUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/GroupUtil.java
@@ -90,14 +90,7 @@ public class GroupUtil {
 		DepotEntryLocalService depotEntryLocalService,
 		GroupLocalService groupLocalService) {
 
-		Group group = groupLocalService.fetchGroup(
-			Long.valueOf(assetLibraryKey));
-
-		if (group != null) {
-			return group;
-		}
-
-		group = groupLocalService.fetchGroup(companyId, assetLibraryKey);
+		Group group = groupLocalService.fetchGroup(companyId, assetLibraryKey);
 
 		if (group != null) {
 			return group;
@@ -115,6 +108,13 @@ public class GroupUtil {
 			if (_log.isDebugEnabled()) {
 				_log.debug(portalException);
 			}
+		}
+
+		group = groupLocalService.fetchGroup(
+			Long.valueOf(assetLibraryKey));
+
+		if (group != null) {
+			return group;
 		}
 
 		return null;

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/GroupUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/GroupUtil.java
@@ -7,9 +7,6 @@ package com.liferay.portal.vulcan.util;
 
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
-import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -96,28 +93,21 @@ public class GroupUtil {
 			return group;
 		}
 
-		try {
-			DepotEntry depotEntry = depotEntryLocalService.fetchDepotEntry(
-				GetterUtil.getLong(assetLibraryKey));
+		long assetLibraryId = GetterUtil.getLong(assetLibraryKey);
 
-			if (depotEntry != null) {
-				return depotEntry.getGroup();
+		DepotEntry depotEntry = depotEntryLocalService.fetchDepotEntry(
+			assetLibraryId);
+
+		if (depotEntry != null) {
+			Group depotEntryGroup = groupLocalService.fetchGroup(
+				depotEntry.getGroupId());
+
+			if (depotEntryGroup != null) {
+				return depotEntryGroup;
 			}
 		}
-		catch (PortalException portalException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(portalException);
-			}
-		}
 
-		group = groupLocalService.fetchGroup(
-			Long.valueOf(assetLibraryKey));
-
-		if (group != null) {
-			return group;
-		}
-
-		return null;
+		return groupLocalService.fetchGroup(assetLibraryId);
 	}
 
 	private static boolean _isDepotOrSite(Group group) {
@@ -127,7 +117,5 @@ public class GroupUtil {
 
 		return false;
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(GroupUtil.class);
 
 }


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-52158

This restores the original lookup order used before https://liferay.atlassian.net/browse/LPD-49536.

# How can you verify that it works?

Site and Asset Library REST integration tests should pass.