### PR TITLE
LPD-50818 | It is not possible to generate json correctly when calling headless API method

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/EmptyCollectionConfig.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/EmptyCollectionConfig.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageCollectionDefinition.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageCollectionDefinition.java
@@ -44,7 +44,8 @@ import javax.xml.bind.annotation.XmlRootElement;
 )
 @JsonFilter("Liferay.Vulcan")
 @XmlRootElement(name = "PageCollectionDefinition")
-public class PageCollectionDefinition implements Serializable {
+public class PageCollectionDefinition
+	extends PageDefinition implements Serializable {
 
 	public static PageCollectionDefinition toDTO(String json) {
 		return ObjectMapperUtil.readValue(PageCollectionDefinition.class, json);
@@ -1093,6 +1094,22 @@ public class PageCollectionDefinition implements Serializable {
 			sb.append("\"");
 
 			sb.append(_escape(templateKey));
+
+			sb.append("\"");
+		}
+
+		Type type = getType();
+
+		if (type != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"type\": ");
+
+			sb.append("\"");
+
+			sb.append(type);
 
 			sb.append("\"");
 		}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageCollectionItemDefinition.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageCollectionItemDefinition.java
@@ -42,7 +42,8 @@ import javax.xml.bind.annotation.XmlRootElement;
 )
 @JsonFilter("Liferay.Vulcan")
 @XmlRootElement(name = "PageCollectionItemDefinition")
-public class PageCollectionItemDefinition implements Serializable {
+public class PageCollectionItemDefinition
+	extends PageDefinition implements Serializable {
 
 	public static PageCollectionItemDefinition toDTO(String json) {
 		return ObjectMapperUtil.readValue(
@@ -149,6 +150,22 @@ public class PageCollectionItemDefinition implements Serializable {
 			else {
 				sb.append(collectionItemConfig);
 			}
+		}
+
+		Type type = getType();
+
+		if (type != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"type\": ");
+
+			sb.append("\"");
+
+			sb.append(type);
+
+			sb.append("\"");
 		}
 
 		sb.append("}");

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageColumnDefinition.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageColumnDefinition.java
@@ -43,7 +43,8 @@ import javax.xml.bind.annotation.XmlRootElement;
 )
 @JsonFilter("Liferay.Vulcan")
 @XmlRootElement(name = "PageColumnDefinition")
-public class PageColumnDefinition implements Serializable {
+public class PageColumnDefinition
+	extends PageDefinition implements Serializable {
 
 	public static PageColumnDefinition toDTO(String json) {
 		return ObjectMapperUtil.readValue(PageColumnDefinition.class, json);
@@ -204,6 +205,22 @@ public class PageColumnDefinition implements Serializable {
 			sb.append("\"size\": ");
 
 			sb.append(size);
+		}
+
+		Type type = getType();
+
+		if (type != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"type\": ");
+
+			sb.append("\"");
+
+			sb.append(type);
+
+			sb.append("\"");
 		}
 
 		sb.append("}");

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageContainerDefinition.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageContainerDefinition.java
@@ -41,7 +41,8 @@ import javax.xml.bind.annotation.XmlRootElement;
 )
 @JsonFilter("Liferay.Vulcan")
 @XmlRootElement(name = "PageContainerDefinition")
-public class PageContainerDefinition implements Serializable {
+public class PageContainerDefinition
+	extends PageDefinition implements Serializable {
 
 	public static PageContainerDefinition toDTO(String json) {
 		return ObjectMapperUtil.readValue(PageContainerDefinition.class, json);
@@ -416,9 +417,7 @@ public class PageContainerDefinition implements Serializable {
 	@JsonIgnore
 	private Supplier<FragmentViewport[]> _fragmentViewportsSupplier;
 
-	@io.swagger.v3.oas.annotations.media.Schema(
-		description = "The page section's html properties"
-	)
+	@io.swagger.v3.oas.annotations.media.Schema
 	@Valid
 	public HtmlProperties getHtmlProperties() {
 		if (_htmlPropertiesSupplier != null) {
@@ -454,7 +453,7 @@ public class PageContainerDefinition implements Serializable {
 		};
 	}
 
-	@GraphQLField(description = "The page section's html properties")
+	@GraphQLField
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected HtmlProperties htmlProperties;
 
@@ -805,6 +804,22 @@ public class PageContainerDefinition implements Serializable {
 			sb.append("\"");
 
 			sb.append(_escape(name));
+
+			sb.append("\"");
+		}
+
+		Type type = getType();
+
+		if (type != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"type\": ");
+
+			sb.append("\"");
+
+			sb.append(type);
 
 			sb.append("\"");
 		}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageDefinition.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageDefinition.java
@@ -10,6 +10,8 @@ import com.fasterxml.jackson.annotation.JsonFilter;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 import com.liferay.petra.function.UnsafeSupplier;
@@ -38,56 +40,100 @@ import javax.xml.bind.annotation.XmlRootElement;
  * @generated
  */
 @Generated("")
-@GraphQLName("HtmlProperties")
+@GraphQLName(description = "The page definition.", value = "PageDefinition")
 @JsonFilter("Liferay.Vulcan")
-@XmlRootElement(name = "HtmlProperties")
-public class HtmlProperties implements Serializable {
+@JsonSubTypes(
+	{
+		@JsonSubTypes.Type(
+			name = "Collection", value = PageCollectionDefinition.class
+		),
+		@JsonSubTypes.Type(
+			name = "CollectionItem", value = PageCollectionItemDefinition.class
+		),
+		@JsonSubTypes.Type(name = "Column", value = PageColumnDefinition.class),
+		@JsonSubTypes.Type(
+			name = "Container", value = PageContainerDefinition.class
+		),
+		@JsonSubTypes.Type(
+			name = "DropZone", value = PageDropZoneDefinition.class
+		),
+		@JsonSubTypes.Type(name = "Form", value = PageFormDefinition.class),
+		@JsonSubTypes.Type(
+			name = "FormStep", value = PageFormStepDefinition.class
+		),
+		@JsonSubTypes.Type(
+			name = "FormStepContainer",
+			value = PageFormStepContainerDefinition.class
+		),
+		@JsonSubTypes.Type(
+			name = "FragmentComposition",
+			value = PageFragmentCompositionInstanceDefinition.class
+		),
+		@JsonSubTypes.Type(
+			name = "FragmentDropZone",
+			value = PageFragmentDropZoneDefinition.class
+		),
+		@JsonSubTypes.Type(
+			name = "Fragment", value = PageFragmentInstanceDefinition.class
+		),
+		@JsonSubTypes.Type(name = "Row", value = PageRowDefinition.class),
+		@JsonSubTypes.Type(
+			name = "Widget", value = PageWidgetInstanceDefinition.class
+		)
+	}
+)
+@JsonTypeInfo(
+	include = JsonTypeInfo.As.PROPERTY, property = "type",
+	use = JsonTypeInfo.Id.NAME, visible = true
+)
+@XmlRootElement(name = "PageDefinition")
+public abstract class PageDefinition implements Serializable {
 
-	public static HtmlProperties toDTO(String json) {
-		return ObjectMapperUtil.readValue(HtmlProperties.class, json);
+	public static PageDefinition toDTO(String json) {
+		return ObjectMapperUtil.readValue(PageDefinition.class, json);
 	}
 
-	public static HtmlProperties unsafeToDTO(String json) {
-		return ObjectMapperUtil.unsafeReadValue(HtmlProperties.class, json);
+	public static PageDefinition unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(PageDefinition.class, json);
 	}
 
-	@io.swagger.v3.oas.annotations.media.Schema
-	@JsonGetter("htmlTag")
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The page element's type (collection, collection item, column, container, drop zone, form, form step, form step container, fragment, fragment composition, fragment drop zone, row, widget or widget section)."
+	)
+	@JsonGetter("type")
 	@Valid
-	public HtmlTag getHtmlTag() {
-		if (_htmlTagSupplier != null) {
-			htmlTag = _htmlTagSupplier.get();
+	public Type getType() {
+		if (_typeSupplier != null) {
+			type = _typeSupplier.get();
 
-			_htmlTagSupplier = null;
+			_typeSupplier = null;
 		}
 
-		return htmlTag;
+		return type;
 	}
 
 	@JsonIgnore
-	public String getHtmlTagAsString() {
-		HtmlTag htmlTag = getHtmlTag();
+	public String getTypeAsString() {
+		Type type = getType();
 
-		if (htmlTag == null) {
+		if (type == null) {
 			return null;
 		}
 
-		return htmlTag.toString();
+		return type.toString();
 	}
 
-	public void setHtmlTag(HtmlTag htmlTag) {
-		this.htmlTag = htmlTag;
+	public void setType(Type type) {
+		this.type = type;
 
-		_htmlTagSupplier = null;
+		_typeSupplier = null;
 	}
 
 	@JsonIgnore
-	public void setHtmlTag(
-		UnsafeSupplier<HtmlTag, Exception> htmlTagUnsafeSupplier) {
-
-		_htmlTagSupplier = () -> {
+	public void setType(UnsafeSupplier<Type, Exception> typeUnsafeSupplier) {
+		_typeSupplier = () -> {
 			try {
-				return htmlTagUnsafeSupplier.get();
+				return typeUnsafeSupplier.get();
 			}
 			catch (RuntimeException runtimeException) {
 				throw runtimeException;
@@ -98,12 +144,14 @@ public class HtmlProperties implements Serializable {
 		};
 	}
 
-	@GraphQLField
+	@GraphQLField(
+		description = "The page element's type (collection, collection item, column, container, drop zone, form, form step, form step container, fragment, fragment composition, fragment drop zone, row, widget or widget section)."
+	)
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
-	protected HtmlTag htmlTag;
+	protected Type type;
 
 	@JsonIgnore
-	private Supplier<HtmlTag> _htmlTagSupplier;
+	private Supplier<Type> _typeSupplier;
 
 	@Override
 	public boolean equals(Object object) {
@@ -111,13 +159,13 @@ public class HtmlProperties implements Serializable {
 			return true;
 		}
 
-		if (!(object instanceof HtmlProperties)) {
+		if (!(object instanceof PageDefinition)) {
 			return false;
 		}
 
-		HtmlProperties htmlProperties = (HtmlProperties)object;
+		PageDefinition pageDefinition = (PageDefinition)object;
 
-		return Objects.equals(toString(), htmlProperties.toString());
+		return Objects.equals(toString(), pageDefinition.toString());
 	}
 
 	@Override
@@ -132,18 +180,18 @@ public class HtmlProperties implements Serializable {
 
 		sb.append("{");
 
-		HtmlTag htmlTag = getHtmlTag();
+		Type type = getType();
 
-		if (htmlTag != null) {
+		if (type != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
 			}
 
-			sb.append("\"htmlTag\": ");
+			sb.append("\"type\": ");
 
 			sb.append("\"");
 
-			sb.append(htmlTag);
+			sb.append(type);
 
 			sb.append("\"");
 		}
@@ -155,26 +203,31 @@ public class HtmlProperties implements Serializable {
 
 	@io.swagger.v3.oas.annotations.media.Schema(
 		accessMode = io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY,
-		defaultValue = "com.liferay.headless.admin.site.dto.v1_0.HtmlProperties",
+		defaultValue = "com.liferay.headless.admin.site.dto.v1_0.PageDefinition",
 		name = "x-class-name"
 	)
 	public String xClassName;
 
-	@GraphQLName("HtmlTag")
-	public static enum HtmlTag {
+	@GraphQLName("Type")
+	public static enum Type {
 
-		ARTICLE("Article"), ASIDE("Aside"), DIV("Div"), FOOTER("Footer"),
-		HEADER("Header"), NAV("Nav"), SECTION("Section");
+		COLLECTION("Collection"), COLLECTION_ITEM("CollectionItem"),
+		COLUMN("Column"), CONTAINER("Container"), DROP_ZONE("DropZone"),
+		FORM("Form"), FORM_STEP("FormStep"),
+		FORM_STEP_CONTAINER("FormStepContainer"),
+		FRAGMENT_COMPOSITION("FragmentComposition"),
+		FRAGMENT_DROP_ZONE("FragmentDropZone"), FRAGMENT("Fragment"),
+		ROW("Row"), WIDGET("Widget");
 
 		@JsonCreator
-		public static HtmlTag create(String value) {
+		public static Type create(String value) {
 			if ((value == null) || value.equals("")) {
 				return null;
 			}
 
-			for (HtmlTag htmlTag : values()) {
-				if (Objects.equals(htmlTag.getValue(), value)) {
-					return htmlTag;
+			for (Type type : values()) {
+				if (Objects.equals(type.getValue(), value)) {
+					return type;
 				}
 			}
 
@@ -191,7 +244,7 @@ public class HtmlProperties implements Serializable {
 			return _value;
 		}
 
-		private HtmlTag(String value) {
+		private Type(String value) {
 			_value = value;
 		}
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageDropZoneDefinition.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageDropZoneDefinition.java
@@ -42,7 +42,8 @@ import javax.xml.bind.annotation.XmlRootElement;
 )
 @JsonFilter("Liferay.Vulcan")
 @XmlRootElement(name = "PageDropZoneDefinition")
-public class PageDropZoneDefinition implements Serializable {
+public class PageDropZoneDefinition
+	extends PageDefinition implements Serializable {
 
 	public static PageDropZoneDefinition toDTO(String json) {
 		return ObjectMapperUtil.readValue(PageDropZoneDefinition.class, json);
@@ -149,6 +150,22 @@ public class PageDropZoneDefinition implements Serializable {
 			else {
 				sb.append(fragmentSettings);
 			}
+		}
+
+		Type type = getType();
+
+		if (type != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"type\": ");
+
+			sb.append("\"");
+
+			sb.append(type);
+
+			sb.append("\"");
 		}
 
 		sb.append("}");

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageElement.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageElement.java
@@ -5,16 +5,12 @@
 
 package com.liferay.headless.admin.site.dto.v1_0;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonFilter;
-import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonValue;
 
 import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
@@ -57,7 +53,7 @@ public class PageElement implements Serializable {
 		description = "The page element's definition."
 	)
 	@Valid
-	public Object getDefinition() {
+	public PageDefinition getDefinition() {
 		if (_definitionSupplier != null) {
 			definition = _definitionSupplier.get();
 
@@ -67,7 +63,7 @@ public class PageElement implements Serializable {
 		return definition;
 	}
 
-	public void setDefinition(Object definition) {
+	public void setDefinition(PageDefinition definition) {
 		this.definition = definition;
 
 		_definitionSupplier = null;
@@ -75,7 +71,7 @@ public class PageElement implements Serializable {
 
 	@JsonIgnore
 	public void setDefinition(
-		UnsafeSupplier<Object, Exception> definitionUnsafeSupplier) {
+		UnsafeSupplier<PageDefinition, Exception> definitionUnsafeSupplier) {
 
 		_definitionSupplier = () -> {
 			try {
@@ -92,10 +88,10 @@ public class PageElement implements Serializable {
 
 	@GraphQLField(description = "The page element's definition.")
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
-	protected Object definition;
+	protected PageDefinition definition;
 
 	@JsonIgnore
-	private Supplier<Object> _definitionSupplier;
+	private Supplier<PageDefinition> _definitionSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema(
 		description = "The page element's external reference code. Unique within the site."
@@ -283,62 +279,6 @@ public class PageElement implements Serializable {
 	@JsonIgnore
 	private Supplier<Integer> _positionSupplier;
 
-	@io.swagger.v3.oas.annotations.media.Schema(
-		description = "The page element's type (collection, collection item, column, container, drop zone, form, form step, form step container, fragment, fragment composition, fragment drop zone, row, widget or widget section)."
-	)
-	@JsonGetter("type")
-	@Valid
-	public Type getType() {
-		if (_typeSupplier != null) {
-			type = _typeSupplier.get();
-
-			_typeSupplier = null;
-		}
-
-		return type;
-	}
-
-	@JsonIgnore
-	public String getTypeAsString() {
-		Type type = getType();
-
-		if (type == null) {
-			return null;
-		}
-
-		return type.toString();
-	}
-
-	public void setType(Type type) {
-		this.type = type;
-
-		_typeSupplier = null;
-	}
-
-	@JsonIgnore
-	public void setType(UnsafeSupplier<Type, Exception> typeUnsafeSupplier) {
-		_typeSupplier = () -> {
-			try {
-				return typeUnsafeSupplier.get();
-			}
-			catch (RuntimeException runtimeException) {
-				throw runtimeException;
-			}
-			catch (Exception exception) {
-				throw new RuntimeException(exception);
-			}
-		};
-	}
-
-	@GraphQLField(
-		description = "The page element's type (collection, collection item, column, container, drop zone, form, form step, form step container, fragment, fragment composition, fragment drop zone, row, widget or widget section)."
-	)
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
-	protected Type type;
-
-	@JsonIgnore
-	private Supplier<Type> _typeSupplier;
-
 	@Override
 	public boolean equals(Object object) {
 		if (this == object) {
@@ -366,7 +306,7 @@ public class PageElement implements Serializable {
 
 		sb.append("{");
 
-		Object definition = getDefinition();
+		PageDefinition definition = getDefinition();
 
 		if (definition != null) {
 			if (sb.length() > 1) {
@@ -375,18 +315,7 @@ public class PageElement implements Serializable {
 
 			sb.append("\"definition\": ");
 
-			if (definition instanceof Map) {
-				sb.append(
-					JSONFactoryUtil.createJSONObject((Map<?, ?>)definition));
-			}
-			else if (definition instanceof String) {
-				sb.append("\"");
-				sb.append(_escape((String)definition));
-				sb.append("\"");
-			}
-			else {
-				sb.append(definition);
-			}
+			sb.append(String.valueOf(definition));
 		}
 
 		String externalReferenceCode = getExternalReferenceCode();
@@ -455,22 +384,6 @@ public class PageElement implements Serializable {
 			sb.append(position);
 		}
 
-		Type type = getType();
-
-		if (type != null) {
-			if (sb.length() > 1) {
-				sb.append(", ");
-			}
-
-			sb.append("\"type\": ");
-
-			sb.append("\"");
-
-			sb.append(type);
-
-			sb.append("\"");
-		}
-
 		sb.append("}");
 
 		return sb.toString();
@@ -482,49 +395,6 @@ public class PageElement implements Serializable {
 		name = "x-class-name"
 	)
 	public String xClassName;
-
-	@GraphQLName("Type")
-	public static enum Type {
-
-		COLLECTION("Collection"), COLLECTION_ITEM("CollectionItem"),
-		COLUMN("Column"), CONTAINER("Container"), DROP_ZONE("DropZone"),
-		FORM("Form"), FORM_STEP("FormStep"),
-		FORM_STEP_CONTAINER("FormStepContainer"), FRAGMENT("Fragment"),
-		FRAGMENT_COMPOSITION("FragmentComposition"),
-		FRAGMENT_DROP_ZONE("FragmentDropZone"), ROW("Row"), WIDGET("Widget");
-
-		@JsonCreator
-		public static Type create(String value) {
-			if ((value == null) || value.equals("")) {
-				return null;
-			}
-
-			for (Type type : values()) {
-				if (Objects.equals(type.getValue(), value)) {
-					return type;
-				}
-			}
-
-			throw new IllegalArgumentException("Invalid enum value: " + value);
-		}
-
-		@JsonValue
-		public String getValue() {
-			return _value;
-		}
-
-		@Override
-		public String toString() {
-			return _value;
-		}
-
-		private Type(String value) {
-			_value = value;
-		}
-
-		private final String _value;
-
-	}
 
 	private static String _escape(Object object) {
 		return StringUtil.replace(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageFormDefinition.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageFormDefinition.java
@@ -40,7 +40,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 )
 @JsonFilter("Liferay.Vulcan")
 @XmlRootElement(name = "PageFormDefinition")
-public class PageFormDefinition implements Serializable {
+public class PageFormDefinition extends PageDefinition implements Serializable {
 
 	public static PageFormDefinition toDTO(String json) {
 		return ObjectMapperUtil.readValue(PageFormDefinition.class, json);
@@ -621,6 +621,22 @@ public class PageFormDefinition implements Serializable {
 			sb.append("\"");
 
 			sb.append(_escape(name));
+
+			sb.append("\"");
+		}
+
+		Type type = getType();
+
+		if (type != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"type\": ");
+
+			sb.append("\"");
+
+			sb.append(type);
 
 			sb.append("\"");
 		}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageFormStepContainerDefinition.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageFormStepContainerDefinition.java
@@ -41,7 +41,8 @@ import javax.xml.bind.annotation.XmlRootElement;
 )
 @JsonFilter("Liferay.Vulcan")
 @XmlRootElement(name = "PageFormStepContainerDefinition")
-public class PageFormStepContainerDefinition implements Serializable {
+public class PageFormStepContainerDefinition
+	extends PageDefinition implements Serializable {
 
 	public static PageFormStepContainerDefinition toDTO(String json) {
 		return ObjectMapperUtil.readValue(
@@ -513,6 +514,22 @@ public class PageFormStepContainerDefinition implements Serializable {
 			sb.append("\"");
 
 			sb.append(_escape(name));
+
+			sb.append("\"");
+		}
+
+		Type type = getType();
+
+		if (type != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"type\": ");
+
+			sb.append("\"");
+
+			sb.append(type);
 
 			sb.append("\"");
 		}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageFormStepDefinition.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageFormStepDefinition.java
@@ -42,7 +42,8 @@ import javax.xml.bind.annotation.XmlRootElement;
 )
 @JsonFilter("Liferay.Vulcan")
 @XmlRootElement(name = "PageFormStepDefinition")
-public class PageFormStepDefinition implements Serializable {
+public class PageFormStepDefinition
+	extends PageDefinition implements Serializable {
 
 	public static PageFormStepDefinition toDTO(String json) {
 		return ObjectMapperUtil.readValue(PageFormStepDefinition.class, json);
@@ -147,6 +148,22 @@ public class PageFormStepDefinition implements Serializable {
 			else {
 				sb.append(formStepConfig);
 			}
+		}
+
+		Type type = getType();
+
+		if (type != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"type\": ");
+
+			sb.append("\"");
+
+			sb.append(type);
+
+			sb.append("\"");
 		}
 
 		sb.append("}");

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageFragmentCompositionInstanceDefinition.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageFragmentCompositionInstanceDefinition.java
@@ -41,7 +41,8 @@ import javax.xml.bind.annotation.XmlRootElement;
 )
 @JsonFilter("Liferay.Vulcan")
 @XmlRootElement(name = "PageFragmentCompositionInstanceDefinition")
-public class PageFragmentCompositionInstanceDefinition implements Serializable {
+public class PageFragmentCompositionInstanceDefinition
+	extends PageDefinition implements Serializable {
 
 	public static PageFragmentCompositionInstanceDefinition toDTO(String json) {
 		return ObjectMapperUtil.readValue(
@@ -144,6 +145,22 @@ public class PageFragmentCompositionInstanceDefinition implements Serializable {
 			sb.append("\"fragmentComposition\": ");
 
 			sb.append(String.valueOf(fragmentComposition));
+		}
+
+		Type type = getType();
+
+		if (type != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"type\": ");
+
+			sb.append("\"");
+
+			sb.append(type);
+
+			sb.append("\"");
 		}
 
 		sb.append("}");

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageFragmentDropZoneDefinition.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageFragmentDropZoneDefinition.java
@@ -39,7 +39,8 @@ import javax.xml.bind.annotation.XmlRootElement;
 )
 @JsonFilter("Liferay.Vulcan")
 @XmlRootElement(name = "PageFragmentDropZoneDefinition")
-public class PageFragmentDropZoneDefinition implements Serializable {
+public class PageFragmentDropZoneDefinition
+	extends PageDefinition implements Serializable {
 
 	public static PageFragmentDropZoneDefinition toDTO(String json) {
 		return ObjectMapperUtil.readValue(
@@ -135,6 +136,22 @@ public class PageFragmentDropZoneDefinition implements Serializable {
 			sb.append("\"");
 
 			sb.append(_escape(fragmentDropZoneId));
+
+			sb.append("\"");
+		}
+
+		Type type = getType();
+
+		if (type != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"type\": ");
+
+			sb.append("\"");
+
+			sb.append(type);
 
 			sb.append("\"");
 		}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageFragmentInstanceDefinition.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageFragmentInstanceDefinition.java
@@ -46,7 +46,8 @@ import javax.xml.bind.annotation.XmlRootElement;
 )
 @JsonFilter("Liferay.Vulcan")
 @XmlRootElement(name = "PageFragmentInstanceDefinition")
-public class PageFragmentInstanceDefinition implements Serializable {
+public class PageFragmentInstanceDefinition
+	extends PageDefinition implements Serializable {
 
 	public static PageFragmentInstanceDefinition toDTO(String json) {
 		return ObjectMapperUtil.readValue(
@@ -1103,6 +1104,22 @@ public class PageFragmentInstanceDefinition implements Serializable {
 			}
 
 			sb.append("]");
+		}
+
+		Type type = getType();
+
+		if (type != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"type\": ");
+
+			sb.append("\"");
+
+			sb.append(type);
+
+			sb.append("\"");
 		}
 
 		sb.append("}");

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageRowDefinition.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageRowDefinition.java
@@ -40,7 +40,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 )
 @JsonFilter("Liferay.Vulcan")
 @XmlRootElement(name = "PageRowDefinition")
-public class PageRowDefinition implements Serializable {
+public class PageRowDefinition extends PageDefinition implements Serializable {
 
 	public static PageRowDefinition toDTO(String json) {
 		return ObjectMapperUtil.readValue(PageRowDefinition.class, json);
@@ -858,6 +858,22 @@ public class PageRowDefinition implements Serializable {
 			sb.append("\"");
 
 			sb.append(_escape(verticalAlignment));
+
+			sb.append("\"");
+		}
+
+		Type type = getType();
+
+		if (type != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"type\": ");
+
+			sb.append("\"");
+
+			sb.append(type);
 
 			sb.append("\"");
 		}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageWidgetInstanceDefinition.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageWidgetInstanceDefinition.java
@@ -41,7 +41,8 @@ import javax.xml.bind.annotation.XmlRootElement;
 )
 @JsonFilter("Liferay.Vulcan")
 @XmlRootElement(name = "PageWidgetInstanceDefinition")
-public class PageWidgetInstanceDefinition implements Serializable {
+public class PageWidgetInstanceDefinition
+	extends PageDefinition implements Serializable {
 
 	public static PageWidgetInstanceDefinition toDTO(String json) {
 		return ObjectMapperUtil.readValue(
@@ -520,6 +521,22 @@ public class PageWidgetInstanceDefinition implements Serializable {
 			sb.append("\"widgetInstance\": ");
 
 			sb.append(String.valueOf(widgetInstance));
+		}
+
+		Type type = getType();
+
+		if (type != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"type\": ");
+
+			sb.append("\"");
+
+			sb.append(type);
+
+			sb.append("\"");
 		}
 
 		sb.append("}");

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/EmptyCollectionConfig.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/EmptyCollectionConfig.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/HtmlProperties.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/HtmlProperties.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/PageCollectionDefinition.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/PageCollectionDefinition.java
@@ -19,7 +19,8 @@ import javax.annotation.Generated;
  * @generated
  */
 @Generated("")
-public class PageCollectionDefinition implements Cloneable, Serializable {
+public class PageCollectionDefinition
+	extends PageDefinition implements Cloneable, Serializable {
 
 	public static PageCollectionDefinition toDTO(String json) {
 		return PageCollectionDefinitionSerDes.toDTO(json);

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/PageCollectionItemDefinition.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/PageCollectionItemDefinition.java
@@ -19,7 +19,8 @@ import javax.annotation.Generated;
  * @generated
  */
 @Generated("")
-public class PageCollectionItemDefinition implements Cloneable, Serializable {
+public class PageCollectionItemDefinition
+	extends PageDefinition implements Cloneable, Serializable {
 
 	public static PageCollectionItemDefinition toDTO(String json) {
 		return PageCollectionItemDefinitionSerDes.toDTO(json);

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/PageColumnDefinition.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/PageColumnDefinition.java
@@ -19,7 +19,8 @@ import javax.annotation.Generated;
  * @generated
  */
 @Generated("")
-public class PageColumnDefinition implements Cloneable, Serializable {
+public class PageColumnDefinition
+	extends PageDefinition implements Cloneable, Serializable {
 
 	public static PageColumnDefinition toDTO(String json) {
 		return PageColumnDefinitionSerDes.toDTO(json);

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/PageContainerDefinition.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/PageContainerDefinition.java
@@ -19,7 +19,8 @@ import javax.annotation.Generated;
  * @generated
  */
 @Generated("")
-public class PageContainerDefinition implements Cloneable, Serializable {
+public class PageContainerDefinition
+	extends PageDefinition implements Cloneable, Serializable {
 
 	public static PageContainerDefinition toDTO(String json) {
 		return PageContainerDefinitionSerDes.toDTO(json);

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/PageDefinition.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/PageDefinition.java
@@ -1,0 +1,125 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.site.client.dto.v1_0;
+
+import com.liferay.headless.admin.site.client.function.UnsafeSupplier;
+import com.liferay.headless.admin.site.client.serdes.v1_0.PageDefinitionSerDes;
+
+import java.io.Serializable;
+
+import java.util.Objects;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Rubén Pulido
+ * @generated
+ */
+@Generated("")
+public abstract class PageDefinition implements Cloneable, Serializable {
+
+	public static PageDefinition toDTO(String json) {
+		return PageDefinitionSerDes.toDTO(json);
+	}
+
+	public Type getType() {
+		return type;
+	}
+
+	public String getTypeAsString() {
+		if (type == null) {
+			return null;
+		}
+
+		return type.toString();
+	}
+
+	public void setType(Type type) {
+		this.type = type;
+	}
+
+	public void setType(UnsafeSupplier<Type, Exception> typeUnsafeSupplier) {
+		try {
+			type = typeUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Type type;
+
+	@Override
+	public PageDefinition clone() throws CloneNotSupportedException {
+		return (PageDefinition)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof PageDefinition)) {
+			return false;
+		}
+
+		PageDefinition pageDefinition = (PageDefinition)object;
+
+		return Objects.equals(toString(), pageDefinition.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return PageDefinitionSerDes.toJSON(this);
+	}
+
+	public static enum Type {
+
+		COLLECTION("Collection"), COLLECTION_ITEM("CollectionItem"),
+		COLUMN("Column"), CONTAINER("Container"), DROP_ZONE("DropZone"),
+		FORM("Form"), FORM_STEP("FormStep"),
+		FORM_STEP_CONTAINER("FormStepContainer"),
+		FRAGMENT_COMPOSITION("FragmentComposition"),
+		FRAGMENT_DROP_ZONE("FragmentDropZone"), FRAGMENT("Fragment"),
+		ROW("Row"), WIDGET("Widget");
+
+		public static Type create(String value) {
+			for (Type type : values()) {
+				if (Objects.equals(type.getValue(), value) ||
+					Objects.equals(type.name(), value)) {
+
+					return type;
+				}
+			}
+
+			return null;
+		}
+
+		public String getValue() {
+			return _value;
+		}
+
+		@Override
+		public String toString() {
+			return _value;
+		}
+
+		private Type(String value) {
+			_value = value;
+		}
+
+		private final String _value;
+
+	}
+
+}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/PageDropZoneDefinition.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/PageDropZoneDefinition.java
@@ -19,7 +19,8 @@ import javax.annotation.Generated;
  * @generated
  */
 @Generated("")
-public class PageDropZoneDefinition implements Cloneable, Serializable {
+public class PageDropZoneDefinition
+	extends PageDefinition implements Cloneable, Serializable {
 
 	public static PageDropZoneDefinition toDTO(String json) {
 		return PageDropZoneDefinitionSerDes.toDTO(json);

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/PageElement.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/PageElement.java
@@ -25,16 +25,16 @@ public class PageElement implements Cloneable, Serializable {
 		return PageElementSerDes.toDTO(json);
 	}
 
-	public Object getDefinition() {
+	public PageDefinition getDefinition() {
 		return definition;
 	}
 
-	public void setDefinition(Object definition) {
+	public void setDefinition(PageDefinition definition) {
 		this.definition = definition;
 	}
 
 	public void setDefinition(
-		UnsafeSupplier<Object, Exception> definitionUnsafeSupplier) {
+		UnsafeSupplier<PageDefinition, Exception> definitionUnsafeSupplier) {
 
 		try {
 			definition = definitionUnsafeSupplier.get();
@@ -44,7 +44,7 @@ public class PageElement implements Cloneable, Serializable {
 		}
 	}
 
-	protected Object definition;
+	protected PageDefinition definition;
 
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
@@ -134,33 +134,6 @@ public class PageElement implements Cloneable, Serializable {
 
 	protected Integer position;
 
-	public Type getType() {
-		return type;
-	}
-
-	public String getTypeAsString() {
-		if (type == null) {
-			return null;
-		}
-
-		return type.toString();
-	}
-
-	public void setType(Type type) {
-		this.type = type;
-	}
-
-	public void setType(UnsafeSupplier<Type, Exception> typeUnsafeSupplier) {
-		try {
-			type = typeUnsafeSupplier.get();
-		}
-		catch (Exception e) {
-			throw new RuntimeException(e);
-		}
-	}
-
-	protected Type type;
-
 	@Override
 	public PageElement clone() throws CloneNotSupportedException {
 		return (PageElement)super.clone();
@@ -190,44 +163,6 @@ public class PageElement implements Cloneable, Serializable {
 
 	public String toString() {
 		return PageElementSerDes.toJSON(this);
-	}
-
-	public static enum Type {
-
-		COLLECTION("Collection"), COLLECTION_ITEM("CollectionItem"),
-		COLUMN("Column"), CONTAINER("Container"), DROP_ZONE("DropZone"),
-		FORM("Form"), FORM_STEP("FormStep"),
-		FORM_STEP_CONTAINER("FormStepContainer"), FRAGMENT("Fragment"),
-		FRAGMENT_COMPOSITION("FragmentComposition"),
-		FRAGMENT_DROP_ZONE("FragmentDropZone"), ROW("Row"), WIDGET("Widget");
-
-		public static Type create(String value) {
-			for (Type type : values()) {
-				if (Objects.equals(type.getValue(), value) ||
-					Objects.equals(type.name(), value)) {
-
-					return type;
-				}
-			}
-
-			return null;
-		}
-
-		public String getValue() {
-			return _value;
-		}
-
-		@Override
-		public String toString() {
-			return _value;
-		}
-
-		private Type(String value) {
-			_value = value;
-		}
-
-		private final String _value;
-
 	}
 
 }

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/PageFormDefinition.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/PageFormDefinition.java
@@ -19,7 +19,8 @@ import javax.annotation.Generated;
  * @generated
  */
 @Generated("")
-public class PageFormDefinition implements Cloneable, Serializable {
+public class PageFormDefinition
+	extends PageDefinition implements Cloneable, Serializable {
 
 	public static PageFormDefinition toDTO(String json) {
 		return PageFormDefinitionSerDes.toDTO(json);

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/PageFormStepContainerDefinition.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/PageFormStepContainerDefinition.java
@@ -20,7 +20,7 @@ import javax.annotation.Generated;
  */
 @Generated("")
 public class PageFormStepContainerDefinition
-	implements Cloneable, Serializable {
+	extends PageDefinition implements Cloneable, Serializable {
 
 	public static PageFormStepContainerDefinition toDTO(String json) {
 		return PageFormStepContainerDefinitionSerDes.toDTO(json);

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/PageFormStepDefinition.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/PageFormStepDefinition.java
@@ -19,7 +19,8 @@ import javax.annotation.Generated;
  * @generated
  */
 @Generated("")
-public class PageFormStepDefinition implements Cloneable, Serializable {
+public class PageFormStepDefinition
+	extends PageDefinition implements Cloneable, Serializable {
 
 	public static PageFormStepDefinition toDTO(String json) {
 		return PageFormStepDefinitionSerDes.toDTO(json);

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/PageFragmentCompositionInstanceDefinition.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/PageFragmentCompositionInstanceDefinition.java
@@ -20,7 +20,7 @@ import javax.annotation.Generated;
  */
 @Generated("")
 public class PageFragmentCompositionInstanceDefinition
-	implements Cloneable, Serializable {
+	extends PageDefinition implements Cloneable, Serializable {
 
 	public static PageFragmentCompositionInstanceDefinition toDTO(String json) {
 		return PageFragmentCompositionInstanceDefinitionSerDes.toDTO(json);

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/PageFragmentDropZoneDefinition.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/PageFragmentDropZoneDefinition.java
@@ -19,7 +19,8 @@ import javax.annotation.Generated;
  * @generated
  */
 @Generated("")
-public class PageFragmentDropZoneDefinition implements Cloneable, Serializable {
+public class PageFragmentDropZoneDefinition
+	extends PageDefinition implements Cloneable, Serializable {
 
 	public static PageFragmentDropZoneDefinition toDTO(String json) {
 		return PageFragmentDropZoneDefinitionSerDes.toDTO(json);

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/PageFragmentInstanceDefinition.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/PageFragmentInstanceDefinition.java
@@ -21,7 +21,8 @@ import javax.annotation.Generated;
  * @generated
  */
 @Generated("")
-public class PageFragmentInstanceDefinition implements Cloneable, Serializable {
+public class PageFragmentInstanceDefinition
+	extends PageDefinition implements Cloneable, Serializable {
 
 	public static PageFragmentInstanceDefinition toDTO(String json) {
 		return PageFragmentInstanceDefinitionSerDes.toDTO(json);

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/PageRowDefinition.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/PageRowDefinition.java
@@ -19,7 +19,8 @@ import javax.annotation.Generated;
  * @generated
  */
 @Generated("")
-public class PageRowDefinition implements Cloneable, Serializable {
+public class PageRowDefinition
+	extends PageDefinition implements Cloneable, Serializable {
 
 	public static PageRowDefinition toDTO(String json) {
 		return PageRowDefinitionSerDes.toDTO(json);

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/PageWidgetInstanceDefinition.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/PageWidgetInstanceDefinition.java
@@ -19,7 +19,8 @@ import javax.annotation.Generated;
  * @generated
  */
 @Generated("")
-public class PageWidgetInstanceDefinition implements Cloneable, Serializable {
+public class PageWidgetInstanceDefinition
+	extends PageDefinition implements Cloneable, Serializable {
 
 	public static PageWidgetInstanceDefinition toDTO(String json) {
 		return PageWidgetInstanceDefinitionSerDes.toDTO(json);

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/EmptyCollectionConfigSerDes.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/EmptyCollectionConfigSerDes.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/HtmlPropertiesSerDes.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/HtmlPropertiesSerDes.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/PageCollectionDefinitionSerDes.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/PageCollectionDefinitionSerDes.java
@@ -281,6 +281,20 @@ public class PageCollectionDefinitionSerDes {
 			sb.append("\"");
 		}
 
+		if (pageCollectionDefinition.getType() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"type\": ");
+
+			sb.append("\"");
+
+			sb.append(pageCollectionDefinition.getType());
+
+			sb.append("\"");
+		}
+
 		sb.append("}");
 
 		return sb.toString();
@@ -457,6 +471,13 @@ public class PageCollectionDefinitionSerDes {
 				String.valueOf(pageCollectionDefinition.getTemplateKey()));
 		}
 
+		if (pageCollectionDefinition.getType() == null) {
+			map.put("type", null);
+		}
+		else {
+			map.put("type", String.valueOf(pageCollectionDefinition.getType()));
+		}
+
 		return map;
 	}
 
@@ -530,6 +551,9 @@ public class PageCollectionDefinitionSerDes {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "templateKey")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "type")) {
 				return false;
 			}
 
@@ -675,6 +699,13 @@ public class PageCollectionDefinitionSerDes {
 				if (jsonParserFieldValue != null) {
 					pageCollectionDefinition.setTemplateKey(
 						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "type")) {
+				if (jsonParserFieldValue != null) {
+					pageCollectionDefinition.setType(
+						PageCollectionDefinition.Type.create(
+							(String)jsonParserFieldValue));
 				}
 			}
 		}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/PageCollectionItemDefinitionSerDes.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/PageCollectionItemDefinitionSerDes.java
@@ -73,6 +73,20 @@ public class PageCollectionItemDefinitionSerDes {
 			}
 		}
 
+		if (pageCollectionItemDefinition.getType() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"type\": ");
+
+			sb.append("\"");
+
+			sb.append(pageCollectionItemDefinition.getType());
+
+			sb.append("\"");
+		}
+
 		sb.append("}");
 
 		return sb.toString();
@@ -105,6 +119,14 @@ public class PageCollectionItemDefinitionSerDes {
 					pageCollectionItemDefinition.getCollectionItemConfig()));
 		}
 
+		if (pageCollectionItemDefinition.getType() == null) {
+			map.put("type", null);
+		}
+		else {
+			map.put(
+				"type", String.valueOf(pageCollectionItemDefinition.getType()));
+		}
+
 		return map;
 	}
 
@@ -126,6 +148,9 @@ public class PageCollectionItemDefinitionSerDes {
 			if (Objects.equals(jsonParserFieldName, "collectionItemConfig")) {
 				return false;
 			}
+			else if (Objects.equals(jsonParserFieldName, "type")) {
+				return false;
+			}
 
 			return false;
 		}
@@ -139,6 +164,13 @@ public class PageCollectionItemDefinitionSerDes {
 				if (jsonParserFieldValue != null) {
 					pageCollectionItemDefinition.setCollectionItemConfig(
 						(Object)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "type")) {
+				if (jsonParserFieldValue != null) {
+					pageCollectionItemDefinition.setType(
+						PageCollectionItemDefinition.Type.create(
+							(String)jsonParserFieldValue));
 				}
 			}
 		}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/PageColumnDefinitionSerDes.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/PageColumnDefinitionSerDes.java
@@ -83,6 +83,20 @@ public class PageColumnDefinitionSerDes {
 			sb.append(pageColumnDefinition.getSize());
 		}
 
+		if (pageColumnDefinition.getType() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"type\": ");
+
+			sb.append("\"");
+
+			sb.append(pageColumnDefinition.getType());
+
+			sb.append("\"");
+		}
+
 		sb.append("}");
 
 		return sb.toString();
@@ -120,6 +134,13 @@ public class PageColumnDefinitionSerDes {
 			map.put("size", String.valueOf(pageColumnDefinition.getSize()));
 		}
 
+		if (pageColumnDefinition.getType() == null) {
+			map.put("type", null);
+		}
+		else {
+			map.put("type", String.valueOf(pageColumnDefinition.getType()));
+		}
+
 		return map;
 	}
 
@@ -142,6 +163,9 @@ public class PageColumnDefinitionSerDes {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "size")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "type")) {
 				return false;
 			}
 
@@ -174,6 +198,13 @@ public class PageColumnDefinitionSerDes {
 				if (jsonParserFieldValue != null) {
 					pageColumnDefinition.setSize(
 						Integer.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "type")) {
+				if (jsonParserFieldValue != null) {
+					pageColumnDefinition.setType(
+						PageColumnDefinition.Type.create(
+							(String)jsonParserFieldValue));
 				}
 			}
 		}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/PageContainerDefinitionSerDes.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/PageContainerDefinitionSerDes.java
@@ -234,6 +234,20 @@ public class PageContainerDefinitionSerDes {
 			sb.append("\"");
 		}
 
+		if (pageContainerDefinition.getType() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"type\": ");
+
+			sb.append("\"");
+
+			sb.append(pageContainerDefinition.getType());
+
+			sb.append("\"");
+		}
+
 		sb.append("}");
 
 		return sb.toString();
@@ -362,6 +376,13 @@ public class PageContainerDefinitionSerDes {
 			map.put("name", String.valueOf(pageContainerDefinition.getName()));
 		}
 
+		if (pageContainerDefinition.getType() == null) {
+			map.put("type", null);
+		}
+		else {
+			map.put("type", String.valueOf(pageContainerDefinition.getType()));
+		}
+
 		return map;
 	}
 
@@ -418,6 +439,9 @@ public class PageContainerDefinitionSerDes {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "name")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "type")) {
 				return false;
 			}
 
@@ -530,6 +554,13 @@ public class PageContainerDefinitionSerDes {
 				if (jsonParserFieldValue != null) {
 					pageContainerDefinition.setName(
 						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "type")) {
+				if (jsonParserFieldValue != null) {
+					pageContainerDefinition.setType(
+						PageContainerDefinition.Type.create(
+							(String)jsonParserFieldValue));
 				}
 			}
 		}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/PageDefinitionSerDes.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/PageDefinitionSerDes.java
@@ -1,0 +1,343 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.site.client.serdes.v1_0;
+
+import com.liferay.headless.admin.site.client.dto.v1_0.PageCollectionDefinition;
+import com.liferay.headless.admin.site.client.dto.v1_0.PageCollectionItemDefinition;
+import com.liferay.headless.admin.site.client.dto.v1_0.PageColumnDefinition;
+import com.liferay.headless.admin.site.client.dto.v1_0.PageContainerDefinition;
+import com.liferay.headless.admin.site.client.dto.v1_0.PageDefinition;
+import com.liferay.headless.admin.site.client.dto.v1_0.PageDropZoneDefinition;
+import com.liferay.headless.admin.site.client.dto.v1_0.PageFormDefinition;
+import com.liferay.headless.admin.site.client.dto.v1_0.PageFormStepContainerDefinition;
+import com.liferay.headless.admin.site.client.dto.v1_0.PageFormStepDefinition;
+import com.liferay.headless.admin.site.client.dto.v1_0.PageFragmentCompositionInstanceDefinition;
+import com.liferay.headless.admin.site.client.dto.v1_0.PageFragmentDropZoneDefinition;
+import com.liferay.headless.admin.site.client.dto.v1_0.PageFragmentInstanceDefinition;
+import com.liferay.headless.admin.site.client.dto.v1_0.PageRowDefinition;
+import com.liferay.headless.admin.site.client.dto.v1_0.PageWidgetInstanceDefinition;
+import com.liferay.headless.admin.site.client.json.BaseJSONParser;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Rubén Pulido
+ * @generated
+ */
+@Generated("")
+public class PageDefinitionSerDes {
+
+	public static PageDefinition toDTO(String json) {
+		PageDefinitionJSONParser pageDefinitionJSONParser =
+			new PageDefinitionJSONParser();
+
+		return pageDefinitionJSONParser.parseToDTO(json);
+	}
+
+	public static PageDefinition[] toDTOs(String json) {
+		PageDefinitionJSONParser pageDefinitionJSONParser =
+			new PageDefinitionJSONParser();
+
+		return pageDefinitionJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(PageDefinition pageDefinition) {
+		if (pageDefinition == null) {
+			return "null";
+		}
+
+		PageDefinition.Type type = pageDefinition.getType();
+
+		if (type != null) {
+			String typeString = type.toString();
+
+			if (typeString.equals("Collection")) {
+				return PageCollectionDefinitionSerDes.toJSON(
+					(PageCollectionDefinition)pageDefinition);
+			}
+
+			if (typeString.equals("CollectionItem")) {
+				return PageCollectionItemDefinitionSerDes.toJSON(
+					(PageCollectionItemDefinition)pageDefinition);
+			}
+
+			if (typeString.equals("Column")) {
+				return PageColumnDefinitionSerDes.toJSON(
+					(PageColumnDefinition)pageDefinition);
+			}
+
+			if (typeString.equals("Container")) {
+				return PageContainerDefinitionSerDes.toJSON(
+					(PageContainerDefinition)pageDefinition);
+			}
+
+			if (typeString.equals("DropZone")) {
+				return PageDropZoneDefinitionSerDes.toJSON(
+					(PageDropZoneDefinition)pageDefinition);
+			}
+
+			if (typeString.equals("Form")) {
+				return PageFormDefinitionSerDes.toJSON(
+					(PageFormDefinition)pageDefinition);
+			}
+
+			if (typeString.equals("FormStep")) {
+				return PageFormStepDefinitionSerDes.toJSON(
+					(PageFormStepDefinition)pageDefinition);
+			}
+
+			if (typeString.equals("FormStepContainer")) {
+				return PageFormStepContainerDefinitionSerDes.toJSON(
+					(PageFormStepContainerDefinition)pageDefinition);
+			}
+
+			if (typeString.equals("FragmentComposition")) {
+				return PageFragmentCompositionInstanceDefinitionSerDes.toJSON(
+					(PageFragmentCompositionInstanceDefinition)pageDefinition);
+			}
+
+			if (typeString.equals("FragmentDropZone")) {
+				return PageFragmentDropZoneDefinitionSerDes.toJSON(
+					(PageFragmentDropZoneDefinition)pageDefinition);
+			}
+
+			if (typeString.equals("Fragment")) {
+				return PageFragmentInstanceDefinitionSerDes.toJSON(
+					(PageFragmentInstanceDefinition)pageDefinition);
+			}
+
+			if (typeString.equals("Row")) {
+				return PageRowDefinitionSerDes.toJSON(
+					(PageRowDefinition)pageDefinition);
+			}
+
+			if (typeString.equals("Widget")) {
+				return PageWidgetInstanceDefinitionSerDes.toJSON(
+					(PageWidgetInstanceDefinition)pageDefinition);
+			}
+
+			throw new IllegalArgumentException("Unknown type " + typeString);
+		}
+		else {
+			throw new IllegalArgumentException("Missing type parameter");
+		}
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		PageDefinitionJSONParser pageDefinitionJSONParser =
+			new PageDefinitionJSONParser();
+
+		return pageDefinitionJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(PageDefinition pageDefinition) {
+		if (pageDefinition == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		if (pageDefinition.getType() == null) {
+			map.put("type", null);
+		}
+		else {
+			map.put("type", String.valueOf(pageDefinition.getType()));
+		}
+
+		return map;
+	}
+
+	public static class PageDefinitionJSONParser
+		extends BaseJSONParser<PageDefinition> {
+
+		@Override
+		protected PageDefinition createDTO() {
+			return null;
+		}
+
+		@Override
+		protected PageDefinition[] createDTOArray(int size) {
+			return new PageDefinition[size];
+		}
+
+		@Override
+		protected boolean parseMaps(String jsonParserFieldName) {
+			if (Objects.equals(jsonParserFieldName, "type")) {
+				return false;
+			}
+
+			return false;
+		}
+
+		@Override
+		public PageDefinition parseToDTO(String json) {
+			Map<String, Object> jsonMap = parseToMap(json);
+
+			Object type = jsonMap.get("type");
+
+			if (type != null) {
+				String typeString = type.toString();
+
+				if (typeString.equals("Collection")) {
+					return PageCollectionDefinition.toDTO(json);
+				}
+
+				if (typeString.equals("CollectionItem")) {
+					return PageCollectionItemDefinition.toDTO(json);
+				}
+
+				if (typeString.equals("Column")) {
+					return PageColumnDefinition.toDTO(json);
+				}
+
+				if (typeString.equals("Container")) {
+					return PageContainerDefinition.toDTO(json);
+				}
+
+				if (typeString.equals("DropZone")) {
+					return PageDropZoneDefinition.toDTO(json);
+				}
+
+				if (typeString.equals("Form")) {
+					return PageFormDefinition.toDTO(json);
+				}
+
+				if (typeString.equals("FormStep")) {
+					return PageFormStepDefinition.toDTO(json);
+				}
+
+				if (typeString.equals("FormStepContainer")) {
+					return PageFormStepContainerDefinition.toDTO(json);
+				}
+
+				if (typeString.equals("FragmentComposition")) {
+					return PageFragmentCompositionInstanceDefinition.toDTO(
+						json);
+				}
+
+				if (typeString.equals("FragmentDropZone")) {
+					return PageFragmentDropZoneDefinition.toDTO(json);
+				}
+
+				if (typeString.equals("Fragment")) {
+					return PageFragmentInstanceDefinition.toDTO(json);
+				}
+
+				if (typeString.equals("Row")) {
+					return PageRowDefinition.toDTO(json);
+				}
+
+				if (typeString.equals("Widget")) {
+					return PageWidgetInstanceDefinition.toDTO(json);
+				}
+
+				throw new IllegalArgumentException(
+					"Unknown type " + typeString);
+			}
+			else {
+				throw new IllegalArgumentException("Missing type parameter");
+			}
+		}
+
+		@Override
+		protected void setField(
+			PageDefinition pageDefinition, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "type")) {
+				if (jsonParserFieldValue != null) {
+					pageDefinition.setType(
+						PageDefinition.Type.create(
+							(String)jsonParserFieldValue));
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			sb.append(_toJSON(value));
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static String _toJSON(Object value) {
+		if (value == null) {
+			return "null";
+		}
+
+		if (value instanceof Map) {
+			return _toJSON((Map)value);
+		}
+
+		Class<?> clazz = value.getClass();
+
+		if (clazz.isArray()) {
+			StringBuilder sb = new StringBuilder("[");
+
+			Object[] values = (Object[])value;
+
+			for (int i = 0; i < values.length; i++) {
+				sb.append(_toJSON(values[i]));
+
+				if ((i + 1) < values.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+
+			return sb.toString();
+		}
+
+		if (value instanceof String) {
+			return "\"" + _escape(value) + "\"";
+		}
+
+		return String.valueOf(value);
+	}
+
+}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/PageDropZoneDefinitionSerDes.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/PageDropZoneDefinitionSerDes.java
@@ -65,6 +65,20 @@ public class PageDropZoneDefinitionSerDes {
 			}
 		}
 
+		if (pageDropZoneDefinition.getType() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"type\": ");
+
+			sb.append("\"");
+
+			sb.append(pageDropZoneDefinition.getType());
+
+			sb.append("\"");
+		}
+
 		sb.append("}");
 
 		return sb.toString();
@@ -95,6 +109,13 @@ public class PageDropZoneDefinitionSerDes {
 				String.valueOf(pageDropZoneDefinition.getFragmentSettings()));
 		}
 
+		if (pageDropZoneDefinition.getType() == null) {
+			map.put("type", null);
+		}
+		else {
+			map.put("type", String.valueOf(pageDropZoneDefinition.getType()));
+		}
+
 		return map;
 	}
 
@@ -116,6 +137,9 @@ public class PageDropZoneDefinitionSerDes {
 			if (Objects.equals(jsonParserFieldName, "fragmentSettings")) {
 				return false;
 			}
+			else if (Objects.equals(jsonParserFieldName, "type")) {
+				return false;
+			}
 
 			return false;
 		}
@@ -129,6 +153,13 @@ public class PageDropZoneDefinitionSerDes {
 				if (jsonParserFieldValue != null) {
 					pageDropZoneDefinition.setFragmentSettings(
 						(Object)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "type")) {
+				if (jsonParserFieldValue != null) {
+					pageDropZoneDefinition.setType(
+						PageDropZoneDefinition.Type.create(
+							(String)jsonParserFieldValue));
 				}
 			}
 		}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/PageElementSerDes.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/PageElementSerDes.java
@@ -53,14 +53,7 @@ public class PageElementSerDes {
 
 			sb.append("\"definition\": ");
 
-			if (pageElement.getDefinition() instanceof String) {
-				sb.append("\"");
-				sb.append((String)pageElement.getDefinition());
-				sb.append("\"");
-			}
-			else {
-				sb.append(pageElement.getDefinition());
-			}
+			sb.append(String.valueOf(pageElement.getDefinition()));
 		}
 
 		if (pageElement.getExternalReferenceCode() != null) {
@@ -119,20 +112,6 @@ public class PageElementSerDes {
 			sb.append("\"position\": ");
 
 			sb.append(pageElement.getPosition());
-		}
-
-		if (pageElement.getType() != null) {
-			if (sb.length() > 1) {
-				sb.append(", ");
-			}
-
-			sb.append("\"type\": ");
-
-			sb.append("\"");
-
-			sb.append(pageElement.getType());
-
-			sb.append("\"");
 		}
 
 		sb.append("}");
@@ -194,13 +173,6 @@ public class PageElementSerDes {
 			map.put("position", String.valueOf(pageElement.getPosition()));
 		}
 
-		if (pageElement.getType() == null) {
-			map.put("type", null);
-		}
-		else {
-			map.put("type", String.valueOf(pageElement.getType()));
-		}
-
 		return map;
 	}
 
@@ -238,9 +210,6 @@ public class PageElementSerDes {
 			else if (Objects.equals(jsonParserFieldName, "position")) {
 				return false;
 			}
-			else if (Objects.equals(jsonParserFieldName, "type")) {
-				return false;
-			}
 
 			return false;
 		}
@@ -252,7 +221,9 @@ public class PageElementSerDes {
 
 			if (Objects.equals(jsonParserFieldName, "definition")) {
 				if (jsonParserFieldValue != null) {
-					pageElement.setDefinition((Object)jsonParserFieldValue);
+					pageElement.setDefinition(
+						PageDefinitionSerDes.toDTO(
+							(String)jsonParserFieldValue));
 				}
 			}
 			else if (Objects.equals(
@@ -291,12 +262,6 @@ public class PageElementSerDes {
 				if (jsonParserFieldValue != null) {
 					pageElement.setPosition(
 						Integer.valueOf((String)jsonParserFieldValue));
-				}
-			}
-			else if (Objects.equals(jsonParserFieldName, "type")) {
-				if (jsonParserFieldValue != null) {
-					pageElement.setType(
-						PageElement.Type.create((String)jsonParserFieldValue));
 				}
 			}
 		}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/PageFormDefinitionSerDes.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/PageFormDefinitionSerDes.java
@@ -190,6 +190,20 @@ public class PageFormDefinitionSerDes {
 			sb.append("\"");
 		}
 
+		if (pageFormDefinition.getType() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"type\": ");
+
+			sb.append("\"");
+
+			sb.append(pageFormDefinition.getType());
+
+			sb.append("\"");
+		}
+
 		sb.append("}");
 
 		return sb.toString();
@@ -285,6 +299,13 @@ public class PageFormDefinitionSerDes {
 			map.put("name", String.valueOf(pageFormDefinition.getName()));
 		}
 
+		if (pageFormDefinition.getType() == null) {
+			map.put("type", null);
+		}
+		else {
+			map.put("type", String.valueOf(pageFormDefinition.getType()));
+		}
+
 		return map;
 	}
 
@@ -330,6 +351,9 @@ public class PageFormDefinitionSerDes {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "name")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "type")) {
 				return false;
 			}
 
@@ -419,6 +443,13 @@ public class PageFormDefinitionSerDes {
 			else if (Objects.equals(jsonParserFieldName, "name")) {
 				if (jsonParserFieldValue != null) {
 					pageFormDefinition.setName((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "type")) {
+				if (jsonParserFieldValue != null) {
+					pageFormDefinition.setType(
+						PageFormDefinition.Type.create(
+							(String)jsonParserFieldValue));
 				}
 			}
 		}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/PageFormStepContainerDefinitionSerDes.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/PageFormStepContainerDefinitionSerDes.java
@@ -190,6 +190,20 @@ public class PageFormStepContainerDefinitionSerDes {
 			sb.append("\"");
 		}
 
+		if (pageFormStepContainerDefinition.getType() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"type\": ");
+
+			sb.append("\"");
+
+			sb.append(pageFormStepContainerDefinition.getType());
+
+			sb.append("\"");
+		}
+
 		sb.append("}");
 
 		return sb.toString();
@@ -279,6 +293,15 @@ public class PageFormStepContainerDefinitionSerDes {
 				String.valueOf(pageFormStepContainerDefinition.getName()));
 		}
 
+		if (pageFormStepContainerDefinition.getType() == null) {
+			map.put("type", null);
+		}
+		else {
+			map.put(
+				"type",
+				String.valueOf(pageFormStepContainerDefinition.getType()));
+		}
+
 		return map;
 	}
 
@@ -318,6 +341,9 @@ public class PageFormStepContainerDefinitionSerDes {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "name")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "type")) {
 				return false;
 			}
 
@@ -396,6 +422,13 @@ public class PageFormStepContainerDefinitionSerDes {
 				if (jsonParserFieldValue != null) {
 					pageFormStepContainerDefinition.setName(
 						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "type")) {
+				if (jsonParserFieldValue != null) {
+					pageFormStepContainerDefinition.setType(
+						PageFormStepContainerDefinition.Type.create(
+							(String)jsonParserFieldValue));
 				}
 			}
 		}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/PageFormStepDefinitionSerDes.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/PageFormStepDefinitionSerDes.java
@@ -63,6 +63,20 @@ public class PageFormStepDefinitionSerDes {
 			}
 		}
 
+		if (pageFormStepDefinition.getType() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"type\": ");
+
+			sb.append("\"");
+
+			sb.append(pageFormStepDefinition.getType());
+
+			sb.append("\"");
+		}
+
 		sb.append("}");
 
 		return sb.toString();
@@ -93,6 +107,13 @@ public class PageFormStepDefinitionSerDes {
 				String.valueOf(pageFormStepDefinition.getFormStepConfig()));
 		}
 
+		if (pageFormStepDefinition.getType() == null) {
+			map.put("type", null);
+		}
+		else {
+			map.put("type", String.valueOf(pageFormStepDefinition.getType()));
+		}
+
 		return map;
 	}
 
@@ -114,6 +135,9 @@ public class PageFormStepDefinitionSerDes {
 			if (Objects.equals(jsonParserFieldName, "formStepConfig")) {
 				return false;
 			}
+			else if (Objects.equals(jsonParserFieldName, "type")) {
+				return false;
+			}
 
 			return false;
 		}
@@ -127,6 +151,13 @@ public class PageFormStepDefinitionSerDes {
 				if (jsonParserFieldValue != null) {
 					pageFormStepDefinition.setFormStepConfig(
 						(Object)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "type")) {
+				if (jsonParserFieldValue != null) {
+					pageFormStepDefinition.setType(
+						PageFormStepDefinition.Type.create(
+							(String)jsonParserFieldValue));
 				}
 			}
 		}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/PageFragmentCompositionInstanceDefinitionSerDes.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/PageFragmentCompositionInstanceDefinitionSerDes.java
@@ -70,6 +70,20 @@ public class PageFragmentCompositionInstanceDefinitionSerDes {
 						getFragmentComposition()));
 		}
 
+		if (pageFragmentCompositionInstanceDefinition.getType() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"type\": ");
+
+			sb.append("\"");
+
+			sb.append(pageFragmentCompositionInstanceDefinition.getType());
+
+			sb.append("\"");
+		}
+
 		sb.append("}");
 
 		return sb.toString();
@@ -107,6 +121,16 @@ public class PageFragmentCompositionInstanceDefinitionSerDes {
 						getFragmentComposition()));
 		}
 
+		if (pageFragmentCompositionInstanceDefinition.getType() == null) {
+			map.put("type", null);
+		}
+		else {
+			map.put(
+				"type",
+				String.valueOf(
+					pageFragmentCompositionInstanceDefinition.getType()));
+		}
+
 		return map;
 	}
 
@@ -130,6 +154,9 @@ public class PageFragmentCompositionInstanceDefinitionSerDes {
 			if (Objects.equals(jsonParserFieldName, "fragmentComposition")) {
 				return false;
 			}
+			else if (Objects.equals(jsonParserFieldName, "type")) {
+				return false;
+			}
 
 			return false;
 		}
@@ -146,6 +173,13 @@ public class PageFragmentCompositionInstanceDefinitionSerDes {
 						setFragmentComposition(
 							ItemExternalReferenceSerDes.toDTO(
 								(String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "type")) {
+				if (jsonParserFieldValue != null) {
+					pageFragmentCompositionInstanceDefinition.setType(
+						PageFragmentCompositionInstanceDefinition.Type.create(
+							(String)jsonParserFieldValue));
 				}
 			}
 		}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/PageFragmentDropZoneDefinitionSerDes.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/PageFragmentDropZoneDefinitionSerDes.java
@@ -66,6 +66,20 @@ public class PageFragmentDropZoneDefinitionSerDes {
 			sb.append("\"");
 		}
 
+		if (pageFragmentDropZoneDefinition.getType() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"type\": ");
+
+			sb.append("\"");
+
+			sb.append(pageFragmentDropZoneDefinition.getType());
+
+			sb.append("\"");
+		}
+
 		sb.append("}");
 
 		return sb.toString();
@@ -98,6 +112,15 @@ public class PageFragmentDropZoneDefinitionSerDes {
 					pageFragmentDropZoneDefinition.getFragmentDropZoneId()));
 		}
 
+		if (pageFragmentDropZoneDefinition.getType() == null) {
+			map.put("type", null);
+		}
+		else {
+			map.put(
+				"type",
+				String.valueOf(pageFragmentDropZoneDefinition.getType()));
+		}
+
 		return map;
 	}
 
@@ -119,6 +142,9 @@ public class PageFragmentDropZoneDefinitionSerDes {
 			if (Objects.equals(jsonParserFieldName, "fragmentDropZoneId")) {
 				return false;
 			}
+			else if (Objects.equals(jsonParserFieldName, "type")) {
+				return false;
+			}
 
 			return false;
 		}
@@ -132,6 +158,13 @@ public class PageFragmentDropZoneDefinitionSerDes {
 				if (jsonParserFieldValue != null) {
 					pageFragmentDropZoneDefinition.setFragmentDropZoneId(
 						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "type")) {
+				if (jsonParserFieldValue != null) {
+					pageFragmentDropZoneDefinition.setType(
+						PageFragmentDropZoneDefinition.Type.create(
+							(String)jsonParserFieldValue));
 				}
 			}
 		}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/PageFragmentInstanceDefinitionSerDes.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/PageFragmentInstanceDefinitionSerDes.java
@@ -364,6 +364,20 @@ public class PageFragmentInstanceDefinitionSerDes {
 			sb.append("]");
 		}
 
+		if (pageFragmentInstanceDefinition.getType() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"type\": ");
+
+			sb.append("\"");
+
+			sb.append(pageFragmentInstanceDefinition.getType());
+
+			sb.append("\"");
+		}
+
 		sb.append("}");
 
 		return sb.toString();
@@ -546,6 +560,15 @@ public class PageFragmentInstanceDefinitionSerDes {
 					pageFragmentInstanceDefinition.getWidgetInstances()));
 		}
 
+		if (pageFragmentInstanceDefinition.getType() == null) {
+			map.put("type", null);
+		}
+		else {
+			map.put(
+				"type",
+				String.valueOf(pageFragmentInstanceDefinition.getType()));
+		}
+
 		return map;
 	}
 
@@ -615,6 +638,9 @@ public class PageFragmentInstanceDefinitionSerDes {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "widgetInstances")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "type")) {
 				return false;
 			}
 
@@ -773,6 +799,13 @@ public class PageFragmentInstanceDefinitionSerDes {
 
 					pageFragmentInstanceDefinition.setWidgetInstances(
 						widgetInstancesArray);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "type")) {
+				if (jsonParserFieldValue != null) {
+					pageFragmentInstanceDefinition.setType(
+						PageFragmentInstanceDefinition.Type.create(
+							(String)jsonParserFieldValue));
 				}
 			}
 		}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/PageRowDefinitionSerDes.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/PageRowDefinitionSerDes.java
@@ -244,6 +244,20 @@ public class PageRowDefinitionSerDes {
 			sb.append("\"");
 		}
 
+		if (pageRowDefinition.getType() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"type\": ");
+
+			sb.append("\"");
+
+			sb.append(pageRowDefinition.getType());
+
+			sb.append("\"");
+		}
+
 		sb.append("}");
 
 		return sb.toString();
@@ -375,6 +389,13 @@ public class PageRowDefinitionSerDes {
 				String.valueOf(pageRowDefinition.getVerticalAlignment()));
 		}
 
+		if (pageRowDefinition.getType() == null) {
+			map.put("type", null);
+		}
+		else {
+			map.put("type", String.valueOf(pageRowDefinition.getType()));
+		}
+
 		return map;
 	}
 
@@ -432,6 +453,9 @@ public class PageRowDefinitionSerDes {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "verticalAlignment")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "type")) {
 				return false;
 			}
 
@@ -553,6 +577,13 @@ public class PageRowDefinitionSerDes {
 				if (jsonParserFieldValue != null) {
 					pageRowDefinition.setVerticalAlignment(
 						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "type")) {
+				if (jsonParserFieldValue != null) {
+					pageRowDefinition.setType(
+						PageRowDefinition.Type.create(
+							(String)jsonParserFieldValue));
 				}
 			}
 		}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/PageWidgetInstanceDefinitionSerDes.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/PageWidgetInstanceDefinitionSerDes.java
@@ -187,6 +187,20 @@ public class PageWidgetInstanceDefinitionSerDes {
 					pageWidgetInstanceDefinition.getWidgetInstance()));
 		}
 
+		if (pageWidgetInstanceDefinition.getType() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"type\": ");
+
+			sb.append("\"");
+
+			sb.append(pageWidgetInstanceDefinition.getType());
+
+			sb.append("\"");
+		}
+
 		sb.append("}");
 
 		return sb.toString();
@@ -275,6 +289,14 @@ public class PageWidgetInstanceDefinitionSerDes {
 					pageWidgetInstanceDefinition.getWidgetInstance()));
 		}
 
+		if (pageWidgetInstanceDefinition.getType() == null) {
+			map.put("type", null);
+		}
+		else {
+			map.put(
+				"type", String.valueOf(pageWidgetInstanceDefinition.getType()));
+		}
+
 		return map;
 	}
 
@@ -314,6 +336,9 @@ public class PageWidgetInstanceDefinitionSerDes {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "widgetInstance")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "type")) {
 				return false;
 			}
 
@@ -392,6 +417,13 @@ public class PageWidgetInstanceDefinitionSerDes {
 				if (jsonParserFieldValue != null) {
 					pageWidgetInstanceDefinition.setWidgetInstance(
 						WidgetInstanceSerDes.toDTO(
+							(String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "type")) {
+				if (jsonParserFieldValue != null) {
+					pageWidgetInstanceDefinition.setType(
+						PageWidgetInstanceDefinition.Type.create(
 							(String)jsonParserFieldValue));
 				}
 			}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-openapi.yaml
@@ -1282,260 +1282,315 @@ components:
                         The localized Open Graph's titles.
                     type: object
             type: object
+
+        EmptyCollectionConfig:
+            properties:
+                displayMessage:
+                    # @review
+                    description:
+                        Whether to display a message when the collection is empty or no results match the
+                        applied filters (true by default).
+                    type: boolean
+                message_i18n:
+                    additionalProperties:
+                        type: string
+                    # @review
+                    description:
+                        The localized message to display when the collection is empty or no results match the
+                        applied filters ('No Results Found' by default).
+                    type: object
         PageCollectionDefinition:
             # @review
             description:
                 The definition of a Page Collection.
-            properties:
-                collectionReference:
-                    $ref: "#/components/schemas/CollectionReference"
-                collectionViewports:
-                    # @review
-                    description:
-                        A list of viewports of the page collection.
-                    items:
-                        $ref: "#/components/schemas/CollectionViewport"
-                    type: array
-                displayAllItems:
-                    # @review
-                    description:
-                        Whether to show all items when pagination is disabled.
-                    type: boolean
-                displayAllPages:
-                    # @review
-                    description:
-                        Whether to show all pages when pagination is enabled.
-                    type: boolean
-                emptyCollectionConfig:
-                    properties:
-                        displayMessage:
+            allOf:
+                -   $ref: "#/components/schemas/PageDefinition"
+                -   properties:
+                        collectionReference:
+                            $ref: "#/components/schemas/CollectionReference"
+                        collectionViewports:
                             # @review
                             description:
-                                Whether to display a message when the collection is empty or no results match the
-                                applied filters (true by default).
+                                A list of viewports of the page collection.
+                            items:
+                                $ref: "#/components/schemas/CollectionViewport"
+                            type: array
+                        displayAllItems:
+                            # @review
+                            description:
+                                Whether to show all items when pagination is disabled.
                             type: boolean
-                        message_i18n:
-                            additionalProperties:
-                                type: string
+                        displayAllPages:
                             # @review
                             description:
-                                The localized message to display when the collection is empty or no results match the
-                                applied filters ('No Results Found' by default).
+                                Whether to show all pages when pagination is enabled.
+                            type: boolean
+                        emptyCollectionConfig:
+                            $ref: "#/components/schemas/EmptyCollectionConfig"
                             type: object
-                    type: object
-                fragmentStyle:
-                    $ref: "#/components/schemas/FragmentStyle"
-                    # @review
-                    description:
-                        The fragment style of the page collection.
-                fragmentViewports:
-                    # @review
-                    description:
-                        The fragment viewports of the page collection.
-                    items:
-                        $ref: "#/components/schemas/FragmentViewport"
-                    type: array
-                layout:
-                    # @review
-                    description:
-                        the page collection's layout.
-                    properties:
-                        align:
-                            enum: [Baseline, Center, End, None, Start, Stretch]
+                        fragmentStyle:
+                            $ref: "#/components/schemas/FragmentStyle"
+                            # @review
+                            description:
+                                The fragment style of the page collection.
+                        fragmentViewports:
+                            # @review
+                            description:
+                                The fragment viewports of the page collection.
+                            items:
+                                $ref: "#/components/schemas/FragmentViewport"
+                            type: array
+                        layout:
+                            # @review
+                            description:
+                                the page collection's layout.
+                            properties:
+                                align:
+                                    enum: [Baseline, Center, End, None, Start, Stretch]
+                                    type: string
+                                flexWrap:
+                                    enum: [NoWrap, Wrap, WrapReverse]
+                                    type: string
+                                justify:
+                                    enum: [Center, End, None, SpaceAround, SpaceBetween, Start]
+                                    type: string
+                            type: object
+                        listItemStyle:
+                            # @review
+                            description:
+                                The style of a list of items in the page collection.
                             type: string
-                        flexWrap:
-                            enum: [NoWrap, Wrap, WrapReverse]
+                        listStyle:
+                            # @review
+                            description:
+                                The style of a list in the page collection.
                             type: string
-                        justify:
-                            enum: [Center, End, None, SpaceAround, SpaceBetween, Start]
+                        name:
+                            # @review
+                            description:
+                                The custom name of a Page Collection.
                             type: string
-                    type: object
-                listItemStyle:
-                    # @review
-                    description:
-                        The style of a list of items in the page collection.
-                    type: string
-                listStyle:
-                    # @review
-                    description:
-                        The style of a list in the page collection.
-                    type: string
-                name:
-                    # @review
-                    description:
-                        The custom name of a Page Collection.
-                    type: string
-                numberOfColumns:
-                    # @review
-                    description:
-                        The number of columns in the page collection.
-                    type: integer
-                numberOfItems:
-                    # @review
-                    description:
-                        The maximum number of items to display in the page collection when pagination is disabled.
-                    type: integer
-                numberOfItemsPerPage:
-                    # @review
-                    description:
-                        The number of items per page in the page collection.
-                    type: integer
-                numberOfPages:
-                    # @review
-                    description:
-                        The maximum number of pages to show when pagination is enabled.
-                    type: integer
-                paginationType:
-                    # @review
-                    description:
-                        The type of pagination.
-                    enum: [
-                        None,
-                        Numeric,
-                        Regular,
-                        Simple]
-                    type: string
-                templateKey:
-                    # @review
-                    description:
-                        The page collection's template key.
-                    type: string
+                        numberOfColumns:
+                            # @review
+                            description:
+                                The number of columns in the page collection.
+                            type: integer
+                        numberOfItems:
+                            # @review
+                            description:
+                                The maximum number of items to display in the page collection when pagination is disabled.
+                            type: integer
+                        numberOfItemsPerPage:
+                            # @review
+                            description:
+                                The number of items per page in the page collection.
+                            type: integer
+                        numberOfPages:
+                            # @review
+                            description:
+                                The maximum number of pages to show when pagination is enabled.
+                            type: integer
+                        paginationType:
+                            # @review
+                            description:
+                                The type of pagination.
+                            enum: [
+                                None,
+                                Numeric,
+                                Regular,
+                                Simple]
+                            type: string
+                        templateKey:
+                            # @review
+                            description:
+                                The page collection's template key.
+                            type: string
             type: object
         PageCollectionItemDefinition:
             # @review
             description:
                 The definition of a Page Collection Item.
-            properties:
-                collectionItemConfig:
-                    # @review
-                    description:
-                        The page collection item's configuration.
-                    type: object
+            allOf:
+                - $ref: "#/components/schemas/PageDefinition"
+                - properties:
+                    collectionItemConfig:
+                        # @review
+                        description:
+                            The page collection item's configuration.
+                        type: object
             type: object
         PageColumnDefinition:
             # @review
             description:
                 The definition of a Page Column.
-            properties:
-                columnViewports:
-                    # @review
-                    description:
-                        A list of column viewports of the page column definition.
-                    items:
-                        $ref: "#/components/schemas/ColumnViewport"
-                    type: array
-                size:
-                    # @review
-                    description:
-                        The page column's size.
-                    maximum: 12
-                    minimum: 1
-                    type: integer
+            allOf:
+                -   $ref: "#/components/schemas/PageDefinition"
+                -   properties:
+                        columnViewports:
+                                # @review
+                                description:
+                                    A list of column viewports of the page column definition.
+                                items:
+                                    $ref: "#/components/schemas/ColumnViewport"
+                                type: array
+                        size:
+                            # @review
+                            description:
+                                The page column's size.
+                            maximum: 12
+                            minimum: 1
+                            type: integer
             type: object
+        HtmlProperties:
+            type: object
+            properties:
+                htmlTag:
+                    enum: [ Article, Aside, Div, Footer, Header, Nav, Section ]
+                    type: string
         PageContainerDefinition:
             # @review
             description:
                 The definition of a Page section.
-            properties:
-                backgroundFragmentImage:
-                    $ref: "#/components/schemas/FragmentImage"
-                    # @review
-                    description:
-                        The background fragment image of the page section.
-                contentVisibility:
-                    # @review
-                    description:
-                        Defines the content visibility of the container.
-                    type: string
-                cssClasses:
-                    # @review
-                    description:
-                        A list of CSS Classes that are applied to the element.
-                    items:
-                        type: string
-                    type: array
-                customCSS:
-                    # @review
-                    description:
-                        Custom CSS that is applied on the fragment.
-                    type: string
-                customCSSViewports:
-                    # @review
-                    description:
-                        The custom CSS viewports of the page collection.
-                    items:
-                        $ref: "#/components/schemas/CustomCSSViewport"
-                    type: array
-                fragmentLink:
-                    $ref: "#/components/schemas/FragmentLink"
-                    # @review
-                    description:
-                        The fragment link of the page section.
-                fragmentStyle:
-                    $ref: "#/components/schemas/FragmentStyle"
-                    # @review
-                    description:
-                        The fragment style of the page section.
-                fragmentViewports:
-                    # @review
-                    description:
-                        A list of fragment viewports of the page section.
-                    items:
-                        $ref: "#/components/schemas/FragmentViewport"
-                    type: array
-                htmlProperties:
-                    # @review
-                    description:
-                        The page section's html properties
-                    properties:
-                        htmlTag:
-                            enum: [Article, Aside, Div, Footer, Header, Nav, Section]
-                            type: string
-                    type: object
-                indexed:
-                    # @review
-                    description:
-                        A flag that indicates whether the page section is indexed or not.
-                    type: boolean
-                layout:
-                    # @review
-                    description:
-                        the page container's layout.
-                    properties:
-                        containerType:
+            allOf:
+                -   $ref: "#/components/schemas/PageDefinition"
+                -   properties:
+                        backgroundFragmentImage:
+                            $ref: "#/components/schemas/FragmentImage"
                             # @review
                             description:
-                                The container's type (fixed or fluid).
-                            enum: [Fixed, Fluid]
-                            type: string
-                        flexWrap:
-                            enum: [NoWrap, Wrap, WrapReverse]
-                            type: string
-                        widthType:
+                                The background fragment image of the page section.
+                        contentVisibility:
                             # @review
                             description:
-                                The width's type (fixed or fluid).
-                            enum: [Fixed, Fluid]
+                                Defines the content visibility of the container.
                             type: string
-                    type: object
-                name:
-                    # @review
-                    description:
-                        The custom name of a Page section.
-                    type: string
+                        cssClasses:
+                            # @review
+                            description:
+                                A list of CSS Classes that are applied to the element.
+                            items:
+                                type: string
+                            type: array
+                        customCSS:
+                            # @review
+                            description:
+                                Custom CSS that is applied on the fragment.
+                            type: string
+                        customCSSViewports:
+                            # @review
+                            description:
+                                The custom CSS viewports of the page collection.
+                            items:
+                                $ref: "#/components/schemas/CustomCSSViewport"
+                            type: array
+                        fragmentLink:
+                            $ref: "#/components/schemas/FragmentLink"
+                            # @review
+                            description:
+                                The fragment link of the page section.
+                        fragmentStyle:
+                            $ref: "#/components/schemas/FragmentStyle"
+                            # @review
+                            description:
+                                The fragment style of the page section.
+                        fragmentViewports:
+                            # @review
+                            description:
+                                A list of fragment viewports of the page section.
+                            items:
+                                $ref: "#/components/schemas/FragmentViewport"
+                            type: array
+                        htmlProperties:
+                            $ref: "#/components/schemas/HtmlProperties"
+                        indexed:
+                            # @review
+                            description:
+                                A flag that indicates whether the page section is indexed or not.
+                            type: boolean
+                        layout:
+                            # @review
+                            description:
+                                the page container's layout.
+                            properties:
+                                containerType:
+                                    # @review
+                                    description:
+                                        The container's type (fixed or fluid).
+                                    enum: [Fixed, Fluid]
+                                    type: string
+                                flexWrap:
+                                    enum: [NoWrap, Wrap, WrapReverse]
+                                    type: string
+                                widthType:
+                                    # @review
+                                    description:
+                                        The width's type (fixed or fluid).
+                                    enum: [Fixed, Fluid]
+                                    type: string
+                            type: object
+                        name:
+                            # @review
+                            description:
+                                The custom name of a Page section.
+                            type: string
             type: object
         PageDropZoneDefinition:
             # @review
             description:
                 Represent a definition of a Page drop zone.
+            allOf:
+                -   $ref: "#/components/schemas/PageDefinition"
+                -   properties:
+                        fragmentSettings:
+                            # @review
+                            description:
+                                The page drop zone's allowed or unallowed fragments.
+                            oneOf:
+                                -   $ref: "#/components/schemas/FragmentSettingsAllowed"
+                                -   $ref: "#/components/schemas/FragmentSettingsUnallowed"
+            type: object
+        PageDefinition:
+            # @review
+            description:
+                The page definition.
+            discriminator:
+                mapping:
+                    Collection: "#/components/schemas/PageCollectionDefinition"
+                    CollectionItem: "#/components/schemas/PageCollectionItemDefinition"
+                    Column: "#/components/schemas/PageColumnDefinition"
+                    Container: "#/components/schemas/PageContainerDefinition"
+                    DropZone: "#/components/schemas/PageDropZoneDefinition"
+                    Form: "#/components/schemas/PageFormDefinition"
+                    FormStep: "#/components/schemas/PageFormStepDefinition"
+                    FormStepContainer: "#/components/schemas/PageFormStepContainerDefinition"
+                    FragmentComposition: "#/components/schemas/PageFragmentCompositionInstanceDefinition"
+                    FragmentDropZone: "#/components/schemas/PageFragmentDropZoneDefinition"
+                    Fragment: "#/components/schemas/PageFragmentInstanceDefinition"
+                    Row: "#/components/schemas/PageRowDefinition"
+                    Widget: "#/components/schemas/PageWidgetInstanceDefinition"
+                propertyName: type
             properties:
-                fragmentSettings:
+                type:
                     # @review
                     description:
-                        The page drop zone's allowed or unallowed fragments.
-                    oneOf:
-                        -   $ref: "#/components/schemas/FragmentSettingsAllowed"
-                        -   $ref: "#/components/schemas/FragmentSettingsUnallowed"
+                        The page element's type (collection, collection item, column, container, drop zone, form, form
+                        step, form step container, fragment, fragment composition, fragment drop zone, row, widget or
+                        widget section).
+                    enum:
+                        - Collection
+                        - CollectionItem
+                        - Column
+                        - Container
+                        - DropZone
+                        - Form
+                        - FormStep
+                        - FormStepContainer
+                        - FragmentComposition
+                        - FragmentDropZone
+                        - Fragment
+                        - Row
+                        - Widget
+                    type: string
             type: object
         PageElement:
             # @review
@@ -1546,20 +1601,7 @@ components:
                     # @review
                     description:
                         The page element's definition.
-                    oneOf:
-                        -   $ref: "#/components/schemas/PageCollectionDefinition"
-                        -   $ref: "#/components/schemas/PageCollectionItemDefinition"
-                        -   $ref: "#/components/schemas/PageColumnDefinition"
-                        -   $ref: "#/components/schemas/PageContainerDefinition"
-                        -   $ref: "#/components/schemas/PageDropZoneDefinition"
-                        -   $ref: "#/components/schemas/PageFormDefinition"
-                        -   $ref: "#/components/schemas/PageFormStepContainerDefinition"
-                        -   $ref: "#/components/schemas/PageFormStepDefinition"
-                        -   $ref: "#/components/schemas/PageFragmentCompositionInstanceDefinition"
-                        -   $ref: "#/components/schemas/PageFragmentDropZoneDefinition"
-                        -   $ref: "#/components/schemas/PageFragmentInstanceDefinition"
-                        -   $ref: "#/components/schemas/PageRowDefinition"
-                        -   $ref: "#/components/schemas/PageWidgetInstanceDefinition"
+                    $ref: "#/components/schemas/PageDefinition"
                 externalReferenceCode:
                     description:
                         The page element's external reference code. Unique within the site.
@@ -1582,14 +1624,6 @@ components:
                         added at the last valid position.
                     minimum: 0
                     type: integer
-                type:
-                    # @review
-                    description:
-                        The page element's type (collection, collection item, column, container, drop zone, form, form
-                        step, form step container, fragment, fragment composition, fragment drop zone, row, widget or
-                        widget section).
-                    enum: [Collection, CollectionItem, Column, Container, DropZone, Form, FormStep, FormStepContainer, Fragment, FragmentComposition, FragmentDropZone, Row, Widget]
-                    type: string
         PageExperience:
             description:
                 # @review
@@ -1647,382 +1681,396 @@ components:
             # @review
             description:
                 The definition of a page form.
-            properties:
-                cssClasses:
-                    # @review
-                    description:
-                        A list of CSS classes that are applied to the page element.
-                    items:
-                        type: string
-                    type: array
-                customCSS:
-                    # @review
-                    description:
-                        Custom CSS that is applied on the page element.
-                    type: string
-                customCSSViewports:
-                    # @review
-                    description:
-                        The custom CSS viewports of the page form.
-                    items:
-                        $ref: "#/components/schemas/CustomCSSViewport"
-                    type: array
-                formConfig:
-                    # @review
-                    description:
-                        The page form's configuration.
-                    properties:
-                        formReference:
+            allOf:
+                -   $ref: "#/components/schemas/PageDefinition"
+                -   properties:
+                        cssClasses:
                             # @review
                             description:
-                                The form reference.
-                            oneOf:
-                                -   $ref: "#/components/schemas/ClassSubtypeReference"
-                                -   $ref: "#/components/schemas/ContextReference"
-                        formSuccessSubmissionResult:
+                                A list of CSS classes that are applied to the page element.
+                            items:
+                                type: string
+                            type: array
+                        customCSS:
                             # @review
                             description:
-                                The definition for the success message of the form.
-                            oneOf:
-                                -   $ref: "#/components/schemas/MessageFormSubmissionResult"
-                                -   $ref: "#/components/schemas/SitePageFormSubmissionResult"
-                                -   $ref: "#/components/schemas/URLFormSubmissionResult"
+                                Custom CSS that is applied on the page element.
+                            type: string
+                        customCSSViewports:
+                            # @review
+                            description:
+                                The custom CSS viewports of the page form.
+                            items:
+                                $ref: "#/components/schemas/CustomCSSViewport"
+                            type: array
+                        formConfig:
+                            # @review
+                            description:
+                                The page form's configuration.
+                            properties:
+                                formReference:
+                                    # @review
+                                    description:
+                                        The form reference.
+                                    oneOf:
+                                        -   $ref: "#/components/schemas/ClassSubtypeReference"
+                                        -   $ref: "#/components/schemas/ContextReference"
+                                formSuccessSubmissionResult:
+                                    # @review
+                                    description:
+                                        The definition for the success message of the form.
+                                    oneOf:
+                                        -   $ref: "#/components/schemas/MessageFormSubmissionResult"
+                                        -   $ref: "#/components/schemas/SitePageFormSubmissionResult"
+                                        -   $ref: "#/components/schemas/URLFormSubmissionResult"
+                                    type: object
+                                formType:
+                                    enum: [Multistep, Simple]
+                                    type: string
+                                numberOfSteps:
+                                    # @review
+                                    description:
+                                        The page form's number of steps.
+                                    type: integer
                             type: object
-                        formType:
-                            enum: [Multistep, Simple]
-                            type: string
-                        numberOfSteps:
+                        fragmentStyle:
+                            $ref: "#/components/schemas/FragmentStyle"
                             # @review
                             description:
-                                The page form's number of steps.
-                            type: integer
-                    type: object
-                fragmentStyle:
-                    $ref: "#/components/schemas/FragmentStyle"
-                    # @review
-                    description:
-                        The fragment style of a page form.
-                fragmentViewports:
-                    # @review
-                    description:
-                        A list of fragment viewports of a page form.
-                    items:
-                        $ref: "#/components/schemas/FragmentViewport"
-                    type: array
-                indexed:
-                    # @review
-                    description:
-                        A flag that indicates whether the page fragment instance is indexed or not.
-                    type: boolean
-                layout:
-                    # @review
-                    description:
-                        The page form's layout.
-                    properties:
-                        align:
-                            enum: [Baseline, Center, End, None, Start, Stretch]
-                            type: string
-                        contentDisplay:
-                            enum: [Block, FlexColumn, FlexRow]
-                            type: string
-                        flexWrap:
-                            enum: [NoWrap, Wrap, WrapReverse]
-                            type: string
-                        justify:
-                            enum: [Center, End, None, SpaceAround, SpaceBetween, Start]
-                            type: string
-                        widthType:
+                                The fragment style of a page form.
+                        fragmentViewports:
                             # @review
                             description:
-                                The width's type (fixed or fluid).
-                            enum: [Fixed, Fluid]
+                                A list of fragment viewports of a page form.
+                            items:
+                                $ref: "#/components/schemas/FragmentViewport"
+                            type: array
+                        indexed:
+                            # @review
+                            description:
+                                A flag that indicates whether the page fragment instance is indexed or not.
+                            type: boolean
+                        layout:
+                            # @review
+                            description:
+                                The page form's layout.
+                            properties:
+                                align:
+                                    enum: [Baseline, Center, End, None, Start, Stretch]
+                                    type: string
+                                contentDisplay:
+                                    enum: [Block, FlexColumn, FlexRow]
+                                    type: string
+                                flexWrap:
+                                    enum: [NoWrap, Wrap, WrapReverse]
+                                    type: string
+                                justify:
+                                    enum: [Center, End, None, SpaceAround, SpaceBetween, Start]
+                                    type: string
+                                widthType:
+                                    # @review
+                                    description:
+                                        The width's type (fixed or fluid).
+                                    enum: [Fixed, Fluid]
+                                    type: string
+                            type: object
+                        name:
+                            # @review
+                            description:
+                                The custom name of of a page form.
                             type: string
-                    type: object
-                name:
-                    # @review
-                    description:
-                        The custom name of of a page form.
-                    type: string
             type: object
         PageFormStepContainerDefinition:
             # @review
             description:
                 The definition of a page form step container.
-            properties:
-                cssClasses:
-                    # @review
-                    description:
-                        A list of CSS classes that are applied to the page element.
-                    items:
-                        type: string
-                    type: array
-                customCSS:
-                    # @review
-                    description:
-                        Custom CSS that is applied on the page element.
-                    type: string
-                customCSSViewports:
-                    # @review
-                    description:
-                        The custom CSS viewports of the page form.
-                    items:
-                        $ref: "#/components/schemas/CustomCSSViewport"
-                    type: array
-                fragmentStyle:
-                    $ref: "#/components/schemas/FragmentStyle"
-                    # @review
-                    description:
-                        The fragment style of a page form.
-                fragmentViewports:
-                    # @review
-                    description:
-                        A list of fragment viewports of a page form.
-                    items:
-                        $ref: "#/components/schemas/FragmentViewport"
-                    type: array
-                layout:
-                    # @review
-                    description:
-                        The page form's layout.
-                    properties:
-                        align:
-                            enum: [Baseline, Center, End, None, Start, Stretch]
-                            type: string
-                        contentDisplay:
-                            enum: [Block, FlexColumn, FlexRow]
-                            type: string
-                        flexWrap:
-                            enum: [NoWrap, Wrap, WrapReverse]
-                            type: string
-                        justify:
-                            enum: [Center, End, None, SpaceAround, SpaceBetween, Start]
-                            type: string
-                        widthType:
+            allOf:
+                -   $ref: "#/components/schemas/PageDefinition"
+                -   properties:
+                        cssClasses:
                             # @review
                             description:
-                                The width's type (fixed or fluid).
-                            enum: [Fixed, Fluid]
+                                A list of CSS classes that are applied to the page element.
+                            items:
+                                type: string
+                            type: array
+                        customCSS:
+                            # @review
+                            description:
+                                Custom CSS that is applied on the page element.
                             type: string
-                    type: object
-                name:
-                    # @review
-                    description:
-                        The custom name of of a page form.
-                    type: string
+                        customCSSViewports:
+                            # @review
+                            description:
+                                The custom CSS viewports of the page form.
+                            items:
+                                $ref: "#/components/schemas/CustomCSSViewport"
+                            type: array
+                        fragmentStyle:
+                            $ref: "#/components/schemas/FragmentStyle"
+                            # @review
+                            description:
+                                The fragment style of a page form.
+                        fragmentViewports:
+                            # @review
+                            description:
+                                A list of fragment viewports of a page form.
+                            items:
+                                $ref: "#/components/schemas/FragmentViewport"
+                            type: array
+                        layout:
+                            # @review
+                            description:
+                                The page form's layout.
+                            properties:
+                                align:
+                                    enum: [Baseline, Center, End, None, Start, Stretch]
+                                    type: string
+                                contentDisplay:
+                                    enum: [Block, FlexColumn, FlexRow]
+                                    type: string
+                                flexWrap:
+                                    enum: [NoWrap, Wrap, WrapReverse]
+                                    type: string
+                                justify:
+                                    enum: [Center, End, None, SpaceAround, SpaceBetween, Start]
+                                    type: string
+                                widthType:
+                                    # @review
+                                    description:
+                                        The width's type (fixed or fluid).
+                                    enum: [Fixed, Fluid]
+                                    type: string
+                            type: object
+                        name:
+                            # @review
+                            description:
+                                The custom name of of a page form.
+                            type: string
             type: object
         PageFormStepDefinition:
             # @review
             description:
                 The definition of a page form step.
-            properties:
-                formStepConfig:
-                    # @review
-                    description:
-                        The page form step's configuration.
-                    type: object
+            allOf:
+                -   $ref: "#/components/schemas/PageDefinition"
+                -   properties:
+                        formStepConfig:
+                            # @review
+                            description:
+                                The page form step's configuration.
+                            type: object
             type: object
         PageFragmentCompositionInstanceDefinition:
             # @review
             description:
                 The definition of a page fragment composition instance.
-            properties:
-                fragmentComposition:
-                    $ref: "#/components/schemas/ItemExternalReference"
-                    # @review
-                    description:
-                        The reference to the fragment composition that will be used to generate the page elment of type
-                        section that will be added.
+            allOf:
+                -   $ref: "#/components/schemas/PageDefinition"
+                -   properties:
+                        fragmentComposition:
+                            $ref: "#/components/schemas/ItemExternalReference"
+                            # @review
+                            description:
+                                The reference to the fragment composition that will be used to generate the page elment of type
+                                section that will be added.
             type: object
         PageFragmentDropZoneDefinition:
             # @review
             description:
                 The definition of a page fragment drop zone.
-            properties:
-                fragmentDropZoneId:
-                    # @review
-                    description:
-                        The id of the fragment drop zone
-                    type: string
-            type: object
+            allOf:
+                -   $ref: "#/components/schemas/PageDefinition"
+                -   properties:
+                        fragmentDropZoneId:
+                            # @review
+                            description:
+                                The id of the fragment drop zone
+                            type: string
+                    type: object
         PageFragmentInstanceDefinition:
             # @review
             description:
                 A definition of a page fragment instance.
-            properties:
-                cssClasses:
-                    # @review
-                    description:
-                        A list of CSS classes that are applied to the fragment instance.
-                    items:
-                        type: string
-                    type: array
-                customCSS:
-                    # @review
-                    description:
-                        Custom CSS that is applied on the fragment instance.
-                    type: string
-                customCSSViewports:
-                    # @review
-                    description:
-                        The custom CSS viewports of the fragment instance.
-                    items:
-                        $ref: "#/components/schemas/CustomCSSViewport"
-                    type: array
-                datePropagated:
-                    description:
-                        The fragment instance's most recent propagation date.
-                    format: date-time
-                    type: string
-                datePublished:
-                    description:
-                        The fragment instance's most recent publication date.
-                    format: date-time
-                    type: string
-                draftPageElementExternalReferenceCode:
-                    # @review
-                    description:
-                        The external reference code of the corresponding page element in the draft of the page.
-                        Available only in the published page specification.
-                    type: string
-                fragmentConfig:
-                    additionalProperties:
-                        type: object
-                    # @review
-                    description:
-                        The configuration values of the fragment instance.
-                    type: object
-                fragmentFields:
-                    # @review
-                    description:
-                        The fragment field values of the the fragment instance.
-                    items:
-                        $ref: "#/components/schemas/FragmentField"
-                    type: array
-                fragmentReference:
-                    # @review
-                    description:
-                        An external reference to the fragment.
-                    oneOf:
-                        -   $ref: "#/components/schemas/DefaultFragmentReference"
-                        -   $ref: "#/components/schemas/ItemExternalReference"
-                fragmentStyle:
-                    $ref: "#/components/schemas/FragmentStyle"
-                    # @review
-                    description:
-                        The fragment style of the page fragment instance.
-                fragmentViewports:
-                    # @review
-                    description:
-                        A list of fragment viewports of the page fragment instance.
-                    items:
-                        $ref: "#/components/schemas/FragmentViewport"
-                    type: array
-                indexed:
-                    # @review
-                    description:
-                        A flag that indicates whether the page fragment instance is indexed or not.
-                    type: boolean
-                name:
-                    # @review
-                    description:
-                        The custom name of a fragment instance.
-                    type: string
-                namespace:
-                    # @review
-                    description:
-                        The fragment instance's namespace.
-                    type: string
-                uuid:
-                    # @review
-                    description:
-                        A valid external identifier to reference this fragment instance.
-                    type: string
-                widgetInstances:
-                    # @review
-                    description:
-                        A list of widget instances within the fragment instance.
-                    items:
-                        $ref: "#/components/schemas/WidgetInstance"
-                    type: array
+            allOf:
+                -   $ref: "#/components/schemas/PageDefinition"
+                -   properties:
+                        cssClasses:
+                            # @review
+                            description:
+                                A list of CSS classes that are applied to the fragment instance.
+                            items:
+                                type: string
+                            type: array
+                        customCSS:
+                            # @review
+                            description:
+                                Custom CSS that is applied on the fragment instance.
+                            type: string
+                        customCSSViewports:
+                            # @review
+                            description:
+                                The custom CSS viewports of the fragment instance.
+                            items:
+                                $ref: "#/components/schemas/CustomCSSViewport"
+                            type: array
+                        datePropagated:
+                            description:
+                                The fragment instance's most recent propagation date.
+                            format: date-time
+                            type: string
+                        datePublished:
+                            description:
+                                The fragment instance's most recent publication date.
+                            format: date-time
+                            type: string
+                        draftPageElementExternalReferenceCode:
+                            # @review
+                            description:
+                                The external reference code of the corresponding page element in the draft of the page.
+                                Available only in the published page specification.
+                            type: string
+                        fragmentConfig:
+                            additionalProperties:
+                                type: object
+                            # @review
+                            description:
+                                The configuration values of the fragment instance.
+                            type: object
+                        fragmentFields:
+                            # @review
+                            description:
+                                The fragment field values of the the fragment instance.
+                            items:
+                                $ref: "#/components/schemas/FragmentField"
+                            type: array
+                        fragmentReference:
+                            # @review
+                            description:
+                                An external reference to the fragment.
+                            oneOf:
+                                -   $ref: "#/components/schemas/DefaultFragmentReference"
+                                -   $ref: "#/components/schemas/ItemExternalReference"
+                        fragmentStyle:
+                            $ref: "#/components/schemas/FragmentStyle"
+                            # @review
+                            description:
+                                The fragment style of the page fragment instance.
+                        fragmentViewports:
+                            # @review
+                            description:
+                                A list of fragment viewports of the page fragment instance.
+                            items:
+                                $ref: "#/components/schemas/FragmentViewport"
+                            type: array
+                        indexed:
+                            # @review
+                            description:
+                                A flag that indicates whether the page fragment instance is indexed or not.
+                            type: boolean
+                        name:
+                            # @review
+                            description:
+                                The custom name of a fragment instance.
+                            type: string
+                        namespace:
+                            # @review
+                            description:
+                                The fragment instance's namespace.
+                            type: string
+                        uuid:
+                            # @review
+                            description:
+                                A valid external identifier to reference this fragment instance.
+                            type: string
+                        widgetInstances:
+                            # @review
+                            description:
+                                A list of widget instances within the fragment instance.
+                            items:
+                                $ref: "#/components/schemas/WidgetInstance"
+                            type: array
             type: object
         PageRowDefinition:
             # @review
             description:
                 The definition of a page row.
-            properties:
-                cssClasses:
-                    # @review
-                    description:
-                        A list of CSS classes that are applied to the page row.
-                    items:
-                        type: string
-                    type: array
-                customCSS:
-                    # @review
-                    description:
-                        Custom CSS that is applied on the page row.
-                    type: string
-                customCSSViewports:
-                    # @review
-                    description:
-                        The custom CSS viewports of the page row.
-                    items:
-                        $ref: "#/components/schemas/CustomCSSViewport"
-                    type: array
-                fragmentStyle:
-                    $ref: "#/components/schemas/FragmentStyle"
-                    # @review
-                    description:
-                        The fragment style of the page row.
-                fragmentViewports:
-                    # @review
-                    description:
-                        A list of fragment viewports of a page row.
-                    items:
-                        $ref: "#/components/schemas/FragmentViewport"
-                    type: array
-                gutters:
-                    # @review
-                    description:
-                        A flag that indicates whether the page row has gutters.
-                    type: boolean
-                indexed:
-                    # @review
-                    description:
-                        A flag that indicates whether the page row is indexed or not.
-                    type: boolean
-                modulesPerRow:
-                    # @review
-                    description:
-                        The page row's modules per row.
-                    type: integer
-                name:
-                    # @review
-                    description:
-                        The custom name of a page row.
-                    type: string
-                numberOfColumns:
-                    # @review
-                    description:
-                        The page row's number of columns.
-                    type: integer
-                reverseOrder:
-                    # @review
-                    description:
-                        A flag that indicates whether the page row has reverse order.
-                    type: boolean
-                rowViewports:
-                    # @review
-                    description:
-                        A list of viewports of the page row.
-                    items:
-                        $ref: "#/components/schemas/RowViewport"
-                    type: array
-                verticalAlignment:
-                    # @review
-                    description:
-                        The vertical alignment property of the page row.
-                    type: string
+            allOf:
+                -   $ref: "#/components/schemas/PageDefinition"
+                -   properties:
+                        cssClasses:
+                            # @review
+                            description:
+                                A list of CSS classes that are applied to the page row.
+                            items:
+                                type: string
+                            type: array
+                        customCSS:
+                            # @review
+                            description:
+                                Custom CSS that is applied on the page row.
+                            type: string
+                        customCSSViewports:
+                            # @review
+                            description:
+                                The custom CSS viewports of the page row.
+                            items:
+                                $ref: "#/components/schemas/CustomCSSViewport"
+                            type: array
+                        fragmentStyle:
+                            $ref: "#/components/schemas/FragmentStyle"
+                            # @review
+                            description:
+                                The fragment style of the page row.
+                        fragmentViewports:
+                            # @review
+                            description:
+                                A list of fragment viewports of a page row.
+                            items:
+                                $ref: "#/components/schemas/FragmentViewport"
+                            type: array
+                        gutters:
+                            # @review
+                            description:
+                                A flag that indicates whether the page row has gutters.
+                            type: boolean
+                        indexed:
+                            # @review
+                            description:
+                                A flag that indicates whether the page row is indexed or not.
+                            type: boolean
+                        modulesPerRow:
+                            # @review
+                            description:
+                                The page row's modules per row.
+                            type: integer
+                        name:
+                            # @review
+                            description:
+                                The custom name of a page row.
+                            type: string
+                        numberOfColumns:
+                            # @review
+                            description:
+                                The page row's number of columns.
+                            type: integer
+                        reverseOrder:
+                            # @review
+                            description:
+                                A flag that indicates whether the page row has reverse order.
+                            type: boolean
+                        rowViewports:
+                            # @review
+                            description:
+                                A list of viewports of the page row.
+                            items:
+                                $ref: "#/components/schemas/RowViewport"
+                            type: array
+                        verticalAlignment:
+                            # @review
+                            description:
+                                The vertical alignment property of the page row.
+                            type: string
             type: object
         PageRule:
             # @review
@@ -2376,48 +2424,50 @@ components:
             # @review
             description:
                 The definition of a page widget instance.
-            properties:
-                cssClasses:
-                    # @review
-                    description:
-                        A list of CSS classes that are applied to the element.
-                    items:
-                        type: string
-                    type: array
-                customCSS:
-                    # @review
-                    description:
-                        Custom CSS that is applied on the fragment.
-                    type: string
-                customCSSViewports:
-                    # @review
-                    description:
-                        The custom CSS viewports of the page collection.
-                    items:
-                        $ref: "#/components/schemas/CustomCSSViewport"
-                    type: array
-                fragmentStyle:
-                    $ref: "#/components/schemas/FragmentStyle"
-                    # @review
-                    description:
-                        The fragment style of the page widget instance.
-                fragmentViewports:
-                    # @review
-                    description:
-                        A list of fragment viewports of the page widget instance.
-                    items:
-                        $ref: "#/components/schemas/FragmentViewport"
-                    type: array
-                name:
-                    # @review
-                    description:
-                        The custom name of a page widget instance.
-                    type: string
-                widgetInstance:
-                    $ref: "#/components/schemas/WidgetInstance"
-                    # @review
-                    description:
-                        The widget instance.
+            allOf:
+                -   $ref: "#/components/schemas/PageDefinition"
+                -   properties:
+                        cssClasses:
+                            # @review
+                            description:
+                                A list of CSS classes that are applied to the element.
+                            items:
+                                type: string
+                            type: array
+                        customCSS:
+                            # @review
+                            description:
+                                Custom CSS that is applied on the fragment.
+                            type: string
+                        customCSSViewports:
+                            # @review
+                            description:
+                                The custom CSS viewports of the page collection.
+                            items:
+                                $ref: "#/components/schemas/CustomCSSViewport"
+                            type: array
+                        fragmentStyle:
+                            $ref: "#/components/schemas/FragmentStyle"
+                            # @review
+                            description:
+                                The fragment style of the page widget instance.
+                        fragmentViewports:
+                            # @review
+                            description:
+                                A list of fragment viewports of the page widget instance.
+                            items:
+                                $ref: "#/components/schemas/FragmentViewport"
+                            type: array
+                        name:
+                            # @review
+                            description:
+                                The custom name of a page widget instance.
+                            type: string
+                        widgetInstance:
+                            $ref: "#/components/schemas/WidgetInstance"
+                            # @review
+                            description:
+                                The widget instance.
             type: object
         RowViewport:
             # @review

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-openapi.yaml
@@ -424,6 +424,22 @@ components:
                     description:
                         The display page template's SEO settings.
             type: object
+        EmptyCollectionConfig:
+            properties:
+                displayMessage:
+                    # @review
+                    description:
+                        Whether to display a message when the collection is empty or no results match the applied
+                        filters (true by default).
+                    type: boolean
+                message_i18n:
+                    additionalProperties:
+                        type: string
+                    # @review
+                    description:
+                        The localized message to display when the collection is empty or no results match the applied
+                        filters ('No Results Found' by default).
+                    type: object
         FragmentComposition:
             # @review
             description:
@@ -1056,6 +1072,12 @@ components:
                         The old localized relative URLs to the page's rendered content.
                     type: object
             type: object
+        HtmlProperties:
+            properties:
+                htmlTag:
+                    enum: [Article, Aside, Div, Footer, Header, Nav, Section]
+                    type: string
+            type: object
         ItemExternalReference:
             # @review
             description:
@@ -1282,27 +1304,7 @@ components:
                         The localized Open Graph's titles.
                     type: object
             type: object
-
-        EmptyCollectionConfig:
-            properties:
-                displayMessage:
-                    # @review
-                    description:
-                        Whether to display a message when the collection is empty or no results match the
-                        applied filters (true by default).
-                    type: boolean
-                message_i18n:
-                    additionalProperties:
-                        type: string
-                    # @review
-                    description:
-                        The localized message to display when the collection is empty or no results match the
-                        applied filters ('No Results Found' by default).
-                    type: object
         PageCollectionDefinition:
-            # @review
-            description:
-                The definition of a Page Collection.
             allOf:
                 -   $ref: "#/components/schemas/PageDefinition"
                 -   properties:
@@ -1378,7 +1380,8 @@ components:
                         numberOfItems:
                             # @review
                             description:
-                                The maximum number of items to display in the page collection when pagination is disabled.
+                                The maximum number of items to display in the page collection when pagination is
+                                disabled.
                             type: integer
                         numberOfItemsPerPage:
                             # @review
@@ -1405,34 +1408,34 @@ components:
                             description:
                                 The page collection's template key.
                             type: string
+            # @review
+            description:
+                The definition of a Page Collection.
             type: object
         PageCollectionItemDefinition:
+            allOf:
+                -   $ref: "#/components/schemas/PageDefinition"
+                -   properties:
+                        collectionItemConfig:
+                            # @review
+                            description:
+                                The page collection item's configuration.
+                            type: object
             # @review
             description:
                 The definition of a Page Collection Item.
-            allOf:
-                - $ref: "#/components/schemas/PageDefinition"
-                - properties:
-                    collectionItemConfig:
-                        # @review
-                        description:
-                            The page collection item's configuration.
-                        type: object
             type: object
         PageColumnDefinition:
-            # @review
-            description:
-                The definition of a Page Column.
             allOf:
                 -   $ref: "#/components/schemas/PageDefinition"
                 -   properties:
                         columnViewports:
-                                # @review
-                                description:
-                                    A list of column viewports of the page column definition.
-                                items:
-                                    $ref: "#/components/schemas/ColumnViewport"
-                                type: array
+                            # @review
+                            description:
+                                A list of column viewports of the page column definition.
+                            items:
+                                $ref: "#/components/schemas/ColumnViewport"
+                            type: array
                         size:
                             # @review
                             description:
@@ -1440,17 +1443,11 @@ components:
                             maximum: 12
                             minimum: 1
                             type: integer
-            type: object
-        HtmlProperties:
-            type: object
-            properties:
-                htmlTag:
-                    enum: [ Article, Aside, Div, Footer, Header, Nav, Section ]
-                    type: string
-        PageContainerDefinition:
             # @review
             description:
-                The definition of a Page section.
+                The definition of a Page Column.
+            type: object
+        PageContainerDefinition:
             allOf:
                 -   $ref: "#/components/schemas/PageDefinition"
                 -   properties:
@@ -1533,21 +1530,9 @@ components:
                             description:
                                 The custom name of a Page section.
                             type: string
-            type: object
-        PageDropZoneDefinition:
             # @review
             description:
-                Represent a definition of a Page drop zone.
-            allOf:
-                -   $ref: "#/components/schemas/PageDefinition"
-                -   properties:
-                        fragmentSettings:
-                            # @review
-                            description:
-                                The page drop zone's allowed or unallowed fragments.
-                            oneOf:
-                                -   $ref: "#/components/schemas/FragmentSettingsAllowed"
-                                -   $ref: "#/components/schemas/FragmentSettingsUnallowed"
+                The definition of a Page section.
             type: object
         PageDefinition:
             # @review
@@ -1563,9 +1548,9 @@ components:
                     Form: "#/components/schemas/PageFormDefinition"
                     FormStep: "#/components/schemas/PageFormStepDefinition"
                     FormStepContainer: "#/components/schemas/PageFormStepContainerDefinition"
+                    Fragment: "#/components/schemas/PageFragmentInstanceDefinition"
                     FragmentComposition: "#/components/schemas/PageFragmentCompositionInstanceDefinition"
                     FragmentDropZone: "#/components/schemas/PageFragmentDropZoneDefinition"
-                    Fragment: "#/components/schemas/PageFragmentInstanceDefinition"
                     Row: "#/components/schemas/PageRowDefinition"
                     Widget: "#/components/schemas/PageWidgetInstanceDefinition"
                 propertyName: type
@@ -1577,20 +1562,35 @@ components:
                         step, form step container, fragment, fragment composition, fragment drop zone, row, widget or
                         widget section).
                     enum:
-                        - Collection
-                        - CollectionItem
-                        - Column
-                        - Container
-                        - DropZone
-                        - Form
-                        - FormStep
-                        - FormStepContainer
-                        - FragmentComposition
-                        - FragmentDropZone
-                        - Fragment
-                        - Row
-                        - Widget
+                        -   Collection
+                        -   CollectionItem
+                        -   Column
+                        -   Container
+                        -   DropZone
+                        -   Form
+                        -   FormStep
+                        -   FormStepContainer
+                        -   FragmentComposition
+                        -   FragmentDropZone
+                        -   Fragment
+                        -   Row
+                        -   Widget
                     type: string
+            type: object
+        PageDropZoneDefinition:
+            allOf:
+                -   $ref: "#/components/schemas/PageDefinition"
+                -   properties:
+                        fragmentSettings:
+                            # @review
+                            description:
+                                The page drop zone's allowed or unallowed fragments.
+                            oneOf:
+                                -   $ref: "#/components/schemas/FragmentSettingsAllowed"
+                                -   $ref: "#/components/schemas/FragmentSettingsUnallowed"
+            # @review
+            description:
+                Represent a definition of a Page drop zone.
             type: object
         PageElement:
             # @review
@@ -1598,10 +1598,10 @@ components:
                 A page element.
             properties:
                 definition:
+                    $ref: "#/components/schemas/PageDefinition"
                     # @review
                     description:
                         The page element's definition.
-                    $ref: "#/components/schemas/PageDefinition"
                 externalReferenceCode:
                     description:
                         The page element's external reference code. Unique within the site.
@@ -1678,9 +1678,6 @@ components:
                     type: string
             type: object
         PageFormDefinition:
-            # @review
-            description:
-                The definition of a page form.
             allOf:
                 -   $ref: "#/components/schemas/PageDefinition"
                 -   properties:
@@ -1779,11 +1776,11 @@ components:
                             description:
                                 The custom name of of a page form.
                             type: string
-            type: object
-        PageFormStepContainerDefinition:
             # @review
             description:
-                The definition of a page form step container.
+                The definition of a page form.
+            type: object
+        PageFormStepContainerDefinition:
             allOf:
                 -   $ref: "#/components/schemas/PageDefinition"
                 -   properties:
@@ -1847,11 +1844,11 @@ components:
                             description:
                                 The custom name of of a page form.
                             type: string
-            type: object
-        PageFormStepDefinition:
             # @review
             description:
-                The definition of a page form step.
+                The definition of a page form step container.
+            type: object
+        PageFormStepDefinition:
             allOf:
                 -   $ref: "#/components/schemas/PageDefinition"
                 -   properties:
@@ -1860,11 +1857,11 @@ components:
                             description:
                                 The page form step's configuration.
                             type: object
-            type: object
-        PageFragmentCompositionInstanceDefinition:
             # @review
             description:
-                The definition of a page fragment composition instance.
+                The definition of a page form step.
+            type: object
+        PageFragmentCompositionInstanceDefinition:
             allOf:
                 -   $ref: "#/components/schemas/PageDefinition"
                 -   properties:
@@ -1872,13 +1869,13 @@ components:
                             $ref: "#/components/schemas/ItemExternalReference"
                             # @review
                             description:
-                                The reference to the fragment composition that will be used to generate the page elment of type
-                                section that will be added.
-            type: object
-        PageFragmentDropZoneDefinition:
+                                The reference to the fragment composition that will be used to generate the page elment
+                                of type section that will be added.
             # @review
             description:
-                The definition of a page fragment drop zone.
+                The definition of a page fragment composition instance.
+            type: object
+        PageFragmentDropZoneDefinition:
             allOf:
                 -   $ref: "#/components/schemas/PageDefinition"
                 -   properties:
@@ -1888,10 +1885,10 @@ components:
                                 The id of the fragment drop zone
                             type: string
                     type: object
-        PageFragmentInstanceDefinition:
             # @review
             description:
-                A definition of a page fragment instance.
+                The definition of a page fragment drop zone.
+        PageFragmentInstanceDefinition:
             allOf:
                 -   $ref: "#/components/schemas/PageDefinition"
                 -   properties:
@@ -1990,11 +1987,11 @@ components:
                             items:
                                 $ref: "#/components/schemas/WidgetInstance"
                             type: array
-            type: object
-        PageRowDefinition:
             # @review
             description:
-                The definition of a page row.
+                A definition of a page fragment instance.
+            type: object
+        PageRowDefinition:
             allOf:
                 -   $ref: "#/components/schemas/PageDefinition"
                 -   properties:
@@ -2071,6 +2068,9 @@ components:
                             description:
                                 The vertical alignment property of the page row.
                             type: string
+            # @review
+            description:
+                The definition of a page row.
             type: object
         PageRule:
             # @review
@@ -2421,9 +2421,6 @@ components:
                     type: string
             type: object
         PageWidgetInstanceDefinition:
-            # @review
-            description:
-                The definition of a page widget instance.
             allOf:
                 -   $ref: "#/components/schemas/PageDefinition"
                 -   properties:
@@ -2468,6 +2465,9 @@ components:
                             # @review
                             description:
                                 The widget instance.
+            # @review
+            description:
+                The definition of a page widget instance.
             type: object
         RowViewport:
             # @review

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageCollectionDefinitionDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageCollectionDefinitionDTOConverter.java
@@ -12,6 +12,7 @@ import com.liferay.headless.admin.site.dto.v1_0.CollectionItemExternalReference;
 import com.liferay.headless.admin.site.dto.v1_0.CollectionReference;
 import com.liferay.headless.admin.site.dto.v1_0.EmptyCollectionConfig;
 import com.liferay.headless.admin.site.dto.v1_0.PageCollectionDefinition;
+import com.liferay.headless.admin.site.dto.v1_0.PageDefinition;
 import com.liferay.info.list.provider.item.selector.criterion.InfoListProviderItemSelectorReturnType;
 import com.liferay.item.selector.criteria.InfoListItemSelectorReturnType;
 import com.liferay.layout.util.CollectionPaginationUtil;
@@ -83,6 +84,7 @@ public class PageCollectionDefinitionDTOConverter
 							getPaginationType()));
 				setTemplateKey(
 					collectionStyledLayoutStructureItem::getTemplateKey);
+				setType(PageDefinition.Type.COLLECTION);
 			}
 		};
 	}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageColumnDefinitionDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageColumnDefinitionDTOConverter.java
@@ -6,6 +6,7 @@
 package com.liferay.headless.admin.site.internal.dto.v1_0.converter;
 
 import com.liferay.headless.admin.site.dto.v1_0.PageColumnDefinition;
+import com.liferay.headless.admin.site.dto.v1_0.PageDefinition;
 import com.liferay.layout.util.structure.ColumnLayoutStructureItem;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
@@ -36,6 +37,7 @@ public class PageColumnDefinitionDTOConverter
 		return new PageColumnDefinition() {
 			{
 				setSize(columnLayoutStructureItem::getSize);
+				setType(PageDefinition.Type.COLUMN);
 			}
 		};
 	}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageContainerDefinitionDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageContainerDefinitionDTOConverter.java
@@ -7,6 +7,7 @@ package com.liferay.headless.admin.site.internal.dto.v1_0.converter;
 
 import com.liferay.headless.admin.site.dto.v1_0.HtmlProperties;
 import com.liferay.headless.admin.site.dto.v1_0.PageContainerDefinition;
+import com.liferay.headless.admin.site.dto.v1_0.PageDefinition;
 import com.liferay.layout.util.structure.ContainerStyledLayoutStructureItem;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -63,6 +64,7 @@ public class PageContainerDefinitionDTOConverter
 						containerStyledLayoutStructureItem));
 				setIndexed(containerStyledLayoutStructureItem::isIndexed);
 				setName(containerStyledLayoutStructureItem::getName);
+				setType(PageDefinition.Type.CONTAINER);
 			}
 		};
 	}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageElementDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageElementDTOConverter.java
@@ -18,7 +18,6 @@ import com.liferay.headless.admin.site.dto.v1_0.PageFormStepDefinition;
 import com.liferay.headless.admin.site.dto.v1_0.PageFragmentDropZoneDefinition;
 import com.liferay.headless.admin.site.dto.v1_0.PageFragmentInstanceDefinition;
 import com.liferay.headless.admin.site.dto.v1_0.PageRowDefinition;
-import com.liferay.headless.admin.site.internal.dto.v1_0.util.PageElementTypeUtil;
 import com.liferay.layout.util.constants.LayoutDataItemTypeConstants;
 import com.liferay.layout.util.structure.CollectionStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.ColumnLayoutStructureItem;
@@ -109,7 +108,8 @@ public class PageElementDTOConverter
 		};
 	}
 
-	private PageDefinition _getDefinition(LayoutStructureItem layoutStructureItem)
+	private PageDefinition _getDefinition(
+			LayoutStructureItem layoutStructureItem)
 		throws Exception {
 
 		if (Objects.equals(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageElementDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageElementDTOConverter.java
@@ -9,6 +9,7 @@ import com.liferay.headless.admin.site.dto.v1_0.PageCollectionDefinition;
 import com.liferay.headless.admin.site.dto.v1_0.PageCollectionItemDefinition;
 import com.liferay.headless.admin.site.dto.v1_0.PageColumnDefinition;
 import com.liferay.headless.admin.site.dto.v1_0.PageContainerDefinition;
+import com.liferay.headless.admin.site.dto.v1_0.PageDefinition;
 import com.liferay.headless.admin.site.dto.v1_0.PageDropZoneDefinition;
 import com.liferay.headless.admin.site.dto.v1_0.PageElement;
 import com.liferay.headless.admin.site.dto.v1_0.PageFormDefinition;
@@ -104,14 +105,11 @@ public class PageElementDTOConverter
 						return childrenItemIds.indexOf(
 							layoutStructureItem.getItemId());
 					});
-				setType(
-					() -> PageElementTypeUtil.toExternalType(
-						layoutStructureItem.getItemType()));
 			}
 		};
 	}
 
-	private Object _getDefinition(LayoutStructureItem layoutStructureItem)
+	private PageDefinition _getDefinition(LayoutStructureItem layoutStructureItem)
 		throws Exception {
 
 		if (Objects.equals(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageElementDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageElementDTOConverter.java
@@ -124,7 +124,13 @@ public class PageElementDTOConverter
 				layoutStructureItem.getItemType(),
 				LayoutDataItemTypeConstants.TYPE_COLLECTION_ITEM)) {
 
-			return new PageCollectionItemDefinition();
+			PageCollectionItemDefinition pageCollectionItemDefinition =
+				new PageCollectionItemDefinition();
+
+			pageCollectionItemDefinition.setType(
+				PageDefinition.Type.COLLECTION_ITEM);
+
+			return pageCollectionItemDefinition;
 		}
 
 		if (Objects.equals(
@@ -147,7 +153,12 @@ public class PageElementDTOConverter
 				layoutStructureItem.getItemType(),
 				LayoutDataItemTypeConstants.TYPE_DROP_ZONE)) {
 
-			return new PageDropZoneDefinition();
+			PageDropZoneDefinition pageDropZoneDefinition =
+				new PageDropZoneDefinition();
+
+			pageDropZoneDefinition.setType(PageDefinition.Type.DROP_ZONE);
+
+			return pageDropZoneDefinition;
 		}
 
 		if (Objects.equals(
@@ -162,7 +173,12 @@ public class PageElementDTOConverter
 				layoutStructureItem.getItemType(),
 				LayoutDataItemTypeConstants.TYPE_FORM_STEP)) {
 
-			return new PageFormStepDefinition();
+			PageFormStepDefinition pageFormStepDefinition =
+				new PageFormStepDefinition();
+
+			pageFormStepDefinition.setType(PageDefinition.Type.FORM_STEP);
+
+			return pageFormStepDefinition;
 		}
 
 		if (Objects.equals(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageFormDefinitionDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageFormDefinitionDTOConverter.java
@@ -6,6 +6,7 @@
 package com.liferay.headless.admin.site.internal.dto.v1_0.converter;
 
 import com.liferay.headless.admin.site.dto.v1_0.FormConfig;
+import com.liferay.headless.admin.site.dto.v1_0.PageDefinition;
 import com.liferay.headless.admin.site.dto.v1_0.PageFormDefinition;
 import com.liferay.headless.delivery.dto.v1_0.ClassTypeReference;
 import com.liferay.headless.delivery.dto.v1_0.ContextReference;
@@ -59,6 +60,7 @@ public class PageFormDefinitionDTOConverter
 					() -> _toFormConfig(formStyledLayoutStructureItem));
 				setIndexed(formStyledLayoutStructureItem::isIndexed);
 				setName(formStyledLayoutStructureItem::getName);
+				setType(PageDefinition.Type.FORM);
 			}
 		};
 	}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageFormStepContainerDefinitionDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageFormStepContainerDefinitionDTOConverter.java
@@ -5,6 +5,7 @@
 
 package com.liferay.headless.admin.site.internal.dto.v1_0.converter;
 
+import com.liferay.headless.admin.site.dto.v1_0.PageDefinition;
 import com.liferay.headless.admin.site.dto.v1_0.PageFormStepContainerDefinition;
 import com.liferay.layout.util.structure.FormStepContainerStyledLayoutStructureItem;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -56,6 +57,7 @@ public class PageFormStepContainerDefinitionDTOConverter
 				setCustomCSS(
 					formStepContainerStyledLayoutStructureItem::getCustomCSS);
 				setName(formStepContainerStyledLayoutStructureItem::getName);
+				setType(PageDefinition.Type.FORM_STEP_CONTAINER);
 			}
 		};
 	}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageFragmentDropZoneDefinitionDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageFragmentDropZoneDefinitionDTOConverter.java
@@ -5,6 +5,7 @@
 
 package com.liferay.headless.admin.site.internal.dto.v1_0.converter;
 
+import com.liferay.headless.admin.site.dto.v1_0.PageDefinition;
 import com.liferay.headless.admin.site.dto.v1_0.PageFragmentDropZoneDefinition;
 import com.liferay.layout.util.structure.FragmentDropZoneLayoutStructureItem;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
@@ -39,6 +40,7 @@ public class PageFragmentDropZoneDefinitionDTOConverter
 			{
 				setFragmentDropZoneId(
 					fragmentDropZoneLayoutStructureItem::getFragmentDropZoneId);
+				setType(PageDefinition.Type.FRAGMENT_DROP_ZONE);
 			}
 		};
 	}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageFragmentInstanceDefinitionDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageFragmentInstanceDefinitionDTOConverter.java
@@ -12,6 +12,7 @@ import com.liferay.fragment.service.FragmentEntryLinkLocalService;
 import com.liferay.fragment.service.FragmentEntryLocalService;
 import com.liferay.headless.admin.site.dto.v1_0.DefaultFragmentReference;
 import com.liferay.headless.admin.site.dto.v1_0.ItemExternalReference;
+import com.liferay.headless.admin.site.dto.v1_0.PageDefinition;
 import com.liferay.headless.admin.site.dto.v1_0.PageFragmentInstanceDefinition;
 import com.liferay.layout.util.structure.FragmentStyledLayoutStructureItem;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -105,6 +106,7 @@ public class PageFragmentInstanceDefinitionDTOConverter
 				setIndexed(fragmentStyledLayoutStructureItem::isIndexed);
 				setName(fragmentStyledLayoutStructureItem::getName);
 				setNamespace(fragmentEntryLink::getNamespace);
+				setType(PageDefinition.Type.FRAGMENT);
 			}
 		};
 	}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageRowDefinitionDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageRowDefinitionDTOConverter.java
@@ -5,6 +5,7 @@
 
 package com.liferay.headless.admin.site.internal.dto.v1_0.converter;
 
+import com.liferay.headless.admin.site.dto.v1_0.PageDefinition;
 import com.liferay.headless.admin.site.dto.v1_0.PageRowDefinition;
 import com.liferay.layout.util.structure.RowStyledLayoutStructureItem;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -57,6 +58,7 @@ public class PageRowDefinitionDTOConverter
 				setNumberOfColumns(
 					rowStyledLayoutStructureItem::getNumberOfColumns);
 				setReverseOrder(rowStyledLayoutStructureItem::isReverseOrder);
+				setType(PageDefinition.Type.ROW);
 			}
 		};
 	}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/PageElementTypeUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/PageElementTypeUtil.java
@@ -5,6 +5,7 @@
 
 package com.liferay.headless.admin.site.internal.dto.v1_0.util;
 
+import com.liferay.headless.admin.site.dto.v1_0.PageDefinition;
 import com.liferay.headless.admin.site.dto.v1_0.PageElement;
 import com.liferay.layout.util.constants.LayoutDataItemTypeConstants;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -18,11 +19,11 @@ import java.util.Set;
  */
 public class PageElementTypeUtil {
 
-	public static PageElement.Type toExternalType(String internalType) {
-		Set<PageElement.Type> externalTypes =
+	public static PageDefinition.Type toExternalType(String internalType) {
+		Set<PageDefinition.Type> externalTypes =
 			_externalToInternalValuesMap.keySet();
 
-		for (PageElement.Type externalType : externalTypes) {
+		for (PageDefinition.Type externalType : externalTypes) {
 			if (Objects.equals(
 					internalType,
 					_externalToInternalValuesMap.get(externalType))) {
@@ -34,7 +35,7 @@ public class PageElementTypeUtil {
 		throw new UnsupportedOperationException();
 	}
 
-	public static String toInternalType(PageElement.Type externalType) {
+	public static String toInternalType(PageDefinition.Type externalType) {
 		if (_externalToInternalValuesMap.containsKey(externalType)) {
 			return _externalToInternalValuesMap.get(externalType);
 		}
@@ -42,36 +43,36 @@ public class PageElementTypeUtil {
 		throw new UnsupportedOperationException();
 	}
 
-	private static final Map<PageElement.Type, String>
+	private static final Map<PageDefinition.Type, String>
 		_externalToInternalValuesMap = HashMapBuilder.put(
-			PageElement.Type.COLLECTION,
+			PageDefinition.Type.COLLECTION,
 			LayoutDataItemTypeConstants.TYPE_COLLECTION
 		).put(
-			PageElement.Type.COLLECTION_ITEM,
+			PageDefinition.Type.COLLECTION_ITEM,
 			LayoutDataItemTypeConstants.TYPE_COLLECTION_ITEM
 		).put(
-			PageElement.Type.COLUMN, LayoutDataItemTypeConstants.TYPE_COLUMN
+			PageDefinition.Type.COLUMN, LayoutDataItemTypeConstants.TYPE_COLUMN
 		).put(
-			PageElement.Type.CONTAINER,
+			PageDefinition.Type.CONTAINER,
 			LayoutDataItemTypeConstants.TYPE_CONTAINER
 		).put(
-			PageElement.Type.DROP_ZONE,
+			PageDefinition.Type.DROP_ZONE,
 			LayoutDataItemTypeConstants.TYPE_DROP_ZONE
 		).put(
-			PageElement.Type.FORM, LayoutDataItemTypeConstants.TYPE_FORM
+			PageDefinition.Type.FORM, LayoutDataItemTypeConstants.TYPE_FORM
 		).put(
-			PageElement.Type.FORM_STEP,
+			PageDefinition.Type.FORM_STEP,
 			LayoutDataItemTypeConstants.TYPE_FORM_STEP
 		).put(
-			PageElement.Type.FORM_STEP_CONTAINER,
+			PageDefinition.Type.FORM_STEP_CONTAINER,
 			LayoutDataItemTypeConstants.TYPE_FORM_STEP_CONTAINER
 		).put(
-			PageElement.Type.FRAGMENT, LayoutDataItemTypeConstants.TYPE_FRAGMENT
+			PageDefinition.Type.FRAGMENT, LayoutDataItemTypeConstants.TYPE_FRAGMENT
 		).put(
-			PageElement.Type.FRAGMENT_DROP_ZONE,
+			PageDefinition.Type.FRAGMENT_DROP_ZONE,
 			LayoutDataItemTypeConstants.TYPE_FRAGMENT_DROP_ZONE
 		).put(
-			PageElement.Type.ROW, LayoutDataItemTypeConstants.TYPE_ROW
+			PageDefinition.Type.ROW, LayoutDataItemTypeConstants.TYPE_ROW
 		).build();
 
 }

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/PageElementTypeUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/PageElementTypeUtil.java
@@ -6,7 +6,6 @@
 package com.liferay.headless.admin.site.internal.dto.v1_0.util;
 
 import com.liferay.headless.admin.site.dto.v1_0.PageDefinition;
-import com.liferay.headless.admin.site.dto.v1_0.PageElement;
 import com.liferay.layout.util.constants.LayoutDataItemTypeConstants;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 
@@ -67,7 +66,8 @@ public class PageElementTypeUtil {
 			PageDefinition.Type.FORM_STEP_CONTAINER,
 			LayoutDataItemTypeConstants.TYPE_FORM_STEP_CONTAINER
 		).put(
-			PageDefinition.Type.FRAGMENT, LayoutDataItemTypeConstants.TYPE_FRAGMENT
+			PageDefinition.Type.FRAGMENT,
+			LayoutDataItemTypeConstants.TYPE_FRAGMENT
 		).put(
 			PageDefinition.Type.FRAGMENT_DROP_ZONE,
 			LayoutDataItemTypeConstants.TYPE_FRAGMENT_DROP_ZONE

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/graphql/query/v1_0/Query.java
@@ -690,7 +690,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {siteByExternalReferenceCodePageElement(pageElementExternalReferenceCode: ___, pageExperienceExternalReferenceCode: ___, pageSpecificationExternalReferenceCode: ___, siteExternalReferenceCode: ___){definition, externalReferenceCode, pageElements, parentExternalReferenceCode, position, type}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {siteByExternalReferenceCodePageElement(pageElementExternalReferenceCode: ___, pageExperienceExternalReferenceCode: ___, pageSpecificationExternalReferenceCode: ___, siteExternalReferenceCode: ___){definition, externalReferenceCode, pageElements, parentExternalReferenceCode, position}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(
 		description = "Retrieves a page element within an experience of a specific page specification of a site page within a site."

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BasePageElementResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BasePageElementResourceImpl.java
@@ -347,7 +347,7 @@ public abstract class BasePageElementResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PATCH' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/page-specifications/{pageSpecificationExternalReferenceCode}/page-experiences/{pageExperienceExternalReferenceCode}/page-elements/{pageElementExternalReferenceCode}' -d $'{"definition": ___, "externalReferenceCode": ___, "pageElements": ___, "parentExternalReferenceCode": ___, "position": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PATCH' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/page-specifications/{pageSpecificationExternalReferenceCode}/page-experiences/{pageExperienceExternalReferenceCode}/page-elements/{pageElementExternalReferenceCode}' -d $'{"definition": ___, "externalReferenceCode": ___, "pageElements": ___, "parentExternalReferenceCode": ___, "position": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Updates a page element within an experience of a specific page specification of a site page within a site. Updates only the fields received in the request body, leaving any other fields untouched."
@@ -421,10 +421,6 @@ public abstract class BasePageElementResourceImpl
 				pageExperienceExternalReferenceCode,
 				pageElementExternalReferenceCode);
 
-		if (pageElement.getDefinition() != null) {
-			existingPageElement.setDefinition(pageElement.getDefinition());
-		}
-
 		if (pageElement.getExternalReferenceCode() != null) {
 			existingPageElement.setExternalReferenceCode(
 				pageElement.getExternalReferenceCode());
@@ -437,10 +433,6 @@ public abstract class BasePageElementResourceImpl
 
 		if (pageElement.getPosition() != null) {
 			existingPageElement.setPosition(pageElement.getPosition());
-		}
-
-		if (pageElement.getType() != null) {
-			existingPageElement.setType(pageElement.getType());
 		}
 
 		preparePatch(pageElement, existingPageElement);
@@ -535,7 +527,7 @@ public abstract class BasePageElementResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/page-specifications/{pageSpecificationExternalReferenceCode}/page-experiences/{pageExperienceExternalReferenceCode}/page-elements' -d $'{"definition": ___, "externalReferenceCode": ___, "pageElements": ___, "parentExternalReferenceCode": ___, "position": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/page-specifications/{pageSpecificationExternalReferenceCode}/page-experiences/{pageExperienceExternalReferenceCode}/page-elements' -d $'{"definition": ___, "externalReferenceCode": ___, "pageElements": ___, "parentExternalReferenceCode": ___, "position": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Adds a new page element to an experience in a page specification in draft status of a site page."
@@ -601,7 +593,7 @@ public abstract class BasePageElementResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/page-specifications/{pageSpecificationExternalReferenceCode}/page-experiences/{pageExperienceExternalReferenceCode}/page-elements/{pageElementExternalReferenceCode}' -d $'{"definition": ___, "externalReferenceCode": ___, "pageElements": ___, "parentExternalReferenceCode": ___, "position": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/page-specifications/{pageSpecificationExternalReferenceCode}/page-experiences/{pageExperienceExternalReferenceCode}/page-elements/{pageElementExternalReferenceCode}' -d $'{"definition": ___, "externalReferenceCode": ___, "pageElements": ___, "parentExternalReferenceCode": ___, "position": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Updates a page element within an experience of a specific page specification of a site page within a site."

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageExperienceResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageExperienceResourceImpl.java
@@ -218,7 +218,7 @@ public class PageExperienceResourceImpl extends BasePageExperienceResourceImpl {
 
 		LayoutStructureItemImporter layoutStructureItemImporter =
 			LayoutStructureItemImporterUtil.getLayoutStructureItemImporter(
-				pageElement.getType());
+				pageElement.getDefinition().getType());
 
 		layoutStructureItemImporter.addLayoutStructureItem(
 			layoutStructure, layoutStructureItemImporterContext, pageElement);

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageExperienceResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageExperienceResourceImpl.java
@@ -218,7 +218,8 @@ public class PageExperienceResourceImpl extends BasePageExperienceResourceImpl {
 
 		LayoutStructureItemImporter layoutStructureItemImporter =
 			LayoutStructureItemImporterUtil.getLayoutStructureItemImporter(
-				pageElement.getDefinition().getType());
+				pageElement.getDefinition(
+				).getType());
 
 		layoutStructureItemImporter.addLayoutStructureItem(
 			layoutStructure, layoutStructureItemImporterContext, pageElement);

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutStructureItemImporterUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutStructureItemImporterUtil.java
@@ -5,6 +5,7 @@
 
 package com.liferay.headless.admin.site.internal.resource.v1_0.util;
 
+import com.liferay.headless.admin.site.dto.v1_0.PageDefinition;
 import com.liferay.headless.admin.site.dto.v1_0.PageElement;
 import com.liferay.headless.admin.site.internal.resource.v1_0.layout.structure.item.importer.CollectionItemLayoutStructureItemImporter;
 import com.liferay.headless.admin.site.internal.resource.v1_0.layout.structure.item.importer.CollectionLayoutStructureItemImporter;
@@ -27,47 +28,47 @@ import java.util.EnumMap;
 public class LayoutStructureItemImporterUtil {
 
 	public static LayoutStructureItemImporter getLayoutStructureItemImporter(
-		PageElement.Type type) {
+		PageDefinition.Type type) {
 
 		return _layoutStructureItemImporters.get(type);
 	}
 
-	private static final EnumMap<PageElement.Type, LayoutStructureItemImporter>
+	private static final EnumMap<PageDefinition.Type, LayoutStructureItemImporter>
 		_layoutStructureItemImporters;
 
 	static {
-		_layoutStructureItemImporters = new EnumMap<>(PageElement.Type.class);
+		_layoutStructureItemImporters = new EnumMap<>(PageDefinition.Type.class);
 
 		_layoutStructureItemImporters.put(
-			PageElement.Type.COLLECTION,
+			PageDefinition.Type.COLLECTION,
 			new CollectionLayoutStructureItemImporter());
 		_layoutStructureItemImporters.put(
-			PageElement.Type.COLLECTION_ITEM,
+			PageDefinition.Type.COLLECTION_ITEM,
 			new CollectionItemLayoutStructureItemImporter());
 		_layoutStructureItemImporters.put(
-			PageElement.Type.COLUMN, new ColumnLayoutStructureItemImporter());
+			PageDefinition.Type.COLUMN, new ColumnLayoutStructureItemImporter());
 		_layoutStructureItemImporters.put(
-			PageElement.Type.CONTAINER,
+			PageDefinition.Type.CONTAINER,
 			new ContainerLayoutStructureItemImporter());
 		_layoutStructureItemImporters.put(
-			PageElement.Type.DROP_ZONE,
+			PageDefinition.Type.DROP_ZONE,
 			new DropZoneLayoutStructureItemImporter());
 		_layoutStructureItemImporters.put(
-			PageElement.Type.FORM, new FormLayoutStructureItemImporter());
+			PageDefinition.Type.FORM, new FormLayoutStructureItemImporter());
 		_layoutStructureItemImporters.put(
-			PageElement.Type.FORM_STEP,
+			PageDefinition.Type.FORM_STEP,
 			new FormStepItemLayoutStructureItemImporter());
 		_layoutStructureItemImporters.put(
-			PageElement.Type.FORM_STEP_CONTAINER,
+			PageDefinition.Type.FORM_STEP_CONTAINER,
 			new FormStepContainerLayoutStructureItemImporter());
 		_layoutStructureItemImporters.put(
-			PageElement.Type.FRAGMENT_DROP_ZONE,
+			PageDefinition.Type.FRAGMENT_DROP_ZONE,
 			new FragmentDropZoneLayoutStructureItemImporter());
 		_layoutStructureItemImporters.put(
-			PageElement.Type.FRAGMENT,
+			PageDefinition.Type.FRAGMENT,
 			new FragmentLayoutStructureItemImporter());
 		_layoutStructureItemImporters.put(
-			PageElement.Type.ROW, new RowLayoutStructureItemImporter());
+			PageDefinition.Type.ROW, new RowLayoutStructureItemImporter());
 	}
 
 }

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutStructureItemImporterUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutStructureItemImporterUtil.java
@@ -6,7 +6,6 @@
 package com.liferay.headless.admin.site.internal.resource.v1_0.util;
 
 import com.liferay.headless.admin.site.dto.v1_0.PageDefinition;
-import com.liferay.headless.admin.site.dto.v1_0.PageElement;
 import com.liferay.headless.admin.site.internal.resource.v1_0.layout.structure.item.importer.CollectionItemLayoutStructureItemImporter;
 import com.liferay.headless.admin.site.internal.resource.v1_0.layout.structure.item.importer.CollectionLayoutStructureItemImporter;
 import com.liferay.headless.admin.site.internal.resource.v1_0.layout.structure.item.importer.ColumnLayoutStructureItemImporter;
@@ -33,11 +32,13 @@ public class LayoutStructureItemImporterUtil {
 		return _layoutStructureItemImporters.get(type);
 	}
 
-	private static final EnumMap<PageDefinition.Type, LayoutStructureItemImporter>
-		_layoutStructureItemImporters;
+	private static final EnumMap
+		<PageDefinition.Type, LayoutStructureItemImporter>
+			_layoutStructureItemImporters;
 
 	static {
-		_layoutStructureItemImporters = new EnumMap<>(PageDefinition.Type.class);
+		_layoutStructureItemImporters = new EnumMap<>(
+			PageDefinition.Type.class);
 
 		_layoutStructureItemImporters.put(
 			PageDefinition.Type.COLLECTION,
@@ -46,7 +47,8 @@ public class LayoutStructureItemImporterUtil {
 			PageDefinition.Type.COLLECTION_ITEM,
 			new CollectionItemLayoutStructureItemImporter());
 		_layoutStructureItemImporters.put(
-			PageDefinition.Type.COLUMN, new ColumnLayoutStructureItemImporter());
+			PageDefinition.Type.COLUMN,
+			new ColumnLayoutStructureItemImporter());
 		_layoutStructureItemImporters.put(
 			PageDefinition.Type.CONTAINER,
 			new ContainerLayoutStructureItemImporter());

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutStructureUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutStructureUtil.java
@@ -27,7 +27,8 @@ public class LayoutStructureUtil {
 
 		LayoutStructureItemImporter layoutStructureItemImporter =
 			LayoutStructureItemImporterUtil.getLayoutStructureItemImporter(
-				pageElement.getDefinition().getType());
+				pageElement.getDefinition(
+				).getType());
 
 		LayoutStructureItem layoutStructureItem =
 			layoutStructureItemImporter.addLayoutStructureItem(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutStructureUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutStructureUtil.java
@@ -27,7 +27,7 @@ public class LayoutStructureUtil {
 
 		LayoutStructureItemImporter layoutStructureItemImporter =
 			LayoutStructureItemImporterUtil.getLayoutStructureItemImporter(
-				pageElement.getType());
+				pageElement.getDefinition().getType());
 
 		LayoutStructureItem layoutStructureItem =
 			layoutStructureItemImporter.addLayoutStructureItem(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BasePageElementResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BasePageElementResourceTestCase.java
@@ -726,14 +726,6 @@ public abstract class BasePageElementResourceTestCase {
 				continue;
 			}
 
-			if (Objects.equals("type", additionalAssertFieldName)) {
-				if (pageElement.getType() == null) {
-					valid = false;
-				}
-
-				continue;
-			}
-
 			throw new IllegalArgumentException(
 				"Invalid additional assert field name " +
 					additionalAssertFieldName);
@@ -905,16 +897,6 @@ public abstract class BasePageElementResourceTestCase {
 				if (!Objects.deepEquals(
 						pageElement1.getPosition(),
 						pageElement2.getPosition())) {
-
-					return false;
-				}
-
-				continue;
-			}
-
-			if (Objects.equals("type", additionalAssertFieldName)) {
-				if (!Objects.deepEquals(
-						pageElement1.getType(), pageElement2.getType())) {
 
 					return false;
 				}
@@ -1135,11 +1117,6 @@ public abstract class BasePageElementResourceTestCase {
 			sb.append(String.valueOf(pageElement.getPosition()));
 
 			return sb.toString();
-		}
-
-		if (entityFieldName.equals("type")) {
-			throw new IllegalArgumentException(
-				"Invalid entity field " + entityFieldName);
 		}
 
 		throw new IllegalArgumentException(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
@@ -6,20 +6,11 @@
 package com.liferay.headless.admin.site.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.headless.admin.site.client.dto.v1_0.PageContainerDefinition;
 import com.liferay.headless.admin.site.client.dto.v1_0.PageDefinition;
 import com.liferay.headless.admin.site.client.dto.v1_0.PageElement;
 import com.liferay.headless.admin.site.client.dto.v1_0.PageFragmentInstanceDefinition;
 import com.liferay.headless.admin.site.client.problem.Problem;
-import com.liferay.headless.admin.site.client.dto.v1_0.PageContainerDefinition;
-import com.liferay.headless.admin.site.client.dto.v1_0.PageCollectionItemDefinition;
-import com.liferay.headless.admin.site.client.dto.v1_0.PageColumnDefinition;
-import com.liferay.headless.admin.site.client.dto.v1_0.PageCollectionDefinition;
-import com.liferay.headless.admin.site.client.dto.v1_0.PageFormStepDefinition;
-import com.liferay.headless.admin.site.client.dto.v1_0.PageDropZoneDefinition;
-import com.liferay.headless.admin.site.client.dto.v1_0.PageFragmentDropZoneDefinition;
-import com.liferay.headless.admin.site.client.dto.v1_0.PageFormDefinition;
-import com.liferay.headless.admin.site.client.dto.v1_0.PageFormStepContainerDefinition;
-import com.liferay.headless.admin.site.client.dto.v1_0.PageRowDefinition;
 import com.liferay.headless.admin.site.dto.v1_0.DefaultFragmentReference;
 import com.liferay.layout.page.template.model.LayoutPageTemplateStructure;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocalService;
@@ -418,12 +409,16 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 		pageElement.setPageElements(new PageElement[0]);
 		pageElement.setParentExternalReferenceCode(StringPool.BLANK);
 		pageElement.setPosition(_position++);
-		
-		PageContainerDefinition pageContainerDefinition = new PageContainerDefinition();
+
+		PageContainerDefinition pageContainerDefinition =
+			new PageContainerDefinition();
+
 		pageContainerDefinition.setType(type);
+
 		pageContainerDefinition.setIndexed(Boolean.FALSE);
+
 		pageElement.setDefinition(pageContainerDefinition);
-		
+
 		return pageElement;
 	}
 
@@ -526,7 +521,6 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 		randomPageElement.setDefinition(
 			new PageFragmentInstanceDefinition() {
 				{
-					setType(Type.FRAGMENT);
 					setFragmentReference(
 						new DefaultFragmentReference() {
 							{
@@ -534,6 +528,7 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 									() -> "BASIC_COMPONENT-heading");
 							}
 						});
+					setType(Type.FRAGMENT);
 				}
 			});
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
@@ -6,20 +6,21 @@
 package com.liferay.headless.admin.site.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.headless.admin.site.client.dto.v1_0.PageDefinition;
 import com.liferay.headless.admin.site.client.dto.v1_0.PageElement;
+import com.liferay.headless.admin.site.client.dto.v1_0.PageFragmentInstanceDefinition;
 import com.liferay.headless.admin.site.client.problem.Problem;
+import com.liferay.headless.admin.site.client.dto.v1_0.PageContainerDefinition;
+import com.liferay.headless.admin.site.client.dto.v1_0.PageCollectionItemDefinition;
+import com.liferay.headless.admin.site.client.dto.v1_0.PageColumnDefinition;
+import com.liferay.headless.admin.site.client.dto.v1_0.PageCollectionDefinition;
+import com.liferay.headless.admin.site.client.dto.v1_0.PageFormStepDefinition;
+import com.liferay.headless.admin.site.client.dto.v1_0.PageDropZoneDefinition;
+import com.liferay.headless.admin.site.client.dto.v1_0.PageFragmentDropZoneDefinition;
+import com.liferay.headless.admin.site.client.dto.v1_0.PageFormDefinition;
+import com.liferay.headless.admin.site.client.dto.v1_0.PageFormStepContainerDefinition;
+import com.liferay.headless.admin.site.client.dto.v1_0.PageRowDefinition;
 import com.liferay.headless.admin.site.dto.v1_0.DefaultFragmentReference;
-import com.liferay.headless.admin.site.dto.v1_0.PageCollectionDefinition;
-import com.liferay.headless.admin.site.dto.v1_0.PageCollectionItemDefinition;
-import com.liferay.headless.admin.site.dto.v1_0.PageColumnDefinition;
-import com.liferay.headless.admin.site.dto.v1_0.PageContainerDefinition;
-import com.liferay.headless.admin.site.dto.v1_0.PageDropZoneDefinition;
-import com.liferay.headless.admin.site.dto.v1_0.PageFormDefinition;
-import com.liferay.headless.admin.site.dto.v1_0.PageFormStepContainerDefinition;
-import com.liferay.headless.admin.site.dto.v1_0.PageFormStepDefinition;
-import com.liferay.headless.admin.site.dto.v1_0.PageFragmentDropZoneDefinition;
-import com.liferay.headless.admin.site.dto.v1_0.PageFragmentInstanceDefinition;
-import com.liferay.headless.admin.site.dto.v1_0.PageRowDefinition;
 import com.liferay.layout.page.template.model.LayoutPageTemplateStructure;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocalService;
 import com.liferay.layout.test.util.LayoutTestUtil;
@@ -251,14 +252,13 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 	@Override
 	protected String[] getAdditionalAssertFieldNames() {
 		return new String[] {
-			"externalReferenceCode", "parentExternalReferenceCode", "position",
-			"type"
+			"externalReferenceCode", "parentExternalReferenceCode", "position"
 		};
 	}
 
 	@Override
 	protected PageElement randomPageElement() throws Exception {
-		return _randomPageElement(PageElement.Type.CONTAINER);
+		return _randomPageElement(PageDefinition.Type.CONTAINER);
 	}
 
 	@Override
@@ -410,7 +410,7 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 			layoutPageTemplateStructure.getDefaultSegmentsExperienceData());
 	}
 
-	private PageElement _randomPageElement(PageElement.Type type)
+	private PageElement _randomPageElement(PageDefinition.Type type)
 		throws Exception {
 
 		PageElement pageElement = super.randomPageElement();
@@ -418,8 +418,12 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 		pageElement.setPageElements(new PageElement[0]);
 		pageElement.setParentExternalReferenceCode(StringPool.BLANK);
 		pageElement.setPosition(_position++);
-		pageElement.setType(type);
-
+		
+		PageContainerDefinition pageContainerDefinition = new PageContainerDefinition();
+		pageContainerDefinition.setType(type);
+		pageContainerDefinition.setIndexed(Boolean.FALSE);
+		pageElement.setDefinition(pageContainerDefinition);
+		
 		return pageElement;
 	}
 
@@ -427,9 +431,7 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 		throws Exception {
 
 		PageElement randomPageElement = _randomPageElement(
-			PageElement.Type.COLLECTION);
-
-		randomPageElement.setDefinition(new PageCollectionDefinition());
+			PageDefinition.Type.COLLECTION);
 
 		_assertPostSiteSiteByExternalReferenceCodePageExperiencePageElement(
 			randomPageElement);
@@ -439,9 +441,7 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 		throws Exception {
 
 		PageElement randomPageElement = _randomPageElement(
-			PageElement.Type.COLLECTION_ITEM);
-
-		randomPageElement.setDefinition(new PageCollectionItemDefinition());
+			PageDefinition.Type.COLLECTION_ITEM);
 
 		_assertPostSiteSiteByExternalReferenceCodePageExperiencePageElement(
 			randomPageElement);
@@ -451,9 +451,7 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 		throws Exception {
 
 		PageElement randomPageElement = _randomPageElement(
-			PageElement.Type.COLUMN);
-
-		randomPageElement.setDefinition(new PageColumnDefinition());
+			PageDefinition.Type.COLUMN);
 
 		_assertPostSiteSiteByExternalReferenceCodePageExperiencePageElement(
 			randomPageElement);
@@ -463,9 +461,7 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 		throws Exception {
 
 		PageElement randomPageElement = _randomPageElement(
-			PageElement.Type.CONTAINER);
-
-		randomPageElement.setDefinition(new PageContainerDefinition());
+			PageDefinition.Type.CONTAINER);
 
 		_assertPostSiteSiteByExternalReferenceCodePageExperiencePageElement(
 			randomPageElement);
@@ -475,9 +471,7 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 		throws Exception {
 
 		PageElement randomPageElement = _randomPageElement(
-			PageElement.Type.DROP_ZONE);
-
-		randomPageElement.setDefinition(new PageDropZoneDefinition());
+			PageDefinition.Type.DROP_ZONE);
 
 		_assertPostSiteSiteByExternalReferenceCodePageExperiencePageElement(
 			randomPageElement);
@@ -487,9 +481,7 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 		throws Exception {
 
 		PageElement randomPageElement = _randomPageElement(
-			PageElement.Type.FORM);
-
-		randomPageElement.setDefinition(new PageFormDefinition());
+			PageDefinition.Type.FORM);
 
 		_assertPostSiteSiteByExternalReferenceCodePageExperiencePageElement(
 			randomPageElement);
@@ -499,9 +491,7 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 		throws Exception {
 
 		PageElement randomPageElement = _randomPageElement(
-			PageElement.Type.FORM_STEP_CONTAINER);
-
-		randomPageElement.setDefinition(new PageFormStepContainerDefinition());
+			PageDefinition.Type.FORM_STEP_CONTAINER);
 
 		_assertPostSiteSiteByExternalReferenceCodePageExperiencePageElement(
 			randomPageElement);
@@ -511,9 +501,7 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 		throws Exception {
 
 		PageElement randomPageElement = _randomPageElement(
-			PageElement.Type.FORM_STEP);
-
-		randomPageElement.setDefinition(new PageFormStepDefinition());
+			PageDefinition.Type.FORM_STEP);
 
 		_assertPostSiteSiteByExternalReferenceCodePageExperiencePageElement(
 			randomPageElement);
@@ -523,9 +511,7 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 		throws Exception {
 
 		PageElement randomPageElement = _randomPageElement(
-			PageElement.Type.FRAGMENT_DROP_ZONE);
-
-		randomPageElement.setDefinition(new PageFragmentDropZoneDefinition());
+			PageDefinition.Type.FRAGMENT_DROP_ZONE);
 
 		_assertPostSiteSiteByExternalReferenceCodePageExperiencePageElement(
 			randomPageElement);
@@ -535,11 +521,12 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 		throws Exception {
 
 		PageElement randomPageElement = _randomPageElement(
-			PageElement.Type.FRAGMENT);
+			PageDefinition.Type.FRAGMENT);
 
 		randomPageElement.setDefinition(
 			new PageFragmentInstanceDefinition() {
 				{
+					setType(Type.FRAGMENT);
 					setFragmentReference(
 						new DefaultFragmentReference() {
 							{
@@ -558,9 +545,7 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 		throws Exception {
 
 		PageElement randomPageElement = _randomPageElement(
-			PageElement.Type.ROW);
-
-		randomPageElement.setDefinition(new PageRowDefinition());
+			PageDefinition.Type.ROW);
 
 		_assertPostSiteSiteByExternalReferenceCodePageExperiencePageElement(
 			randomPageElement);

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageExperienceResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageExperienceResourceTest.java
@@ -6,6 +6,9 @@
 package com.liferay.headless.admin.site.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.headless.admin.site.client.dto.v1_0.HtmlProperties;
+import com.liferay.headless.admin.site.client.dto.v1_0.PageContainerDefinition;
+import com.liferay.headless.admin.site.client.dto.v1_0.PageDefinition;
 import com.liferay.headless.admin.site.client.dto.v1_0.PageElement;
 import com.liferay.headless.admin.site.client.dto.v1_0.PageExperience;
 import com.liferay.headless.admin.site.client.problem.Problem;
@@ -191,13 +194,30 @@ public class PageExperienceResourceTest
 
 		pageExperience.setName_i18n(
 			Collections.singletonMap("en-US", RandomTestUtil.randomString()));
-		pageExperience.setPageElements(new PageElement[0]);
 
-		SegmentsEntry segmentsEntry = SegmentsTestUtil.addSegmentsEntry(
-			testGroup.getGroupId());
+		pageExperience.setPageElements(
+			new PageElement[] {
+				new PageElement() {{
+					setPageElements(new PageElement[0]);
+					setPosition(0);
+					setDefinition(new PageContainerDefinition() {{
+						setType(PageDefinition.Type.CONTAINER);
+						setIndexed(true);
+					}});
+				}},
+				new PageElement() {{
+					setPageElements(new PageElement[0]);
+					setPosition(1);
+					setDefinition(new PageContainerDefinition() {{
+						setType(PageDefinition.Type.CONTAINER);
+						setIndexed(true);
+					}});
+				}}
+			});
 
 		pageExperience.setSegmentExternalReferenceCode(
-			segmentsEntry.getSegmentsEntryKey());
+			SegmentsTestUtil.addSegmentsEntry(
+				testGroup.getGroupId()).getSegmentsEntryKey());
 
 		pageExperience.setPageSpecificationExternalReferenceCode(
 			_draftLayout.getExternalReferenceCode());

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageExperienceResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageExperienceResourceTest.java
@@ -6,7 +6,6 @@
 package com.liferay.headless.admin.site.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
-import com.liferay.headless.admin.site.client.dto.v1_0.HtmlProperties;
 import com.liferay.headless.admin.site.client.dto.v1_0.PageContainerDefinition;
 import com.liferay.headless.admin.site.client.dto.v1_0.PageDefinition;
 import com.liferay.headless.admin.site.client.dto.v1_0.PageElement;
@@ -17,7 +16,6 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
-import com.liferay.segments.model.SegmentsEntry;
 import com.liferay.segments.service.SegmentsExperienceLocalService;
 import com.liferay.segments.test.util.SegmentsTestUtil;
 
@@ -197,27 +195,38 @@ public class PageExperienceResourceTest
 
 		pageExperience.setPageElements(
 			new PageElement[] {
-				new PageElement() {{
-					setPageElements(new PageElement[0]);
-					setPosition(0);
-					setDefinition(new PageContainerDefinition() {{
-						setType(PageDefinition.Type.CONTAINER);
-						setIndexed(true);
-					}});
-				}},
-				new PageElement() {{
-					setPageElements(new PageElement[0]);
-					setPosition(1);
-					setDefinition(new PageContainerDefinition() {{
-						setType(PageDefinition.Type.CONTAINER);
-						setIndexed(true);
-					}});
-				}}
+				new PageElement() {
+					{
+						setDefinition(
+							new PageContainerDefinition() {
+								{
+									setIndexed(true);
+									setType(PageDefinition.Type.CONTAINER);
+								}
+							});
+						setPageElements(new PageElement[0]);
+						setPosition(0);
+					}
+				},
+				new PageElement() {
+					{
+						setDefinition(
+							new PageContainerDefinition() {
+								{
+									setIndexed(true);
+									setType(PageDefinition.Type.CONTAINER);
+								}
+							});
+						setPageElements(new PageElement[0]);
+						setPosition(1);
+					}
+				}
 			});
 
 		pageExperience.setSegmentExternalReferenceCode(
 			SegmentsTestUtil.addSegmentsEntry(
-				testGroup.getGroupId()).getSegmentsEntryKey());
+				testGroup.getGroupId()
+			).getSegmentsEntryKey());
 
 		pageExperience.setPageSpecificationExternalReferenceCode(
 			_draftLayout.getExternalReferenceCode());

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageSpecificationResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageSpecificationResourceTest.java
@@ -8,9 +8,12 @@ package com.liferay.headless.admin.site.resource.v1_0.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.headless.admin.site.client.dto.v1_0.ContentPageSpecification;
 import com.liferay.headless.admin.site.client.dto.v1_0.ItemExternalReference;
+import com.liferay.headless.admin.site.client.dto.v1_0.PageDefinition;
 import com.liferay.headless.admin.site.client.dto.v1_0.PageElement;
 import com.liferay.headless.admin.site.client.dto.v1_0.PageExperience;
+import com.liferay.headless.admin.site.client.dto.v1_0.PageRowDefinition;
 import com.liferay.headless.admin.site.client.dto.v1_0.PageSpecification;
+import com.liferay.headless.admin.site.client.dto.v1_0.PageContainerDefinition;
 import com.liferay.headless.admin.site.client.dto.v1_0.Settings;
 import com.liferay.headless.admin.site.client.dto.v1_0.WidgetPageSpecification;
 import com.liferay.headless.admin.site.client.pagination.Page;
@@ -553,7 +556,7 @@ public class PageSpecificationResourceTest
 				GetterUtil.getInteger(pageElement.getPosition()),
 				GetterUtil.getInteger(curPageElement.getPosition()));
 			Assert.assertEquals(
-				pageElement.getType(), curPageElement.getType());
+				pageElement.getDefinition().getType(), curPageElement.getDefinition().getType());
 
 			_assertPageElements(
 				curPageElement.getPageElements(),
@@ -923,8 +926,7 @@ public class PageSpecificationResourceTest
 				}
 			};
 
-		settings.setMasterPageItemExternalReference(
-			() -> itemExternalReference);
+		settings.setMasterPageItemExternalReference(() -> itemExternalReference);
 
 		return new Settings() {
 			{
@@ -976,7 +978,14 @@ public class PageSpecificationResourceTest
 					setParentExternalReferenceCode(
 						() -> curParentExternalReferenceCode);
 					setPosition(() -> curPosition);
-					setType(() -> PageElement.Type.CONTAINER);
+
+						setDefinition(() -> new PageContainerDefinition() {
+							{
+								setType(() -> PageDefinition.Type.CONTAINER);
+								setIndexed(() -> Boolean.FALSE);
+							}
+						});
+
 				}
 			};
 		}
@@ -1160,8 +1169,8 @@ public class PageSpecificationResourceTest
 					pageExperience.getPageElements(),
 					pageElement -> {
 						if (Objects.equals(
-								pageElement.getType(),
-								PageElement.Type.DROP_ZONE)) {
+								pageElement.getDefinition().getType(),
+								PageDefinition.Type.DROP_ZONE)) {
 
 							return pageElement;
 						}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageSpecificationResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageSpecificationResourceTest.java
@@ -8,12 +8,11 @@ package com.liferay.headless.admin.site.resource.v1_0.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.headless.admin.site.client.dto.v1_0.ContentPageSpecification;
 import com.liferay.headless.admin.site.client.dto.v1_0.ItemExternalReference;
+import com.liferay.headless.admin.site.client.dto.v1_0.PageContainerDefinition;
 import com.liferay.headless.admin.site.client.dto.v1_0.PageDefinition;
 import com.liferay.headless.admin.site.client.dto.v1_0.PageElement;
 import com.liferay.headless.admin.site.client.dto.v1_0.PageExperience;
-import com.liferay.headless.admin.site.client.dto.v1_0.PageRowDefinition;
 import com.liferay.headless.admin.site.client.dto.v1_0.PageSpecification;
-import com.liferay.headless.admin.site.client.dto.v1_0.PageContainerDefinition;
 import com.liferay.headless.admin.site.client.dto.v1_0.Settings;
 import com.liferay.headless.admin.site.client.dto.v1_0.WidgetPageSpecification;
 import com.liferay.headless.admin.site.client.pagination.Page;
@@ -556,7 +555,10 @@ public class PageSpecificationResourceTest
 				GetterUtil.getInteger(pageElement.getPosition()),
 				GetterUtil.getInteger(curPageElement.getPosition()));
 			Assert.assertEquals(
-				pageElement.getDefinition().getType(), curPageElement.getDefinition().getType());
+				pageElement.getDefinition(
+				).getType(),
+				curPageElement.getDefinition(
+				).getType());
 
 			_assertPageElements(
 				curPageElement.getPageElements(),
@@ -926,7 +928,8 @@ public class PageSpecificationResourceTest
 				}
 			};
 
-		settings.setMasterPageItemExternalReference(() -> itemExternalReference);
+		settings.setMasterPageItemExternalReference(
+			() -> itemExternalReference);
 
 		return new Settings() {
 			{
@@ -964,6 +967,13 @@ public class PageSpecificationResourceTest
 
 			pageElements[i] = new PageElement() {
 				{
+					setDefinition(
+						() -> new PageContainerDefinition() {
+							{
+								setIndexed(() -> Boolean.FALSE);
+								setType(() -> PageDefinition.Type.CONTAINER);
+							}
+						});
 					setExternalReferenceCode(curExternalReferenceCode);
 					setPageElements(
 						() -> {
@@ -978,14 +988,6 @@ public class PageSpecificationResourceTest
 					setParentExternalReferenceCode(
 						() -> curParentExternalReferenceCode);
 					setPosition(() -> curPosition);
-
-						setDefinition(() -> new PageContainerDefinition() {
-							{
-								setType(() -> PageDefinition.Type.CONTAINER);
-								setIndexed(() -> Boolean.FALSE);
-							}
-						});
-
 				}
 			};
 		}
@@ -1169,7 +1171,8 @@ public class PageSpecificationResourceTest
 					pageExperience.getPageElements(),
 					pageElement -> {
 						if (Objects.equals(
-								pageElement.getDefinition().getType(),
+								pageElement.getDefinition(
+								).getType(),
 								PageDefinition.Type.DROP_ZONE)) {
 
 							return pageElement;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-50818

We need to talk. 

Before, we encountered an error because we weren't explicitly indicating to the OpenAPI specification that the type was related to its definition. As a solution, we propose using discriminators to inform RestBuilder about this relationship. We need to schedule a discussion with the other team about this approach.