### PR TITLE
LPD-54819 Add support in @FeatureFlags annotation to manage each value individually

### DIFF
--- a/modules/apps/analytics/analytics-machine-learning-test/src/testIntegration/java/com/liferay/analytics/machine/learning/internal/recommendation/info/collection/provider/test/MostViewedContentRecommendationInfoItemCollectionProviderTest.java
+++ b/modules/apps/analytics/analytics-machine-learning-test/src/testIntegration/java/com/liferay/analytics/machine/learning/internal/recommendation/info/collection/provider/test/MostViewedContentRecommendationInfoItemCollectionProviderTest.java
@@ -29,7 +29,7 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.search.test.util.IdempotentRetryAssert;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -46,7 +46,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Eudaldo Alonso
  */
-@FeatureFlags("LRAC-14771")
+@FeatureFlag("LRAC-14771")
 @RunWith(Arquillian.class)
 public class MostViewedContentRecommendationInfoItemCollectionProviderTest {
 

--- a/modules/apps/analytics/analytics-machine-learning-test/src/testIntegration/java/com/liferay/analytics/machine/learning/internal/recommendation/info/collection/provider/test/UserContentRecommendationInfoItemCollectionProviderTest.java
+++ b/modules/apps/analytics/analytics-machine-learning-test/src/testIntegration/java/com/liferay/analytics/machine/learning/internal/recommendation/info/collection/provider/test/UserContentRecommendationInfoItemCollectionProviderTest.java
@@ -29,7 +29,7 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.search.test.util.IdempotentRetryAssert;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -46,7 +46,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Eudaldo Alonso
  */
-@FeatureFlags("LRAC-14771")
+@FeatureFlag("LRAC-14771")
 @RunWith(Arquillian.class)
 public class UserContentRecommendationInfoItemCollectionProviderTest {
 

--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/exportimport/portlet/preferences/processor/test/AssetCategoriesNavigationPortletPreferencesProcessorTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/exportimport/portlet/preferences/processor/test/AssetCategoriesNavigationPortletPreferencesProcessorTest.java
@@ -21,7 +21,7 @@ import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -39,7 +39,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Jürgen Kappler
  */
-@FeatureFlags("LPD-27566")
+@FeatureFlag("LPD-27566")
 @RunWith(Arquillian.class)
 public class AssetCategoriesNavigationPortletPreferencesProcessorTest {
 

--- a/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/frontend/taglib/form/navigator/test/AssetPublisherConfigurationFormNavigatorTest.java
+++ b/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/frontend/taglib/form/navigator/test/AssetPublisherConfigurationFormNavigatorTest.java
@@ -27,7 +27,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -86,7 +86,7 @@ public class AssetPublisherConfigurationFormNavigatorTest {
 		ServiceContextThreadLocal.popServiceContext();
 	}
 
-	@FeatureFlags(enable = false, value = "LPD-13311")
+	@FeatureFlag(enable = false, value = "LPD-13311")
 	@Test
 	public void testViewOrderOfFieldsetsInAssetSelectionWhenSelectionStyleIsDynamic1()
 		throws PortalException {
@@ -98,7 +98,7 @@ public class AssetPublisherConfigurationFormNavigatorTest {
 			});
 	}
 
-	@FeatureFlags("LPD-13311")
+	@FeatureFlag("LPD-13311")
 	@Test
 	public void testViewOrderOfFieldsetsInAssetSelectionWhenSelectionStyleIsDynamic2()
 		throws PortalException {

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/exportimport/data/handler/test/BatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/exportimport/data/handler/test/BatchEnginePortletDataHandlerTest.java
@@ -46,7 +46,7 @@ import com.liferay.portal.kernel.xml.SAXReader;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LogEntry;
 import com.liferay.portal.test.log.LoggerTestUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -77,7 +77,7 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 /**
  * @author Vendel Toreki
  */
-@FeatureFlags("LPD-35914")
+@FeatureFlag("LPD-35914")
 @RunWith(Arquillian.class)
 public class BatchEnginePortletDataHandlerTest {
 

--- a/modules/apps/batch-planner/batch-planner-test/src/testIntegration/java/com/liferay/batch/planner/batch/engine/broker/test/BatchEngineBrokerTest.java
+++ b/modules/apps/batch-planner/batch-planner-test/src/testIntegration/java/com/liferay/batch/planner/batch/engine/broker/test/BatchEngineBrokerTest.java
@@ -124,6 +124,7 @@ import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -177,7 +178,11 @@ import org.junit.runner.RunWith;
 /**
  * @author Matija Petanjek
  */
-@FeatureFlags({"LPD-34594", "LPS-135430"})
+@FeatureFlags(
+	featureFlags = {
+		@FeatureFlag(value = "LPD-34594"), @FeatureFlag(value = "LPS-135430")
+	}
+)
 @RunWith(Arquillian.class)
 public class BatchEngineBrokerTest {
 

--- a/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/item/selector/web/internal/display/context/test/BlogsItemSelectorViewDisplayContextTest.java
+++ b/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/item/selector/web/internal/display/context/test/BlogsItemSelectorViewDisplayContextTest.java
@@ -21,7 +21,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -76,7 +76,7 @@ public class BlogsItemSelectorViewDisplayContextTest {
 				_getThemeDisplay()));
 	}
 
-	@FeatureFlags("LPD-29516")
+	@FeatureFlag("LPD-29516")
 	@Test
 	public void testShowDragAndDropZoneWithWorkflowEnabledAndFeatureFlagEnabled()
 		throws Exception {

--- a/modules/apps/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/service/test/CalendarBookingLocalServiceTest.java
+++ b/modules/apps/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/service/test/CalendarBookingLocalServiceTest.java
@@ -57,7 +57,7 @@ import com.liferay.portal.kernel.workflow.WorkflowTaskManager;
 import com.liferay.portal.search.test.rule.SearchTestRule;
 import com.liferay.portal.test.mail.MailMessage;
 import com.liferay.portal.test.mail.MailServiceTestUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -507,7 +507,7 @@ public class CalendarBookingLocalServiceTest {
 		Assert.assertTrue(secondChildCalendarBooking.isDenied());
 	}
 
-	@FeatureFlags("LPD-31212")
+	@FeatureFlag("LPD-31212")
 	@Test
 	public void testAddCalendarBookingWithVideoDescription() throws Exception {
 		ServiceContext serviceContext = createServiceContext();

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/portlet/action/test/InviteUsersMVCResourceCommandTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/portlet/action/test/InviteUsersMVCResourceCommandTest.java
@@ -33,7 +33,7 @@ import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.mail.MailMessage;
 import com.liferay.portal.test.mail.MailServiceTestUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -69,7 +69,7 @@ public class InviteUsersMVCResourceCommandTest {
 			0, RandomTestUtil.randomString(), null);
 	}
 
-	@FeatureFlags("LPD-11212")
+	@FeatureFlag("LPD-11212")
 	@Test
 	public void testGetInviteUsersEmailNotificationBody() throws Exception {
 		_testGetInviteUsers(_ctCollection);
@@ -101,7 +101,7 @@ public class InviteUsersMVCResourceCommandTest {
 					"<br />")));
 	}
 
-	@FeatureFlags("LPD-11212")
+	@FeatureFlag("LPD-11212")
 	@Test
 	public void testGetInviteUsersWithCustomEmailFromAddressAndEmailFromName()
 		throws Exception {
@@ -134,7 +134,7 @@ public class InviteUsersMVCResourceCommandTest {
 		}
 	}
 
-	@FeatureFlags("LPD-11212")
+	@FeatureFlag("LPD-11212")
 	@Test
 	public void testGetInviteUsersWithCustomInvitationEmailBodyAndInvitationEmailSubject()
 		throws Exception {

--- a/modules/apps/commerce/commerce-payment-test/src/testIntegration/java/com/liferay/commerce/payment/service/test/CommercePaymentEntryLocalServiceTest.java
+++ b/modules/apps/commerce/commerce-payment-test/src/testIntegration/java/com/liferay/commerce/payment/service/test/CommercePaymentEntryLocalServiceTest.java
@@ -33,7 +33,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -53,7 +53,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Crescenzo Rega
  */
-@FeatureFlags("LPD-10562")
+@FeatureFlag("LPD-10562")
 @RunWith(Arquillian.class)
 public class CommercePaymentEntryLocalServiceTest {
 

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/internal/health/status/test/CPConfigurationListEligibilityCommerceHealthStatusTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/internal/health/status/test/CPConfigurationListEligibilityCommerceHealthStatusTest.java
@@ -45,7 +45,7 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -65,7 +65,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
 /**
  * @author Stefano Motta
  */
-@FeatureFlags("LPD-10889")
+@FeatureFlag("LPD-10889")
 @RunWith(Arquillian.class)
 public class CPConfigurationListEligibilityCommerceHealthStatusTest {
 

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/test/CommerceChannelRelLocalServiceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/test/CommerceChannelRelLocalServiceTest.java
@@ -37,7 +37,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -138,7 +138,7 @@ public class CommerceChannelRelLocalServiceTest {
 				"Channel Test"));
 	}
 
-	@FeatureFlags("LPD-34908")
+	@FeatureFlag("LPD-34908")
 	@Test
 	public void testCommerceChannelCommerceCurrencyVisibility()
 		throws Exception {

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/internal/upgrade/v13_0_1/test/ReturnsManagerRoleUpgradeProcessTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/internal/upgrade/v13_0_1/test/ReturnsManagerRoleUpgradeProcessTest.java
@@ -31,7 +31,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -51,7 +51,7 @@ import org.junit.runner.RunWith;
  * @author Crescenzo Rega
  */
 @DataGuard(scope = DataGuard.Scope.NONE)
-@FeatureFlags("LPD-10562")
+@FeatureFlag("LPD-10562")
 @RunWith(Arquillian.class)
 public class ReturnsManagerRoleUpgradeProcessTest {
 

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/ProductConfigurationResourceTest.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/ProductConfigurationResourceTest.java
@@ -30,7 +30,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.util.PropsUtil;
@@ -91,21 +91,21 @@ public class ProductConfigurationResourceTest
 		}
 	}
 
-	@FeatureFlags("LPD-10889")
+	@FeatureFlag("LPD-10889")
 	@Override
 	@Test
 	public void testDeleteProductConfiguration() throws Exception {
 		super.testDeleteProductConfiguration();
 	}
 
-	@FeatureFlags("LPD-10889")
+	@FeatureFlag("LPD-10889")
 	@Override
 	@Test
 	public void testDeleteProductConfigurationBatch() throws Exception {
 		super.testDeleteProductConfigurationBatch();
 	}
 
-	@FeatureFlags("LPD-10889")
+	@FeatureFlag("LPD-10889")
 	@Override
 	@Test
 	public void testDeleteProductConfigurationByExternalReferenceCode()
@@ -114,7 +114,7 @@ public class ProductConfigurationResourceTest
 		super.testDeleteProductConfigurationByExternalReferenceCode();
 	}
 
-	@FeatureFlags("LPD-10889")
+	@FeatureFlag("LPD-10889")
 	@Override
 	@Test
 	public void testGetProductByExternalReferenceCodeConfiguration()
@@ -123,14 +123,14 @@ public class ProductConfigurationResourceTest
 		super.testGetProductByExternalReferenceCodeConfiguration();
 	}
 
-	@FeatureFlags("LPD-10889")
+	@FeatureFlag("LPD-10889")
 	@Override
 	@Test
 	public void testGetProductConfiguration() throws Exception {
 		super.testGetProductConfiguration();
 	}
 
-	@FeatureFlags("LPD-10889")
+	@FeatureFlag("LPD-10889")
 	@Override
 	@Test
 	public void testGetProductConfigurationByExternalReferenceCode()
@@ -139,7 +139,7 @@ public class ProductConfigurationResourceTest
 		super.testGetProductConfigurationByExternalReferenceCode();
 	}
 
-	@FeatureFlags("LPD-10889")
+	@FeatureFlag("LPD-10889")
 	@Override
 	@Test
 	public void testGetProductConfigurationListByExternalReferenceCodeProductConfigurationsPage()
@@ -149,7 +149,7 @@ public class ProductConfigurationResourceTest
 			testGetProductConfigurationListByExternalReferenceCodeProductConfigurationsPage();
 	}
 
-	@FeatureFlags("LPD-10889")
+	@FeatureFlag("LPD-10889")
 	@Override
 	@Test
 	public void testGetProductConfigurationListByExternalReferenceCodeProductConfigurationsPageWithFilterDateTimeEquals()
@@ -159,7 +159,7 @@ public class ProductConfigurationResourceTest
 			testGetProductConfigurationListByExternalReferenceCodeProductConfigurationsPageWithFilterDateTimeEquals();
 	}
 
-	@FeatureFlags("LPD-10889")
+	@FeatureFlag("LPD-10889")
 	@Override
 	@Test
 	public void testGetProductConfigurationListByExternalReferenceCodeProductConfigurationsPageWithPagination()
@@ -169,7 +169,7 @@ public class ProductConfigurationResourceTest
 			testGetProductConfigurationListByExternalReferenceCodeProductConfigurationsPageWithPagination();
 	}
 
-	@FeatureFlags("LPD-10889")
+	@FeatureFlag("LPD-10889")
 	@Override
 	@Test
 	public void testGetProductConfigurationListIdProductConfigurationsPage()
@@ -178,7 +178,7 @@ public class ProductConfigurationResourceTest
 		super.testGetProductConfigurationListIdProductConfigurationsPage();
 	}
 
-	@FeatureFlags("LPD-10889")
+	@FeatureFlag("LPD-10889")
 	@Override
 	@Test
 	public void testGetProductConfigurationListIdProductConfigurationsPageWithPagination()
@@ -188,21 +188,21 @@ public class ProductConfigurationResourceTest
 			testGetProductConfigurationListIdProductConfigurationsPageWithPagination();
 	}
 
-	@FeatureFlags("LPD-10889")
+	@FeatureFlag("LPD-10889")
 	@Override
 	@Test
 	public void testGetProductIdConfiguration() throws Exception {
 		super.testGetProductIdConfiguration();
 	}
 
-	@FeatureFlags("LPD-10889")
+	@FeatureFlag("LPD-10889")
 	@Override
 	@Test
 	public void testGraphQLDeleteProductConfiguration() throws Exception {
 		super.testGraphQLDeleteProductConfiguration();
 	}
 
-	@FeatureFlags("LPD-10889")
+	@FeatureFlag("LPD-10889")
 	@Override
 	@Test
 	public void testGraphQLGetProductByExternalReferenceCodeConfiguration()
@@ -211,7 +211,7 @@ public class ProductConfigurationResourceTest
 		super.testGraphQLGetProductByExternalReferenceCodeConfiguration();
 	}
 
-	@FeatureFlags("LPD-10889")
+	@FeatureFlag("LPD-10889")
 	@Override
 	@Test
 	public void testGraphQLGetProductByExternalReferenceCodeConfigurationNotFound()
@@ -221,14 +221,14 @@ public class ProductConfigurationResourceTest
 			testGraphQLGetProductByExternalReferenceCodeConfigurationNotFound();
 	}
 
-	@FeatureFlags("LPD-10889")
+	@FeatureFlag("LPD-10889")
 	@Override
 	@Test
 	public void testGraphQLGetProductConfiguration() throws Exception {
 		super.testGraphQLGetProductConfiguration();
 	}
 
-	@FeatureFlags("LPD-10889")
+	@FeatureFlag("LPD-10889")
 	@Override
 	@Test
 	public void testGraphQLGetProductConfigurationByExternalReferenceCode()
@@ -237,14 +237,14 @@ public class ProductConfigurationResourceTest
 		super.testGraphQLGetProductConfigurationByExternalReferenceCode();
 	}
 
-	@FeatureFlags("LPD-10889")
+	@FeatureFlag("LPD-10889")
 	@Override
 	@Test
 	public void testGraphQLGetProductIdConfiguration() throws Exception {
 		super.testGraphQLGetProductIdConfiguration();
 	}
 
-	@FeatureFlags("LPD-10889")
+	@FeatureFlag("LPD-10889")
 	@Override
 	@Test
 	public void testGraphQLGetProductIdConfigurationNotFound()
@@ -300,14 +300,14 @@ public class ProductConfigurationResourceTest
 			).build());
 	}
 
-	@FeatureFlags("LPD-10889")
+	@FeatureFlag("LPD-10889")
 	@Override
 	@Test
 	public void testPatchProductConfiguration() throws Exception {
 		super.testPatchProductConfiguration();
 	}
 
-	@FeatureFlags("LPD-10889")
+	@FeatureFlag("LPD-10889")
 	@Override
 	@Test
 	public void testPatchProductConfigurationByExternalReferenceCode()
@@ -355,7 +355,7 @@ public class ProductConfigurationResourceTest
 			).build());
 	}
 
-	@FeatureFlags("LPD-10889")
+	@FeatureFlag("LPD-10889")
 	@Override
 	@Test
 	public void testPostProductConfigurationListByExternalReferenceCodeProductConfiguration()
@@ -365,7 +365,7 @@ public class ProductConfigurationResourceTest
 			testPostProductConfigurationListByExternalReferenceCodeProductConfiguration();
 	}
 
-	@FeatureFlags("LPD-10889")
+	@FeatureFlag("LPD-10889")
 	@Override
 	@Test
 	public void testPostProductConfigurationListIdProductConfiguration()

--- a/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceDBPartitionTest.java
+++ b/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceDBPartitionTest.java
@@ -65,7 +65,7 @@ import com.liferay.portal.service.impl.ClassNameLocalServiceImpl;
 import com.liferay.portal.service.impl.CompanyLocalServiceImpl;
 import com.liferay.portal.service.impl.ResourceActionLocalServiceImpl;
 import com.liferay.portal.spring.aop.AopInvocationHandler;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -264,7 +264,7 @@ public class CompanyLocalServiceDBPartitionTest
 		}
 	}
 
-	@FeatureFlags("LPD-11342")
+	@FeatureFlag("LPD-11342")
 	@Test
 	public void testAddDBPartitionCompany() throws Exception {
 		Company company = CompanyTestUtil.addCompany();
@@ -342,7 +342,7 @@ public class CompanyLocalServiceDBPartitionTest
 		}
 	}
 
-	@FeatureFlags("LPD-11342")
+	@FeatureFlag("LPD-11342")
 	@Test
 	public void testAddDBPartitionCompanyWhenCompanyLocalServiceFails()
 		throws Exception {
@@ -395,7 +395,7 @@ public class CompanyLocalServiceDBPartitionTest
 		}
 	}
 
-	@FeatureFlags("LPD-11342")
+	@FeatureFlag("LPD-11342")
 	@Test
 	public void testAddDBPartitionCompanyWhenDBPartitionUtilFails()
 		throws Exception {
@@ -480,7 +480,7 @@ public class CompanyLocalServiceDBPartitionTest
 		}
 	}
 
-	@FeatureFlags("LPD-11342")
+	@FeatureFlag("LPD-11342")
 	@Test
 	public void testCopyDBPartitionCompany() throws Exception {
 		int rulesCount = _getRulesCount(defaultPartitionName);
@@ -572,7 +572,7 @@ public class CompanyLocalServiceDBPartitionTest
 		}
 	}
 
-	@FeatureFlags("LPD-11342")
+	@FeatureFlag("LPD-11342")
 	@Test
 	public void testCopyDBPartitionCompanyWhenCompanyLocalServiceFails()
 		throws Exception {
@@ -607,7 +607,7 @@ public class CompanyLocalServiceDBPartitionTest
 		}
 	}
 
-	@FeatureFlags("LPD-11342")
+	@FeatureFlag("LPD-11342")
 	@Test
 	public void testCopyDBPartitionCompanyWhenDBPartitionUtilFails()
 		throws Exception {

--- a/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceTest.java
+++ b/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceTest.java
@@ -107,7 +107,7 @@ import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -953,7 +953,7 @@ public class CompanyLocalServiceTest {
 		_companyLocalService.deleteCompany(companyId);
 	}
 
-	@FeatureFlags("LPD-11342")
+	@FeatureFlag("LPD-11342")
 	@Test
 	public void testExtractCompany() throws Exception {
 		Assume.assumeTrue(_db.isSupportsDBPartition());
@@ -1006,7 +1006,7 @@ public class CompanyLocalServiceTest {
 		}
 	}
 
-	@FeatureFlags("LPD-11342")
+	@FeatureFlag("LPD-11342")
 	@Test
 	public void testExtractCompanyDefaultCompany() {
 		Assume.assumeTrue(_db.isSupportsDBPartition());
@@ -1022,7 +1022,7 @@ public class CompanyLocalServiceTest {
 		}
 	}
 
-	@FeatureFlags("LPD-11342")
+	@FeatureFlag("LPD-11342")
 	@Test
 	public void testExtractCompanyWhenDBPartitionUtilFails() throws Exception {
 		Assume.assumeTrue(_db.isSupportsDBPartition());

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/instance/lifecycle/test/DepotRolesPortalInstanceLifecycleListenerTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/instance/lifecycle/test/DepotRolesPortalInstanceLifecycleListenerTest.java
@@ -20,7 +20,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -46,7 +46,7 @@ public class DepotRolesPortalInstanceLifecycleListenerTest {
 			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
 
-	@FeatureFlags("LPD-17564")
+	@FeatureFlag("LPD-17564")
 	@Test
 	public void testAddCompany() throws Exception {
 		Company company = null;

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/security/permission/contributor/test/DepotRoleContributorTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/security/permission/contributor/test/DepotRoleContributorTest.java
@@ -26,7 +26,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -57,7 +57,7 @@ public class DepotRoleContributorTest {
 		_group = GroupTestUtil.addGroup();
 	}
 
-	@FeatureFlags("LPD-17564")
+	@FeatureFlag("LPD-17564")
 	@Test
 	public void testCMSConsumerRoleAssignment() throws Exception {
 		Group group = GroupTestUtil.addGroup(

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/store/test/DLStoreStoreAreaTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/store/test/DLStoreStoreAreaTest.java
@@ -22,7 +22,7 @@ import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -41,7 +41,7 @@ import org.osgi.service.cm.ConfigurationAdmin;
 /**
  * @author Adolfo Pérez
  */
-@FeatureFlags("LPS-174816")
+@FeatureFlag("LPS-174816")
 @RunWith(Arquillian.class)
 public class DLStoreStoreAreaTest {
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/test/DDMStructureServiceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/test/DDMStructureServiceTest.java
@@ -38,7 +38,7 @@ import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.search.test.rule.SearchTestRule;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.TransactionalTestRule;
@@ -57,7 +57,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Rafael Praxedes
  */
-@FeatureFlags("LPD-34651")
+@FeatureFlag("LPD-34651")
 @RunWith(Arquillian.class)
 public class DDMStructureServiceTest extends BaseDDMServiceTestCase {
 

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutExportImportTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutExportImportTest.java
@@ -55,7 +55,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.segments.service.SegmentsExperienceLocalService;
@@ -630,7 +630,7 @@ public class LayoutExportImportTest extends BaseExportImportTestCase {
 		_assertNewFriendlyURL(layoutB, friendlyURLA);
 	}
 
-	@FeatureFlags("LPS-199086")
+	@FeatureFlag("LPS-199086")
 	@Test
 	public void testLayoutExportImportWithChildLayoutReferencedWithButtonAndChildLayoutHasParentLayout()
 		throws Exception {
@@ -693,7 +693,7 @@ public class LayoutExportImportTest extends BaseExportImportTestCase {
 		Assert.assertNotNull(importedLayout);
 	}
 
-	@FeatureFlags("LPS-199086")
+	@FeatureFlag("LPS-199086")
 	@Test
 	@TestInfo("LPD-6808: AC9-AC10")
 	public void testLayoutExportImportWithModifiedContentAndExistingParentAndChildLayoutsOnImportSide()
@@ -777,7 +777,7 @@ public class LayoutExportImportTest extends BaseExportImportTestCase {
 			).size());
 	}
 
-	@FeatureFlags("LPS-199086")
+	@FeatureFlag("LPS-199086")
 	@Test
 	@TestInfo("LPD-6808: AC9-AC11")
 	public void testLayoutExportImportWithModifiedContentAndNonexistentParentAndChildLayoutsOnImportSide()
@@ -823,7 +823,7 @@ public class LayoutExportImportTest extends BaseExportImportTestCase {
 		Assert.assertNotNull(importedChildLayout);
 	}
 
-	@FeatureFlags("LPS-199086")
+	@FeatureFlag("LPS-199086")
 	@Test
 	@TestInfo("LPD-6808: AC12-AC13")
 	public void testLayoutExportImportWithUncheckedConfigurationAndModifiedContentAndExistingParentAndChildLayoutsOnImportSide()
@@ -907,7 +907,7 @@ public class LayoutExportImportTest extends BaseExportImportTestCase {
 			).size());
 	}
 
-	@FeatureFlags("LPS-199086")
+	@FeatureFlag("LPS-199086")
 	@Test
 	@TestInfo("LPD-6808: AC12-AC14")
 	public void testLayoutExportImportWithUncheckedConfigurationAndModifiedContentAndNonexistentParentAndChildLayoutsOnImportSide()

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
@@ -86,7 +86,7 @@ import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.model.impl.ThemeSettingImpl;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.segments.service.SegmentsExperienceLocalService;
@@ -896,7 +896,7 @@ public class LayoutSetPrototypePropagationTest
 				userGroup.getGroupId(), true));
 	}
 
-	@FeatureFlags(enable = false, value = "LPD-38869")
+	@FeatureFlag(enable = false, value = "LPD-38869")
 	@Test
 	public void testThemeSettingsAfterLayoutPropagation() throws Exception {
 		LayoutSet prototypePrivateLayoutSet =
@@ -933,7 +933,7 @@ public class LayoutSetPrototypePropagationTest
 			propagatedLayoutSet.getThemeId());
 	}
 
-	@FeatureFlags("LPD-38869")
+	@FeatureFlag("LPD-38869")
 	@Test
 	public void testThemeSettingsAfterLayoutPropagationWithPrivateLinkEnabled()
 		throws Exception {
@@ -1003,7 +1003,7 @@ public class LayoutSetPrototypePropagationTest
 		}
 	}
 
-	@FeatureFlags("LPD-38869")
+	@FeatureFlag("LPD-38869")
 	@Test
 	public void testThemeSettingsAfterLayoutPropagationWithPublicLinkEnabled()
 		throws Exception {

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-test/src/testIntegration/java/com/liferay/fragment/collection/contributor/basic/component/test/BasicComponentFragmentCollectionContributorTest.java
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-test/src/testIntegration/java/com/liferay/fragment/collection/contributor/basic/component/test/BasicComponentFragmentCollectionContributorTest.java
@@ -30,7 +30,7 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -57,7 +57,7 @@ import org.springframework.mock.web.MockHttpServletResponse;
 /**
  * @author Víctor Galán
  */
-@FeatureFlags("LPD-17564")
+@FeatureFlag("LPD-17564")
 @RunWith(Arquillian.class)
 public class BasicComponentFragmentCollectionContributorTest {
 

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-editable-test/src/testIntegration/java/com/liferay/fragment/entry/processor/editable/test/EditableFragmentEntryProcessorTest.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-editable-test/src/testIntegration/java/com/liferay/fragment/entry/processor/editable/test/EditableFragmentEntryProcessorTest.java
@@ -101,7 +101,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -790,7 +790,7 @@ public class EditableFragmentEntryProcessorTest {
 		Assert.assertEquals(labelMap.get(LocaleUtil.SPAIN), textNode.text());
 	}
 
-	@FeatureFlags("LPD-39437")
+	@FeatureFlag("LPD-39437")
 	@Test
 	public void testFragmentEntryProcessorEditableAssertAnalyticsAttributesWithMappedImageInViewMode()
 		throws Exception {
@@ -853,7 +853,7 @@ public class EditableFragmentEntryProcessorTest {
 			element.attr("data-analytics-asset-type"));
 	}
 
-	@FeatureFlags("LPD-39437")
+	@FeatureFlag("LPD-39437")
 	@Test
 	public void testFragmentEntryProcessorEditableAssertAnalyticsAttributesWithMappedTextInEditMode()
 		throws Exception {
@@ -902,7 +902,7 @@ public class EditableFragmentEntryProcessorTest {
 		Assert.assertTrue(attribute.isEmpty());
 	}
 
-	@FeatureFlags("LPD-39437")
+	@FeatureFlag("LPD-39437")
 	@Test
 	public void testFragmentEntryProcessorEditableAssertAnalyticsAttributesWithMappedTextInViewMode()
 		throws Exception {

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-test/src/testIntegration/java/com/liferay/fragment/entry/processor/internal/util/test/FragmentEntryProcessorHelperTest.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-test/src/testIntegration/java/com/liferay/fragment/entry/processor/internal/util/test/FragmentEntryProcessorHelperTest.java
@@ -85,7 +85,7 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LogEntry;
 import com.liferay.portal.test.log.LoggerTestUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -664,7 +664,7 @@ public class FragmentEntryProcessorHelperTest {
 				LocaleUtil.US));
 	}
 
-	@FeatureFlags("LPD-19955")
+	@FeatureFlag("LPD-19955")
 	@Test
 	@TestInfo({"LPD-12834", "LPD-52354"})
 	public void testHasViewPermission() throws Exception {

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/input/template/parser/test/FragmentEntryInputTemplateNodeContextHelperTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/input/template/parser/test/FragmentEntryInputTemplateNodeContextHelperTest.java
@@ -81,6 +81,7 @@ import com.liferay.portal.kernel.util.MimeTypesUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TempFileEntryUtil;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -370,7 +371,11 @@ public class FragmentEntryInputTemplateNodeContextHelperTest {
 		}
 	}
 
-	@FeatureFlags({"LPD-32050", "LPD-37927"})
+	@FeatureFlags(
+		featureFlags = {
+			@FeatureFlag(value = "LPD-32050"), @FeatureFlag(value = "LPD-37927")
+		}
+	)
 	@Test
 	public void testToInputTemplateNodeLocalizedInputValue() throws Exception {
 		ObjectDefinition objectDefinition =

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/renderer/test/ContentObjectFragmentRendererTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/renderer/test/ContentObjectFragmentRendererTest.java
@@ -58,7 +58,7 @@ import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.struts.Definition;
 import com.liferay.portal.struts.TilesUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -114,7 +114,7 @@ public class ContentObjectFragmentRendererTest {
 		ServiceContextThreadLocal.popServiceContext();
 	}
 
-	@FeatureFlags("LPD-39437")
+	@FeatureFlag("LPD-39437")
 	@Test
 	public void testRenderAssertAnalyticsAttributesInEditMode()
 		throws Exception {
@@ -125,7 +125,7 @@ public class ContentObjectFragmentRendererTest {
 		Assert.assertFalse(content.contains("data-analytics-asset-action"));
 	}
 
-	@FeatureFlags("LPD-39437")
+	@FeatureFlag("LPD-39437")
 	@Test
 	public void testRenderAssertAnalyticsAttributesInViewMode()
 		throws Exception {

--- a/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/display/context/FragmentDisplayContextTest.java
+++ b/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/display/context/FragmentDisplayContextTest.java
@@ -13,7 +13,7 @@ import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import javax.portlet.RenderRequest;
@@ -34,7 +34,7 @@ import org.mockito.Mockito;
 /**
  * @author Bárbara Cabrera
  */
-@FeatureFlags("LPD-34938")
+@FeatureFlag("LPD-34938")
 public class FragmentDisplayContextTest {
 
 	@ClassRule

--- a/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/servlet/taglib/util/BasicFragmentCompositionActionDropdownItemsProviderTest.java
+++ b/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/servlet/taglib/util/BasicFragmentCompositionActionDropdownItemsProviderTest.java
@@ -6,7 +6,7 @@
 package com.liferay.fragment.web.internal.servlet.taglib.util;
 
 import com.liferay.fragment.model.FragmentComposition;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import org.junit.ClassRule;
@@ -43,7 +43,7 @@ public class BasicFragmentCompositionActionDropdownItemsProviderTest
 			"change-thumbnail", "rename", "export", "move", "delete");
 	}
 
-	@FeatureFlags("LPD-34938")
+	@FeatureFlag("LPD-34938")
 	@Test
 	public void testGetActionDropdownItemsForMarketplaceFragmentComposition()
 		throws Exception {

--- a/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/servlet/taglib/util/BasicFragmentEntryActionDropdownItemsProviderTest.java
+++ b/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/servlet/taglib/util/BasicFragmentEntryActionDropdownItemsProviderTest.java
@@ -7,7 +7,7 @@ package com.liferay.fragment.web.internal.servlet.taglib.util;
 
 import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.portal.kernel.test.TestInfo;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import org.junit.ClassRule;
@@ -85,7 +85,7 @@ public class BasicFragmentEntryActionDropdownItemsProviderTest
 			"edit", "make-a-copy");
 	}
 
-	@FeatureFlags("LPD-34938")
+	@FeatureFlag("LPD-34938")
 	@Test
 	public void testGetActionDropdownItemstForMarketplaceFragmentEntry()
 		throws Exception {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/DisplayPageTemplateFolderResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/DisplayPageTemplateFolderResourceTest.java
@@ -18,7 +18,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.Validator;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -34,7 +34,7 @@ import org.junit.runner.RunWith;
  * @author Rubén Pulido
  * @author Bárbara Cabrera
  */
-@FeatureFlags("LPD-35443")
+@FeatureFlag("LPD-35443")
 @RunWith(Arquillian.class)
 public class DisplayPageTemplateFolderResourceTest
 	extends BaseDisplayPageTemplateFolderResourceTestCase {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/DisplayPageTemplateResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/DisplayPageTemplateResourceTest.java
@@ -59,7 +59,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -85,7 +85,7 @@ import org.junit.runner.RunWith;
  * @author Rubén Pulido
  * @author Lourdes Fernández Besada
  */
-@FeatureFlags("LPD-35443")
+@FeatureFlag("LPD-35443")
 @RunWith(Arquillian.class)
 public class DisplayPageTemplateResourceTest
 	extends BaseDisplayPageTemplateResourceTestCase {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/FriendlyUrlHistoryResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/FriendlyUrlHistoryResourceTest.java
@@ -28,7 +28,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -47,7 +47,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Rubén Pulido
  */
-@FeatureFlags("LPD-35443")
+@FeatureFlag("LPD-35443")
 @RunWith(Arquillian.class)
 public class FriendlyUrlHistoryResourceTest
 	extends BaseFriendlyUrlHistoryResourceTestCase {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/MasterPageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/MasterPageResourceTest.java
@@ -50,7 +50,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -71,7 +71,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Rubén Pulido
  */
-@FeatureFlags("LPD-35443")
+@FeatureFlag("LPD-35443")
 @RunWith(Arquillian.class)
 public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
@@ -30,7 +30,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.segments.constants.SegmentsExperienceConstants;
 import com.liferay.segments.model.SegmentsExperience;
@@ -45,7 +45,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Rubén Pulido
  */
-@FeatureFlags("LPD-35443")
+@FeatureFlag("LPD-35443")
 @RunWith(Arquillian.class)
 public class PageElementResourceTest extends BasePageElementResourceTestCase {
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageExperienceResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageExperienceResourceTest.java
@@ -14,7 +14,7 @@ import com.liferay.headless.admin.site.client.problem.Problem;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.segments.service.SegmentsExperienceLocalService;
 import com.liferay.segments.test.util.SegmentsTestUtil;
@@ -29,7 +29,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Rubén Pulido
  */
-@FeatureFlags("LPD-35443")
+@FeatureFlag("LPD-35443")
 @RunWith(Arquillian.class)
 public class PageExperienceResourceTest
 	extends BasePageExperienceResourceTestCase {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageSpecificationResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageSpecificationResourceTest.java
@@ -49,7 +49,7 @@ import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -74,7 +74,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Rubén Pulido
  */
-@FeatureFlags("LPD-35443")
+@FeatureFlag("LPD-35443")
 @RunWith(Arquillian.class)
 public class PageSpecificationResourceTest
 	extends BasePageSpecificationResourceTestCase {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageTemplateResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageTemplateResourceTest.java
@@ -48,7 +48,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -68,7 +68,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Rubén Pulido
  */
-@FeatureFlags("LPD-35443")
+@FeatureFlag("LPD-35443")
 @RunWith(Arquillian.class)
 public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageTemplateSetResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageTemplateSetResourceTest.java
@@ -19,7 +19,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.Validator;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -34,7 +34,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Rubén Pulido
  */
-@FeatureFlags("LPD-35443")
+@FeatureFlag("LPD-35443")
 @RunWith(Arquillian.class)
 public class PageTemplateSetResourceTest
 	extends BasePageTemplateSetResourceTestCase {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
@@ -43,7 +43,7 @@ import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.Validator;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -68,7 +68,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Rubén Pulido
  */
-@FeatureFlags("LPD-35443")
+@FeatureFlag("LPD-35443")
 @RunWith(Arquillian.class)
 public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/UtilityPageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/UtilityPageResourceTest.java
@@ -39,7 +39,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -62,7 +62,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Rubén Pulido
  */
-@FeatureFlags("LPD-35443")
+@FeatureFlag("LPD-35443")
 @RunWith(Arquillian.class)
 public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/WidgetPageWidgetInstanceResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/WidgetPageWidgetInstanceResourceTest.java
@@ -15,7 +15,7 @@ import com.liferay.portal.kernel.model.LayoutTypePortlet;
 import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 
 import org.junit.Assert;
@@ -26,7 +26,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Rubén Pulido
  */
-@FeatureFlags("LPD-35443")
+@FeatureFlag("LPD-35443")
 @RunWith(Arquillian.class)
 public class WidgetPageWidgetInstanceResourceTest
 	extends BaseWidgetPageWidgetInstanceResourceTestCase {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/KeywordResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/KeywordResourceTest.java
@@ -27,7 +27,7 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.util.PropsValues;
 
@@ -43,7 +43,7 @@ import org.junit.runner.RunWith;
  * @author Javier Gamarra
  */
 @DataGuard(scope = DataGuard.Scope.METHOD)
-@FeatureFlags("LPD-17564")
+@FeatureFlag("LPD-17564")
 @RunWith(Arquillian.class)
 public class KeywordResourceTest extends BaseKeywordResourceTestCase {
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
@@ -37,7 +37,7 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.util.PropsValues;
 
@@ -57,7 +57,7 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
  * @author Javier Gamarra
  */
 @DataGuard(scope = DataGuard.Scope.METHOD)
-@FeatureFlags("LPD-17564")
+@FeatureFlag("LPD-17564")
 @RunWith(Arquillian.class)
 public class TaxonomyVocabularyResourceTest
 	extends BaseTaxonomyVocabularyResourceTestCase {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/AccountGroupResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/AccountGroupResourceTest.java
@@ -55,7 +55,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.portal.vulcan.permission.PermissionUtil;
@@ -124,7 +124,7 @@ public class AccountGroupResourceTest extends BaseAccountGroupResourceTestCase {
 		_testPatchAccountGroupByExternalReferenceCodeWithoutName();
 	}
 
-	@FeatureFlags("LPD-47858")
+	@FeatureFlag("LPD-47858")
 	@Override
 	@Test
 	public void testPostAccountGroup() throws Exception {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/AccountResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/AccountResourceTest.java
@@ -87,7 +87,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.portal.vulcan.permission.PermissionUtil;
@@ -465,7 +465,7 @@ public class AccountResourceTest extends BaseAccountResourceTestCase {
 					organization2.getOrganizationId()));
 	}
 
-	@FeatureFlags("LPD-47858")
+	@FeatureFlag("LPD-47858")
 	@Override
 	@Test
 	public void testPostAccount() throws Exception {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/RoleResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/RoleResourceTest.java
@@ -46,7 +46,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.SynchronousMailTestRule;
 import com.liferay.portal.util.PropsValues;
@@ -258,7 +258,7 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 		}
 	}
 
-	@FeatureFlags("LPD-47858")
+	@FeatureFlag("LPD-47858")
 	@Override
 	@Test
 	public void testPostRole() throws Exception {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/SharedAssetResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/SharedAssetResourceTest.java
@@ -41,7 +41,7 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MimeTypesUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -65,7 +65,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Javier Gamarra
  */
-@FeatureFlags("LPD-17564")
+@FeatureFlag("LPD-17564")
 @RunWith(Arquillian.class)
 public class SharedAssetResourceTest extends BaseSharedAssetResourceTestCase {
 

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/AssetLibraryResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/AssetLibraryResourceTest.java
@@ -17,7 +17,7 @@ import com.liferay.portal.kernel.service.UserGroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.odata.entity.EntityField;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 
 import java.util.ArrayList;
@@ -30,7 +30,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Roberto Díaz
  */
-@FeatureFlags("LPD-17564")
+@FeatureFlag("LPD-17564")
 @RunWith(Arquillian.class)
 public class AssetLibraryResourceTest extends BaseAssetLibraryResourceTestCase {
 

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/SiteResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/SiteResourceTest.java
@@ -10,7 +10,7 @@ import com.liferay.headless.asset.library.client.dto.v1_0.Site;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
 import java.util.ArrayList;
@@ -22,7 +22,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Roberto Díaz
  */
-@FeatureFlags("LPD-17564")
+@FeatureFlag("LPD-17564")
 @RunWith(Arquillian.class)
 public class SiteResourceTest extends BaseSiteResourceTestCase {
 

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserAccountResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserAccountResourceTest.java
@@ -11,7 +11,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.odata.entity.EntityField;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -22,7 +22,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Roberto Díaz
  */
-@FeatureFlags("LPD-17564")
+@FeatureFlag("LPD-17564")
 @RunWith(Arquillian.class)
 public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserGroupResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/UserGroupResourceTest.java
@@ -14,7 +14,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.odata.entity.EntityField;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 
 import java.util.ArrayList;
@@ -28,7 +28,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Roberto Díaz
  */
-@FeatureFlags("LPD-17564")
+@FeatureFlag("LPD-17564")
 @RunWith(Arquillian.class)
 public class UserGroupResourceTest extends BaseUserGroupResourceTestCase {
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/application/provider/test/APIApplicationProviderTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/application/provider/test/APIApplicationProviderTest.java
@@ -15,7 +15,7 @@ import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.Http;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -30,7 +30,7 @@ import org.junit.Test;
 /**
  * @author Alejandro Tardín
  */
-@FeatureFlags("LPS-178642")
+@FeatureFlag("LPS-178642")
 public class APIApplicationProviderTest extends BaseTestCase {
 
 	@ClassRule

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/instance/lifecycle/test/APIApplicationPublisherPortalInstanceLifecycleListenerTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/instance/lifecycle/test/APIApplicationPublisherPortalInstanceLifecycleListenerTest.java
@@ -19,7 +19,7 @@ import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -35,7 +35,7 @@ import org.osgi.util.promise.Promise;
 /**
  * @author Carlos Correa
  */
-@FeatureFlags("LPS-178642")
+@FeatureFlag("LPS-178642")
 public class APIApplicationPublisherPortalInstanceLifecycleListenerTest
 	extends BaseTestCase {
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/internal/upgrade/v0_1_0/test/APIPropertiesToAPIPropertiesUpgradeProcessTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/internal/upgrade/v0_1_0/test/APIPropertiesToAPIPropertiesUpgradeProcessTest.java
@@ -18,7 +18,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.SystemProperties;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -40,7 +40,7 @@ import org.springframework.util.Assert;
 /**
  * @author Alejandro Tardín
  */
-@FeatureFlags("LPS-178642")
+@FeatureFlag("LPS-178642")
 public class APIPropertiesToAPIPropertiesUpgradeProcessTest
 	extends BaseTestCase {
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/internal/upgrade/v0_2_0/test/ListTypeDefinitionsUpgradeProcessTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/internal/upgrade/v0_2_0/test/ListTypeDefinitionsUpgradeProcessTest.java
@@ -24,7 +24,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.zip.ZipWriter;
 import com.liferay.portal.kernel.zip.ZipWriterFactory;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
@@ -53,7 +53,7 @@ import org.osgi.framework.FrameworkUtil;
 /**
  * @author Alberto Javier Moreno Lage
  */
-@FeatureFlags("LPS-178642")
+@FeatureFlag("LPS-178642")
 @RunWith(Arquillian.class)
 public class ListTypeDefinitionsUpgradeProcessTest {
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APIApplicationPublisherObjectEntryModelListenerTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APIApplicationPublisherObjectEntryModelListenerTest.java
@@ -13,14 +13,14 @@ import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 
 import org.junit.Test;
 
 /**
  * @author Sergio Jiménez del Coso
  */
-@FeatureFlags("LPS-178642")
+@FeatureFlag("LPS-178642")
 public class APIApplicationPublisherObjectEntryModelListenerTest
 	extends BaseTestCase {
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APIApplicationRelevantObjectEntryModelListenerTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APIApplicationRelevantObjectEntryModelListenerTest.java
@@ -13,7 +13,7 @@ import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -24,7 +24,7 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 /**
  * @author Sergio Jiménez del Coso
  */
-@FeatureFlags("LPS-178642")
+@FeatureFlag("LPS-178642")
 public class APIApplicationRelevantObjectEntryModelListenerTest
 	extends BaseTestCase {
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APIEndpointRelevantObjectEntryModelListenerTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APIEndpointRelevantObjectEntryModelListenerTest.java
@@ -23,7 +23,7 @@ import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 
 import java.util.Collections;
 
@@ -36,7 +36,7 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 /**
  * @author Sergio Jiménez del Coso
  */
-@FeatureFlags("LPS-178642")
+@FeatureFlag("LPS-178642")
 public class APIEndpointRelevantObjectEntryModelListenerTest
 	extends BaseTestCase {
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APIFilterRelevantObjectEntryModelListenerTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APIFilterRelevantObjectEntryModelListenerTest.java
@@ -19,7 +19,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TextFormatter;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import org.junit.Before;
@@ -34,7 +34,7 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
  * @author Alberto Javier Moreno Lage
  */
 @DataGuard(scope = DataGuard.Scope.METHOD)
-@FeatureFlags("LPS-178642")
+@FeatureFlag("LPS-178642")
 public class APIFilterRelevantObjectEntryModelListenerTest
 	extends BaseTestCase {
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APIPropertyRelevantObjectEntryModelListenerTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APIPropertyRelevantObjectEntryModelListenerTest.java
@@ -26,7 +26,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 
 import java.util.Arrays;
@@ -41,7 +41,7 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 /**
  * @author Sergio Jiménez del Coso
  */
-@FeatureFlags("LPS-178642")
+@FeatureFlag("LPS-178642")
 public class APIPropertyRelevantObjectEntryModelListenerTest
 	extends BaseTestCase {
 
@@ -294,7 +294,7 @@ public class APIPropertyRelevantObjectEntryModelListenerTest
 			apiPropertiesJSONArray.toString(), JSONCompareMode.LENIENT);
 	}
 
-	@FeatureFlags("LPD-10964")
+	@FeatureFlag("LPD-10964")
 	@Test
 	public void testAddRecordAPIProperty() throws Exception {
 		JSONObject apiApplicationJSONObject = HTTPTestUtil.invokeToJSONObject(

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APISchemaRelevantObjectEntryModelListenerTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APISchemaRelevantObjectEntryModelListenerTest.java
@@ -19,7 +19,7 @@ import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 
 import java.util.Collections;
 
@@ -30,7 +30,7 @@ import org.junit.Test;
 /**
  * @author Sergio Jiménez del Coso
  */
-@FeatureFlags("LPS-178642")
+@FeatureFlag("LPS-178642")
 public class APISchemaRelevantObjectEntryModelListenerTest
 	extends BaseTestCase {
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APISortRelevantObjectEntryModelListenerTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/model/listener/test/APISortRelevantObjectEntryModelListenerTest.java
@@ -19,7 +19,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TextFormatter;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import org.junit.Before;
@@ -34,7 +34,7 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
  * @author Sergio Jiménez del Coso
  */
 @DataGuard(scope = DataGuard.Scope.METHOD)
-@FeatureFlags("LPS-178642")
+@FeatureFlag("LPS-178642")
 public class APISortRelevantObjectEntryModelListenerTest extends BaseTestCase {
 
 	@ClassRule

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderOpenAPIResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderOpenAPIResourceTest.java
@@ -52,6 +52,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
@@ -73,7 +74,11 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
  * @author Carlos Correa
  */
 @DataGuard(scope = DataGuard.Scope.METHOD)
-@FeatureFlags({"LPD-10964", "LPS-178642"})
+@FeatureFlags(
+	featureFlags = {
+		@FeatureFlag(value = "LPD-10964"), @FeatureFlag(value = "LPS-178642")
+	}
+)
 @RunWith(Arquillian.class)
 public class HeadlessBuilderOpenAPIResourceTest extends BaseTestCase {
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderResourceTest.java
@@ -80,7 +80,7 @@ import com.liferay.portal.security.service.access.policy.model.SAPEntry;
 import com.liferay.portal.security.service.access.policy.service.SAPEntryLocalService;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.util.PropsValues;
@@ -111,7 +111,7 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
  * @author Luis Miguel Barcos
  */
 @DataGuard(scope = DataGuard.Scope.METHOD)
-@FeatureFlags("LPS-178642")
+@FeatureFlag("LPS-178642")
 public class HeadlessBuilderResourceTest extends BaseTestCase {
 
 	@ClassRule
@@ -1525,7 +1525,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 			JSONCompareMode.LENIENT);
 	}
 
-	@FeatureFlags("LPD-10964")
+	@FeatureFlag("LPD-10964")
 	@Test
 	public void testGetWithRecordProperty() throws Exception {
 		_addAPIApplicationWithRecordProperty(
@@ -2646,7 +2646,7 @@ public class HeadlessBuilderResourceTest extends BaseTestCase {
 		Assert.assertEquals(textPropertyValue, values.get("textField"));
 	}
 
-	@FeatureFlags("LPD-10964")
+	@FeatureFlag("LPD-10964")
 	@Test
 	public void testPostWithRecordProperty() throws Exception {
 		_addAPIApplicationWithRecordProperty(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/ContentSetElementResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/ContentSetElementResourceTest.java
@@ -28,7 +28,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.search.test.rule.SearchTestRule;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 
 import java.util.Collections;
@@ -69,7 +69,7 @@ public class ContentSetElementResourceTest
 			AssetListEntryTypeConstants.TYPE_DYNAMIC, _serviceContext);
 	}
 
-	@FeatureFlags("LPD-32867")
+	@FeatureFlag("LPD-32867")
 	@Override
 	@Test
 	public void testGetSiteContentSetProviderByKeyContentSetElementsPage()
@@ -86,7 +86,7 @@ public class ContentSetElementResourceTest
 		}
 	}
 
-	@FeatureFlags("LPD-32867")
+	@FeatureFlag("LPD-32867")
 	@Override
 	@Test
 	public void testGetSiteContentSetProviderByKeyContentSetElementsPageWithPagination()

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/DocumentMetadataSetResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/DocumentMetadataSetResourceTest.java
@@ -17,7 +17,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -35,7 +35,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Javier Gamarra
  */
-@FeatureFlags("LPD-34651")
+@FeatureFlag("LPD-34651")
 @RunWith(Arquillian.class)
 public class DocumentMetadataSetResourceTest
 	extends BaseDocumentMetadataSetResourceTestCase {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/SitePageResourceTest.java
@@ -105,7 +105,7 @@ import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LogEntry;
 import com.liferay.portal.test.log.LoggerTestUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.segments.constants.SegmentsEntryConstants;
@@ -136,7 +136,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Javier Gamarra
  */
-@FeatureFlags("LPS-178052")
+@FeatureFlag("LPS-178052")
 @RunWith(Arquillian.class)
 public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 
@@ -341,7 +341,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			sitePagesJSONObject.get("totalCount"));
 	}
 
-	@FeatureFlags("LPS-178052")
+	@FeatureFlag("LPS-178052")
 	@Override
 	@Test
 	public void testPostSiteSitePage() throws Exception {

--- a/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/CollaboratorResourceTest.java
+++ b/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/CollaboratorResourceTest.java
@@ -30,7 +30,7 @@ import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -53,7 +53,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Alicia García
  */
-@FeatureFlags("LPD-17564")
+@FeatureFlag("LPD-17564")
 @RunWith(Arquillian.class)
 public class CollaboratorResourceTest extends BaseCollaboratorResourceTestCase {
 

--- a/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/ObjectEntryFolderResourceTest.java
+++ b/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/ObjectEntryFolderResourceTest.java
@@ -24,7 +24,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.odata.entity.StringEntityField;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 
 import java.util.Collections;
@@ -38,7 +38,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Alicia García
  */
-@FeatureFlags("LPD-17564")
+@FeatureFlag("LPD-17564")
 @RunWith(Arquillian.class)
 public class ObjectEntryFolderResourceTest
 	extends BaseObjectEntryFolderResourceTestCase {

--- a/modules/apps/info/info-test/src/testIntegration/java/com/liferay/info/request/struts/test/EditInfoItemStrutsActionTest.java
+++ b/modules/apps/info/info-test/src/testIntegration/java/com/liferay/info/request/struts/test/EditInfoItemStrutsActionTest.java
@@ -93,7 +93,7 @@ import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LogEntry;
 import com.liferay.portal.test.log.LoggerTestUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.upload.test.util.UploadTestUtil;
@@ -160,7 +160,7 @@ public class EditInfoItemStrutsActionTest {
 		_layout = _addLayout();
 	}
 
-	@FeatureFlags("LPD-21926")
+	@FeatureFlag("LPD-21926")
 	@Test
 	@TestInfo("LPD-50584")
 	public void testAddAndUpdateInfoItemFriendlyURL() throws Exception {
@@ -374,7 +374,7 @@ public class EditInfoItemStrutsActionTest {
 			null, null);
 	}
 
-	@FeatureFlags("LPS-187754")
+	@FeatureFlag("LPS-187754")
 	@Test
 	public void testAddInfoItemWithDraftStatus() throws Exception {
 		_testAddInfoItem(

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/exportimport/data/handler/test/JournalExportImportTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/exportimport/data/handler/test/JournalExportImportTest.java
@@ -78,7 +78,7 @@ import com.liferay.portal.kernel.zip.ZipReaderFactory;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LogEntry;
 import com.liferay.portal.test.log.LoggerTestUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.staging.configuration.StagingConfiguration;
@@ -136,7 +136,7 @@ public class JournalExportImportTest extends BasePortletExportImportTestCase {
 		exportImportJournalArticle(true);
 	}
 
-	@FeatureFlags("LPS-199086")
+	@FeatureFlag("LPS-199086")
 	@Test
 	@TestInfo("LPD-6808: AC15-AC16")
 	public void testExportImportJournalArticleWithLayoutURLLayoutDoesNotExistOnImportSide()
@@ -187,7 +187,7 @@ public class JournalExportImportTest extends BasePortletExportImportTestCase {
 		}
 	}
 
-	@FeatureFlags("LPS-199086")
+	@FeatureFlag("LPS-199086")
 	@Test
 	@TestInfo("LPD-6808: AC15-AC17")
 	public void testExportImportJournalArticleWithLayoutURLLayoutExistOnImportSide()

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/display/context/test/JournalEditArticleDisplayContextTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/display/context/test/JournalEditArticleDisplayContextTest.java
@@ -30,7 +30,7 @@ import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -65,7 +65,7 @@ public class JournalEditArticleDisplayContextTest {
 		_user = TestPropsValues.getUser();
 	}
 
-	@FeatureFlags("LPD-11228")
+	@FeatureFlag("LPD-11228")
 	@Test
 	public void testIsShowPublishModal() throws Exception {
 		ServiceContext serviceContext =

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBArticleLocalServiceTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBArticleLocalServiceTest.java
@@ -55,7 +55,7 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -1059,7 +1059,7 @@ public class KBArticleLocalServiceTest {
 				KBArticleConstants.getClassName(), kbArticle.getClassPK()));
 	}
 
-	@FeatureFlags("LPD-11003")
+	@FeatureFlag("LPD-11003")
 	@Test
 	public void testDeleteKBArticleWithLock() throws PortalException {
 		KBArticle kbArticle = _addKbArticle();
@@ -1069,7 +1069,7 @@ public class KBArticleLocalServiceTest {
 			() -> _kbArticleLocalService.deleteKBArticle(kbArticle));
 	}
 
-	@FeatureFlags("LPD-11003")
+	@FeatureFlag("LPD-11003")
 	@Test
 	public void testDeleteKBArticleWithLockByPreviousUser() throws Exception {
 		KBArticle kbArticle = _addKbArticle();
@@ -1095,7 +1095,7 @@ public class KBArticleLocalServiceTest {
 			WorkflowConstants.STATUS_DRAFT, kbArticle.getStatus());
 	}
 
-	@FeatureFlags("LPD-11003")
+	@FeatureFlag("LPD-11003")
 	@Test
 	public void testExpireKBArticleWithLock() throws PortalException {
 		KBArticle kbArticle = _addKbArticle();
@@ -1107,7 +1107,7 @@ public class KBArticleLocalServiceTest {
 				_serviceContext));
 	}
 
-	@FeatureFlags("LPD-11003")
+	@FeatureFlag("LPD-11003")
 	@Test
 	public void testExpireKBArticleWithLockByPreviousUser() throws Exception {
 		KBArticle kbArticle = _addKbArticle();
@@ -1445,7 +1445,7 @@ public class KBArticleLocalServiceTest {
 			kbArticle.getParentResourcePrimKey());
 	}
 
-	@FeatureFlags("LPD-11003")
+	@FeatureFlag("LPD-11003")
 	@Test
 	public void testMoveKBArticleToTrashKBArticleWithLock()
 		throws PortalException {
@@ -1458,7 +1458,7 @@ public class KBArticleLocalServiceTest {
 				_user.getUserId(), kbArticle.getResourcePrimKey()));
 	}
 
-	@FeatureFlags("LPD-11003")
+	@FeatureFlag("LPD-11003")
 	@Test
 	public void testMoveKBArticleToTrashKBArticleWithLockByPreviousUser()
 		throws Exception {
@@ -1471,7 +1471,7 @@ public class KBArticleLocalServiceTest {
 				_user.getUserId(), kbArticle.getResourcePrimKey()));
 	}
 
-	@FeatureFlags("LPD-11003")
+	@FeatureFlag("LPD-11003")
 	@Test
 	public void testMoveKBArticleWithLock() throws PortalException {
 		KBArticle kbArticle = _addKbArticle();
@@ -1485,7 +1485,7 @@ public class KBArticleLocalServiceTest {
 				parentKBArticle.getPriority()));
 	}
 
-	@FeatureFlags("LPD-11003")
+	@FeatureFlag("LPD-11003")
 	@Test
 	public void testMoveKBArticleWithLockByPreviousUser() throws Exception {
 		KBArticle kbArticle = _addKbArticle();
@@ -1582,7 +1582,7 @@ public class KBArticleLocalServiceTest {
 		Assert.assertNull(latestKBArticle.getReviewDate());
 	}
 
-	@FeatureFlags("LPD-11003")
+	@FeatureFlag("LPD-11003")
 	@Test
 	public void testRevertKBArticleWithLock() throws PortalException {
 		KBArticle kbArticle = _addKbArticle();
@@ -1602,7 +1602,7 @@ public class KBArticleLocalServiceTest {
 				_serviceContext));
 	}
 
-	@FeatureFlags("LPD-11003")
+	@FeatureFlag("LPD-11003")
 	@Test
 	public void testRevertKBArticleWithLockByPreviousUser() throws Exception {
 		KBArticle kbArticle = _addKbArticle();
@@ -1622,7 +1622,7 @@ public class KBArticleLocalServiceTest {
 				_serviceContext));
 	}
 
-	@FeatureFlags("LPD-11003")
+	@FeatureFlag("LPD-11003")
 	@Test
 	public void testUpdateAndUnlockKBArticleWithPreviousLockByCurrentUser()
 		throws Exception {
@@ -1873,7 +1873,7 @@ public class KBArticleLocalServiceTest {
 		Assert.assertTrue(assetEntry.isVisible());
 	}
 
-	@FeatureFlags("LPD-11003")
+	@FeatureFlag("LPD-11003")
 	@Test
 	public void testUpdateKBArticleWithLockByPreviousUser() throws Exception {
 		KBArticle kbArticle = _addKbArticle();
@@ -1887,7 +1887,7 @@ public class KBArticleLocalServiceTest {
 				null, null, new ServiceContext()));
 	}
 
-	@FeatureFlags("LPD-11003")
+	@FeatureFlag("LPD-11003")
 	@Test
 	public void testUpdateKBArticleWithoutPreviousLock() throws Exception {
 		KBArticle kbArticle = _addKbArticle();
@@ -1903,7 +1903,7 @@ public class KBArticleLocalServiceTest {
 				_user.getUserId(), kbArticle.getResourcePrimKey()));
 	}
 
-	@FeatureFlags("LPD-11003")
+	@FeatureFlag("LPD-11003")
 	@Test
 	public void testUpdateKBArticleWithPreviousLockByCurrentUser()
 		throws Exception {

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBArticleServiceTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/test/KBArticleServiceTest.java
@@ -27,7 +27,7 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -67,7 +67,7 @@ public class KBArticleServiceTest {
 		_testPortletId = "TEST_PORTLET_" + RandomTestUtil.randomString();
 	}
 
-	@FeatureFlags("LPD-11003")
+	@FeatureFlag("LPD-11003")
 	@Test
 	public void testForceLockKBArticle() throws Exception {
 		KBArticle kbArticle = _addKbArticle(new Date());

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/sidebar/panel/test/PageRulesPageEditorSidebarPanelTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/sidebar/panel/test/PageRulesPageEditorSidebarPanelTest.java
@@ -24,7 +24,7 @@ import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -39,7 +39,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Eudaldo Alonso
  */
-@FeatureFlags("LPS-169837")
+@FeatureFlag("LPS-169837")
 @RunWith(Arquillian.class)
 public class PageRulesPageEditorSidebarPanelTest {
 

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/ExportImportLayoutPageTemplateEntriesTest.java
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/ExportImportLayoutPageTemplateEntriesTest.java
@@ -85,7 +85,7 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.zip.ZipWriter;
 import com.liferay.portal.kernel.zip.ZipWriterFactory;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -1176,7 +1176,7 @@ public class ExportImportLayoutPageTemplateEntriesTest {
 		_validateImportExport(expectedFile, inputFile);
 	}
 
-	@FeatureFlags("LPD-37927")
+	@FeatureFlag("LPD-37927")
 	@Test
 	public void testImportExportLayoutPageTemplateEntryLocalizationConfig()
 		throws Exception {

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/test/LayoutImplTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/test/LayoutImplTest.java
@@ -30,7 +30,7 @@ import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.model.impl.LayoutTypeControllerImpl;
 import com.liferay.portal.model.impl.ThemeSettingImpl;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -369,7 +369,7 @@ public class LayoutImplTest {
 		}
 	}
 
-	@FeatureFlags("LPD-38869")
+	@FeatureFlag("LPD-38869")
 	@Test
 	public void testPrivateLayoutGetTheme() throws Exception {
 		_assertGetTheme(LayoutTestUtil.addTypePortletLayout(_group, true));

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/taglib/test/RenderLayoutStructureTagTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/taglib/test/RenderLayoutStructureTagTest.java
@@ -167,6 +167,7 @@ import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -243,7 +244,7 @@ public class RenderLayoutStructureTagTest {
 		ServiceContextThreadLocal.popServiceContext();
 	}
 
-	@FeatureFlags("LPD-21926")
+	@FeatureFlag("LPD-21926")
 	@Test
 	@TestInfo({"LPD-50584", "LPD-52416"})
 	public void testDisplayPageTemplateWithMappedFriendlyURLInfoField()
@@ -1164,7 +1165,11 @@ public class RenderLayoutStructureTagTest {
 			actualJournalArticle.getArticleId());
 	}
 
-	@FeatureFlags({"LPD-32050", "LPD-37927"})
+	@FeatureFlags(
+		featureFlags = {
+			@FeatureFlag(value = "LPD-32050"), @FeatureFlag(value = "LPD-37927")
+		}
+	)
 	@Test
 	@TestInfo("LPD-48715")
 	public void testRenderCollectionStyledLayoutStructureItemWithLocalizedObjectField()

--- a/modules/apps/layout/layout-utility-page-test/src/testIntegration/java/com/liferay/layout/utility/page/kernel/test/LayoutUtilityPageEntryViewRendererRegistryUtilTest.java
+++ b/modules/apps/layout/layout-utility-page-test/src/testIntegration/java/com/liferay/layout/utility/page/kernel/test/LayoutUtilityPageEntryViewRendererRegistryUtilTest.java
@@ -9,7 +9,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.layout.utility.page.kernel.LayoutUtilityPageEntryViewRendererRegistryUtil;
 import com.liferay.layout.utility.page.kernel.constants.LayoutUtilityPageEntryConstants;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import org.junit.Assert;
@@ -21,7 +21,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Istvan Sajtos
  */
-@FeatureFlags("LPD-6378")
+@FeatureFlag("LPD-6378")
 @RunWith(Arquillian.class)
 public class LayoutUtilityPageEntryViewRendererRegistryUtilTest {
 

--- a/modules/apps/login/login-test/src/testIntegration/java/com/liferay/login/internal/portlet/action/test/LoginActionTest.java
+++ b/modules/apps/login/login-test/src/testIntegration/java/com/liferay/login/internal/portlet/action/test/LoginActionTest.java
@@ -45,7 +45,7 @@ import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.site.initializer.SiteInitializer;
@@ -65,7 +65,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Jorge García
  */
-@FeatureFlags("LPD-6378")
+@FeatureFlag("LPD-6378")
 @RunWith(Arquillian.class)
 public class LoginActionTest {
 

--- a/modules/apps/login/login-web-test/src/testIntegration/java/com/liferay/login/web/internal/portlet/action/test/LoginMVCActionCommandTest.java
+++ b/modules/apps/login/login-web-test/src/testIntegration/java/com/liferay/login/web/internal/portlet/action/test/LoginMVCActionCommandTest.java
@@ -37,7 +37,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -56,7 +56,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
 /**
  * @author Istvan Sajtos
  */
-@FeatureFlags("LPD-6378")
+@FeatureFlag("LPD-6378")
 @RunWith(Arquillian.class)
 public class LoginMVCActionCommandTest {
 

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
@@ -76,7 +76,7 @@ import com.liferay.portal.kernel.util.TextFormatter;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.language.LanguageResources;
 import com.liferay.portal.odata.entity.EntityField;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
@@ -99,7 +99,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Javier Gamarra
  */
-@FeatureFlags("LPD-34594")
+@FeatureFlag("LPD-34594")
 @RunWith(Arquillian.class)
 public class ObjectDefinitionResourceTest
 	extends BaseObjectDefinitionResourceTestCase {
@@ -573,7 +573,7 @@ public class ObjectDefinitionResourceTest
 		_testPostObjectDefinitionBatch();
 	}
 
-	@FeatureFlags("LPD-32050")
+	@FeatureFlag("LPD-32050")
 	@Override
 	@Test
 	public void testPutObjectDefinition() throws Exception {

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectRelationshipResourceTest.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectRelationshipResourceTest.java
@@ -16,7 +16,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 
 import org.junit.After;
@@ -30,7 +30,7 @@ import org.junit.runner.RunWith;
  * @author Javier Gamarra
  * @author Murilo Stodolni
  */
-@FeatureFlags("LPD-34594")
+@FeatureFlag("LPD-34594")
 @RunWith(Arquillian.class)
 public class ObjectRelationshipResourceTest
 	extends BaseObjectRelationshipResourceTestCase {

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/test/java/com/liferay/object/dynamic/data/mapping/form/field/type/internal/attachment/AttachmentDDMFormFieldTemplateContextContributorTest.java
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/test/java/com/liferay/object/dynamic/data/mapping/form/field/type/internal/attachment/AttachmentDDMFormFieldTemplateContextContributorTest.java
@@ -18,7 +18,7 @@ import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.upload.configuration.UploadServletRequestConfigurationProvider;
 import com.liferay.portal.kernel.util.MapUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.util.Map;
@@ -36,7 +36,7 @@ import org.skyscreamer.jsonassert.JSONAssert;
 /**
  * @author Pedro Leite
  */
-@FeatureFlags("LPD-32050")
+@FeatureFlag("LPD-32050")
 public class AttachmentDDMFormFieldTemplateContextContributorTest
 	extends BaseDDMFormFieldTemplateContextContributorTestCase {
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -156,6 +156,7 @@ import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.searcher.SearchResponse;
 import com.liferay.portal.search.searcher.Searcher;
 import com.liferay.portal.security.script.management.test.rule.ScriptManagementConfigurationTestRule;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -213,7 +214,12 @@ import org.junit.runner.RunWith;
 /**
  * @author Feliphe Marinho
  */
-@FeatureFlags({"LPD-32050", "LPD-34594", "LPS-164801", "LPS-172017"})
+@FeatureFlags(
+	featureFlags = {
+		@FeatureFlag(value = "LPD-32050"), @FeatureFlag(value = "LPD-34594"),
+		@FeatureFlag(value = "LPS-164801"), @FeatureFlag(value = "LPS-172017")
+	}
+)
 @RunWith(Arquillian.class)
 public class DefaultObjectEntryManagerImplTest
 	extends BaseObjectEntryManagerImplTestCase {
@@ -2197,7 +2203,7 @@ public class DefaultObjectEntryManagerImplTest
 			});
 	}
 
-	@FeatureFlags("LPD-21926")
+	@FeatureFlag("LPD-21926")
 	@Test
 	public void testAddOrUpdateObjectEntryWithFriendlyURL() throws Exception {
 		ObjectDefinition objectDefinition =
@@ -4098,7 +4104,7 @@ public class DefaultObjectEntryManagerImplTest
 			1, String.valueOf(parentObjectEntry2.getId()), page);
 	}
 
-	@FeatureFlags("LPD-17564")
+	@FeatureFlag("LPD-17564")
 	@Test
 	public void testGetObjectEntryByVersion() throws Exception {
 		_objectDefinition1.setEnableObjectEntryVersioning(true);
@@ -4471,7 +4477,7 @@ public class DefaultObjectEntryManagerImplTest
 		Assert.assertEquals(objectEntries.toString(), 1, objectEntries.size());
 	}
 
-	@FeatureFlags("LPD-17564")
+	@FeatureFlag("LPD-17564")
 	@Test
 	public void testGetVersionedObjectEntries() throws Exception {
 		_objectDefinition1.setEnableObjectEntryVersioning(true);
@@ -4994,7 +5000,7 @@ public class DefaultObjectEntryManagerImplTest
 			"Edited", objectEntry.getPropertyValue("textObjectFieldName"));
 	}
 
-	@FeatureFlags("LPD-17564")
+	@FeatureFlag("LPD-17564")
 	@Test
 	public void testRestoreObjectEntryByVersion() throws Exception {
 		_objectDefinition1.setEnableObjectEntryVersioning(true);

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/CollaboratorResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/CollaboratorResourceTest.java
@@ -34,7 +34,7 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -61,7 +61,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Mikel Lorza
  */
-@FeatureFlags("LPD-17564")
+@FeatureFlag("LPD-17564")
 @RunWith(Arquillian.class)
 public class CollaboratorResourceTest {
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -167,6 +167,7 @@ import com.liferay.portal.spring.transaction.TransactionExecutor;
 import com.liferay.portal.spring.transaction.TransactionInterceptor;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -230,7 +231,9 @@ import org.springframework.transaction.support.DefaultTransactionStatus;
 /**
  * @author Luis Miguel Barcos
  */
-@FeatureFlags({"LPD-45945", "LPS-164801"})
+@FeatureFlags(
+	featureFlags = {@FeatureFlag("LPD-45945"), @FeatureFlag("LPS-164801")}
+)
 @RunWith(Arquillian.class)
 public class ObjectEntryResourceTest {
 
@@ -6951,7 +6954,7 @@ public class ObjectEntryResourceTest {
 			listTypeDefinition);
 	}
 
-	@FeatureFlags("LPD-21926")
+	@FeatureFlag("LPD-21926")
 	@Test
 	public void testGetObjectEntryWithFriendlyURL() throws Exception {
 		_objectDefinition1.setEnableFriendlyURLCustomization(true);
@@ -7544,7 +7547,7 @@ public class ObjectEntryResourceTest {
 		_assertItem(0, jsonObject, _OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1);
 	}
 
-	@FeatureFlags("LPD-21926")
+	@FeatureFlag("LPD-21926")
 	@Test
 	public void testPatchObjectEntryWithFriendlyURL() throws Exception {
 		_objectDefinition1.setEnableFriendlyURLCustomization(true);
@@ -7911,7 +7914,7 @@ public class ObjectEntryResourceTest {
 		Assert.assertNull(objectEntryJSONObject.get("permissions"));
 	}
 
-	@FeatureFlags("LPD-39967")
+	@FeatureFlag("LPD-39967")
 	@Test
 	public void testPatchPutCustomObjectEntryByExternalReferenceCodeWithAttachmentObjectField()
 		throws Exception {
@@ -7944,7 +7947,7 @@ public class ObjectEntryResourceTest {
 			Http.Method.PUT, jsonObject.getLong("id"));
 	}
 
-	@FeatureFlags("LPD-39967")
+	@FeatureFlag("LPD-39967")
 	@Test
 	public void testPatchPutCustomObjectEntryWithAttachmentObjectField()
 		throws Exception {
@@ -7980,7 +7983,7 @@ public class ObjectEntryResourceTest {
 			Http.Method.PUT, _siteScopedObjectDefinition1);
 	}
 
-	@FeatureFlags("LPD-39967")
+	@FeatureFlag("LPD-39967")
 	@Test
 	public void testPostCustomObjectEntryWithAttachmentObjectField()
 		throws Exception {
@@ -7990,7 +7993,7 @@ public class ObjectEntryResourceTest {
 			_siteScopedObjectDefinition1);
 	}
 
-	@FeatureFlags("LPD-39967")
+	@FeatureFlag("LPD-39967")
 	@Test
 	public void testPostCustomObjectEntryWithAttachmentObjectFieldInDifferentCompany()
 		throws Exception {
@@ -9953,7 +9956,7 @@ public class ObjectEntryResourceTest {
 			false);
 	}
 
-	@FeatureFlags("LPD-32050")
+	@FeatureFlag("LPD-32050")
 	@Test
 	public void testPutCustomObjectEntryWithLocalizedAttachmentObjectField()
 		throws Exception {

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/OpenAPIResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/OpenAPIResourceTest.java
@@ -45,7 +45,7 @@ import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.util.PropsValues;
@@ -362,7 +362,7 @@ public class OpenAPIResourceTest {
 		}
 	}
 
-	@FeatureFlags("LPS-180090")
+	@FeatureFlag("LPS-180090")
 	@Test
 	public void testGetOpenAPIWithActions() throws Exception {
 		_assertOpenAPI("expected_openapi_actions.json", _objectDefinition);

--- a/modules/apps/object/object-service/src/test/java/com/liferay/object/model/impl/ObjectDefinitionImplTest.java
+++ b/modules/apps/object/object-service/src/test/java/com/liferay/object/model/impl/ObjectDefinitionImplTest.java
@@ -16,7 +16,7 @@ import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TextFormatter;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import org.junit.Assert;
@@ -80,7 +80,7 @@ public class ObjectDefinitionImplTest {
 		}
 	}
 
-	@FeatureFlags("LPD-34594")
+	@FeatureFlag("LPD-34594")
 	@Test
 	public void testGetRESTContextPathRootDescendantNode() {
 

--- a/modules/apps/object/object-storage-salesforce-test/src/testIntegration/java/com/liferay/object/storage/salesforce/internal/rest/manager/v1_0/test/SalesforceObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-storage-salesforce-test/src/testIntegration/java/com/liferay/object/storage/salesforce/internal/rest/manager/v1_0/test/SalesforceObjectEntryManagerImplTest.java
@@ -41,7 +41,7 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Time;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -75,7 +75,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Guilherme Camacho
  */
-@FeatureFlags("LPS-135430")
+@FeatureFlag("LPS-135430")
 @RunWith(Arquillian.class)
 public class SalesforceObjectEntryManagerImplTest
 	extends BaseObjectEntryManagerImplTestCase {

--- a/modules/apps/object/object-storage-sugarcrm-test/src/testIntegration/java/com/liferay/object/storage/sugarcrm/internal/rest/manager/v1_0/test/SugarCRMObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-storage-sugarcrm-test/src/testIntegration/java/com/liferay/object/storage/sugarcrm/internal/rest/manager/v1_0/test/SugarCRMObjectEntryManagerImplTest.java
@@ -28,7 +28,7 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -56,7 +56,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Maurice Sepe
  */
-@FeatureFlags("LPS-135430")
+@FeatureFlag("LPS-135430")
 @RunWith(Arquillian.class)
 public class SugarCRMObjectEntryManagerImplTest
 	extends BaseObjectEntryManagerImplTestCase {

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/info/permission/provider/test/ObjectEntryInfoPermissionProviderTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/info/permission/provider/test/ObjectEntryInfoPermissionProviderTest.java
@@ -21,7 +21,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PersistenceTestRule;
@@ -54,7 +54,7 @@ public class ObjectEntryInfoPermissionProviderTest {
 		_testHasViewPermissionForUnmodifiableSystemObjectDefinition();
 	}
 
-	@FeatureFlags("LPD-17564")
+	@FeatureFlag("LPD-17564")
 	@Test
 	public void testHasViewPermissionWithFF() throws Exception {
 		_testHasViewPermissionForCustomObjectDefinition();

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/search/test/ObjectEntryIndexerReindexTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/search/test/ObjectEntryIndexerReindexTest.java
@@ -42,7 +42,7 @@ import com.liferay.portal.search.test.util.FieldValuesAssert;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LogEntry;
 import com.liferay.portal.test.log.LoggerTestUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -63,7 +63,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Victor Kammerer
  */
-@FeatureFlags("LPD-32050")
+@FeatureFlag("LPD-32050")
 @RunWith(Arquillian.class)
 public class ObjectEntryIndexerReindexTest {
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectActionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectActionLocalServiceTest.java
@@ -138,6 +138,7 @@ import com.liferay.portal.kernel.workflow.WorkflowTask;
 import com.liferay.portal.kernel.workflow.WorkflowTaskManager;
 import com.liferay.portal.security.script.management.test.rule.ScriptManagementConfigurationTestRule;
 import com.liferay.portal.security.script.management.test.util.ScriptManagementConfigurationTestUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -178,7 +179,11 @@ import org.osgi.framework.FrameworkUtil;
 /**
  * @author Brian Wing Shun Chan
  */
-@FeatureFlags({"LPD-34594", "LPS-173537"})
+@FeatureFlags(
+	featureFlags = {
+		@FeatureFlag(value = "LPD-34594"), @FeatureFlag(value = "LPS-173537")
+	}
+)
 @RunWith(Arquillian.class)
 public class ObjectActionLocalServiceTest {
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
@@ -128,6 +128,7 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.language.override.model.PLOEntry;
 import com.liferay.portal.language.override.service.PLOEntryLocalService;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -169,7 +170,11 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
  * @author Marco Leo
  * @author Brian Wing Shun Chan
  */
-@FeatureFlags({"LPD-21926", "LPD-34594"})
+@FeatureFlags(
+	featureFlags = {
+		@FeatureFlag(value = "LPD-21926"), @FeatureFlag(value = "LPD-34594")
+	}
+)
 @RunWith(Arquillian.class)
 public class ObjectDefinitionLocalServiceTest {
 
@@ -1344,7 +1349,11 @@ public class ObjectDefinitionLocalServiceTest {
 		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
 	}
 
-	@FeatureFlags({"LPD-17564", "LPD-32050"})
+	@FeatureFlags(
+		featureFlags = {
+			@FeatureFlag(value = "LPD-17564"), @FeatureFlag(value = "LPD-32050")
+		}
+	)
 	@Test
 	public void testAddSystemObjectDefinition() throws Exception {
 
@@ -2033,7 +2042,7 @@ public class ObjectDefinitionLocalServiceTest {
 			modifiableSystemObjectDefinition.getObjectDefinitionId());
 	}
 
-	@FeatureFlags("LPD-17564")
+	@FeatureFlag("LPD-17564")
 	@Test
 	public void testDeleteObjectDefinitionWithObjectEntries() throws Exception {
 		String objectFieldName = StringUtil.randomId();
@@ -2750,7 +2759,7 @@ public class ObjectDefinitionLocalServiceTest {
 		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
 	}
 
-	@FeatureFlags("LPD-17564")
+	@FeatureFlag("LPD-17564")
 	@Test
 	public void testUpdateCustomObjectDefinition() throws Exception {
 		ObjectDefinition objectDefinition =
@@ -3095,7 +3104,7 @@ public class ObjectDefinitionLocalServiceTest {
 		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition2);
 	}
 
-	@FeatureFlags("LPD-32050")
+	@FeatureFlag("LPD-32050")
 	@Test
 	public void testUpdateSystemObjectDefinition() throws Exception {
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -190,7 +190,7 @@ import com.liferay.portal.security.script.management.test.rule.ScriptManagementC
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LogEntry;
 import com.liferay.portal.test.log.LoggerTestUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -256,7 +256,7 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
  * @author Marco Leo
  * @author Brian Wing Shun Chan
  */
-@FeatureFlags("LPD-34594")
+@FeatureFlag("LPD-34594")
 @RunWith(Arquillian.class)
 public class ObjectEntryLocalServiceTest {
 
@@ -668,7 +668,7 @@ public class ObjectEntryLocalServiceTest {
 		}
 	}
 
-	@FeatureFlags("LPD-32050")
+	@FeatureFlag("LPD-32050")
 	@Test
 	public void testAddObjectEntry() throws Exception {
 		_assertCount(0);
@@ -1027,7 +1027,7 @@ public class ObjectEntryLocalServiceTest {
 			modifiableSystemObjectDefinition.getObjectDefinitionId());
 	}
 
-	@FeatureFlags("LPD-32050")
+	@FeatureFlag("LPD-32050")
 	@Test
 	public void testAddObjectEntryAfterDeletingLocalizedObjectField()
 		throws Exception {
@@ -1683,7 +1683,7 @@ public class ObjectEntryLocalServiceTest {
 		_objectFieldLocalService.deleteObjectField(objectField2);
 	}
 
-	@FeatureFlags("LPD-32050")
+	@FeatureFlag("LPD-32050")
 	@Test
 	public void testAddObjectEntryWithFormulaObjectFieldAndObjectRelationship()
 		throws Exception {
@@ -2027,7 +2027,7 @@ public class ObjectEntryLocalServiceTest {
 			_objectEntryLocalService, _objectRelationshipLocalService);
 	}
 
-	@FeatureFlags("LPD-32050")
+	@FeatureFlag("LPD-32050")
 	@Test
 	public void testAddObjectEntryWithLocalizedAttachmentObjectField()
 		throws Exception {
@@ -2114,7 +2114,7 @@ public class ObjectEntryLocalServiceTest {
 		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
 	}
 
-	@FeatureFlags("LPD-32050")
+	@FeatureFlag("LPD-32050")
 	@Test
 	public void testAddObjectEntryWithLocalizedBooleanObjectField()
 		throws Exception {
@@ -2668,7 +2668,7 @@ public class ObjectEntryLocalServiceTest {
 		_assertCount(8);
 	}
 
-	@FeatureFlags("LPD-31212")
+	@FeatureFlag("LPD-31212")
 	@Test
 	public void testAddObjectEntryWithRichTextObjectField() throws Exception {
 		ObjectDefinition objectDefinition = _publishCustomObjectDefinition(
@@ -3002,7 +3002,7 @@ public class ObjectEntryLocalServiceTest {
 				tempFileEntry2.getFileEntryId()));
 	}
 
-	@FeatureFlags("LPD-21926")
+	@FeatureFlag("LPD-21926")
 	@Test
 	public void testAddOrUpdateObjectEntryWithFriendlyURL() throws Exception {
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryServiceTest.java
@@ -66,7 +66,7 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
@@ -96,7 +96,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Marco Leo
  */
-@FeatureFlags("LPD-34594")
+@FeatureFlag("LPD-34594")
 @RunWith(Arquillian.class)
 public class ObjectEntryServiceTest {
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryVersionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryVersionLocalServiceTest.java
@@ -39,7 +39,7 @@ import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.workflow.WorkflowDefinition;
 import com.liferay.portal.kernel.workflow.WorkflowTask;
 import com.liferay.portal.kernel.workflow.WorkflowTaskManager;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -62,7 +62,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Feliphe Marinho
  */
-@FeatureFlags("LPD-17564")
+@FeatureFlag("LPD-17564")
 @RunWith(Arquillian.class)
 public class ObjectEntryVersionLocalServiceTest {
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectFieldLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectFieldLocalServiceTest.java
@@ -88,7 +88,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.SystemProperties;
 import com.liferay.portal.kernel.util.TempFileEntryUtil;
 import com.liferay.portal.kernel.util.TextFormatter;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
@@ -116,7 +116,7 @@ import org.junit.runner.RunWith;
  * @author Marco Leo
  * @author Brian Wing Shun Chan
  */
-@FeatureFlags("LPD-34594")
+@FeatureFlag("LPD-34594")
 @RunWith(Arquillian.class)
 public class ObjectFieldLocalServiceTest {
 
@@ -138,7 +138,7 @@ public class ObjectFieldLocalServiceTest {
 					ListTypeEntryUtil.createListTypeEntry(_listTypeEntryKey)));
 	}
 
-	@FeatureFlags("LPD-32050")
+	@FeatureFlag("LPD-32050")
 	@Test
 	public void testAddCustomObjectField() throws Exception {
 		AssertUtils.assertFailure(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectRelationshipLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectRelationshipLocalServiceTest.java
@@ -97,7 +97,7 @@ import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.SystemProperties;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -132,7 +132,7 @@ import org.osgi.framework.ServiceReference;
 /**
  * @author Brian Wing Shun Chan
  */
-@FeatureFlags("LPD-34594")
+@FeatureFlag("LPD-34594")
 @RunWith(Arquillian.class)
 public class ObjectRelationshipLocalServiceTest {
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/tree/test/ObjectDefinitionTreeFactoryTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/tree/test/ObjectDefinitionTreeFactoryTest.java
@@ -11,7 +11,7 @@ import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.test.util.TreeTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -23,7 +23,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Feliphe Marinho
  */
-@FeatureFlags("LPD-34594")
+@FeatureFlag("LPD-34594")
 @RunWith(Arquillian.class)
 public class ObjectDefinitionTreeFactoryTest {
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/tree/test/TreeTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/tree/test/TreeTest.java
@@ -17,7 +17,7 @@ import com.liferay.object.tree.constants.TreeConstants;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -34,7 +34,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Feliphe Marinho
  */
-@FeatureFlags("LPD-34594")
+@FeatureFlag("LPD-34594")
 @RunWith(Arquillian.class)
 public class TreeTest {
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/asset/model/test/ObjectEntryFolderAssetRendererFactoryTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/asset/model/test/ObjectEntryFolderAssetRendererFactoryTest.java
@@ -21,7 +21,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -36,7 +36,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Mikel Lorza
  */
-@FeatureFlags("LPD-17564")
+@FeatureFlag("LPD-17564")
 @RunWith(Arquillian.class)
 public class ObjectEntryFolderAssetRendererFactoryTest {
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/object/definitions/portlet/action/test/BoundObjectDefinitionsExportImportTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/object/definitions/portlet/action/test/BoundObjectDefinitionsExportImportTest.java
@@ -19,7 +19,7 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.Validator;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.vulcan.pagination.Page;
@@ -35,7 +35,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Guilherme Sá
  */
-@FeatureFlags("LPD-34594")
+@FeatureFlag("LPD-34594")
 @RunWith(Arquillian.class)
 public class BoundObjectDefinitionsExportImportTest
 	extends BaseExportImportTestCase {

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/object/definitions/portlet/action/test/ObjectDefinitionExportImportTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/object/definitions/portlet/action/test/ObjectDefinitionExportImportTest.java
@@ -32,7 +32,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.vulcan.pagination.Page;
@@ -49,7 +49,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Gabriel Albuquerque
  */
-@FeatureFlags("LPD-34594")
+@FeatureFlag("LPD-34594")
 @RunWith(Arquillian.class)
 public class ObjectDefinitionExportImportTest extends BaseExportImportTestCase {
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/object/entries/display/context/test/ObjectEntryDisplayContextTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/object/entries/display/context/test/ObjectEntryDisplayContextTest.java
@@ -30,7 +30,7 @@ import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -48,7 +48,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
 /**
  * @author Pedro Leite
  */
-@FeatureFlags("LPD-34594")
+@FeatureFlag("LPD-34594")
 @RunWith(Arquillian.class)
 public class ObjectEntryDisplayContextTest {
 

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/ElasticsearchIndexSearcherSearchAfterTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/ElasticsearchIndexSearcherSearchAfterTest.java
@@ -33,7 +33,7 @@ import com.liferay.portal.search.sort.Sorts;
 import com.liferay.portal.search.test.util.IdempotentRetryAssert;
 import com.liferay.portal.search.test.util.indexing.DocumentFixture;
 import com.liferay.portal.search.test.util.indexing.IndexingFixture;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.util.ArrayList;
@@ -57,7 +57,7 @@ import org.mockito.Mockito;
 /**
  * @author Joshua Cords
  */
-@FeatureFlags("LPS-172416")
+@FeatureFlag("LPS-172416")
 public class ElasticsearchIndexSearcherSearchAfterTest {
 
 	@ClassRule

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/index/CompanyIndexFactoryTest.java
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/java/com/liferay/portal/search/elasticsearch7/internal/index/CompanyIndexFactoryTest.java
@@ -21,7 +21,7 @@ import com.liferay.portal.search.spi.index.configuration.contributor.CompanyInde
 import com.liferay.portal.search.spi.index.configuration.contributor.helper.MappingsHelper;
 import com.liferay.portal.search.spi.index.configuration.contributor.helper.SettingsHelper;
 import com.liferay.portal.search.spi.index.listener.CompanyIndexListener;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.io.IOException;
@@ -484,7 +484,7 @@ public class CompanyIndexFactoryTest {
 		_assertIndexSettings(1, 2);
 	}
 
-	@FeatureFlags("LPD-7822")
+	@FeatureFlag("LPD-7822")
 	@Test
 	public void testInitializeIndexAfterIndexExists() throws Exception {
 		initializeIndex();

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/OpenSearchIndexSearcherSearchAfterTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/OpenSearchIndexSearcherSearchAfterTest.java
@@ -31,7 +31,7 @@ import com.liferay.portal.search.sort.Sorts;
 import com.liferay.portal.search.test.util.IdempotentRetryAssert;
 import com.liferay.portal.search.test.util.indexing.DocumentFixture;
 import com.liferay.portal.search.test.util.indexing.IndexingFixture;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.util.ArrayList;
@@ -55,7 +55,7 @@ import org.mockito.Mockito;
 /**
  * @author Joshua Cords
  */
-@FeatureFlags("LPS-172416")
+@FeatureFlag("LPS-172416")
 public class OpenSearchIndexSearcherSearchAfterTest {
 
 	@ClassRule

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/index/CompanyIndexFactoryTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/index/CompanyIndexFactoryTest.java
@@ -23,7 +23,7 @@ import com.liferay.portal.search.spi.index.configuration.contributor.CompanyInde
 import com.liferay.portal.search.spi.index.configuration.contributor.helper.MappingsHelper;
 import com.liferay.portal.search.spi.index.configuration.contributor.helper.SettingsHelper;
 import com.liferay.portal.search.spi.index.listener.CompanyIndexListener;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.util.ArrayList;
@@ -476,7 +476,7 @@ public class CompanyIndexFactoryTest extends BaseOpenSearchTestCase {
 		_assertIndexSettings(1, 2);
 	}
 
-	@FeatureFlags("LPD-7822")
+	@FeatureFlag("LPD-7822")
 	@Test
 	public void testInitializeIndexAfterIndexExists() throws Exception {
 		initializeIndex();

--- a/modules/apps/portal-search/portal-search-admin-web/src/test/java/com/liferay/portal/search/admin/web/internal/portlet/action/SearchAdminControlPanelEntryTest.java
+++ b/modules/apps/portal-search/portal-search-admin-web/src/test/java/com/liferay/portal/search/admin/web/internal/portlet/action/SearchAdminControlPanelEntryTest.java
@@ -12,7 +12,7 @@ import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.search.admin.web.internal.portlet.SearchAdminControlPanelEntry;
 import com.liferay.portal.search.configuration.ReindexConfiguration;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import org.junit.Assert;
@@ -26,7 +26,7 @@ import org.mockito.Mockito;
 /**
  * @author Gustavo Lima
  */
-@FeatureFlags("LPS-183672")
+@FeatureFlag("LPS-183672")
 public class SearchAdminControlPanelEntryTest {
 
 	@ClassRule

--- a/modules/apps/portal-search/portal-search-rest-test/src/testIntegration/java/com/liferay/portal/search/rest/resource/v1_0/test/SearchResultResourceTest.java
+++ b/modules/apps/portal-search/portal-search-rest-test/src/testIntegration/java/com/liferay/portal/search/rest/resource/v1_0/test/SearchResultResourceTest.java
@@ -65,6 +65,7 @@ import com.liferay.portal.search.rest.dto.v1_0.FacetConfiguration;
 import com.liferay.portal.search.rest.dto.v1_0.SearchRequestBody;
 import com.liferay.portal.search.rest.dto.v1_0.SearchResult;
 import com.liferay.portal.search.rest.pagination.SearchPage;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -109,7 +110,11 @@ import org.junit.runner.RunWith;
  * @author Petteri Karttunen
  * @author Almir Ferreira
  */
-@FeatureFlags({"LPD-11232", "LPS-179669"})
+@FeatureFlags(
+	featureFlags = {
+		@FeatureFlag(value = "LPD-11232"), @FeatureFlag(value = "LPS-179669")
+	}
+)
 @RunWith(Arquillian.class)
 public class SearchResultResourceTest extends BaseSearchResultResourceTestCase {
 

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactoryTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/search/bar/portlet/display/context/factory/SearchBarPortletDisplayContextFactoryTest.java
@@ -38,7 +38,7 @@ import com.liferay.portal.search.web.internal.search.bar.portlet.display.context
 import com.liferay.portal.search.web.internal.search.bar.portlet.helper.SearchBarPrecedenceHelper;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchRequest;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchResponse;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.portlet.PortletPreferencesImpl;
 
@@ -65,7 +65,7 @@ import org.mockito.Mockito;
  * @author Adam Brandizzi
  * @author Petteri Karttunne
  */
-@FeatureFlags("LPD-35128")
+@FeatureFlag("LPD-35128")
 public class SearchBarPortletDisplayContextFactoryTest {
 
 	@ClassRule

--- a/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/ml/embedding/text/TextEmbeddingDocumentContributorTest.java
+++ b/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/ml/embedding/text/TextEmbeddingDocumentContributorTest.java
@@ -19,7 +19,7 @@ import com.liferay.portal.search.configuration.SemanticSearchConfigurationProvid
 import com.liferay.portal.search.engine.SearchEngineInformation;
 import com.liferay.portal.search.ml.embedding.text.TextEmbeddingRetriever;
 import com.liferay.portal.search.rest.dto.v1_0.EmbeddingProviderConfiguration;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.util.Locale;
@@ -34,7 +34,7 @@ import org.mockito.Mockito;
 /**
  * @author Petteri Karttunen
  */
-@FeatureFlags("LPS-122920")
+@FeatureFlag("LPS-122920")
 public class TextEmbeddingDocumentContributorTest {
 
 	@ClassRule

--- a/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/ml/embedding/text/TextEmbeddingProvidersHolderImplTest.java
+++ b/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/ml/embedding/text/TextEmbeddingProvidersHolderImplTest.java
@@ -8,7 +8,7 @@ package com.liferay.portal.search.internal.ml.embedding.text;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.util.List;
@@ -23,7 +23,7 @@ import org.mockito.Mockito;
 /**
  * @author Petteri Karttunen
  */
-@FeatureFlags("LPS-122920")
+@FeatureFlag("LPS-122920")
 public class TextEmbeddingProvidersHolderImplTest {
 
 	@ClassRule

--- a/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/ml/embedding/text/TextEmbeddingRetrieverTest.java
+++ b/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/ml/embedding/text/TextEmbeddingRetrieverTest.java
@@ -15,7 +15,7 @@ import com.liferay.portal.search.configuration.SemanticSearchConfiguration;
 import com.liferay.portal.search.configuration.SemanticSearchConfigurationProvider;
 import com.liferay.portal.search.ml.embedding.EmbeddingProviderStatus;
 import com.liferay.portal.search.rest.dto.v1_0.EmbeddingProviderConfiguration;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.util.Arrays;
@@ -30,7 +30,7 @@ import org.mockito.Mockito;
 /**
  * @author Petteri Karttunen
  */
-@FeatureFlags("LPS-122920")
+@FeatureFlag("LPS-122920")
 public class TextEmbeddingRetrieverTest {
 
 	@ClassRule

--- a/modules/apps/portal-security/portal-security-content-security-policy-test/src/testIntegration/java/com/liferay/portal/security/content/security/policy/test/ContentSecurityPolicyFilterTest.java
+++ b/modules/apps/portal-security/portal-security-content-security-policy-test/src/testIntegration/java/com/liferay/portal/security/content/security/policy/test/ContentSecurityPolicyFilterTest.java
@@ -14,7 +14,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -37,7 +37,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Olivér Kecskeméty
  */
-@FeatureFlags("LPS-134060")
+@FeatureFlag("LPS-134060")
 @RunWith(Arquillian.class)
 public class ContentSecurityPolicyFilterTest {
 

--- a/modules/apps/portal-store/portal-store-gcs-test/src/testIntegration/java/com/liferay/portal/store/gcs/test/GCSStoreStoreAreaProcessorTest.java
+++ b/modules/apps/portal-store/portal-store-gcs-test/src/testIntegration/java/com/liferay/portal/store/gcs/test/GCSStoreStoreAreaProcessorTest.java
@@ -27,7 +27,7 @@ import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -51,7 +51,7 @@ import org.osgi.service.cm.ConfigurationAdmin;
 /**
  * @author Adolfo Pérez
  */
-@FeatureFlags("LPS-174816")
+@FeatureFlag("LPS-174816")
 @RunWith(Arquillian.class)
 public class GCSStoreStoreAreaProcessorTest {
 

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/util/test/GroupUtilTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/util/test/GroupUtilTest.java
@@ -16,7 +16,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.vulcan.util.GroupUtil;
@@ -77,7 +77,7 @@ public class GroupUtilTest {
 				_groupLocalService));
 	}
 
-	@FeatureFlags("LPD-17564")
+	@FeatureFlag("LPD-17564")
 	@Test
 	public void testGetDepotGroupIdWithFF() throws Exception {
 		_testGetDepotGroupId();

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/internal/operation/test/DBPartitionCopyPortalInstanceOperationTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/internal/operation/test/DBPartitionCopyPortalInstanceOperationTest.java
@@ -14,7 +14,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -31,7 +31,7 @@ public class DBPartitionCopyPortalInstanceOperationTest
 		return "CopyPortalInstanceOperation";
 	}
 
-	@FeatureFlags("LPD-11342")
+	@FeatureFlag("LPD-11342")
 	@Test
 	public void testDeployConfigurationFileWithFF() throws Exception {
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
@@ -79,7 +79,7 @@ public class DBPartitionCopyPortalInstanceOperationTest
 		assertConfigurationFileIsDeletedAfterDeploy(_PID);
 	}
 
-	@FeatureFlags("LPD-11342")
+	@FeatureFlag("LPD-11342")
 	@Test
 	public void testDeployConfigurationWithFF() throws Exception {
 		try (SafeCloseable safeCloseable =

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/internal/operation/test/DBPartitionExtractPortalInstanceOperationTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/internal/operation/test/DBPartitionExtractPortalInstanceOperationTest.java
@@ -12,7 +12,7 @@ import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -29,7 +29,7 @@ public class DBPartitionExtractPortalInstanceOperationTest
 		return "ExtractPortalInstanceOperation";
 	}
 
-	@FeatureFlags("LPD-11342")
+	@FeatureFlag("LPD-11342")
 	@Test
 	public void testDeployConfigurationFileWithFF() throws Exception {
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
@@ -62,7 +62,7 @@ public class DBPartitionExtractPortalInstanceOperationTest
 		assertConfigurationFileIsDeletedAfterDeploy(_PID);
 	}
 
-	@FeatureFlags("LPD-11342")
+	@FeatureFlag("LPD-11342")
 	@Test
 	public void testDeployConfigurationWithFF() throws Exception {
 		try (SafeCloseable safeCloseable =

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/internal/operation/test/DBPartitionInsertPortalInstanceOperationTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/internal/operation/test/DBPartitionInsertPortalInstanceOperationTest.java
@@ -12,7 +12,7 @@ import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -29,7 +29,7 @@ public class DBPartitionInsertPortalInstanceOperationTest
 		return "InsertPortalInstanceOperation";
 	}
 
-	@FeatureFlags("LPD-11342")
+	@FeatureFlag("LPD-11342")
 	@Test
 	public void testDeployConfigurationFileWithFF() throws Exception {
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
@@ -71,7 +71,7 @@ public class DBPartitionInsertPortalInstanceOperationTest
 		assertConfigurationFileIsDeletedAfterDeploy(_PID);
 	}
 
-	@FeatureFlags("LPD-11342")
+	@FeatureFlag("LPD-11342")
 	@Test
 	public void testDeployConfigurationWithFF() throws Exception {
 		try (SafeCloseable safeCloseable =

--- a/modules/apps/sharing/sharing-document-library-test/src/testIntegration/java/com/liferay/sharing/document/library/internal/display/context/test/SharingDLViewFileVersionDisplayContextTest.java
+++ b/modules/apps/sharing/sharing-document-library-test/src/testIntegration/java/com/liferay/sharing/document/library/internal/display/context/test/SharingDLViewFileVersionDisplayContextTest.java
@@ -40,7 +40,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -84,7 +84,7 @@ public class SharingDLViewFileVersionDisplayContextTest {
 		_group = GroupTestUtil.addGroup();
 	}
 
-	@FeatureFlags("LPS-197477")
+	@FeatureFlag("LPS-197477")
 	@Test
 	public void testGetActionDropdownItems() throws PortalException {
 		FileEntry fileEntry = _dlAppLocalService.addFileEntry(

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/web/internal/asset/model/test/SharingEntryAssetRendererFactoryTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/web/internal/asset/model/test/SharingEntryAssetRendererFactoryTest.java
@@ -20,7 +20,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -40,7 +40,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Mikel Lorza
  */
-@FeatureFlags("LPD-17564")
+@FeatureFlag("LPD-17564")
 @RunWith(Arquillian.class)
 public class SharingEntryAssetRendererFactoryTest {
 

--- a/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/web/internal/interpreter/test/AssetRendererSharingEntryInterpreterTest.java
+++ b/modules/apps/sharing/sharing-test/src/testIntegration/java/com/liferay/sharing/web/internal/interpreter/test/AssetRendererSharingEntryInterpreterTest.java
@@ -29,7 +29,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -55,7 +55,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Mikel Lorza
  */
-@FeatureFlags("LPD-17564")
+@FeatureFlag("LPD-17564")
 @RunWith(Arquillian.class)
 public class AssetRendererSharingEntryInterpreterTest {
 

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test/src/testIntegration/java/com/liferay/site/initializer/extender/internal/test/BundleSiteInitializerTest.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test/src/testIntegration/java/com/liferay/site/initializer/extender/internal/test/BundleSiteInitializerTest.java
@@ -194,7 +194,7 @@ import com.liferay.portal.language.override.service.PLOEntryLocalService;
 import com.liferay.portal.security.script.management.test.rule.ScriptManagementConfigurationTestRule;
 import com.liferay.portal.security.service.access.policy.model.SAPEntry;
 import com.liferay.portal.security.service.access.policy.service.SAPEntryLocalService;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -390,7 +390,7 @@ public class BundleSiteInitializerTest {
 		}
 	}
 
-	@FeatureFlags("LPD-19870")
+	@FeatureFlag("LPD-19870")
 	@Test
 	public void testSerialize() throws Exception {
 		File tempDir1 = _getTempDir(

--- a/modules/apps/site-initializer/site-initializer-welcome-test/src/testIntegration/java/com/liferay/site/initializer/welcome/test/WelcomeSiteInitializerTest.java
+++ b/modules/apps/site-initializer/site-initializer-welcome-test/src/testIntegration/java/com/liferay/site/initializer/welcome/test/WelcomeSiteInitializerTest.java
@@ -43,7 +43,7 @@ import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -134,7 +134,7 @@ public class WelcomeSiteInitializerTest {
 		Assert.assertTrue(html.contains("Enjoy using the best DXP on Earth!"));
 	}
 
-	@FeatureFlags("LPD-6378")
+	@FeatureFlag("LPD-6378")
 	@Test
 	public void testCreateAccountLayoutUtilityPageEntryPageDefinition()
 		throws Exception {
@@ -175,7 +175,7 @@ public class WelcomeSiteInitializerTest {
 			_removeUUIDs(pageDefinition2.toString()));
 	}
 
-	@FeatureFlags("LPD-6378")
+	@FeatureFlag("LPD-6378")
 	@Test
 	public void testForgotPasswordLayoutUtilityPageEntryPageDefinition()
 		throws Exception {
@@ -216,7 +216,7 @@ public class WelcomeSiteInitializerTest {
 			_removeUUIDs(pageDefinition2.toString()));
 	}
 
-	@FeatureFlags("LPD-6378")
+	@FeatureFlag("LPD-6378")
 	@Test
 	public void testInitialize() throws PortalException {
 		SiteInitializer siteInitializer =
@@ -247,7 +247,7 @@ public class WelcomeSiteInitializerTest {
 					LayoutUtilityPageEntryConstants.TYPE_LOGIN));
 	}
 
-	@FeatureFlags("LPD-6378")
+	@FeatureFlag("LPD-6378")
 	@Test
 	public void testLoginLayoutUtilityPageEntryPageDefinition()
 		throws Exception {

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/AllSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/AllSectionDisplayContextTest.java
@@ -20,7 +20,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -41,7 +41,7 @@ import org.springframework.mock.web.MockHttpServletResponse;
 /**
  * @author Eudaldo Alonso
  */
-@FeatureFlags("LPD-17564")
+@FeatureFlag("LPD-17564")
 @RunWith(Arquillian.class)
 @Sync
 public class AllSectionDisplayContextTest

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ContentsSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ContentsSectionDisplayContextTest.java
@@ -24,7 +24,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -46,7 +46,7 @@ import org.springframework.mock.web.MockHttpServletResponse;
 /**
  * @author Mikel Lorza
  */
-@FeatureFlags("LPD-17564")
+@FeatureFlag("LPD-17564")
 @RunWith(Arquillian.class)
 @Sync
 public class ContentsSectionDisplayContextTest

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/FilesSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/FilesSectionDisplayContextTest.java
@@ -21,7 +21,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -42,7 +42,7 @@ import org.springframework.mock.web.MockHttpServletResponse;
 /**
  * @author Eudaldo Alonso
  */
-@FeatureFlags("LPD-17564")
+@FeatureFlag("LPD-17564")
 @RunWith(Arquillian.class)
 @Sync
 public class FilesSectionDisplayContextTest

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/model/listener/test/GroupModelListenerTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/model/listener/test/GroupModelListenerTest.java
@@ -20,7 +20,7 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -43,7 +43,7 @@ public class GroupModelListenerTest {
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
 
-	@FeatureFlags("LPD-17564")
+	@FeatureFlag("LPD-17564")
 	@Test
 	public void testAddDepotEntry() throws Exception {
 		_depotEntry = _depotEntryLocalService.addDepotEntry(
@@ -74,7 +74,7 @@ public class GroupModelListenerTest {
 					ObjectEntryFolder::getName)));
 	}
 
-	@FeatureFlags("LPD-17564")
+	@FeatureFlag("LPD-17564")
 	@Test
 	public void testDeleteDepotEntry() throws Exception {
 		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/struts/test/AddStructuredContentItemStrutsActionTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/struts/test/AddStructuredContentItemStrutsActionTest.java
@@ -49,7 +49,7 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -73,7 +73,7 @@ import org.springframework.mock.web.MockHttpServletResponse;
 /**
  * @author Lourdes Fernández Besada
  */
-@FeatureFlags("LPD-17564")
+@FeatureFlag("LPD-17564")
 @RunWith(Arquillian.class)
 public class AddStructuredContentItemStrutsActionTest {
 

--- a/modules/apps/staging/staging-test/src/testIntegration/java/com/liferay/staging/test/LocalStagingPublishParentLayoutsByDefaultTest.java
+++ b/modules/apps/staging/staging-test/src/testIntegration/java/com/liferay/staging/test/LocalStagingPublishParentLayoutsByDefaultTest.java
@@ -42,7 +42,7 @@ import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -60,7 +60,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
 /**
  * @author Daniel Szimko
  */
-@FeatureFlags("LPS-199086")
+@FeatureFlag("LPS-199086")
 @RunWith(Arquillian.class)
 @Sync(cleanTransaction = true)
 public class LocalStagingPublishParentLayoutsByDefaultTest

--- a/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/internal/upgrade/v1_7_0/test/StyleBookEntryThemeIdUpgradeProcessTest.java
+++ b/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/internal/upgrade/v1_7_0/test/StyleBookEntryThemeIdUpgradeProcessTest.java
@@ -21,7 +21,7 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LogEntry;
 import com.liferay.portal.test.log.LoggerTestUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
@@ -57,7 +57,7 @@ public class StyleBookEntryThemeIdUpgradeProcessTest {
 			_group, TestPropsValues.getUserId());
 	}
 
-	@FeatureFlags("LPD-30204")
+	@FeatureFlag("LPD-30204")
 	@Test
 	public void testUpgrade() throws Exception {
 		long groupId = RandomTestUtil.randomLong();

--- a/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/internal/upgrade/v1_8_0/test/StyleBookEntryVersionThemeIdUpgradeProcessTest.java
+++ b/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/internal/upgrade/v1_8_0/test/StyleBookEntryVersionThemeIdUpgradeProcessTest.java
@@ -19,7 +19,7 @@ import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LogEntry;
 import com.liferay.portal.test.log.LoggerTestUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
@@ -59,7 +59,7 @@ public class StyleBookEntryVersionThemeIdUpgradeProcessTest {
 			_group, TestPropsValues.getUserId());
 	}
 
-	@FeatureFlags("LPD-30204")
+	@FeatureFlag("LPD-30204")
 	@Test
 	public void testUpgrade() throws Exception {
 		long groupId = RandomTestUtil.randomLong();

--- a/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/service/test/StyleBookEntryLocalServiceTest.java
+++ b/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/service/test/StyleBookEntryLocalServiceTest.java
@@ -25,7 +25,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.Validator;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -93,7 +93,7 @@ public class StyleBookEntryLocalServiceTest {
 			null, RandomTestUtil.randomString(), _serviceContext);
 	}
 
-	@FeatureFlags(enable = false, value = "LPD-13311")
+	@FeatureFlag(enable = false, value = "LPD-13311")
 	@Test
 	public void testAddStyleBookEntryWithFrontendTokensFromClientExtensionEntry()
 		throws Exception {

--- a/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/util/test/DefaultStyleBookEntryUtilTest.java
+++ b/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/util/test/DefaultStyleBookEntryUtilTest.java
@@ -21,7 +21,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.style.book.model.StyleBookEntry;
@@ -128,7 +128,7 @@ public class DefaultStyleBookEntryUtilTest {
 			defaultStyleBookEntry.getStyleBookEntryId());
 	}
 
-	@FeatureFlags("LPD-30204")
+	@FeatureFlag("LPD-30204")
 	@Test
 	public void testGetDefaultStyleBookEntry2() throws Exception {
 		StyleBookEntry styleBookEntry1 = _addStyleBookEntry(false);
@@ -221,7 +221,7 @@ public class DefaultStyleBookEntryUtilTest {
 			"styles-from-theme");
 	}
 
-	@FeatureFlags("LPD-30204")
+	@FeatureFlag("LPD-30204")
 	@Test
 	public void testGetStyleBookEntryNameWithMasterLayoutWithoutStyleBookEntry2()
 		throws Exception {
@@ -259,7 +259,7 @@ public class DefaultStyleBookEntryUtilTest {
 				_layout, null, null));
 	}
 
-	@FeatureFlags("LPD-30204")
+	@FeatureFlag("LPD-30204")
 	@Test
 	public void testGetStyleBookEntryNameWithoutMasterLayout2() {
 		Assert.assertEquals(

--- a/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/util/test/StyleBookUtilTest.java
+++ b/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/util/test/StyleBookUtilTest.java
@@ -22,7 +22,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.style.book.model.StyleBookEntry;
@@ -61,13 +61,13 @@ public class StyleBookUtilTest {
 		_testGetStyleFromThemeStyleBookEntry("styles-from-theme");
 	}
 
-	@FeatureFlags("LPD-30204")
+	@FeatureFlag("LPD-30204")
 	@Test
 	public void testGetStyleFromThemeStyleBookEntry2() throws Exception {
 		_testGetStyleFromThemeStyleBookEntry("styles-from-x");
 	}
 
-	@FeatureFlags("LPD-30204")
+	@FeatureFlag("LPD-30204")
 	@Test
 	public void testGetThemeName() {
 		Locale locale = LocaleUtil.US;
@@ -104,7 +104,7 @@ public class StyleBookUtilTest {
 		}
 	}
 
-	@FeatureFlags("LPD-30204")
+	@FeatureFlag("LPD-30204")
 	@Test
 	public void testIsThemeInactive() throws PortalException {
 		Assert.assertTrue(

--- a/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/ExportImportStyleBookEntriesMVCResourceCommandTest.java
+++ b/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/ExportImportStyleBookEntriesMVCResourceCommandTest.java
@@ -26,7 +26,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -117,7 +117,7 @@ public class ExportImportStyleBookEntriesMVCResourceCommandTest {
 				_targetGroup.getGroupId(), styleBookEntryKey2));
 	}
 
-	@FeatureFlags("LPD-30204")
+	@FeatureFlag("LPD-30204")
 	@Test
 	public void testExportImportSingleStyleBookEntry() throws Exception {
 		String name = RandomTestUtil.randomString();

--- a/modules/apps/user/user-test/src/testIntegration/java/com/liferay/user/service/test/UserLocalServiceTest.java
+++ b/modules/apps/user/user-test/src/testIntegration/java/com/liferay/user/service/test/UserLocalServiceTest.java
@@ -96,7 +96,7 @@ import com.liferay.portal.security.audit.event.generators.constants.EventTypes;
 import com.liferay.portal.security.ldap.test.util.configuration.LDAPAuthConfigurationProviderTemporarySwapper;
 import com.liferay.portal.service.impl.UserLocalServiceImpl;
 import com.liferay.portal.spring.aop.AopInvocationHandler;
-import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -1132,7 +1132,7 @@ public class UserLocalServiceTest {
 		Assert.assertTrue(ArrayUtil.contains(user.getRoleIds(), roleId));
 	}
 
-	@FeatureFlags(enable = false, value = "LPD-36010")
+	@FeatureFlag(enable = false, value = "LPD-36010")
 	@Test
 	public void testSortUsersByLastLoginDate() throws Exception {
 		Calendar calendar = Calendar.getInstance();

--- a/modules/util/source-formatter/src/main/resources/documentation/check/java_test_method_annotations_check.md
+++ b/modules/util/source-formatter/src/main/resources/documentation/check/java_test_method_annotations_check.md
@@ -60,7 +60,12 @@ public class ObjectEntryResourceTest {
 Correct:
 
 ```java
-@FeatureFlags({"LPS-153117", "LPS-154672"})
+@FeatureFlags(
+	featureFlags = {
+		@FeatureFlag(value = "LPS-153117"),
+		@FeatureFlag(value = "LPS-154672")
+	}
+)
 @RunWith(Arquillian.class)
 public class ObjectEntryResourceTest {
 
@@ -97,7 +102,7 @@ public void testImportFragmentsWithFolderResources() throws Exception {
 Correct:
 
 ```java
-@FeatureFlags("LPS-158675")
+@FeatureFlag("LPS-158675")
 @Test
 public void testImportFragmentsWithFolderResources() throws Exception {
     File fileWithFolderResources = _generateZipFileWithFolderResources();

--- a/portal-impl/test/unit/com/liferay/portal/test/rule/FeatureFlagTestRuleTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/test/rule/FeatureFlagTestRuleTest.java
@@ -21,7 +21,12 @@ import org.junit.Test;
 /**
  * @author Drew Brokke
  */
-@FeatureFlag("CLASS-123")
+@FeatureFlags(
+	featureFlags = {
+		@FeatureFlag(value = "CLASS-123"),
+		@FeatureFlag(enable = false, value = "CLASS-456")
+	}
+)
 public class FeatureFlagTestRuleTest {
 
 	@ClassRule
@@ -42,6 +47,7 @@ public class FeatureFlagTestRuleTest {
 	@Test
 	public void testAnnotateClass() throws Exception {
 		Assert.assertTrue(FeatureFlagManagerUtil.isEnabled("CLASS-123"));
+		Assert.assertFalse(FeatureFlagManagerUtil.isEnabled("CLASS-456"));
 	}
 
 	@FeatureFlag("METHOD-123")
@@ -50,9 +56,45 @@ public class FeatureFlagTestRuleTest {
 		Assert.assertTrue(FeatureFlagManagerUtil.isEnabled("METHOD-123"));
 	}
 
+	@FeatureFlags(
+		featureFlags = {
+			@FeatureFlag(enable = false, value = "CLASS-123"),
+			@FeatureFlag("METHOD-123"), @FeatureFlag("METHOD-234")
+		}
+	)
+	@Test
+	public void testAnnotateMethodAndClassWithFeatureFlags() throws Exception {
+		Assert.assertFalse(FeatureFlagManagerUtil.isEnabled("CLASS-123"));
+		Assert.assertTrue(FeatureFlagManagerUtil.isEnabled("METHOD-123"));
+		Assert.assertTrue(FeatureFlagManagerUtil.isEnabled("METHOD-234"));
+	}
+
+	@FeatureFlags(
+		featureFlags = {
+			@FeatureFlag(value = "METHOD-123"), @FeatureFlag("METHOD-234")
+		}
+	)
+	@Test
+	public void testAnnotateMethodWithFeatureFlags() throws Exception {
+		Assert.assertTrue(FeatureFlagManagerUtil.isEnabled("METHOD-123"));
+		Assert.assertTrue(FeatureFlagManagerUtil.isEnabled("METHOD-234"));
+	}
+
 	@FeatureFlag(enable = false, value = "METHOD-456")
 	@Test
 	public void testDisableFeatureFlag() {
+		Assert.assertFalse(FeatureFlagManagerUtil.isEnabled("METHOD-456"));
+	}
+
+	@FeatureFlags(
+		featureFlags = {
+			@FeatureFlag(value = "METHOD-123"),
+			@FeatureFlag(enable = false, value = "METHOD-456")
+		}
+	)
+	@Test
+	public void testDisableFeatureFlags() {
+		Assert.assertTrue(FeatureFlagManagerUtil.isEnabled("METHOD-123"));
 		Assert.assertFalse(FeatureFlagManagerUtil.isEnabled("METHOD-456"));
 	}
 

--- a/portal-impl/test/unit/com/liferay/portal/test/rule/FeatureFlagTestRuleTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/test/rule/FeatureFlagTestRuleTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 /**
  * @author Drew Brokke
  */
-@FeatureFlags("CLASS-123")
+@FeatureFlag("CLASS-123")
 public class FeatureFlagTestRuleTest {
 
 	@ClassRule
@@ -44,13 +44,13 @@ public class FeatureFlagTestRuleTest {
 		Assert.assertTrue(FeatureFlagManagerUtil.isEnabled("CLASS-123"));
 	}
 
-	@FeatureFlags("METHOD-123")
+	@FeatureFlag("METHOD-123")
 	@Test
 	public void testAnnotateMethod() throws Exception {
 		Assert.assertTrue(FeatureFlagManagerUtil.isEnabled("METHOD-123"));
 	}
 
-	@FeatureFlags(enable = false, value = "METHOD-456")
+	@FeatureFlag(enable = false, value = "METHOD-456")
 	@Test
 	public void testDisableFeatureFlag() {
 		Assert.assertFalse(FeatureFlagManagerUtil.isEnabled("METHOD-456"));

--- a/portal-test/bnd.bnd
+++ b/portal-test/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 27.0.2
+Bundle-Version: 28.0.0
 Export-Package:\
 	com.liferay.portal.kernel.dao.db.test,\
 	com.liferay.portal.kernel.test,\

--- a/portal-test/src/com/liferay/portal/test/rule/FeatureFlag.java
+++ b/portal-test/src/com/liferay/portal/test/rule/FeatureFlag.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/portal-test/src/com/liferay/portal/test/rule/FeatureFlag.java
+++ b/portal-test/src/com/liferay/portal/test/rule/FeatureFlag.java
@@ -12,14 +12,15 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * @author Alejandro Tardín
  * @author Carlos Correa
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.METHOD})
-public @interface FeatureFlags {
+public @interface FeatureFlag {
 
-	public FeatureFlag[] featureFlags();
+	public boolean enable() default true;
+
+	public String value();
 
 }

--- a/portal-test/src/com/liferay/portal/test/rule/FeatureFlagTestRule.java
+++ b/portal-test/src/com/liferay/portal/test/rule/FeatureFlagTestRule.java
@@ -11,10 +11,10 @@ import com.liferay.portal.kernel.feature.flag.FeatureFlagListener;
 import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.test.rule.AbstractTestRule;
+import com.liferay.portal.kernel.util.KeyValuePair;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.util.PropsUtil;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -109,29 +109,53 @@ public class FeatureFlagTestRule
 	}
 
 	private Map<String, String> _updateFeatureFlags(Description description) {
+		Map<String, String> previousValues = new HashMap<>();
+
 		FeatureFlags featureFlags = description.getAnnotation(
 			FeatureFlags.class);
 
-		if (featureFlags == null) {
-			return Collections.emptyMap();
+		if (featureFlags != null) {
+			for (FeatureFlag featureFlag : featureFlags.featureFlags()) {
+				if (featureFlag == null) {
+					continue;
+				}
+
+				KeyValuePair previousKeyValuePair = _updateFeatureFlags(
+					featureFlag);
+
+				previousValues.put(
+					previousKeyValuePair.getKey(),
+					previousKeyValuePair.getValue());
+			}
 		}
 
-		Map<String, String> previousValues = new HashMap<>();
+		FeatureFlag featureFlag = description.getAnnotation(FeatureFlag.class);
 
-		for (String key : featureFlags.value()) {
-			String featureFlagKey = "feature.flag." + key;
+		if (featureFlag != null) {
+			KeyValuePair previousKeyValuePair = _updateFeatureFlags(
+				featureFlag);
 
-			previousValues.put(featureFlagKey, PropsUtil.get(featureFlagKey));
-
-			PropsUtil.addProperties(
-				UnicodePropertiesBuilder.setProperty(
-					featureFlagKey, String.valueOf(featureFlags.enable())
-				).build());
-
-			_invokeFeatureFlagListeners(key, featureFlags.enable());
+			previousValues.put(
+				previousKeyValuePair.getKey(), previousKeyValuePair.getValue());
 		}
 
 		return previousValues;
+	}
+
+	private KeyValuePair _updateFeatureFlags(FeatureFlag featureFlag) {
+		String featureFlagKey = "feature.flag." + featureFlag.value();
+
+		KeyValuePair previousKeyValuePair = new KeyValuePair(
+			featureFlagKey, PropsUtil.get(featureFlagKey));
+
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				featureFlagKey, String.valueOf(featureFlag.enable())
+			).build());
+
+		_invokeFeatureFlagListeners(featureFlag.value(), featureFlag.enable());
+
+		return previousKeyValuePair;
 	}
 
 	private final boolean _enableFeatureFlagListeners;

--- a/portal-test/src/com/liferay/portal/test/rule/packageinfo
+++ b/portal-test/src/com/liferay/portal/test/rule/packageinfo
@@ -1,1 +1,1 @@
-version 8.1.0
+version 9.0.0


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPD-54819

---

The purpose of this PR is to update the `@FeatureFlags` Java annotation to be able to manage each feature flag value individually, as:

- For deprecation feature flags, the default value is true
- For development or beta feature flags, the default value is false

So, there is a need from Integration Tests to be able to set some feature flags to false and some to true