### PR TITLE
LPD 54860 | Ensure decimal precision in formula field division across databases

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-expression/src/main/java/com/liferay/dynamic/data/mapping/expression/internal/parser/DDMExpressionDSLExpressionVisitor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-expression/src/main/java/com/liferay/dynamic/data/mapping/expression/internal/parser/DDMExpressionDSLExpressionVisitor.java
@@ -86,10 +86,10 @@ public class DDMExpressionDSLExpressionVisitor
 	public Object visitDivisionExpression(
 		@NotNull DivisionExpressionContext divisionExpressionContext) {
 
-		Expression<Number> expression1 = (Expression<Number>)_getExpression(
-			visitChild(divisionExpressionContext, 0));
-		Expression<Number> expression2 = (Expression<Number>)_getExpression(
-			visitChild(divisionExpressionContext, 2));
+		Expression<Float> expression1 = DSLFunctionFactoryUtil.castFloat(
+			_getExpression(visitChild(divisionExpressionContext, 0)));
+		Expression<Float> expression2 = DSLFunctionFactoryUtil.castFloat(
+			_getExpression(visitChild(divisionExpressionContext, 2)));
 
 		return DSLFunctionFactoryUtil.divide(expression1, expression2);
 	}

--- a/modules/core/petra/petra-sql-dsl-api/src/main/java/com/liferay/petra/sql/dsl/DSLFunctionFactoryUtil.java
+++ b/modules/core/petra/petra-sql-dsl-api/src/main/java/com/liferay/petra/sql/dsl/DSLFunctionFactoryUtil.java
@@ -66,6 +66,10 @@ public class DSLFunctionFactoryUtil {
 		return _DSL_FUNCTION_FACTORY.castClobText(expression);
 	}
 
+	public static Expression<Float> castFloat(Expression<?> expression) {
+		return _DSL_FUNCTION_FACTORY.castFloat(expression);
+	}
+
 	public static Expression<Long> castLong(Expression<?> expression) {
 		return _DSL_FUNCTION_FACTORY.castLong(expression);
 	}

--- a/modules/core/petra/petra-sql-dsl-api/src/main/java/com/liferay/petra/sql/dsl/factory/DSLFunctionFactory.java
+++ b/modules/core/petra/petra-sql-dsl-api/src/main/java/com/liferay/petra/sql/dsl/factory/DSLFunctionFactory.java
@@ -36,6 +36,8 @@ public interface DSLFunctionFactory {
 
 	public Expression<String> castClobText(Expression<Clob> expression);
 
+	public Expression<Float> castFloat(Expression<?> expression);
+
 	public Expression<Long> castLong(Expression<?> expression);
 
 	public Expression<String> castText(Expression<?> expression);

--- a/modules/core/petra/petra-sql-dsl-spi/src/main/java/com/liferay/petra/sql/dsl/spi/expression/DSLFunctionType.java
+++ b/modules/core/petra/petra-sql-dsl-spi/src/main/java/com/liferay/petra/sql/dsl/spi/expression/DSLFunctionType.java
@@ -20,6 +20,9 @@ public class DSLFunctionType {
 	public static final DSLFunctionType CAST_CLOB_TEXT = new DSLFunctionType(
 		"CAST_CLOB_TEXT(", ")");
 
+	public static final DSLFunctionType CAST_FLOAT = new DSLFunctionType(
+		"CAST_FLOAT(", ")");
+
 	public static final DSLFunctionType CAST_LONG = new DSLFunctionType(
 		"CAST_LONG(", ")");
 

--- a/modules/core/petra/petra-sql-dsl-spi/src/main/java/com/liferay/petra/sql/dsl/spi/factory/DefaultDSLFunctionFactory.java
+++ b/modules/core/petra/petra-sql-dsl-spi/src/main/java/com/liferay/petra/sql/dsl/spi/factory/DefaultDSLFunctionFactory.java
@@ -73,6 +73,11 @@ public class DefaultDSLFunctionFactory implements DSLFunctionFactory {
 	}
 
 	@Override
+	public Expression<Float> castFloat(Expression<?> expression) {
+		return new DSLFunction<>(DSLFunctionType.CAST_FLOAT, expression);
+	}
+
+	@Override
 	public Expression<Long> castLong(Expression<?> expression) {
 		return new DSLFunction<>(DSLFunctionType.CAST_LONG, expression);
 	}

--- a/modules/core/petra/petra-sql-dsl-spi/src/test/java/com/liferay/petra/sql/dsl/spi/SQLDSLTest.java
+++ b/modules/core/petra/petra-sql-dsl-spi/src/test/java/com/liferay/petra/sql/dsl/spi/SQLDSLTest.java
@@ -499,6 +499,11 @@ public class SQLDSLTest {
 				DSLFunctionFactoryUtil.castLong(
 					MainExampleTable.INSTANCE.nameColumn)));
 		Assert.assertEquals(
+			"CAST_FLOAT(MainExample.name)",
+			String.valueOf(
+				DSLFunctionFactoryUtil.castFloat(
+					MainExampleTable.INSTANCE.nameColumn)));
+		Assert.assertEquals(
 			"CAST_TEXT(MainExample.mainExampleId)",
 			String.valueOf(
 				DSLFunctionFactoryUtil.castText(

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/impl/test/DSLQueryEntryPersistenceImplTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/impl/test/DSLQueryEntryPersistenceImplTest.java
@@ -345,7 +345,9 @@ public class DSLQueryEntryPersistenceImplTest {
 			_dslQueryEntryPersistence.dslQuery(
 				DSLQueryFactoryUtil.select(
 					DSLFunctionFactoryUtil.divide(
-						DSLQueryStatusEntryTable.INSTANCE.dslQueryStatusEntryId,
+						DSLFunctionFactoryUtil.castFloat(
+							DSLQueryStatusEntryTable.INSTANCE.
+								dslQueryStatusEntryId),
 						new Scalar<>(2L)
 					).as(
 						"alias", Double.class

--- a/portal-impl/src/com/liferay/portal/dao/sql/transformer/BaseSQLTransformerLogic.java
+++ b/portal-impl/src/com/liferay/portal/dao/sql/transformer/BaseSQLTransformerLogic.java
@@ -70,6 +70,17 @@ public abstract class BaseSQLTransformerLogic implements SQLTransformerLogic {
 			"CAST_CLOB_TEXT\\((.*)\\)", Pattern.CASE_INSENSITIVE);
 	}
 
+	protected Function<String, String> getCastFloatFunction() {
+		return _getCastFunction(
+			matcher -> replaceCastFloat(matcher), "CAST_FLOAT",
+			getCastFloatPattern());
+	}
+
+	protected Pattern getCastFloatPattern() {
+		return Pattern.compile(
+			"CAST_FLOAT\\((.*)\\)", Pattern.CASE_INSENSITIVE);
+	}
+
 	protected Function<String, String> getCastLongFunction() {
 		return _getCastFunction(
 			matcher -> replaceCastLong(matcher), "CAST_LONG",
@@ -214,6 +225,10 @@ public abstract class BaseSQLTransformerLogic implements SQLTransformerLogic {
 
 	protected String replaceCastClobText(Matcher matcher) {
 		return replaceCastText(matcher);
+	}
+
+	protected String replaceCastFloat(Matcher matcher) {
+		return matcher.replaceAll("CAST($1 AS FLOAT)");
 	}
 
 	protected String replaceCastLong(Matcher matcher) {

--- a/portal-impl/src/com/liferay/portal/dao/sql/transformer/DB2SQLTransformerLogic.java
+++ b/portal-impl/src/com/liferay/portal/dao/sql/transformer/DB2SQLTransformerLogic.java
@@ -27,7 +27,7 @@ public class DB2SQLTransformerLogic extends BaseSQLTransformerLogic {
 		Function[] functions = {
 			getAggregationFunction(), getBooleanFunction(),
 			getCastClobTextFunction(), getCastLongFunction(),
-			getCastTextFunction(), getConcatFunction(),
+			getCastFloatFunction(), getCastTextFunction(), getConcatFunction(),
 			getDropTableIfExistsTextFunction(), getIntegerDivisionFunction(),
 			getNullDateFunction(), _getCaseWhenThenFunction(),
 			_getLikeFunction(), _getSelectFunction()

--- a/portal-impl/src/com/liferay/portal/dao/sql/transformer/HypersonicSQLTransformerLogic.java
+++ b/portal-impl/src/com/liferay/portal/dao/sql/transformer/HypersonicSQLTransformerLogic.java
@@ -24,8 +24,9 @@ public class HypersonicSQLTransformerLogic extends BaseSQLTransformerLogic {
 		Function[] functions = {
 			getAggregationFunction(), getBooleanFunction(),
 			getCastClobTextFunction(), getCastLongFunction(),
-			getCastTextFunction(), getDropTableIfExistsTextFunction(),
-			getIntegerDivisionFunction(), getNullDateFunction()
+			getCastFloatFunction(), getCastTextFunction(),
+			getDropTableIfExistsTextFunction(), getIntegerDivisionFunction(),
+			getNullDateFunction()
 		};
 
 		if (!db.isSupportsStringCaseSensitiveQuery()) {

--- a/portal-impl/src/com/liferay/portal/dao/sql/transformer/MySQLSQLTransformerLogic.java
+++ b/portal-impl/src/com/liferay/portal/dao/sql/transformer/MySQLSQLTransformerLogic.java
@@ -22,9 +22,9 @@ public class MySQLSQLTransformerLogic extends BaseSQLTransformerLogic {
 		Function[] functions = {
 			getAggregationFunction(), getBitwiseCheckFunction(),
 			getBooleanFunction(), getCastClobTextFunction(),
-			getCastLongFunction(), getCastTextFunction(),
-			getDropTableIfExistsTextFunction(), getIntegerDivisionFunction(),
-			getNullDateFunction()
+			getCastLongFunction(), getCastFloatFunction(),
+			getCastTextFunction(), getDropTableIfExistsTextFunction(),
+			getIntegerDivisionFunction(), getNullDateFunction()
 		};
 
 		if (!db.isSupportsStringCaseSensitiveQuery()) {
@@ -32,6 +32,11 @@ public class MySQLSQLTransformerLogic extends BaseSQLTransformerLogic {
 		}
 
 		setFunctions(functions);
+	}
+
+	@Override
+	protected String replaceCastFloat(Matcher matcher) {
+		return matcher.replaceAll("CAST($1 AS DECIMAL(9, 7))");
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/dao/sql/transformer/OracleSQLTransformerLogic.java
+++ b/portal-impl/src/com/liferay/portal/dao/sql/transformer/OracleSQLTransformerLogic.java
@@ -26,7 +26,7 @@ public class OracleSQLTransformerLogic extends BaseSQLTransformerLogic {
 		Function[] functions = {
 			getAggregationFunction(), getBooleanFunction(),
 			getCastClobTextFunction(), getCastLongFunction(),
-			getCastTextFunction(), getConcatFunction(),
+			getCastFloatFunction(), getCastTextFunction(), getConcatFunction(),
 			getDropTableIfExistsTextFunction(), getIntegerDivisionFunction(),
 			getNullDateFunction(), _getEscapeFunction(),
 			_getNotEqualsBlankStringFunction()

--- a/portal-impl/src/com/liferay/portal/dao/sql/transformer/PostgreSQLTransformerLogic.java
+++ b/portal-impl/src/com/liferay/portal/dao/sql/transformer/PostgreSQLTransformerLogic.java
@@ -25,10 +25,10 @@ public class PostgreSQLTransformerLogic extends BaseSQLTransformerLogic {
 		Function[] functions = {
 			getAggregationFunction(), getBitwiseCheckFunction(),
 			getBooleanFunction(), getCastClobTextFunction(),
-			getCastLongFunction(), getCastTextFunction(),
-			getDropTableIfExistsTextFunction(), getInstrFunction(),
-			getIntegerDivisionFunction(), _getNegativeComparisonFunction(),
-			_getNullDateFunction()
+			getCastLongFunction(), getCastFloatFunction(),
+			getCastTextFunction(), getDropTableIfExistsTextFunction(),
+			getInstrFunction(), getIntegerDivisionFunction(),
+			_getNegativeComparisonFunction(), _getNullDateFunction()
 		};
 
 		if (!db.isSupportsStringCaseSensitiveQuery()) {

--- a/portal-impl/src/com/liferay/portal/dao/sql/transformer/SQLServerSQLTransformerLogic.java
+++ b/portal-impl/src/com/liferay/portal/dao/sql/transformer/SQLServerSQLTransformerLogic.java
@@ -23,7 +23,8 @@ public class SQLServerSQLTransformerLogic extends BaseSQLTransformerLogic {
 		Function[] functions = {
 			getAggregationFunction(), getBitwiseCheckFunction(),
 			getBooleanFunction(), getCastClobTextFunction(),
-			getCastLongFunction(), getCastTextFunction(), getConcatFunction(),
+			getCastLongFunction(), getCastFloatFunction(),
+			getCastTextFunction(), getConcatFunction(),
 			getDropTableIfExistsTextFunction(), getInstrFunction(),
 			getIntegerDivisionFunction(), getLengthFunction(), getModFunction(),
 			getNullDateFunction(), getSubstrFunction()

--- a/portal-impl/test/unit/com/liferay/portal/dao/sql/transformer/BaseSQLTransformerLogicTestCase.java
+++ b/portal-impl/test/unit/com/liferay/portal/dao/sql/transformer/BaseSQLTransformerLogicTestCase.java
@@ -62,6 +62,13 @@ public abstract class BaseSQLTransformerLogicTestCase {
 	}
 
 	@Test
+	public void testReplaceCastFloat() {
+		Assert.assertEquals(
+			getCastFloatTransformedSQL(),
+			sqlTransformer.transform(getCastFloatOriginalSQL()));
+	}
+
+	@Test
 	public void testReplaceCastLong() {
 		Assert.assertEquals(
 			getCastLongTransformedSQL(),
@@ -203,6 +210,16 @@ public abstract class BaseSQLTransformerLogicTestCase {
 	protected String getCastClobTextTransformedSQL() {
 		return "select foo || (foo || (bar || foo)), foo || (bar || foo) " +
 			"from Foo";
+	}
+
+	protected String getCastFloatOriginalSQL() {
+		return "select CAST_FLOAT(1 + (CAST_FLOAT(foo) - (bar x 2))), " +
+			"CAST_FLOAT(foo + (bar x 3)) from Foo";
+	}
+
+	protected String getCastFloatTransformedSQL() {
+		return "select (CAST 1 + ((CAST foo as FLOAT) - (bar x 2)) as FLOAT)" +
+			", (CAST foo + (bar x 3) as FLOAT) from Foo";
 	}
 
 	protected String getCastLongOriginalSQL() {

--- a/portal-impl/test/unit/com/liferay/portal/dao/sql/transformer/MySQLSQLTransformerLogicTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/dao/sql/transformer/MySQLSQLTransformerLogicTest.java
@@ -104,6 +104,12 @@ public class MySQLSQLTransformerLogicTest
 		return "select * from Foo where foo = 0 and bar = 1";
 	}
 
+	protected String getCastFloatTransformedSQL() {
+		return "select (CAST 1 + ((CAST foo as DECIMAL(9, 7)) - (bar x 2)) " +
+			"as DECIMAL(9, 7)), (CAST foo + (bar x 3) as DECIMAL(9, 7)) from " +
+				"Foo";
+	}
+
 	@Override
 	protected String getIntegerDivisionTransformedSQL() {
 		return "select foo DIV bar from Foo";


### PR DESCRIPTION
Built on top of https://github.com/liferay-core-infra/liferay-portal/pull/8366
This PR addresses one of two issues causing test failures after switching CI to PostgreSQL.

**Issue 1** – Decimal Precision in Division:
Some databases (e.g. PostgreSQL) perform integer division by default. As a result, even when the formula output type is set to decimal, the returned result lacks decimal precision. [Test that exposed the issue](https://github.com/liferay/liferay-portal/blob/955da66a9503b24ac824318c2fbff39865929bce/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java#L1975-L1996)
✅ This PR fixes this behavior by ensuring decimal division is used consistently.

**Issue 2** – Division by Zero:
Division by zero is handled differently across databases.

- MySQL returns 0
- PostgreSQL throws an exception

❌ This PR does not address the division by zero behavior.
✅ The issue has been raised with the BPM team to clarify the expected behavior across different databases.

Related Jira Ticket: https://liferay.atlassian.net/browse/LPD-54860