### PR TITLE
LPD 54869 | Move OperateCustomObjectAndRelatedCustomObjectsWithinSingleRequest#CanCreateCustomObjectEntriesWithPutChildObjectInManyToManyRelationshipWithItse to Integration

### DIFF
--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/OperateCustomObjectAndRelatedCustomObjectsWithinSingleRequest.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/OperateCustomObjectAndRelatedCustomObjectsWithinSingleRequest.testcase
@@ -156,51 +156,6 @@ definition {
 	}
 
 	@disable-webdriver = "true"
-	@priority = 4
-	test CanCreateCustomObjectEntriesWithPutChildObjectInManyToManyRelationshipWithItself {
-		property portal.acceptance = "true";
-
-		task ("And Given two Student entries are created with postStudent including studentsStudents with another Student entry information") {
-			var response = CustomObjectAPI.createObjectEntryAndRelatedObjects(
-				en_US_plural_label = "students",
-				externalReferenceCode = "ableErc",
-				fieldName = "name",
-				fieldValue = "Able",
-				nestedField = "studentsStudents",
-				numberOfRelatedObjectEntries = 1,
-				relatedEntryFieldName = "name");
-		}
-
-		task ("When with putStudent and studentId including studentsStudents with new Student entry information to update Student entry") {
-			var studentId = JSONPathUtil.getIdValue(response = ${response});
-
-			CustomObjectAPI.updateObjectEntryAndRelatedObjectsByPut(
-				en_US_plural_label = "students",
-				externalReferenceCode = "ableErc",
-				fieldName = "name",
-				fieldValue = "Able-update",
-				nestedField = "studentsStudents",
-				numberOfRelatedObjectEntries = 1,
-				objectEntryId = ${studentId},
-				relatedEntryFieldName = "name");
-		}
-
-		task ("Then the original Student entry is updated") {
-			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
-				en_US_plural_label = "students",
-				expectedValues = "Able-update,name0,name0-update",
-				objectJsonPath = "$.items[*].name");
-		}
-
-		task ("And Then one more Student entry is created") {
-			CustomObjectAPI.assertCorrectObjectEntryValuesInResponse(
-				en_US_plural_label = "students",
-				expectedValues = 3,
-				objectJsonPath = "$.totalCount");
-		}
-	}
-
-	@disable-webdriver = "true"
 	@priority = 3
 	test CanCreateCustomObjectEntriesWithPutParentObjectInManyToManyRelationship {
 		property portal.acceptance = "true";

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -9537,12 +9537,6 @@ public class ObjectEntryResourceTest {
 						"externalReferenceCode", _ERC_VALUE_3
 					))
 			).put(
-				"lastPage", 1
-			).put(
-				"page", 1
-			).put(
-				"pageSize", 20
-			).put(
 				"totalCount", 2
 			).toString(),
 			HTTPTestUtil.invokeToJSONObject(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -9500,7 +9500,60 @@ public class ObjectEntryResourceTest {
 			_objectDefinition1, _objectDefinition1, TestPropsValues.getUserId(),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
+		String objectFieldValue1 = RandomTestUtil.randomString();
+		String objectFieldValue2 = RandomTestUtil.randomString();
+		String objectFieldValue3 = RandomTestUtil.randomString();
+
 		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				_OBJECT_FIELD_NAME_1, objectFieldValue1
+			).put(
+				_objectRelationship1.getName(),
+				JSONUtil.putAll(
+					JSONUtil.put(
+						_OBJECT_FIELD_NAME_1, objectFieldValue2
+					).put(
+						"externalReferenceCode", _ERC_VALUE_2
+					),
+					JSONUtil.put(
+						_OBJECT_FIELD_NAME_1, objectFieldValue3
+					).put(
+						"externalReferenceCode", _ERC_VALUE_3
+					))
+			).toString(),
+			StringBundler.concat(
+				_objectDefinition1.getRESTContextPath(),
+				"/by-external-reference-code/", _ERC_VALUE_1),
+			Http.Method.PUT);
+
+		JSONAssert.assertEquals(
+			JSONUtil.put(
+				"items",
+				JSONUtil.putAll(
+					JSONUtil.put(
+						_OBJECT_FIELD_NAME_1, objectFieldValue2
+					).put(
+						"externalReferenceCode", _ERC_VALUE_2
+					),
+					JSONUtil.put(
+						_OBJECT_FIELD_NAME_1, objectFieldValue3
+					).put(
+						"externalReferenceCode", _ERC_VALUE_3
+					))
+			).put(
+				"totalCount", 2
+			).toString(),
+			HTTPTestUtil.invokeToJSONObject(
+				null,
+				StringBundler.concat(
+					_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
+					jsonObject.get("id"), StringPool.SLASH,
+					_objectRelationship1.getName()),
+				Http.Method.GET
+			).toString(),
+			JSONCompareMode.LENIENT);
+
+		HTTPTestUtil.invokeToJSONObject(
 			JSONUtil.put(
 				_OBJECT_FIELD_NAME_1, _NEW_OBJECT_FIELD_VALUE_1
 			).put(
@@ -9524,7 +9577,9 @@ public class ObjectEntryResourceTest {
 
 		JSONAssert.assertEquals(
 			JSONUtil.put(
-				"items",
+				_OBJECT_FIELD_NAME_1, _NEW_OBJECT_FIELD_VALUE_1
+			).put(
+				_objectRelationship1.getName(),
 				JSONUtil.putAll(
 					JSONUtil.put(
 						_OBJECT_FIELD_NAME_1, _NEW_OBJECT_FIELD_VALUE_2
@@ -9536,14 +9591,12 @@ public class ObjectEntryResourceTest {
 					).put(
 						"externalReferenceCode", _ERC_VALUE_3
 					))
-			).put(
-				"totalCount", 2
 			).toString(),
 			HTTPTestUtil.invokeToJSONObject(
 				null,
 				StringBundler.concat(
 					_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
-					jsonObject.get("id"), StringPool.SLASH,
+					jsonObject.get("id"), "?nestedFields=",
 					_objectRelationship1.getName()),
 				Http.Method.GET
 			).toString(),


### PR DESCRIPTION
See Related Jira Ticket: https://liferay.atlassian.net/browse/LPD-54869