### PR TITLE
LPD-48723 - Fix decimal precision and division by zero in FORMULA fields

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-expression/src/main/java/com/liferay/dynamic/data/mapping/expression/internal/parser/DDMExpressionDSLExpressionVisitor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-expression/src/main/java/com/liferay/dynamic/data/mapping/expression/internal/parser/DDMExpressionDSLExpressionVisitor.java
@@ -29,6 +29,7 @@ import com.liferay.dynamic.data.mapping.expression.internal.parser.generated.DDM
 import com.liferay.petra.sql.dsl.DSLFunctionFactoryUtil;
 import com.liferay.petra.sql.dsl.expression.Expression;
 import com.liferay.petra.sql.dsl.spi.expression.DSLFunction;
+import com.liferay.petra.sql.dsl.spi.expression.DSLFunctionType;
 import com.liferay.petra.sql.dsl.spi.expression.Scalar;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -88,8 +89,11 @@ public class DDMExpressionDSLExpressionVisitor
 
 		Expression<Number> expression1 = (Expression<Number>)_getExpression(
 			visitChild(divisionExpressionContext, 0));
-		Expression<Number> expression2 = (Expression<Number>)_getExpression(
-			visitChild(divisionExpressionContext, 2));
+
+		Expression<Number> expression2 = new DSLFunction<>(
+			new DSLFunctionType("NULLIF(", ")"),
+			_getExpression(visitChild(divisionExpressionContext, 2)),
+			new Scalar<>(0));
 
 		return DSLFunctionFactoryUtil.floatDivide(expression1, expression2);
 	}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-expression/src/main/java/com/liferay/dynamic/data/mapping/expression/internal/parser/DDMExpressionDSLExpressionVisitor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-expression/src/main/java/com/liferay/dynamic/data/mapping/expression/internal/parser/DDMExpressionDSLExpressionVisitor.java
@@ -29,7 +29,7 @@ import com.liferay.dynamic.data.mapping.expression.internal.parser.generated.DDM
 import com.liferay.petra.sql.dsl.DSLFunctionFactoryUtil;
 import com.liferay.petra.sql.dsl.expression.Expression;
 import com.liferay.petra.sql.dsl.spi.expression.DSLFunction;
-import com.liferay.petra.sql.dsl.spi.expression.DSLFunctionType;
+import com.liferay.petra.sql.dsl.spi.expression.NullExpression;
 import com.liferay.petra.sql.dsl.spi.expression.Scalar;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -89,13 +89,18 @@ public class DDMExpressionDSLExpressionVisitor
 
 		Expression<Number> expression1 = (Expression<Number>)_getExpression(
 			visitChild(divisionExpressionContext, 0));
+		Expression<Number> expression2 = (Expression<Number>)_getExpression(
+			visitChild(divisionExpressionContext, 2));
 
-		Expression<Number> expression2 = new DSLFunction<>(
-			new DSLFunctionType("NULLIF(", ")"),
-			_getExpression(visitChild(divisionExpressionContext, 2)),
-			new Scalar<>(0));
-
-		return DSLFunctionFactoryUtil.floatDivide(expression1, expression2);
+		return DSLFunctionFactoryUtil.caseWhenThen(
+			expression2.eq(new Scalar<>(0)),
+			(Expression<Float>)(Expression<?>)NullExpression.INSTANCE
+		).whenThen(
+			expression2.isNull(),
+			(Expression<Float>)(Expression<?>)NullExpression.INSTANCE
+		).elseEnd(
+			DSLFunctionFactoryUtil.floatDivide(expression1, expression2)
+		);
 	}
 
 	@Override

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -153,6 +153,7 @@ import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
 import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.randomizerbumpers.NumericStringRandomizerBumper;
 import com.liferay.portal.kernel.test.randomizerbumpers.UniqueStringRandomizerBumper;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -1608,6 +1609,7 @@ public class ObjectEntryLocalServiceTest {
 	}
 
 	@Test
+	@TestInfo("LPD-54861")
 	public void testAddObjectEntryWithFormulaObjectField() throws Exception {
 		ObjectField objectField1 = _addCustomObjectField(
 			new FormulaObjectFieldBuilder(
@@ -1656,6 +1658,80 @@ public class ObjectEntryLocalServiceTest {
 					).build())
 			).build());
 
+		ObjectField objectField3 = _addCustomObjectField(
+			new FormulaObjectFieldBuilder(
+			).labelMap(
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString())
+			).name(
+				"bodyMassIndex"
+			).objectDefinitionId(
+				_objectDefinition.getObjectDefinitionId()
+			).objectFieldSettings(
+				Arrays.asList(
+					new ObjectFieldSettingBuilder(
+					).name(
+						"script"
+					).value(
+						"weight / height"
+					).build(),
+					new ObjectFieldSettingBuilder(
+					).name(
+						"output"
+					).value(
+						ObjectFieldConstants.BUSINESS_TYPE_DECIMAL
+					).build())
+			).build());
+
+		ObjectField objectField4 = _addCustomObjectField(
+			new FormulaObjectFieldBuilder(
+			).labelMap(
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString())
+			).name(
+				"decimalDivision"
+			).objectDefinitionId(
+				_objectDefinition.getObjectDefinitionId()
+			).objectFieldSettings(
+				Arrays.asList(
+					new ObjectFieldSettingBuilder(
+					).name(
+						"script"
+					).value(
+						"weight / id"
+					).build(),
+					new ObjectFieldSettingBuilder(
+					).name(
+						"output"
+					).value(
+						ObjectFieldConstants.BUSINESS_TYPE_DECIMAL
+					).build())
+			).build());
+
+		ObjectField objectField5 = _addCustomObjectField(
+			new FormulaObjectFieldBuilder(
+			).labelMap(
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString())
+			).name(
+				"integerDivision"
+			).objectDefinitionId(
+				_objectDefinition.getObjectDefinitionId()
+			).objectFieldSettings(
+				Arrays.asList(
+					new ObjectFieldSettingBuilder(
+					).name(
+						"script"
+					).value(
+						"weight / id"
+					).build(),
+					new ObjectFieldSettingBuilder(
+					).name(
+						"output"
+					).value(
+						ObjectFieldConstants.BUSINESS_TYPE_INTEGER
+					).build())
+			).build());
+
+		Double randomDouble = RandomTestUtil.randomDouble();
+
 		ObjectEntry objectEntry = _addObjectEntry(
 			HashMapBuilder.<String, Serializable>put(
 				"emailAddress", RandomTestUtil.randomString()
@@ -1664,7 +1740,7 @@ public class ObjectEntryLocalServiceTest {
 			).put(
 				"listTypeEntryKeyRequired", "listTypeEntryKey1"
 			).put(
-				"weight", 65D
+				"weight", randomDouble
 			).build());
 
 		Assert.assertEquals(
@@ -1672,18 +1748,43 @@ public class ObjectEntryLocalServiceTest {
 			MapUtil.getDouble(
 				_objectEntryLocalService.getValues(
 					objectEntry.getObjectEntryId()),
-				"idSum"),
+				objectField1.getName()),
 			0);
+
 		Assert.assertEquals(
-			75D,
+			randomDouble + 10,
 			MapUtil.getDouble(
 				_objectEntryLocalService.getValues(
 					objectEntry.getObjectEntryId()),
-				"overweight"),
+				objectField2.getName()),
+			0);
+
+		Assert.assertEquals(
+			0D,
+			MapUtil.getDouble(
+				_objectEntryLocalService.getValues(objectEntry),
+				objectField3.getName()),
+			0);
+
+		Assert.assertEquals(
+			randomDouble / objectEntry.getObjectEntryId(),
+			MapUtil.getDouble(
+				_objectEntryLocalService.getValues(objectEntry),
+				objectField4.getName()),
+			0);
+
+		Assert.assertEquals(
+			(int)(randomDouble / objectEntry.getObjectEntryId()),
+			MapUtil.getDouble(
+				_objectEntryLocalService.getValues(objectEntry),
+				objectField5.getName()),
 			0);
 
 		_objectFieldLocalService.deleteObjectField(objectField1);
 		_objectFieldLocalService.deleteObjectField(objectField2);
+		_objectFieldLocalService.deleteObjectField(objectField3);
+		_objectFieldLocalService.deleteObjectField(objectField4);
+		_objectFieldLocalService.deleteObjectField(objectField5);
 	}
 
 	@FeatureFlag("LPD-32050")

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -1771,7 +1771,7 @@ public class ObjectEntryLocalServiceTest {
 			MapUtil.getDouble(
 				_objectEntryLocalService.getValues(objectEntry),
 				objectField4.getName()),
-			0);
+			0.001);
 
 		Assert.assertEquals(
 			(int)(randomDouble / objectEntry.getObjectEntryId()),


### PR DESCRIPTION
Built on top of https://github.com/brianchandotcom/liferay-portal/pull/161787 and https://github.com/liferay-core-infra/liferay-portal/pull/8438

Slack discussion: https://liferay.slack.com/archives/C01FP01V5L0/p1744188914903959

**Issue 1** – Decimal Precision in Division:
Some databases (e.g. PostgreSQL) perform integer division by default. As a result, even when the formula output type is set to decimal, the returned result lacks decimal precision. [Test that exposed the issue](https://github.com/liferay/liferay-portal/blob/955da66a9503b24ac824318c2fbff39865929bce/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java#L1975-L1996)

**Issue 2** – Division by Zero:
Division by zero is handled differently across databases.
- MySQL returns 0
- PostgreSQL throws an exception

Related Jira Ticket: https://liferay.atlassian.net/browse/LPD-48723