### PR TITLE
LPD-49422 | Fix operationId calculation

### DIFF
--- a/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/ERCAssetLibraryTestEntityResource.java
+++ b/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/ERCAssetLibraryTestEntityResource.java
@@ -54,10 +54,9 @@ public interface ERCAssetLibraryTestEntityResource {
 				String assetLibraryExternalReferenceCode)
 		throws Exception;
 
-	public ERCAssetLibraryTestEntity
-			getAssetLibraryERCAssetLibraryTestEntityErcAssetLibraryTestEntityExternalReferenceCode(
-				String assetLibraryExternalReferenceCode,
-				String ercAssetLibraryTestEntityExternalReferenceCode)
+	public ERCAssetLibraryTestEntity getAssetLibraryERCAssetLibraryTestEntity(
+			String assetLibraryExternalReferenceCode,
+			String ercAssetLibraryTestEntityExternalReferenceCode)
 		throws Exception;
 
 	public Response postAssetLibraryERCAssetLibraryTestEntitiesPageExportBatch(
@@ -75,11 +74,10 @@ public interface ERCAssetLibraryTestEntityResource {
 			Object object)
 		throws Exception;
 
-	public ERCAssetLibraryTestEntity
-			putAssetLibraryERCAssetLibraryTestEntityErcAssetLibraryTestEntityExternalReferenceCode(
-				String assetLibraryExternalReferenceCode,
-				String ercAssetLibraryTestEntityExternalReferenceCode,
-				ERCAssetLibraryTestEntity ercAssetLibraryTestEntity)
+	public ERCAssetLibraryTestEntity putAssetLibraryERCAssetLibraryTestEntity(
+			String assetLibraryExternalReferenceCode,
+			String ercAssetLibraryTestEntityExternalReferenceCode,
+			ERCAssetLibraryTestEntity ercAssetLibraryTestEntity)
 		throws Exception;
 
 	public default void setContextAcceptLanguage(

--- a/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/ERCSiteTestEntityResource.java
+++ b/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/ERCSiteTestEntityResource.java
@@ -53,10 +53,9 @@ public interface ERCSiteTestEntityResource {
 			String siteExternalReferenceCode)
 		throws Exception;
 
-	public ERCSiteTestEntity
-			getSiteERCSiteTestEntityErcSiteTestEntityExternalReferenceCode(
-				String ercSiteTestEntityExternalReferenceCode,
-				String siteExternalReferenceCode)
+	public ERCSiteTestEntity getSiteERCSiteTestEntity(
+			String ercSiteTestEntityExternalReferenceCode,
+			String siteExternalReferenceCode)
 		throws Exception;
 
 	public Response postSiteERCSiteTestEntitiesPageExportBatch(
@@ -73,11 +72,10 @@ public interface ERCSiteTestEntityResource {
 			String siteExternalReferenceCode, String callbackURL, Object object)
 		throws Exception;
 
-	public ERCSiteTestEntity
-			putSiteERCSiteTestEntityErcSiteTestEntityExternalReferenceCode(
-				String ercSiteTestEntityExternalReferenceCode,
-				String siteExternalReferenceCode,
-				ERCSiteTestEntity ercSiteTestEntity)
+	public ERCSiteTestEntity putSiteERCSiteTestEntity(
+			String ercSiteTestEntityExternalReferenceCode,
+			String siteExternalReferenceCode,
+			ERCSiteTestEntity ercSiteTestEntity)
 		throws Exception;
 
 	public default void setContextAcceptLanguage(

--- a/modules/util/portal-tools-rest-builder-test-client-js/src/apis/ERCAssetLibraryTestEntityAPI.ts
+++ b/modules/util/portal-tools-rest-builder-test-client-js/src/apis/ERCAssetLibraryTestEntityAPI.ts
@@ -86,7 +86,7 @@ export class ERCAssetLibraryTestEntityAPI {
 				 * @param ercAssetLibraryTestEntityExternalReferenceCode
 		 * @param headers Optional custom request headers
 		 */
-		public async getAssetLibraryERCAssetLibraryTestEntityErcAssetLibraryTestEntityExternalReferenceCode(
+		public async getAssetLibraryERCAssetLibraryTestEntity(
 						assetLibraryExternalReferenceCode: string,
 						ercAssetLibraryTestEntityExternalReferenceCode: string,
 			headers?: {[name: string]: string},
@@ -103,11 +103,11 @@ export class ERCAssetLibraryTestEntityAPI {
 			const queryParameters: any = {};
 
 						if (assetLibraryExternalReferenceCode === null || assetLibraryExternalReferenceCode === undefined) {
-							throw new Error("Required parameter assetLibraryExternalReferenceCode was null or undefined when calling getAssetLibraryERCAssetLibraryTestEntityErcAssetLibraryTestEntityExternalReferenceCode.");
+							throw new Error("Required parameter assetLibraryExternalReferenceCode was null or undefined when calling getAssetLibraryERCAssetLibraryTestEntity.");
 						}
 
 						if (ercAssetLibraryTestEntityExternalReferenceCode === null || ercAssetLibraryTestEntityExternalReferenceCode === undefined) {
-							throw new Error("Required parameter ercAssetLibraryTestEntityExternalReferenceCode was null or undefined when calling getAssetLibraryERCAssetLibraryTestEntityErcAssetLibraryTestEntityExternalReferenceCode.");
+							throw new Error("Required parameter ercAssetLibraryTestEntityExternalReferenceCode was null or undefined when calling getAssetLibraryERCAssetLibraryTestEntity.");
 						}
 
 			const queryString = Object.keys(queryParameters).length ?
@@ -249,7 +249,7 @@ export class ERCAssetLibraryTestEntityAPI {
 		 		* @param requestBody Request body that can be one of multiple content types
 		 * @param headers Optional custom request headers
 		 */
-		public async putAssetLibraryERCAssetLibraryTestEntityErcAssetLibraryTestEntityExternalReferenceCodeWithContentType(
+		public async putAssetLibraryERCAssetLibraryTestEntityWithContentType(
 						assetLibraryExternalReferenceCode: string,
 						ercAssetLibraryTestEntityExternalReferenceCode: string,
 					requestBody:
@@ -288,11 +288,11 @@ export class ERCAssetLibraryTestEntityAPI {
 			const queryParameters: any = {};
 
 						if (assetLibraryExternalReferenceCode === null || assetLibraryExternalReferenceCode === undefined) {
-							throw new Error("Required parameter assetLibraryExternalReferenceCode was null or undefined when calling putAssetLibraryERCAssetLibraryTestEntityErcAssetLibraryTestEntityExternalReferenceCode.");
+							throw new Error("Required parameter assetLibraryExternalReferenceCode was null or undefined when calling putAssetLibraryERCAssetLibraryTestEntity.");
 						}
 
 						if (ercAssetLibraryTestEntityExternalReferenceCode === null || ercAssetLibraryTestEntityExternalReferenceCode === undefined) {
-							throw new Error("Required parameter ercAssetLibraryTestEntityExternalReferenceCode was null or undefined when calling putAssetLibraryERCAssetLibraryTestEntityErcAssetLibraryTestEntityExternalReferenceCode.");
+							throw new Error("Required parameter ercAssetLibraryTestEntityExternalReferenceCode was null or undefined when calling putAssetLibraryERCAssetLibraryTestEntity.");
 						}
 
 			const queryString = Object.keys(queryParameters).length ?
@@ -333,7 +333,7 @@ export class ERCAssetLibraryTestEntityAPI {
 							 * @param ercAssetLibraryTestEntityExternalReferenceCode
 						 * @param eRCAssetLibraryTestEntity
 					 */
-					public async putAssetLibraryERCAssetLibraryTestEntityErcAssetLibraryTestEntityExternalReferenceCode(
+					public async putAssetLibraryERCAssetLibraryTestEntity(
 									assetLibraryExternalReferenceCode: string,
 									ercAssetLibraryTestEntityExternalReferenceCode: string,
 							eRCAssetLibraryTestEntity?: ERCAssetLibraryTestEntity,
@@ -342,7 +342,7 @@ export class ERCAssetLibraryTestEntityAPI {
 							body: ERCAssetLibraryTestEntity;
 						response: Response;
 					}> {
-						return this.putAssetLibraryERCAssetLibraryTestEntityErcAssetLibraryTestEntityExternalReferenceCodeWithContentType(
+						return this.putAssetLibraryERCAssetLibraryTestEntityWithContentType(
 										assetLibraryExternalReferenceCode,
 										ercAssetLibraryTestEntityExternalReferenceCode,
 							{

--- a/modules/util/portal-tools-rest-builder-test-client-js/src/apis/ERCSiteTestEntityAPI.ts
+++ b/modules/util/portal-tools-rest-builder-test-client-js/src/apis/ERCSiteTestEntityAPI.ts
@@ -86,7 +86,7 @@ export class ERCSiteTestEntityAPI {
 				 * @param siteExternalReferenceCode
 		 * @param headers Optional custom request headers
 		 */
-		public async getSiteERCSiteTestEntityErcSiteTestEntityExternalReferenceCode(
+		public async getSiteERCSiteTestEntity(
 						ercSiteTestEntityExternalReferenceCode: string,
 						siteExternalReferenceCode: string,
 			headers?: {[name: string]: string},
@@ -103,11 +103,11 @@ export class ERCSiteTestEntityAPI {
 			const queryParameters: any = {};
 
 						if (ercSiteTestEntityExternalReferenceCode === null || ercSiteTestEntityExternalReferenceCode === undefined) {
-							throw new Error("Required parameter ercSiteTestEntityExternalReferenceCode was null or undefined when calling getSiteERCSiteTestEntityErcSiteTestEntityExternalReferenceCode.");
+							throw new Error("Required parameter ercSiteTestEntityExternalReferenceCode was null or undefined when calling getSiteERCSiteTestEntity.");
 						}
 
 						if (siteExternalReferenceCode === null || siteExternalReferenceCode === undefined) {
-							throw new Error("Required parameter siteExternalReferenceCode was null or undefined when calling getSiteERCSiteTestEntityErcSiteTestEntityExternalReferenceCode.");
+							throw new Error("Required parameter siteExternalReferenceCode was null or undefined when calling getSiteERCSiteTestEntity.");
 						}
 
 			const queryString = Object.keys(queryParameters).length ?
@@ -249,7 +249,7 @@ export class ERCSiteTestEntityAPI {
 		 		* @param requestBody Request body that can be one of multiple content types
 		 * @param headers Optional custom request headers
 		 */
-		public async putSiteERCSiteTestEntityErcSiteTestEntityExternalReferenceCodeWithContentType(
+		public async putSiteERCSiteTestEntityWithContentType(
 						ercSiteTestEntityExternalReferenceCode: string,
 						siteExternalReferenceCode: string,
 					requestBody:
@@ -288,11 +288,11 @@ export class ERCSiteTestEntityAPI {
 			const queryParameters: any = {};
 
 						if (ercSiteTestEntityExternalReferenceCode === null || ercSiteTestEntityExternalReferenceCode === undefined) {
-							throw new Error("Required parameter ercSiteTestEntityExternalReferenceCode was null or undefined when calling putSiteERCSiteTestEntityErcSiteTestEntityExternalReferenceCode.");
+							throw new Error("Required parameter ercSiteTestEntityExternalReferenceCode was null or undefined when calling putSiteERCSiteTestEntity.");
 						}
 
 						if (siteExternalReferenceCode === null || siteExternalReferenceCode === undefined) {
-							throw new Error("Required parameter siteExternalReferenceCode was null or undefined when calling putSiteERCSiteTestEntityErcSiteTestEntityExternalReferenceCode.");
+							throw new Error("Required parameter siteExternalReferenceCode was null or undefined when calling putSiteERCSiteTestEntity.");
 						}
 
 			const queryString = Object.keys(queryParameters).length ?
@@ -333,7 +333,7 @@ export class ERCSiteTestEntityAPI {
 							 * @param siteExternalReferenceCode
 						 * @param eRCSiteTestEntity
 					 */
-					public async putSiteERCSiteTestEntityErcSiteTestEntityExternalReferenceCode(
+					public async putSiteERCSiteTestEntity(
 									ercSiteTestEntityExternalReferenceCode: string,
 									siteExternalReferenceCode: string,
 							eRCSiteTestEntity?: ERCSiteTestEntity,
@@ -342,7 +342,7 @@ export class ERCSiteTestEntityAPI {
 							body: ERCSiteTestEntity;
 						response: Response;
 					}> {
-						return this.putSiteERCSiteTestEntityErcSiteTestEntityExternalReferenceCodeWithContentType(
+						return this.putSiteERCSiteTestEntityWithContentType(
 										ercSiteTestEntityExternalReferenceCode,
 										siteExternalReferenceCode,
 							{

--- a/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/ERCAssetLibraryTestEntityResource.java
+++ b/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/ERCAssetLibraryTestEntityResource.java
@@ -43,14 +43,13 @@ public interface ERCAssetLibraryTestEntityResource {
 				String assetLibraryExternalReferenceCode)
 		throws Exception;
 
-	public ERCAssetLibraryTestEntity
-			getAssetLibraryERCAssetLibraryTestEntityErcAssetLibraryTestEntityExternalReferenceCode(
-				String assetLibraryExternalReferenceCode,
-				String ercAssetLibraryTestEntityExternalReferenceCode)
+	public ERCAssetLibraryTestEntity getAssetLibraryERCAssetLibraryTestEntity(
+			String assetLibraryExternalReferenceCode,
+			String ercAssetLibraryTestEntityExternalReferenceCode)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			getAssetLibraryERCAssetLibraryTestEntityErcAssetLibraryTestEntityExternalReferenceCodeHttpResponse(
+			getAssetLibraryERCAssetLibraryTestEntityHttpResponse(
 				String assetLibraryExternalReferenceCode,
 				String ercAssetLibraryTestEntityExternalReferenceCode)
 		throws Exception;
@@ -88,15 +87,14 @@ public interface ERCAssetLibraryTestEntityResource {
 				Object object)
 		throws Exception;
 
-	public ERCAssetLibraryTestEntity
-			putAssetLibraryERCAssetLibraryTestEntityErcAssetLibraryTestEntityExternalReferenceCode(
-				String assetLibraryExternalReferenceCode,
-				String ercAssetLibraryTestEntityExternalReferenceCode,
-				ERCAssetLibraryTestEntity ercAssetLibraryTestEntity)
+	public ERCAssetLibraryTestEntity putAssetLibraryERCAssetLibraryTestEntity(
+			String assetLibraryExternalReferenceCode,
+			String ercAssetLibraryTestEntityExternalReferenceCode,
+			ERCAssetLibraryTestEntity ercAssetLibraryTestEntity)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			putAssetLibraryERCAssetLibraryTestEntityErcAssetLibraryTestEntityExternalReferenceCodeHttpResponse(
+			putAssetLibraryERCAssetLibraryTestEntityHttpResponse(
 				String assetLibraryExternalReferenceCode,
 				String ercAssetLibraryTestEntityExternalReferenceCode,
 				ERCAssetLibraryTestEntity ercAssetLibraryTestEntity)
@@ -323,13 +321,13 @@ public interface ERCAssetLibraryTestEntityResource {
 		}
 
 		public ERCAssetLibraryTestEntity
-				getAssetLibraryERCAssetLibraryTestEntityErcAssetLibraryTestEntityExternalReferenceCode(
+				getAssetLibraryERCAssetLibraryTestEntity(
 					String assetLibraryExternalReferenceCode,
 					String ercAssetLibraryTestEntityExternalReferenceCode)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				getAssetLibraryERCAssetLibraryTestEntityErcAssetLibraryTestEntityExternalReferenceCodeHttpResponse(
+				getAssetLibraryERCAssetLibraryTestEntityHttpResponse(
 					assetLibraryExternalReferenceCode,
 					ercAssetLibraryTestEntityExternalReferenceCode);
 
@@ -393,7 +391,7 @@ public interface ERCAssetLibraryTestEntityResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				getAssetLibraryERCAssetLibraryTestEntityErcAssetLibraryTestEntityExternalReferenceCodeHttpResponse(
+				getAssetLibraryERCAssetLibraryTestEntityHttpResponse(
 					String assetLibraryExternalReferenceCode,
 					String ercAssetLibraryTestEntityExternalReferenceCode)
 			throws Exception {
@@ -783,14 +781,14 @@ public interface ERCAssetLibraryTestEntityResource {
 		}
 
 		public ERCAssetLibraryTestEntity
-				putAssetLibraryERCAssetLibraryTestEntityErcAssetLibraryTestEntityExternalReferenceCode(
+				putAssetLibraryERCAssetLibraryTestEntity(
 					String assetLibraryExternalReferenceCode,
 					String ercAssetLibraryTestEntityExternalReferenceCode,
 					ERCAssetLibraryTestEntity ercAssetLibraryTestEntity)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				putAssetLibraryERCAssetLibraryTestEntityErcAssetLibraryTestEntityExternalReferenceCodeHttpResponse(
+				putAssetLibraryERCAssetLibraryTestEntityHttpResponse(
 					assetLibraryExternalReferenceCode,
 					ercAssetLibraryTestEntityExternalReferenceCode,
 					ercAssetLibraryTestEntity);
@@ -855,7 +853,7 @@ public interface ERCAssetLibraryTestEntityResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				putAssetLibraryERCAssetLibraryTestEntityErcAssetLibraryTestEntityExternalReferenceCodeHttpResponse(
+				putAssetLibraryERCAssetLibraryTestEntityHttpResponse(
 					String assetLibraryExternalReferenceCode,
 					String ercAssetLibraryTestEntityExternalReferenceCode,
 					ERCAssetLibraryTestEntity ercAssetLibraryTestEntity)

--- a/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/ERCSiteTestEntityResource.java
+++ b/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/ERCSiteTestEntityResource.java
@@ -41,16 +41,14 @@ public interface ERCSiteTestEntityResource {
 			String siteExternalReferenceCode)
 		throws Exception;
 
-	public ERCSiteTestEntity
-			getSiteERCSiteTestEntityErcSiteTestEntityExternalReferenceCode(
-				String ercSiteTestEntityExternalReferenceCode,
-				String siteExternalReferenceCode)
+	public ERCSiteTestEntity getSiteERCSiteTestEntity(
+			String ercSiteTestEntityExternalReferenceCode,
+			String siteExternalReferenceCode)
 		throws Exception;
 
-	public HttpInvoker.HttpResponse
-			getSiteERCSiteTestEntityErcSiteTestEntityExternalReferenceCodeHttpResponse(
-				String ercSiteTestEntityExternalReferenceCode,
-				String siteExternalReferenceCode)
+	public HttpInvoker.HttpResponse getSiteERCSiteTestEntityHttpResponse(
+			String ercSiteTestEntityExternalReferenceCode,
+			String siteExternalReferenceCode)
 		throws Exception;
 
 	public void postSiteERCSiteTestEntitiesPageExportBatch(
@@ -82,18 +80,16 @@ public interface ERCSiteTestEntityResource {
 			String siteExternalReferenceCode, String callbackURL, Object object)
 		throws Exception;
 
-	public ERCSiteTestEntity
-			putSiteERCSiteTestEntityErcSiteTestEntityExternalReferenceCode(
-				String ercSiteTestEntityExternalReferenceCode,
-				String siteExternalReferenceCode,
-				ERCSiteTestEntity ercSiteTestEntity)
+	public ERCSiteTestEntity putSiteERCSiteTestEntity(
+			String ercSiteTestEntityExternalReferenceCode,
+			String siteExternalReferenceCode,
+			ERCSiteTestEntity ercSiteTestEntity)
 		throws Exception;
 
-	public HttpInvoker.HttpResponse
-			putSiteERCSiteTestEntityErcSiteTestEntityExternalReferenceCodeHttpResponse(
-				String ercSiteTestEntityExternalReferenceCode,
-				String siteExternalReferenceCode,
-				ERCSiteTestEntity ercSiteTestEntity)
+	public HttpInvoker.HttpResponse putSiteERCSiteTestEntityHttpResponse(
+			String ercSiteTestEntityExternalReferenceCode,
+			String siteExternalReferenceCode,
+			ERCSiteTestEntity ercSiteTestEntity)
 		throws Exception;
 
 	public static class Builder {
@@ -314,14 +310,13 @@ public interface ERCSiteTestEntityResource {
 			return httpInvoker.invoke();
 		}
 
-		public ERCSiteTestEntity
-				getSiteERCSiteTestEntityErcSiteTestEntityExternalReferenceCode(
-					String ercSiteTestEntityExternalReferenceCode,
-					String siteExternalReferenceCode)
+		public ERCSiteTestEntity getSiteERCSiteTestEntity(
+				String ercSiteTestEntityExternalReferenceCode,
+				String siteExternalReferenceCode)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				getSiteERCSiteTestEntityErcSiteTestEntityExternalReferenceCodeHttpResponse(
+				getSiteERCSiteTestEntityHttpResponse(
 					ercSiteTestEntityExternalReferenceCode,
 					siteExternalReferenceCode);
 
@@ -384,10 +379,9 @@ public interface ERCSiteTestEntityResource {
 			}
 		}
 
-		public HttpInvoker.HttpResponse
-				getSiteERCSiteTestEntityErcSiteTestEntityExternalReferenceCodeHttpResponse(
-					String ercSiteTestEntityExternalReferenceCode,
-					String siteExternalReferenceCode)
+		public HttpInvoker.HttpResponse getSiteERCSiteTestEntityHttpResponse(
+				String ercSiteTestEntityExternalReferenceCode,
+				String siteExternalReferenceCode)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -766,15 +760,14 @@ public interface ERCSiteTestEntityResource {
 			return httpInvoker.invoke();
 		}
 
-		public ERCSiteTestEntity
-				putSiteERCSiteTestEntityErcSiteTestEntityExternalReferenceCode(
-					String ercSiteTestEntityExternalReferenceCode,
-					String siteExternalReferenceCode,
-					ERCSiteTestEntity ercSiteTestEntity)
+		public ERCSiteTestEntity putSiteERCSiteTestEntity(
+				String ercSiteTestEntityExternalReferenceCode,
+				String siteExternalReferenceCode,
+				ERCSiteTestEntity ercSiteTestEntity)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				putSiteERCSiteTestEntityErcSiteTestEntityExternalReferenceCodeHttpResponse(
+				putSiteERCSiteTestEntityHttpResponse(
 					ercSiteTestEntityExternalReferenceCode,
 					siteExternalReferenceCode, ercSiteTestEntity);
 
@@ -837,11 +830,10 @@ public interface ERCSiteTestEntityResource {
 			}
 		}
 
-		public HttpInvoker.HttpResponse
-				putSiteERCSiteTestEntityErcSiteTestEntityExternalReferenceCodeHttpResponse(
-					String ercSiteTestEntityExternalReferenceCode,
-					String siteExternalReferenceCode,
-					ERCSiteTestEntity ercSiteTestEntity)
+		public HttpInvoker.HttpResponse putSiteERCSiteTestEntityHttpResponse(
+				String ercSiteTestEntityExternalReferenceCode,
+				String siteExternalReferenceCode,
+				ERCSiteTestEntity ercSiteTestEntity)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();

--- a/modules/util/portal-tools-rest-builder-test-impl/rest-openapi.yaml
+++ b/modules/util/portal-tools-rest-builder-test-impl/rest-openapi.yaml
@@ -359,7 +359,7 @@ paths:
             tags: ["ERCAssetLibraryTestEntity"]
     /asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/{ercAssetLibraryTestEntityExternalReferenceCode}:
         get:
-            operationId: getAssetLibraryERCAssetLibraryTestEntityErcAssetLibraryTestEntityExternalReferenceCode
+            operationId: getAssetLibraryERCAssetLibraryTestEntity
             parameters:
                 -   in: path
                     name: assetLibraryExternalReferenceCode
@@ -384,7 +384,7 @@ paths:
                         "OK"
             tags: ["ERCAssetLibraryTestEntity"]
         put:
-            operationId: putAssetLibraryERCAssetLibraryTestEntityErcAssetLibraryTestEntityExternalReferenceCode
+            operationId: putAssetLibraryERCAssetLibraryTestEntity
             parameters:
                 -   in: path
                     name: assetLibraryExternalReferenceCode
@@ -972,7 +972,7 @@ paths:
             tags: ["ERCSiteTestEntity"]
     /sites/{siteExternalReferenceCode}/erc-site-test-entities/{ercSiteTestEntityExternalReferenceCode}:
         get:
-            operationId: getSiteERCSiteTestEntityErcSiteTestEntityExternalReferenceCode
+            operationId: getSiteERCSiteTestEntity
             parameters:
                 -   in: path
                     name: ercSiteTestEntityExternalReferenceCode
@@ -997,7 +997,7 @@ paths:
                         "OK"
             tags: ["ERCSiteTestEntity"]
         put:
-            operationId: putSiteERCSiteTestEntityErcSiteTestEntityExternalReferenceCode
+            operationId: putSiteERCSiteTestEntity
             parameters:
                 -   in: path
                     name: ercSiteTestEntityExternalReferenceCode

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseERCAssetLibraryTestEntityResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseERCAssetLibraryTestEntityResourceImpl.java
@@ -137,18 +137,17 @@ public abstract class BaseERCAssetLibraryTestEntityResourceImpl
 	)
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public ERCAssetLibraryTestEntity
-			getAssetLibraryERCAssetLibraryTestEntityErcAssetLibraryTestEntityExternalReferenceCode(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("assetLibraryExternalReferenceCode")
-				String assetLibraryExternalReferenceCode,
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam(
-					"ercAssetLibraryTestEntityExternalReferenceCode"
-				)
-				String ercAssetLibraryTestEntityExternalReferenceCode)
+	public ERCAssetLibraryTestEntity getAssetLibraryERCAssetLibraryTestEntity(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("assetLibraryExternalReferenceCode")
+			String assetLibraryExternalReferenceCode,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam(
+				"ercAssetLibraryTestEntityExternalReferenceCode"
+			)
+			String ercAssetLibraryTestEntityExternalReferenceCode)
 		throws Exception {
 
 		return new ERCAssetLibraryTestEntity();
@@ -357,19 +356,18 @@ public abstract class BaseERCAssetLibraryTestEntityResourceImpl
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@javax.ws.rs.PUT
 	@Override
-	public ERCAssetLibraryTestEntity
-			putAssetLibraryERCAssetLibraryTestEntityErcAssetLibraryTestEntityExternalReferenceCode(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("assetLibraryExternalReferenceCode")
-				String assetLibraryExternalReferenceCode,
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam(
-					"ercAssetLibraryTestEntityExternalReferenceCode"
-				)
-				String ercAssetLibraryTestEntityExternalReferenceCode,
-				ERCAssetLibraryTestEntity ercAssetLibraryTestEntity)
+	public ERCAssetLibraryTestEntity putAssetLibraryERCAssetLibraryTestEntity(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("assetLibraryExternalReferenceCode")
+			String assetLibraryExternalReferenceCode,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam(
+				"ercAssetLibraryTestEntityExternalReferenceCode"
+			)
+			String ercAssetLibraryTestEntityExternalReferenceCode,
+			ERCAssetLibraryTestEntity ercAssetLibraryTestEntity)
 		throws Exception {
 
 		return new ERCAssetLibraryTestEntity();

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseERCSiteTestEntityResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseERCSiteTestEntityResourceImpl.java
@@ -132,16 +132,15 @@ public abstract class BaseERCSiteTestEntityResourceImpl
 	)
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public ERCSiteTestEntity
-			getSiteERCSiteTestEntityErcSiteTestEntityExternalReferenceCode(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("ercSiteTestEntityExternalReferenceCode")
-				String ercSiteTestEntityExternalReferenceCode,
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("siteExternalReferenceCode")
-				String siteExternalReferenceCode)
+	public ERCSiteTestEntity getSiteERCSiteTestEntity(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("ercSiteTestEntityExternalReferenceCode")
+			String ercSiteTestEntityExternalReferenceCode,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("siteExternalReferenceCode")
+			String siteExternalReferenceCode)
 		throws Exception {
 
 		return new ERCSiteTestEntity();
@@ -341,17 +340,16 @@ public abstract class BaseERCSiteTestEntityResourceImpl
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@javax.ws.rs.PUT
 	@Override
-	public ERCSiteTestEntity
-			putSiteERCSiteTestEntityErcSiteTestEntityExternalReferenceCode(
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("ercSiteTestEntityExternalReferenceCode")
-				String ercSiteTestEntityExternalReferenceCode,
-				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-				@javax.validation.constraints.NotNull
-				@javax.ws.rs.PathParam("siteExternalReferenceCode")
-				String siteExternalReferenceCode,
-				ERCSiteTestEntity ercSiteTestEntity)
+	public ERCSiteTestEntity putSiteERCSiteTestEntity(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("ercSiteTestEntityExternalReferenceCode")
+			String ercSiteTestEntityExternalReferenceCode,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("siteExternalReferenceCode")
+			String siteExternalReferenceCode,
+			ERCSiteTestEntity ercSiteTestEntity)
 		throws Exception {
 
 		return new ERCSiteTestEntity();

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseERCAssetLibraryTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseERCAssetLibraryTestEntityResourceTestCase.java
@@ -324,7 +324,7 @@ public abstract class BaseERCAssetLibraryTestEntityResourceTestCase {
 	}
 
 	@Test
-	public void testGetAssetLibraryERCAssetLibraryTestEntityErcAssetLibraryTestEntityExternalReferenceCode()
+	public void testGetAssetLibraryERCAssetLibraryTestEntity()
 		throws Exception {
 
 		Assert.assertTrue(false);
@@ -356,7 +356,7 @@ public abstract class BaseERCAssetLibraryTestEntityResourceTestCase {
 	}
 
 	@Test
-	public void testPutAssetLibraryERCAssetLibraryTestEntityErcAssetLibraryTestEntityExternalReferenceCode()
+	public void testPutAssetLibraryERCAssetLibraryTestEntity()
 		throws Exception {
 
 		Assert.assertTrue(false);

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseERCSiteTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseERCSiteTestEntityResourceTestCase.java
@@ -287,9 +287,7 @@ public abstract class BaseERCSiteTestEntityResourceTestCase {
 	}
 
 	@Test
-	public void testGetSiteERCSiteTestEntityErcSiteTestEntityExternalReferenceCode()
-		throws Exception {
-
+	public void testGetSiteERCSiteTestEntity() throws Exception {
 		Assert.assertTrue(false);
 	}
 
@@ -315,9 +313,7 @@ public abstract class BaseERCSiteTestEntityResourceTestCase {
 	}
 
 	@Test
-	public void testPutSiteERCSiteTestEntityErcSiteTestEntityExternalReferenceCode()
-		throws Exception {
-
+	public void testPutSiteERCSiteTestEntity() throws Exception {
 		Assert.assertTrue(false);
 	}
 

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
@@ -1059,14 +1059,13 @@ public class ResourceOpenAPIParser {
 					operationIdSegments.size() - 1);
 
 				if (pathName.endsWith("ExternalReferenceCode")) {
-					String externalReferenceCodeSubjectName =
-						StringUtil.upperCaseFirstLetter(
-							CamelCaseUtil.toCamelCase(
+					if (!(StringUtil.toLowerCase(
+							previousMethodNameSegment
+						).endsWith(
+							StringUtil.toLowerCase(
 								pathSegment.replaceAll(
-									"\\{|-?ExternalReferenceCode}", "")));
-
-					if (!(previousMethodNameSegment.endsWith(
-							externalReferenceCodeSubjectName) ||
+									"\\{|-?ExternalReferenceCode}", ""))
+						) ||
 						  previousMethodNameSegment.endsWith(pathName) ||
 						  Objects.equals(
 							  previousMethodNameSegment, "AssetLibrary") ||


### PR DESCRIPTION
Related Jira Ticket: https://liferay.atlassian.net/browse/LPD-49422

Expected behavior:

```
/sites/{siteExternalReferenceCode}/blog-postings/{blogPostingExternalReferenceCode}:

    getSiteBlogPosting

/sites/{sideId}/blog-postings/by-external-reference-code/{blogPostingExternalReferenceCode}:

    getSiteBlogPostingByExternalReferenceCode



/asset-libraries/{assetLibraryExternalReferenceCode}/blog-postings/{blogPostingExternalReferenceCode}:

    getAssetLibraryBlogPosting

/asset-libraries/{assetLibraryId}/blog-postings/by-external-reference-code/{blogPostingExternalReferenceCode}:

    getAssetLibraryBlogPostingByExternalReferenceCode
```