### PR TITLE
LPD-55431 Improve Playwright debug experience

### DIFF
--- a/modules/test/playwright/fixtures/backendPageTest.ts
+++ b/modules/test/playwright/fixtures/backendPageTest.ts
@@ -24,6 +24,8 @@ const backendPageTest = test.extend<BackendPage>({
 		const backendContext = await browser.newContext();
 		const backendPage = await backendContext.newPage();
 
+		await page.bringToFront();
+
 		await performLoginViaApi({page: backendPage, screenName: 'test'});
 
 		try {

--- a/modules/test/playwright/utils/performLogin.ts
+++ b/modules/test/playwright/utils/performLogin.ts
@@ -130,8 +130,10 @@ export async function performLoginViaApi({
 
 		expect(alternateName).toBe(screenName);
 	}
-	catch {
-		throw new Error('Login via API failed');
+	catch (error) {
+		error.message = `Login via API failed\n\n${error.message}`;
+
+		throw error;
 	}
 
 	return await page.context().cookies();


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-55431

Focus window in --headed mode / debug and enhance login error output

# How am I fixing it?

Moving forward le maing page after open the backend page and preserving the original error on login

# How can you verify that it works?

Launch some test with vs code debug or with `--headed` option like:

```sh
playwright test -g @LPS-195766 --headed
```