### PR TITLE
LPD-55420 Make the objectRelationship nestedField work when trying to access company object data from a site object entry

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -837,9 +837,19 @@ public class ObjectEntryDTOConverter
 							relatedObjectDefinition.getCompanyId(),
 							objectRelationship.getType());
 
+				long relatedObjectDefinitionGroupId = groupId;
+
+				if (Objects.equals(
+						relatedObjectDefinition.getScope(),
+						ObjectDefinitionConstants.SCOPE_COMPANY)) {
+
+					relatedObjectDefinitionGroupId = 0;
+				}
+
 				List<?> relatedModels =
 					objectRelatedModelsProvider.getRelatedModels(
-						groupId, objectRelationship.getObjectRelationshipId(),
+						relatedObjectDefinitionGroupId,
+						objectRelationship.getObjectRelationshipId(),
 						primaryKey, null, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
 				if (relatedObjectDefinition.isUnmodifiableSystemObject()) {

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
@@ -58,6 +58,7 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -756,6 +757,67 @@ public class ObjectEntryRelatedObjectsResourceTest {
 			null, _getEndpoint(StringUtil.randomId()), Http.Method.GET);
 
 		Assert.assertEquals("NOT_FOUND", jsonObject.getString("status"));
+	}
+
+	@Test
+	public void testGetRelatedObjectEntryWithDifferentScope() throws Exception {
+		ObjectDefinition companyScopedObjectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				Collections.singletonList(
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
+						RandomTestUtil.randomString(), _OBJECT_FIELD_NAME_1,
+						false)),
+				ObjectDefinitionConstants.SCOPE_COMPANY);
+
+		ObjectDefinition siteScopedObjectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				Collections.singletonList(
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
+						RandomTestUtil.randomString(), _OBJECT_FIELD_NAME_1,
+						false)),
+				ObjectDefinitionConstants.SCOPE_SITE);
+
+		ObjectEntry objectEntry1 = ObjectEntryTestUtil.addObjectEntry(
+			companyScopedObjectDefinition, _OBJECT_FIELD_NAME_1,
+			_OBJECT_FIELD_VALUE_1);
+
+		ObjectEntry objectEntry2 = ObjectEntryTestUtil.addObjectEntry(
+			siteScopedObjectDefinition, _OBJECT_FIELD_NAME_1,
+			_OBJECT_FIELD_VALUE_2);
+
+		ObjectRelationship objectRelationship = _addObjectRelationship(
+			companyScopedObjectDefinition, siteScopedObjectDefinition,
+			objectEntry1.getPrimaryKey(), objectEntry2.getPrimaryKey(),
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		JSONAssert.assertEquals(
+			JSONUtil.put(
+				_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_2
+			).put(
+				"externalReferenceCode", objectEntry2.getExternalReferenceCode()
+			).put(
+				objectRelationship.getName(),
+				JSONUtil.putAll(
+					JSONUtil.put(
+						_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1
+					).put(
+						"externalReferenceCode",
+						objectEntry1.getExternalReferenceCode()
+					))
+			).toString(),
+			HTTPTestUtil.invokeToJSONObject(
+				null,
+				_getEndpoint(
+					true, String.valueOf(objectEntry2.getPrimaryKey()),
+					objectRelationship.getName(),
+					siteScopedObjectDefinition.getRESTContextPath()),
+				Http.Method.GET
+			).toString(),
+			JSONCompareMode.LENIENT);
 	}
 
 	@Test
@@ -1490,18 +1552,22 @@ public class ObjectEntryRelatedObjectsResourceTest {
 	}
 
 	private String _getEndpoint(
-		boolean manyToOne, String objectEntryId,
-		String objectRelationshipName) {
+		boolean manyToOne, String objectEntryId, String objectRelationshipName,
+		String restContextPath) {
+
+		if (restContextPath == null) {
+			restContextPath = _objectDefinition1.getRESTContextPath();
+		}
 
 		if (manyToOne) {
 			return StringBundler.concat(
-				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
-				objectEntryId, "?nestedFields=", objectRelationshipName);
+				restContextPath, StringPool.SLASH, objectEntryId,
+				"?nestedFields=", objectRelationshipName);
 		}
 
 		return StringBundler.concat(
-			_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
-			objectEntryId, StringPool.SLASH, objectRelationshipName);
+			restContextPath, StringPool.SLASH, objectEntryId, StringPool.SLASH,
+			objectRelationshipName);
 	}
 
 	private String _getEndpoint(String name) {
@@ -1527,7 +1593,7 @@ public class ObjectEntryRelatedObjectsResourceTest {
 				null,
 				_getEndpoint(
 					manyToOne, customObjectEntryId,
-					objectRelationship.getName()),
+					objectRelationship.getName(), null),
 				Http.Method.GET);
 
 		if (manyToOne) {
@@ -1843,7 +1909,7 @@ public class ObjectEntryRelatedObjectsResourceTest {
 						null,
 						_getEndpoint(
 							manyToOne, customObjectEntryId,
-							objectRelationship.getName()),
+							objectRelationship.getName(), null),
 						Http.Method.GET);
 
 				if (manyToOne) {
@@ -1942,7 +2008,7 @@ public class ObjectEntryRelatedObjectsResourceTest {
 						_getEndpoint(
 							manyToOne,
 							customObjectEntryJSONObject.getString("id"),
-							objectRelationship.getName()),
+							objectRelationship.getName(), null),
 						Http.Method.GET);
 
 				if (manyToOne) {

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
@@ -90,7 +90,8 @@ public class ObjectEntryRelatedObjectsResourceTest {
 		_objectDefinition1 = ObjectDefinitionTestUtil.publishObjectDefinition(
 			Collections.singletonList(
 				ObjectFieldUtil.createObjectField(
-					"Text", "String", true, true, null,
+					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+					ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
 					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME_1,
 					false)));
 
@@ -100,7 +101,8 @@ public class ObjectEntryRelatedObjectsResourceTest {
 		_objectDefinition2 = ObjectDefinitionTestUtil.publishObjectDefinition(
 			Collections.singletonList(
 				ObjectFieldUtil.createObjectField(
-					"Text", "String", true, true, null,
+					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+					ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
 					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME_2,
 					false)));
 
@@ -112,7 +114,8 @@ public class ObjectEntryRelatedObjectsResourceTest {
 		_objectDefinition3 = ObjectDefinitionTestUtil.publishObjectDefinition(
 			Collections.singletonList(
 				ObjectFieldUtil.createObjectField(
-					"Text", "String", true, true, null,
+					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+					ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
 					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME_2,
 					false)));
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
@@ -58,7 +58,6 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -1552,14 +1551,14 @@ public class ObjectEntryRelatedObjectsResourceTest {
 	}
 
 	private String _getEndpoint(
-		boolean manyToOne, String objectEntryId, String objectRelationshipName,
+		boolean manyTo, String objectEntryId, String objectRelationshipName,
 		String restContextPath) {
 
 		if (restContextPath == null) {
 			restContextPath = _objectDefinition1.getRESTContextPath();
 		}
 
-		if (manyToOne) {
+		if (manyTo) {
 			return StringBundler.concat(
 				restContextPath, StringPool.SLASH, objectEntryId,
 				"?nestedFields=", objectRelationshipName);

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
@@ -95,6 +95,8 @@ public class ObjectEntryRelatedObjectsResourceTest {
 					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME_1,
 					false)));
 
+		_objectDefinitions.add(_objectDefinition1);
+
 		_objectEntry1 = ObjectEntryTestUtil.addObjectEntry(
 			_objectDefinition1, _OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1);
 
@@ -105,6 +107,8 @@ public class ObjectEntryRelatedObjectsResourceTest {
 					ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
 					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME_2,
 					false)));
+
+		_objectDefinitions.add(_objectDefinition2);
 
 		_objectEntry2 = ObjectEntryTestUtil.addObjectEntry(
 			_objectDefinition2, _OBJECT_FIELD_NAME_2, _OBJECT_FIELD_VALUE_2);
@@ -118,6 +122,8 @@ public class ObjectEntryRelatedObjectsResourceTest {
 					ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
 					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME_2,
 					false)));
+
+		_objectDefinitions.add(_objectDefinition3);
 
 		_objectEntry4 = ObjectEntryTestUtil.addObjectEntry(
 			_objectDefinition3, _OBJECT_FIELD_NAME_2,
@@ -143,12 +149,10 @@ public class ObjectEntryRelatedObjectsResourceTest {
 				objectRelationship);
 		}
 
-		_objectDefinitionLocalService.deleteObjectDefinition(
-			_objectDefinition1);
-		_objectDefinitionLocalService.deleteObjectDefinition(
-			_objectDefinition2);
-		_objectDefinitionLocalService.deleteObjectDefinition(
-			_objectDefinition3);
+		for (ObjectDefinition objectDefinition : _objectDefinitions) {
+			_objectDefinitionLocalService.deleteObjectDefinition(
+				objectDefinition);
+		}
 	}
 
 	@Test
@@ -773,6 +777,8 @@ public class ObjectEntryRelatedObjectsResourceTest {
 						false)),
 				ObjectDefinitionConstants.SCOPE_SITE);
 
+		_objectDefinitions.add(siteScopedObjectDefinition);
+
 		ObjectEntry objectEntry2 = ObjectEntryTestUtil.addObjectEntry(
 			siteScopedObjectDefinition, _OBJECT_FIELD_NAME_1,
 			_OBJECT_FIELD_VALUE_2);
@@ -853,6 +859,8 @@ public class ObjectEntryRelatedObjectsResourceTest {
 						RandomTestUtil.randomString(), "able", false)),
 				ObjectDefinitionConstants.SCOPE_SITE,
 				TestPropsValues.getUserId());
+
+		_objectDefinitions.add(siteScopedObjectDefinition);
 
 		ObjectEntry siteObjectEntry = ObjectEntryTestUtil.addObjectEntry(
 			siteScopedObjectDefinition, "able", RandomTestUtil.randomString());
@@ -2126,6 +2134,7 @@ public class ObjectEntryRelatedObjectsResourceTest {
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
 
+	private final List<ObjectDefinition> _objectDefinitions = new ArrayList<>();
 	private ObjectEntry _objectEntry1;
 	private ObjectEntry _objectEntry2;
 	private ObjectEntry _objectEntry3;

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
@@ -806,9 +806,8 @@ public class ObjectEntryRelatedObjectsResourceTest {
 			HTTPTestUtil.invokeToJSONObject(
 				null,
 				_getEndpoint(
-					true, String.valueOf(objectEntry2.getPrimaryKey()),
-					objectRelationship.getName(),
-					siteScopedObjectDefinition.getRESTContextPath()),
+					String.valueOf(objectEntry2.getPrimaryKey()),
+					objectRelationship, siteScopedObjectDefinition),
 				Http.Method.GET
 			).toString(),
 			JSONCompareMode.LENIENT);
@@ -1547,25 +1546,6 @@ public class ObjectEntryRelatedObjectsResourceTest {
 		_objectDefinitionLocalService.updateObjectDefinition(objectDefinition);
 	}
 
-	private String _getEndpoint(
-		boolean manyTo, String objectEntryId, String objectRelationshipName,
-		String restContextPath) {
-
-		if (restContextPath == null) {
-			restContextPath = _objectDefinition1.getRESTContextPath();
-		}
-
-		if (manyTo) {
-			return StringBundler.concat(
-				restContextPath, StringPool.SLASH, objectEntryId,
-				"?nestedFields=", objectRelationshipName);
-		}
-
-		return StringBundler.concat(
-			restContextPath, StringPool.SLASH, objectEntryId, StringPool.SLASH,
-			objectRelationshipName);
-	}
-
 	private String _getEndpoint(String name) {
 		return StringBundler.concat(
 			_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
@@ -1575,6 +1555,15 @@ public class ObjectEntryRelatedObjectsResourceTest {
 	private String _getEndpoint(String name, long primaryKey) {
 		return StringBundler.concat(
 			_getEndpoint(name), StringPool.SLASH, primaryKey);
+	}
+
+	private String _getEndpoint(
+		String objectEntryId, ObjectRelationship objectRelationship,
+		ObjectDefinition objectDefinition) {
+
+		return StringBundler.concat(
+			objectDefinition.getRESTContextPath(), StringPool.SLASH,
+			objectEntryId, "?nestedFields=", objectRelationship.getName());
 	}
 
 	private String _getSystemObjectEntryId(
@@ -1588,8 +1577,8 @@ public class ObjectEntryRelatedObjectsResourceTest {
 			HTTPTestUtil.invokeToJSONObject(
 				null,
 				_getEndpoint(
-					manyToOne, customObjectEntryId,
-					objectRelationship.getName(), null),
+					customObjectEntryId, objectRelationship,
+					_objectDefinition1),
 				Http.Method.GET);
 
 		if (manyToOne) {
@@ -1598,10 +1587,12 @@ public class ObjectEntryRelatedObjectsResourceTest {
 					objectRelationship.getName());
 		}
 		else {
-			JSONArray itemsJSONArray = customObjectEntryJSONObject.getJSONArray(
-				"items");
-
-			systemObjectEntryJSONObject = itemsJSONArray.getJSONObject(0);
+			systemObjectEntryJSONObject =
+				customObjectEntryJSONObject.getJSONArray(
+					objectRelationship.getName()
+				).getJSONObject(
+					0
+				);
 		}
 
 		return systemObjectEntryJSONObject.getString("id");
@@ -1904,8 +1895,8 @@ public class ObjectEntryRelatedObjectsResourceTest {
 					HTTPTestUtil.invokeToJSONObject(
 						null,
 						_getEndpoint(
-							manyToOne, customObjectEntryId,
-							objectRelationship.getName(), null),
+							customObjectEntryId, objectRelationship,
+							_objectDefinition1),
 						Http.Method.GET);
 
 				if (manyToOne) {
@@ -1918,10 +1909,12 @@ public class ObjectEntryRelatedObjectsResourceTest {
 								"Id", "ERC")));
 				}
 
-				JSONArray itemsJSONArray =
-					systemObjectEntryJSONObject.getJSONArray("items");
-
-				systemObjectEntryJSONObject = itemsJSONArray.getJSONObject(0);
+				systemObjectEntryJSONObject =
+					systemObjectEntryJSONObject.getJSONArray(
+						objectRelationship.getName()
+					).getJSONObject(
+						0
+					);
 
 				return systemObjectEntryJSONObject.getString(
 					"externalReferenceCode");
@@ -2002,9 +1995,8 @@ public class ObjectEntryRelatedObjectsResourceTest {
 					HTTPTestUtil.invokeToJSONObject(
 						null,
 						_getEndpoint(
-							manyToOne,
 							customObjectEntryJSONObject.getString("id"),
-							objectRelationship.getName(), null),
+							objectRelationship, _objectDefinition1),
 						Http.Method.GET);
 
 				if (manyToOne) {
@@ -2017,10 +2009,12 @@ public class ObjectEntryRelatedObjectsResourceTest {
 								"Id", "ERC")));
 				}
 
-				JSONArray itemsJSONArray =
-					systemObjectEntryJSONObject.getJSONArray("items");
-
-				systemObjectEntryJSONObject = itemsJSONArray.getJSONObject(0);
+				systemObjectEntryJSONObject =
+					systemObjectEntryJSONObject.getJSONArray(
+						objectRelationship.getName()
+					).getJSONObject(
+						0
+					);
 
 				return systemObjectEntryJSONObject.getString(
 					"externalReferenceCode");

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
@@ -763,16 +763,6 @@ public class ObjectEntryRelatedObjectsResourceTest {
 
 	@Test
 	public void testGetRelatedObjectEntryWithDifferentScope() throws Exception {
-		ObjectDefinition companyScopedObjectDefinition =
-			ObjectDefinitionTestUtil.publishObjectDefinition(
-				Collections.singletonList(
-					ObjectFieldUtil.createObjectField(
-						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-						ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
-						RandomTestUtil.randomString(), _OBJECT_FIELD_NAME_1,
-						false)),
-				ObjectDefinitionConstants.SCOPE_COMPANY);
-
 		ObjectDefinition siteScopedObjectDefinition =
 			ObjectDefinitionTestUtil.publishObjectDefinition(
 				Collections.singletonList(
@@ -783,17 +773,13 @@ public class ObjectEntryRelatedObjectsResourceTest {
 						false)),
 				ObjectDefinitionConstants.SCOPE_SITE);
 
-		ObjectEntry objectEntry1 = ObjectEntryTestUtil.addObjectEntry(
-			companyScopedObjectDefinition, _OBJECT_FIELD_NAME_1,
-			_OBJECT_FIELD_VALUE_1);
-
 		ObjectEntry objectEntry2 = ObjectEntryTestUtil.addObjectEntry(
 			siteScopedObjectDefinition, _OBJECT_FIELD_NAME_1,
 			_OBJECT_FIELD_VALUE_2);
 
 		ObjectRelationship objectRelationship = _addObjectRelationship(
-			companyScopedObjectDefinition, siteScopedObjectDefinition,
-			objectEntry1.getPrimaryKey(), objectEntry2.getPrimaryKey(),
+			_objectDefinition1, siteScopedObjectDefinition,
+			_objectEntry1.getPrimaryKey(), objectEntry2.getPrimaryKey(),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
 		JSONAssert.assertEquals(
@@ -808,7 +794,7 @@ public class ObjectEntryRelatedObjectsResourceTest {
 						_OBJECT_FIELD_NAME_1, _OBJECT_FIELD_VALUE_1
 					).put(
 						"externalReferenceCode",
-						objectEntry1.getExternalReferenceCode()
+						_objectEntry1.getExternalReferenceCode()
 					))
 			).toString(),
 			HTTPTestUtil.invokeToJSONObject(


### PR DESCRIPTION
**What's changed?:**
- Now during the processing of the relationship nested fields, a new scope check has been added to make sure the related object definition is recovered properly when the call is made from the site side.
- New test has been added for the failing use case and some small refactoring has been done to get the file in a cleaner state.

See the following **Jira Ticket**: [LPP-58825](https://liferay.atlassian.net/browse/LPP-58825)