### PR TITLE
LPD-54757 Updating CustomFieldsUtil class to avoid ClassCastExceptions when the data type is not the final one

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-test/build.gradle
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/build.gradle
@@ -18,6 +18,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-form-field-type-api")
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-test-util")
+	testIntegrationImplementation project(":apps:expando:expando-test-util")
 	testIntegrationImplementation project(":apps:fragment:fragment-api")
 	testIntegrationImplementation project(":apps:headless:headless-batch-engine:headless-batch-engine-client")
 	testIntegrationImplementation project(":apps:headless:headless-delivery:headless-delivery-api")

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentResourceTest.java
@@ -36,6 +36,13 @@ import com.liferay.dynamic.data.mapping.storage.StorageType;
 import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestHelper;
 import com.liferay.dynamic.data.mapping.test.util.DDMTemplateTestUtil;
 import com.liferay.dynamic.data.mapping.util.DDMFormValuesToFieldsConverter;
+import com.liferay.expando.kernel.model.ExpandoColumn;
+import com.liferay.expando.kernel.model.ExpandoColumnConstants;
+import com.liferay.expando.kernel.model.ExpandoTable;
+import com.liferay.expando.kernel.service.ExpandoColumnLocalService;
+import com.liferay.expando.test.util.ExpandoTestUtil;
+import com.liferay.headless.delivery.client.custom.field.CustomField;
+import com.liferay.headless.delivery.client.custom.field.CustomValue;
 import com.liferay.headless.delivery.client.dto.v1_0.ContentDocument;
 import com.liferay.headless.delivery.client.dto.v1_0.ContentField;
 import com.liferay.headless.delivery.client.dto.v1_0.ContentFieldValue;
@@ -77,6 +84,7 @@ import com.liferay.portal.kernel.service.UserGroupRoleLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.template.TemplateConstants;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.RoleTestUtil;
@@ -94,6 +102,7 @@ import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.SynchronousMailTestRule;
@@ -109,6 +118,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.junit.After;
@@ -169,6 +179,10 @@ public class StructuredContentResourceTest
 			testGroup, "test-localized-ddm-structure.json");
 		_unlocalizedDDMStructure = _addDDMStructure(
 			testGroup, "test-unlocalized-ddm-structure.json");
+
+		_expandoTable = ExpandoTestUtil.addTable(
+			_portal.getClassNameId(JournalArticle.class.getName()),
+			"CUSTOM_FIELDS");
 	}
 
 	@After
@@ -712,6 +726,16 @@ public class StructuredContentResourceTest
 	}
 
 	@Override
+	@Test
+	public void testPutSiteStructuredContentByExternalReferenceCode()
+		throws Exception {
+
+		super.testPutSiteStructuredContentByExternalReferenceCode();
+
+		_testPutSiteStructuredContentByExternalReferenceCodeWithExpandoField();
+	}
+
+	@Override
 	protected String[] getAdditionalAssertFieldNames() {
 		return new String[] {
 			"contentStructureId", "description", "priority", "title"
@@ -935,6 +959,30 @@ public class StructuredContentResourceTest
 			_read("test-structured-content-template.vm"), LocaleUtil.US);
 	}
 
+	private ExpandoColumn _addExpandoColumn(
+			Object defaultData, String displayType, ExpandoTable expandoTable,
+			int type)
+		throws Exception {
+
+		ExpandoColumn expandoColumn = ExpandoTestUtil.addColumn(
+			expandoTable, "A" + RandomTestUtil.randomString(), type,
+			defaultData);
+
+		if (displayType != null) {
+			UnicodeProperties unicodeProperties =
+				expandoColumn.getTypeSettingsProperties();
+
+			unicodeProperties.putAll(
+				HashMapBuilder.put(
+					ExpandoColumnConstants.PROPERTY_DISPLAY_TYPE, displayType
+				).build());
+
+			expandoColumn.setTypeSettingsProperties(unicodeProperties);
+		}
+
+		return _expandoColumnLocalService.updateExpandoColumn(expandoColumn);
+	}
+
 	private void _assertFilterSiteStructuredContentsPageFilteredByDateField(
 			Locale locale)
 		throws Exception {
@@ -1069,6 +1117,18 @@ public class StructuredContentResourceTest
 				_jsonDDMFormDeserializer.deserialize(builder.build());
 
 		return ddmFormDeserializerDeserializeResponse.getDDMForm();
+	}
+
+	private CustomField _getCustomField(
+		CustomField[] customFields, String name) {
+
+		for (CustomField customField : customFields) {
+			if (Objects.equals(customField.getName(), name)) {
+				return customField;
+			}
+		}
+
+		return null;
 	}
 
 	private String _randomColor() {
@@ -2429,6 +2489,102 @@ public class StructuredContentResourceTest
 		Assert.assertEquals(1, jsonObject.getLong("totalItemsCount"));
 	}
 
+	private void _testPutSiteStructuredContentByExternalReferenceCodeWithExpandoField()
+		throws Exception {
+
+		StructuredContent postStructuredContent =
+			testPutSiteStructuredContentByExternalReferenceCode_addStructuredContent();
+
+		long randomLong = RandomTestUtil.randomLong(
+			Long.MIN_VALUE, Long.MAX_VALUE);
+		short randomShort1 = (short)RandomTestUtil.randomInt(
+			Short.MIN_VALUE, Short.MAX_VALUE);
+		short randomShort2 = (short)RandomTestUtil.randomInt(
+			Short.MIN_VALUE, Short.MAX_VALUE);
+
+		ExpandoColumn longExpandoColumn = _addExpandoColumn(
+			null, null, _expandoTable, ExpandoColumnConstants.LONG);
+		ExpandoColumn shortExpandoColumn = _addExpandoColumn(
+			null, null, _expandoTable, ExpandoColumnConstants.SHORT);
+		ExpandoColumn shortArrayExpandoColumn = _addExpandoColumn(
+			null, null, _expandoTable, ExpandoColumnConstants.SHORT_ARRAY);
+
+		CustomField longCustomField = new CustomField() {
+			{
+				customValue = new CustomValue() {
+					{
+						data = randomLong;
+					}
+				};
+				dataType = "Integer";
+				name = longExpandoColumn.getName();
+			}
+		};
+
+		CustomField shortCustomField = new CustomField() {
+			{
+				customValue = new CustomValue() {
+					{
+						data = randomShort1;
+					}
+				};
+				dataType = "Integer";
+				name = shortExpandoColumn.getName();
+			}
+		};
+
+		CustomField shortArrayCustomField = new CustomField() {
+			{
+				customValue = new CustomValue() {
+					{
+						data = Arrays.asList(randomShort2);
+					}
+				};
+				dataType = "Integer";
+				name = shortArrayExpandoColumn.getName();
+			}
+		};
+
+		StructuredContent randomStructuredContent = new StructuredContent() {
+			{
+				contentStructureId = _ddmStructure.getStructureId();
+				customFields = new CustomField[] {
+					longCustomField, shortCustomField, shortArrayCustomField
+				};
+				title = StringUtil.toLowerCase(RandomTestUtil.randomString());
+			}
+		};
+
+		StructuredContent putStructuredContent =
+			structuredContentResource.
+				putSiteStructuredContentByExternalReferenceCode(
+					testPutSiteStructuredContentByExternalReferenceCode_getSiteId(
+						postStructuredContent),
+					postStructuredContent.getExternalReferenceCode(),
+					randomStructuredContent);
+
+		assertValid(putStructuredContent);
+
+		CustomField[] customFields = putStructuredContent.getCustomFields();
+
+		Assert.assertNotNull(customFields);
+
+		CustomField customField = _getCustomField(
+			customFields, longExpandoColumn.getName());
+
+		Assert.assertNotNull(customField);
+
+		customField = _getCustomField(
+			customFields, shortExpandoColumn.getName());
+
+		Assert.assertNotNull(customField);
+
+		customField = _getCustomField(
+			customFields, shortArrayCustomField.getName());
+
+		Assert.assertNotNull(customField);
+	}
+
 	private JSONObject _waitForFinish(
 			String expectedExecuteStatus, boolean importTask,
 			JSONObject jsonObject)
@@ -2484,6 +2640,13 @@ public class StructuredContentResourceTest
 	private DDMTemplate _ddmTemplate;
 	private DDMStructure _depotDDMStructure;
 	private DLFileEntry _dlFileEntry;
+
+	@Inject
+	private ExpandoColumnLocalService _expandoColumnLocalService;
+
+	@DeleteAfterTestRun
+	private ExpandoTable _expandoTable;
+
 	private DDMStructure _irrelevantDDMStructure;
 	private JournalFolder _irrelevantJournalFolder;
 

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/custom/field/CustomFieldsUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/custom/field/CustomFieldsUtil.java
@@ -152,6 +152,12 @@ public class CustomFieldsUtil {
 						(Function<Collection<Number>, Serializable>)
 							ArrayUtil::toLongArray));
 			}
+			else if (ExpandoColumnConstants.NUMBER == attributeType) {
+				map.put(name, GetterUtil.getNumber(data));
+			}
+			else if (ExpandoColumnConstants.NUMBER_ARRAY == attributeType) {
+				map.put(name, _toArray(data, CustomFieldsUtil::_toNumberArray));
+			}
 			else if (ExpandoColumnConstants.SHORT == attributeType) {
 				map.put(name, GetterUtil.getShort(data));
 			}
@@ -389,6 +395,29 @@ public class CustomFieldsUtil {
 
 			while (iterator.hasNext()) {
 				newArray[i++] = _parseDate(iterator.next());
+			}
+		}
+
+		return newArray;
+	}
+
+	private static Number[] _toNumberArray(Collection<Number> collection) {
+		Number[] newArray = new Number[collection.size()];
+
+		if (collection instanceof List) {
+			List<Number> list = (List<Number>)collection;
+
+			for (int i = 0; i < list.size(); i++) {
+				newArray[i] = GetterUtil.getNumber(list.get(i));
+			}
+		}
+		else {
+			int i = 0;
+
+			Iterator<Number> iterator = collection.iterator();
+
+			while (iterator.hasNext()) {
+				newArray[i++] = GetterUtil.getNumber(iterator.next());
 			}
 		}
 

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/custom/field/CustomFieldsUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/custom/field/CustomFieldsUtil.java
@@ -127,6 +127,9 @@ public class CustomFieldsUtil {
 			else if (ExpandoColumnConstants.INTEGER_ARRAY == attributeType) {
 				map.put(name, _toArray(data, ArrayUtil::toIntArray));
 			}
+			else if (ExpandoColumnConstants.LONG == attributeType) {
+				map.put(name, GetterUtil.getLong(data));
+			}
 			else if (ExpandoColumnConstants.LONG_ARRAY == attributeType) {
 				map.put(
 					name,
@@ -134,6 +137,17 @@ public class CustomFieldsUtil {
 						data,
 						(Function<Collection<Number>, Serializable>)
 							ArrayUtil::toLongArray));
+			}
+			else if (ExpandoColumnConstants.SHORT == attributeType) {
+				map.put(name, GetterUtil.getShort(data));
+			}
+			else if (ExpandoColumnConstants.SHORT_ARRAY == attributeType) {
+				map.put(
+					name,
+					_toArray(
+						data,
+						(Function<Collection<Number>, Serializable>)
+							ArrayUtil::toShortArray));
 			}
 			else if (ExpandoColumnConstants.STRING_ARRAY == attributeType) {
 				map.put(name, _toArray(data, ArrayUtil::toStringArray));

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/custom/field/CustomFieldsUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/custom/field/CustomFieldsUtil.java
@@ -115,6 +115,9 @@ public class CustomFieldsUtil {
 			else if (ExpandoColumnConstants.DATE_ARRAY == attributeType) {
 				map.put(name, _toArray(data, CustomFieldsUtil::_toDateArray));
 			}
+			else if (ExpandoColumnConstants.DOUBLE == attributeType) {
+				map.put(name, GetterUtil.getDouble(data));
+			}
 			else if (ExpandoColumnConstants.DOUBLE_ARRAY == attributeType) {
 				map.put(name, _toArray(data, ArrayUtil::toDoubleArray));
 			}
@@ -168,6 +171,9 @@ public class CustomFieldsUtil {
 						data,
 						(Function<Collection<Number>, Serializable>)
 							ArrayUtil::toShortArray));
+			}
+			else if (ExpandoColumnConstants.STRING == attributeType) {
+				map.put(name, GetterUtil.getString(data));
 			}
 			else if (ExpandoColumnConstants.STRING_ARRAY == attributeType) {
 				map.put(name, _toArray(data, ArrayUtil::toStringArray));

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/custom/field/CustomFieldsUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/custom/field/CustomFieldsUtil.java
@@ -118,6 +118,9 @@ public class CustomFieldsUtil {
 			else if (ExpandoColumnConstants.DOUBLE_ARRAY == attributeType) {
 				map.put(name, _toArray(data, ArrayUtil::toDoubleArray));
 			}
+			else if (ExpandoColumnConstants.FLOAT == attributeType) {
+				map.put(name, GetterUtil.getFloat(data));
+			}
 			else if (ExpandoColumnConstants.FLOAT_ARRAY == attributeType) {
 				map.put(name, _toArray(data, ArrayUtil::toFloatArray));
 			}

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/custom/field/CustomFieldsUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/custom/field/CustomFieldsUtil.java
@@ -168,12 +168,7 @@ public class CustomFieldsUtil {
 				map.put(name, GetterUtil.getShort(data));
 			}
 			else if (ExpandoColumnConstants.SHORT_ARRAY == attributeType) {
-				map.put(
-					name,
-					_toArray(
-						data,
-						(Function<Collection<Number>, Serializable>)
-							ArrayUtil::toShortArray));
+				map.put(name, _toArray(data, ArrayUtil::toShortArray));
 			}
 			else if (ExpandoColumnConstants.STRING == attributeType) {
 				map.put(name, GetterUtil.getString(data));

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/custom/field/CustomFieldsUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/custom/field/CustomFieldsUtil.java
@@ -509,9 +509,13 @@ public class CustomFieldsUtil {
 	private static void _validateArrayCustomField(
 		CustomField customField, Object value, Class<?>... classes) {
 
-		boolean valid = false;
+		if (value == null) {
+			return;
+		}
 
 		for (Class<?> clazz : classes) {
+			boolean valid = true;
+
 			if (Collection.class.isInstance(value)) {
 				Collection<?> collection = (Collection<?>)value;
 
@@ -521,8 +525,15 @@ public class CustomFieldsUtil {
 					valid = _isValidCustomField(iterator.next(), clazz);
 				}
 			}
-			else if (Array.getLength(value) > 0) {
-				valid = _isValidCustomField(Array.get(value, 0), clazz);
+			else if (value.getClass(
+					).isArray()) {
+
+				if (Array.getLength(value) > 0) {
+					valid = _isValidCustomField(Array.get(value, 0), clazz);
+				}
+			}
+			else {
+				valid = false;
 			}
 
 			if (valid) {
@@ -530,11 +541,8 @@ public class CustomFieldsUtil {
 			}
 		}
 
-		if (!valid) {
-			throw new IllegalArgumentException(
-				"Unexpected type for the Custom Field: " +
-					customField.getName());
-		}
+		throw new IllegalArgumentException(
+			"Unexpected type for the Custom Field: " + customField.getName());
 	}
 
 	private static void _validateCustomField(

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/custom/field/CustomFieldsUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/custom/field/CustomFieldsUtil.java
@@ -106,7 +106,10 @@ public class CustomFieldsUtil {
 
 			Object data = customValue.getData();
 
-			if (ExpandoColumnConstants.BOOLEAN_ARRAY == attributeType) {
+			if (ExpandoColumnConstants.BOOLEAN == attributeType) {
+				map.put(name, GetterUtil.getBoolean(data));
+			}
+			else if (ExpandoColumnConstants.BOOLEAN_ARRAY == attributeType) {
 				map.put(name, _toArray(data, ArrayUtil::toBooleanArray));
 			}
 			else if (ExpandoColumnConstants.DATE == attributeType) {

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/custom/field/CustomFieldsUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/custom/field/CustomFieldsUtil.java
@@ -111,7 +111,10 @@ public class CustomFieldsUtil {
 
 			int attributeType = expandoBridge.getAttributeType(name);
 
-			if (ExpandoColumnConstants.isArray(attributeType)) {
+			if (ExpandoColumnConstants.isArray(attributeType) &&
+				(attributeType !=
+					ExpandoColumnConstants.STRING_ARRAY_LOCALIZED)) {
+
 				_validateArray(customField, data);
 			}
 

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/custom/field/CustomFieldsUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/custom/field/CustomFieldsUtil.java
@@ -401,9 +401,7 @@ public class CustomFieldsUtil {
 			Iterator<T> iterator = (Iterator<T>)collection.iterator();
 
 			while (iterator.hasNext()) {
-				T value = iterator.next();
-
-				Array.set(newArray, i++, function.apply(value));
+				Array.set(newArray, i++, function.apply(iterator.next()));
 			}
 		}
 

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/custom/field/CustomFieldsUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/custom/field/CustomFieldsUtil.java
@@ -104,7 +104,10 @@ public class CustomFieldsUtil {
 
 			Object data = customValue.getData();
 
-			if (ExpandoColumnConstants.DATE == attributeType) {
+			if (ExpandoColumnConstants.BOOLEAN_ARRAY == attributeType) {
+				map.put(name, _toArray(data, ArrayUtil::toBooleanArray));
+			}
+			else if (ExpandoColumnConstants.DATE == attributeType) {
 				map.put(name, _parseDate(String.valueOf(data)));
 			}
 			else if (ExpandoColumnConstants.DOUBLE_ARRAY == attributeType) {

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/custom/field/CustomFieldsUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/custom/field/CustomFieldsUtil.java
@@ -31,7 +31,6 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
@@ -98,39 +97,75 @@ public class CustomFieldsUtil {
 			companyId, className);
 
 		for (CustomField customField : customFields) {
-			String name = customField.getName();
-
-			int attributeType = expandoBridge.getAttributeType(name);
-
 			CustomValue customValue = customField.getCustomValue();
 
 			Object data = customValue.getData();
 
+			if ((data == null) && (customValue.getData_i18n() == null) &&
+				(customValue.getGeo() == null)) {
+
+				continue;
+			}
+
+			String name = customField.getName();
+
+			int attributeType = expandoBridge.getAttributeType(name);
+
+			if (ExpandoColumnConstants.isArray(attributeType)) {
+				_validateArray(customField, data);
+			}
+
 			if (ExpandoColumnConstants.BOOLEAN == attributeType) {
+				_validateCustomField(customField, data, Boolean.class);
+
 				map.put(name, GetterUtil.getBoolean(data));
 			}
 			else if (ExpandoColumnConstants.BOOLEAN_ARRAY == attributeType) {
-				map.put(name, _toArray(data, ArrayUtil::toBooleanArray));
+				_validateArrayCustomField(customField, data, Boolean.class);
+
+				map.put(
+					name,
+					_toArray(boolean.class, data, GetterUtil::getBoolean));
 			}
 			else if (ExpandoColumnConstants.DATE == attributeType) {
-				map.put(name, _parseDate(String.valueOf(data)));
+				_validateCustomField(
+					customField, data, Date.class, String.class);
+
+				map.put(name, _toDate(data));
 			}
 			else if (ExpandoColumnConstants.DATE_ARRAY == attributeType) {
-				map.put(name, _toArray(data, CustomFieldsUtil::_toDateArray));
+				_validateArrayCustomField(
+					customField, data, Date.class, String.class);
+
+				map.put(
+					name,
+					_toArray(Date.class, data, CustomFieldsUtil::_toDate));
 			}
 			else if (ExpandoColumnConstants.DOUBLE == attributeType) {
+				_validateCustomField(customField, data, Number.class);
+
 				map.put(name, GetterUtil.getDouble(data));
 			}
 			else if (ExpandoColumnConstants.DOUBLE_ARRAY == attributeType) {
-				map.put(name, _toArray(data, ArrayUtil::toDoubleArray));
+				_validateArrayCustomField(customField, data, Number.class);
+
+				map.put(
+					name, _toArray(double.class, data, GetterUtil::getDouble));
 			}
 			else if (ExpandoColumnConstants.FLOAT == attributeType) {
+				_validateCustomField(customField, data, Number.class);
+
 				map.put(name, GetterUtil.getFloat(data));
 			}
 			else if (ExpandoColumnConstants.FLOAT_ARRAY == attributeType) {
-				map.put(name, _toArray(data, ArrayUtil::toFloatArray));
+				_validateArrayCustomField(customField, data, Number.class);
+
+				map.put(
+					name, _toArray(float.class, data, GetterUtil::getFloat));
 			}
 			else if (ExpandoColumnConstants.GEOLOCATION == attributeType) {
+				_validateCustomField(customField, data, Geo.class);
+
 				Geo geo = customValue.getGeo();
 
 				map.put(
@@ -142,41 +177,64 @@ public class CustomFieldsUtil {
 					).toString());
 			}
 			else if (ExpandoColumnConstants.INTEGER == attributeType) {
+				_validateCustomField(customField, data, Number.class);
+
 				map.put(name, GetterUtil.getInteger(data));
 			}
 			else if (ExpandoColumnConstants.INTEGER_ARRAY == attributeType) {
-				map.put(name, _toArray(data, ArrayUtil::toIntArray));
+				_validateArrayCustomField(customField, data, Number.class);
+
+				map.put(
+					name, _toArray(int.class, data, GetterUtil::getInteger));
 			}
 			else if (ExpandoColumnConstants.LONG == attributeType) {
+				_validateCustomField(customField, data, Number.class);
+
 				map.put(name, GetterUtil.getLong(data));
 			}
 			else if (ExpandoColumnConstants.LONG_ARRAY == attributeType) {
-				map.put(
-					name,
-					_toArray(
-						data,
-						(Function<Collection<Number>, Serializable>)
-							ArrayUtil::toLongArray));
+				_validateArrayCustomField(customField, data, Number.class);
+
+				map.put(name, _toArray(long.class, data, GetterUtil::getLong));
 			}
 			else if (ExpandoColumnConstants.NUMBER == attributeType) {
+				_validateCustomField(customField, data, Number.class);
+
 				map.put(name, GetterUtil.getNumber(data));
 			}
 			else if (ExpandoColumnConstants.NUMBER_ARRAY == attributeType) {
-				map.put(name, _toArray(data, CustomFieldsUtil::_toNumberArray));
+				_validateArrayCustomField(customField, data, Number.class);
+
+				map.put(
+					name, _toArray(Number.class, data, GetterUtil::getNumber));
 			}
 			else if (ExpandoColumnConstants.SHORT == attributeType) {
+				_validateCustomField(customField, data, Number.class);
+
 				map.put(name, GetterUtil.getShort(data));
 			}
 			else if (ExpandoColumnConstants.SHORT_ARRAY == attributeType) {
-				map.put(name, _toArray(data, ArrayUtil::toShortArray));
+				_validateArrayCustomField(customField, data, Number.class);
+
+				map.put(
+					name, _toArray(short.class, data, GetterUtil::getShort));
 			}
 			else if (ExpandoColumnConstants.STRING == attributeType) {
+				_validateCustomField(customField, data, String.class);
+
 				map.put(name, GetterUtil.getString(data));
 			}
 			else if (ExpandoColumnConstants.STRING_ARRAY == attributeType) {
-				map.put(name, _toArray(data, ArrayUtil::toStringArray));
+				_validateArrayCustomField(customField, data, String.class);
+
+				map.put(
+					name, _toArray(String.class, data, GetterUtil::getString));
 			}
 			else if (ExpandoColumnConstants.STRING_LOCALIZED == attributeType) {
+				_validateCustomField(customField, data, String.class);
+				_validateCustomField(
+					customField, customValue.getData_i18n(), Map.class);
+
 				map.put(
 					name,
 					(Serializable)LocalizedMapUtil.getLocalizedMap(
@@ -293,27 +351,60 @@ public class CustomFieldsUtil {
 		return false;
 	}
 
-	private static Date _parseDate(String data) {
-		DateFormat dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+	private static boolean _isValidCustomField(
+		Object value, Class<?>... classes) {
 
-		try {
-			return dateFormat.parse(data);
+		if (value == null) {
+			return true;
 		}
-		catch (ParseException parseException) {
-			throw new IllegalArgumentException(
-				"Unable to parse date from " + data, parseException);
+
+		for (Class<?> clazz : classes) {
+			if (clazz.isInstance(value)) {
+				return true;
+			}
 		}
+
+		return false;
 	}
 
-	private static <T> Serializable _toArray(
-		Object data, Function<Collection<T>, Serializable> function) {
+	private static <T, U> Serializable _toArray(
+		Class<? extends U> clazz, Object data, Function<Object, U> function) {
 
-		if (data instanceof Collection) {
-			return function.apply((Collection)data);
+		Serializable newArray = null;
+
+		Class<?> dataClass = data.getClass();
+
+		if (dataClass.isArray()) {
+			if (clazz.equals(dataClass.getComponentType())) {
+				return (Serializable)data;
+			}
+
+			int length = Array.getLength(data);
+
+			newArray = (Serializable)Array.newInstance(clazz, length);
+
+			for (int i = 0; i < length; i++) {
+				Array.set(newArray, i, function.apply(Array.get(data, i)));
+			}
+		}
+		else if (data instanceof Collection) {
+			Collection<?> collection = (Collection<?>)data;
+
+			newArray = (Serializable)Array.newInstance(
+				clazz, collection.size());
+
+			int i = 0;
+
+			Iterator<T> iterator = (Iterator<T>)collection.iterator();
+
+			while (iterator.hasNext()) {
+				T value = iterator.next();
+
+				Array.set(newArray, i++, function.apply(value));
+			}
 		}
 
-		return (Serializable)data;
+		return newArray;
 	}
 
 	private static CustomField _toCustomField(
@@ -382,50 +473,76 @@ public class CustomFieldsUtil {
 		};
 	}
 
-	private static Date[] _toDateArray(Collection<String> collection) {
-		Date[] newArray = new Date[collection.size()];
-
-		if (collection instanceof List) {
-			List<String> list = (List<String>)collection;
-
-			for (int i = 0; i < list.size(); i++) {
-				newArray[i] = _parseDate(list.get(i));
-			}
-		}
-		else {
-			int i = 0;
-
-			Iterator<String> iterator = collection.iterator();
-
-			while (iterator.hasNext()) {
-				newArray[i++] = _parseDate(iterator.next());
-			}
+	private static Date _toDate(Object data) {
+		if (data instanceof Date) {
+			return (Date)data;
 		}
 
-		return newArray;
+		DateFormat dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		try {
+			return dateFormat.parse((String)data);
+		}
+		catch (ParseException parseException) {
+			throw new IllegalArgumentException(
+				"Unable to parse date from " + data, parseException);
+		}
 	}
 
-	private static Number[] _toNumberArray(Collection<Number> collection) {
-		Number[] newArray = new Number[collection.size()];
+	private static void _validateArray(CustomField customField, Object value) {
+		if ((value instanceof Collection<?>) ||
+			value.getClass(
+			).isArray()) {
 
-		if (collection instanceof List) {
-			List<Number> list = (List<Number>)collection;
-
-			for (int i = 0; i < list.size(); i++) {
-				newArray[i] = GetterUtil.getNumber(list.get(i));
-			}
-		}
-		else {
-			int i = 0;
-
-			Iterator<Number> iterator = collection.iterator();
-
-			while (iterator.hasNext()) {
-				newArray[i++] = GetterUtil.getNumber(iterator.next());
-			}
+			return;
 		}
 
-		return newArray;
+		throw new IllegalArgumentException(
+			"Unexpected type for the Custom Field: " + customField.getName() +
+				", Array or Collection expected");
+	}
+
+	private static void _validateArrayCustomField(
+		CustomField customField, Object value, Class<?>... classes) {
+
+		boolean valid = false;
+
+		for (Class<?> clazz : classes) {
+			if (Collection.class.isInstance(value)) {
+				Collection<?> collection = (Collection<?>)value;
+
+				Iterator<?> iterator = collection.iterator();
+
+				if (iterator.hasNext()) {
+					valid = _isValidCustomField(iterator.next(), clazz);
+				}
+			}
+			else if (Array.getLength(value) > 0) {
+				valid = _isValidCustomField(Array.get(value, 0), clazz);
+			}
+
+			if (valid) {
+				return;
+			}
+		}
+
+		if (!valid) {
+			throw new IllegalArgumentException(
+				"Unexpected type for the Custom Field: " +
+					customField.getName());
+		}
+	}
+
+	private static void _validateCustomField(
+		CustomField customField, Object value, Class<?>... classes) {
+
+		if (_isValidCustomField(value, classes)) {
+			return;
+		}
+
+		throw new IllegalArgumentException(
+			"Unexpected type for the Custom Field: " + customField.getName());
 	}
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/custom/field/CustomFieldsUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/custom/field/CustomFieldsUtil.java
@@ -30,6 +30,8 @@ import java.text.ParseException;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
@@ -109,6 +111,9 @@ public class CustomFieldsUtil {
 			}
 			else if (ExpandoColumnConstants.DATE == attributeType) {
 				map.put(name, _parseDate(String.valueOf(data)));
+			}
+			else if (ExpandoColumnConstants.DATE_ARRAY == attributeType) {
+				map.put(name, _toArray(data, CustomFieldsUtil::_toDateArray));
 			}
 			else if (ExpandoColumnConstants.DOUBLE_ARRAY == attributeType) {
 				map.put(name, _toArray(data, ArrayUtil::toDoubleArray));
@@ -272,7 +277,7 @@ public class CustomFieldsUtil {
 		return false;
 	}
 
-	private static Serializable _parseDate(String data) {
+	private static Date _parseDate(String data) {
 		DateFormat dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
 			"yyyy-MM-dd'T'HH:mm:ss'Z'");
 
@@ -359,6 +364,29 @@ public class CustomFieldsUtil {
 				setName(entry::getKey);
 			}
 		};
+	}
+
+	private static Date[] _toDateArray(Collection<String> collection) {
+		Date[] newArray = new Date[collection.size()];
+
+		if (collection instanceof List) {
+			List<String> list = (List<String>)collection;
+
+			for (int i = 0; i < list.size(); i++) {
+				newArray[i] = _parseDate(list.get(i));
+			}
+		}
+		else {
+			int i = 0;
+
+			Iterator<String> iterator = collection.iterator();
+
+			while (iterator.hasNext()) {
+				newArray[i++] = _parseDate(iterator.next());
+			}
+		}
+
+		return newArray;
 	}
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/custom/field/CustomFieldsUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/custom/field/CustomFieldsUtil.java
@@ -135,6 +135,9 @@ public class CustomFieldsUtil {
 						"longitude", geo.getLongitude()
 					).toString());
 			}
+			else if (ExpandoColumnConstants.INTEGER == attributeType) {
+				map.put(name, GetterUtil.getInteger(data));
+			}
 			else if (ExpandoColumnConstants.INTEGER_ARRAY == attributeType) {
 				map.put(name, _toArray(data, ArrayUtil::toIntArray));
 			}

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/custom/field/test/CustomFieldsUtilTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/custom/field/test/CustomFieldsUtilTest.java
@@ -1960,6 +1960,370 @@ public class CustomFieldsUtilTest {
 			).build());
 	}
 
+	@Test
+	@TestInfo("LPD-54757")
+	public void testToMapExpectedClassAndValueInvalidValues() throws Exception {
+
+		// Boolean
+
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			"Unexpected type for the Custom Field: " +
+				_expandoColumn1.getName(),
+			() -> _testToMapExpectedClassAndValue(
+				_buildCustomField("true", null, _expandoColumn1, null), null,
+				null));
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			"Unexpected type for the Custom Field: " +
+				_expandoColumn1.getName(),
+			() -> _testToMapExpectedClassAndValue(
+				_buildCustomField(_DATA_INT, null, _expandoColumn1, null), null,
+				null));
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			"Unexpected type for the Custom Field: " +
+				_expandoColumn1.getName(),
+			() -> _testToMapExpectedClassAndValue(
+				_buildCustomField(
+					Arrays.asList(_DATA_INT), null, _expandoColumn1, null),
+				null, null));
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			"Unexpected type for the Custom Field: " +
+				_expandoColumn1.getName(),
+			() -> _testToMapExpectedClassAndValue(
+				_buildCustomField(
+					new boolean[] {false}, null, _expandoColumn1, null),
+				null, null));
+
+		// Boolean array
+
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			"Unexpected type for the Custom Field: " +
+				_expandoColumn2.getName(),
+			() -> _testToMapExpectedClassAndValue(
+				_buildCustomField(
+					Arrays.asList("true"), null, _expandoColumn2, null),
+				null, null));
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			"Unexpected type for the Custom Field: " +
+				_expandoColumn2.getName(),
+			() -> _testToMapExpectedClassAndValue(
+				_buildCustomField(
+					Arrays.asList(_DATA_INT), null, _expandoColumn2, null),
+				null, null));
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			"Unexpected type for the Custom Field: " +
+				_expandoColumn2.getName() + ", Array or Collection expected",
+			() -> _testToMapExpectedClassAndValue(
+				_buildCustomField(_DATA_INT, null, _expandoColumn2, null), null,
+				null));
+
+		// Date
+
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			"Unexpected type for the Custom Field: " +
+				_expandoColumn3.getName(),
+			() -> _testToMapExpectedClassAndValue(
+				_buildCustomField(_DATA_INT, null, _expandoColumn3, null), null,
+				null));
+
+		// Date array
+
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			"Unexpected type for the Custom Field: " +
+				_expandoColumn4.getName(),
+			() -> _testToMapExpectedClassAndValue(
+				_buildCustomField(
+					Arrays.asList(_DATA_INT), null, _expandoColumn4, null),
+				null, null));
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			"Unexpected type for the Custom Field: " +
+				_expandoColumn4.getName() + ", Array or Collection expected",
+			() -> _testToMapExpectedClassAndValue(
+				_buildCustomField(_DATA_INT, null, _expandoColumn4, null), null,
+				null));
+
+		// Double
+
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			"Unexpected type for the Custom Field: " +
+				_expandoColumn5.getName(),
+			() -> _testToMapExpectedClassAndValue(
+				_buildCustomField(_DATA_STRING, null, _expandoColumn5, null),
+				null, null));
+
+		// Double array
+
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			"Unexpected type for the Custom Field: " +
+				_expandoColumn6.getName(),
+			() -> _testToMapExpectedClassAndValue(
+				_buildCustomField(
+					Arrays.asList(_DATA_STRING), null, _expandoColumn6, null),
+				null, null));
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			"Unexpected type for the Custom Field: " +
+				_expandoColumn7.getName(),
+			() -> _testToMapExpectedClassAndValue(
+				_buildCustomField(
+					Arrays.asList(_DATA_STRING), null, _expandoColumn7, null),
+				null, null));
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			"Unexpected type for the Custom Field: " +
+				_expandoColumn8.getName(),
+			() -> _testToMapExpectedClassAndValue(
+				_buildCustomField(
+					Arrays.asList(_DATA_STRING), null, _expandoColumn8, null),
+				null, null));
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			"Unexpected type for the Custom Field: " +
+				_expandoColumn8.getName() + ", Array or Collection expected",
+			() -> _testToMapExpectedClassAndValue(
+				_buildCustomField(_DATA_INT, null, _expandoColumn8, null), null,
+				null));
+
+		// Float
+
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			"Unexpected type for the Custom Field: " +
+				_expandoColumn9.getName(),
+			() -> _testToMapExpectedClassAndValue(
+				_buildCustomField(_DATA_STRING, null, _expandoColumn9, null),
+				null, null));
+
+		// Float array
+
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			"Unexpected type for the Custom Field: " +
+				_expandoColumn10.getName(),
+			() -> _testToMapExpectedClassAndValue(
+				_buildCustomField(
+					Arrays.asList(_DATA_STRING), null, _expandoColumn10, null),
+				null, null));
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			"Unexpected type for the Custom Field: " +
+				_expandoColumn10.getName() + ", Array or Collection expected",
+			() -> _testToMapExpectedClassAndValue(
+				_buildCustomField(_DATA_INT, null, _expandoColumn10, null),
+				null, null));
+
+		// Integer
+
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			"Unexpected type for the Custom Field: " +
+				_expandoColumn12.getName(),
+			() -> _testToMapExpectedClassAndValue(
+				_buildCustomField(_DATA_STRING, null, _expandoColumn12, null),
+				null, null));
+
+		// Integer array
+
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			"Unexpected type for the Custom Field: " +
+				_expandoColumn13.getName(),
+			() -> _testToMapExpectedClassAndValue(
+				_buildCustomField(
+					Arrays.asList(_DATA_STRING), null, _expandoColumn13, null),
+				null, null));
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			"Unexpected type for the Custom Field: " +
+				_expandoColumn13.getName() + ", Array or Collection expected",
+			() -> _testToMapExpectedClassAndValue(
+				_buildCustomField(_DATA_INT, null, _expandoColumn13, null),
+				null, null));
+
+		// Long
+
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			"Unexpected type for the Custom Field: " +
+				_expandoColumn14.getName(),
+			() -> _testToMapExpectedClassAndValue(
+				_buildCustomField(_DATA_STRING, null, _expandoColumn14, null),
+				null, null));
+
+		// Long array
+
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			"Unexpected type for the Custom Field: " +
+				_expandoColumn15.getName(),
+			() -> _testToMapExpectedClassAndValue(
+				_buildCustomField(
+					Arrays.asList(_DATA_STRING), null, _expandoColumn15, null),
+				null, null));
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			"Unexpected type for the Custom Field: " +
+				_expandoColumn15.getName() + ", Array or Collection expected",
+			() -> _testToMapExpectedClassAndValue(
+				_buildCustomField(_DATA_INT, null, _expandoColumn15, null),
+				null, null));
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			"Unexpected type for the Custom Field: " +
+				_expandoColumn16.getName(),
+			() -> _testToMapExpectedClassAndValue(
+				_buildCustomField(
+					Arrays.asList(_DATA_STRING), null, _expandoColumn16, null),
+				null, null));
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			"Unexpected type for the Custom Field: " +
+				_expandoColumn16.getName() + ", Array or Collection expected",
+			() -> _testToMapExpectedClassAndValue(
+				_buildCustomField(_DATA_INT, null, _expandoColumn16, null),
+				null, null));
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			"Unexpected type for the Custom Field: " +
+				_expandoColumn17.getName(),
+			() -> _testToMapExpectedClassAndValue(
+				_buildCustomField(
+					Arrays.asList(_DATA_STRING), null, _expandoColumn17, null),
+				null, null));
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			"Unexpected type for the Custom Field: " +
+				_expandoColumn17.getName() + ", Array or Collection expected",
+			() -> _testToMapExpectedClassAndValue(
+				_buildCustomField(_DATA_INT, null, _expandoColumn17, null),
+				null, null));
+
+		// Number
+
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			"Unexpected type for the Custom Field: " +
+				_expandoColumn18.getName(),
+			() -> _testToMapExpectedClassAndValue(
+				_buildCustomField(_DATA_STRING, null, _expandoColumn18, null),
+				null, null));
+
+		// Number array
+
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			"Unexpected type for the Custom Field: " +
+				_expandoColumn19.getName(),
+			() -> _testToMapExpectedClassAndValue(
+				_buildCustomField(
+					Arrays.asList(_DATA_STRING), null, _expandoColumn19, null),
+				null, null));
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			"Unexpected type for the Custom Field: " +
+				_expandoColumn19.getName() + ", Array or Collection expected",
+			() -> _testToMapExpectedClassAndValue(
+				_buildCustomField(_DATA_INT, null, _expandoColumn19, null),
+				null, null));
+
+		// Short
+
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			"Unexpected type for the Custom Field: " +
+				_expandoColumn20.getName(),
+			() -> _testToMapExpectedClassAndValue(
+				_buildCustomField(_DATA_STRING, null, _expandoColumn20, null),
+				null, null));
+
+		// Short array
+
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			"Unexpected type for the Custom Field: " +
+				_expandoColumn21.getName(),
+			() -> _testToMapExpectedClassAndValue(
+				_buildCustomField(
+					Arrays.asList(_DATA_STRING), null, _expandoColumn21, null),
+				null, null));
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			"Unexpected type for the Custom Field: " +
+				_expandoColumn21.getName() + ", Array or Collection expected",
+			() -> _testToMapExpectedClassAndValue(
+				_buildCustomField(_DATA_INT, null, _expandoColumn21, null),
+				null, null));
+
+		// String
+
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			"Unexpected type for the Custom Field: " +
+				_expandoColumn22.getName(),
+			() -> _testToMapExpectedClassAndValue(
+				_buildCustomField(_DATA_INT, null, _expandoColumn22, null),
+				null, null));
+
+		// String array
+
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			"Unexpected type for the Custom Field: " +
+				_expandoColumn23.getName(),
+			() -> _testToMapExpectedClassAndValue(
+				_buildCustomField(
+					Arrays.asList(_DATA_INT), null, _expandoColumn23, null),
+				null, null));
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			"Unexpected type for the Custom Field: " +
+				_expandoColumn23.getName() + ", Array or Collection expected",
+			() -> _testToMapExpectedClassAndValue(
+				_buildCustomField(_DATA_INT, null, _expandoColumn23, null),
+				null, null));
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			"Unexpected type for the Custom Field: " +
+				_expandoColumn24.getName(),
+			() -> _testToMapExpectedClassAndValue(
+				_buildCustomField(
+					Arrays.asList(_DATA_INT), null, _expandoColumn24, null),
+				null, null));
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			"Unexpected type for the Custom Field: " +
+				_expandoColumn24.getName() + ", Array or Collection expected",
+			() -> _testToMapExpectedClassAndValue(
+				_buildCustomField(_DATA_INT, null, _expandoColumn24, null),
+				null, null));
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			"Unexpected type for the Custom Field: " +
+				_expandoColumn25.getName(),
+			() -> _testToMapExpectedClassAndValue(
+				_buildCustomField(
+					Arrays.asList(_DATA_INT), null, _expandoColumn25, null),
+				null, null));
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			"Unexpected type for the Custom Field: " +
+				_expandoColumn25.getName() + ", Array or Collection expected",
+			() -> _testToMapExpectedClassAndValue(
+				_buildCustomField(_DATA_INT, null, _expandoColumn25, null),
+				null, null));
+	}
+
 	private ExpandoColumn _addExpandoColumn(
 			Object defaultData, String displayType, ExpandoTable expandoTable,
 			int type)

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/custom/field/test/CustomFieldsUtilTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/custom/field/test/CustomFieldsUtilTest.java
@@ -1347,6 +1347,34 @@ public class CustomFieldsUtilTest {
 			map.toString(), _initialExpandoColumnsCount + 27, map.size());
 	}
 
+	@Test
+	public void testToMapWithIntegerValueForLongField() throws Exception {
+		CustomField[] customFields = new CustomField[] {
+			new CustomField() {
+				{
+					customValue = new CustomValue() {
+						{
+							data = _DATA_INT;
+						}
+					};
+					dataType = "Integer";
+					name = _expandoColumn14.getName();
+				}
+			}
+		};
+
+		Map<String, Serializable> map = CustomFieldsUtil.toMap(
+			_clazz.getName(), TestPropsValues.getCompanyId(), customFields,
+			LocaleUtil.getDefault());
+
+		Assert.assertEquals((long)_DATA_INT, map.get(_expandoColumn14.getName()));
+
+		Assert.assertTrue(
+			"Value should be of type Long but was " + 
+			map.get(_expandoColumn14.getName()).getClass().getName(),
+			map.get(_expandoColumn14.getName()) instanceof Long);
+	}
+
 	private ExpandoColumn _addExpandoColumn(
 			Object defaultData, String displayType, ExpandoTable expandoTable,
 			int type)
@@ -1432,6 +1460,8 @@ public class CustomFieldsUtilTest {
 	private static final double _DATA_DOUBLE = RandomTestUtil.randomDouble();
 
 	private static final long _DATA_LONG = RandomTestUtil.randomLong();
+
+	private static final int _DATA_INT = RandomTestUtil.randomInt();
 
 	private static final String _DATA_STRING = RandomTestUtil.randomString();
 

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/custom/field/test/CustomFieldsUtilTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/custom/field/test/CustomFieldsUtilTest.java
@@ -44,13 +44,14 @@ import java.math.BigDecimal;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.List;
-import java.util.ArrayList;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -1353,99 +1354,6 @@ public class CustomFieldsUtilTest {
 			map.toString(), _initialExpandoColumnsCount + 27, map.size());
 	}
 
-
-	private void _testToMapWithIntegerValueForLongField() throws Exception {
-		CustomField[] customFields = new CustomField[] {
-			new CustomField() {
-				{
-					customValue = new CustomValue() {
-						{
-							data = _DATA_INT;
-						}
-					};
-					dataType = "Integer";
-					name = _expandoColumn14.getName();
-				}
-			}
-		};
-
-		Map<String, Serializable> map = CustomFieldsUtil.toMap(
-			_clazz.getName(), TestPropsValues.getCompanyId(), customFields,
-			LocaleUtil.getDefault());
-
-		Assert.assertEquals((long)_DATA_INT, map.get(_expandoColumn14.getName()));
-
-		Assert.assertTrue(
-			"Value should be of type Long but was " + 
-			map.get(_expandoColumn14.getName()).getClass().getName(),
-			map.get(_expandoColumn14.getName()) instanceof Long);
-	}
-
-
-	private void _testToMapWithIntegerValueForShortField() throws Exception {
-		CustomField[] customFields = new CustomField[] {
-			new CustomField() {
-				{
-					customValue = new CustomValue() {
-						{
-							data = _DATA_INT;
-						}
-					};
-					dataType = "Integer";
-					name = _expandoColumn20.getName();
-				}
-			}
-		};
-
-		Map<String, Serializable> map = CustomFieldsUtil.toMap(
-			_clazz.getName(), TestPropsValues.getCompanyId(), customFields,
-			LocaleUtil.getDefault());
-
-		Assert.assertEquals((short)_DATA_INT, map.get(_expandoColumn20.getName()));
-		
-		Assert.assertTrue(
-			"Value should be of type Short but was " + 
-			map.get(_expandoColumn20.getName()).getClass().getName(),
-			map.get(_expandoColumn20.getName()) instanceof Short);
-	}
-
-
-	private void _testToMapWithIntegerArrayForShortArrayField() throws Exception {
-		List<Integer> integerCollection = new ArrayList<>();
-		integerCollection.add(_DATA_INT);
-		
-		CustomField[] customFields = new CustomField[] {
-			new CustomField() {
-				{
-					customValue = new CustomValue() {
-						{
-							data = integerCollection;
-						}
-					};
-					dataType = "Integer";
-					name = _expandoColumn21.getName();
-				}
-			}
-		};
-
-		Map<String, Serializable> map = CustomFieldsUtil.toMap(
-			_clazz.getName(), TestPropsValues.getCompanyId(), customFields,
-			LocaleUtil.getDefault());
-
-		short[] result = (short[])map.get(_expandoColumn21.getName());
-
-		Assert.assertEquals(integerCollection.size(), result.length);
-		for (int i = 0; i < integerCollection.size(); i++) {
-			Assert.assertEquals(
-				(short)(int)integerCollection.get(i), result[i]);
-		}
-
-		Assert.assertTrue(
-			"Value should be of type short[] but was " + 
-			map.get(_expandoColumn21.getName()).getClass().getName(),
-			map.get(_expandoColumn21.getName()) instanceof short[]);
-	}
-
 	private ExpandoColumn _addExpandoColumn(
 			Object defaultData, String displayType, ExpandoTable expandoTable,
 			int type)
@@ -1528,11 +1436,121 @@ public class CustomFieldsUtilTest {
 		throw new NoSuchValueException();
 	}
 
+	private void _testToMapWithIntegerArrayForShortArrayField()
+		throws Exception {
+
+		List<Integer> integerCollection = new ArrayList<>();
+
+		integerCollection.add(_DATA_INT);
+
+		CustomField[] customFields = {
+			new CustomField() {
+				{
+					customValue = new CustomValue() {
+						{
+							data = integerCollection;
+						}
+					};
+					dataType = "Integer";
+					name = _expandoColumn21.getName();
+				}
+			}
+		};
+
+		Map<String, Serializable> map = CustomFieldsUtil.toMap(
+			_clazz.getName(), TestPropsValues.getCompanyId(), customFields,
+			LocaleUtil.getDefault());
+
+		short[] result = (short[])map.get(_expandoColumn21.getName());
+
+		Assert.assertEquals(
+			Arrays.toString(result), integerCollection.size(), result.length);
+
+		for (int i = 0; i < integerCollection.size(); i++) {
+			Assert.assertEquals(
+				"Element at index " + i, (short)(int)integerCollection.get(i),
+				result[i]);
+		}
+
+		String className = map.get(
+			_expandoColumn21.getName()
+		).getClass(
+		).getName();
+
+		Assert.assertTrue(
+			"Value should be of type short[] but was " + className,
+			map.get(_expandoColumn21.getName()) instanceof short[]);
+	}
+
+	private void _testToMapWithIntegerValueForLongField() throws Exception {
+		CustomField[] customFields = {
+			new CustomField() {
+				{
+					customValue = new CustomValue() {
+						{
+							data = _DATA_INT;
+						}
+					};
+					dataType = "Integer";
+					name = _expandoColumn14.getName();
+				}
+			}
+		};
+
+		Map<String, Serializable> map = CustomFieldsUtil.toMap(
+			_clazz.getName(), TestPropsValues.getCompanyId(), customFields,
+			LocaleUtil.getDefault());
+
+		Assert.assertEquals(
+			(long)_DATA_INT, map.get(_expandoColumn14.getName()));
+
+		String className = map.get(
+			_expandoColumn14.getName()
+		).getClass(
+		).getName();
+
+		Assert.assertTrue(
+			"Value should be of type Long but was " + className,
+			map.get(_expandoColumn14.getName()) instanceof Long);
+	}
+
+	private void _testToMapWithIntegerValueForShortField() throws Exception {
+		CustomField[] customFields = {
+			new CustomField() {
+				{
+					customValue = new CustomValue() {
+						{
+							data = _DATA_INT;
+						}
+					};
+					dataType = "Integer";
+					name = _expandoColumn20.getName();
+				}
+			}
+		};
+
+		Map<String, Serializable> map = CustomFieldsUtil.toMap(
+			_clazz.getName(), TestPropsValues.getCompanyId(), customFields,
+			LocaleUtil.getDefault());
+
+		Assert.assertEquals(
+			(short)_DATA_INT, map.get(_expandoColumn20.getName()));
+
+		String className = map.get(
+			_expandoColumn20.getName()
+		).getClass(
+		).getName();
+
+		Assert.assertTrue(
+			"Value should be of type Short but was " + className,
+			map.get(_expandoColumn20.getName()) instanceof Short);
+	}
+
 	private static final double _DATA_DOUBLE = RandomTestUtil.randomDouble();
 
-	private static final long _DATA_LONG = RandomTestUtil.randomLong();
-
 	private static final int _DATA_INT = RandomTestUtil.randomInt();
+
+	private static final long _DATA_LONG = RandomTestUtil.randomLong();
 
 	private static final String _DATA_STRING = RandomTestUtil.randomString();
 

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/custom/field/test/CustomFieldsUtilTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/custom/field/test/CustomFieldsUtilTest.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.test.AssertUtils;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -1279,6 +1280,75 @@ public class CustomFieldsUtilTest {
 			(Map)map.get(_expandoColumn27.getName()));
 		Assert.assertEquals(
 			map.toString(), _initialExpandoColumnsCount + 27, map.size());
+	}
+
+	@Test
+	public void testToMapDefaultCustomFieldValues() throws Exception {
+		Map<String, Serializable> map = CustomFieldsUtil.toMap(
+			_clazz.getName(), TestPropsValues.getCompanyId(),
+			CustomFieldsUtil.toCustomFields(
+				true, _clazz.getName(), RandomTestUtil.randomLong(),
+				TestPropsValues.getCompanyId(), LocaleUtil.getDefault()),
+			LocaleUtil.getDefault());
+
+		Assert.assertFalse((boolean)map.get(_expandoColumn1.getName()));
+		Assert.assertArrayEquals(
+			new boolean[0], (boolean[])map.get(_expandoColumn2.getName()));
+		Assert.assertEquals(new Date(0), map.get(_expandoColumn3.getName()));
+		Assert.assertArrayEquals(
+			new Date[0], (Date[])map.get(_expandoColumn4.getName()));
+		Assert.assertEquals(0.0, map.get(_expandoColumn5.getName()));
+		Assert.assertArrayEquals(
+			new double[] {0.0}, (double[])map.get(_expandoColumn6.getName()),
+			0);
+		Assert.assertArrayEquals(
+			new double[] {0.0}, (double[])map.get(_expandoColumn7.getName()),
+			0);
+		Assert.assertArrayEquals(
+			new double[] {_DATA_DOUBLE},
+			(double[])map.get(_expandoColumn8.getName()), 0);
+		Assert.assertEquals((float)0.0, map.get(_expandoColumn9.getName()));
+		Assert.assertArrayEquals(
+			new float[0], (float[])map.get(_expandoColumn10.getName()), 0);
+		Assert.assertEquals("{}", map.get(_expandoColumn11.getName()));
+		Assert.assertEquals(0, map.get(_expandoColumn12.getName()));
+		Assert.assertArrayEquals(
+			new int[0], (int[])map.get(_expandoColumn13.getName()));
+		Assert.assertEquals(0L, map.get(_expandoColumn14.getName()));
+		Assert.assertArrayEquals(
+			new long[] {0L}, (long[])map.get(_expandoColumn15.getName()));
+		Assert.assertArrayEquals(
+			new long[] {0L}, (long[])map.get(_expandoColumn16.getName()));
+		Assert.assertArrayEquals(
+			new long[] {_DATA_LONG},
+			(long[])map.get(_expandoColumn17.getName()));
+		Assert.assertEquals(0, map.get(_expandoColumn18.getName()));
+		Assert.assertArrayEquals(
+			new Number[0], (Number[])map.get(_expandoColumn19.getName()));
+		Assert.assertEquals((short)0, map.get(_expandoColumn20.getName()));
+		Assert.assertArrayEquals(
+			new short[0], (short[])map.get(_expandoColumn21.getName()));
+		Assert.assertEquals("", map.get(_expandoColumn22.getName()));
+		Assert.assertArrayEquals(
+			new String[] {"false"},
+			(String[])map.get(_expandoColumn23.getName()));
+		Assert.assertArrayEquals(
+			new String[] {"false"},
+			(String[])map.get(_expandoColumn24.getName()));
+		Assert.assertArrayEquals(
+			new String[] {_DATA_STRING},
+			(String[])map.get(_expandoColumn25.getName()));
+		Assert.assertEquals(
+			new HashMap<>(), map.get(_expandoColumn26.getName()));
+		Assert.assertEquals(
+			new HashMap<>(), map.get(_expandoColumn27.getName()));
+		Assert.assertEquals(
+			map.toString(), _initialExpandoColumnsCount + 27, map.size());
+	}
+
+	@Test
+	@TestInfo("LPD-54757")
+	public void testToMapExpectedClassAndValue() throws Exception {
 
 		// Boolean
 
@@ -1295,18 +1365,26 @@ public class CustomFieldsUtilTest {
 
 		// Date
 
+		Date randomDate1 = RandomTestUtil.nextDate();
+
+		randomDate1 = new Date((randomDate1.getTime() / 1000) * 1000);
+
 		_testToMapExpectedClassAndValue(
 			_buildCustomField(
-				_dateFormat.format(randomDate), null, _expandoColumn3, null),
-			Date.class, randomDate);
+				_dateFormat.format(randomDate1), null, _expandoColumn3, null),
+			Date.class, randomDate1);
 
 		// Date array
 
+		Date randomDate2 = RandomTestUtil.nextDate();
+
+		randomDate2 = new Date((randomDate2.getTime() / 1000) * 1000);
+
 		_testToMapExpectedClassAndValue(
 			_buildCustomField(
-				Arrays.asList(_dateFormat.format(randomDate)), null,
+				Arrays.asList(_dateFormat.format(randomDate2)), null,
 				_expandoColumn4, null),
-			Date[].class, new Date[] {randomDate});
+			Date[].class, new Date[] {randomDate2});
 
 		// Double
 
@@ -1350,6 +1428,9 @@ public class CustomFieldsUtilTest {
 			float[].class, new float[] {_DATA_FLOAT});
 
 		// Geolocation
+
+		double randomDouble1 = RandomTestUtil.randomDouble();
+		double randomDouble2 = RandomTestUtil.randomDouble();
 
 		_testToMapExpectedClassAndValue(
 			_buildCustomField(
@@ -1532,6 +1613,8 @@ public class CustomFieldsUtilTest {
 
 		// String localized
 
+		String randomString = RandomTestUtil.randomString();
+
 		_testToMapExpectedClassAndValue(
 			_buildCustomField(
 				_DATA_STRING,
@@ -1551,70 +1634,6 @@ public class CustomFieldsUtilTest {
 			).put(
 				_ptLocale, randomString
 			).build());
-	}
-
-	@Test
-	public void testToMapDefaultCustomFieldValues() throws Exception {
-		Map<String, Serializable> map = CustomFieldsUtil.toMap(
-			_clazz.getName(), TestPropsValues.getCompanyId(),
-			CustomFieldsUtil.toCustomFields(
-				true, _clazz.getName(), RandomTestUtil.randomLong(),
-				TestPropsValues.getCompanyId(), LocaleUtil.getDefault()),
-			LocaleUtil.getDefault());
-
-		Assert.assertFalse((boolean)map.get(_expandoColumn1.getName()));
-		Assert.assertArrayEquals(
-			new boolean[0], (boolean[])map.get(_expandoColumn2.getName()));
-		Assert.assertEquals(new Date(0), map.get(_expandoColumn3.getName()));
-		Assert.assertArrayEquals(
-			new Date[0], (Date[])map.get(_expandoColumn4.getName()));
-		Assert.assertEquals(0.0, map.get(_expandoColumn5.getName()));
-		Assert.assertArrayEquals(
-			new double[] {0.0}, (double[])map.get(_expandoColumn6.getName()),
-			0);
-		Assert.assertArrayEquals(
-			new double[] {0.0}, (double[])map.get(_expandoColumn7.getName()),
-			0);
-		Assert.assertArrayEquals(
-			new double[] {_DATA_DOUBLE},
-			(double[])map.get(_expandoColumn8.getName()), 0);
-		Assert.assertEquals((float)0.0, map.get(_expandoColumn9.getName()));
-		Assert.assertArrayEquals(
-			new float[0], (float[])map.get(_expandoColumn10.getName()), 0);
-		Assert.assertEquals("{}", map.get(_expandoColumn11.getName()));
-		Assert.assertEquals(0, map.get(_expandoColumn12.getName()));
-		Assert.assertArrayEquals(
-			new int[0], (int[])map.get(_expandoColumn13.getName()));
-		Assert.assertEquals(0L, map.get(_expandoColumn14.getName()));
-		Assert.assertArrayEquals(
-			new long[] {0L}, (long[])map.get(_expandoColumn15.getName()));
-		Assert.assertArrayEquals(
-			new long[] {0L}, (long[])map.get(_expandoColumn16.getName()));
-		Assert.assertArrayEquals(
-			new long[] {_DATA_LONG},
-			(long[])map.get(_expandoColumn17.getName()));
-		Assert.assertEquals(0, map.get(_expandoColumn18.getName()));
-		Assert.assertArrayEquals(
-			new Number[0], (Number[])map.get(_expandoColumn19.getName()));
-		Assert.assertEquals((short)0, map.get(_expandoColumn20.getName()));
-		Assert.assertArrayEquals(
-			new short[0], (short[])map.get(_expandoColumn21.getName()));
-		Assert.assertEquals("", map.get(_expandoColumn22.getName()));
-		Assert.assertArrayEquals(
-			new String[] {"false"},
-			(String[])map.get(_expandoColumn23.getName()));
-		Assert.assertArrayEquals(
-			new String[] {"false"},
-			(String[])map.get(_expandoColumn24.getName()));
-		Assert.assertArrayEquals(
-			new String[] {_DATA_STRING},
-			(String[])map.get(_expandoColumn25.getName()));
-		Assert.assertEquals(
-			new HashMap<>(), map.get(_expandoColumn26.getName()));
-		Assert.assertEquals(
-			new HashMap<>(), map.get(_expandoColumn27.getName()));
-		Assert.assertEquals(
-			map.toString(), _initialExpandoColumnsCount + 27, map.size());
 	}
 
 	private ExpandoColumn _addExpandoColumn(

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/custom/field/test/CustomFieldsUtilTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/custom/field/test/CustomFieldsUtilTest.java
@@ -1737,6 +1737,17 @@ public class CustomFieldsUtilTest {
 		}
 
 		Assert.assertTrue(expectedClass.isInstance(actualValue));
+
+		// Add value to assert the Service Layer admits the value
+
+		ExpandoTestUtil.addValues(_expandoTable, _user.getPrimaryKey(), map);
+
+		Assert.assertNotNull(
+			_getCustomField(
+				CustomFieldsUtil.toCustomFields(
+					true, _clazz.getName(), _user.getPrimaryKey(),
+					TestPropsValues.getCompanyId(), LocaleUtil.getDefault()),
+				_expandoColumn1.getName()));
 	}
 
 	private static final double _DATA_DOUBLE = RandomTestUtil.randomDouble();

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/custom/field/test/CustomFieldsUtilTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/custom/field/test/CustomFieldsUtilTest.java
@@ -1283,9 +1283,13 @@ public class CustomFieldsUtilTest {
 		Assert.assertEquals(
 			map.toString(), _initialExpandoColumnsCount + 27, map.size());
 
-		_testToMapWithIntegerValueForLongField();
-		_testToMapWithIntegerValueForShortField();
-		_testToMapWithIntegerArrayForShortArrayField();
+		_testToMapExpectedClassAndValue(
+			_expandoColumn14, Long.class, (long)_DATA_INT, _DATA_INT);
+		_testToMapExpectedClassAndValue(
+			_expandoColumn20, Short.class, (short)_DATA_INT, _DATA_INT);
+		_testToMapExpectedClassAndValue(
+			_expandoColumn21, short[].class, new short[] {(short)_DATA_INT},
+			Arrays.asList(_DATA_INT));
 	}
 
 	@Test
@@ -1434,79 +1438,31 @@ public class CustomFieldsUtilTest {
 		throw new NoSuchValueException();
 	}
 
-	private void _testToMapWithIntegerArrayForShortArrayField()
+	private void _testToMapExpectedClassAndValue(
+			ExpandoColumn expandoColumn, Class<?> expectedClass,
+			Object expectedValue, Object value)
 		throws Exception {
 
-		CustomField[] customFields = {
-			new CustomField() {
-				{
-					customValue = new CustomValue() {
-						{
-							data = Arrays.asList(_DATA_INT);
-						}
-					};
-					name = _expandoColumn21.getName();
-				}
-			}
-		};
-
 		Map<String, Serializable> map = CustomFieldsUtil.toMap(
-			_clazz.getName(), TestPropsValues.getCompanyId(), customFields,
+			_clazz.getName(), TestPropsValues.getCompanyId(),
+			new CustomField[] {
+				new CustomField() {
+					{
+						customValue = new CustomValue() {
+							{
+								data = value;
+							}
+						};
+						name = expandoColumn.getName();
+					}
+				}
+			},
 			LocaleUtil.getDefault());
 
-		Object value = map.get(_expandoColumn21.getName());
+		Object actualValue = map.get(expandoColumn.getName());
 
-		Assert.assertArrayEquals(
-			new short[] {(short)_DATA_INT}, (short[])value);
-		Assert.assertTrue(value instanceof short[]);
-	}
-
-	private void _testToMapWithIntegerValueForLongField() throws Exception {
-		CustomField[] customFields = {
-			new CustomField() {
-				{
-					customValue = new CustomValue() {
-						{
-							data = _DATA_INT;
-						}
-					};
-					name = _expandoColumn14.getName();
-				}
-			}
-		};
-
-		Map<String, Serializable> map = CustomFieldsUtil.toMap(
-			_clazz.getName(), TestPropsValues.getCompanyId(), customFields,
-			LocaleUtil.getDefault());
-
-		Object value = map.get(_expandoColumn14.getName());
-
-		Assert.assertEquals((long)_DATA_INT, value);
-		Assert.assertTrue(value instanceof Long);
-	}
-
-	private void _testToMapWithIntegerValueForShortField() throws Exception {
-		CustomField[] customFields = {
-			new CustomField() {
-				{
-					customValue = new CustomValue() {
-						{
-							data = _DATA_INT;
-						}
-					};
-					name = _expandoColumn20.getName();
-				}
-			}
-		};
-
-		Map<String, Serializable> map = CustomFieldsUtil.toMap(
-			_clazz.getName(), TestPropsValues.getCompanyId(), customFields,
-			LocaleUtil.getDefault());
-
-		Object value = map.get(_expandoColumn20.getName());
-
-		Assert.assertEquals((short)_DATA_INT, value);
-		Assert.assertTrue(value instanceof Short);
+		Assert.assertTrue(Objects.deepEquals(expectedValue, actualValue));
+		Assert.assertTrue(expectedClass.isInstance(actualValue));
 	}
 
 	private static final double _DATA_DOUBLE = RandomTestUtil.randomDouble();

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/custom/field/test/CustomFieldsUtilTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/custom/field/test/CustomFieldsUtilTest.java
@@ -1391,6 +1391,12 @@ public class CustomFieldsUtilTest {
 		_testToMapExpectedClassAndValue(
 			_buildCustomField(_DATA_DOUBLE, null, _expandoColumn5, null),
 			Double.class, _DATA_DOUBLE);
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(_DATA_FLOAT, null, _expandoColumn5, null),
+			Double.class, (double)_DATA_FLOAT);
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(_DATA_INT, null, _expandoColumn5, null),
+			Double.class, (double)_DATA_INT);
 
 		// Double array
 
@@ -1400,12 +1406,36 @@ public class CustomFieldsUtilTest {
 			double[].class, new double[] {_DATA_DOUBLE});
 		_testToMapExpectedClassAndValue(
 			_buildCustomField(
+				Arrays.asList(_DATA_FLOAT), null, _expandoColumn6, null),
+			double[].class, new double[] {(double)_DATA_FLOAT});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				Arrays.asList(_DATA_INT), null, _expandoColumn6, null),
+			double[].class, new double[] {(double)_DATA_INT});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
 				Arrays.asList(_DATA_DOUBLE), null, _expandoColumn7, null),
 			double[].class, new double[] {_DATA_DOUBLE});
 		_testToMapExpectedClassAndValue(
 			_buildCustomField(
+				Arrays.asList(_DATA_FLOAT), null, _expandoColumn7, null),
+			double[].class, new double[] {(double)_DATA_FLOAT});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				Arrays.asList(_DATA_INT), null, _expandoColumn7, null),
+			double[].class, new double[] {(double)_DATA_INT});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
 				Arrays.asList(_DATA_DOUBLE), null, _expandoColumn8, null),
 			double[].class, new double[] {_DATA_DOUBLE});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				Arrays.asList(_DATA_FLOAT), null, _expandoColumn8, null),
+			double[].class, new double[] {(double)_DATA_FLOAT});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				Arrays.asList(_DATA_INT), null, _expandoColumn8, null),
+			double[].class, new double[] {(double)_DATA_INT});
 
 		// Float
 

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/custom/field/test/CustomFieldsUtilTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/custom/field/test/CustomFieldsUtilTest.java
@@ -44,11 +44,9 @@ import java.math.BigDecimal;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -1439,19 +1437,14 @@ public class CustomFieldsUtilTest {
 	private void _testToMapWithIntegerArrayForShortArrayField()
 		throws Exception {
 
-		List<Integer> integerCollection = new ArrayList<>();
-
-		integerCollection.add(_DATA_INT);
-
 		CustomField[] customFields = {
 			new CustomField() {
 				{
 					customValue = new CustomValue() {
 						{
-							data = integerCollection;
+							data = Arrays.asList(_DATA_INT);
 						}
 					};
-					dataType = "Integer";
 					name = _expandoColumn21.getName();
 				}
 			}
@@ -1461,25 +1454,11 @@ public class CustomFieldsUtilTest {
 			_clazz.getName(), TestPropsValues.getCompanyId(), customFields,
 			LocaleUtil.getDefault());
 
-		short[] result = (short[])map.get(_expandoColumn21.getName());
+		Object value = map.get(_expandoColumn21.getName());
 
-		Assert.assertEquals(
-			Arrays.toString(result), integerCollection.size(), result.length);
-
-		for (int i = 0; i < integerCollection.size(); i++) {
-			Assert.assertEquals(
-				"Element at index " + i, (short)(int)integerCollection.get(i),
-				result[i]);
-		}
-
-		String className = map.get(
-			_expandoColumn21.getName()
-		).getClass(
-		).getName();
-
-		Assert.assertTrue(
-			"Value should be of type short[] but was " + className,
-			map.get(_expandoColumn21.getName()) instanceof short[]);
+		Assert.assertArrayEquals(
+			new short[] {(short)_DATA_INT}, (short[])value);
+		Assert.assertTrue(value instanceof short[]);
 	}
 
 	private void _testToMapWithIntegerValueForLongField() throws Exception {
@@ -1491,7 +1470,6 @@ public class CustomFieldsUtilTest {
 							data = _DATA_INT;
 						}
 					};
-					dataType = "Integer";
 					name = _expandoColumn14.getName();
 				}
 			}
@@ -1501,17 +1479,10 @@ public class CustomFieldsUtilTest {
 			_clazz.getName(), TestPropsValues.getCompanyId(), customFields,
 			LocaleUtil.getDefault());
 
-		Assert.assertEquals(
-			(long)_DATA_INT, map.get(_expandoColumn14.getName()));
+		Object value = map.get(_expandoColumn14.getName());
 
-		String className = map.get(
-			_expandoColumn14.getName()
-		).getClass(
-		).getName();
-
-		Assert.assertTrue(
-			"Value should be of type Long but was " + className,
-			map.get(_expandoColumn14.getName()) instanceof Long);
+		Assert.assertEquals((long)_DATA_INT, value);
+		Assert.assertTrue(value instanceof Long);
 	}
 
 	private void _testToMapWithIntegerValueForShortField() throws Exception {
@@ -1523,7 +1494,6 @@ public class CustomFieldsUtilTest {
 							data = _DATA_INT;
 						}
 					};
-					dataType = "Integer";
 					name = _expandoColumn20.getName();
 				}
 			}
@@ -1533,17 +1503,10 @@ public class CustomFieldsUtilTest {
 			_clazz.getName(), TestPropsValues.getCompanyId(), customFields,
 			LocaleUtil.getDefault());
 
-		Assert.assertEquals(
-			(short)_DATA_INT, map.get(_expandoColumn20.getName()));
+		Object value = map.get(_expandoColumn20.getName());
 
-		String className = map.get(
-			_expandoColumn20.getName()
-		).getClass(
-		).getName();
-
-		Assert.assertTrue(
-			"Value should be of type Short but was " + className,
-			map.get(_expandoColumn20.getName()) instanceof Short);
+		Assert.assertEquals((short)_DATA_INT, value);
+		Assert.assertTrue(value instanceof Short);
 	}
 
 	private static final double _DATA_DOUBLE = RandomTestUtil.randomDouble();

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/custom/field/test/CustomFieldsUtilTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/custom/field/test/CustomFieldsUtilTest.java
@@ -335,15 +335,12 @@ public class CustomFieldsUtilTest {
 			},
 			_getCustomField(customFields, _expandoColumn2.getName()));
 
-		DateFormat dateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
-
 		_assertEquals(
 			new CustomField() {
 				{
 					customValue = new CustomValue() {
 						{
-							data = dateFormat.format(randomDate);
+							data = _dateFormat.format(randomDate);
 						}
 					};
 					dataType = "";
@@ -1283,13 +1280,277 @@ public class CustomFieldsUtilTest {
 		Assert.assertEquals(
 			map.toString(), _initialExpandoColumnsCount + 27, map.size());
 
+		// Boolean
+
 		_testToMapExpectedClassAndValue(
-			_expandoColumn14, Long.class, (long)_DATA_INT, _DATA_INT);
+			_buildCustomField(true, null, _expandoColumn1, null), Boolean.class,
+			true);
+
+		// Boolean array
+
 		_testToMapExpectedClassAndValue(
-			_expandoColumn20, Short.class, (short)_DATA_INT, _DATA_INT);
+			_buildCustomField(
+				Arrays.asList(false, true), null, _expandoColumn2, null),
+			boolean[].class, new boolean[] {false, true});
+
+		// Date
+
 		_testToMapExpectedClassAndValue(
-			_expandoColumn21, short[].class, new short[] {(short)_DATA_INT},
-			Arrays.asList(_DATA_INT));
+			_buildCustomField(
+				_dateFormat.format(randomDate), null, _expandoColumn3, null),
+			Date.class, randomDate);
+
+		// Date array
+
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				Arrays.asList(_dateFormat.format(randomDate)), null,
+				_expandoColumn4, null),
+			Date[].class, new Date[] {randomDate});
+
+		// Double
+
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(_DATA_DOUBLE, null, _expandoColumn5, null),
+			Double.class, _DATA_DOUBLE);
+
+		// Double array
+
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				Arrays.asList(_DATA_DOUBLE), null, _expandoColumn6, null),
+			double[].class, new double[] {_DATA_DOUBLE});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				Arrays.asList(_DATA_DOUBLE), null, _expandoColumn7, null),
+			double[].class, new double[] {_DATA_DOUBLE});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				Arrays.asList(_DATA_DOUBLE), null, _expandoColumn8, null),
+			double[].class, new double[] {_DATA_DOUBLE});
+
+		// Float
+
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(_DATA_DOUBLE, null, _expandoColumn9, null),
+			Float.class, (float)_DATA_DOUBLE);
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(_DATA_FLOAT, null, _expandoColumn9, null),
+			Float.class, _DATA_FLOAT);
+
+		// Float array
+
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				Arrays.asList(_DATA_DOUBLE), null, _expandoColumn10, null),
+			float[].class, new float[] {(float)_DATA_DOUBLE});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				Arrays.asList(_DATA_FLOAT), null, _expandoColumn10, null),
+			float[].class, new float[] {_DATA_FLOAT});
+
+		// Geolocation
+
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				null, null, _expandoColumn11,
+				new Geo() {
+					{
+						latitude = randomDouble1;
+						longitude = randomDouble2;
+					}
+				}),
+			String.class,
+			JSONUtil.put(
+				"latitude", randomDouble1
+			).put(
+				"longitude", randomDouble2
+			).toString());
+
+		// Integer
+
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new BigDecimal(_DATA_INT), null, _expandoColumn12, null),
+			Integer.class, _DATA_INT);
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(_DATA_INT, null, _expandoColumn12, null),
+			Integer.class, _DATA_INT);
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(_DATA_LONG, null, _expandoColumn12, null),
+			Integer.class, (int)_DATA_LONG);
+
+		// Integer array
+
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				Arrays.asList(new BigDecimal(_DATA_INT)), null,
+				_expandoColumn13, null),
+			int[].class, new int[] {_DATA_INT});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				Arrays.asList(_DATA_INT), null, _expandoColumn13, null),
+			int[].class, new int[] {_DATA_INT});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				Arrays.asList(_DATA_LONG), null, _expandoColumn13, null),
+			int[].class, new int[] {(int)_DATA_LONG});
+
+		// Long
+
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new BigDecimal(_DATA_LONG), null, _expandoColumn14, null),
+			Long.class, _DATA_LONG);
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(_DATA_INT, null, _expandoColumn14, null),
+			Long.class, (long)_DATA_INT);
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(_DATA_LONG, null, _expandoColumn14, null),
+			Long.class, _DATA_LONG);
+
+		// Long array
+
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				Arrays.asList(new BigDecimal(_DATA_LONG)), null,
+				_expandoColumn15, null),
+			long[].class, new long[] {_DATA_LONG});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				Arrays.asList(_DATA_INT), null, _expandoColumn15, null),
+			long[].class, new long[] {(long)_DATA_INT});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				Arrays.asList(_DATA_LONG), null, _expandoColumn15, null),
+			long[].class, new long[] {_DATA_LONG});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				Arrays.asList(new BigDecimal(_DATA_LONG)), null,
+				_expandoColumn16, null),
+			long[].class, new long[] {_DATA_LONG});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				Arrays.asList(_DATA_INT), null, _expandoColumn16, null),
+			long[].class, new long[] {(long)_DATA_INT});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				Arrays.asList(_DATA_LONG), null, _expandoColumn16, null),
+			long[].class, new long[] {_DATA_LONG});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				Arrays.asList(new BigDecimal(_DATA_LONG)), null,
+				_expandoColumn17, null),
+			long[].class, new long[] {_DATA_LONG});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				Arrays.asList(_DATA_INT), null, _expandoColumn17, null),
+			long[].class, new long[] {(long)_DATA_INT});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				Arrays.asList(_DATA_LONG), null, _expandoColumn17, null),
+			long[].class, new long[] {_DATA_LONG});
+
+		// Number
+
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new BigDecimal(_DATA_LONG), null, _expandoColumn18, null),
+			Number.class, new BigDecimal(_DATA_LONG));
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(_DATA_INT, null, _expandoColumn18, null),
+			Number.class, _DATA_INT);
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(_DATA_LONG, null, _expandoColumn18, null),
+			Number.class, _DATA_LONG);
+
+		// Number array
+
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				Arrays.asList(new BigDecimal(_DATA_LONG)), null,
+				_expandoColumn19, null),
+			Number[].class, new Number[] {new BigDecimal(_DATA_LONG)});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				Arrays.asList(_DATA_INT), null, _expandoColumn19, null),
+			Number[].class, new Number[] {_DATA_INT});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				Arrays.asList(_DATA_LONG), null, _expandoColumn19, null),
+			Number[].class, new Number[] {_DATA_LONG});
+
+		// Short
+
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new BigDecimal(_DATA_LONG), null, _expandoColumn20, null),
+			Short.class, (short)_DATA_LONG);
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(_DATA_INT, null, _expandoColumn20, null),
+			Short.class, (short)_DATA_INT);
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(_DATA_LONG, null, _expandoColumn20, null),
+			Short.class, (short)_DATA_LONG);
+
+		// Short array
+
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				Arrays.asList(new BigDecimal(_DATA_LONG)), null,
+				_expandoColumn21, null),
+			short[].class, new short[] {(short)_DATA_LONG});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				Arrays.asList(_DATA_INT), null, _expandoColumn21, null),
+			short[].class, new short[] {(short)_DATA_INT});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				Arrays.asList(_DATA_LONG), null, _expandoColumn21, null),
+			short[].class, new short[] {(short)_DATA_LONG});
+
+		// String
+
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(_DATA_STRING, null, _expandoColumn22, null),
+			String.class, _DATA_STRING);
+
+		// String array
+
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				Arrays.asList(_DATA_STRING), null, _expandoColumn23, null),
+			String[].class, new String[] {_DATA_STRING});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				Arrays.asList(_DATA_STRING), null, _expandoColumn24, null),
+			String[].class, new String[] {_DATA_STRING});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				Arrays.asList(_DATA_STRING), null, _expandoColumn25, null),
+			String[].class, new String[] {_DATA_STRING});
+
+		// String localized
+
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				_DATA_STRING,
+				HashMapBuilder.put(
+					"en-US", _DATA_STRING
+				).put(
+					"fr-FR", randomString
+				).put(
+					"pt-BR", randomString
+				).build(),
+				_expandoColumn27, null),
+			Map.class,
+			HashMapBuilder.put(
+				_enLocale, _DATA_STRING
+			).put(
+				_frLocale, randomString
+			).put(
+				_ptLocale, randomString
+			).build());
 	}
 
 	@Test
@@ -1426,6 +1687,24 @@ public class CustomFieldsUtilTest {
 		Assert.assertEquals(geo1.getLongitude(), geo2.getLongitude());
 	}
 
+	private CustomField _buildCustomField(
+		Object data, Map<String, String> data_i18n, ExpandoColumn expandoColumn,
+		Geo geo) {
+
+		CustomValue customValue = new CustomValue();
+
+		customValue.setData(data);
+		customValue.setData_i18n(data_i18n);
+		customValue.setGeo(geo);
+
+		CustomField customField = new CustomField();
+
+		customField.setCustomValue(customValue);
+		customField.setName(expandoColumn.getName());
+
+		return customField;
+	}
+
 	private CustomField _getCustomField(CustomField[] customFields, String name)
 		throws Exception {
 
@@ -1439,39 +1718,39 @@ public class CustomFieldsUtilTest {
 	}
 
 	private void _testToMapExpectedClassAndValue(
-			ExpandoColumn expandoColumn, Class<?> expectedClass,
-			Object expectedValue, Object value)
+			CustomField customField, Class<?> expectedClass,
+			Object expectedValue)
 		throws Exception {
 
 		Map<String, Serializable> map = CustomFieldsUtil.toMap(
 			_clazz.getName(), TestPropsValues.getCompanyId(),
-			new CustomField[] {
-				new CustomField() {
-					{
-						customValue = new CustomValue() {
-							{
-								data = value;
-							}
-						};
-						name = expandoColumn.getName();
-					}
-				}
-			},
-			LocaleUtil.getDefault());
+			new CustomField[] {customField}, LocaleUtil.getDefault());
 
-		Object actualValue = map.get(expandoColumn.getName());
+		Object actualValue = map.get(customField.getName());
 
-		Assert.assertTrue(Objects.deepEquals(expectedValue, actualValue));
+		if (expectedClass == Map.class) {
+			AssertUtils.assertEquals(
+				(Map<Locale, ?>)expectedValue, (Map<Locale, ?>)actualValue);
+		}
+		else {
+			Assert.assertTrue(Objects.deepEquals(expectedValue, actualValue));
+		}
+
 		Assert.assertTrue(expectedClass.isInstance(actualValue));
 	}
 
 	private static final double _DATA_DOUBLE = RandomTestUtil.randomDouble();
+
+	private static final float _DATA_FLOAT = RandomTestUtil.randomFloat();
 
 	private static final int _DATA_INT = RandomTestUtil.randomInt();
 
 	private static final long _DATA_LONG = RandomTestUtil.randomLong();
 
 	private static final String _DATA_STRING = RandomTestUtil.randomString();
+
+	private static final DateFormat _dateFormat = new SimpleDateFormat(
+		"yyyy-MM-dd'T'HH:mm:ss'Z'");
 
 	@Inject
 	private ClassNameLocalService _classNameLocalService;

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/custom/field/test/CustomFieldsUtilTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/custom/field/test/CustomFieldsUtilTest.java
@@ -1283,6 +1283,10 @@ public class CustomFieldsUtilTest {
 			(Map)map.get(_expandoColumn27.getName()));
 		Assert.assertEquals(
 			map.toString(), _initialExpandoColumnsCount + 27, map.size());
+
+		_testToMapWithIntegerValueForLongField();
+		_testToMapWithIntegerValueForShortField();
+		_testToMapWithIntegerArrayForShortArrayField();
 	}
 
 	@Test
@@ -1349,8 +1353,8 @@ public class CustomFieldsUtilTest {
 			map.toString(), _initialExpandoColumnsCount + 27, map.size());
 	}
 
-	@Test
-	public void testToMapWithIntegerValueForLongField() throws Exception {
+
+	private void _testToMapWithIntegerValueForLongField() throws Exception {
 		CustomField[] customFields = new CustomField[] {
 			new CustomField() {
 				{
@@ -1377,8 +1381,8 @@ public class CustomFieldsUtilTest {
 			map.get(_expandoColumn14.getName()) instanceof Long);
 	}
 
-	@Test
-	public void testToMapWithIntegerValueForShortField() throws Exception {
+
+	private void _testToMapWithIntegerValueForShortField() throws Exception {
 		CustomField[] customFields = new CustomField[] {
 			new CustomField() {
 				{
@@ -1405,8 +1409,8 @@ public class CustomFieldsUtilTest {
 			map.get(_expandoColumn20.getName()) instanceof Short);
 	}
 
-	@Test
-	public void testToMapWithIntegerArrayForShortArrayField() throws Exception {
+
+	private void _testToMapWithIntegerArrayForShortArrayField() throws Exception {
 		List<Integer> integerCollection = new ArrayList<>();
 		integerCollection.add(_DATA_INT);
 		

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/custom/field/test/CustomFieldsUtilTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/custom/field/test/CustomFieldsUtilTest.java
@@ -49,6 +49,8 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.List;
+import java.util.ArrayList;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -1373,6 +1375,71 @@ public class CustomFieldsUtilTest {
 			"Value should be of type Long but was " + 
 			map.get(_expandoColumn14.getName()).getClass().getName(),
 			map.get(_expandoColumn14.getName()) instanceof Long);
+	}
+
+	@Test
+	public void testToMapWithIntegerValueForShortField() throws Exception {
+		CustomField[] customFields = new CustomField[] {
+			new CustomField() {
+				{
+					customValue = new CustomValue() {
+						{
+							data = _DATA_INT;
+						}
+					};
+					dataType = "Integer";
+					name = _expandoColumn20.getName();
+				}
+			}
+		};
+
+		Map<String, Serializable> map = CustomFieldsUtil.toMap(
+			_clazz.getName(), TestPropsValues.getCompanyId(), customFields,
+			LocaleUtil.getDefault());
+
+		Assert.assertEquals((short)_DATA_INT, map.get(_expandoColumn20.getName()));
+		
+		Assert.assertTrue(
+			"Value should be of type Short but was " + 
+			map.get(_expandoColumn20.getName()).getClass().getName(),
+			map.get(_expandoColumn20.getName()) instanceof Short);
+	}
+
+	@Test
+	public void testToMapWithIntegerArrayForShortArrayField() throws Exception {
+		List<Integer> integerCollection = new ArrayList<>();
+		integerCollection.add(_DATA_INT);
+		
+		CustomField[] customFields = new CustomField[] {
+			new CustomField() {
+				{
+					customValue = new CustomValue() {
+						{
+							data = integerCollection;
+						}
+					};
+					dataType = "Integer";
+					name = _expandoColumn21.getName();
+				}
+			}
+		};
+
+		Map<String, Serializable> map = CustomFieldsUtil.toMap(
+			_clazz.getName(), TestPropsValues.getCompanyId(), customFields,
+			LocaleUtil.getDefault());
+
+		short[] result = (short[])map.get(_expandoColumn21.getName());
+
+		Assert.assertEquals(integerCollection.size(), result.length);
+		for (int i = 0; i < integerCollection.size(); i++) {
+			Assert.assertEquals(
+				(short)(int)integerCollection.get(i), result[i]);
+		}
+
+		Assert.assertTrue(
+			"Value should be of type short[] but was " + 
+			map.get(_expandoColumn21.getName()).getClass().getName(),
+			map.get(_expandoColumn21.getName()) instanceof short[]);
 	}
 
 	private ExpandoColumn _addExpandoColumn(

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/custom/field/test/CustomFieldsUtilTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/custom/field/test/CustomFieldsUtilTest.java
@@ -1355,12 +1355,29 @@ public class CustomFieldsUtilTest {
 		_testToMapExpectedClassAndValue(
 			_buildCustomField(true, null, _expandoColumn1, null), Boolean.class,
 			true);
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(Boolean.TRUE, null, _expandoColumn1, null),
+			Boolean.class, true);
 
 		// Boolean array
 
 		_testToMapExpectedClassAndValue(
 			_buildCustomField(
 				Arrays.asList(false, true), null, _expandoColumn2, null),
+			boolean[].class, new boolean[] {false, true});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				Arrays.asList(Boolean.FALSE, Boolean.TRUE), null,
+				_expandoColumn2, null),
+			boolean[].class, new boolean[] {false, true});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new boolean[] {false, true}, null, _expandoColumn2, null),
+			boolean[].class, new boolean[] {false, true});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new Boolean[] {Boolean.FALSE, Boolean.TRUE}, null,
+				_expandoColumn2, null),
 			boolean[].class, new boolean[] {false, true});
 
 		// Date
@@ -1372,6 +1389,9 @@ public class CustomFieldsUtilTest {
 		_testToMapExpectedClassAndValue(
 			_buildCustomField(
 				_dateFormat.format(randomDate1), null, _expandoColumn3, null),
+			Date.class, randomDate1);
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(randomDate1, null, _expandoColumn3, null),
 			Date.class, randomDate1);
 
 		// Date array
@@ -1385,6 +1405,19 @@ public class CustomFieldsUtilTest {
 				Arrays.asList(_dateFormat.format(randomDate2)), null,
 				_expandoColumn4, null),
 			Date[].class, new Date[] {randomDate2});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new String[] {_dateFormat.format(randomDate2)}, null,
+				_expandoColumn4, null),
+			Date[].class, new Date[] {randomDate2});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				Arrays.asList(randomDate2), null, _expandoColumn4, null),
+			Date[].class, new Date[] {randomDate2});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new Date[] {randomDate2}, null, _expandoColumn4, null),
+			Date[].class, new Date[] {randomDate2});
 
 		// Double
 
@@ -1396,6 +1429,18 @@ public class CustomFieldsUtilTest {
 			Double.class, (double)_DATA_FLOAT);
 		_testToMapExpectedClassAndValue(
 			_buildCustomField(_DATA_INT, null, _expandoColumn5, null),
+			Double.class, (double)_DATA_INT);
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				Double.valueOf(_DATA_DOUBLE), null, _expandoColumn5, null),
+			Double.class, _DATA_DOUBLE);
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				Float.valueOf(_DATA_FLOAT), null, _expandoColumn5, null),
+			Double.class, (double)_DATA_FLOAT);
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				Integer.valueOf(_DATA_INT), null, _expandoColumn5, null),
 			Double.class, (double)_DATA_INT);
 
 		// Double array
@@ -1414,6 +1459,33 @@ public class CustomFieldsUtilTest {
 			double[].class, new double[] {(double)_DATA_INT});
 		_testToMapExpectedClassAndValue(
 			_buildCustomField(
+				new double[] {_DATA_DOUBLE}, null, _expandoColumn6, null),
+			double[].class, new double[] {_DATA_DOUBLE});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new float[] {_DATA_FLOAT}, null, _expandoColumn6, null),
+			double[].class, new double[] {(double)_DATA_FLOAT});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new int[] {_DATA_INT}, null, _expandoColumn6, null),
+			double[].class, new double[] {(double)_DATA_INT});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new Double[] {Double.valueOf(_DATA_DOUBLE)}, null,
+				_expandoColumn6, null),
+			double[].class, new double[] {_DATA_DOUBLE});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new Float[] {Float.valueOf(_DATA_FLOAT)}, null, _expandoColumn6,
+				null),
+			double[].class, new double[] {(double)_DATA_FLOAT});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new Integer[] {Integer.valueOf(_DATA_INT)}, null,
+				_expandoColumn6, null),
+			double[].class, new double[] {(double)_DATA_INT});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
 				Arrays.asList(_DATA_DOUBLE), null, _expandoColumn7, null),
 			double[].class, new double[] {_DATA_DOUBLE});
 		_testToMapExpectedClassAndValue(
@@ -1426,6 +1498,33 @@ public class CustomFieldsUtilTest {
 			double[].class, new double[] {(double)_DATA_INT});
 		_testToMapExpectedClassAndValue(
 			_buildCustomField(
+				new double[] {_DATA_DOUBLE}, null, _expandoColumn7, null),
+			double[].class, new double[] {_DATA_DOUBLE});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new float[] {_DATA_FLOAT}, null, _expandoColumn7, null),
+			double[].class, new double[] {(double)_DATA_FLOAT});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new int[] {_DATA_INT}, null, _expandoColumn7, null),
+			double[].class, new double[] {(double)_DATA_INT});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new Double[] {Double.valueOf(_DATA_DOUBLE)}, null,
+				_expandoColumn7, null),
+			double[].class, new double[] {_DATA_DOUBLE});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new Float[] {Float.valueOf(_DATA_FLOAT)}, null, _expandoColumn7,
+				null),
+			double[].class, new double[] {(double)_DATA_FLOAT});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new Integer[] {Integer.valueOf(_DATA_INT)}, null,
+				_expandoColumn7, null),
+			double[].class, new double[] {(double)_DATA_INT});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
 				Arrays.asList(_DATA_DOUBLE), null, _expandoColumn8, null),
 			double[].class, new double[] {_DATA_DOUBLE});
 		_testToMapExpectedClassAndValue(
@@ -1435,6 +1534,33 @@ public class CustomFieldsUtilTest {
 		_testToMapExpectedClassAndValue(
 			_buildCustomField(
 				Arrays.asList(_DATA_INT), null, _expandoColumn8, null),
+			double[].class, new double[] {(double)_DATA_INT});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new double[] {_DATA_DOUBLE}, null, _expandoColumn8, null),
+			double[].class, new double[] {_DATA_DOUBLE});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new float[] {_DATA_FLOAT}, null, _expandoColumn8, null),
+			double[].class, new double[] {(double)_DATA_FLOAT});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new int[] {_DATA_INT}, null, _expandoColumn8, null),
+			double[].class, new double[] {(double)_DATA_INT});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new Double[] {Double.valueOf(_DATA_DOUBLE)}, null,
+				_expandoColumn8, null),
+			double[].class, new double[] {_DATA_DOUBLE});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new Float[] {Float.valueOf(_DATA_FLOAT)}, null, _expandoColumn8,
+				null),
+			double[].class, new double[] {(double)_DATA_FLOAT});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new Integer[] {Integer.valueOf(_DATA_INT)}, null,
+				_expandoColumn8, null),
 			double[].class, new double[] {(double)_DATA_INT});
 
 		// Float
@@ -1455,6 +1581,24 @@ public class CustomFieldsUtilTest {
 		_testToMapExpectedClassAndValue(
 			_buildCustomField(
 				Arrays.asList(_DATA_FLOAT), null, _expandoColumn10, null),
+			float[].class, new float[] {_DATA_FLOAT});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new double[] {_DATA_DOUBLE}, null, _expandoColumn10, null),
+			float[].class, new float[] {(float)_DATA_DOUBLE});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new float[] {_DATA_FLOAT}, null, _expandoColumn10, null),
+			float[].class, new float[] {_DATA_FLOAT});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new Double[] {Double.valueOf(_DATA_DOUBLE)}, null,
+				_expandoColumn10, null),
+			float[].class, new float[] {(float)_DATA_DOUBLE});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new Float[] {Float.valueOf(_DATA_FLOAT)}, null,
+				_expandoColumn10, null),
 			float[].class, new float[] {_DATA_FLOAT});
 
 		// Geolocation
@@ -1506,6 +1650,29 @@ public class CustomFieldsUtilTest {
 			_buildCustomField(
 				Arrays.asList(_DATA_LONG), null, _expandoColumn13, null),
 			int[].class, new int[] {(int)_DATA_LONG});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new BigDecimal[] {new BigDecimal(_DATA_INT)}, null,
+				_expandoColumn13, null),
+			int[].class, new int[] {_DATA_INT});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new int[] {_DATA_INT}, null, _expandoColumn13, null),
+			int[].class, new int[] {_DATA_INT});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new long[] {_DATA_LONG}, null, _expandoColumn13, null),
+			int[].class, new int[] {(int)_DATA_LONG});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new Integer[] {Integer.valueOf(_DATA_INT)}, null,
+				_expandoColumn13, null),
+			int[].class, new int[] {_DATA_INT});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new Long[] {Long.valueOf(_DATA_LONG)}, null, _expandoColumn13,
+				null),
+			int[].class, new int[] {(int)_DATA_LONG});
 
 		// Long
 
@@ -1537,6 +1704,29 @@ public class CustomFieldsUtilTest {
 			long[].class, new long[] {_DATA_LONG});
 		_testToMapExpectedClassAndValue(
 			_buildCustomField(
+				new BigDecimal[] {new BigDecimal(_DATA_LONG)}, null,
+				_expandoColumn15, null),
+			long[].class, new long[] {_DATA_LONG});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new int[] {_DATA_INT}, null, _expandoColumn15, null),
+			long[].class, new long[] {(long)_DATA_INT});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new long[] {_DATA_LONG}, null, _expandoColumn15, null),
+			long[].class, new long[] {_DATA_LONG});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new Integer[] {Integer.valueOf(_DATA_INT)}, null,
+				_expandoColumn15, null),
+			long[].class, new long[] {(long)_DATA_INT});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new Long[] {Long.valueOf(_DATA_LONG)}, null, _expandoColumn15,
+				null),
+			long[].class, new long[] {_DATA_LONG});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
 				Arrays.asList(new BigDecimal(_DATA_LONG)), null,
 				_expandoColumn16, null),
 			long[].class, new long[] {_DATA_LONG});
@@ -1550,6 +1740,29 @@ public class CustomFieldsUtilTest {
 			long[].class, new long[] {_DATA_LONG});
 		_testToMapExpectedClassAndValue(
 			_buildCustomField(
+				new BigDecimal[] {new BigDecimal(_DATA_LONG)}, null,
+				_expandoColumn16, null),
+			long[].class, new long[] {_DATA_LONG});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new int[] {_DATA_INT}, null, _expandoColumn16, null),
+			long[].class, new long[] {(long)_DATA_INT});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new long[] {_DATA_LONG}, null, _expandoColumn16, null),
+			long[].class, new long[] {_DATA_LONG});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new Integer[] {Integer.valueOf(_DATA_INT)}, null,
+				_expandoColumn16, null),
+			long[].class, new long[] {(long)_DATA_INT});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new Long[] {Long.valueOf(_DATA_LONG)}, null, _expandoColumn16,
+				null),
+			long[].class, new long[] {_DATA_LONG});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
 				Arrays.asList(new BigDecimal(_DATA_LONG)), null,
 				_expandoColumn17, null),
 			long[].class, new long[] {_DATA_LONG});
@@ -1560,6 +1773,29 @@ public class CustomFieldsUtilTest {
 		_testToMapExpectedClassAndValue(
 			_buildCustomField(
 				Arrays.asList(_DATA_LONG), null, _expandoColumn17, null),
+			long[].class, new long[] {_DATA_LONG});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new BigDecimal[] {new BigDecimal(_DATA_LONG)}, null,
+				_expandoColumn17, null),
+			long[].class, new long[] {_DATA_LONG});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new int[] {_DATA_INT}, null, _expandoColumn17, null),
+			long[].class, new long[] {(long)_DATA_INT});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new long[] {_DATA_LONG}, null, _expandoColumn17, null),
+			long[].class, new long[] {_DATA_LONG});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new Integer[] {Integer.valueOf(_DATA_INT)}, null,
+				_expandoColumn17, null),
+			long[].class, new long[] {(long)_DATA_INT});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new Long[] {Long.valueOf(_DATA_LONG)}, null, _expandoColumn17,
+				null),
 			long[].class, new long[] {_DATA_LONG});
 
 		// Number
@@ -1590,6 +1826,29 @@ public class CustomFieldsUtilTest {
 			_buildCustomField(
 				Arrays.asList(_DATA_LONG), null, _expandoColumn19, null),
 			Number[].class, new Number[] {_DATA_LONG});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new BigDecimal[] {new BigDecimal(_DATA_LONG)}, null,
+				_expandoColumn19, null),
+			Number[].class, new Number[] {new BigDecimal(_DATA_LONG)});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new int[] {_DATA_INT}, null, _expandoColumn19, null),
+			Number[].class, new Number[] {_DATA_INT});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new long[] {_DATA_LONG}, null, _expandoColumn19, null),
+			Number[].class, new Number[] {_DATA_LONG});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new Integer[] {Integer.valueOf(_DATA_INT)}, null,
+				_expandoColumn19, null),
+			Number[].class, new Number[] {_DATA_INT});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new Long[] {Long.valueOf(_DATA_LONG)}, null, _expandoColumn19,
+				null),
+			Number[].class, new Number[] {_DATA_LONG});
 
 		// Short
 
@@ -1619,6 +1878,29 @@ public class CustomFieldsUtilTest {
 			_buildCustomField(
 				Arrays.asList(_DATA_LONG), null, _expandoColumn21, null),
 			short[].class, new short[] {(short)_DATA_LONG});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new BigDecimal[] {new BigDecimal(_DATA_LONG)}, null,
+				_expandoColumn21, null),
+			short[].class, new short[] {(short)_DATA_LONG});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new int[] {_DATA_INT}, null, _expandoColumn21, null),
+			short[].class, new short[] {(short)_DATA_INT});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new long[] {_DATA_LONG}, null, _expandoColumn21, null),
+			short[].class, new short[] {(short)_DATA_LONG});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new Integer[] {Integer.valueOf(_DATA_INT)}, null,
+				_expandoColumn21, null),
+			short[].class, new short[] {(short)_DATA_INT});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new Long[] {Long.valueOf(_DATA_LONG)}, null, _expandoColumn21,
+				null),
+			short[].class, new short[] {(short)_DATA_LONG});
 
 		// String
 
@@ -1634,11 +1916,23 @@ public class CustomFieldsUtilTest {
 			String[].class, new String[] {_DATA_STRING});
 		_testToMapExpectedClassAndValue(
 			_buildCustomField(
+				new String[] {_DATA_STRING}, null, _expandoColumn23, null),
+			String[].class, new String[] {_DATA_STRING});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
 				Arrays.asList(_DATA_STRING), null, _expandoColumn24, null),
 			String[].class, new String[] {_DATA_STRING});
 		_testToMapExpectedClassAndValue(
 			_buildCustomField(
+				new String[] {_DATA_STRING}, null, _expandoColumn24, null),
+			String[].class, new String[] {_DATA_STRING});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
 				Arrays.asList(_DATA_STRING), null, _expandoColumn25, null),
+			String[].class, new String[] {_DATA_STRING});
+		_testToMapExpectedClassAndValue(
+			_buildCustomField(
+				new String[] {_DATA_STRING}, null, _expandoColumn25, null),
 			String[].class, new String[] {_DATA_STRING});
 
 		// String localized

--- a/portal-kernel/src/com/liferay/portal/kernel/util/ArrayUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/ArrayUtil.java
@@ -2045,14 +2045,16 @@ public class ArrayUtil {
 		return newArray;
 	}
 
-	public static short[] toShortArray(Collection<Short> collection) {
+	public static short[] toShortArray(
+		Collection<? extends Number> collection) {
+
 		short[] newArray = new short[collection.size()];
 
 		if (collection instanceof List) {
-			List<Short> list = (List<Short>)collection;
+			List<Number> list = (List<Number>)collection;
 
 			for (int i = 0; i < list.size(); i++) {
-				Short value = list.get(i);
+				Number value = list.get(i);
 
 				newArray[i] = value.shortValue();
 			}
@@ -2060,10 +2062,10 @@ public class ArrayUtil {
 		else {
 			int i = 0;
 
-			Iterator<Short> iterator = collection.iterator();
+			Iterator<? extends Number> iterator = collection.iterator();
 
 			while (iterator.hasNext()) {
-				Short value = iterator.next();
+				Number value = iterator.next();
 
 				newArray[i++] = value.shortValue();
 			}


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPD-54757

See: https://github.com/brianchandotcom/liferay-portal/pull/161828

---

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPP-58709

Updating the custom fields of a structured content via the API results in a ClassCastException.

# How are we fixing it?

Added appropriate condition checks to ensure the field values are converted to the expected types

cc/ @ak-ragnor @jkappler @movaldivia 