### PR TITLE
LPD-54068 Make sure guest view permission is not lost while propagating the changes of a page with a Master Page template between Site Templates and SIte

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PortletDataContextImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PortletDataContextImpl.java
@@ -1428,7 +1428,7 @@ public class PortletDataContextImpl implements PortletDataContext {
 				continue;
 			}
 
-			if (isPrivateLayout() &&
+			if (isOriginalPrivateLayout() &&
 				resourceName.equals(Layout.class.getName()) &&
 				roleName.equals(RoleConstants.GUEST) &&
 				!_isGroupLayoutSetPrototype()) {

--- a/modules/test/playwright/helpers/json-web-services/JSONWebServicesLayoutSetPrototypeApiHelper.ts
+++ b/modules/test/playwright/helpers/json-web-services/JSONWebServicesLayoutSetPrototypeApiHelper.ts
@@ -7,8 +7,8 @@ import {liferayConfig} from '../../liferay.config';
 import {ApiHelpers} from '../ApiHelpers';
 
 export type LayoutSetPrototype = {
-	layoutSetPrototypeId: string;
 	companyId: string;
+	layoutSetPrototypeId: string;
 	nameCurrentValue: string;
 	uuid: string;
 };

--- a/modules/test/playwright/helpers/json-web-services/JSONWebServicesLayoutSetPrototypeApiHelper.ts
+++ b/modules/test/playwright/helpers/json-web-services/JSONWebServicesLayoutSetPrototypeApiHelper.ts
@@ -8,6 +8,7 @@ import {ApiHelpers} from '../ApiHelpers';
 
 export type LayoutSetPrototype = {
 	layoutSetPrototypeId: string;
+	companyId: string;
 	nameCurrentValue: string;
 	uuid: string;
 };

--- a/modules/test/playwright/tests/layout-set-prototype-web/main/siteTemplatesPropagation.spec.ts
+++ b/modules/test/playwright/tests/layout-set-prototype-web/main/siteTemplatesPropagation.spec.ts
@@ -149,9 +149,6 @@ test(
 		sitesPage,
 	}) => {
 		const siteTemplateName: string = 'template-' + getRandomString();
-		const masterPageName: string = 'masterPage-' + getRandomString();
-		const pageName: string = 'page-' + getRandomString();
-		const siteName: string = 'site-' + getRandomString();
 
 		const layoutSetPrototype = await createSiteTemplate({
 			apiHelpers,
@@ -174,19 +171,20 @@ test(
 
 		// Create a Master Page
 
-		const masterPage =
-			await apiHelpers.jsonWebServicesLayoutPageTemplateEntry.addLayoutPageTemplateEntry(
-				{
-					groupId: layoutSetPrototypeGroup.groupId,
-					name: masterPageName,
-					type: 'master-layout',
-				}
-			);
+		const masterPageName: string = 'masterPage-' + getRandomString();
+		await apiHelpers.jsonWebServicesLayoutPageTemplateEntry.addLayoutPageTemplateEntry(
+			{
+				groupId: layoutSetPrototypeGroup.groupId,
+				name: masterPageName,
+				type: 'master-layout',
+			}
+		);
 
 		await productMenuPage.goToPages();
 
 		// Create a page based on the Master Page
 
+		const pageName: string = 'page-' + getRandomString();
 		await pagesAdminPage.createNewPage({
 			draft: true,
 			name: pageName,
@@ -199,6 +197,7 @@ test(
 
 		// Create a site using the site template
 
+		const siteName: string = 'site-' + getRandomString();
 		const siteId = await sitesPage.createSite({
 			isCustom: true,
 			siteName,
@@ -269,7 +268,7 @@ test(
 
 		// Go to the site created pages
 
-		await page.goto(`/web/${siteName}`);
+		await page.goto(newSiteURL);
 
 		await productMenuPage.goToPages();
 
@@ -287,6 +286,6 @@ test(
 
 		// Go to the page created TODO: Make it not logged
 
-		await page.goto(`/web/${siteName}${pageData.friendlyUrlPath}`);
+		await page.goto(`${newSiteURL}${pageData.friendlyUrlPath}`);
 	}
 );

--- a/modules/test/playwright/tests/layout-set-prototype-web/main/siteTemplatesPropagation.spec.ts
+++ b/modules/test/playwright/tests/layout-set-prototype-web/main/siteTemplatesPropagation.spec.ts
@@ -9,6 +9,7 @@ import {applicationsMenuPageTest} from '../../../fixtures/applicationsMenuPageTe
 import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
 import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../fixtures/loginTest';
+import {masterPagesPagesTest} from '../../../fixtures/masterPagesPagesTest';
 import {pageEditorPagesTest} from '../../../fixtures/pageEditorPagesTest';
 import {pageTemplatesPagesTest} from '../../../fixtures/pageTemplatesPagesTest';
 import {pageViewModePagesTest} from '../../../fixtures/pageViewModePagesTest';
@@ -19,18 +20,19 @@ import getRandomString from '../../../utils/getRandomString';
 import createSiteTemplate from './utils/createSiteTemplate';
 
 export const test = mergeTests(
-	dataApiHelpersTest,
 	applicationsMenuPageTest,
-	loginTest(),
+	dataApiHelpersTest,
 	featureFlagsTest({
 		'LPD-39304': {enabled: true},
 	}),
+	loginTest(),
+	masterPagesPagesTest,
 	pagesAdminPagesTest,
 	pageEditorPagesTest,
 	pageTemplatesPagesTest,
+	pageViewModePagesTest,
 	productMenuPageTest,
-	sitesPageTest,
-	pageViewModePagesTest
+	sitesPageTest
 );
 
 test('User is able to propagate pages separately on site templates', async ({
@@ -133,3 +135,158 @@ test('User is able to propagate pages separately on site templates', async ({
 			!homePageModificationDateAfter !== homePageModificationDateBefore
 	).toEqual(true);
 });
+
+test(
+	'Guest view permission is not lost when a page generated from Master Page change is propagated to the site of a Site Template',
+	{tag: ['@LPD-54068']},
+	async ({
+		apiHelpers,
+		applicationsMenuPage,
+		page,
+		pageEditorPage,
+		pagesAdminPage,
+		productMenuPage,
+		sitesPage,
+	}) => {
+		const siteTemplateName: string = 'template-' + getRandomString();
+		const masterPageName: string = 'masterPage-' + getRandomString();
+		const pageName: string = 'page-' + getRandomString();
+		const siteName: string = 'site-' + getRandomString();
+
+		const layoutSetPrototype = await createSiteTemplate({
+			apiHelpers,
+			layoutsUpdateable: true,
+			page,
+			productMenuPage,
+			templateName: siteTemplateName,
+		});
+
+		await apiHelpers.data.push({
+			id: layoutSetPrototype.layoutSetPrototypeId,
+			type: 'layoutSetPrototype',
+		});
+
+		const layoutSetPrototypeGroup =
+			await apiHelpers.jsonWebServicesGroup.getGroupByKey(
+				layoutSetPrototype.companyId,
+				layoutSetPrototype.layoutSetPrototypeId
+			);
+
+		// Create a Master Page
+
+		const masterPage =
+			await apiHelpers.jsonWebServicesLayoutPageTemplateEntry.addLayoutPageTemplateEntry(
+				{
+					groupId: layoutSetPrototypeGroup.groupId,
+					name: masterPageName,
+					type: 'master-layout',
+				}
+			);
+
+		await productMenuPage.goToPages();
+
+		// Create a page based on the Master Page
+
+		await pagesAdminPage.createNewPage({
+			draft: true,
+			name: pageName,
+			template: masterPageName,
+		});
+
+		await pageEditorPage.publishPage();
+
+		await applicationsMenuPage.goToSites();
+
+		// Create a site using the site template
+
+		const siteId = await sitesPage.createSite({
+			isCustom: true,
+			siteName,
+			templateName: siteTemplateName,
+		});
+
+		await apiHelpers.data.push({id: siteId, type: 'site'});
+
+		const newSiteURL = `/web/${siteName}`;
+
+		// Go to the site when it is available
+
+		await expect
+			.poll(
+				async () => {
+					await page.goto(newSiteURL);
+
+					return page.getByText('Page Not Found Go Back').isVisible();
+				},
+				{
+					timeout: 6000,
+				}
+			)
+			.toBe(false);
+
+		await productMenuPage.goToPages();
+
+		// Here I should add the assert
+
+		await page
+			.getByRole('menuitem', {
+				name: `Move ${pageName} Select ${pageName}`,
+			})
+			.getByLabel('Open Page Options Menu')
+			.click();
+		await page.getByRole('menuitem', {name: 'Permissions'}).click();
+
+		const guestViewPermissionCheckbox =
+			await page.locator('#guest_ACTION_VIEW');
+
+		// await expect(guestViewPermissionCheckbox).toBeChecked();
+
+		// Obtain the data from the page created
+
+		const pageData = await apiHelpers.headlessDelivery.getSitePage(
+			pageName,
+			siteId
+		);
+
+		// Go to the page created TODO: Make it not logged
+
+		await page.goto(`${newSiteURL}${pageData.friendlyUrlPath}`);
+
+		// TODO: assert 'not-found' not present
+
+		// Go back to the site template
+
+		await page.goto(
+			`/group/template-${layoutSetPrototype.layoutSetPrototypeId}`
+		);
+
+		// Add a button to the page
+
+		await productMenuPage.goToPages();
+		await page.getByText(pageName).click();
+		await pageEditorPage.addFragment('Basic Components', 'Button');
+		await pageEditorPage.publishPage();
+
+		// Go to the site created pages
+
+		await page.goto(`/web/${siteName}`);
+
+		await productMenuPage.goToPages();
+
+		// Here I should add the assert
+
+		await page
+			.getByRole('menuitem', {
+				name: `Move ${pageName} Select ${pageName}`,
+			})
+			.getByLabel('Open Page Options Menu')
+			.click();
+		await page.getByRole('menuitem', {name: 'Permissions'}).click();
+
+		// expect(guestViewPermissionCheckbox).toBeChecked();
+
+		// Go to the page created TODO: Make it not logged
+
+		await page.goto(`/web/${siteName}${pageData.friendlyUrlPath}`);
+	}
+);

--- a/modules/test/playwright/tests/layout-set-prototype-web/main/siteTemplatesPropagation.spec.ts
+++ b/modules/test/playwright/tests/layout-set-prototype-web/main/siteTemplatesPropagation.spec.ts
@@ -137,7 +137,7 @@ test('User is able to propagate pages separately on site templates', async ({
 });
 
 test(
-	'Guest view permission is not lost when a page generated from Master Page change is propagated to the site of a Site Template',
+	'Guest view permission is not lost when a change in a page generated from a Master Page is propagated from a Site Template to a Site',
 	{tag: ['@LPD-54068']},
 	async ({
 		apiHelpers,
@@ -182,12 +182,10 @@ test(
 
 		const pageName: string = 'page-' + getRandomString();
 		await pagesAdminPage.createNewPage({
-			draft: true,
+			draft: false,
 			name: pageName,
 			template: masterPageName,
 		});
-
-		await pageEditorPage.publishPage();
 
 		await applicationsMenuPage.goToSites();
 
@@ -236,11 +234,6 @@ test(
 
 		await expect(guestViewPermissionCheckbox).toBeChecked();
 
-		const pageData = await apiHelpers.headlessDelivery.getSitePage(
-			pageName,
-			siteId
-		);
-
 		await page.goto(
 			`/group/template-${layoutSetPrototype.layoutSetPrototypeId}`
 		);
@@ -250,7 +243,7 @@ test(
 		await pageEditorPage.addFragment('Basic Components', 'Button');
 		await pageEditorPage.publishPage();
 
-		// Force the propagation of the chganges
+		// Force the propagation of the changes
 
 		await applicationsMenuPage.goto();
 

--- a/modules/test/playwright/tests/layout-set-prototype-web/main/siteTemplatesPropagation.spec.ts
+++ b/modules/test/playwright/tests/layout-set-prototype-web/main/siteTemplatesPropagation.spec.ts
@@ -169,8 +169,6 @@ test(
 				layoutSetPrototype.layoutSetPrototypeId
 			);
 
-		// Create a Master Page
-
 		const masterPageName: string = 'masterPage-' + getRandomString();
 		await apiHelpers.jsonWebServicesLayoutPageTemplateEntry.addLayoutPageTemplateEntry(
 			{
@@ -182,8 +180,6 @@ test(
 
 		await productMenuPage.goToPages();
 
-		// Create a page based on the Master Page
-
 		const pageName: string = 'page-' + getRandomString();
 		await pagesAdminPage.createNewPage({
 			draft: true,
@@ -194,8 +190,6 @@ test(
 		await pageEditorPage.publishPage();
 
 		await applicationsMenuPage.goToSites();
-
-		// Create a site using the site template
 
 		const siteName: string = 'site-' + getRandomString();
 		const siteId = await sitesPage.createSite({
@@ -225,8 +219,6 @@ test(
 
 		await productMenuPage.goToPages();
 
-		// Here I should add the assert
-
 		await page
 			.getByRole('menuitem', {
 				name: `Move ${pageName} Select ${pageName}`,
@@ -235,44 +227,36 @@ test(
 			.click();
 		await page.getByRole('menuitem', {name: 'Permissions'}).click();
 
+		const permissionsFrameLocator = await page.frameLocator(
+			'iframe[title="Permissions"]'
+		);
+
 		const guestViewPermissionCheckbox =
-			await page.locator('#guest_ACTION_VIEW');
+			permissionsFrameLocator.locator('#guest_ACTION_VIEW');
 
-		// await expect(guestViewPermissionCheckbox).toBeChecked();
-
-		// Obtain the data from the page created
+		await expect(guestViewPermissionCheckbox).toBeChecked();
 
 		const pageData = await apiHelpers.headlessDelivery.getSitePage(
 			pageName,
 			siteId
 		);
 
-		// Go to the page created TODO: Make it not logged
-
-		await page.goto(`${newSiteURL}${pageData.friendlyUrlPath}`);
-
-		// TODO: assert 'not-found' not present
-
-		// Go back to the site template
-
 		await page.goto(
 			`/group/template-${layoutSetPrototype.layoutSetPrototypeId}`
 		);
-
-		// Add a button to the page
 
 		await productMenuPage.goToPages();
 		await page.getByText(pageName).click();
 		await pageEditorPage.addFragment('Basic Components', 'Button');
 		await pageEditorPage.publishPage();
 
-		// Go to the site created pages
+		// Force the propagation of the chganges
+
+		await applicationsMenuPage.goto();
 
 		await page.goto(newSiteURL);
 
 		await productMenuPage.goToPages();
-
-		// Here I should add the assert
 
 		await page
 			.getByRole('menuitem', {
@@ -282,10 +266,6 @@ test(
 			.click();
 		await page.getByRole('menuitem', {name: 'Permissions'}).click();
 
-		// expect(guestViewPermissionCheckbox).toBeChecked();
-
-		// Go to the page created TODO: Make it not logged
-
-		await page.goto(`${newSiteURL}${pageData.friendlyUrlPath}`);
+		await expect(guestViewPermissionCheckbox).toBeChecked();
 	}
 );


### PR DESCRIPTION
**What's changed?**
- Changed the `isPrivateLayout()` usage for `isOriginalPrivateLayout` to propagate the Guest View permission properly.

**What's new?**
- A test has been added for checking the previously failing use case.

See the following Jira tickets: [LPD-54068](https://liferay.atlassian.net/browse/LPD-54068), [LPP-58518](https://liferay.atlassian.net/browse/LPP-58518) 