### PR TITLE
LPD-56242 Improve ObjectEntryResourceTest by getting rid of some objectDefinitions, we can use the existing ones

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -1698,7 +1698,7 @@ public class ObjectEntryResourceTest {
 		_objectEntry3 = ObjectEntryTestUtil.addObjectEntry(
 			_objectDefinition3, _OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3);
 		_objectEntry4 = ObjectEntryTestUtil.addObjectEntry(
-			_objectDefinition5, _OBJECT_FIELD_NAME_4, _OBJECT_FIELD_VALUE_4);
+			_objectDefinition5, _OBJECT_FIELD_NAME_TEXT, _OBJECT_FIELD_VALUE_4);
 
 		_objectRelationship1 = _addObjectRelationshipAndRelateObjectEntries(
 			_objectDefinition1, _objectDefinition2,
@@ -2163,7 +2163,7 @@ public class ObjectEntryResourceTest {
 				String.format(
 					"%s/%s/%s/%s eq '%s'", _objectRelationship1.getName(),
 					_objectRelationship2.getName(),
-					_objectRelationship3.getName(), _OBJECT_FIELD_NAME_4,
+					_objectRelationship3.getName(), _OBJECT_FIELD_NAME_TEXT,
 					_OBJECT_FIELD_VALUE_4)),
 			_objectDefinition1);
 		_assertFilterString(
@@ -2172,7 +2172,7 @@ public class ObjectEntryResourceTest {
 				String.format(
 					"%s/%s/%s/%s eq '%s'", _objectRelationship1.getName(),
 					_objectRelationship4.getName(),
-					_objectRelationship3.getName(), _OBJECT_FIELD_NAME_4,
+					_objectRelationship3.getName(), _OBJECT_FIELD_NAME_TEXT,
 					_OBJECT_FIELD_VALUE_4)),
 			_objectDefinition1);
 	}
@@ -5509,7 +5509,7 @@ public class ObjectEntryResourceTest {
 			new String[] {ActionKeys.UPDATE, ActionKeys.VIEW});
 
 		_objectEntry4 = ObjectEntryTestUtil.addObjectEntry(
-			_objectDefinition5, _OBJECT_FIELD_NAME_4, _OBJECT_FIELD_VALUE_4);
+			_objectDefinition5, _OBJECT_FIELD_NAME_TEXT, _OBJECT_FIELD_VALUE_4);
 
 		_userAccountJSONObject = UserAccountTestUtil.addUserAccountJSONObject(
 			_systemObjectDefinitionManager,

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -682,19 +682,6 @@ public class ObjectEntryResourceTest {
 					false)),
 			ObjectDefinitionConstants.SCOPE_COMPANY);
 
-		_objectDefinition4 = ObjectDefinitionTestUtil.publishObjectDefinition(
-			Arrays.asList(
-				ObjectFieldUtil.createObjectField(
-					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-					ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
-					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME_4, false),
-				ObjectFieldUtil.createObjectField(
-					_listTypeDefinition.getListTypeDefinitionId(),
-					ObjectFieldConstants.BUSINESS_TYPE_MULTISELECT_PICKLIST,
-					null, ObjectFieldConstants.DB_TYPE_STRING, true, false,
-					null, RandomTestUtil.randomString(),
-					_OBJECT_FIELD_NAME_MULTISELECT_PICKLIST, false, false)));
-
 		_objectDefinition5 = ObjectDefinitionTestUtil.publishObjectDefinition(
 			true, ObjectDefinitionTestUtil.getRandomName(),
 			Arrays.asList(
@@ -1017,8 +1004,6 @@ public class ObjectEntryResourceTest {
 			_objectDefinition2);
 		_objectDefinitionLocalService.deleteObjectDefinition(
 			_objectDefinition3);
-		_objectDefinitionLocalService.deleteObjectDefinition(
-			_objectDefinition4);
 		_objectDefinitionLocalService.deleteObjectDefinition(
 			_objectDefinition5);
 		_objectDefinitionLocalService.deleteObjectDefinition(
@@ -1713,7 +1698,7 @@ public class ObjectEntryResourceTest {
 		_objectEntry3 = ObjectEntryTestUtil.addObjectEntry(
 			_objectDefinition3, _OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3);
 		_objectEntry4 = ObjectEntryTestUtil.addObjectEntry(
-			_objectDefinition4, _OBJECT_FIELD_NAME_4, _OBJECT_FIELD_VALUE_4);
+			_objectDefinition5, _OBJECT_FIELD_NAME_4, _OBJECT_FIELD_VALUE_4);
 
 		_objectRelationship1 = _addObjectRelationshipAndRelateObjectEntries(
 			_objectDefinition1, _objectDefinition2,
@@ -2163,7 +2148,7 @@ public class ObjectEntryResourceTest {
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		_objectRelationship3 = _addObjectRelationshipAndRelateObjectEntries(
-			_objectDefinition3, _objectDefinition4,
+			_objectDefinition3, _objectDefinition5,
 			_objectEntry3.getPrimaryKey(), _objectEntry4.getPrimaryKey(),
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
@@ -5524,7 +5509,7 @@ public class ObjectEntryResourceTest {
 			new String[] {ActionKeys.UPDATE, ActionKeys.VIEW});
 
 		_objectEntry4 = ObjectEntryTestUtil.addObjectEntry(
-			_objectDefinition4, _OBJECT_FIELD_NAME_4, _OBJECT_FIELD_VALUE_4);
+			_objectDefinition5, _OBJECT_FIELD_NAME_4, _OBJECT_FIELD_VALUE_4);
 
 		_userAccountJSONObject = UserAccountTestUtil.addUserAccountJSONObject(
 			_systemObjectDefinitionManager,
@@ -5560,7 +5545,7 @@ public class ObjectEntryResourceTest {
 			_objectEntry3.getPrimaryKey(), _userAccountJSONObject.getLong("id"),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 		_objectRelationship5 = _addObjectRelationshipAndRelateObjectEntries(
-			_userSystemObjectDefinition, _objectDefinition4,
+			_userSystemObjectDefinition, _objectDefinition5,
 			_userAccountJSONObject.getLong("id"), _objectEntry4.getPrimaryKey(),
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
@@ -18163,7 +18148,6 @@ public class ObjectEntryResourceTest {
 	private ObjectDefinition _objectDefinition1;
 	private ObjectDefinition _objectDefinition2;
 	private ObjectDefinition _objectDefinition3;
-	private ObjectDefinition _objectDefinition4;
 	private ObjectDefinition _objectDefinition5;
 
 	@Inject

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -682,7 +682,7 @@ public class ObjectEntryResourceTest {
 					false)),
 			ObjectDefinitionConstants.SCOPE_COMPANY);
 
-		_objectDefinition5 = ObjectDefinitionTestUtil.publishObjectDefinition(
+		_objectDefinition4 = ObjectDefinitionTestUtil.publishObjectDefinition(
 			true, ObjectDefinitionTestUtil.getRandomName(),
 			Arrays.asList(
 				new TextObjectFieldBuilder(
@@ -716,7 +716,7 @@ public class ObjectEntryResourceTest {
 			TestPropsValues.getUserId());
 
 		_objectEntry5 = ObjectEntryTestUtil.addObjectEntry(
-			_objectDefinition5,
+			_objectDefinition4,
 			HashMapBuilder.<String, Serializable>put(
 				_OBJECT_FIELD_NAME_LONG_TEXT, "name2_text_english"
 			).put(
@@ -1005,7 +1005,7 @@ public class ObjectEntryResourceTest {
 		_objectDefinitionLocalService.deleteObjectDefinition(
 			_objectDefinition3);
 		_objectDefinitionLocalService.deleteObjectDefinition(
-			_objectDefinition5);
+			_objectDefinition4);
 		_objectDefinitionLocalService.deleteObjectDefinition(
 			_siteScopedObjectDefinition1);
 		_objectDefinitionLocalService.deleteObjectDefinition(
@@ -1698,7 +1698,7 @@ public class ObjectEntryResourceTest {
 		_objectEntry3 = ObjectEntryTestUtil.addObjectEntry(
 			_objectDefinition3, _OBJECT_FIELD_NAME_3, _OBJECT_FIELD_VALUE_3);
 		_objectEntry4 = ObjectEntryTestUtil.addObjectEntry(
-			_objectDefinition5, _OBJECT_FIELD_NAME_TEXT, _OBJECT_FIELD_VALUE_4);
+			_objectDefinition4, _OBJECT_FIELD_NAME_TEXT, _OBJECT_FIELD_VALUE_4);
 
 		_objectRelationship1 = _addObjectRelationshipAndRelateObjectEntries(
 			_objectDefinition1, _objectDefinition2,
@@ -2148,7 +2148,7 @@ public class ObjectEntryResourceTest {
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		_objectRelationship3 = _addObjectRelationshipAndRelateObjectEntries(
-			_objectDefinition3, _objectDefinition5,
+			_objectDefinition3, _objectDefinition4,
 			_objectEntry3.getPrimaryKey(), _objectEntry4.getPrimaryKey(),
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
@@ -5509,7 +5509,7 @@ public class ObjectEntryResourceTest {
 			new String[] {ActionKeys.UPDATE, ActionKeys.VIEW});
 
 		_objectEntry4 = ObjectEntryTestUtil.addObjectEntry(
-			_objectDefinition5, _OBJECT_FIELD_NAME_TEXT, _OBJECT_FIELD_VALUE_4);
+			_objectDefinition4, _OBJECT_FIELD_NAME_TEXT, _OBJECT_FIELD_VALUE_4);
 
 		_userAccountJSONObject = UserAccountTestUtil.addUserAccountJSONObject(
 			_systemObjectDefinitionManager,
@@ -5545,7 +5545,7 @@ public class ObjectEntryResourceTest {
 			_objectEntry3.getPrimaryKey(), _userAccountJSONObject.getLong("id"),
 			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 		_objectRelationship5 = _addObjectRelationshipAndRelateObjectEntries(
-			_userSystemObjectDefinition, _objectDefinition5,
+			_userSystemObjectDefinition, _objectDefinition4,
 			_userAccountJSONObject.getLong("id"), _objectEntry4.getPrimaryKey(),
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
@@ -7120,7 +7120,7 @@ public class ObjectEntryResourceTest {
 			).toString(),
 			HTTPTestUtil.invokeToJSONObject(
 				null,
-				_objectDefinition5.getRESTContextPath() + StringPool.SLASH +
+				_objectDefinition4.getRESTContextPath() + StringPool.SLASH +
 					_objectEntry5.getObjectEntryId(),
 				HashMapBuilder.put(
 					"Accept-Language", "es-ES"
@@ -7143,7 +7143,7 @@ public class ObjectEntryResourceTest {
 			).toString(),
 			HTTPTestUtil.invokeToJSONObject(
 				null,
-				_objectDefinition5.getRESTContextPath() + StringPool.SLASH +
+				_objectDefinition4.getRESTContextPath() + StringPool.SLASH +
 					_objectEntry5.getObjectEntryId(),
 				HashMapBuilder.put(
 					"Accept-Language", ""
@@ -7166,7 +7166,7 @@ public class ObjectEntryResourceTest {
 			).toString(),
 			HTTPTestUtil.invokeToJSONObject(
 				null,
-				_objectDefinition5.getRESTContextPath() + StringPool.SLASH +
+				_objectDefinition4.getRESTContextPath() + StringPool.SLASH +
 					_objectEntry5.getObjectEntryId(),
 				HashMapBuilder.put(
 					"Accept-Language", "de-DE"
@@ -7189,7 +7189,7 @@ public class ObjectEntryResourceTest {
 			).toString(),
 			HTTPTestUtil.invokeToJSONObject(
 				null,
-				_objectDefinition5.getRESTContextPath() + StringPool.SLASH +
+				_objectDefinition4.getRESTContextPath() + StringPool.SLASH +
 					_objectEntry5.getObjectEntryId(),
 				Http.Method.GET
 			).toString(),
@@ -18148,7 +18148,7 @@ public class ObjectEntryResourceTest {
 	private ObjectDefinition _objectDefinition1;
 	private ObjectDefinition _objectDefinition2;
 	private ObjectDefinition _objectDefinition3;
-	private ObjectDefinition _objectDefinition5;
+	private ObjectDefinition _objectDefinition4;
 
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -759,13 +759,6 @@ public class ObjectEntryResourceTest {
 				).build()
 			).build());
 
-		_objectDefinition6 = ObjectDefinitionTestUtil.publishObjectDefinition(
-			Collections.singletonList(
-				ObjectFieldUtil.createObjectField(
-					"Text", "String", true, true, null,
-					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME_TEXT,
-					false)));
-
 		objectDefinitionName = ObjectDefinitionTestUtil.getRandomName();
 
 		_siteScopedObjectDefinition1 =
@@ -1028,8 +1021,6 @@ public class ObjectEntryResourceTest {
 			_objectDefinition4);
 		_objectDefinitionLocalService.deleteObjectDefinition(
 			_objectDefinition5);
-		_objectDefinitionLocalService.deleteObjectDefinition(
-			_objectDefinition6);
 		_objectDefinitionLocalService.deleteObjectDefinition(
 			_siteScopedObjectDefinition1);
 		_objectDefinitionLocalService.deleteObjectDefinition(
@@ -5766,46 +5757,46 @@ public class ObjectEntryResourceTest {
 	@Test
 	public void testGetObjectEntriesWithPagination() throws Exception {
 		ObjectEntryTestUtil.addObjectEntry(
-			_objectDefinition6, _OBJECT_FIELD_NAME_TEXT,
+			_objectDefinition1, _OBJECT_FIELD_NAME_TEXT,
 			_NEW_OBJECT_FIELD_VALUE_1);
 		ObjectEntryTestUtil.addObjectEntry(
-			_objectDefinition6, _OBJECT_FIELD_NAME_TEXT,
+			_objectDefinition1, _OBJECT_FIELD_NAME_TEXT,
 			_NEW_OBJECT_FIELD_VALUE_1);
 		ObjectEntryTestUtil.addObjectEntry(
-			_objectDefinition6, _OBJECT_FIELD_NAME_TEXT,
+			_objectDefinition1, _OBJECT_FIELD_NAME_TEXT,
 			_NEW_OBJECT_FIELD_VALUE_1);
 		ObjectEntryTestUtil.addObjectEntry(
-			_objectDefinition6, _OBJECT_FIELD_NAME_TEXT,
+			_objectDefinition1, _OBJECT_FIELD_NAME_TEXT,
 			_NEW_OBJECT_FIELD_VALUE_1);
 		ObjectEntryTestUtil.addObjectEntry(
-			_objectDefinition6, _OBJECT_FIELD_NAME_TEXT,
+			_objectDefinition1, _OBJECT_FIELD_NAME_TEXT,
 			_NEW_OBJECT_FIELD_VALUE_1);
 		ObjectEntryTestUtil.addObjectEntry(
-			_objectDefinition6, _OBJECT_FIELD_NAME_TEXT,
+			_objectDefinition1, _OBJECT_FIELD_NAME_TEXT,
 			_NEW_OBJECT_FIELD_VALUE_1);
 		ObjectEntryTestUtil.addObjectEntry(
-			_objectDefinition6, _OBJECT_FIELD_NAME_TEXT,
+			_objectDefinition1, _OBJECT_FIELD_NAME_TEXT,
 			_NEW_OBJECT_FIELD_VALUE_1);
 
-		_assertPagination(7, _objectDefinition6);
+		_assertPagination(7, _objectDefinition1);
 
 		ObjectEntryTestUtil.addObjectEntry(
-			_objectDefinition6, _OBJECT_FIELD_NAME_TEXT,
+			_objectDefinition1, _OBJECT_FIELD_NAME_TEXT,
 			_NEW_OBJECT_FIELD_VALUE_1);
 		ObjectEntryTestUtil.addObjectEntry(
-			_objectDefinition6, _OBJECT_FIELD_NAME_TEXT,
+			_objectDefinition1, _OBJECT_FIELD_NAME_TEXT,
 			_NEW_OBJECT_FIELD_VALUE_1);
 
-		_assertPagination(9, _objectDefinition6);
+		_assertPagination(9, _objectDefinition1);
 
 		ObjectEntryTestUtil.addObjectEntry(
-			_objectDefinition6, _OBJECT_FIELD_NAME_TEXT,
+			_objectDefinition1, _OBJECT_FIELD_NAME_TEXT,
 			_NEW_OBJECT_FIELD_VALUE_1);
 		ObjectEntryTestUtil.addObjectEntry(
-			_objectDefinition6, _OBJECT_FIELD_NAME_TEXT,
+			_objectDefinition1, _OBJECT_FIELD_NAME_TEXT,
 			_NEW_OBJECT_FIELD_VALUE_1);
 
-		_assertPagination(11, _objectDefinition6);
+		_assertPagination(11, _objectDefinition1);
 	}
 
 	@Test
@@ -18174,7 +18165,6 @@ public class ObjectEntryResourceTest {
 	private ObjectDefinition _objectDefinition3;
 	private ObjectDefinition _objectDefinition4;
 	private ObjectDefinition _objectDefinition5;
-	private ObjectDefinition _objectDefinition6;
 
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -685,15 +685,6 @@ public class ObjectEntryResourceTest {
 		_objectDefinition4 = ObjectDefinitionTestUtil.publishObjectDefinition(
 			true, ObjectDefinitionTestUtil.getRandomName(),
 			Arrays.asList(
-				new TextObjectFieldBuilder(
-				).labelMap(
-					LocalizedMapUtil.getLocalizedMap(
-						RandomTestUtil.randomString())
-				).localized(
-					true
-				).name(
-					_OBJECT_FIELD_NAME_TEXT
-				).build(),
 				new LongTextObjectFieldBuilder(
 				).labelMap(
 					LocalizedMapUtil.getLocalizedMap(
@@ -701,7 +692,7 @@ public class ObjectEntryResourceTest {
 				).localized(
 					true
 				).name(
-					_OBJECT_FIELD_NAME_LONG_TEXT
+					_OBJECT_FIELD_NAME_LOCALIZED_LONG_TEXT
 				).build(),
 				new RichTextObjectFieldBuilder(
 				).labelMap(
@@ -710,35 +701,59 @@ public class ObjectEntryResourceTest {
 				).localized(
 					true
 				).name(
-					_OBJECT_FIELD_NAME_RICH_TEXT
-				).build()),
+					_OBJECT_FIELD_NAME_LOCALIZED_RICH_TEXT
+				).build(),
+				new TextObjectFieldBuilder(
+				).labelMap(
+					LocalizedMapUtil.getLocalizedMap(
+						RandomTestUtil.randomString())
+				).localized(
+					true
+				).name(
+					_OBJECT_FIELD_NAME_LOCALIZED_TEXT
+				).build(),
+				ObjectFieldUtil.createObjectField(
+					ObjectFieldConstants.BUSINESS_TYPE_LONG_TEXT,
+					ObjectFieldConstants.DB_TYPE_CLOB, false, false, null,
+					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME_LONG_TEXT,
+					false),
+				ObjectFieldUtil.createObjectField(
+					ObjectFieldConstants.BUSINESS_TYPE_RICH_TEXT,
+					ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
+					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME_RICH_TEXT,
+					false),
+				ObjectFieldUtil.createObjectField(
+					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+					ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
+					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME_TEXT,
+					false)),
 			ObjectDefinitionConstants.SCOPE_COMPANY,
 			TestPropsValues.getUserId());
 
 		_objectEntry5 = ObjectEntryTestUtil.addObjectEntry(
 			_objectDefinition4,
 			HashMapBuilder.<String, Serializable>put(
-				_OBJECT_FIELD_NAME_LONG_TEXT, "name2_text_english"
+				_OBJECT_FIELD_NAME_LOCALIZED_LONG_TEXT, "name2_text_english"
 			).put(
-				_OBJECT_FIELD_NAME_LONG_TEXT + "_i18n",
+				_OBJECT_FIELD_NAME_LOCALIZED_LONG_TEXT + "_i18n",
 				HashMapBuilder.<String, Serializable>put(
 					"en_US", "longTextEng"
 				).put(
 					"es_ES", "longTextEsp"
 				).build()
 			).put(
-				_OBJECT_FIELD_NAME_RICH_TEXT, "<p>c</p>\\n"
+				_OBJECT_FIELD_NAME_LOCALIZED_RICH_TEXT, "<p>c</p>\\n"
 			).put(
-				_OBJECT_FIELD_NAME_RICH_TEXT + "_i18n",
+				_OBJECT_FIELD_NAME_LOCALIZED_RICH_TEXT + "_i18n",
 				HashMapBuilder.<String, Serializable>put(
 					"en_US", "<p>richTextEng</p>"
 				).put(
 					"es_ES", "<p>richTextEsp</p>"
 				).build()
 			).put(
-				_OBJECT_FIELD_NAME_TEXT, "name1_text_english"
+				_OBJECT_FIELD_NAME_LOCALIZED_TEXT, "name1_text_english"
 			).put(
-				_OBJECT_FIELD_NAME_TEXT + "_i18n",
+				_OBJECT_FIELD_NAME_LOCALIZED_TEXT + "_i18n",
 				HashMapBuilder.<String, Serializable>put(
 					"en_US", "textEng"
 				).put(
@@ -5556,7 +5571,7 @@ public class ObjectEntryResourceTest {
 			_objectRelationship1.getName(), ".", _objectRelationship2.getName(),
 			".", _objectRelationship3.getName(), ".",
 			_objectRelationship4.getName(), ".", _objectRelationship5.getName(),
-			".", _OBJECT_FIELD_NAME_4, "&nestedFields=",
+			".", _OBJECT_FIELD_NAME_TEXT, "&nestedFields=",
 			_objectRelationship1.getName(), ",", _objectRelationship2.getName(),
 			",", _objectRelationship3.getName(), ",",
 			_objectRelationship4.getName(), ",", _objectRelationship5.getName(),
@@ -5583,7 +5598,8 @@ public class ObjectEntryResourceTest {
 				{"", "", Boolean.TRUE.toString()},
 				{"", "", Boolean.TRUE.toString()},
 				{
-					_OBJECT_FIELD_NAME_4, String.valueOf(_OBJECT_FIELD_VALUE_4),
+					_OBJECT_FIELD_NAME_TEXT,
+					String.valueOf(_OBJECT_FIELD_VALUE_4),
 					Boolean.TRUE.toString()
 				}
 			},
@@ -7110,13 +7126,14 @@ public class ObjectEntryResourceTest {
 
 		JSONAssert.assertEquals(
 			JSONUtil.put(
-				_OBJECT_FIELD_NAME_LONG_TEXT, "longTextEsp"
+				_OBJECT_FIELD_NAME_LOCALIZED_LONG_TEXT, "longTextEsp"
 			).put(
-				_OBJECT_FIELD_NAME_RICH_TEXT, "<p>richTextEsp</p>"
+				_OBJECT_FIELD_NAME_LOCALIZED_RICH_TEXT, "<p>richTextEsp</p>"
 			).put(
-				_OBJECT_FIELD_NAME_RICH_TEXT + "RawText", "richTextEsp"
+				_OBJECT_FIELD_NAME_LOCALIZED_RICH_TEXT + "RawText",
+				"richTextEsp"
 			).put(
-				_OBJECT_FIELD_NAME_TEXT, "textEsp"
+				_OBJECT_FIELD_NAME_LOCALIZED_TEXT, "textEsp"
 			).toString(),
 			HTTPTestUtil.invokeToJSONObject(
 				null,
@@ -7133,13 +7150,14 @@ public class ObjectEntryResourceTest {
 
 		JSONAssert.assertEquals(
 			JSONUtil.put(
-				_OBJECT_FIELD_NAME_LONG_TEXT, "longTextEng"
+				_OBJECT_FIELD_NAME_LOCALIZED_LONG_TEXT, "longTextEng"
 			).put(
-				_OBJECT_FIELD_NAME_RICH_TEXT, "<p>richTextEng</p>"
+				_OBJECT_FIELD_NAME_LOCALIZED_RICH_TEXT, "<p>richTextEng</p>"
 			).put(
-				_OBJECT_FIELD_NAME_RICH_TEXT + "RawText", "richTextEng"
+				_OBJECT_FIELD_NAME_LOCALIZED_RICH_TEXT + "RawText",
+				"richTextEng"
 			).put(
-				_OBJECT_FIELD_NAME_TEXT, "textEng"
+				_OBJECT_FIELD_NAME_LOCALIZED_TEXT, "textEng"
 			).toString(),
 			HTTPTestUtil.invokeToJSONObject(
 				null,
@@ -7156,13 +7174,14 @@ public class ObjectEntryResourceTest {
 
 		JSONAssert.assertEquals(
 			JSONUtil.put(
-				_OBJECT_FIELD_NAME_LONG_TEXT, "longTextEng"
+				_OBJECT_FIELD_NAME_LOCALIZED_LONG_TEXT, "longTextEng"
 			).put(
-				_OBJECT_FIELD_NAME_RICH_TEXT, "<p>richTextEng</p>"
+				_OBJECT_FIELD_NAME_LOCALIZED_RICH_TEXT, "<p>richTextEng</p>"
 			).put(
-				_OBJECT_FIELD_NAME_RICH_TEXT + "RawText", "richTextEng"
+				_OBJECT_FIELD_NAME_LOCALIZED_RICH_TEXT + "RawText",
+				"richTextEng"
 			).put(
-				_OBJECT_FIELD_NAME_TEXT, "textEng"
+				_OBJECT_FIELD_NAME_LOCALIZED_TEXT, "textEng"
 			).toString(),
 			HTTPTestUtil.invokeToJSONObject(
 				null,
@@ -7179,13 +7198,14 @@ public class ObjectEntryResourceTest {
 
 		JSONAssert.assertEquals(
 			JSONUtil.put(
-				_OBJECT_FIELD_NAME_LONG_TEXT, "longTextEng"
+				_OBJECT_FIELD_NAME_LOCALIZED_LONG_TEXT, "longTextEng"
 			).put(
-				_OBJECT_FIELD_NAME_RICH_TEXT, "<p>richTextEng</p>"
+				_OBJECT_FIELD_NAME_LOCALIZED_RICH_TEXT, "<p>richTextEng</p>"
 			).put(
-				_OBJECT_FIELD_NAME_RICH_TEXT + "RawText", "richTextEng"
+				_OBJECT_FIELD_NAME_LOCALIZED_RICH_TEXT + "RawText",
+				"richTextEng"
 			).put(
-				_OBJECT_FIELD_NAME_TEXT, "textEng"
+				_OBJECT_FIELD_NAME_LOCALIZED_TEXT, "textEng"
 			).toString(),
 			HTTPTestUtil.invokeToJSONObject(
 				null,
@@ -18012,9 +18032,6 @@ public class ObjectEntryResourceTest {
 	private static final String _OBJECT_FIELD_NAME_3 =
 		"x" + RandomTestUtil.randomString();
 
-	private static final String _OBJECT_FIELD_NAME_4 =
-		"x" + RandomTestUtil.randomString();
-
 	private static final String
 		_OBJECT_FIELD_NAME_ATTACHMENT_DOCS_AND_MEDIA_SOURCE =
 			"x" + RandomTestUtil.randomString();
@@ -18043,6 +18060,15 @@ public class ObjectEntryResourceTest {
 		"x" + RandomTestUtil.randomString();
 
 	private static final String _OBJECT_FIELD_NAME_INTEGER =
+		"x" + RandomTestUtil.randomString();
+
+	private static final String _OBJECT_FIELD_NAME_LOCALIZED_LONG_TEXT =
+		"x" + RandomTestUtil.randomString();
+
+	private static final String _OBJECT_FIELD_NAME_LOCALIZED_RICH_TEXT =
+		"x" + RandomTestUtil.randomString();
+
+	private static final String _OBJECT_FIELD_NAME_LOCALIZED_TEXT =
 		"x" + RandomTestUtil.randomString();
 
 	private static final String _OBJECT_FIELD_NAME_LONG_INTEGER =


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPD-56242

---

The purpose of this PR is to remove some object definitions created in the `setUp` method and reuse the existing ones. With that, we avoid the creation of 2 Object Definitions x 99 tests = 198 object definitions