### PR TITLE
LPD-54955 Deactivate consistently failing test

### DIFF
--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-test/src/testIntegration/java/com/liferay/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-test/src/testIntegration/java/com/liferay/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
@@ -51,6 +51,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -161,6 +162,7 @@ public class ExportTaskResourceTest {
 		_logCaptures.forEach(LogCapture::close);
 	}
 
+	@Ignore
 	@Test
 	public void testPostExportTask() {
 		Assert.assertFalse(_testableClassNames.isEmpty());

--- a/modules/apps/headless/headless-discovery/headless-discovery-test/src/testFunctional/tests/HeadlessDiscovery.testcase
+++ b/modules/apps/headless/headless-discovery/headless-discovery-test/src/testFunctional/tests/HeadlessDiscovery.testcase
@@ -61,7 +61,7 @@ definition {
 
 	@priority = 5
 	test CanConsumeGraphQLAPIsForHeadlessAdminTaxonomy {
-		property portal.acceptance = "true";
+		property portal.acceptance = "quarantine";
 
 		task ("Given a vocabulary is added") {
 			JSONCategory.addVocabulary(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/Staging.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/Staging.testcase
@@ -2750,7 +2750,7 @@ definition {
 
 	@priority = 3
 	test StagingOnlyApprovedPublishToLive {
-		property portal.acceptance = "true";
+		property portal.acceptance = "quarantine";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 


### PR DESCRIPTION
Hi team,
The tests in this PR have been consistently failing in the Acceptance test suite.
[LocalFile.HeadlessDiscovery#CanConsumeGraphQLAPIsForHeadlessAdminTaxonomy](https://testray.liferay.com/#/project/35392/routines/590307/build/220029652/case-result/220101709)
[LocalFile.Staging#StagingOnlyApprovedPublishToLive](https://testray.liferay.com/#/project/35392/routines/590307/build/220029652/case-result/220093096)
[com.liferay.object.rest.internal.manager.v1_0.test.DefaultObjectEntryManagerImplTest](https://testray.liferay.com/#/project/35392/routines/590307/build/220029652/case-result/220101509)

Whether these are bugs or test fixes, if these are lower priority tests that will not be fixed in the near future it might be best to deactivate for now so it's not muddying test results or using up CI resources. For more information, please see this [Slack post](https://liferay.slack.com/archives/C0251HKT0K0/p1747027740422599).

If everything looks good, please forward. If not, please let the Release team know in #t-release on Slack. Thanks!