### PR TITLE
LPD-54955 Deactivate consistently failing test

### DIFF
--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-test/src/testIntegration/java/com/liferay/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-test/src/testIntegration/java/com/liferay/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
@@ -51,6 +51,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -161,6 +162,7 @@ public class ExportTaskResourceTest {
 		_logCaptures.forEach(LogCapture::close);
 	}
 
+	@Ignore
 	@Test
 	public void testPostExportTask() {
 		Assert.assertFalse(_testableClassNames.isEmpty());

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/Staging.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/Staging.testcase
@@ -2750,7 +2750,7 @@ definition {
 
 	@priority = 3
 	test StagingOnlyApprovedPublishToLive {
-		property portal.acceptance = "true";
+		property portal.acceptance = "quarantine";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 


### PR DESCRIPTION
Resent from https://github.com/liferay-headless/liferay-portal/pull/2829 to take off [LocalFile.HeadlessDiscovery#CanConsumeGraphQLAPIsForHeadlessAdminTaxonomy](https://testray.liferay.com/#/project/35392/routines/590307/build/220029652/case-result/220101709). 
[Reference](https://liferay.slack.com/archives/C0251HKT0K0/p1748230082024759?thread_ts=1747210292.681799&cid=C0251HKT0K0)