### PR TITLE
LPD-56611 [test-fix] export-import-web/main/stagingUseCase.spec.ts:34:1 › non modified referred content cannot publish to live when enable include if modified option

### DIFF
--- a/modules/test/playwright/tests/export-import-web/main/pages/StagingPage.ts
+++ b/modules/test/playwright/tests/export-import-web/main/pages/StagingPage.ts
@@ -87,8 +87,8 @@ export class StagingPage {
 				.click();
 
 			await this.page
-				.getByRole('radio', {exact: true, name: 'Include If Modified'})
-				.click();
+				.locator('input[type="radio"][value="include-if-modified"]')
+				.check();
 		}
 
 		await this.page


### PR DESCRIPTION
https://issues.liferay.com/browse/LPD-56611