### PR TITLE
LPD-56916 [Text Fix] Remote staging (unexpected logout)

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/Staging.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Staging.macro
@@ -797,7 +797,7 @@ definition {
 	}
 
 	@summary = "Default summary"
-	macro enableDeleteApplicationDataBeforeImport() {
+	macro enableDeleteApplicationDataBeforeImport(navigate = null) {
 		ApplicationsMenu.gotoPortlet(
 			category = "Configuration",
 			panel = "Control Panel",
@@ -815,7 +815,9 @@ definition {
 				toggle_state = "Disabled");
 		}
 
-		Navigator.openURL();
+		if (${navigate} != "false") {
+			Navigator.openURL();
+		}
 	}
 
 	@summary = "Default summary"

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/exportimport/ExportImportPortlet.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/exportimport/ExportImportPortlet.testcase
@@ -937,7 +937,7 @@ definition {
 				specificURL = "http://www.able.com:8080",
 				userEmailAddress = "test@www.able.com");
 
-			Staging.enableDeleteApplicationDataBeforeImport();
+			Staging.enableDeleteApplicationDataBeforeImport(navigate = "false");
 
 			WebContentNavigator.openWebContentAdmin(
 				baseURL = "http://www.able.com:8080",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/exportimport/ImportProcess.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/exportimport/ImportProcess.testcase
@@ -334,7 +334,7 @@ definition {
 				userEmailAddress = "test@liferay.com",
 				virtualHostsURL = "http://www.able.com:8080");
 
-			Staging.enableDeleteApplicationDataBeforeImport();
+			Staging.enableDeleteApplicationDataBeforeImport(navigate = "false");
 
 			JSONWebcontent.addWebContent(
 				content = "WC WebContent Content",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/RemoteStaging.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/RemoteStaging.testcase
@@ -1114,7 +1114,7 @@ definition {
 				specificURL = "http://localhost:9080",
 				userEmailAddress = "test@liferay.com");
 
-			Staging.enableDeleteApplicationDataBeforeImport();
+			Staging.enableDeleteApplicationDataBeforeImport(navigate = "false");
 		}
 
 		task ("Click Cancel in the confirmation dialog will return to the import tab") {


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-56916

One test started failing after fixing other tests in [LPD-55860](https://liferay.atlassian.net/browse/LPD-55860), where the Deprecation Feature Flag was enabled via the UI.

# How am I fixing it?

Added an option to skip the default navigation.
The default behavior navigates to the default instance, which causes a logout when working with remote staging.

# How can you verify that it works?

We need to wait until poshi test should pass