### PR TITLE
LPD-58393 Remove low priority Headless tests from Acceptance

### DIFF
--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/DisableKeywordsAndCategoriesWhenCategorizationIsNotEnabled.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/DisableKeywordsAndCategoriesWhenCategorizationIsNotEnabled.testcase
@@ -29,8 +29,6 @@ definition {
 
 	@priority = 3
 	test CanGetParametersOfKeywordsAndCategoriesInEndpoint {
-		property portal.acceptance = "true";
-
 		task ("when I navigate to c/university endpoint postUniversity") {
 			APIExplorer.navigateToOpenAPI(
 				api = "c",
@@ -167,8 +165,6 @@ definition {
 
 	@priority = 3
 	test CannotGetKeywordsAndCategoriesWhenCategorizationNotEnabled {
-		property portal.acceptance = "true";
-
 		task ("when I navigate to c/university endpoint postUniversity") {
 			ObjectDefinitionAPI.updateObjectDefinitionById(
 				objectDefinitionId = ${staticUniversityObjectId},
@@ -200,8 +196,6 @@ definition {
 
 	@priority = 3
 	test CannotSeeTaxonomyCategoryBriefInSchemaWhenCategorizationNotEnabled {
-		property portal.acceptance = "true";
-
 		task ("when I navigate to c/university endpoint postUniversity") {
 			ObjectDefinitionAPI.updateObjectDefinitionById(
 				objectDefinitionId = ${staticUniversityObjectId},

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/ExposeBatchActionForObjectAdminAPI.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/ExposeBatchActionForObjectAdminAPI.testcase
@@ -123,8 +123,6 @@ definition {
 	@disable-webdriver = "true"
 	@priority = 3
 	test IncludeCreateBatchInActionsForObjectSchemas {
-		property portal.acceptance = "true";
-
 		task ("When with get request and objectDefinitionId to retrieve objectAction, objectField, objectLayout, objectRelationship, objectValidationRule and objectView") {
 			var objectSchemas = "object-actions,object-fields,object-layouts,object-relationships,object-validation-rules,object-views";
 		}

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/FilterCustomObjectsMultipleLevelsRelationshipsWithStringFunctions.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/FilterCustomObjectsMultipleLevelsRelationshipsWithStringFunctions.testcase
@@ -450,8 +450,6 @@ definition {
 	@disable-webdriver = "true"
 	@priority = 3
 	test CannotFilterByStringFunctionsWithNonExistentFieldValue {
-		property portal.acceptance = "true";
-
 		task ("And Given a oneToMany relationship universityStudents") {
 			ObjectDefinitionAPI.createRelationshipWithObjectDefinitionNames(
 				childObjectName = "Student",
@@ -512,8 +510,6 @@ definition {
 	@disable-webdriver = "true"
 	@priority = 3
 	test CannotFilterStudentsByStringFunctions {
-		property portal.acceptance = "true";
-
 		task ("And Given a oneToMany relationship universityStudents") {
 			ObjectDefinitionAPI.createRelationshipWithObjectDefinitionNames(
 				childObjectName = "Student",
@@ -580,8 +576,6 @@ definition {
 	@disable-webdriver = "true"
 	@priority = 3
 	test CannotGetSubjectsDetasilsWhenFilterOverFieldsWithNoRelatedEntriesByContainsFunctions {
-		property portal.acceptance = "true";
-
 		task ("And Given a oneToMany relationship universityStudents") {
 			ObjectDefinitionAPI.createRelationshipWithObjectDefinitionNames(
 				childObjectName = "Student",
@@ -624,8 +618,6 @@ definition {
 	@disable-webdriver = "true"
 	@priority = 3
 	test CannotGetSubjectsDetasilsWhenFilterOverFieldsWithNoRelatedEntriesByStartswithFunctions {
-		property portal.acceptance = "true";
-
 		task ("And Given a oneToMany relationship universityStudents") {
 			ObjectDefinitionAPI.createRelationshipWithObjectDefinitionNames(
 				childObjectName = "Student",

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/ManageKeywordsAssociatedToObjectEntries.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/ManageKeywordsAssociatedToObjectEntries.testcase
@@ -68,8 +68,6 @@ definition {
 
 	@priority = 3
 	test CanCreateSiteScopedKeywordWhileUpdatingSiteScopedObjectEntry {
-		property portal.acceptance = "true";
-
 		task ("And Given object definition 'Student' with name field and Scope: Site created") {
 			ObjectDefinitionAPI.createAndPublishObjectDefinition(
 				en_US_label = "student",

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/ManageSystemObjectRelationshipWhenRelatedCustomObjectIsDeactivated.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/ManageSystemObjectRelationshipWhenRelatedCustomObjectIsDeactivated.testcase
@@ -131,8 +131,6 @@ definition {
 
 	@priority = 3
 	test CannotGetManyToManyRelationshipDetailsWhenCustomObjectIsDeactivated {
-		property portal.acceptance = "true";
-
 		task ("When I deactivate the custom object") {
 			ObjectAdmin.openObjectAdmin();
 
@@ -209,8 +207,6 @@ definition {
 
 	@priority = 3
 	test CannotGetOneToManyRelationshipDetailsWhenCustomObjectIsDeactivated {
-		property portal.acceptance = "true";
-
 		task ("When I deactivate the custom object") {
 			ObjectAdmin.openObjectAdmin();
 

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/OperateCustomObjectAndRelatedCustomObjectsWithinSingleRequest.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/OperateCustomObjectAndRelatedCustomObjectsWithinSingleRequest.testcase
@@ -58,8 +58,6 @@ definition {
 	@disable-webdriver = "true"
 	@priority = 3
 	test CanCreateCustomObjectEntriesWithPatchObjectInManyToManyRelationship {
-		property portal.acceptance = "true";
-
 		task ("And Given Student and Subject entries are created with postStudent including studentsSubjects with Subject entries information") {
 			var response = CustomObjectAPI.createObjectEntryAndRelatedObjects(
 				en_US_plural_label = "students",
@@ -158,8 +156,6 @@ definition {
 	@disable-webdriver = "true"
 	@priority = 3
 	test CanCreateCustomObjectEntriesWithPutParentObjectInManyToManyRelationship {
-		property portal.acceptance = "true";
-
 		task ("And Given Student and Subject entries are created with postStudent including studentsSubjects with Subject entries information") {
 			var response = CustomObjectAPI.createObjectEntryAndRelatedObjects(
 				en_US_plural_label = "students",
@@ -319,8 +315,6 @@ definition {
 	@disable-webdriver = "true"
 	@priority = 3
 	test CannotCreateCustomObjectsEntriesWithNonexistentNestedFieldInManyToManyRelationships {
-		property portal.acceptance = "true";
-
 		task ("When creating a Student entry with postStudent including nonexistent nestedField with Subject entries information") {
 			CustomObjectAPI.createObjectEntryAndRelatedObjects(
 				en_US_plural_label = "subjects",
@@ -429,8 +423,6 @@ definition {
 	@disable-webdriver = "true"
 	@priority = 3
 	test CanUpdateCustomObjectEntriesWithPutChildObjectInManyToManyRelationship {
-		property portal.acceptance = "true";
-
 		task ("And Given Subject and Student entries with custom ERCs are created with postSubject including studentsSubjects with Student entries information") {
 			var response = CustomObjectAPI.createObjectEntryAndRelatedObjects(
 				en_US_plural_label = "subjects",

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/RetrieveRelatedElementsOfSystemObjectAsNestedFieldsByManyToMany.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/RetrieveRelatedElementsOfSystemObjectAsNestedFieldsByManyToMany.testcase
@@ -78,8 +78,6 @@ definition {
 	@disable-webdriver = "true"
 	@priority = 3
 	test CanGetRelationshipDetailsInNestedFieldsWithoutRelatedEntries {
-		property portal.acceptance = "true";
-
 		task ("When I call userAccount object GET endpoint with nestedFields=usersFoundations") {
 			var response = UserAccountAPI.getSystemObjectsWithNestedField(
 				parameter = "nestedFields",
@@ -99,8 +97,6 @@ definition {
 	@disable-webdriver = "true"
 	@priority = 3
 	test CanNotGetRelationshipDetailsInNestedFieldsAfterRelationshipIsDeleted {
-		property portal.acceptance = "true";
-
 		task ("And Given I relate the foundation entry with the userAccount entry through the userAccount PUT endpoint") {
 			UserAccountAPI.relateObjectEntries(
 				customObjectId = ${staticObjectEntryId1},

--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/RetrieveTheRelatedElementsOfSystemObject.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/RetrieveTheRelatedElementsOfSystemObject.testcase
@@ -78,8 +78,6 @@ definition {
 	@disable-webdriver = "true"
 	@priority = 3
 	test CanGetRelationshipDetailsThroughRelationshipEndpointWithoutRelatedEntries {
-		property portal.acceptance = "true";
-
 		task ("When I call userAccount object GET endpoint with {userAccountId}/usersFoundations") {
 			UserAccountAPI.getRelationshipByUserAccountId(
 				relationshipName = "usersFoundations",
@@ -98,8 +96,6 @@ definition {
 	@disable-webdriver = "true"
 	@priority = 3
 	test CanNotGetDetailsAfterRelationshipIsDeleted {
-		property portal.acceptance = "true";
-
 		task ("And Given I relate the secondFoundation entry with the userAccount entry through the userAccount PUT endpoint") {
 			UserAccountAPI.relateObjectEntries(
 				customObjectId = ${staticObjectEntryId3},

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/exportimport/ExportImport.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/exportimport/ExportImport.testcase
@@ -969,8 +969,6 @@ definition {
 	@description = "Verify is possible export/import a Private Page."
 	@priority = 3
 	test ExportImportPrivatePage {
-		property portal.acceptance = "true";
-
 		task ("Enable private pages") {
 			PagesAdmin.enablePrivatePages();
 		}
@@ -1450,7 +1448,6 @@ definition {
 	@description = "Verify is possible export/import validation."
 	@priority = 3
 	test ExportImportValidation {
-		property portal.acceptance = "true";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
@@ -1668,7 +1665,6 @@ definition {
 	@description = "This is a use case for LPS-88498. Verify if a Guest is able to export files."
 	@priority = 3
 	test ExportViaGuest {
-		property portal.acceptance = "true";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/exportimport/ExportImportPortlet.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/exportimport/ExportImportPortlet.testcase
@@ -527,7 +527,6 @@ definition {
 	@description = "This is a use case for LPS-83326 and LPS-99287. Verify is possible export/import Web Content Folder with a Workflow."
 	@priority = 3
 	test ExportImportWebContentFolderWithWorkflow {
-		property portal.acceptance = "true";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/sitetemplates/cpsitetemplates/CPSitetemplates.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/sitetemplates/cpsitetemplates/CPSitetemplates.testcase
@@ -695,8 +695,6 @@ definition {
 	@description = "User is not able to delete sites templates which are associated to existing sites."
 	@priority = 3
 	test DeleteSiteTemplateAssociatedWithASite {
-		property portal.acceptance = "true";
-
 		task ("Given: User adds new site template and a new site based on this site template") {
 			SiteTemplates.addCP(
 				siteTemplateActive = "Yes",
@@ -916,8 +914,6 @@ definition {
 	@description = "Sites created from templates should only be editable by connecting users with admin rights."
 	@priority = 3
 	test OnlySiteAdminCanModifyPageAssociatedWithSiteTemplate {
-		property portal.acceptance = "true";
-
 		task ("Given: User adds new site template and a new site based on this site template") {
 			SiteTemplates.addCP(siteTemplateName = "Site Template Name");
 
@@ -976,7 +972,6 @@ definition {
 	@description = "User can reset changes made on already existing portlets on sites which are based on site templates."
 	@priority = 3
 	test ResetPageChanges {
-		property portal.acceptance = "true";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/sitetemplates/usecase/SitetemplatesUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/sitetemplates/usecase/SitetemplatesUsecase.testcase
@@ -100,7 +100,6 @@ definition {
 	@description = "This is a use case for LPS-51432 and LPS-95113. Pages associated with a site template cannot be deleted and removing a parent page on a site template will delete the same page and the child page also on the connected sites, if propagation is enabled."
 	@priority = 3
 	test AdminCanNotAddASubpageOfAChildPageLinkedToSiteTemplatePage {
-		property portal.acceptance = "true";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
@@ -443,7 +442,6 @@ definition {
 	@priority = 3
 	test SitesDynamicTemplateInheritance {
 		property custom.properties = "jsonws.web.service.paths.excludes=";
-		property portal.acceptance = "true";
 
 		var siteName = TestCase.getSiteName(siteName = ${siteName});
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/pgstaging/CPRolesPGStaging.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/pgstaging/CPRolesPGStaging.testcase
@@ -45,8 +45,6 @@ definition {
 
 	@priority = 3
 	test AccessStaging {
-		property portal.acceptance = "true";
-
 		task ("Given: a regular user is added") {
 			JSONStaging.enableLocalStaging(groupName = "Site Name");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/RemoteStaging.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/RemoteStaging.testcase
@@ -848,7 +848,6 @@ definition {
 	@description = "This is a use case for LPS-82839 and LPS-190360 TC-4. Web contents can be published on remote staging."
 	@priority = 3
 	test StagingRemoteLiveWebContentViaPortletCP {
-		property portal.acceptance = "true";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/Staging.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/Staging.testcase
@@ -1263,8 +1263,6 @@ definition {
 
 	@priority = 3
 	test ImportLarFrom70ToCurrent {
-		property portal.acceptance = "true";
-
 		WebContentNavigator.openWebContentAdmin(siteURLKey = "guest");
 
 		LAR.importPortlet(
@@ -1377,8 +1375,6 @@ definition {
 
 	@priority = 3
 	test NotStagedAssets {
-		property portal.acceptance = "true";
-
 		Staging.openStagingAdmin(siteURLKey = "site-name");
 
 		Staging.activateStagingCP(
@@ -2693,7 +2689,6 @@ definition {
 
 	@priority = 3
 	test StagingMultipleDM {
-		property portal.acceptance = "true";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/StagingActivation.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/StagingActivation.testcase
@@ -76,7 +76,6 @@ definition {
 		property custom.properties = "auth.verifier.TunnelAuthVerifier.hosts.allowed=${line.separator}tunneling.servlet.shared.secret=1234567890123456";
 		property databases.size = "1";
 		property minimum.slave.ram = "24";
-		property portal.acceptance = "true";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
@@ -112,7 +111,6 @@ definition {
 	@description = "Verify that the recycle bin of the site is automatically emptied before turning on local staging."
 	@priority = 3
 	test DeleteRecycleBinOnStagingActivation {
-		property portal.acceptance = "true";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/StagingUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/StagingUsecase.testcase
@@ -584,8 +584,6 @@ definition {
 
 	@priority = 3
 	test ContentCannotBeCreatedOnLive {
-		property portal.acceptance = "true";
-
 		task ("When: User open tags admin panel on live site") {
 			Tag.openTagsAdmin(siteURLKey = "site-name");
 		}
@@ -811,7 +809,6 @@ definition {
 
 	@priority = 3
 	test ImportLARsOnStagedSite {
-		property portal.acceptance = "true";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
@@ -1505,8 +1502,6 @@ definition {
 	@description = "This is a use case for LPS-84418 and LPS-117578."
 	@priority = 3
 	test PublishWithImpossibleDateRange {
-		property portal.acceptance = "true";
-
 		task ("When: User open staging site") {
 			Navigator.openStagingSiteURL(siteName = "Site Name");
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/StagingUsecaseWithOrganization.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/StagingUsecaseWithOrganization.testcase
@@ -33,7 +33,6 @@ definition {
 	@priority = 3
 	test StagingOrganizations {
 		property custom.properties = "jsonws.web.service.paths.excludes=";
-		property portal.acceptance = "true";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/StagingUsecaseWithVersioning.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/StagingUsecaseWithVersioning.testcase
@@ -983,8 +983,6 @@ definition {
 
 	@priority = 3
 	test StagingSiteVariationIncompletePage {
-		property portal.acceptance = "true";
-
 		Staging.addSitePagesVariationPG(sitePagesVariationName = "Site Pages Variation Name");
 
 		PagesAdmin.openPagesAdmin(siteURLKey = "site-name-staging");


### PR DESCRIPTION
Hello,
The Release team is looking to remove Poshi tests that are marked as priority 3 or lower from running on the Acceptance Test Suite.
If you believe any of these tests should not be removed, please let us know so we can update the priority and keep the test running on Acceptance.
Thank you!

https://liferay.atlassian.net/browse/LPD-58393
https://liferay.atlassian.net/browse/LPD-58065