### PR TITLE
LPD-33459 API Applications appear duplicated in API Explorer once accesed 

### DIFF
--- a/modules/apps/headless/headless-discovery/headless-discovery-impl/src/main/java/com/liferay/headless/discovery/internal/jaxrs/resource/v1_0/HeadlessDiscoveryOpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-discovery/headless-discovery-impl/src/main/java/com/liferay/headless/discovery/internal/jaxrs/resource/v1_0/HeadlessDiscoveryOpenAPIResourceImpl.java
@@ -203,7 +203,7 @@ public class HeadlessDiscoveryOpenAPIResourceImpl {
 
 			String path = resourceMethodInfoDTO.path;
 
-			if (path.contains("/openapi")) {
+			if (path.contains("/openapi") && paths.isEmpty()) {
 				String openAPIPath = StringUtil.replace(
 					resourceMethodInfoDTO.path, "{type:json|yaml}", "yaml");
 


### PR DESCRIPTION
[LPD-33459](https://liferay.atlassian.net/browse/LPD-33459)

It is shown twice because in the variable `paths`  is added twice, 
* first when we check the methods ([applicationDTO.resourceDTOs](https://github.com/liferay/liferay-portal/blob/master/modules/apps/headless/headless-discovery/headless-discovery-impl/src/main/java/com/liferay/headless/discovery/internal/jaxrs/resource/v1_0/HeadlessDiscoveryOpenAPIResourceImpl.java#L263-L264))
* the second when we check the resource ([applicationDTO.resourceMethods](https://github.com/liferay/liferay-portal/blob/master/modules/apps/headless/headless-discovery/headless-discovery-impl/src/main/java/com/liferay/headless/discovery/internal/jaxrs/resource/v1_0/HeadlessDiscoveryOpenAPIResourceImpl.java#L267)). 

One solution could be to not add the resource but that field has value in two cases (that I have seen):
* when we have selected one Rest Application (in the menu)
* and the cases `/functional-cookies-entries`, `/necessary-cookies-entries`, `/performance-cookies-entries`, `/personalization-cookies-entries` (from Objects)

So the solution has been to check if the paths is empty before to add a new path, because for an application, the path is going to be the same, so it should be enough one. But I'm not sure if that it is true (the variable is in plural). In that case the validation should be to check if it does not contain the path instead of is empty.

