### PR TITLE
LPD-61406 Remove duplicated EntityModelResourceImplementation

### DIFF
--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/StructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/StructuredContentResourceImpl.java
@@ -65,7 +65,6 @@ import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
-import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.EntityExtensionUtil;
 import com.liferay.portal.vulcan.util.LocalDateTimeUtil;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
@@ -96,7 +95,7 @@ import org.osgi.service.component.annotations.ServiceScope;
 	scope = ServiceScope.PROTOTYPE, service = StructuredContentResource.class
 )
 public class StructuredContentResourceImpl
-	extends BaseStructuredContentResourceImpl implements EntityModelResource {
+	extends BaseStructuredContentResourceImpl {
 
 	@Override
 	public void deleteStructuredContentByVersion(


### PR DESCRIPTION
Recently we modified REST Builder so that the EntityModelResource implementation in ResourceImpl was independent from the `generateBatch` configuration at a autogenerated level. ([LPD-57032](https://liferay.atlassian.net/browse/LPD-57032))

StructuredContentResourceImpl implemented this interface manually, but the changes of the PR made so that in the BaseImplementation was already overridden. 

This PR removes this duplication and fixes the `JAXRSResourceTest` test that was failing.

See the following Jira Ticket: [LPD-61384](https://liferay.atlassian.net/browse/LPD-61384)