### PR TITLE
LPD-61120 Autogenerate permissions doGet/doPut logic also for ERC exclusive REST Builder modules

### DIFF
--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/rest-openapi.yaml
@@ -742,7 +742,7 @@ components:
 info:
     description:
         "Headless Delivery Commerce Cart API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.delivery.cart.client', and version '4.0.51'."
+        artifact ID 'com.liferay.headless.commerce.delivery.cart.client', and version '4.0.52'."
     license:
         name: Apache 2.0
         url: http://www.apache.org/licenses/LICENSE-2.0.html

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -42,7 +42,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Headless Delivery Commerce Cart API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.delivery.cart.client', and version '4.0.51'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery Commerce Cart API", version = "v1.0")
+	info = @Info(description = "Headless Delivery Commerce Cart API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.delivery.cart.client', and version '4.0.52'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery Commerce Cart API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/rest-openapi.yaml
@@ -957,7 +957,7 @@ components:
 info:
     description:
         "Headless Delivery Commerce Order API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.delivery.order.client', and version '1.0.32'."
+        artifact ID 'com.liferay.headless.commerce.delivery.order.client', and version '1.0.33'."
     license:
         name: Apache 2.0
         url: http://www.apache.org/licenses/LICENSE-2.0.html

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -42,7 +42,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Headless Delivery Commerce Order API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.delivery.order.client', and version '1.0.32'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery Commerce Order API", version = "v1.0")
+	info = @Info(description = "Headless Delivery Commerce Order API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.delivery.order.client', and version '1.0.33'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery Commerce Order API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/rest-openapi.yaml
@@ -284,7 +284,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.asset.library.client', and version '1.0.6'."
+        'com.liferay.headless.asset.library.client', and version '1.0.7'."
     license:
         name: Apache 2.0
         url: http://www.apache.org/licenses/LICENSE-2.0.html

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -42,7 +42,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.asset.library.client', and version '1.0.6'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Asset Library Headless API", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.asset.library.client', and version '1.0.7'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Asset Library Headless API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/object/object-admin-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-admin-rest-impl/rest-openapi.yaml
@@ -696,7 +696,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.object.admin.rest.client', and version '1.0.80'."
+        'com.liferay.object.admin.rest.client', and version '1.0.81'."
     license:
         name: Apache 2.0
         url: http://www.apache.org/licenses/LICENSE-2.0.html

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -42,7 +42,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.object.admin.rest.client', and version '1.0.80'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Object", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.object.admin.rest.client', and version '1.0.81'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Object", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/rest-openapi.yaml
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/rest-openapi.yaml
@@ -570,7 +570,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.portal.workflow.metrics.rest.client', and version '3.0.44'."
+        'com.liferay.portal.workflow.metrics.rest.client', and version '3.0.45'."
     license:
         name: Apache 2.0
         url: http://www.apache.org/licenses/LICENSE-2.0.html

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -42,7 +42,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.portal.workflow.metrics.rest.client', and version '3.0.44'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.portal.workflow.metrics.rest.client', and version '3.0.45'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/rest-openapi.yaml
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/rest-openapi.yaml
@@ -588,7 +588,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.search.experiences.rest.client', and version '3.0.38'."
+        'com.liferay.search.experiences.rest.client', and version '3.0.39'."
     license:
         name: Apache 2.0
         url: http://www.apache.org/licenses/LICENSE-2.0.html

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -42,7 +42,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.search.experiences.rest.client', and version '3.0.38'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.search.experiences.rest.client', and version '3.0.39'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/ERCAssetLibraryTestEntityResource.java
+++ b/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/ERCAssetLibraryTestEntityResource.java
@@ -64,6 +64,13 @@ public interface ERCAssetLibraryTestEntityResource {
 			String ercAssetLibraryTestEntityExternalReferenceCode)
 		throws Exception;
 
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			getAssetLibraryERCAssetLibraryTestEntityPermissionsPage(
+				String assetLibraryExternalReferenceCode,
+				String ercAssetLibraryTestEntityExternalReferenceCode,
+				String roleNames)
+		throws Exception;
+
 	public Response postAssetLibraryERCAssetLibraryTestEntitiesPageExportBatch(
 			String assetLibraryExternalReferenceCode, String callbackURL,
 			String contentType, String fieldNames)
@@ -83,6 +90,13 @@ public interface ERCAssetLibraryTestEntityResource {
 			String assetLibraryExternalReferenceCode,
 			String ercAssetLibraryTestEntityExternalReferenceCode,
 			ERCAssetLibraryTestEntity ercAssetLibraryTestEntity)
+		throws Exception;
+
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putAssetLibraryERCAssetLibraryTestEntityPermissionsPage(
+				String assetLibraryExternalReferenceCode,
+				String ercAssetLibraryTestEntityExternalReferenceCode,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public default void setContextAcceptLanguage(

--- a/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/ERCSiteTestEntityResource.java
+++ b/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/ERCSiteTestEntityResource.java
@@ -63,6 +63,12 @@ public interface ERCSiteTestEntityResource {
 			String ercSiteTestEntityExternalReferenceCode)
 		throws Exception;
 
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			getSiteERCSiteTestEntityPermissionsPage(
+				String siteExternalReferenceCode,
+				String ercSiteTestEntityExternalReferenceCode, String roleNames)
+		throws Exception;
+
 	public Response postSiteERCSiteTestEntitiesPageExportBatch(
 			String siteExternalReferenceCode, String callbackURL,
 			String contentType, String fieldNames)
@@ -81,6 +87,13 @@ public interface ERCSiteTestEntityResource {
 			String siteExternalReferenceCode,
 			String ercSiteTestEntityExternalReferenceCode,
 			ERCSiteTestEntity ercSiteTestEntity)
+		throws Exception;
+
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putSiteERCSiteTestEntityPermissionsPage(
+				String siteExternalReferenceCode,
+				String ercSiteTestEntityExternalReferenceCode,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public default void setContextAcceptLanguage(

--- a/modules/util/portal-tools-rest-builder-test-client-js/src/apis/ERCAssetLibraryTestEntityAPI.ts
+++ b/modules/util/portal-tools-rest-builder-test-client-js/src/apis/ERCAssetLibraryTestEntityAPI.ts
@@ -203,6 +203,84 @@ export class ERCAssetLibraryTestEntityAPI {
 		/**
 		 * 
 				 * @param assetLibraryExternalReferenceCode
+				 * @param ercAssetLibraryTestEntityExternalReferenceCode
+				 * @param fields
+				 * @param restrictFields
+				 * @param roleNames
+		 * @param headers Optional custom request headers
+		 */
+		public async getAssetLibraryERCAssetLibraryTestEntityPermissionsPage(
+						assetLibraryExternalReferenceCode: string,
+						ercAssetLibraryTestEntityExternalReferenceCode: string,
+						fields?: string,
+						restrictFields?: string,
+						roleNames?: string,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body?: any;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/{ercAssetLibraryTestEntityExternalReferenceCode}/permissions"
+						.replace("{assetLibraryExternalReferenceCode}",encodeURIComponent(assetLibraryExternalReferenceCode))
+										.replace("{ercAssetLibraryTestEntityExternalReferenceCode}",encodeURIComponent(ercAssetLibraryTestEntityExternalReferenceCode))
+																;
+
+			const queryParameters: any = {};
+
+						if (assetLibraryExternalReferenceCode === null || assetLibraryExternalReferenceCode === undefined) {
+							throw new Error("Required parameter assetLibraryExternalReferenceCode was null or undefined when calling getAssetLibraryERCAssetLibraryTestEntityPermissionsPage.");
+						}
+
+						if (ercAssetLibraryTestEntityExternalReferenceCode === null || ercAssetLibraryTestEntityExternalReferenceCode === undefined) {
+							throw new Error("Required parameter ercAssetLibraryTestEntityExternalReferenceCode was null or undefined when calling getAssetLibraryERCAssetLibraryTestEntityPermissionsPage.");
+						}
+
+						if (fields !== undefined) {
+							queryParameters["fields"] = ObjectSerializer.serialize(fields, "string");
+						}
+
+						if (restrictFields !== undefined) {
+							queryParameters["restrictFields"] = ObjectSerializer.serialize(restrictFields, "string");
+						}
+
+						if (roleNames !== undefined) {
+							queryParameters["roleNames"] = ObjectSerializer.serialize(roleNames, "string");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "GET",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: await response.json(), response};
+					}
+					else {
+						return {body: await response.text(), response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * 
+				 * @param assetLibraryExternalReferenceCode
 		 		* @param requestBody Request body that can be one of multiple content types
 		 * @param headers Optional custom request headers
 		 */
@@ -414,4 +492,64 @@ export class ERCAssetLibraryTestEntityAPI {
 							headers
 						);
 					}
+		/**
+		 * 
+				 * @param assetLibraryExternalReferenceCode
+				 * @param ercAssetLibraryTestEntityExternalReferenceCode
+		 * @param headers Optional custom request headers
+		 */
+		public async putAssetLibraryERCAssetLibraryTestEntityPermissionsPage(
+						assetLibraryExternalReferenceCode: string,
+						ercAssetLibraryTestEntityExternalReferenceCode: string,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body?: any;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/{ercAssetLibraryTestEntityExternalReferenceCode}/permissions"
+						.replace("{assetLibraryExternalReferenceCode}",encodeURIComponent(assetLibraryExternalReferenceCode))
+										.replace("{ercAssetLibraryTestEntityExternalReferenceCode}",encodeURIComponent(ercAssetLibraryTestEntityExternalReferenceCode))
+				;
+
+			const queryParameters: any = {};
+
+						if (assetLibraryExternalReferenceCode === null || assetLibraryExternalReferenceCode === undefined) {
+							throw new Error("Required parameter assetLibraryExternalReferenceCode was null or undefined when calling putAssetLibraryERCAssetLibraryTestEntityPermissionsPage.");
+						}
+
+						if (ercAssetLibraryTestEntityExternalReferenceCode === null || ercAssetLibraryTestEntityExternalReferenceCode === undefined) {
+							throw new Error("Required parameter ercAssetLibraryTestEntityExternalReferenceCode was null or undefined when calling putAssetLibraryERCAssetLibraryTestEntityPermissionsPage.");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "PUT",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: await response.json(), response};
+					}
+					else {
+						return {body: await response.text(), response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
 }

--- a/modules/util/portal-tools-rest-builder-test-client-js/src/apis/ERCSiteTestEntityAPI.ts
+++ b/modules/util/portal-tools-rest-builder-test-client-js/src/apis/ERCSiteTestEntityAPI.ts
@@ -203,6 +203,84 @@ export class ERCSiteTestEntityAPI {
 		/**
 		 * 
 				 * @param siteExternalReferenceCode
+				 * @param ercSiteTestEntityExternalReferenceCode
+				 * @param fields
+				 * @param restrictFields
+				 * @param roleNames
+		 * @param headers Optional custom request headers
+		 */
+		public async getSiteERCSiteTestEntityPermissionsPage(
+						siteExternalReferenceCode: string,
+						ercSiteTestEntityExternalReferenceCode: string,
+						fields?: string,
+						restrictFields?: string,
+						roleNames?: string,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body?: any;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/{ercSiteTestEntityExternalReferenceCode}/permissions"
+						.replace("{siteExternalReferenceCode}",encodeURIComponent(siteExternalReferenceCode))
+										.replace("{ercSiteTestEntityExternalReferenceCode}",encodeURIComponent(ercSiteTestEntityExternalReferenceCode))
+																;
+
+			const queryParameters: any = {};
+
+						if (siteExternalReferenceCode === null || siteExternalReferenceCode === undefined) {
+							throw new Error("Required parameter siteExternalReferenceCode was null or undefined when calling getSiteERCSiteTestEntityPermissionsPage.");
+						}
+
+						if (ercSiteTestEntityExternalReferenceCode === null || ercSiteTestEntityExternalReferenceCode === undefined) {
+							throw new Error("Required parameter ercSiteTestEntityExternalReferenceCode was null or undefined when calling getSiteERCSiteTestEntityPermissionsPage.");
+						}
+
+						if (fields !== undefined) {
+							queryParameters["fields"] = ObjectSerializer.serialize(fields, "string");
+						}
+
+						if (restrictFields !== undefined) {
+							queryParameters["restrictFields"] = ObjectSerializer.serialize(restrictFields, "string");
+						}
+
+						if (roleNames !== undefined) {
+							queryParameters["roleNames"] = ObjectSerializer.serialize(roleNames, "string");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "GET",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: await response.json(), response};
+					}
+					else {
+						return {body: await response.text(), response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * 
+				 * @param siteExternalReferenceCode
 		 		* @param requestBody Request body that can be one of multiple content types
 		 * @param headers Optional custom request headers
 		 */
@@ -414,4 +492,64 @@ export class ERCSiteTestEntityAPI {
 							headers
 						);
 					}
+		/**
+		 * 
+				 * @param siteExternalReferenceCode
+				 * @param ercSiteTestEntityExternalReferenceCode
+		 * @param headers Optional custom request headers
+		 */
+		public async putSiteERCSiteTestEntityPermissionsPage(
+						siteExternalReferenceCode: string,
+						ercSiteTestEntityExternalReferenceCode: string,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body?: any;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/{ercSiteTestEntityExternalReferenceCode}/permissions"
+						.replace("{siteExternalReferenceCode}",encodeURIComponent(siteExternalReferenceCode))
+										.replace("{ercSiteTestEntityExternalReferenceCode}",encodeURIComponent(ercSiteTestEntityExternalReferenceCode))
+				;
+
+			const queryParameters: any = {};
+
+						if (siteExternalReferenceCode === null || siteExternalReferenceCode === undefined) {
+							throw new Error("Required parameter siteExternalReferenceCode was null or undefined when calling putSiteERCSiteTestEntityPermissionsPage.");
+						}
+
+						if (ercSiteTestEntityExternalReferenceCode === null || ercSiteTestEntityExternalReferenceCode === undefined) {
+							throw new Error("Required parameter ercSiteTestEntityExternalReferenceCode was null or undefined when calling putSiteERCSiteTestEntityPermissionsPage.");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "PUT",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: await response.json(), response};
+					}
+					else {
+						return {body: await response.text(), response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
 }

--- a/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/ERCAssetLibraryTestEntityResource.java
+++ b/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/ERCAssetLibraryTestEntityResource.java
@@ -8,6 +8,7 @@ package com.liferay.portal.tools.rest.builder.test.client.resource.v1_0;
 import com.liferay.portal.tools.rest.builder.test.client.dto.v1_0.ERCAssetLibraryTestEntity;
 import com.liferay.portal.tools.rest.builder.test.client.http.HttpInvoker;
 import com.liferay.portal.tools.rest.builder.test.client.pagination.Page;
+import com.liferay.portal.tools.rest.builder.test.client.permission.Permission;
 import com.liferay.portal.tools.rest.builder.test.client.problem.Problem;
 import com.liferay.portal.tools.rest.builder.test.client.serdes.v1_0.ERCAssetLibraryTestEntitySerDes;
 
@@ -15,7 +16,9 @@ import jakarta.annotation.Generated;
 
 import java.net.URL;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -65,6 +68,20 @@ public interface ERCAssetLibraryTestEntityResource {
 				String ercAssetLibraryTestEntityExternalReferenceCode)
 		throws Exception;
 
+	public Page<Permission>
+			getAssetLibraryERCAssetLibraryTestEntityPermissionsPage(
+				String assetLibraryExternalReferenceCode,
+				String ercAssetLibraryTestEntityExternalReferenceCode,
+				String roleNames)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			getAssetLibraryERCAssetLibraryTestEntityPermissionsPageHttpResponse(
+				String assetLibraryExternalReferenceCode,
+				String ercAssetLibraryTestEntityExternalReferenceCode,
+				String roleNames)
+		throws Exception;
+
 	public void postAssetLibraryERCAssetLibraryTestEntitiesPageExportBatch(
 			String assetLibraryExternalReferenceCode, String callbackURL,
 			String contentType, String fieldNames)
@@ -109,6 +126,20 @@ public interface ERCAssetLibraryTestEntityResource {
 				String assetLibraryExternalReferenceCode,
 				String ercAssetLibraryTestEntityExternalReferenceCode,
 				ERCAssetLibraryTestEntity ercAssetLibraryTestEntity)
+		throws Exception;
+
+	public Page<Permission>
+			putAssetLibraryERCAssetLibraryTestEntityPermissionsPage(
+				String assetLibraryExternalReferenceCode,
+				String ercAssetLibraryTestEntityExternalReferenceCode,
+				Permission[] permissions)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			putAssetLibraryERCAssetLibraryTestEntityPermissionsPageHttpResponse(
+				String assetLibraryExternalReferenceCode,
+				String ercAssetLibraryTestEntityExternalReferenceCode,
+				Permission[] permissions)
 		throws Exception;
 
 	public static class Builder {
@@ -548,6 +579,129 @@ public interface ERCAssetLibraryTestEntityResource {
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
 						"/o/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/{ercAssetLibraryTestEntityExternalReferenceCode}");
+
+			httpInvoker.path(
+				"assetLibraryExternalReferenceCode",
+				assetLibraryExternalReferenceCode);
+			httpInvoker.path(
+				"ercAssetLibraryTestEntityExternalReferenceCode",
+				ercAssetLibraryTestEntityExternalReferenceCode);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public Page<Permission>
+				getAssetLibraryERCAssetLibraryTestEntityPermissionsPage(
+					String assetLibraryExternalReferenceCode,
+					String ercAssetLibraryTestEntityExternalReferenceCode,
+					String roleNames)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getAssetLibraryERCAssetLibraryTestEntityPermissionsPageHttpResponse(
+					assetLibraryExternalReferenceCode,
+					ercAssetLibraryTestEntityExternalReferenceCode, roleNames);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return Page.of(content, Permission::toDTO);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				getAssetLibraryERCAssetLibraryTestEntityPermissionsPageHttpResponse(
+					String assetLibraryExternalReferenceCode,
+					String ercAssetLibraryTestEntityExternalReferenceCode,
+					String roleNames)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			if (roleNames != null) {
+				httpInvoker.parameter("roleNames", String.valueOf(roleNames));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/{ercAssetLibraryTestEntityExternalReferenceCode}/permissions");
 
 			httpInvoker.path(
 				"assetLibraryExternalReferenceCode",
@@ -1014,6 +1168,134 @@ public interface ERCAssetLibraryTestEntityResource {
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
 						"/o/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/{ercAssetLibraryTestEntityExternalReferenceCode}");
+
+			httpInvoker.path(
+				"assetLibraryExternalReferenceCode",
+				assetLibraryExternalReferenceCode);
+			httpInvoker.path(
+				"ercAssetLibraryTestEntityExternalReferenceCode",
+				ercAssetLibraryTestEntityExternalReferenceCode);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public Page<Permission>
+				putAssetLibraryERCAssetLibraryTestEntityPermissionsPage(
+					String assetLibraryExternalReferenceCode,
+					String ercAssetLibraryTestEntityExternalReferenceCode,
+					Permission[] permissions)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				putAssetLibraryERCAssetLibraryTestEntityPermissionsPageHttpResponse(
+					assetLibraryExternalReferenceCode,
+					ercAssetLibraryTestEntityExternalReferenceCode,
+					permissions);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return Page.of(content, Permission::toDTO);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				putAssetLibraryERCAssetLibraryTestEntityPermissionsPageHttpResponse(
+					String assetLibraryExternalReferenceCode,
+					String ercAssetLibraryTestEntityExternalReferenceCode,
+					Permission[] permissions)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			List<String> values = new ArrayList<>();
+
+			for (Permission permissionValue : permissions) {
+				values.add(String.valueOf(permissionValue));
+			}
+
+			httpInvoker.body(values.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.PUT);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/{ercAssetLibraryTestEntityExternalReferenceCode}/permissions");
 
 			httpInvoker.path(
 				"assetLibraryExternalReferenceCode",

--- a/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/ERCSiteTestEntityResource.java
+++ b/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/ERCSiteTestEntityResource.java
@@ -8,6 +8,7 @@ package com.liferay.portal.tools.rest.builder.test.client.resource.v1_0;
 import com.liferay.portal.tools.rest.builder.test.client.dto.v1_0.ERCSiteTestEntity;
 import com.liferay.portal.tools.rest.builder.test.client.http.HttpInvoker;
 import com.liferay.portal.tools.rest.builder.test.client.pagination.Page;
+import com.liferay.portal.tools.rest.builder.test.client.permission.Permission;
 import com.liferay.portal.tools.rest.builder.test.client.problem.Problem;
 import com.liferay.portal.tools.rest.builder.test.client.serdes.v1_0.ERCSiteTestEntitySerDes;
 
@@ -15,7 +16,9 @@ import jakarta.annotation.Generated;
 
 import java.net.URL;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -61,6 +64,17 @@ public interface ERCSiteTestEntityResource {
 			String ercSiteTestEntityExternalReferenceCode)
 		throws Exception;
 
+	public Page<Permission> getSiteERCSiteTestEntityPermissionsPage(
+			String siteExternalReferenceCode,
+			String ercSiteTestEntityExternalReferenceCode, String roleNames)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			getSiteERCSiteTestEntityPermissionsPageHttpResponse(
+				String siteExternalReferenceCode,
+				String ercSiteTestEntityExternalReferenceCode, String roleNames)
+		throws Exception;
+
 	public void postSiteERCSiteTestEntitiesPageExportBatch(
 			String siteExternalReferenceCode, String callbackURL,
 			String contentType, String fieldNames)
@@ -100,6 +114,19 @@ public interface ERCSiteTestEntityResource {
 			String siteExternalReferenceCode,
 			String ercSiteTestEntityExternalReferenceCode,
 			ERCSiteTestEntity ercSiteTestEntity)
+		throws Exception;
+
+	public Page<Permission> putSiteERCSiteTestEntityPermissionsPage(
+			String siteExternalReferenceCode,
+			String ercSiteTestEntityExternalReferenceCode,
+			Permission[] permissions)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			putSiteERCSiteTestEntityPermissionsPageHttpResponse(
+				String siteExternalReferenceCode,
+				String ercSiteTestEntityExternalReferenceCode,
+				Permission[] permissions)
 		throws Exception;
 
 	public static class Builder {
@@ -533,6 +560,126 @@ public interface ERCSiteTestEntityResource {
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
 						"/o/test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/{ercSiteTestEntityExternalReferenceCode}");
+
+			httpInvoker.path(
+				"siteExternalReferenceCode", siteExternalReferenceCode);
+			httpInvoker.path(
+				"ercSiteTestEntityExternalReferenceCode",
+				ercSiteTestEntityExternalReferenceCode);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public Page<Permission> getSiteERCSiteTestEntityPermissionsPage(
+				String siteExternalReferenceCode,
+				String ercSiteTestEntityExternalReferenceCode, String roleNames)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getSiteERCSiteTestEntityPermissionsPageHttpResponse(
+					siteExternalReferenceCode,
+					ercSiteTestEntityExternalReferenceCode, roleNames);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return Page.of(content, Permission::toDTO);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				getSiteERCSiteTestEntityPermissionsPageHttpResponse(
+					String siteExternalReferenceCode,
+					String ercSiteTestEntityExternalReferenceCode,
+					String roleNames)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			if (roleNames != null) {
+				httpInvoker.parameter("roleNames", String.valueOf(roleNames));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/{ercSiteTestEntityExternalReferenceCode}/permissions");
 
 			httpInvoker.path(
 				"siteExternalReferenceCode", siteExternalReferenceCode);
@@ -987,6 +1134,131 @@ public interface ERCSiteTestEntityResource {
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
 						"/o/test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/{ercSiteTestEntityExternalReferenceCode}");
+
+			httpInvoker.path(
+				"siteExternalReferenceCode", siteExternalReferenceCode);
+			httpInvoker.path(
+				"ercSiteTestEntityExternalReferenceCode",
+				ercSiteTestEntityExternalReferenceCode);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public Page<Permission> putSiteERCSiteTestEntityPermissionsPage(
+				String siteExternalReferenceCode,
+				String ercSiteTestEntityExternalReferenceCode,
+				Permission[] permissions)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				putSiteERCSiteTestEntityPermissionsPageHttpResponse(
+					siteExternalReferenceCode,
+					ercSiteTestEntityExternalReferenceCode, permissions);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return Page.of(content, Permission::toDTO);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				putSiteERCSiteTestEntityPermissionsPageHttpResponse(
+					String siteExternalReferenceCode,
+					String ercSiteTestEntityExternalReferenceCode,
+					Permission[] permissions)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			List<String> values = new ArrayList<>();
+
+			for (Permission permissionValue : permissions) {
+				values.add(String.valueOf(permissionValue));
+			}
+
+			httpInvoker.body(values.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.PUT);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/{ercSiteTestEntityExternalReferenceCode}/permissions");
 
 			httpInvoker.path(
 				"siteExternalReferenceCode", siteExternalReferenceCode);

--- a/modules/util/portal-tools-rest-builder-test-impl/rest-openapi.yaml
+++ b/modules/util/portal-tools-rest-builder-test-impl/rest-openapi.yaml
@@ -521,6 +521,61 @@ paths:
                     description:
                         "OK"
             tags: ["ERCAssetLibraryTestEntity"]
+    "/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/{ercAssetLibraryTestEntityExternalReferenceCode}/permissions":
+        get:
+            operationId: getAssetLibraryERCAssetLibraryTestEntityPermissionsPage
+            parameters:
+                -   in: path
+                    name: assetLibraryExternalReferenceCode
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: ercAssetLibraryTestEntityExternalReferenceCode
+                    required: true
+                    schema:
+                        type: string
+                -   in: query
+                    name: fields
+                    schema:
+                        type: string
+                -   in: query
+                    name: restrictFields
+                    schema:
+                        type: string
+                -   in: query
+                    name: roleNames
+                    schema:
+                        type: string
+            responses:
+                204:
+                    content:
+                        application/json: {}
+                        application/xml: {}
+            tags: ["ERCAssetLibraryTestEntity"]
+        put:
+            operationId: putAssetLibraryERCAssetLibraryTestEntityPermissionsPage
+            parameters:
+                -   in: path
+                    name: assetLibraryExternalReferenceCode
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: ercAssetLibraryTestEntityExternalReferenceCode
+                    required: true
+                    schema:
+                        type: string
+            requestBody:
+                content:
+                    application/json: {}
+                    application/xml: {}
+            responses:
+                204:
+                    content:
+                        application/json: {}
+                        application/xml: {}
+            tags: ["ERCAssetLibraryTestEntity"]
     "/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities":
         get:
             operationId: getAssetLibraryERCScopedTestEntitiesPage
@@ -1921,6 +1976,63 @@ paths:
                         "application/xml":
                             schema:
                                 $ref: "#/components/schemas/ERCSiteTestEntity"
+                    description:
+                        "OK"
+            tags: ["ERCSiteTestEntity"]
+    "/sites/{siteExternalReferenceCode}/erc-site-test-entities/{ercSiteTestEntityExternalReferenceCode}/permissions":
+        get:
+            operationId: getSiteERCSiteTestEntityPermissionsPage
+            parameters:
+                -   in: path
+                    name: siteExternalReferenceCode
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: ercSiteTestEntityExternalReferenceCode
+                    required: true
+                    schema:
+                        type: string
+                -   in: query
+                    name: fields
+                    schema:
+                        type: string
+                -   in: query
+                    name: restrictFields
+                    schema:
+                        type: string
+                -   in: query
+                    name: roleNames
+                    schema:
+                        type: string
+            responses:
+                200:
+                    content:
+                        application/json: {}
+                        application/xml: {}
+            tags: ["ERCSiteTestEntity"]
+        put:
+            operationId: putSiteERCSiteTestEntityPermissionsPage
+            parameters:
+                -   in: path
+                    name: siteExternalReferenceCode
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: ercSiteTestEntityExternalReferenceCode
+                    required: true
+                    schema:
+                        type: string
+            requestBody:
+                content:
+                    application/json: {}
+                    application/xml: {}
+            responses:
+                200:
+                    content:
+                        application/json: {}
+                        application/xml: {}
                     description:
                         "OK"
             tags: ["ERCSiteTestEntity"]

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/graphql/mutation/v1_0/Mutation.java
@@ -500,6 +500,33 @@ public class Mutation {
 	}
 
 	@GraphQLField
+	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
+			updateAssetLibraryERCAssetLibraryTestEntityPermissionsPage(
+				@GraphQLName("assetLibraryExternalReferenceCode") @NotEmpty
+					String assetLibraryExternalReferenceCode,
+				@GraphQLName("ercAssetLibraryTestEntityExternalReferenceCode")
+					String ercAssetLibraryTestEntityExternalReferenceCode,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_ercAssetLibraryTestEntityResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			ercAssetLibraryTestEntityResource -> {
+				Page paginationPage =
+					ercAssetLibraryTestEntityResource.
+						putAssetLibraryERCAssetLibraryTestEntityPermissionsPage(
+							assetLibraryExternalReferenceCode,
+							ercAssetLibraryTestEntityExternalReferenceCode,
+							permissions);
+
+				return paginationPage.getItems();
+			});
+	}
+
+	@GraphQLField
 	public boolean deleteAssetLibraryERCScopedTestEntity(
 			@GraphQLName("assetLibraryExternalReferenceCode") @NotEmpty String
 				assetLibraryExternalReferenceCode,
@@ -769,6 +796,33 @@ public class Mutation {
 				ercSiteTestEntityResource.putSiteERCSiteTestEntity(
 					siteExternalReferenceCode,
 					ercSiteTestEntityExternalReferenceCode, ercSiteTestEntity));
+	}
+
+	@GraphQLField
+	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
+			updateSiteERCSiteTestEntityPermissionsPage(
+				@GraphQLName("siteExternalReferenceCode") @NotEmpty String
+					siteExternalReferenceCode,
+				@GraphQLName("ercSiteTestEntityExternalReferenceCode") String
+					ercSiteTestEntityExternalReferenceCode,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_ercSiteTestEntityResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			ercSiteTestEntityResource -> {
+				Page paginationPage =
+					ercSiteTestEntityResource.
+						putSiteERCSiteTestEntityPermissionsPage(
+							siteExternalReferenceCode,
+							ercSiteTestEntityExternalReferenceCode,
+							permissions);
+
+				return paginationPage.getItems();
+			});
 	}
 
 	@GraphQLField

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/graphql/query/v1_0/Query.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/graphql/query/v1_0/Query.java
@@ -386,6 +386,33 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {assetLibraryERCAssetLibraryTestEntityPermissions(assetLibraryExternalReferenceCode: ___, ercAssetLibraryTestEntityExternalReferenceCode: ___, roleNames: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
+	 */
+	@GraphQLField
+	public ERCAssetLibraryTestEntityPage
+			assetLibraryERCAssetLibraryTestEntityPermissions(
+				@GraphQLName("assetLibraryExternalReferenceCode") @NotEmpty
+					String assetLibraryExternalReferenceCode,
+				@GraphQLName("ercAssetLibraryTestEntityExternalReferenceCode")
+					String ercAssetLibraryTestEntityExternalReferenceCode,
+				@GraphQLName("roleNames") String roleNames)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_ercAssetLibraryTestEntityResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			ercAssetLibraryTestEntityResource ->
+				new ERCAssetLibraryTestEntityPage(
+					ercAssetLibraryTestEntityResource.
+						getAssetLibraryERCAssetLibraryTestEntityPermissionsPage(
+							assetLibraryExternalReferenceCode,
+							ercAssetLibraryTestEntityExternalReferenceCode,
+							roleNames)));
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
 	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {assetLibraryERCScopedTestEntities(assetLibraryExternalReferenceCode: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField
@@ -505,6 +532,30 @@ public class Query {
 				ercSiteTestEntityResource.getSiteERCSiteTestEntity(
 					siteExternalReferenceCode,
 					ercSiteTestEntityExternalReferenceCode));
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {eRCSiteTestEntityPermissions(ercSiteTestEntityExternalReferenceCode: ___, roleNames: ___, siteExternalReferenceCode: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
+	 */
+	@GraphQLField
+	public ERCSiteTestEntityPage eRCSiteTestEntityPermissions(
+			@GraphQLName("siteExternalReferenceCode") @NotEmpty String
+				siteExternalReferenceCode,
+			@GraphQLName("ercSiteTestEntityExternalReferenceCode") String
+				ercSiteTestEntityExternalReferenceCode,
+			@GraphQLName("roleNames") String roleNames)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_ercSiteTestEntityResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			ercSiteTestEntityResource -> new ERCSiteTestEntityPage(
+				ercSiteTestEntityResource.
+					getSiteERCSiteTestEntityPermissionsPage(
+						siteExternalReferenceCode,
+						ercSiteTestEntityExternalReferenceCode, roleNames)));
 	}
 
 	/**

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -260,6 +260,11 @@ public class ServletDataImpl implements ServletData {
 							ERCAssetLibraryTestEntityResourceImpl.class,
 							"putAssetLibraryERCAssetLibraryTestEntity"));
 					put(
+						"mutation#updateAssetLibraryERCAssetLibraryTestEntityPermissionsPage",
+						new ObjectValuePair<>(
+							ERCAssetLibraryTestEntityResourceImpl.class,
+							"putAssetLibraryERCAssetLibraryTestEntityPermissionsPage"));
+					put(
 						"mutation#deleteAssetLibraryERCScopedTestEntity",
 						new ObjectValuePair<>(
 							ERCScopedTestEntityResourceImpl.class,
@@ -334,6 +339,11 @@ public class ServletDataImpl implements ServletData {
 						new ObjectValuePair<>(
 							ERCSiteTestEntityResourceImpl.class,
 							"putSiteERCSiteTestEntity"));
+					put(
+						"mutation#updateSiteERCSiteTestEntityPermissionsPage",
+						new ObjectValuePair<>(
+							ERCSiteTestEntityResourceImpl.class,
+							"putSiteERCSiteTestEntityPermissionsPage"));
 					put(
 						"mutation#createFiltersPageExportBatch",
 						new ObjectValuePair<>(
@@ -586,6 +596,11 @@ public class ServletDataImpl implements ServletData {
 							ERCAssetLibraryTestEntityResourceImpl.class,
 							"getAssetLibraryERCAssetLibraryTestEntity"));
 					put(
+						"query#assetLibraryERCAssetLibraryTestEntityPermissions",
+						new ObjectValuePair<>(
+							ERCAssetLibraryTestEntityResourceImpl.class,
+							"getAssetLibraryERCAssetLibraryTestEntityPermissionsPage"));
+					put(
 						"query#assetLibraryERCScopedTestEntities",
 						new ObjectValuePair<>(
 							ERCScopedTestEntityResourceImpl.class,
@@ -615,6 +630,11 @@ public class ServletDataImpl implements ServletData {
 						new ObjectValuePair<>(
 							ERCSiteTestEntityResourceImpl.class,
 							"getSiteERCSiteTestEntity"));
+					put(
+						"query#eRCSiteTestEntityPermissions",
+						new ObjectValuePair<>(
+							ERCSiteTestEntityResourceImpl.class,
+							"getSiteERCSiteTestEntityPermissionsPage"));
 					put(
 						"query#entityModelResourceTestEntities1",
 						new ObjectValuePair<>(

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseERCAssetLibraryTestEntityResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseERCAssetLibraryTestEntityResourceImpl.java
@@ -34,8 +34,10 @@ import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
+import com.liferay.portal.vulcan.fields.NestedFieldsSupplier;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.UriInfoUtil;
@@ -114,6 +116,11 @@ public abstract class BaseERCAssetLibraryTestEntityResourceImpl
 		throws Exception {
 	}
 
+	protected abstract Page<ERCAssetLibraryTestEntity>
+			doGetAssetLibraryERCAssetLibraryTestEntitiesPage(
+				String assetLibraryExternalReferenceCode)
+		throws Exception;
+
 	/**
 	 * Invoke this method with the command line:
 	 *
@@ -140,7 +147,7 @@ public abstract class BaseERCAssetLibraryTestEntityResourceImpl
 	)
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<ERCAssetLibraryTestEntity>
+	public final Page<ERCAssetLibraryTestEntity>
 			getAssetLibraryERCAssetLibraryTestEntitiesPage(
 				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 				@jakarta.validation.constraints.NotNull
@@ -148,7 +155,33 @@ public abstract class BaseERCAssetLibraryTestEntityResourceImpl
 				String assetLibraryExternalReferenceCode)
 		throws Exception {
 
-		return Page.of(Collections.emptyList());
+		Page<ERCAssetLibraryTestEntity> ercAssetLibraryTestEntitiesPage =
+			doGetAssetLibraryERCAssetLibraryTestEntitiesPage(
+				assetLibraryExternalReferenceCode);
+
+		for (ERCAssetLibraryTestEntity ercAssetLibraryTestEntity :
+				ercAssetLibraryTestEntitiesPage.getItems()) {
+
+			ercAssetLibraryTestEntity.setPermissions(
+				() -> NestedFieldsSupplier.supply(
+					"permissions",
+					nestedField -> {
+						Page<Permission> permissionsPage =
+							getAssetLibraryERCAssetLibraryTestEntityPermissionsPage(
+								assetLibraryExternalReferenceCode,
+								ercAssetLibraryTestEntity.
+									getExternalReferenceCode(),
+								null);
+
+						Collection<Permission> permissions =
+							permissionsPage.getItems();
+
+						return permissions.toArray(
+							new Permission[permissions.size()]);
+					}));
+		}
+
+		return ercAssetLibraryTestEntitiesPage;
 	}
 
 	/**
@@ -195,6 +228,69 @@ public abstract class BaseERCAssetLibraryTestEntityResourceImpl
 		throws Exception {
 
 		return new ERCAssetLibraryTestEntity();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/{ercAssetLibraryTestEntityExternalReferenceCode}/permissions'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "assetLibraryExternalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "ercAssetLibraryTestEntityExternalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "fields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "restrictFields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "roleNames"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(
+				name = "ERCAssetLibraryTestEntity"
+			)
+		}
+	)
+	@jakarta.ws.rs.GET
+	@jakarta.ws.rs.Path(
+		"/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/{ercAssetLibraryTestEntityExternalReferenceCode}/permissions"
+	)
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Page<Permission>
+			getAssetLibraryERCAssetLibraryTestEntityPermissionsPage(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("assetLibraryExternalReferenceCode")
+				String assetLibraryExternalReferenceCode,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam(
+					"ercAssetLibraryTestEntityExternalReferenceCode"
+				)
+				String ercAssetLibraryTestEntityExternalReferenceCode,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.ws.rs.QueryParam("roleNames")
+				String roleNames)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	/**
@@ -272,6 +368,12 @@ public abstract class BaseERCAssetLibraryTestEntityResourceImpl
 		).build();
 	}
 
+	protected abstract ERCAssetLibraryTestEntity
+			doPostAssetLibraryERCAssetLibraryTestEntity(
+				String assetLibraryExternalReferenceCode,
+				ERCAssetLibraryTestEntity ercAssetLibraryTestEntity)
+		throws Exception;
+
 	/**
 	 * Invoke this method with the command line:
 	 *
@@ -299,15 +401,41 @@ public abstract class BaseERCAssetLibraryTestEntityResourceImpl
 	@jakarta.ws.rs.POST
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public ERCAssetLibraryTestEntity postAssetLibraryERCAssetLibraryTestEntity(
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.validation.constraints.NotNull
-			@jakarta.ws.rs.PathParam("assetLibraryExternalReferenceCode")
-			String assetLibraryExternalReferenceCode,
-			ERCAssetLibraryTestEntity ercAssetLibraryTestEntity)
+	public final ERCAssetLibraryTestEntity
+			postAssetLibraryERCAssetLibraryTestEntity(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("assetLibraryExternalReferenceCode")
+				String assetLibraryExternalReferenceCode,
+				ERCAssetLibraryTestEntity ercAssetLibraryTestEntity)
 		throws Exception {
 
-		return new ERCAssetLibraryTestEntity();
+		Permission[] permissions = ercAssetLibraryTestEntity.getPermissions();
+
+		ERCAssetLibraryTestEntity postERCAssetLibraryTestEntity =
+			doPostAssetLibraryERCAssetLibraryTestEntity(
+				assetLibraryExternalReferenceCode, ercAssetLibraryTestEntity);
+
+		if (permissions != null) {
+			Page<Permission> permissionsPage =
+				putAssetLibraryERCAssetLibraryTestEntityPermissionsPage(
+					assetLibraryExternalReferenceCode,
+					postERCAssetLibraryTestEntity.getExternalReferenceCode(),
+					permissions);
+
+			postERCAssetLibraryTestEntity.setPermissions(
+				() -> NestedFieldsSupplier.supply(
+					"permissions",
+					nestedField -> {
+						Collection<Permission> collection =
+							permissionsPage.getItems();
+
+						return collection.toArray(
+							new Permission[collection.size()]);
+					}));
+		}
+
+		return postERCAssetLibraryTestEntity;
 	}
 
 	/**
@@ -415,6 +543,56 @@ public abstract class BaseERCAssetLibraryTestEntityResourceImpl
 		throws Exception {
 
 		return new ERCAssetLibraryTestEntity();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'PUT' 'http://localhost:8080/o/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/{ercAssetLibraryTestEntityExternalReferenceCode}/permissions'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "assetLibraryExternalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "ercAssetLibraryTestEntityExternalReferenceCode"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(
+				name = "ERCAssetLibraryTestEntity"
+			)
+		}
+	)
+	@jakarta.ws.rs.Consumes({"application/json", "application/xml"})
+	@jakarta.ws.rs.Path(
+		"/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/{ercAssetLibraryTestEntityExternalReferenceCode}/permissions"
+	)
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@jakarta.ws.rs.PUT
+	@Override
+	public Page<Permission>
+			putAssetLibraryERCAssetLibraryTestEntityPermissionsPage(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("assetLibraryExternalReferenceCode")
+				String assetLibraryExternalReferenceCode,
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam(
+					"ercAssetLibraryTestEntityExternalReferenceCode"
+				)
+				String ercAssetLibraryTestEntityExternalReferenceCode,
+				Permission[] permissions)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseERCSiteTestEntityResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseERCSiteTestEntityResourceImpl.java
@@ -34,8 +34,10 @@ import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
+import com.liferay.portal.vulcan.fields.NestedFieldsSupplier;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.UriInfoUtil;
@@ -110,6 +112,10 @@ public abstract class BaseERCSiteTestEntityResourceImpl
 		throws Exception {
 	}
 
+	protected abstract Page<ERCSiteTestEntity> doGetSiteERCSiteTestEntitiesPage(
+			String siteExternalReferenceCode)
+		throws Exception;
+
 	/**
 	 * Invoke this method with the command line:
 	 *
@@ -134,14 +140,38 @@ public abstract class BaseERCSiteTestEntityResourceImpl
 	)
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<ERCSiteTestEntity> getSiteERCSiteTestEntitiesPage(
+	public final Page<ERCSiteTestEntity> getSiteERCSiteTestEntitiesPage(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.validation.constraints.NotNull
 			@jakarta.ws.rs.PathParam("siteExternalReferenceCode")
 			String siteExternalReferenceCode)
 		throws Exception {
 
-		return Page.of(Collections.emptyList());
+		Page<ERCSiteTestEntity> ercSiteTestEntitiesPage =
+			doGetSiteERCSiteTestEntitiesPage(siteExternalReferenceCode);
+
+		for (ERCSiteTestEntity ercSiteTestEntity :
+				ercSiteTestEntitiesPage.getItems()) {
+
+			ercSiteTestEntity.setPermissions(
+				() -> NestedFieldsSupplier.supply(
+					"permissions",
+					nestedField -> {
+						Page<Permission> permissionsPage =
+							getSiteERCSiteTestEntityPermissionsPage(
+								siteExternalReferenceCode,
+								ercSiteTestEntity.getExternalReferenceCode(),
+								null);
+
+						Collection<Permission> permissions =
+							permissionsPage.getItems();
+
+						return permissions.toArray(
+							new Permission[permissions.size()]);
+					}));
+		}
+
+		return ercSiteTestEntitiesPage;
 	}
 
 	/**
@@ -184,6 +214,64 @@ public abstract class BaseERCSiteTestEntityResourceImpl
 		throws Exception {
 
 		return new ERCSiteTestEntity();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/{ercSiteTestEntityExternalReferenceCode}/permissions'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "siteExternalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "ercSiteTestEntityExternalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "fields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "restrictFields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "roleNames"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(name = "ERCSiteTestEntity")
+		}
+	)
+	@jakarta.ws.rs.GET
+	@jakarta.ws.rs.Path(
+		"/sites/{siteExternalReferenceCode}/erc-site-test-entities/{ercSiteTestEntityExternalReferenceCode}/permissions"
+	)
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Page<Permission> getSiteERCSiteTestEntityPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("siteExternalReferenceCode")
+			String siteExternalReferenceCode,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("ercSiteTestEntityExternalReferenceCode")
+			String ercSiteTestEntityExternalReferenceCode,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("roleNames")
+			String roleNames)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	/**
@@ -259,6 +347,11 @@ public abstract class BaseERCSiteTestEntityResourceImpl
 		).build();
 	}
 
+	protected abstract ERCSiteTestEntity doPostSiteERCSiteTestEntity(
+			String siteExternalReferenceCode,
+			ERCSiteTestEntity ercSiteTestEntity)
+		throws Exception;
+
 	/**
 	 * Invoke this method with the command line:
 	 *
@@ -284,7 +377,7 @@ public abstract class BaseERCSiteTestEntityResourceImpl
 	@jakarta.ws.rs.POST
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public ERCSiteTestEntity postSiteERCSiteTestEntity(
+	public final ERCSiteTestEntity postSiteERCSiteTestEntity(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.validation.constraints.NotNull
 			@jakarta.ws.rs.PathParam("siteExternalReferenceCode")
@@ -292,7 +385,31 @@ public abstract class BaseERCSiteTestEntityResourceImpl
 			ERCSiteTestEntity ercSiteTestEntity)
 		throws Exception {
 
-		return new ERCSiteTestEntity();
+		Permission[] permissions = ercSiteTestEntity.getPermissions();
+
+		ERCSiteTestEntity postERCSiteTestEntity = doPostSiteERCSiteTestEntity(
+			siteExternalReferenceCode, ercSiteTestEntity);
+
+		if (permissions != null) {
+			Page<Permission> permissionsPage =
+				putSiteERCSiteTestEntityPermissionsPage(
+					siteExternalReferenceCode,
+					postERCSiteTestEntity.getExternalReferenceCode(),
+					permissions);
+
+			postERCSiteTestEntity.setPermissions(
+				() -> NestedFieldsSupplier.supply(
+					"permissions",
+					nestedField -> {
+						Collection<Permission> collection =
+							permissionsPage.getItems();
+
+						return collection.toArray(
+							new Permission[collection.size()]);
+					}));
+		}
+
+		return postERCSiteTestEntity;
 	}
 
 	/**
@@ -393,6 +510,51 @@ public abstract class BaseERCSiteTestEntityResourceImpl
 		throws Exception {
 
 		return new ERCSiteTestEntity();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'PUT' 'http://localhost:8080/o/test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/{ercSiteTestEntityExternalReferenceCode}/permissions'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "siteExternalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "ercSiteTestEntityExternalReferenceCode"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(name = "ERCSiteTestEntity")
+		}
+	)
+	@jakarta.ws.rs.Consumes({"application/json", "application/xml"})
+	@jakarta.ws.rs.Path(
+		"/sites/{siteExternalReferenceCode}/erc-site-test-entities/{ercSiteTestEntityExternalReferenceCode}/permissions"
+	)
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@jakarta.ws.rs.PUT
+	@Override
+	public Page<Permission> putSiteERCSiteTestEntityPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("siteExternalReferenceCode")
+			String siteExternalReferenceCode,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("ercSiteTestEntityExternalReferenceCode")
+			String ercSiteTestEntityExternalReferenceCode,
+			Permission[] permissions)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Override

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/ERCAssetLibraryTestEntityResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/ERCAssetLibraryTestEntityResourceImpl.java
@@ -5,7 +5,9 @@
 
 package com.liferay.portal.tools.rest.builder.test.internal.resource.v1_0;
 
+import com.liferay.portal.tools.rest.builder.test.dto.v1_0.ERCAssetLibraryTestEntity;
 import com.liferay.portal.tools.rest.builder.test.resource.v1_0.ERCAssetLibraryTestEntityResource;
+import com.liferay.portal.vulcan.pagination.Page;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ServiceScope;
@@ -20,4 +22,26 @@ import org.osgi.service.component.annotations.ServiceScope;
 )
 public class ERCAssetLibraryTestEntityResourceImpl
 	extends BaseERCAssetLibraryTestEntityResourceImpl {
+
+	@Override
+	protected Page<ERCAssetLibraryTestEntity>
+			doGetAssetLibraryERCAssetLibraryTestEntitiesPage(
+				String assetLibraryExternalReferenceCode)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Override
+	protected ERCAssetLibraryTestEntity
+			doPostAssetLibraryERCAssetLibraryTestEntity(
+				String assetLibraryExternalReferenceCode,
+				ERCAssetLibraryTestEntity ercAssetLibraryTestEntity)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
 }

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/ERCAssetLibraryTestEntityResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/ERCAssetLibraryTestEntityResourceImpl.java
@@ -29,8 +29,7 @@ public class ERCAssetLibraryTestEntityResourceImpl
 				String assetLibraryExternalReferenceCode)
 		throws Exception {
 
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
@@ -40,8 +39,7 @@ public class ERCAssetLibraryTestEntityResourceImpl
 				ERCAssetLibraryTestEntity ercAssetLibraryTestEntity)
 		throws Exception {
 
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
+		throw new UnsupportedOperationException();
 	}
 
 }

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/ERCSiteTestEntityResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/ERCSiteTestEntityResourceImpl.java
@@ -5,7 +5,9 @@
 
 package com.liferay.portal.tools.rest.builder.test.internal.resource.v1_0;
 
+import com.liferay.portal.tools.rest.builder.test.dto.v1_0.ERCSiteTestEntity;
 import com.liferay.portal.tools.rest.builder.test.resource.v1_0.ERCSiteTestEntityResource;
+import com.liferay.portal.vulcan.pagination.Page;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ServiceScope;
@@ -19,4 +21,24 @@ import org.osgi.service.component.annotations.ServiceScope;
 )
 public class ERCSiteTestEntityResourceImpl
 	extends BaseERCSiteTestEntityResourceImpl {
+
+	@Override
+	protected Page<ERCSiteTestEntity> doGetSiteERCSiteTestEntitiesPage(
+			String siteExternalReferenceCode)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Override
+	protected ERCSiteTestEntity doPostSiteERCSiteTestEntity(
+			String siteExternalReferenceCode,
+			ERCSiteTestEntity ercSiteTestEntity)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
 }

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/ERCSiteTestEntityResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/ERCSiteTestEntityResourceImpl.java
@@ -27,8 +27,7 @@ public class ERCSiteTestEntityResourceImpl
 			String siteExternalReferenceCode)
 		throws Exception {
 
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
@@ -37,8 +36,7 @@ public class ERCSiteTestEntityResourceImpl
 			ERCSiteTestEntity ercSiteTestEntity)
 		throws Exception {
 
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
+		throw new UnsupportedOperationException();
 	}
 
 }

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseERCAssetLibraryTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseERCAssetLibraryTestEntityResourceTestCase.java
@@ -25,10 +25,12 @@ import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.RoleConstants;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -43,6 +45,7 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.tools.rest.builder.test.client.dto.v1_0.ERCAssetLibraryTestEntity;
 import com.liferay.portal.tools.rest.builder.test.client.http.HttpInvoker;
 import com.liferay.portal.tools.rest.builder.test.client.pagination.Page;
+import com.liferay.portal.tools.rest.builder.test.client.permission.Permission;
 import com.liferay.portal.tools.rest.builder.test.client.resource.v1_0.ERCAssetLibraryTestEntityResource;
 import com.liferay.portal.tools.rest.builder.test.client.serdes.v1_0.ERCAssetLibraryTestEntitySerDes;
 import com.liferay.portal.util.PropsValues;
@@ -149,6 +152,19 @@ public abstract class BaseERCAssetLibraryTestEntityResourceTestCase {
 		).locale(
 			LocaleUtil.getDefault()
 		).build();
+
+		permissionsERCAssetLibraryTestEntityResource =
+			ERCAssetLibraryTestEntityResource.builder(
+			).authentication(
+				_testCompanyAdminUser.getEmailAddress(),
+				PropsValues.DEFAULT_ADMIN_PASSWORD
+			).endpoint(
+				testCompany.getVirtualHostname(), 8080, "http"
+			).locale(
+				LocaleUtil.getDefault()
+			).parameter(
+				"nestedFields", "permissions"
+			).build();
 	}
 
 	@After
@@ -341,6 +357,23 @@ public abstract class BaseERCAssetLibraryTestEntityResourceTestCase {
 			page,
 			testGetAssetLibraryERCAssetLibraryTestEntitiesPage_getExpectedActions(
 				assetLibraryExternalReferenceCode));
+
+		for (ERCAssetLibraryTestEntity ercAssetLibraryTestEntity :
+				page.getItems()) {
+
+			Assert.assertNull(ercAssetLibraryTestEntity.getPermissions());
+		}
+
+		page =
+			permissionsERCAssetLibraryTestEntityResource.
+				getAssetLibraryERCAssetLibraryTestEntitiesPage(
+					assetLibraryExternalReferenceCode);
+
+		for (ERCAssetLibraryTestEntity ercAssetLibraryTestEntity :
+				page.getItems()) {
+
+			Assert.assertNotNull(ercAssetLibraryTestEntity.getPermissions());
+		}
 	}
 
 	protected Map<String, Map<String, String>>
@@ -555,6 +588,34 @@ public abstract class BaseERCAssetLibraryTestEntityResourceTestCase {
 	}
 
 	@Test
+	public void testGetAssetLibraryERCAssetLibraryTestEntityPermissionsPage()
+		throws Exception {
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		ERCAssetLibraryTestEntity postERCAssetLibraryTestEntity =
+			testGetAssetLibraryERCAssetLibraryTestEntityPermissionsPage_addERCAssetLibraryTestEntity();
+
+		Page<Permission> page =
+			ercAssetLibraryTestEntityResource.
+				getAssetLibraryERCAssetLibraryTestEntityPermissionsPage(
+					testDepotEntryGroup.getExternalReferenceCode(),
+					postERCAssetLibraryTestEntity.getExternalReferenceCode(),
+					RoleConstants.GUEST);
+
+		Assert.assertNotNull(page);
+	}
+
+	protected ERCAssetLibraryTestEntity
+			testGetAssetLibraryERCAssetLibraryTestEntityPermissionsPage_addERCAssetLibraryTestEntity()
+		throws Exception {
+
+		return ercAssetLibraryTestEntityResource.
+			postAssetLibraryERCAssetLibraryTestEntity(
+				testDepotEntryGroup.getExternalReferenceCode(),
+				randomERCAssetLibraryTestEntity());
+	}
+
+	@Test
 	public void testPostAssetLibraryERCAssetLibraryTestEntity()
 		throws Exception {
 
@@ -568,10 +629,39 @@ public abstract class BaseERCAssetLibraryTestEntityResourceTestCase {
 		assertEquals(
 			randomERCAssetLibraryTestEntity, postERCAssetLibraryTestEntity);
 		assertValid(postERCAssetLibraryTestEntity);
+
+		ERCAssetLibraryTestEntity randomPermissionsERCAssetLibraryTestEntity1 =
+			randomPermissionsERCAssetLibraryTestEntity();
+
+		ERCAssetLibraryTestEntity postPermissionsERCAssetLibraryTestEntity1 =
+			testPostAssetLibraryERCAssetLibraryTestEntity_addERCAssetLibraryTestEntity(
+				randomPermissionsERCAssetLibraryTestEntity1);
+
+		Assert.assertNull(
+			postPermissionsERCAssetLibraryTestEntity1.getPermissions());
+
+		ERCAssetLibraryTestEntity randomPermissionsERCAssetLibraryTestEntity2 =
+			randomPermissionsERCAssetLibraryTestEntity();
+
+		ERCAssetLibraryTestEntity postPermissionsERCAssetLibraryTestEntity2 =
+			testPostAssetLibraryERCAssetLibraryTestEntity_addPermissionsERCAssetLibraryTestEntity(
+				randomPermissionsERCAssetLibraryTestEntity2);
+
+		Assert.assertNotNull(
+			postPermissionsERCAssetLibraryTestEntity2.getPermissions());
 	}
 
 	protected ERCAssetLibraryTestEntity
 			testPostAssetLibraryERCAssetLibraryTestEntity_addERCAssetLibraryTestEntity(
+				ERCAssetLibraryTestEntity ercAssetLibraryTestEntity)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected ERCAssetLibraryTestEntity
+			testPostAssetLibraryERCAssetLibraryTestEntity_addPermissionsERCAssetLibraryTestEntity(
 				ERCAssetLibraryTestEntity ercAssetLibraryTestEntity)
 		throws Exception {
 
@@ -615,6 +705,61 @@ public abstract class BaseERCAssetLibraryTestEntityResourceTestCase {
 
 	protected ERCAssetLibraryTestEntity
 			testPutAssetLibraryERCAssetLibraryTestEntity_addERCAssetLibraryTestEntity()
+		throws Exception {
+
+		return ercAssetLibraryTestEntityResource.
+			postAssetLibraryERCAssetLibraryTestEntity(
+				testDepotEntryGroup.getExternalReferenceCode(),
+				randomERCAssetLibraryTestEntity());
+	}
+
+	@Test
+	public void testPutAssetLibraryERCAssetLibraryTestEntityPermissionsPage()
+		throws Exception {
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		ERCAssetLibraryTestEntity ercAssetLibraryTestEntity =
+			testPutAssetLibraryERCAssetLibraryTestEntityPermissionsPage_addERCAssetLibraryTestEntity();
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
+			RoleConstants.TYPE_REGULAR);
+
+		assertHttpResponseStatusCode(
+			200,
+			ercAssetLibraryTestEntityResource.
+				putAssetLibraryERCAssetLibraryTestEntityPermissionsPageHttpResponse(
+					ercAssetLibraryTestEntity.
+						getAssetLibraryExternalReferenceCode(),
+					null,
+					new Permission[] {
+						new Permission() {
+							{
+								setActionIds(new String[] {"PERMISSIONS"});
+								setRoleName(role.getName());
+							}
+						}
+					}));
+
+		assertHttpResponseStatusCode(
+			404,
+			ercAssetLibraryTestEntityResource.
+				putAssetLibraryERCAssetLibraryTestEntityPermissionsPageHttpResponse(
+					ercAssetLibraryTestEntity.
+						getAssetLibraryExternalReferenceCode(),
+					null,
+					new Permission[] {
+						new Permission() {
+							{
+								setActionIds(new String[] {"-"});
+								setRoleName("-");
+							}
+						}
+					}));
+	}
+
+	protected ERCAssetLibraryTestEntity
+			testPutAssetLibraryERCAssetLibraryTestEntityPermissionsPage_addERCAssetLibraryTestEntity()
 		throws Exception {
 
 		return ercAssetLibraryTestEntityResource.
@@ -1429,6 +1574,29 @@ public abstract class BaseERCAssetLibraryTestEntityResourceTestCase {
 		return randomERCAssetLibraryTestEntity();
 	}
 
+	protected ERCAssetLibraryTestEntity
+			randomPermissionsERCAssetLibraryTestEntity()
+		throws Exception {
+
+		ERCAssetLibraryTestEntity ercAssetLibraryTestEntity =
+			randomERCAssetLibraryTestEntity();
+
+		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
+			RoleConstants.TYPE_REGULAR);
+
+		ercAssetLibraryTestEntity.setPermissions(
+			new Permission[] {
+				new Permission() {
+					{
+						setActionIds(new String[] {"VIEW"});
+						setRoleName(role.getName());
+					}
+				}
+			});
+
+		return ercAssetLibraryTestEntity;
+	}
+
 	protected final JSONObject waitForFinish(
 			String expectedExecuteStatus, JSONObject jsonObject)
 		throws Exception {
@@ -1455,6 +1623,8 @@ public abstract class BaseERCAssetLibraryTestEntityResourceTestCase {
 		ercAssetLibraryTestEntityResource;
 	protected ImportTaskResource importTaskResource;
 	protected com.liferay.portal.kernel.model.Group irrelevantGroup;
+	protected ERCAssetLibraryTestEntityResource
+		permissionsERCAssetLibraryTestEntityResource;
 	protected com.liferay.portal.kernel.model.Company testCompany;
 	protected DepotEntry irrelevantDepotEntry;
 	protected com.liferay.portal.kernel.model.Group irrelevantDepotEntryGroup;

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseERCSiteTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseERCSiteTestEntityResourceTestCase.java
@@ -25,9 +25,11 @@ import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.RoleConstants;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
@@ -41,6 +43,7 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.tools.rest.builder.test.client.dto.v1_0.ERCSiteTestEntity;
 import com.liferay.portal.tools.rest.builder.test.client.http.HttpInvoker;
 import com.liferay.portal.tools.rest.builder.test.client.pagination.Page;
+import com.liferay.portal.tools.rest.builder.test.client.permission.Permission;
 import com.liferay.portal.tools.rest.builder.test.client.resource.v1_0.ERCSiteTestEntityResource;
 import com.liferay.portal.tools.rest.builder.test.client.serdes.v1_0.ERCSiteTestEntitySerDes;
 import com.liferay.portal.util.PropsValues;
@@ -123,6 +126,19 @@ public abstract class BaseERCSiteTestEntityResourceTestCase {
 		).locale(
 			LocaleUtil.getDefault()
 		).build();
+
+		permissionsERCSiteTestEntityResource =
+			ERCSiteTestEntityResource.builder(
+			).authentication(
+				_testCompanyAdminUser.getEmailAddress(),
+				PropsValues.DEFAULT_ADMIN_PASSWORD
+			).endpoint(
+				testCompany.getVirtualHostname(), 8080, "http"
+			).locale(
+				LocaleUtil.getDefault()
+			).parameter(
+				"nestedFields", "permissions"
+			).build();
 	}
 
 	@After
@@ -379,6 +395,18 @@ public abstract class BaseERCSiteTestEntityResourceTestCase {
 			page,
 			testGetSiteERCSiteTestEntitiesPage_getExpectedActions(
 				siteExternalReferenceCode));
+
+		for (ERCSiteTestEntity ercSiteTestEntity : page.getItems()) {
+			Assert.assertNull(ercSiteTestEntity.getPermissions());
+		}
+
+		page =
+			permissionsERCSiteTestEntityResource.getSiteERCSiteTestEntitiesPage(
+				siteExternalReferenceCode);
+
+		for (ERCSiteTestEntity ercSiteTestEntity : page.getItems()) {
+			Assert.assertNotNull(ercSiteTestEntity.getPermissions());
+		}
 	}
 
 	protected Map<String, Map<String, String>>
@@ -580,6 +608,29 @@ public abstract class BaseERCSiteTestEntityResourceTestCase {
 	}
 
 	@Test
+	public void testGetSiteERCSiteTestEntityPermissionsPage() throws Exception {
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		ERCSiteTestEntity postERCSiteTestEntity =
+			testGetSiteERCSiteTestEntityPermissionsPage_addERCSiteTestEntity();
+
+		Page<Permission> page =
+			ercSiteTestEntityResource.getSiteERCSiteTestEntityPermissionsPage(
+				testGroup.getExternalReferenceCode(),
+				postERCSiteTestEntity.getExternalReferenceCode(),
+				RoleConstants.GUEST);
+
+		Assert.assertNotNull(page);
+	}
+
+	protected ERCSiteTestEntity
+			testGetSiteERCSiteTestEntityPermissionsPage_addERCSiteTestEntity()
+		throws Exception {
+
+		return ercSiteTestEntityResource.postSiteERCSiteTestEntity(
+			testGroup.getExternalReferenceCode(), randomERCSiteTestEntity());
+	}
+
+	@Test
 	public void testPostSiteERCSiteTestEntity() throws Exception {
 		ERCSiteTestEntity randomERCSiteTestEntity = randomERCSiteTestEntity();
 
@@ -589,10 +640,38 @@ public abstract class BaseERCSiteTestEntityResourceTestCase {
 
 		assertEquals(randomERCSiteTestEntity, postERCSiteTestEntity);
 		assertValid(postERCSiteTestEntity);
+
+		ERCSiteTestEntity randomPermissionsERCSiteTestEntity1 =
+			randomPermissionsERCSiteTestEntity();
+
+		ERCSiteTestEntity postPermissionsERCSiteTestEntity1 =
+			testPostSiteERCSiteTestEntity_addERCSiteTestEntity(
+				randomPermissionsERCSiteTestEntity1);
+
+		Assert.assertNull(postPermissionsERCSiteTestEntity1.getPermissions());
+
+		ERCSiteTestEntity randomPermissionsERCSiteTestEntity2 =
+			randomPermissionsERCSiteTestEntity();
+
+		ERCSiteTestEntity postPermissionsERCSiteTestEntity2 =
+			testPostSiteERCSiteTestEntity_addPermissionsERCSiteTestEntity(
+				randomPermissionsERCSiteTestEntity2);
+
+		Assert.assertNotNull(
+			postPermissionsERCSiteTestEntity2.getPermissions());
 	}
 
 	protected ERCSiteTestEntity
 			testPostSiteERCSiteTestEntity_addERCSiteTestEntity(
+				ERCSiteTestEntity ercSiteTestEntity)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected ERCSiteTestEntity
+			testPostSiteERCSiteTestEntity_addPermissionsERCSiteTestEntity(
 				ERCSiteTestEntity ercSiteTestEntity)
 		throws Exception {
 
@@ -638,6 +717,53 @@ public abstract class BaseERCSiteTestEntityResourceTestCase {
 
 	protected ERCSiteTestEntity
 			testPutSiteERCSiteTestEntity_addERCSiteTestEntity()
+		throws Exception {
+
+		return ercSiteTestEntityResource.postSiteERCSiteTestEntity(
+			testGroup.getExternalReferenceCode(), randomERCSiteTestEntity());
+	}
+
+	@Test
+	public void testPutSiteERCSiteTestEntityPermissionsPage() throws Exception {
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		ERCSiteTestEntity ercSiteTestEntity =
+			testPutSiteERCSiteTestEntityPermissionsPage_addERCSiteTestEntity();
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
+			RoleConstants.TYPE_REGULAR);
+
+		assertHttpResponseStatusCode(
+			200,
+			ercSiteTestEntityResource.
+				putSiteERCSiteTestEntityPermissionsPageHttpResponse(
+					ercSiteTestEntity.getSiteExternalReferenceCode(), null,
+					new Permission[] {
+						new Permission() {
+							{
+								setActionIds(new String[] {"PERMISSIONS"});
+								setRoleName(role.getName());
+							}
+						}
+					}));
+
+		assertHttpResponseStatusCode(
+			404,
+			ercSiteTestEntityResource.
+				putSiteERCSiteTestEntityPermissionsPageHttpResponse(
+					ercSiteTestEntity.getSiteExternalReferenceCode(), null,
+					new Permission[] {
+						new Permission() {
+							{
+								setActionIds(new String[] {"-"});
+								setRoleName("-");
+							}
+						}
+					}));
+	}
+
+	protected ERCSiteTestEntity
+			testPutSiteERCSiteTestEntityPermissionsPage_addERCSiteTestEntity()
 		throws Exception {
 
 		return ercSiteTestEntityResource.postSiteERCSiteTestEntity(
@@ -1508,6 +1634,27 @@ public abstract class BaseERCSiteTestEntityResourceTestCase {
 		return randomERCSiteTestEntity();
 	}
 
+	protected ERCSiteTestEntity randomPermissionsERCSiteTestEntity()
+		throws Exception {
+
+		ERCSiteTestEntity ercSiteTestEntity = randomERCSiteTestEntity();
+
+		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
+			RoleConstants.TYPE_REGULAR);
+
+		ercSiteTestEntity.setPermissions(
+			new Permission[] {
+				new Permission() {
+					{
+						setActionIds(new String[] {"VIEW"});
+						setRoleName(role.getName());
+					}
+				}
+			});
+
+		return ercSiteTestEntity;
+	}
+
 	protected final JSONObject waitForFinish(
 			String expectedExecuteStatus, JSONObject jsonObject)
 		throws Exception {
@@ -1533,6 +1680,7 @@ public abstract class BaseERCSiteTestEntityResourceTestCase {
 	protected ERCSiteTestEntityResource ercSiteTestEntityResource;
 	protected ImportTaskResource importTaskResource;
 	protected com.liferay.portal.kernel.model.Group irrelevantGroup;
+	protected ERCSiteTestEntityResource permissionsERCSiteTestEntityResource;
 	protected com.liferay.portal.kernel.model.Company testCompany;
 	protected com.liferay.portal.kernel.model.Group testGroup;
 

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
@@ -751,9 +751,12 @@ public class FreeMarkerTool {
 		String httpMethod, List<JavaMethodSignature> javaMethodSignatures,
 		String parentSchemaName, String schemaName) {
 
+		if (parentSchemaName == null) {
+			return null;
+		}
+
 		for (JavaMethodSignature javaMethodSignature : javaMethodSignatures) {
-			if ((parentSchemaName != null) &&
-				Objects.equals(
+			if (Objects.equals(
 					javaMethodSignature.getMethodName(),
 					StringBundler.concat(
 						httpMethod, parentSchemaName, schemaName,

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
@@ -747,6 +747,49 @@ public class FreeMarkerTool {
 		return parentJavaMethodSignatures;
 	}
 
+	public JavaMethodSignature getParentPermissionsPageJavaMethodSignature(
+		String httpMethod, List<JavaMethodSignature> javaMethodSignatures,
+		String parentSchemaName, String schemaName) {
+
+		for (JavaMethodSignature javaMethodSignature : javaMethodSignatures) {
+			if ((parentSchemaName != null) &&
+				Objects.equals(
+					javaMethodSignature.getMethodName(),
+					StringBundler.concat(
+						httpMethod, parentSchemaName, schemaName,
+						"PermissionsPage")) &&
+				hasPathParameter(
+					javaMethodSignature,
+					TextFormatter.format(parentSchemaName, TextFormatter.I) +
+						"ExternalReferenceCode") &&
+				hasPathParameter(
+					javaMethodSignature,
+					TextFormatter.format(schemaName, TextFormatter.I) +
+						"ExternalReferenceCode")) {
+
+				return javaMethodSignature;
+			}
+		}
+
+		return null;
+	}
+
+	public JavaMethodSignature getPermissionsPageJavaMethodSignature(
+		String httpMethod, List<JavaMethodSignature> javaMethodSignatures,
+		String schemaName) {
+
+		for (JavaMethodSignature javaMethodSignature : javaMethodSignatures) {
+			if (Objects.equals(
+					javaMethodSignature.getMethodName(),
+					httpMethod + schemaName + "PermissionsPage")) {
+
+				return javaMethodSignature;
+			}
+		}
+
+		return null;
+	}
+
 	public JavaMethodSignature getPostSchemaJavaMethodSignature(
 		List<JavaMethodSignature> javaMethodSignatures, String parameterName,
 		String schemaName) {
@@ -1004,6 +1047,21 @@ public class FreeMarkerTool {
 		return false;
 	}
 
+	public boolean hasPathParameter(
+		JavaMethodSignature javaMethodSignature, String parameterName) {
+
+		List<JavaMethodParameter> javaMethodParameters =
+			javaMethodSignature.getPathJavaMethodParameters();
+
+		for (JavaMethodParameter javaMethodParameter : javaMethodParameters) {
+			if (parameterName.equals(javaMethodParameter.getParameterName())) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	public boolean hasPostSchemaJavaMethodSignature(
 		List<JavaMethodSignature> javaMethodSignatures, String parameterName,
 		String schemaName) {
@@ -1127,32 +1185,36 @@ public class FreeMarkerTool {
 
 		Map<String, Schema> propertySchemas = schema.getPropertySchemas();
 
+		JavaMethodSignature getPermissionsPageJavaMethodSignature =
+			getPermissionsPageJavaMethodSignature(
+				"get", javaMethodSignatures, schemaName);
+
+		JavaMethodSignature putPermissionsPageJavaMethodSignature =
+			getPermissionsPageJavaMethodSignature(
+				"put", javaMethodSignatures, schemaName);
+
+		String parentSchemaName = GetterUtil.getString(
+			javaMethodSignature.getParentSchemaName());
+
+		JavaMethodSignature getParentPermissionsPageJavaMethodSignature =
+			getParentPermissionsPageJavaMethodSignature(
+				"get", javaMethodSignatures, parentSchemaName, schemaName);
+
+		JavaMethodSignature putParentPermissionsPageJavaMethodSignature =
+			getParentPermissionsPageJavaMethodSignature(
+				"put", javaMethodSignatures, parentSchemaName, schemaName);
+
 		if (MapUtil.isEmpty(propertySchemas) ||
 			!propertySchemas.containsKey("permissions") ||
-			((!containsJavaMethodSignature(
-				javaMethodSignatures, "get" + schemaName + "PermissionsPage") ||
-			  !containsJavaMethodSignature(
-				  javaMethodSignatures,
-				  "put" + schemaName + "PermissionsPage")) &&
-			 (!containsJavaMethodSignature(
-				 javaMethodSignatures,
-				 "getSite" + schemaName + "PermissionsPage") ||
-			  !containsJavaMethodSignature(
-				  javaMethodSignatures,
-				  "putSite" + schemaName + "PermissionsPage")) &&
-			 (!containsJavaMethodSignature(
-				 javaMethodSignatures,
-				 "getAssetLibrary" + schemaName + "PermissionsPage") ||
-			  !containsJavaMethodSignature(
-				  javaMethodSignatures,
-				  "putAssetLibrary" + schemaName + "PermissionsPage")))) {
+			(((getPermissionsPageJavaMethodSignature == null) ||
+			  (putPermissionsPageJavaMethodSignature == null)) &&
+			 ((getParentPermissionsPageJavaMethodSignature == null) ||
+			  (putParentPermissionsPageJavaMethodSignature == null)))) {
 
 			return false;
 		}
 
 		String methodName = javaMethodSignature.getMethodName();
-		String parentSchemaName = GetterUtil.getString(
-			javaMethodSignature.getParentSchemaName());
 		String pluralSchemaName = TextFormatter.formatPlural(schemaName);
 
 		if (!(methodName.equals(

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
@@ -777,22 +777,6 @@ public class FreeMarkerTool {
 		return null;
 	}
 
-	public JavaMethodSignature getPermissionsPageJavaMethodSignature(
-		String httpMethod, List<JavaMethodSignature> javaMethodSignatures,
-		String schemaName) {
-
-		for (JavaMethodSignature javaMethodSignature : javaMethodSignatures) {
-			if (Objects.equals(
-					javaMethodSignature.getMethodName(),
-					httpMethod + schemaName + "PermissionsPage")) {
-
-				return javaMethodSignature;
-			}
-		}
-
-		return null;
-	}
-
 	public JavaMethodSignature getPostSchemaJavaMethodSignature(
 		List<JavaMethodSignature> javaMethodSignatures, String parameterName,
 		String schemaName) {

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
@@ -1185,36 +1185,15 @@ public class FreeMarkerTool {
 
 		Map<String, Schema> propertySchemas = schema.getPropertySchemas();
 
-		JavaMethodSignature getPermissionsPageJavaMethodSignature =
-			getPermissionsPageJavaMethodSignature(
-				"get", javaMethodSignatures, schemaName);
-
-		JavaMethodSignature putPermissionsPageJavaMethodSignature =
-			getPermissionsPageJavaMethodSignature(
-				"put", javaMethodSignatures, schemaName);
-
-		String parentSchemaName = GetterUtil.getString(
-			javaMethodSignature.getParentSchemaName());
-
-		JavaMethodSignature getParentPermissionsPageJavaMethodSignature =
-			getParentPermissionsPageJavaMethodSignature(
-				"get", javaMethodSignatures, parentSchemaName, schemaName);
-
-		JavaMethodSignature putParentPermissionsPageJavaMethodSignature =
-			getParentPermissionsPageJavaMethodSignature(
-				"put", javaMethodSignatures, parentSchemaName, schemaName);
-
 		if (MapUtil.isEmpty(propertySchemas) ||
-			!propertySchemas.containsKey("permissions") ||
-			(((getPermissionsPageJavaMethodSignature == null) ||
-			  (putPermissionsPageJavaMethodSignature == null)) &&
-			 ((getParentPermissionsPageJavaMethodSignature == null) ||
-			  (putParentPermissionsPageJavaMethodSignature == null)))) {
+			!propertySchemas.containsKey("permissions")) {
 
 			return false;
 		}
 
 		String methodName = javaMethodSignature.getMethodName();
+		String parentSchemaName = GetterUtil.getString(
+			javaMethodSignature.getParentSchemaName());
 		String pluralSchemaName = TextFormatter.formatPlural(schemaName);
 
 		if (!(methodName.equals(

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
@@ -1129,10 +1129,23 @@ public class FreeMarkerTool {
 
 		if (MapUtil.isEmpty(propertySchemas) ||
 			!propertySchemas.containsKey("permissions") ||
-			!containsJavaMethodSignature(
+			((!containsJavaMethodSignature(
 				javaMethodSignatures, "get" + schemaName + "PermissionsPage") ||
-			!containsJavaMethodSignature(
-				javaMethodSignatures, "put" + schemaName + "PermissionsPage")) {
+			  !containsJavaMethodSignature(
+				  javaMethodSignatures,
+				  "put" + schemaName + "PermissionsPage")) &&
+			 (!containsJavaMethodSignature(
+				 javaMethodSignatures,
+				 "getSite" + schemaName + "PermissionsPage") ||
+			  !containsJavaMethodSignature(
+				  javaMethodSignatures,
+				  "putSite" + schemaName + "PermissionsPage")) &&
+			 (!containsJavaMethodSignature(
+				 javaMethodSignatures,
+				 "getAssetLibrary" + schemaName + "PermissionsPage") ||
+			  !containsJavaMethodSignature(
+				  javaMethodSignatures,
+				  "putAssetLibrary" + schemaName + "PermissionsPage")))) {
 
 			return false;
 		}

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
@@ -751,7 +751,10 @@ public class FreeMarkerTool {
 		String httpMethod, List<JavaMethodSignature> javaMethodSignatures,
 		String parentSchemaName, String schemaName) {
 
-		if (parentSchemaName == null) {
+		if ((parentSchemaName == null) ||
+			!(Objects.equals(parentSchemaName, "AssetLibrary") ||
+			  Objects.equals(parentSchemaName, "Site"))) {
+
 			return null;
 		}
 

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -251,18 +251,18 @@ public abstract class Base${schemaName}ResourceImpl
 								${schemaVarName}.setPermissions(
 									() -> NestedFieldsSupplier.supply("permissions", nestedField -> {
 										Page<Permission> permissionsPage =
-										<#if getPermissionsPageJavaMethodSignature?has_content>
-											${getPermissionsPageJavaMethodSignature.methodName}(
-												<#if properties?keys?seq_contains("id")>
-													${schemaVarName}.getId()
-												<#elseif properties?keys?seq_contains(schemaVarName + "Id")>
-													${schemaVarName}.get${schemaVarName}Id()
-												<#else>
-													${schemaVarName}Id
-												</#if>
-										<#elseif getParentPermissionsPageJavaMethodSignature?has_content>
-											${getParentPermissionsPageJavaMethodSignature.methodName}(${parentSchemaName?uncap_first}ExternalReferenceCode, ${schemaVarName}.getExternalReferenceCode()
-										</#if>
+											<#if getPermissionsPageJavaMethodSignature?has_content>
+												${getPermissionsPageJavaMethodSignature.methodName}(
+													<#if properties?keys?seq_contains("id")>
+														${schemaVarName}.getId()
+													<#elseif properties?keys?seq_contains(schemaVarName + "Id")>
+														${schemaVarName}.get${schemaVarName}Id()
+													<#else>
+														${schemaVarName}Id
+													</#if>
+											<#elseif getParentPermissionsPageJavaMethodSignature?has_content>
+												${getParentPermissionsPageJavaMethodSignature.methodName}(${parentSchemaName?uncap_first}ExternalReferenceCode, ${schemaVarName}.getExternalReferenceCode()
+											</#if>
 											, null);
 
 										Collection<Permission> permissions = permissionsPage.getItems();
@@ -278,23 +278,23 @@ public abstract class Base${schemaName}ResourceImpl
 							${httpMethod}${schemaName}.setPermissions(
 								() -> NestedFieldsSupplier.supply("permissions", nestedField -> {
 									Page<Permission> permissionsPage =
-									<#if getPermissionsPageJavaMethodSignature?has_content>
-										${getPermissionsPageJavaMethodSignature.methodName}(
-											<#if properties?keys?seq_contains("id")>
-												${httpMethod}${schemaName}.getId()
-											<#elseif properties?keys?seq_contains(schemaVarName + "Id")>
-												${httpMethod}${schemaName}.get${schemaVarName}Id()
-											<#else>
-												${schemaVarName}Id
-											</#if>
-									<#elseif getParentPermissionsPageJavaMethodSignature?has_content>
-										${getParentPermissionsPageJavaMethodSignature.methodName}(${parentSchemaName?uncap_first}ExternalReferenceCode, ${httpMethod}${schemaName}.getExternalReferenceCode()
-									</#if>
-											, null);
+										<#if getPermissionsPageJavaMethodSignature?has_content>
+											${getPermissionsPageJavaMethodSignature.methodName}(
+												<#if properties?keys?seq_contains("id")>
+													${httpMethod}${schemaName}.getId()
+												<#elseif properties?keys?seq_contains(schemaVarName + "Id")>
+													${httpMethod}${schemaName}.get${schemaVarName}Id()
+												<#else>
+													${schemaVarName}Id
+												</#if>
+										<#elseif getParentPermissionsPageJavaMethodSignature?has_content>
+											${getParentPermissionsPageJavaMethodSignature.methodName}(${parentSchemaName?uncap_first}ExternalReferenceCode, ${httpMethod}${schemaName}.getExternalReferenceCode()
+										</#if>
+										, null);
 
-										Collection<Permission> permissions = permissionsPage.getItems();
+									Collection<Permission> permissions = permissionsPage.getItems();
 
-										return permissions.toArray(new Permission[permissions.size()]);
+									return permissions.toArray(new Permission[permissions.size()]);
 								}));
 
 							return ${httpMethod}${schemaName};
@@ -316,18 +316,18 @@ public abstract class Base${schemaName}ResourceImpl
 
 					if (permissions != null) {
 						Page<Permission> permissionsPage =
-						<#if putPermissionsPageJavaMethodSignature?has_content>
-							${putPermissionsPageJavaMethodSignature.methodName}(
-								<#if properties?keys?seq_contains("id")>
-									${httpMethod}${schemaName}.getId()
-								<#elseif properties?keys?seq_contains(schemaVarName + "Id")>
-									${httpMethod}${schemaName}.get${schemaVarName}Id()
-								<#else>
-									${schemaVarName}Id
-								</#if>
-						<#elseif putParentPermissionsPageJavaMethodSignature?has_content>
-							${putParentPermissionsPageJavaMethodSignature.methodName}(${parentSchemaName?uncap_first}ExternalReferenceCode, ${httpMethod}${schemaName}.getExternalReferenceCode()
-						</#if>
+							<#if putPermissionsPageJavaMethodSignature?has_content>
+								${putPermissionsPageJavaMethodSignature.methodName}(
+									<#if properties?keys?seq_contains("id")>
+										${httpMethod}${schemaName}.getId()
+									<#elseif properties?keys?seq_contains(schemaVarName + "Id")>
+										${httpMethod}${schemaName}.get${schemaVarName}Id()
+									<#else>
+										${schemaVarName}Id
+									</#if>
+							<#elseif putParentPermissionsPageJavaMethodSignature?has_content>
+								${putParentPermissionsPageJavaMethodSignature.methodName}(${parentSchemaName?uncap_first}ExternalReferenceCode, ${httpMethod}${schemaName}.getExternalReferenceCode()
+							</#if>
 							, permissions);
 
 						${httpMethod}${schemaName}.setPermissions(
@@ -340,7 +340,6 @@ public abstract class Base${schemaName}ResourceImpl
 
 					return ${httpMethod}${schemaName};
 				</#if>
-
 			}
 
 			<#continue>

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -203,8 +203,8 @@ public abstract class Base${schemaName}ResourceImpl
 
 		<#if freeMarkerTool.isGeneratePermissions(configYAML, javaMethodSignature, javaMethodSignatures, schema, schemaName)>
 			<#assign
-				getPermissionsPageJavaMethodSignature = freeMarkerTool.getPermissionsPageJavaMethodSignature("get", javaMethodSignatures, schemaName)!""
-				putPermissionsPageJavaMethodSignature = freeMarkerTool.getPermissionsPageJavaMethodSignature("put", javaMethodSignatures, schemaName)!""
+				getPermissionsPageJavaMethodSignature = freeMarkerTool.getJavaMethodSignature(javaMethodSignatures, "get" + schemaName + "PermissionsPage")!""
+				putPermissionsPageJavaMethodSignature = freeMarkerTool.getJavaMethodSignature(javaMethodSignatures, "put" + schemaName + "PermissionsPage")!""
 			/>
 
 			<#if !(getPermissionsPageJavaMethodSignature?has_content || putPermissionsPageJavaMethodSignature?has_content)>

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -230,15 +230,20 @@ public abstract class Base${schemaName}ResourceImpl
 							for (${schemaName} ${schemaVarName} : ${schemaVarNames}Page.getItems()) {
 								${schemaVarName}.setPermissions(
 									() -> NestedFieldsSupplier.supply("permissions", nestedField -> {
-										Page<Permission> permissionsPage = get${schemaName}PermissionsPage(
-											<#if properties?keys?seq_contains("id")>
-												${schemaVarName}.getId()
-											<#elseif properties?keys?seq_contains(schemaVarName + "Id")>
-												${schemaVarName}.get${schemaVarName}Id()
-											<#else>
-												${schemaVarName}Id
-											</#if>
-
+										Page<Permission> permissionsPage =
+										<#if freeMarkerTool.getPermissionsPageJavaMethodSignature("get", javaMethodSignatures, schemaName)??>
+											get${schemaName}PermissionsPage(
+												<#if properties?keys?seq_contains("id")>
+													${schemaVarName}.getId()
+												<#elseif properties?keys?seq_contains(schemaVarName + "Id")>
+													${schemaVarName}.get${schemaVarName}Id()
+												<#else>
+													${schemaVarName}Id
+												</#if>
+										<#elseif freeMarkerTool.getParentPermissionsPageJavaMethodSignature("get", javaMethodSignatures, parentSchemaName, schemaName)??>
+											get${parentSchemaName}${schemaName}PermissionsPage(
+												${parentSchemaName?uncap_first}ExternalReferenceCode, ${schemaVarName}.getExternalReferenceCode()
+										</#if>
 											, null);
 
 										Collection<Permission> permissions = permissionsPage.getItems();
@@ -253,15 +258,20 @@ public abstract class Base${schemaName}ResourceImpl
 						<#if properties?keys?seq_contains("permissions")>
 							${httpMethod}${schemaName}.setPermissions(
 								() -> NestedFieldsSupplier.supply("permissions", nestedField -> {
-										Page<Permission> permissionsPage = get${schemaName}PermissionsPage(
-											<#if properties?keys?seq_contains("id")>
-												${httpMethod}${schemaName}.getId()
-											<#elseif properties?keys?seq_contains(schemaVarName + "Id")>
-												${httpMethod}${schemaName}.get${schemaVarName}Id()
-											<#else>
-												${schemaVarName}Id
-											</#if>
-
+									Page<Permission> permissionsPage =
+									<#if freeMarkerTool.getPermissionsPageJavaMethodSignature("get", javaMethodSignatures, schemaName)??>
+										get${schemaName}PermissionsPage(
+										<#if properties?keys?seq_contains("id")>
+											${httpMethod}${schemaName}.getId()
+										<#elseif properties?keys?seq_contains(schemaVarName + "Id")>
+											${httpMethod}${schemaName}.get${schemaVarName}Id()
+										<#else>
+											${schemaVarName}Id
+										</#if>
+									<#elseif freeMarkerTool.getParentPermissionsPageJavaMethodSignature("get", javaMethodSignatures, parentSchemaName, schemaName)??>
+										get${parentSchemaName}${schemaName}PermissionsPage(
+											${parentSchemaName?uncap_first}ExternalReferenceCode, ${httpMethod}${schemaName}.getExternalReferenceCode()
+									</#if>
 											, null);
 
 										Collection<Permission> permissions = permissionsPage.getItems();
@@ -287,7 +297,9 @@ public abstract class Base${schemaName}ResourceImpl
 						);
 
 					if (permissions != null) {
-						Page<Permission> permissionsPage = put${schemaName}PermissionsPage(
+						Page<Permission> permissionsPage =
+						<#if freeMarkerTool.getPermissionsPageJavaMethodSignature("put", javaMethodSignatures, schemaName)??>
+							put${schemaName}PermissionsPage(
 							<#if properties?keys?seq_contains("id")>
 								${httpMethod}${schemaName}.getId()
 							<#elseif properties?keys?seq_contains(schemaVarName + "Id")>
@@ -295,7 +307,10 @@ public abstract class Base${schemaName}ResourceImpl
 							<#else>
 								${schemaVarName}Id
 							</#if>
-
+						<#elseif freeMarkerTool.getParentPermissionsPageJavaMethodSignature("put", javaMethodSignatures, parentSchemaName, schemaName)??>
+							put${parentSchemaName}${schemaName}PermissionsPage(
+								${parentSchemaName?uncap_first}ExternalReferenceCode, ${httpMethod}${schemaName}.getExternalReferenceCode()
+						</#if>
 							, permissions);
 
 						${httpMethod}${schemaName}.setPermissions(

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -428,19 +428,23 @@ public abstract class Base${schemaName}ResourceImpl
 					throw new UnsupportedOperationException("This method needs to be implemented");
 				</#if>
 			<#elseif stringUtil.equals(javaMethodSignature.methodName, "getAssetLibrary" + schemaName + "PermissionsPage")>
-				<#assign generateGetPermissionCheckerMethods = true />
+				<#if freeMarkerTool.hasParameter(javaMethodSignature, "assetLibraryId")>
+					<#assign generateGetPermissionCheckerMethods = true />
 
-				String portletName = getPermissionCheckerPortletName(assetLibraryId);
+					String portletName = getPermissionCheckerPortletName(assetLibraryId);
 
-				PermissionServiceUtil.checkPermission(assetLibraryId, portletName, assetLibraryId);
+					PermissionServiceUtil.checkPermission(assetLibraryId, portletName, assetLibraryId);
 
-				return toPermissionPage(
-					<@getActions
-						resourceId="assetLibraryId"
-						resourceName="portletName"
-						source="AssetLibrary" + schemaName
-					/>,
-					assetLibraryId, portletName, roleNames);
+					return toPermissionPage(
+						<@getActions
+							resourceId="assetLibraryId"
+							resourceName="portletName"
+							source="AssetLibrary" + schemaName
+						/>,
+						assetLibraryId, portletName, roleNames);
+				<#else>
+					throw new UnsupportedOperationException("This method needs to be implemented");
+				</#if>
 			<#elseif stringUtil.equals(javaMethodSignature.methodName, "getSite" + schemaName + "PermissionsPage")>
 				<#if freeMarkerTool.hasParameter(javaMethodSignature, "siteId")>
 					<#assign generateGetPermissionCheckerMethods = true />
@@ -481,21 +485,25 @@ public abstract class Base${schemaName}ResourceImpl
 					throw new UnsupportedOperationException("This method needs to be implemented");
 				</#if>
 			<#elseif stringUtil.equals(javaMethodSignature.methodName, "putAssetLibrary" + schemaName + "PermissionsPage")>
-				<#assign generateGetPermissionCheckerMethods = true />
+				<#if freeMarkerTool.hasParameter(javaMethodSignature, "assetLibraryId")>
+					<#assign generateGetPermissionCheckerMethods = true />
 
-				String portletName = getPermissionCheckerPortletName(assetLibraryId);
+					String portletName = getPermissionCheckerPortletName(assetLibraryId);
 
-				<@updateResourcePermissions
-					groupId = "assetLibraryId"
-					resourceId = "assetLibraryId"
-					resourceName = "portletName"
-				>
-					<@getActions
-						resourceId="assetLibraryId"
-						resourceName="portletName"
-						source="AssetLibrary" + schemaName
-					/>
-				</@updateResourcePermissions>
+					<@updateResourcePermissions
+						groupId = "assetLibraryId"
+						resourceId = "assetLibraryId"
+						resourceName = "portletName"
+					>
+						<@getActions
+							resourceId="assetLibraryId"
+							resourceName="portletName"
+							source="AssetLibrary" + schemaName
+						/>
+					</@updateResourcePermissions>
+				<#else>
+					throw new UnsupportedOperationException("This method needs to be implemented");
+				</#if>
 			<#elseif stringUtil.equals(javaMethodSignature.methodName, "putSite" + schemaName + "PermissionsPage")>
 				<#if freeMarkerTool.hasParameter(javaMethodSignature, "siteId")>
 					<#assign generateGetPermissionCheckerMethods = true />

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -261,8 +261,7 @@ public abstract class Base${schemaName}ResourceImpl
 													${schemaVarName}Id
 												</#if>
 										<#elseif getParentPermissionsPageJavaMethodSignature?has_content>
-											${getParentPermissionsPageJavaMethodSignature.methodName}(
-												${parentSchemaName?uncap_first}ExternalReferenceCode, ${schemaVarName}.getExternalReferenceCode()
+											${getParentPermissionsPageJavaMethodSignature.methodName}(${parentSchemaName?uncap_first}ExternalReferenceCode, ${schemaVarName}.getExternalReferenceCode()
 										</#if>
 											, null);
 
@@ -289,8 +288,7 @@ public abstract class Base${schemaName}ResourceImpl
 											${schemaVarName}Id
 										</#if>
 									<#elseif getParentPermissionsPageJavaMethodSignature?has_content>
-										${getParentPermissionsPageJavaMethodSignature.methodName}(
-											${parentSchemaName?uncap_first}ExternalReferenceCode, ${httpMethod}${schemaName}.getExternalReferenceCode()
+										${getParentPermissionsPageJavaMethodSignature.methodName}(${parentSchemaName?uncap_first}ExternalReferenceCode, ${httpMethod}${schemaName}.getExternalReferenceCode()
 									</#if>
 											, null);
 
@@ -328,8 +326,7 @@ public abstract class Base${schemaName}ResourceImpl
 								${schemaVarName}Id
 							</#if>
 						<#elseif putParentPermissionsPageJavaMethodSignature?has_content>
-							${putParentPermissionsPageJavaMethodSignature.methodName}(
-								${parentSchemaName?uncap_first}ExternalReferenceCode, ${httpMethod}${schemaName}.getExternalReferenceCode()
+							${putParentPermissionsPageJavaMethodSignature.methodName}(${parentSchemaName?uncap_first}ExternalReferenceCode, ${httpMethod}${schemaName}.getExternalReferenceCode()
 						</#if>
 							, permissions);
 

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -198,6 +198,20 @@ public abstract class Base${schemaName}ResourceImpl
 		</#if>
 
 		<#if generatePermissions>
+			<#assign
+				getPermissionsPageJavaMethodSignature = freeMarkerTool.getPermissionsPageJavaMethodSignature("get", javaMethodSignatures, schemaName)!""
+				putPermissionsPageJavaMethodSignature = freeMarkerTool.getPermissionsPageJavaMethodSignature("put", javaMethodSignatures, schemaName)!""
+			/>
+
+			<#if !(getPermissionsPageJavaMethodSignature?has_content || putPermissionsPageJavaMethodSignature?has_content)>
+				<#assign
+					getParentPermissionsPageJavaMethodSignature = freeMarkerTool.getParentPermissionsPageJavaMethodSignature("get", javaMethodSignatures, parentSchemaName, schemaName)!""
+					putParentPermissionsPageJavaMethodSignature = freeMarkerTool.getParentPermissionsPageJavaMethodSignature("put", javaMethodSignatures, parentSchemaName, schemaName)!""
+				/>
+			</#if>
+		</#if>
+
+		<#if generatePermissions && ((getPermissionsPageJavaMethodSignature?has_content && putPermissionsPageJavaMethodSignature?has_content) || (getParentPermissionsPageJavaMethodSignature?has_content && putParentPermissionsPageJavaMethodSignature?has_content))>
 			protected abstract ${javaMethodSignature.returnType} do${stringUtil.upperCaseFirstLetter(javaMethodSignature.methodName)}(${freeMarkerTool.getResourceParameters(configYAML, javaMethodSignature.javaMethodParameters, javaMethodSignature.operation, allSchemas, false)}) throws Exception;
 
 			<#if configYAML.application??>
@@ -231,7 +245,7 @@ public abstract class Base${schemaName}ResourceImpl
 								${schemaVarName}.setPermissions(
 									() -> NestedFieldsSupplier.supply("permissions", nestedField -> {
 										Page<Permission> permissionsPage =
-										<#if freeMarkerTool.getPermissionsPageJavaMethodSignature("get", javaMethodSignatures, schemaName)??>
+										<#if getPermissionsPageJavaMethodSignature?has_content>
 											get${schemaName}PermissionsPage(
 												<#if properties?keys?seq_contains("id")>
 													${schemaVarName}.getId()
@@ -240,7 +254,7 @@ public abstract class Base${schemaName}ResourceImpl
 												<#else>
 													${schemaVarName}Id
 												</#if>
-										<#elseif freeMarkerTool.getParentPermissionsPageJavaMethodSignature("get", javaMethodSignatures, parentSchemaName, schemaName)??>
+										<#elseif getParentPermissionsPageJavaMethodSignature?has_content>
 											get${parentSchemaName}${schemaName}PermissionsPage(
 												${parentSchemaName?uncap_first}ExternalReferenceCode, ${schemaVarName}.getExternalReferenceCode()
 										</#if>
@@ -259,7 +273,7 @@ public abstract class Base${schemaName}ResourceImpl
 							${httpMethod}${schemaName}.setPermissions(
 								() -> NestedFieldsSupplier.supply("permissions", nestedField -> {
 									Page<Permission> permissionsPage =
-									<#if freeMarkerTool.getPermissionsPageJavaMethodSignature("get", javaMethodSignatures, schemaName)??>
+									<#if getPermissionsPageJavaMethodSignature?has_content>
 										get${schemaName}PermissionsPage(
 										<#if properties?keys?seq_contains("id")>
 											${httpMethod}${schemaName}.getId()
@@ -268,7 +282,7 @@ public abstract class Base${schemaName}ResourceImpl
 										<#else>
 											${schemaVarName}Id
 										</#if>
-									<#elseif freeMarkerTool.getParentPermissionsPageJavaMethodSignature("get", javaMethodSignatures, parentSchemaName, schemaName)??>
+									<#elseif getParentPermissionsPageJavaMethodSignature?has_content>
 										get${parentSchemaName}${schemaName}PermissionsPage(
 											${parentSchemaName?uncap_first}ExternalReferenceCode, ${httpMethod}${schemaName}.getExternalReferenceCode()
 									</#if>
@@ -298,7 +312,7 @@ public abstract class Base${schemaName}ResourceImpl
 
 					if (permissions != null) {
 						Page<Permission> permissionsPage =
-						<#if freeMarkerTool.getPermissionsPageJavaMethodSignature("put", javaMethodSignatures, schemaName)??>
+						<#if putPermissionsPageJavaMethodSignature?has_content>
 							put${schemaName}PermissionsPage(
 							<#if properties?keys?seq_contains("id")>
 								${httpMethod}${schemaName}.getId()
@@ -307,7 +321,7 @@ public abstract class Base${schemaName}ResourceImpl
 							<#else>
 								${schemaVarName}Id
 							</#if>
-						<#elseif freeMarkerTool.getParentPermissionsPageJavaMethodSignature("put", javaMethodSignatures, parentSchemaName, schemaName)??>
+						<#elseif putParentPermissionsPageJavaMethodSignature?has_content>
 							put${parentSchemaName}${schemaName}PermissionsPage(
 								${parentSchemaName?uncap_first}ExternalReferenceCode, ${httpMethod}${schemaName}.getExternalReferenceCode()
 						</#if>

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -246,7 +246,7 @@ public abstract class Base${schemaName}ResourceImpl
 									() -> NestedFieldsSupplier.supply("permissions", nestedField -> {
 										Page<Permission> permissionsPage =
 										<#if getPermissionsPageJavaMethodSignature?has_content>
-											get${schemaName}PermissionsPage(
+											${getPermissionsPageJavaMethodSignature.methodName}(
 												<#if properties?keys?seq_contains("id")>
 													${schemaVarName}.getId()
 												<#elseif properties?keys?seq_contains(schemaVarName + "Id")>
@@ -255,7 +255,7 @@ public abstract class Base${schemaName}ResourceImpl
 													${schemaVarName}Id
 												</#if>
 										<#elseif getParentPermissionsPageJavaMethodSignature?has_content>
-											get${parentSchemaName}${schemaName}PermissionsPage(
+											${getParentPermissionsPageJavaMethodSignature.methodName}(
 												${parentSchemaName?uncap_first}ExternalReferenceCode, ${schemaVarName}.getExternalReferenceCode()
 										</#if>
 											, null);
@@ -274,7 +274,7 @@ public abstract class Base${schemaName}ResourceImpl
 								() -> NestedFieldsSupplier.supply("permissions", nestedField -> {
 									Page<Permission> permissionsPage =
 									<#if getPermissionsPageJavaMethodSignature?has_content>
-										get${schemaName}PermissionsPage(
+										${getPermissionsPageJavaMethodSignature.methodName}(
 										<#if properties?keys?seq_contains("id")>
 											${httpMethod}${schemaName}.getId()
 										<#elseif properties?keys?seq_contains(schemaVarName + "Id")>
@@ -283,7 +283,7 @@ public abstract class Base${schemaName}ResourceImpl
 											${schemaVarName}Id
 										</#if>
 									<#elseif getParentPermissionsPageJavaMethodSignature?has_content>
-										get${parentSchemaName}${schemaName}PermissionsPage(
+										${getParentPermissionsPageJavaMethodSignature.methodName}(
 											${parentSchemaName?uncap_first}ExternalReferenceCode, ${httpMethod}${schemaName}.getExternalReferenceCode()
 									</#if>
 											, null);
@@ -313,7 +313,7 @@ public abstract class Base${schemaName}ResourceImpl
 					if (permissions != null) {
 						Page<Permission> permissionsPage =
 						<#if putPermissionsPageJavaMethodSignature?has_content>
-							put${schemaName}PermissionsPage(
+							${putPermissionsPageJavaMethodSignature.methodName}(
 							<#if properties?keys?seq_contains("id")>
 								${httpMethod}${schemaName}.getId()
 							<#elseif properties?keys?seq_contains(schemaVarName + "Id")>
@@ -322,7 +322,7 @@ public abstract class Base${schemaName}ResourceImpl
 								${schemaVarName}Id
 							</#if>
 						<#elseif putParentPermissionsPageJavaMethodSignature?has_content>
-							put${parentSchemaName}${schemaName}PermissionsPage(
+							${putParentPermissionsPageJavaMethodSignature.methodName}(
 								${parentSchemaName?uncap_first}ExternalReferenceCode, ${httpMethod}${schemaName}.getExternalReferenceCode()
 						</#if>
 							, permissions);

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -146,8 +146,12 @@ public abstract class Base${schemaName}ResourceImpl
 		</#if>
 
 		<#assign
-			generatePermissions = freeMarkerTool.isGeneratePermissions(configYAML, javaMethodSignature, javaMethodSignatures, schema, schemaName)
+			generatePermissions = false
+			getParentPermissionsPageJavaMethodSignature = ""
+			getPermissionsPageJavaMethodSignature = ""
 			httpMethod = freeMarkerTool.getHTTPMethod(javaMethodSignature.operation)
+			putParentPermissionsPageJavaMethodSignature = ""
+			putPermissionsPageJavaMethodSignature = ""
 			parentSchemaName = javaMethodSignature.parentSchemaName!
 		/>
 
@@ -197,7 +201,7 @@ public abstract class Base${schemaName}ResourceImpl
 			</#if>
 		</#if>
 
-		<#if generatePermissions>
+		<#if freeMarkerTool.isGeneratePermissions(configYAML, javaMethodSignature, javaMethodSignatures, schema, schemaName)>
 			<#assign
 				getPermissionsPageJavaMethodSignature = freeMarkerTool.getPermissionsPageJavaMethodSignature("get", javaMethodSignatures, schemaName)!""
 				putPermissionsPageJavaMethodSignature = freeMarkerTool.getPermissionsPageJavaMethodSignature("put", javaMethodSignatures, schemaName)!""
@@ -211,7 +215,9 @@ public abstract class Base${schemaName}ResourceImpl
 			</#if>
 		</#if>
 
-		<#if generatePermissions && ((getPermissionsPageJavaMethodSignature?has_content && putPermissionsPageJavaMethodSignature?has_content) || (getParentPermissionsPageJavaMethodSignature?has_content && putParentPermissionsPageJavaMethodSignature?has_content))>
+		<#if ((getPermissionsPageJavaMethodSignature?has_content && putPermissionsPageJavaMethodSignature?has_content) || (getParentPermissionsPageJavaMethodSignature?has_content && putParentPermissionsPageJavaMethodSignature?has_content))>
+			<#assign generatePermissions = true />
+
 			protected abstract ${javaMethodSignature.returnType} do${stringUtil.upperCaseFirstLetter(javaMethodSignature.methodName)}(${freeMarkerTool.getResourceParameters(configYAML, javaMethodSignature.javaMethodParameters, javaMethodSignature.operation, allSchemas, false)}) throws Exception;
 
 			<#if configYAML.application??>

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -280,13 +280,13 @@ public abstract class Base${schemaName}ResourceImpl
 									Page<Permission> permissionsPage =
 									<#if getPermissionsPageJavaMethodSignature?has_content>
 										${getPermissionsPageJavaMethodSignature.methodName}(
-										<#if properties?keys?seq_contains("id")>
-											${httpMethod}${schemaName}.getId()
-										<#elseif properties?keys?seq_contains(schemaVarName + "Id")>
-											${httpMethod}${schemaName}.get${schemaVarName}Id()
-										<#else>
-											${schemaVarName}Id
-										</#if>
+											<#if properties?keys?seq_contains("id")>
+												${httpMethod}${schemaName}.getId()
+											<#elseif properties?keys?seq_contains(schemaVarName + "Id")>
+												${httpMethod}${schemaName}.get${schemaVarName}Id()
+											<#else>
+												${schemaVarName}Id
+											</#if>
 									<#elseif getParentPermissionsPageJavaMethodSignature?has_content>
 										${getParentPermissionsPageJavaMethodSignature.methodName}(${parentSchemaName?uncap_first}ExternalReferenceCode, ${httpMethod}${schemaName}.getExternalReferenceCode()
 									</#if>
@@ -318,13 +318,13 @@ public abstract class Base${schemaName}ResourceImpl
 						Page<Permission> permissionsPage =
 						<#if putPermissionsPageJavaMethodSignature?has_content>
 							${putPermissionsPageJavaMethodSignature.methodName}(
-							<#if properties?keys?seq_contains("id")>
-								${httpMethod}${schemaName}.getId()
-							<#elseif properties?keys?seq_contains(schemaVarName + "Id")>
-								${httpMethod}${schemaName}.get${schemaVarName}Id()
-							<#else>
-								${schemaVarName}Id
-							</#if>
+								<#if properties?keys?seq_contains("id")>
+									${httpMethod}${schemaName}.getId()
+								<#elseif properties?keys?seq_contains(schemaVarName + "Id")>
+									${httpMethod}${schemaName}.get${schemaVarName}Id()
+								<#else>
+									${schemaVarName}Id
+								</#if>
 						<#elseif putParentPermissionsPageJavaMethodSignature?has_content>
 							${putParentPermissionsPageJavaMethodSignature.methodName}(${parentSchemaName?uncap_first}ExternalReferenceCode, ${httpMethod}${schemaName}.getExternalReferenceCode()
 						</#if>

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
@@ -54,7 +54,7 @@ import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 />
 
 <#list javaMethodSignatures as javaMethodSignature>
-	<#if freeMarkerTool.isGeneratePermissions(configYAML, javaMethodSignature, javaMethodSignatures, schema, schemaName)>
+	<#if freeMarkerTool.isGeneratePermissions(configYAML, javaMethodSignature, javaMethodSignatures, schema, schemaName) && ((freeMarkerTool.getPermissionsPageJavaMethodSignature("get", javaMethodSignatures, schemaName)?? && freeMarkerTool.getPermissionsPageJavaMethodSignature("put", javaMethodSignatures, schemaName)??) || (freeMarkerTool.getParentPermissionsPageJavaMethodSignature("get", javaMethodSignatures, javaMethodSignature.parentSchemaName, schemaName)?? && freeMarkerTool.getParentPermissionsPageJavaMethodSignature("put", javaMethodSignatures, javaMethodSignature.parentSchemaName, schemaName)??))>
 		<#assign generatePermissionsJavaMethodSignatures = generatePermissionsJavaMethodSignatures + [javaMethodSignature] />
 	</#if>
 </#list>

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
@@ -54,7 +54,7 @@ import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 />
 
 <#list javaMethodSignatures as javaMethodSignature>
-	<#if freeMarkerTool.isGeneratePermissions(configYAML, javaMethodSignature, javaMethodSignatures, schema, schemaName) && ((freeMarkerTool.getPermissionsPageJavaMethodSignature("get", javaMethodSignatures, schemaName)?? && freeMarkerTool.getPermissionsPageJavaMethodSignature("put", javaMethodSignatures, schemaName)??) || (freeMarkerTool.getParentPermissionsPageJavaMethodSignature("get", javaMethodSignatures, javaMethodSignature.parentSchemaName, schemaName)?? && freeMarkerTool.getParentPermissionsPageJavaMethodSignature("put", javaMethodSignatures, javaMethodSignature.parentSchemaName, schemaName)??))>
+	<#if freeMarkerTool.isGeneratePermissions(configYAML, javaMethodSignature, javaMethodSignatures, schema, schemaName) && ((freeMarkerTool.getJavaMethodSignature(javaMethodSignatures, "get" + schemaName + "PermissionsPage")?? && freeMarkerTool.getJavaMethodSignature(javaMethodSignatures, "get" + schemaName + "PermissionsPage")??) || (freeMarkerTool.getParentPermissionsPageJavaMethodSignature("get", javaMethodSignatures, javaMethodSignature.parentSchemaName, schemaName)?? && freeMarkerTool.getParentPermissionsPageJavaMethodSignature("put", javaMethodSignatures, javaMethodSignature.parentSchemaName, schemaName)??))>
 		<#assign generatePermissionsJavaMethodSignatures = generatePermissionsJavaMethodSignatures + [javaMethodSignature] />
 	</#if>
 </#list>


### PR DESCRIPTION
What's new?
- The "doGet/Put" logic now gets autogenerated when the put and get `sites/{siteExternalReferenceCode}/entity/{entityExternalReferenceCode}/permissions` or `asset-libraries/{assetLibraryExternalReferenceCode}/entity/{entityExternalReferenceCode}/permissions` endpoints are present.
- Test module has been updated to make sure the new usecases are taken into account.

Take a look at the following Jira ticket: [LPD-61105](https://liferay.atlassian.net/browse/LPD-61105)