### PR TITLE
LPD-62455-v3 Layout settings are not updated in staging

### DIFF
--- a/modules/apps/portlet-preferences/portlet-preferences-test/src/testIntegration/java/com/liferay/portlet/preferences/test/PortletPreferencesLocalServiceTest.java
+++ b/modules/apps/portlet-preferences/portlet-preferences-test/src/testIntegration/java/com/liferay/portlet/preferences/test/PortletPreferencesLocalServiceTest.java
@@ -7,7 +7,6 @@ package com.liferay.portlet.preferences.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.exportimport.kernel.service.StagingLocalService;
-import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringPool;
@@ -26,6 +25,8 @@ import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalServiceWrapper;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.ServiceWrapper;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.CompanyProviderClassTestRule;
@@ -1328,9 +1329,9 @@ public class PortletPreferencesLocalServiceTest
 
 	@Test
 	public void testUpdateTypeSettingsLayoutRevision() throws Exception {
-		String originalName = PrincipalThreadLocal.getName();
+		Layout layout = LayoutTestUtil.addTypeContentLayout(testGroup);
 
-		Layout layoutInit = LayoutTestUtil.addTypeContentLayout(testGroup);
+		String originalName = PrincipalThreadLocal.getName();
 
 		try {
 			PrincipalThreadLocal.setName(TestPropsValues.getUserId());
@@ -1344,8 +1345,8 @@ public class PortletPreferencesLocalServiceTest
 
 			Layout stagingLayout =
 				_layoutLocalService.getLayoutByUuidAndGroupId(
-					layoutInit.getUuid(), stagingGroup.getGroupId(),
-					layoutInit.isPrivateLayout());
+					layout.getUuid(), stagingGroup.getGroupId(),
+					layout.isPrivateLayout());
 
 			Layout draftLayout = stagingLayout.fetchDraftLayout();
 
@@ -1363,7 +1364,12 @@ public class PortletPreferencesLocalServiceTest
 				draftLayout.getLayoutId(),
 				typeSettingsUnicodeProperties.toString());
 
-			ContentLayoutTestUtil.publishLayout(draftLayout, stagingLayout);
+			ServiceContext serviceContext =
+				ServiceContextTestUtil.getServiceContext();
+
+			serviceContext.setAttribute("exporting", Boolean.FALSE);
+
+			ServiceContextThreadLocal.pushServiceContext(serviceContext);
 
 			portletPreferencesLocalService.updatePreferences(
 				PortletKeys.PREFS_OWNER_ID_DEFAULT,
@@ -1394,6 +1400,7 @@ public class PortletPreferencesLocalServiceTest
 		}
 		finally {
 			PrincipalThreadLocal.setName(originalName);
+			ServiceContextThreadLocal.popServiceContext();
 		}
 	}
 

--- a/modules/apps/portlet-preferences/portlet-preferences-test/src/testIntegration/java/com/liferay/portlet/preferences/test/PortletPreferencesLocalServiceTest.java
+++ b/modules/apps/portlet-preferences/portlet-preferences-test/src/testIntegration/java/com/liferay/portlet/preferences/test/PortletPreferencesLocalServiceTest.java
@@ -1355,7 +1355,8 @@ public class PortletPreferencesLocalServiceTest
 			String propertyKey = RandomTestUtil.randomString();
 			String propertyValue = RandomTestUtil.randomString();
 
-			typeSettingsUnicodeProperties.setProperty(propertyKey, propertyValue);
+			typeSettingsUnicodeProperties.setProperty(
+				propertyKey, propertyValue);
 
 			_layoutLocalService.updateLayout(
 				draftLayout.getGroupId(), draftLayout.isPrivateLayout(),

--- a/modules/apps/portlet-preferences/portlet-preferences-test/src/testIntegration/java/com/liferay/portlet/preferences/test/PortletPreferencesLocalServiceTest.java
+++ b/modules/apps/portlet-preferences/portlet-preferences-test/src/testIntegration/java/com/liferay/portlet/preferences/test/PortletPreferencesLocalServiceTest.java
@@ -6,6 +6,8 @@
 package com.liferay.portlet.preferences.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.exportimport.kernel.service.StagingLocalService;
+import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringPool;
@@ -13,11 +15,15 @@ import com.liferay.portal.deploy.hot.ServiceBag;
 import com.liferay.portal.kernel.bean.ClassLoaderBeanHandler;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutRevision;
+import com.liferay.portal.kernel.model.LayoutStagingHandler;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.model.PortletApp;
 import com.liferay.portal.kernel.model.PortletPreferences;
 import com.liferay.portal.kernel.model.PortletPreferencesIds;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalServiceWrapper;
 import com.liferay.portal.kernel.service.ServiceWrapper;
@@ -25,12 +31,17 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.CompanyProviderClassTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.model.impl.PortletAppImpl;
 import com.liferay.portal.spring.aop.AopInvocationHandler;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portlet.PortletPreferencesImpl;
 import com.liferay.portlet.StrictPortletPreferencesImpl;
 
@@ -61,11 +72,13 @@ public class PortletPreferencesLocalServiceTest
 	@ClassRule
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
-		new LiferayIntegrationTestRule() {
-			{
-				skipTestRule(CompanyProviderClassTestRule.INSTANCE);
-			}
-		};
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule() {
+				{
+					skipTestRule(CompanyProviderClassTestRule.INSTANCE);
+				}
+			},
+			PermissionCheckerMethodTestRule.INSTANCE);
 
 	@BeforeClass
 	public static void setUpClass() {
@@ -1313,6 +1326,76 @@ public class PortletPreferencesLocalServiceTest
 		assertValues(currentJxPortletPreferences, _NAME, _MULTIPLE_VALUES);
 	}
 
+	@Test
+	public void testUpdateTypeSettingsLayoutRevision() throws Exception {
+		String originalName = PrincipalThreadLocal.getName();
+
+		Layout layoutInit = LayoutTestUtil.addTypeContentLayout(testGroup);
+
+		try {
+			PrincipalThreadLocal.setName(TestPropsValues.getUserId());
+
+			_stagingLocalService.enableLocalStaging(
+				TestPropsValues.getUserId(), testGroup, true, false,
+				ServiceContextTestUtil.getServiceContext(
+					testGroup, TestPropsValues.getUserId()));
+
+			Group stagingGroup = testGroup.getStagingGroup();
+
+			Layout stagingLayout =
+				_layoutLocalService.getLayoutByUuidAndGroupId(
+					layoutInit.getUuid(), stagingGroup.getGroupId(),
+					layoutInit.isPrivateLayout());
+
+			Layout draftLayout = stagingLayout.fetchDraftLayout();
+
+			UnicodeProperties typeSettingsUnicodeProperties =
+				draftLayout.getTypeSettingsProperties();
+
+			String property = RandomTestUtil.randomString();
+			String valueProperty = RandomTestUtil.randomString();
+
+			typeSettingsUnicodeProperties.setProperty(property, valueProperty);
+
+			_layoutLocalService.updateLayout(
+				draftLayout.getGroupId(), draftLayout.isPrivateLayout(),
+				draftLayout.getLayoutId(),
+				typeSettingsUnicodeProperties.toString());
+
+			ContentLayoutTestUtil.publishLayout(draftLayout, stagingLayout);
+
+			portletPreferencesLocalService.updatePreferences(
+				PortletKeys.PREFS_OWNER_ID_DEFAULT,
+				PortletKeys.PREFS_OWNER_TYPE_LAYOUT, stagingLayout.getPlid(),
+				testPortlet.getPortletId(),
+				getPortletPreferencesXML(_NAME, _SINGLE_VALUE));
+
+			Layout updatedLayout = _layoutLocalService.getLayout(
+				stagingLayout.getPlid());
+
+			LayoutStagingHandler layoutStagingHandler =
+				new LayoutStagingHandler(updatedLayout);
+
+			LayoutRevision layoutRevision =
+				layoutStagingHandler.getLayoutRevision();
+
+			Assert.assertTrue(
+				layoutRevision.getTypeSettings(
+				).contains(
+					property + "=" + valueProperty
+				));
+
+			Assert.assertTrue(
+				updatedLayout.getTypeSettings(
+				).contains(
+					property + "=" + valueProperty
+				));
+		}
+		finally {
+			PrincipalThreadLocal.setName(originalName);
+		}
+	}
+
 	protected void assertEmptyPortletPreferencesMap(
 		jakarta.portlet.PortletPreferences jxPortletPreferences) {
 
@@ -1445,7 +1528,13 @@ public class PortletPreferencesLocalServiceTest
 	@DeleteAfterTestRun
 	private final List<Group> _groups = new ArrayList<>();
 
+	@Inject
+	private LayoutLocalService _layoutLocalService;
+
 	private ServiceBag<PortletPreferencesLocalService> _serviceBag;
+
+	@Inject
+	private StagingLocalService _stagingLocalService;
 
 	private static class TestPortletPreferencesLocalServiceWrapper
 		extends PortletPreferencesLocalServiceWrapper {

--- a/modules/apps/portlet-preferences/portlet-preferences-test/src/testIntegration/java/com/liferay/portlet/preferences/test/PortletPreferencesLocalServiceTest.java
+++ b/modules/apps/portlet-preferences/portlet-preferences-test/src/testIntegration/java/com/liferay/portlet/preferences/test/PortletPreferencesLocalServiceTest.java
@@ -1352,10 +1352,10 @@ public class PortletPreferencesLocalServiceTest
 			UnicodeProperties typeSettingsUnicodeProperties =
 				draftLayout.getTypeSettingsProperties();
 
-			String property = RandomTestUtil.randomString();
-			String valueProperty = RandomTestUtil.randomString();
+			String propertyKey = RandomTestUtil.randomString();
+			String propertyValue = RandomTestUtil.randomString();
 
-			typeSettingsUnicodeProperties.setProperty(property, valueProperty);
+			typeSettingsUnicodeProperties.setProperty(propertyKey, propertyValue);
 
 			_layoutLocalService.updateLayout(
 				draftLayout.getGroupId(), draftLayout.isPrivateLayout(),
@@ -1382,13 +1382,13 @@ public class PortletPreferencesLocalServiceTest
 			Assert.assertTrue(
 				layoutRevision.getTypeSettings(
 				).contains(
-					property + "=" + valueProperty
+					propertyKey + "=" + propertyValue
 				));
 
 			Assert.assertTrue(
 				updatedLayout.getTypeSettings(
 				).contains(
-					property + "=" + valueProperty
+					propertyKey + "=" + propertyValue
 				));
 		}
 		finally {

--- a/portal-impl/src/com/liferay/portal/service/impl/PortletPreferencesLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletPreferencesLocalServiceImpl.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutRevisionLocalService;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.service.PortletPreferenceValueLocalService;
@@ -943,13 +944,27 @@ public class PortletPreferencesLocalServiceImpl
 
 			serviceContext.setAttribute("revisionInProgress", hasWorkflowTask);
 
+			Layout layout = _layoutLocalService.getLayout(
+				layoutRevision.getPlid());
+
+			Layout draftLayout = layout.fetchDraftLayout();
+
+			String typeSettings = null;
+
+			if (draftLayout != null) {
+				typeSettings = draftLayout.getTypeSettings();
+			}
+			else {
+				typeSettings = layoutRevision.getTypeSettings();
+			}
+
 			layoutRevision = _layoutRevisionLocalService.updateLayoutRevision(
 				serviceContext.getUserId(),
 				layoutRevision.getLayoutRevisionId(),
 				layoutRevision.getLayoutBranchId(), layoutRevision.getName(),
 				layoutRevision.getTitle(), layoutRevision.getDescription(),
 				layoutRevision.getKeywords(), layoutRevision.getRobots(),
-				layoutRevision.getTypeSettings(), layoutRevision.getIconImage(),
+				typeSettings, layoutRevision.getIconImage(),
 				layoutRevision.getIconImageId(), layoutRevision.getThemeId(),
 				layoutRevision.getColorSchemeId(), layoutRevision.getCss(),
 				serviceContext);
@@ -1153,6 +1168,9 @@ public class PortletPreferencesLocalServiceImpl
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		PortletPreferencesLocalServiceImpl.class);
+
+	@BeanReference(type = LayoutLocalService.class)
+	private LayoutLocalService _layoutLocalService;
 
 	@BeanReference(type = LayoutPersistence.class)
 	private LayoutPersistence _layoutPersistence;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-62455

New pr to make [Brian's changes](https://github.com/brianchandotcom/liferay-portal/pull/164560#issuecomment-3193123633). 

## Problem
When Staging is enabled,  the `typesettings` are getting from `LauoutRevision` table, but it is not updated. It is only updated  `Layout` table. 

## Solution
When the `Layout` table is updated, we have updated the `LayoutRevision` table entry when Staging is enabled (`portal-impl/src/com/liferay/portal/service/impl/PortletPreferencesLocalServiceImpl.java`)


## Test
Go to **modules/apps/portlet-preferences/portlet-preferences-test** and run
`gw testIntegration --tests PortletPreferencesLocalServiceTest.testUpdateTypeSettingsLayoutRevision`

```
com.liferay.portlet.preferences.test.PortletPreferencesLocalServiceTest STANDARD_OUT
    Loading jar:file:/home/alvaro/workspace/Liferay/liferay-portal/bundles/tomcat-10.1.43/webapps/ROOT/WEB-INF/shielded-container-lib/portal-impl.jar!/system.properties
    Loading jar:file:/home/alvaro/workspace/Liferay/liferay-portal/liferay-portal/.m2/com/liferay/portal/com.liferay.portal.impl/116.0.0-SNAPSHOT/com.liferay.portal.impl-116.0.0-SNAPSHOT.jar!/system.properties

com.liferay.portlet.preferences.test.PortletPreferencesLocalServiceTest > testUpdateTypeSettingsLayoutRevision STARTED

com.liferay.portlet.preferences.test.PortletPreferencesLocalServiceTest > testUpdateTypeSettingsLayoutRevision PASSED

> Task :apps:portlet-preferences:portlet-preferences-test:stopTestableTomcat


BUILD SUCCESSFUL in 19s
284 actionable tasks: 7 executed, 277 up-to-date
```

More info in the [comment](https://liferay.atlassian.net/browse/LPD-62455?focusedCommentId=2993484). 