### PR TITLE
LPD-62806 CMS asset type does not appear in table view

### DIFF
--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/ObjectDefinitionBrief.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/ObjectDefinitionBrief.java
@@ -1,0 +1,363 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.rest.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+import java.io.Serializable;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+@GraphQLName("ObjectDefinitionBrief")
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "ObjectDefinitionBrief")
+public class ObjectDefinitionBrief implements Serializable {
+
+	public static ObjectDefinitionBrief toDTO(String json) {
+		return ObjectMapperUtil.readValue(ObjectDefinitionBrief.class, json);
+	}
+
+	public static ObjectDefinitionBrief unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(
+			ObjectDefinitionBrief.class, json);
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The object definition's external reference code."
+	)
+	public String getExternalReferenceCode() {
+		if (_externalReferenceCodeSupplier != null) {
+			externalReferenceCode = _externalReferenceCodeSupplier.get();
+
+			_externalReferenceCodeSupplier = null;
+		}
+
+		return externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		this.externalReferenceCode = externalReferenceCode;
+
+		_externalReferenceCodeSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setExternalReferenceCode(
+		UnsafeSupplier<String, Exception> externalReferenceCodeUnsafeSupplier) {
+
+		_externalReferenceCodeSupplier = () -> {
+			try {
+				return externalReferenceCodeUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "The object definition's external reference code."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String externalReferenceCode;
+
+	@JsonIgnore
+	private Supplier<String> _externalReferenceCodeSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The object definition's label."
+	)
+	public String getLabel() {
+		if (_labelSupplier != null) {
+			label = _labelSupplier.get();
+
+			_labelSupplier = null;
+		}
+
+		return label;
+	}
+
+	public void setLabel(String label) {
+		this.label = label;
+
+		_labelSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setLabel(
+		UnsafeSupplier<String, Exception> labelUnsafeSupplier) {
+
+		_labelSupplier = () -> {
+			try {
+				return labelUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(description = "The object definition's label.")
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String label;
+
+	@JsonIgnore
+	private Supplier<String> _labelSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The object folder's external reference code."
+	)
+	public String getObjectFolderExternalReferenceCode() {
+		if (_objectFolderExternalReferenceCodeSupplier != null) {
+			objectFolderExternalReferenceCode =
+				_objectFolderExternalReferenceCodeSupplier.get();
+
+			_objectFolderExternalReferenceCodeSupplier = null;
+		}
+
+		return objectFolderExternalReferenceCode;
+	}
+
+	public void setObjectFolderExternalReferenceCode(
+		String objectFolderExternalReferenceCode) {
+
+		this.objectFolderExternalReferenceCode =
+			objectFolderExternalReferenceCode;
+
+		_objectFolderExternalReferenceCodeSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setObjectFolderExternalReferenceCode(
+		UnsafeSupplier<String, Exception>
+			objectFolderExternalReferenceCodeUnsafeSupplier) {
+
+		_objectFolderExternalReferenceCodeSupplier = () -> {
+			try {
+				return objectFolderExternalReferenceCodeUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(description = "The object folder's external reference code.")
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String objectFolderExternalReferenceCode;
+
+	@JsonIgnore
+	private Supplier<String> _objectFolderExternalReferenceCodeSupplier;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof ObjectDefinitionBrief)) {
+			return false;
+		}
+
+		ObjectDefinitionBrief objectDefinitionBrief =
+			(ObjectDefinitionBrief)object;
+
+		return Objects.equals(toString(), objectDefinitionBrief.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		String externalReferenceCode = getExternalReferenceCode();
+
+		if (externalReferenceCode != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"externalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(externalReferenceCode));
+
+			sb.append("\"");
+		}
+
+		String label = getLabel();
+
+		if (label != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"label\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(label));
+
+			sb.append("\"");
+		}
+
+		String objectFolderExternalReferenceCode =
+			getObjectFolderExternalReferenceCode();
+
+		if (objectFolderExternalReferenceCode != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"objectFolderExternalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(objectFolderExternalReferenceCode));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		accessMode = io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.object.rest.dto.v1_0.ObjectDefinitionBrief",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof Map) {
+						sb.append(_toJSON((Map<String, ?>)valueArray[i]));
+					}
+					else if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+	private Map<String, Serializable> _extendedProperties;
+
+}

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/SystemProperties.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/SystemProperties.java
@@ -50,6 +50,51 @@ public class SystemProperties implements Serializable {
 
 	@io.swagger.v3.oas.annotations.media.Schema
 	@Valid
+	public ObjectDefinitionBrief getObjectDefinitionBrief() {
+		if (_objectDefinitionBriefSupplier != null) {
+			objectDefinitionBrief = _objectDefinitionBriefSupplier.get();
+
+			_objectDefinitionBriefSupplier = null;
+		}
+
+		return objectDefinitionBrief;
+	}
+
+	public void setObjectDefinitionBrief(
+		ObjectDefinitionBrief objectDefinitionBrief) {
+
+		this.objectDefinitionBrief = objectDefinitionBrief;
+
+		_objectDefinitionBriefSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setObjectDefinitionBrief(
+		UnsafeSupplier<ObjectDefinitionBrief, Exception>
+			objectDefinitionBriefUnsafeSupplier) {
+
+		_objectDefinitionBriefSupplier = () -> {
+			try {
+				return objectDefinitionBriefUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected ObjectDefinitionBrief objectDefinitionBrief;
+
+	@JsonIgnore
+	private Supplier<ObjectDefinitionBrief> _objectDefinitionBriefSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	@Valid
 	public Version getVersion() {
 		if (_versionSupplier != null) {
 			version = _versionSupplier.get();
@@ -116,6 +161,19 @@ public class SystemProperties implements Serializable {
 		StringBundler sb = new StringBundler();
 
 		sb.append("{");
+
+		ObjectDefinitionBrief objectDefinitionBrief =
+			getObjectDefinitionBrief();
+
+		if (objectDefinitionBrief != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"objectDefinitionBrief\": ");
+
+			sb.append(String.valueOf(objectDefinitionBrief));
+		}
 
 		Version version = getVersion();
 

--- a/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/dto/v1_0/packageinfo
+++ b/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 2.4.0
+version 2.5.0

--- a/modules/apps/object/object-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-rest-impl/rest-openapi.yaml
@@ -96,6 +96,24 @@ components:
                         type: string
                     readOnly: true
                     type: object
+        ObjectDefinitionBrief:
+            properties:
+                externalReferenceCode:
+                    description:
+                        The object definition's external reference code.
+                    readOnly: true
+                    type: string
+                label:
+                    description:
+                        The object definition's label.
+                    readOnly: true
+                    type: string
+                objectFolderExternalReferenceCode:
+                    description:
+                        The object folder's external reference code.
+                    readOnly: true
+                    type: string
+            type: object
         ObjectEntry:
             properties:
                 actions:
@@ -225,6 +243,8 @@ components:
             type: object
         SystemProperties:
             properties:
+                objectDefinitionBrief:
+                    $ref: "#/components/schemas/ObjectDefinitionBrief"
                 version:
                     $ref: "#/components/schemas/Version"
             type: object

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -39,6 +39,7 @@ import com.liferay.object.rest.dto.v1_0.AuditFieldChange;
 import com.liferay.object.rest.dto.v1_0.FileEntry;
 import com.liferay.object.rest.dto.v1_0.Folder;
 import com.liferay.object.rest.dto.v1_0.ListEntry;
+import com.liferay.object.rest.dto.v1_0.ObjectDefinitionBrief;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
 import com.liferay.object.rest.dto.v1_0.Scope;
 import com.liferay.object.rest.dto.v1_0.Status;
@@ -118,6 +119,7 @@ import java.sql.Timestamp;
 
 import java.text.SimpleDateFormat;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
@@ -431,10 +433,11 @@ public class ObjectEntryDTOConverter
 					() -> _getAttribute(
 						objectEntryVersion,
 						objectEntryVersion -> _toSystemProperties(
-							objectDefinition, objectEntryVersion.getVersion()),
+							dtoConverterContext.getLocale(), objectDefinition,
+							objectEntryVersion.getVersion()),
 						serviceBuilderObjectEntry,
 						serviceBuilderObjectEntry -> _toSystemProperties(
-							objectDefinition,
+							dtoConverterContext.getLocale(), objectDefinition,
 							serviceBuilderObjectEntry.getVersion())));
 				setTaxonomyCategoryBriefs(
 					() -> {
@@ -1121,6 +1124,20 @@ public class ObjectEntryDTOConverter
 		return false;
 	}
 
+	private boolean _isShowObjectDefinitionBrief() {
+		NestedFieldsContext nestedFieldsContext =
+			NestedFieldsContextThreadLocal.getNestedFieldsContext();
+
+		if (nestedFieldsContext == null) {
+			return false;
+		}
+
+		List<String> nestedFields = new ArrayList<>(
+			nestedFieldsContext.getNestedFields());
+
+		return nestedFields.contains("systemProperties.objectDefinitionBrief");
+	}
+
 	private AuditEvent[] _toAuditEvents(
 			DTOConverterContext dtoConverterContext,
 			ObjectDefinition objectDefinition,
@@ -1228,6 +1245,20 @@ public class ObjectEntryDTOConverter
 		}
 
 		return ExtendedEntity.extend(dto, nestedFieldsRelatedProperties, null);
+	}
+
+	private ObjectDefinitionBrief _toObjectDefinitionBrief(
+		Locale locale, ObjectDefinition objectDefinition) {
+
+		return new ObjectDefinitionBrief() {
+			{
+				setExternalReferenceCode(
+					objectDefinition::getExternalReferenceCode);
+				setLabel(() -> objectDefinition.getLabel(locale));
+				setObjectFolderExternalReferenceCode(
+					objectDefinition::getObjectFolderExternalReferenceCode);
+			}
+		};
 	}
 
 	private Permission[] _toPermissions(
@@ -1392,22 +1423,36 @@ public class ObjectEntryDTOConverter
 	}
 
 	private SystemProperties _toSystemProperties(
-		ObjectDefinition objectDefinition, int versionInt) {
+		Locale locale, ObjectDefinition objectDefinition, int versionInt) {
 
-		if (!objectDefinition.isEnableObjectEntryVersioning()) {
+		boolean enableObjectEntryVersioning =
+			objectDefinition.isEnableObjectEntryVersioning();
+		boolean showObjectDefinitionBrief = _isShowObjectDefinitionBrief();
+
+		if (!enableObjectEntryVersioning && !showObjectDefinitionBrief) {
 			return null;
 		}
 
-		return new SystemProperties() {
-			{
-				setVersion(
-					() -> new Version() {
-						{
-							setNumber(() -> versionInt);
-						}
-					});
-			}
-		};
+		SystemProperties systemProperties = new SystemProperties();
+
+		if (showObjectDefinitionBrief) {
+			systemProperties.setObjectDefinitionBrief(
+				() -> NestedFieldsSupplier.supply(
+					"systemProperties.objectDefinitionBrief",
+					nestedField -> _toObjectDefinitionBrief(
+						locale, objectDefinition)));
+		}
+
+		if (enableObjectEntryVersioning) {
+			systemProperties.setVersion(
+				() -> new Version() {
+					{
+						setNumber(() -> versionInt);
+					}
+				});
+		}
+
+		return systemProperties;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -119,7 +119,6 @@ import java.sql.Timestamp;
 
 import java.text.SimpleDateFormat;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
@@ -430,15 +429,18 @@ public class ObjectEntryDTOConverter
 							dtoConverterContext.getLocale(),
 							serviceBuilderObjectEntry.getStatus())));
 				setSystemProperties(
-					() -> _getAttribute(
-						objectEntryVersion,
-						objectEntryVersion -> _toSystemProperties(
+					() -> {
+						if (objectEntryVersion != null) {
+							return _toSystemProperties(
+								dtoConverterContext.getLocale(),
+								objectDefinition,
+								objectEntryVersion.getVersion());
+						}
+
+						return _toSystemProperties(
 							dtoConverterContext.getLocale(), objectDefinition,
-							objectEntryVersion.getVersion()),
-						serviceBuilderObjectEntry,
-						serviceBuilderObjectEntry -> _toSystemProperties(
-							dtoConverterContext.getLocale(), objectDefinition,
-							serviceBuilderObjectEntry.getVersion())));
+							serviceBuilderObjectEntry.getVersion());
+					});
 				setTaxonomyCategoryBriefs(
 					() -> {
 						if (objectEntryVersion != null) {
@@ -1124,20 +1126,6 @@ public class ObjectEntryDTOConverter
 		return false;
 	}
 
-	private boolean _isShowObjectDefinitionBrief() {
-		NestedFieldsContext nestedFieldsContext =
-			NestedFieldsContextThreadLocal.getNestedFieldsContext();
-
-		if (nestedFieldsContext == null) {
-			return false;
-		}
-
-		List<String> nestedFields = new ArrayList<>(
-			nestedFieldsContext.getNestedFields());
-
-		return nestedFields.contains("systemProperties.objectDefinitionBrief");
-	}
-
 	private AuditEvent[] _toAuditEvents(
 			DTOConverterContext dtoConverterContext,
 			ObjectDefinition objectDefinition,
@@ -1423,24 +1411,27 @@ public class ObjectEntryDTOConverter
 	}
 
 	private SystemProperties _toSystemProperties(
-		Locale locale, ObjectDefinition objectDefinition, int versionInt) {
+			Locale locale, ObjectDefinition objectDefinition, int versionInt)
+		throws Exception {
 
 		boolean enableObjectEntryVersioning =
 			objectDefinition.isEnableObjectEntryVersioning();
-		boolean showObjectDefinitionBrief = _isShowObjectDefinitionBrief();
 
-		if (!enableObjectEntryVersioning && !showObjectDefinitionBrief) {
+		ObjectDefinitionBrief objectDefinitionBrief =
+			NestedFieldsSupplier.supply(
+				"systemProperties.objectDefinitionBrief",
+				nestedField -> _toObjectDefinitionBrief(
+					locale, objectDefinition));
+
+		if (!enableObjectEntryVersioning && (objectDefinitionBrief == null)) {
 			return null;
 		}
 
 		SystemProperties systemProperties = new SystemProperties();
 
-		if (showObjectDefinitionBrief) {
+		if (objectDefinitionBrief != null) {
 			systemProperties.setObjectDefinitionBrief(
-				() -> NestedFieldsSupplier.supply(
-					"systemProperties.objectDefinitionBrief",
-					nestedField -> _toObjectDefinitionBrief(
-						locale, objectDefinition)));
+				() -> objectDefinitionBrief);
 		}
 
 		if (enableObjectEntryVersioning) {

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -5803,6 +5803,57 @@ public class ObjectEntryResourceTest {
 		Assert.assertEquals(1, itemsJSONArray.length());
 	}
 
+	@FeatureFlag("LPD-17564")
+	@Test
+	public void testGetObjectEntriesSystemProperties() throws Exception {
+		ObjectEntryTestUtil.addObjectEntry(
+			_objectDefinition1, _OBJECT_FIELD_NAME_TEXT,
+			_NEW_OBJECT_FIELD_VALUE_1);
+
+		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+			null, _objectDefinition1.getRESTContextPath(), Http.Method.GET);
+
+		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
+
+		Assert.assertEquals(
+			itemsJSONArray.toString(), 1, itemsJSONArray.length());
+
+		JSONObject objectEntryJSONObject = itemsJSONArray.getJSONObject(0);
+
+		Assert.assertNull(
+			objectEntryJSONObject.getJSONObject("systemProperties"));
+
+		jsonObject = HTTPTestUtil.invokeToJSONObject(
+			null,
+			_objectDefinition1.getRESTContextPath() +
+				"?nestedFields=systemProperties.objectDefinitionBrief",
+			Http.Method.GET);
+
+		itemsJSONArray = jsonObject.getJSONArray("items");
+
+		Assert.assertEquals(
+			itemsJSONArray.toString(), 1, itemsJSONArray.length());
+
+		objectEntryJSONObject = itemsJSONArray.getJSONObject(0);
+
+		JSONObject systemPropertiesJSONObject =
+			objectEntryJSONObject.getJSONObject("systemProperties");
+
+		JSONObject objectDefinitionBriefJSONObject =
+			systemPropertiesJSONObject.getJSONObject("objectDefinitionBrief");
+
+		Assert.assertEquals(
+			_objectDefinition1.getExternalReferenceCode(),
+			objectDefinitionBriefJSONObject.getString("externalReferenceCode"));
+		Assert.assertEquals(
+			_objectDefinition1.getLabel(LocaleUtil.getDefault()),
+			objectDefinitionBriefJSONObject.getString("label"));
+		Assert.assertEquals(
+			_objectDefinition1.getObjectFolderExternalReferenceCode(),
+			objectDefinitionBriefJSONObject.getString(
+				"objectFolderExternalReferenceCode"));
+	}
+
 	@Test
 	public void testGetObjectEntriesVersionsPage() throws Exception {
 		_objectDefinition1.setEnableObjectEntryVersioning(true);

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi.json
@@ -1112,6 +1112,36 @@
 					"name": "ObjectEntry"
 				}
 			},
+			"ObjectDefinitionBrief": {
+				"properties": {
+					"externalReferenceCode": {
+						"description": "The object definition's external reference code.",
+						"readOnly": true,
+						"type": "string"
+					},
+					"label": {
+						"description": "The object definition's label.",
+						"readOnly": true,
+						"type": "string"
+					},
+					"objectFolderExternalReferenceCode": {
+						"description": "The object folder's external reference code.",
+						"readOnly": true,
+						"type": "string"
+					},
+					"x-class-name": {
+						"default": "com.liferay.object.rest.dto.v1_0.ObjectDefinitionBrief",
+						"readOnly": true,
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": [
+				],
+				"xml": {
+					"name": "ObjectDefinitionBrief"
+				}
+			},
 			"PageCollaborator": {
 				"properties": {
 					"actions": {

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions.json
@@ -572,6 +572,36 @@
 					"name": "ObjectEntry"
 				}
 			},
+			"ObjectDefinitionBrief": {
+				"properties": {
+					"externalReferenceCode": {
+						"description": "The object definition's external reference code.",
+						"readOnly": true,
+						"type": "string"
+					},
+					"label": {
+						"description": "The object definition's label.",
+						"readOnly": true,
+						"type": "string"
+					},
+					"objectFolderExternalReferenceCode": {
+						"description": "The object folder's external reference code.",
+						"readOnly": true,
+						"type": "string"
+					},
+					"x-class-name": {
+						"default": "com.liferay.object.rest.dto.v1_0.ObjectDefinitionBrief",
+						"readOnly": true,
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": [
+				],
+				"xml": {
+					"name": "ObjectDefinitionBrief"
+				}
+			},
 			"PageCollaborator": {
 				"properties": {
 					"actions": {

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions_object_action.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions_object_action.json
@@ -584,6 +584,36 @@
 					"name": "ObjectEntry"
 				}
 			},
+			"ObjectDefinitionBrief": {
+				"properties": {
+					"externalReferenceCode": {
+						"description": "The object definition's external reference code.",
+						"readOnly": true,
+						"type": "string"
+					},
+					"label": {
+						"description": "The object definition's label.",
+						"readOnly": true,
+						"type": "string"
+					},
+					"objectFolderExternalReferenceCode": {
+						"description": "The object folder's external reference code.",
+						"readOnly": true,
+						"type": "string"
+					},
+					"x-class-name": {
+						"default": "com.liferay.object.rest.dto.v1_0.ObjectDefinitionBrief",
+						"readOnly": true,
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": [
+				],
+				"xml": {
+					"name": "ObjectDefinitionBrief"
+				}
+			},
 			"PageCollaborator": {
 				"properties": {
 					"actions": {

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_categorization_disabled.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_categorization_disabled.json
@@ -388,6 +388,36 @@
 					"name": "ObjectEntry"
 				}
 			},
+			"ObjectDefinitionBrief": {
+				"properties": {
+					"externalReferenceCode": {
+						"description": "The object definition's external reference code.",
+						"readOnly": true,
+						"type": "string"
+					},
+					"label": {
+						"description": "The object definition's label.",
+						"readOnly": true,
+						"type": "string"
+					},
+					"objectFolderExternalReferenceCode": {
+						"description": "The object folder's external reference code.",
+						"readOnly": true,
+						"type": "string"
+					},
+					"x-class-name": {
+						"default": "com.liferay.object.rest.dto.v1_0.ObjectDefinitionBrief",
+						"readOnly": true,
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": [
+				],
+				"xml": {
+					"name": "ObjectDefinitionBrief"
+				}
+			},
 			"PageCollaborator": {
 				"properties": {
 					"actions": {

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_related.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_related.json
@@ -1532,6 +1532,36 @@
 					"name": "ObjectEntry"
 				}
 			},
+			"ObjectDefinitionBrief": {
+				"properties": {
+					"externalReferenceCode": {
+						"description": "The object definition's external reference code.",
+						"readOnly": true,
+						"type": "string"
+					},
+					"label": {
+						"description": "The object definition's label.",
+						"readOnly": true,
+						"type": "string"
+					},
+					"objectFolderExternalReferenceCode": {
+						"description": "The object folder's external reference code.",
+						"readOnly": true,
+						"type": "string"
+					},
+					"x-class-name": {
+						"default": "com.liferay.object.rest.dto.v1_0.ObjectDefinitionBrief",
+						"readOnly": true,
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": [
+				],
+				"xml": {
+					"name": "ObjectDefinitionBrief"
+				}
+			},
 			"PageCollaborator": {
 				"properties": {
 					"actions": {

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_site.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_site.json
@@ -414,6 +414,36 @@
 					"name": "ObjectEntry"
 				}
 			},
+			"ObjectDefinitionBrief": {
+				"properties": {
+					"externalReferenceCode": {
+						"description": "The object definition's external reference code.",
+						"readOnly": true,
+						"type": "string"
+					},
+					"label": {
+						"description": "The object definition's label.",
+						"readOnly": true,
+						"type": "string"
+					},
+					"objectFolderExternalReferenceCode": {
+						"description": "The object folder's external reference code.",
+						"readOnly": true,
+						"type": "string"
+					},
+					"x-class-name": {
+						"default": "com.liferay.object.rest.dto.v1_0.ObjectDefinitionBrief",
+						"readOnly": true,
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": [
+				],
+				"xml": {
+					"name": "ObjectDefinitionBrief"
+				}
+			},
 			"PageCollaborator": {
 				"properties": {
 					"actions": {

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
@@ -176,7 +176,7 @@ public abstract class BaseSectionDisplayContext {
 	}
 
 	public String getAPIURL() {
-		StringBundler sb = new StringBundler(7);
+		StringBundler sb = new StringBundler(8);
 
 		sb.append("/o/search/v1.0/search?emptySearch=true&filter=");
 
@@ -200,7 +200,8 @@ public abstract class BaseSectionDisplayContext {
 			sb.append(getCMSSectionFilterString());
 		}
 
-		sb.append("&nestedFields=embedded,file.thumbnailURL");
+		sb.append("&nestedFields=embedded,file.thumbnailURL,");
+		sb.append("systemProperties.objectDefinitionBrief");
 
 		return sb.toString();
 	}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/view/table/BaseContentsSectionTableFDSView.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/view/table/BaseContentsSectionTableFDSView.java
@@ -34,9 +34,7 @@ public abstract class BaseContentsSectionTableFDSView extends BaseTableFDSView {
 				true
 			)
 		).add(
-			"embedded.objectDefinitionName", "type",
-			fdsTableSchemaField -> fdsTableSchemaField.setContentRenderer(
-				"typeTableCellRenderer")
+			"embedded.systemProperties.objectDefinitionBrief.label", "type"
 		).add(
 			"embedded.scopeKey", "space",
 			fdsTableSchemaField -> fdsTableSchemaField.setContentRenderer(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/view/table/RecycleBinSectionTableFDSView.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/view/table/RecycleBinSectionTableFDSView.java
@@ -41,7 +41,7 @@ public class RecycleBinSectionTableFDSView extends BaseTableFDSView {
 				true
 			)
 		).add(
-			"embedded.objectDefinitionName", "type"
+			"embedded.systemProperties.objectDefinitionBrief.label", "type"
 		).add(
 			"embedded.scopeKey", "space",
 			fdsTableSchemaField -> fdsTableSchemaField.setContentRenderer(


### PR DESCRIPTION
CMS asset type does not appear in table view

# What is this trying to solve?

[Link to ticket](https://issues.liferay.com/browse/LPD-62806)

Views in CMS are not showing the type of asset, and are showing nothing

# How am I fixing it?

We are adding a new nested property to systemProperties of objectEntries that's called objectDefinitionBrief that contains the label, ERC and object folder ERC of the object definition, that way we can have the properties to display them in the view.

The logic is adapted so that the systemProperties prop is not shown when there's no versioning and no nested property.


# How can you verify that it works?

There is an integration test included, and the issue can be tested following the steps in the ticket