### PR TITLE
LPD-48514: Fix company group creation issues

### DIFF
--- a/modules/apps/staging/staging-impl/src/main/java/com/liferay/staging/internal/instance/lifecycle/AddCompanyGroupPortalInstanceLifecycleListener.java
+++ b/modules/apps/staging/staging-impl/src/main/java/com/liferay/staging/internal/instance/lifecycle/AddCompanyGroupPortalInstanceLifecycleListener.java
@@ -7,13 +7,17 @@ package com.liferay.staging.internal.instance.lifecycle;
 
 import com.liferay.portal.instance.lifecycle.BasePortalInstanceLifecycleListener;
 import com.liferay.portal.instance.lifecycle.PortalInstanceLifecycleListener;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagListener;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.MapUtil;
@@ -21,12 +25,15 @@ import com.liferay.staging.StagingGroupHelper;
 import com.liferay.staging.internal.constants.CompanyGroupConstants;
 
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Alejandro Tardín
+ * @author Petteri Karttunen
  */
 @Component(service = PortalInstanceLifecycleListener.class)
 public class AddCompanyGroupPortalInstanceLifecycleListener
@@ -34,54 +41,88 @@ public class AddCompanyGroupPortalInstanceLifecycleListener
 
 	@Override
 	public void portalInstanceRegistered(Company company) {
-		_bundleContext.registerService(
+		if (FeatureFlagManagerUtil.isEnabled(
+				company.getCompanyId(), "LPD-35914")) {
+
+			_addCompanyGroup(company.getCompanyId());
+		}
+	}
+
+	@Override
+	public void portalInstanceUnregistered(Company company) {
+		_deleteCompanyGroup(company.getCompanyId());
+	}
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_serviceRegistration = bundleContext.registerService(
 			FeatureFlagListener.class,
 			(companyId, featureFlagKey, enabled) -> {
-				try {
-					Group group = _groupLocalService.fetchFriendlyURLGroup(
-						company.getCompanyId(),
-						CompanyGroupConstants.FRIENDLY_URL);
-
-					if (group != null) {
-						_groupLocalService.deleteGroup(group);
-					}
-
-					if (!enabled) {
-						return;
-					}
-
-					_groupLocalService.addGroup(
-						_userLocalService.getGuestUserId(
-							company.getCompanyId()),
-						GroupConstants.DEFAULT_PARENT_GROUP_ID,
-						StagingGroupHelper.class.getName(), companyId,
-						GroupConstants.DEFAULT_LIVE_GROUP_ID, null, null,
-						GroupConstants.TYPE_SITE_RESTRICTED, true,
-						GroupConstants.DEFAULT_MEMBERSHIP_RESTRICTION,
-						CompanyGroupConstants.FRIENDLY_URL, false, true, null);
-				}
-				catch (Exception exception) {
-					_log.error(exception);
+				if (enabled) {
+					_companyLocalService.forEachCompanyId(
+						this::_addCompanyGroup);
 				}
 			},
 			MapUtil.singletonDictionary("feature.flag.key", "LPD-35914"));
 	}
 
-	@Activate
-	protected void activate(BundleContext bundleContext) {
-		_bundleContext = bundleContext;
+	@Deactivate
+	protected void deactivate() {
+		if (_serviceRegistration != null) {
+			_serviceRegistration.unregister();
+		}
+	}
+
+	private void _addCompanyGroup(long companyId) {
+		try {
+			Group group = _groupLocalService.fetchFriendlyURLGroup(
+				companyId, CompanyGroupConstants.FRIENDLY_URL);
+
+			if (group != null) {
+				return;
+			}
+
+			_groupLocalService.addGroup(
+				_userLocalService.getGuestUserId(companyId),
+				GroupConstants.DEFAULT_PARENT_GROUP_ID,
+				StagingGroupHelper.class.getName(), CompanyConstants.SYSTEM,
+				GroupConstants.DEFAULT_LIVE_GROUP_ID, null, null,
+				GroupConstants.TYPE_SITE_RESTRICTED, true,
+				GroupConstants.DEFAULT_MEMBERSHIP_RESTRICTION,
+				CompanyGroupConstants.FRIENDLY_URL, false, true, null);
+		}
+		catch (PortalException portalException) {
+			_log.error(portalException);
+		}
+	}
+
+	private void _deleteCompanyGroup(long companyId) {
+		try {
+			Group group = _groupLocalService.fetchFriendlyURLGroup(
+				companyId, CompanyGroupConstants.FRIENDLY_URL);
+
+			if (group != null) {
+				_groupLocalService.deleteGroup(group);
+			}
+		}
+		catch (PortalException portalException) {
+			_log.error(portalException);
+		}
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		AddCompanyGroupPortalInstanceLifecycleListener.class);
 
-	private BundleContext _bundleContext;
+	@Reference
+	private CompanyLocalService _companyLocalService;
 
 	@Reference
 	private GroupLocalService _groupLocalService;
 
 	@Reference(target = ModuleServiceLifecycle.PORTAL_INITIALIZED)
 	private ModuleServiceLifecycle _moduleServiceLifecycle;
+
+	private volatile ServiceRegistration<?> _serviceRegistration;
 
 	@Reference
 	private UserLocalService _userLocalService;


### PR DESCRIPTION
- https://liferay.atlassian.net/browse/LPD-48514

This is a version removing the unnecessary `EveryNodeEveryStartup` and the deletion of the company group when disabling the FF, to reduce the DB calls on startup, as required by the core team. The revert for the original version [here](https://github.com/brianchandotcom/liferay-portal/commit/4877c09a78b90c7c7187ea742e7a0d3ff23c1127) 
