### PR TITLE
LPD-64409 Add methods to retrieve versioned entries by ERC in service builder

### DIFF
--- a/modules/apps/fragment/fragment-api/bnd.bnd
+++ b/modules/apps/fragment/fragment-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Fragment API
 Bundle-SymbolicName: com.liferay.fragment.api
-Bundle-Version: 55.0.1
+Bundle-Version: 55.1.0
 Export-Package:\
 	com.liferay.fragment.cache,\
 	com.liferay.fragment.configuration,\

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLocalService.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLocalService.java
@@ -267,6 +267,10 @@ public interface FragmentEntryLocalService
 		String externalReferenceCode, long groupId);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public FragmentEntry fetchFragmentEntryByExternalReferenceCode(
+		String externalReferenceCode, long groupId, boolean head);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public FragmentEntry fetchFragmentEntryByUuidAndGroupId(
 		String uuid, long groupId);
 
@@ -374,6 +378,11 @@ public interface FragmentEntryLocalService
 	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public FragmentEntry getFragmentEntry(long fragmentEntryId)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public FragmentEntry getFragmentEntryByExternalReferenceCode(
+			String externalReferenceCode, long groupId, boolean head)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLocalServiceUtil.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLocalServiceUtil.java
@@ -290,6 +290,13 @@ public class FragmentEntryLocalServiceUtil {
 			externalReferenceCode, groupId);
 	}
 
+	public static FragmentEntry fetchFragmentEntryByExternalReferenceCode(
+		String externalReferenceCode, long groupId, boolean head) {
+
+		return getService().fetchFragmentEntryByExternalReferenceCode(
+			externalReferenceCode, groupId, head);
+	}
+
 	public static FragmentEntry fetchFragmentEntryByUuidAndGroupId(
 		String uuid, long groupId) {
 
@@ -449,6 +456,14 @@ public class FragmentEntryLocalServiceUtil {
 		throws PortalException {
 
 		return getService().getFragmentEntry(fragmentEntryId);
+	}
+
+	public static FragmentEntry getFragmentEntryByExternalReferenceCode(
+			String externalReferenceCode, long groupId, boolean head)
+		throws PortalException {
+
+		return getService().getFragmentEntryByExternalReferenceCode(
+			externalReferenceCode, groupId, head);
 	}
 
 	public static FragmentEntry getFragmentEntryByUuidAndGroupId(

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLocalServiceWrapper.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLocalServiceWrapper.java
@@ -327,6 +327,15 @@ public class FragmentEntryLocalServiceWrapper
 	}
 
 	@Override
+	public FragmentEntry fetchFragmentEntryByExternalReferenceCode(
+		String externalReferenceCode, long groupId, boolean head) {
+
+		return _fragmentEntryLocalService.
+			fetchFragmentEntryByExternalReferenceCode(
+				externalReferenceCode, groupId, head);
+	}
+
+	@Override
 	public FragmentEntry fetchFragmentEntryByUuidAndGroupId(
 		String uuid, long groupId) {
 
@@ -520,6 +529,16 @@ public class FragmentEntryLocalServiceWrapper
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _fragmentEntryLocalService.getFragmentEntry(fragmentEntryId);
+	}
+
+	@Override
+	public FragmentEntry getFragmentEntryByExternalReferenceCode(
+			String externalReferenceCode, long groupId, boolean head)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _fragmentEntryLocalService.
+			getFragmentEntryByExternalReferenceCode(
+				externalReferenceCode, groupId, head);
 	}
 
 	@Override

--- a/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/service/packageinfo
+++ b/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/service/packageinfo
@@ -1,1 +1,1 @@
-version 14.0.0
+version 14.1.0

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/base/FragmentEntryLocalServiceBaseImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/base/FragmentEntryLocalServiceBaseImpl.java
@@ -280,6 +280,23 @@ public abstract class FragmentEntryLocalServiceBaseImpl
 		return fragmentEntryPersistence.fetchByPrimaryKey(fragmentEntryId);
 	}
 
+	@Override
+	public FragmentEntry fetchFragmentEntryByExternalReferenceCode(
+		String externalReferenceCode, long groupId, boolean head) {
+
+		return fragmentEntryPersistence.fetchByERC_G_Head(
+			externalReferenceCode, groupId, head);
+	}
+
+	@Override
+	public FragmentEntry getFragmentEntryByExternalReferenceCode(
+			String externalReferenceCode, long groupId, boolean head)
+		throws PortalException {
+
+		return fragmentEntryPersistence.findByERC_G_Head(
+			externalReferenceCode, groupId, head);
+	}
+
 	/**
 	 * Returns the fragment entry with the primary key.
 	 *

--- a/modules/apps/style-book/style-book-api/bnd.bnd
+++ b/modules/apps/style-book/style-book-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Style Book API
 Bundle-SymbolicName: com.liferay.style.book.api
-Bundle-Version: 10.0.3
+Bundle-Version: 10.1.0
 Export-Package:\
 	com.liferay.style.book.constants,\
 	com.liferay.style.book.exception,\

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryLocalService.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryLocalService.java
@@ -274,6 +274,10 @@ public interface StyleBookEntryLocalService
 		long groupId, String styleBookEntryKey);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public StyleBookEntry fetchStyleBookEntryByExternalReferenceCode(
+		String externalReferenceCode, long groupId, boolean head);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public StyleBookEntry fetchStyleBookEntryByUuidAndGroupId(
 		String uuid, long groupId);
 
@@ -368,6 +372,11 @@ public interface StyleBookEntryLocalService
 	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public StyleBookEntry getStyleBookEntry(long styleBookEntryId)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public StyleBookEntry getStyleBookEntryByExternalReferenceCode(
+			String externalReferenceCode, long groupId, boolean head)
 		throws PortalException;
 
 	@Override

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryLocalServiceUtil.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryLocalServiceUtil.java
@@ -303,6 +303,13 @@ public class StyleBookEntryLocalServiceUtil {
 		return getService().fetchStyleBookEntry(groupId, styleBookEntryKey);
 	}
 
+	public static StyleBookEntry fetchStyleBookEntryByExternalReferenceCode(
+		String externalReferenceCode, long groupId, boolean head) {
+
+		return getService().fetchStyleBookEntryByExternalReferenceCode(
+			externalReferenceCode, groupId, head);
+	}
+
 	public static StyleBookEntry fetchStyleBookEntryByUuidAndGroupId(
 		String uuid, long groupId) {
 
@@ -436,6 +443,14 @@ public class StyleBookEntryLocalServiceUtil {
 		throws PortalException {
 
 		return getService().getStyleBookEntry(styleBookEntryId);
+	}
+
+	public static StyleBookEntry getStyleBookEntryByExternalReferenceCode(
+			String externalReferenceCode, long groupId, boolean head)
+		throws PortalException {
+
+		return getService().getStyleBookEntryByExternalReferenceCode(
+			externalReferenceCode, groupId, head);
 	}
 
 	public static com.liferay.style.book.model.StyleBookEntryVersion getVersion(

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryLocalServiceWrapper.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryLocalServiceWrapper.java
@@ -341,6 +341,15 @@ public class StyleBookEntryLocalServiceWrapper
 	}
 
 	@Override
+	public StyleBookEntry fetchStyleBookEntryByExternalReferenceCode(
+		String externalReferenceCode, long groupId, boolean head) {
+
+		return _styleBookEntryLocalService.
+			fetchStyleBookEntryByExternalReferenceCode(
+				externalReferenceCode, groupId, head);
+	}
+
+	@Override
 	public StyleBookEntry fetchStyleBookEntryByUuidAndGroupId(
 		String uuid, long groupId) {
 
@@ -500,6 +509,16 @@ public class StyleBookEntryLocalServiceWrapper
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _styleBookEntryLocalService.getStyleBookEntry(styleBookEntryId);
+	}
+
+	@Override
+	public StyleBookEntry getStyleBookEntryByExternalReferenceCode(
+			String externalReferenceCode, long groupId, boolean head)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _styleBookEntryLocalService.
+			getStyleBookEntryByExternalReferenceCode(
+				externalReferenceCode, groupId, head);
 	}
 
 	@Override

--- a/modules/apps/style-book/style-book-api/src/main/resources/com/liferay/style/book/service/packageinfo
+++ b/modules/apps/style-book/style-book-api/src/main/resources/com/liferay/style/book/service/packageinfo
@@ -1,1 +1,1 @@
-version 6.0.0
+version 6.1.0

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/base/StyleBookEntryLocalServiceBaseImpl.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/base/StyleBookEntryLocalServiceBaseImpl.java
@@ -271,6 +271,23 @@ public abstract class StyleBookEntryLocalServiceBaseImpl
 		return styleBookEntryPersistence.fetchByPrimaryKey(styleBookEntryId);
 	}
 
+	@Override
+	public StyleBookEntry fetchStyleBookEntryByExternalReferenceCode(
+		String externalReferenceCode, long groupId, boolean head) {
+
+		return styleBookEntryPersistence.fetchByERC_G_Head(
+			externalReferenceCode, groupId, head);
+	}
+
+	@Override
+	public StyleBookEntry getStyleBookEntryByExternalReferenceCode(
+			String externalReferenceCode, long groupId, boolean head)
+		throws PortalException {
+
+		return styleBookEntryPersistence.findByERC_G_Head(
+			externalReferenceCode, groupId, head);
+	}
+
 	/**
 	 * Returns the style book entry with the primary key.
 	 *

--- a/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/service/ERCVersionedEntryLocalService.java
+++ b/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/service/ERCVersionedEntryLocalService.java
@@ -235,6 +235,10 @@ public interface ERCVersionedEntryLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ERCVersionedEntry fetchERCVersionedEntry(long ercVersionedEntryId);
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public ERCVersionedEntry fetchERCVersionedEntryByExternalReferenceCode(
+		String externalReferenceCode, long groupId, boolean head);
+
 	@Override
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ERCVersionedEntryVersion fetchLatestVersion(
@@ -292,6 +296,11 @@ public interface ERCVersionedEntryLocalService
 	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ERCVersionedEntry getERCVersionedEntry(long ercVersionedEntryId)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public ERCVersionedEntry getERCVersionedEntryByExternalReferenceCode(
+			String externalReferenceCode, long groupId, boolean head)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/service/ERCVersionedEntryLocalServiceUtil.java
+++ b/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/service/ERCVersionedEntryLocalServiceUtil.java
@@ -247,6 +247,14 @@ public class ERCVersionedEntryLocalServiceUtil {
 		return getService().fetchERCVersionedEntry(ercVersionedEntryId);
 	}
 
+	public static ERCVersionedEntry
+		fetchERCVersionedEntryByExternalReferenceCode(
+			String externalReferenceCode, long groupId, boolean head) {
+
+		return getService().fetchERCVersionedEntryByExternalReferenceCode(
+			externalReferenceCode, groupId, head);
+	}
+
 	public static
 		com.liferay.portal.tools.service.builder.test.model.
 			ERCVersionedEntryVersion fetchLatestVersion(
@@ -322,6 +330,14 @@ public class ERCVersionedEntryLocalServiceUtil {
 		throws PortalException {
 
 		return getService().getERCVersionedEntry(ercVersionedEntryId);
+	}
+
+	public static ERCVersionedEntry getERCVersionedEntryByExternalReferenceCode(
+			String externalReferenceCode, long groupId, boolean head)
+		throws PortalException {
+
+		return getService().getERCVersionedEntryByExternalReferenceCode(
+			externalReferenceCode, groupId, head);
 	}
 
 	public static

--- a/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/service/ERCVersionedEntryLocalServiceWrapper.java
+++ b/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/service/ERCVersionedEntryLocalServiceWrapper.java
@@ -299,6 +299,16 @@ public class ERCVersionedEntryLocalServiceWrapper
 	}
 
 	@Override
+	public com.liferay.portal.tools.service.builder.test.model.ERCVersionedEntry
+		fetchERCVersionedEntryByExternalReferenceCode(
+			String externalReferenceCode, long groupId, boolean head) {
+
+		return _ercVersionedEntryLocalService.
+			fetchERCVersionedEntryByExternalReferenceCode(
+				externalReferenceCode, groupId, head);
+	}
+
+	@Override
 	public
 		com.liferay.portal.tools.service.builder.test.model.
 			ERCVersionedEntryVersion fetchLatestVersion(
@@ -394,6 +404,17 @@ public class ERCVersionedEntryLocalServiceWrapper
 
 		return _ercVersionedEntryLocalService.getERCVersionedEntry(
 			ercVersionedEntryId);
+	}
+
+	@Override
+	public com.liferay.portal.tools.service.builder.test.model.ERCVersionedEntry
+			getERCVersionedEntryByExternalReferenceCode(
+				String externalReferenceCode, long groupId, boolean head)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _ercVersionedEntryLocalService.
+			getERCVersionedEntryByExternalReferenceCode(
+				externalReferenceCode, groupId, head);
 	}
 
 	@Override

--- a/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/base/ERCVersionedEntryLocalServiceBaseImpl.java
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/base/ERCVersionedEntryLocalServiceBaseImpl.java
@@ -266,6 +266,23 @@ public abstract class ERCVersionedEntryLocalServiceBaseImpl
 			ercVersionedEntryId);
 	}
 
+	@Override
+	public ERCVersionedEntry fetchERCVersionedEntryByExternalReferenceCode(
+		String externalReferenceCode, long groupId, boolean head) {
+
+		return ercVersionedEntryPersistence.fetchByERC_G_Head(
+			externalReferenceCode, groupId, head);
+	}
+
+	@Override
+	public ERCVersionedEntry getERCVersionedEntryByExternalReferenceCode(
+			String externalReferenceCode, long groupId, boolean head)
+		throws PortalException {
+
+		return ercVersionedEntryPersistence.findByERC_G_Head(
+			externalReferenceCode, groupId, head);
+	}
+
 	/**
 	 * Returns the erc versioned entry with the primary key.
 	 *

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/service_base_impl.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/service_base_impl.ftl
@@ -507,17 +507,29 @@ import org.osgi.service.component.annotations.Reference;
 			</#if>
 		</#if>
 
-		<#if entity.hasExternalReferenceCode() && !entity.versionEntity??>
+		<#if entity.hasExternalReferenceCode()>
 			<#if serviceBuilder.isVersionGTE_7_4_0()>
-				@Override
-				public ${entity.name} fetch${entity.name}ByExternalReferenceCode(String externalReferenceCode, long ${entity.externalReferenceCode}Id) <#if (serviceBaseExceptions?size gt 0)>throws ${stringUtil.merge(serviceBaseExceptions)} </#if>{
-					return ${entity.variableName}Persistence.fetchByERC_${entity.externalReferenceCode?cap_first[0..0]}(externalReferenceCode, ${entity.externalReferenceCode}Id);
-				}
+				<#if entity.versionEntity??>
+					@Override
+					public ${entity.name} fetch${entity.name}ByExternalReferenceCode(String externalReferenceCode, long ${entity.externalReferenceCode}Id, boolean head) <#if (serviceBaseExceptions?size gt 0)>throws ${stringUtil.merge(serviceBaseExceptions)} </#if>{
+						return ${entity.variableName}Persistence.fetchByERC_${entity.externalReferenceCode?cap_first[0..0]}_Head(externalReferenceCode, ${entity.externalReferenceCode}Id, head);
+					}
 
-				@Override
-				public ${entity.name} get${entity.name}ByExternalReferenceCode(String externalReferenceCode, long ${entity.externalReferenceCode}Id) throws PortalException {
-					return ${entity.variableName}Persistence.findByERC_${entity.externalReferenceCode?cap_first[0..0]}(externalReferenceCode, ${entity.externalReferenceCode}Id);
-				}
+					@Override
+					public ${entity.name} get${entity.name}ByExternalReferenceCode(String externalReferenceCode, long ${entity.externalReferenceCode}Id, boolean head) throws PortalException {
+						return ${entity.variableName}Persistence.findByERC_${entity.externalReferenceCode?cap_first[0..0]}_Head(externalReferenceCode, ${entity.externalReferenceCode}Id, head);
+					}
+				<#else>
+					@Override
+					public ${entity.name} fetch${entity.name}ByExternalReferenceCode(String externalReferenceCode, long ${entity.externalReferenceCode}Id) <#if (serviceBaseExceptions?size gt 0)>throws ${stringUtil.merge(serviceBaseExceptions)} </#if>{
+						return ${entity.variableName}Persistence.fetchByERC_${entity.externalReferenceCode?cap_first[0..0]}(externalReferenceCode, ${entity.externalReferenceCode}Id);
+					}
+
+					@Override
+					public ${entity.name} get${entity.name}ByExternalReferenceCode(String externalReferenceCode, long ${entity.externalReferenceCode}Id) throws PortalException {
+						return ${entity.variableName}Persistence.findByERC_${entity.externalReferenceCode?cap_first[0..0]}(externalReferenceCode, ${entity.externalReferenceCode}Id);
+					}
+				</#if>
 			<#else>
 				@Deprecated
 				@Override


### PR DESCRIPTION
## Issue

Get and Fetch by external reference code methods are not being generated for versioned entities. For persistence, the methods were added in https://github.com/brianchandotcom/liferay-portal/pull/151240, but services were forgotten.

## Solution

Generate methods to get/fetch by ERC for Versioned entities in the base service class