### PR TITLE
LPD-66187 Publishing old non-batch entities does not work from Asset Libraries

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/ExportImportHelperImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/ExportImportHelperImpl.java
@@ -204,12 +204,11 @@ public class ExportImportHelperImpl implements ExportImportHelper {
 		}
 
 		if (stagingGroupHelper.isDepotGroup(groupId)) {
-			List<Portlet> portlets = _getPortlets(
-				companyId, new DataLevel[] {DataLevel.DEPOT, DataLevel.SITE},
-				excludeDataAlwaysStaged);
-
-			return portlets.stream(
-			).filter(
+			return ListUtil.filter(
+				_getPortlets(
+					companyId,
+					new DataLevel[] {DataLevel.DEPOT, DataLevel.SITE},
+					excludeDataAlwaysStaged),
 				portlet -> {
 					PortletDataHandler portletDataHandler =
 						portlet.getPortletDataHandlerInstance();
@@ -217,8 +216,7 @@ public class ExportImportHelperImpl implements ExportImportHelper {
 					return portletDataHandler.isDataDepotLevel() ||
 						   (portletDataHandler.isDataSiteLevel() &&
 							!portletDataHandler.isBatch());
-				}
-			).toList();
+				});
 		}
 
 		return _getPortlets(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-66187

related test failures:
https://liferay.atlassian.net/browse/LPD-65637
https://liferay.atlassian.net/browse/LPD-65644
https://liferay.atlassian.net/browse/LPD-65647
https://liferay.atlassian.net/browse/LPD-65669
https://liferay.atlassian.net/browse/LPD-65638

see: https://github.com/liferay-headless/liferay-portal/pull/3140 + @vendeltoreki 's review