### PR TITLE
LPD-63419 Update many to many payload at export time with minimum information

### DIFF
--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
@@ -12,8 +12,11 @@ import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.exportimport.data.handler.base.BaseStagedModelDataHandler;
+import com.liferay.exportimport.kernel.configuration.ExportImportConfigurationParameterMapFactoryUtil;
 import com.liferay.exportimport.kernel.configuration.ExportImportConfigurationSettingsMapFactoryUtil;
 import com.liferay.exportimport.kernel.configuration.constants.ExportImportConfigurationConstants;
+import com.liferay.exportimport.kernel.lar.ExportImportHelperUtil;
+import com.liferay.exportimport.kernel.lar.ExportImportPathUtil;
 import com.liferay.exportimport.kernel.lar.ManifestSummary;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.PortletDataContextFactoryUtil;
@@ -87,12 +90,14 @@ import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TempFileEntryUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.xml.Document;
 import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.kernel.xml.SAXReader;
+import com.liferay.portal.kernel.zip.ZipReaderFactory;
 import com.liferay.portal.odata.entity.DateTimeEntityField;
 import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -129,6 +134,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -331,6 +337,98 @@ public class BatchEnginePortletDataHandlerTest {
 			ObjectDefinitionConstants.SCOPE_COMPANY);
 		_testExportImportObjectEntriesWithErrorReport(
 			GroupTestUtil.addGroup(), ObjectDefinitionConstants.SCOPE_SITE);
+	}
+
+	@Test
+	@TestInfo("LPD-LPD-63419")
+	public void testExportImportObjectEntriesWithManyToManyRelationship()
+		throws Exception {
+
+		Group group = GroupTestUtil.addGroup();
+
+		ObjectDefinition objectDefinition1 = _addObjectDefinition(
+			ObjectDefinitionConstants.SCOPE_SITE);
+
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			_getObjectEntryGroupId(
+				group.getGroupId(), ObjectDefinitionConstants.SCOPE_SITE),
+			objectDefinition1, RandomTestUtil.randomString());
+
+		ObjectDefinition objectDefinition2 = _addObjectDefinition(
+			ObjectDefinitionConstants.SCOPE_SITE);
+
+		ObjectEntry objectEntry2 = _addObjectEntry(
+			_getObjectEntryGroupId(
+				group.getGroupId(), ObjectDefinitionConstants.SCOPE_SITE),
+			objectDefinition2, RandomTestUtil.randomString());
+
+		ObjectRelationship objectRelationship =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectRelationshipLocalService, objectDefinition1,
+				objectDefinition2,
+				ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
+				StringUtil.randomId(),
+				ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		ObjectRelationshipTestUtil.relateObjectEntries(
+			objectEntry1.getPrimaryKey(), objectEntry2.getPrimaryKey(),
+			objectRelationship, TestPropsValues.getUserId());
+
+		File larFile = _exportLayouts(
+			false, group.getGroupId(), false, new long[0], objectDefinition1,
+			objectDefinition2);
+
+		Map<String, String[]> parameterMap =
+			ExportImportConfigurationParameterMapFactoryUtil.
+				buildParameterMap();
+
+		String userIdStrategyString = MapUtil.getString(
+			parameterMap, PortletDataHandlerKeys.USER_ID_STRATEGY);
+
+		PortletDataContext portletDataContext =
+			PortletDataContextFactoryUtil.createImportPortletDataContext(
+				group.getCompanyId(), group.getGroupId(), parameterMap,
+				ExportImportHelperUtil.getUserIdStrategy(
+					TestPropsValues.getUserId(), userIdStrategyString),
+				_zipReaderFactory.getZipReader(larFile));
+
+		String objectDefinition1Path = StringPool.FORWARD_SLASH.concat(
+			objectDefinition1.getName(
+			).concat(
+				".json"
+			));
+
+		String objectEntry1Path = ExportImportPathUtil.getRootPath(
+			portletDataContext
+		).concat(
+			objectDefinition1Path
+		);
+
+		String objectDefinition2Path = StringPool.FORWARD_SLASH.concat(
+			objectDefinition2.getName(
+			).concat(
+				".json"
+			));
+
+		String objectEntry2Path = ExportImportPathUtil.getRootPath(
+			portletDataContext
+		).concat(
+			objectDefinition2Path
+		);
+
+		JSONArray objectEntry1jsonArray = JSONFactoryUtil.createJSONArray(
+			portletDataContext.getZipEntryAsString(objectEntry1Path));
+
+		_assertJSONIncludesOnlyScopeAndERCForRelationships(
+			group, objectRelationship.getName(),
+			objectEntry2.getExternalReferenceCode(), objectEntry1jsonArray);
+
+		JSONArray objectEntry2jsonArray = JSONFactoryUtil.createJSONArray(
+			portletDataContext.getZipEntryAsString(objectEntry2Path));
+
+		_assertJSONIncludesOnlyScopeAndERCForRelationships(
+			group, objectRelationship.getName(),
+			objectEntry1.getExternalReferenceCode(), objectEntry2jsonArray);
 	}
 
 	@Ignore("LPD-40798")
@@ -954,6 +1052,36 @@ public class BatchEnginePortletDataHandlerTest {
 			ContentTypes.TEXT_PLAIN);
 	}
 
+	private void _assertJSONIncludesOnlyScopeAndERCForRelationships(
+		Group group, String relFieldName, String externalReferenceCode,
+		JSONArray jsonArray) {
+
+		for (Object entryObject : jsonArray) {
+			JSONObject entryJSONObject = (JSONObject)entryObject;
+
+			JSONArray relJSONArray = entryJSONObject.getJSONArray(relFieldName);
+
+			JSONObject relItemJSONObject = relJSONArray.getJSONObject(0);
+
+			Set<String> keys = relItemJSONObject.keySet();
+
+			Assert.assertEquals(
+				SetUtil.fromArray(
+					"scopeId", "scopeKey", "externalReferenceCode"),
+				keys);
+
+			Assert.assertEquals(
+				group.getGroupId(), relItemJSONObject.getLong("scopeId"));
+
+			Assert.assertEquals(
+				group.getGroupKey(), relItemJSONObject.getString("scopeKey"));
+
+			Assert.assertEquals(
+				externalReferenceCode,
+				relItemJSONObject.getString("externalReferenceCode"));
+		}
+	}
+
 	private void _assertNull(
 		long objectDefinitionId, ObjectEntry... objectEntries) {
 
@@ -1535,6 +1663,9 @@ public class BatchEnginePortletDataHandlerTest {
 
 	@Inject
 	private StagingLocalService _stagingLocalService;
+
+	@Inject
+	private ZipReaderFactory _zipReaderFactory;
 
 	private static class TestExportImportVulcanBatchEngineTaskItemDelegate
 		implements EntityModelResource,

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -15,6 +15,7 @@ import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.exportimport.attachment.ExportImportAttachmentManager;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.list.type.model.ListTypeEntry;
 import com.liferay.list.type.service.ListTypeEntryLocalService;
 import com.liferay.object.constants.ObjectActionKeys;
@@ -87,6 +88,7 @@ import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HtmlParserUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -615,13 +617,24 @@ public class ObjectEntryDTOConverter
 										primaryKey);
 						}
 
-						relatedObjectEntryAtomicReference.set(
-							toDTO(
-								_getDTOConverterContext(
-									dtoConverterContext,
-									serviceBuilderObjectEntry.
-										getObjectEntryId()),
-								serviceBuilderObjectEntry));
+						if (ExportImportThreadLocal.isExportInProcess()) {
+							relatedObjectEntryAtomicReference.set(
+								(Serializable)_toERCAndScope(
+									_objectDefinitionLocalService.
+										getObjectDefinition(
+											objectRelationship.
+												getObjectDefinitionId1()),
+									serviceBuilderObjectEntry));
+						}
+						else {
+							relatedObjectEntryAtomicReference.set(
+								toDTO(
+									_getDTOConverterContext(
+										dtoConverterContext,
+										serviceBuilderObjectEntry.
+											getObjectEntryId()),
+									serviceBuilderObjectEntry));
+						}
 					}
 
 					return relatedObjectEntryAtomicReference.get();
@@ -736,20 +749,12 @@ public class ObjectEntryDTOConverter
 
 		UriInfo uriInfo = dtoConverterContext.getUriInfo();
 
-		DTOConverterContext defaultDTOConverterContext =
-			new DefaultDTOConverterContext(
-				dtoConverterContext.isAcceptAllLanguages(), null,
-				dtoConverterContext.getDTOConverterRegistry(),
-				dtoConverterContext.getHttpServletRequest(), objectEntryId,
-				dtoConverterContext.getLocale(), uriInfo,
-				dtoConverterContext.getUser());
-
-		defaultDTOConverterContext.setAttribute(
-			"preferApproved",
-			GetterUtil.getBoolean(
-				dtoConverterContext.getAttribute("preferApproved")));
-
-		return defaultDTOConverterContext;
+		return new DefaultDTOConverterContext(
+			dtoConverterContext.isAcceptAllLanguages(), null,
+			dtoConverterContext.getDTOConverterRegistry(),
+			dtoConverterContext.getHttpServletRequest(), objectEntryId,
+			dtoConverterContext.getLocale(), uriInfo,
+			dtoConverterContext.getUser());
 	}
 
 	private FileEntry _getFileEntry(
@@ -1022,19 +1027,33 @@ public class ObjectEntryDTOConverter
 						Object.class);
 				}
 
+				if (!ExportImportThreadLocal.isExportInProcess()) {
+					return () -> TransformUtil.transformToArray(
+						relatedModels,
+						relatedModel -> {
+							com.liferay.object.model.ObjectEntry objectEntry =
+								(com.liferay.object.model.ObjectEntry)
+									relatedModel;
+
+							return toDTO(
+								_getDTOConverterContext(
+									dtoConverterContext,
+									objectEntry.getObjectEntryId()),
+								objectEntry);
+						},
+						ObjectEntry.class);
+				}
+
 				return () -> TransformUtil.transformToArray(
 					relatedModels,
 					relatedModel -> {
 						com.liferay.object.model.ObjectEntry objectEntry =
 							(com.liferay.object.model.ObjectEntry)relatedModel;
 
-						return toDTO(
-							_getDTOConverterContext(
-								dtoConverterContext,
-								objectEntry.getObjectEntryId()),
-							objectEntry);
+						return _toERCAndScope(
+							relatedObjectDefinition, objectEntry);
 					},
-					ObjectEntry.class);
+					Object.class);
 			});
 	}
 
@@ -1317,6 +1336,21 @@ public class ObjectEntryDTOConverter
 			AuditFieldChange.class);
 	}
 
+	private Map<String, Object> _toERCAndScope(
+		ObjectDefinition relatedObjectDefinition,
+		com.liferay.object.model.ObjectEntry relatedObjectEntry) {
+
+		return HashMapBuilder.<String, Object>put(
+			"externalReferenceCode",
+			relatedObjectEntry.getExternalReferenceCode()
+		).put(
+			"scopeId", relatedObjectEntry.getGroupId()
+		).put(
+			"scopeKey",
+			_getScopeKey(relatedObjectDefinition, relatedObjectEntry)
+		).build();
+	}
+
 	private ExtendedEntity _toExtendedEntity(
 			BaseModel<?> baseModel, DTOConverterContext dtoConverterContext,
 			ObjectDefinition objectDefinition,
@@ -1506,7 +1540,7 @@ public class ObjectEntryDTOConverter
 		Map<String, UnsafeSupplier<Object, Exception>>
 			nestedFieldsRelatedProperties = _getNestedFieldsRelatedProperties(
 				dtoConverterContext, objectEntry.getGroupId(), objectDefinition,
-				objectEntry.getHeadObjectEntryId());
+				objectEntry.getObjectEntryId());
 
 		if (nestedFieldsRelatedProperties != null) {
 			unsafeSuppliers.putAll(nestedFieldsRelatedProperties);


### PR DESCRIPTION
[LPD-63419](https://liferay.atlassian.net/browse/LPD-63419)


This story delivers optimizations to the work in [LPD-60059](https://liferay.atlassian.net/browse/LPD-60059). The changes are covered by [BatchEnginePortletDataHandlerTest.testExportImportCompanyGroupObjectEntriesWithRelatedObjectEntries](https://github.com/DaniSzimko/liferay-portal/blob/LPD-63419/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java#L309) and [BatchEnginePortletDataHandlerTest.testExportImportSiteObjectEntriesWithRelatedObjectEntries](https://github.com/DaniSzimko/liferay-portal/blob/LPD-63419/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java#L459)