### PR TITLE
LPD-67548 Technical Task | [Test Fix] ObjectFieldResourceTest and ObjectFolderResourceTest

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -1323,14 +1323,7 @@ public class GraphQLServletExtender {
 			Dictionary<String, Object> dictionary =
 				configurations[0].getProperties();
 
-			Object graphQLEnabledValue =
-				(dictionary != null) ? dictionary.get("graphQLEnabled") : null;
-
-			if (graphQLEnabledValue instanceof Boolean) {
-				return (Boolean)graphQLEnabledValue;
-			}
-
-			return true;
+			return GetterUtil.get(dictionary.get("graphQLEnabled"), true);
 		}
 
 		return true;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPD-67548

Since the issue occurs in the object and in commerce components (see [this](https://testray.liferay.com/web/testray#/project/35392/routines/590307/build/334036527?filter=%7B%22status%22%3A%5B%22FAILED%22%5D%2C%22error%22%3A%22testGraphQL%22%7D&filterSchema=buildResults&page=1)), and tests are autogenerated, I think that modifying the core code would be the best solution. 

**The goal**:
Avoid a NullPointerException in GraphQLServletExtender._isGraphQLEnabled by safely handling cases where the configuration exists but the "graphQLEnabled" property is not set. Default to true when the property is null or not a Boolean, matching the existing behavior for missing configurations. This prevents intermittent CI test failures.