### PR TITLE
LPD-67761 Fix for testAddObjectEntryWithDynamicObjectFieldValues

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/jackson/databind/ObjectMapperProviderUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/jackson/databind/ObjectMapperProviderUtil.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonFactoryBuilder;
 import com.fasterxml.jackson.core.StreamReadConstraints;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -76,6 +77,8 @@ public class ObjectMapperProviderUtil {
 			_getJsonFactory(_jsonStringMaxLength)) {
 
 			{
+				configure(
+					DeserializationFeature.USE_JAVA_ARRAY_FOR_JSON_ARRAY, true);
 				configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
 				enable(SerializationFeature.INDENT_OUTPUT);
 				registerModule(


### PR DESCRIPTION
Test failure: [LPD-67761](https://liferay.atlassian.net/browse/LPD-67761)  caused  by [LPD-65423)](https://liferay.atlassian.net/browse/LPD-65423)
