### PR TITLE
LPD-69580 Technical Task | Restore item reference handling in BatchEngineImportTaskItemReaderUtil.convertValue to preserve classExternalReferenceCode on import errors

### DIFF
--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/reader/BatchEngineImportTaskItemReaderUtil.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/reader/BatchEngineImportTaskItemReaderUtil.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -55,16 +56,16 @@ public class BatchEngineImportTaskItemReaderUtil {
 			List<ItemReaderPostAction> itemReaderPostActions)
 		throws BatchEngineImportTaskExecutorException {
 
-		final Object[] itemObject = new Object[1];
+		AtomicReference<T> atomicReference = new AtomicReference<>();
 
 		try {
 			return _convertValue(
 				batchEngineImportTask, itemClass, fieldNameValueMap,
-				itemReaderPostActions, itemObject);
+				itemReaderPostActions, atomicReference);
 		}
 		catch (Exception exception) {
 			throw new BatchEngineImportTaskExecutorException(
-				itemObject[0], exception);
+				atomicReference.get(), exception);
 		}
 	}
 
@@ -158,7 +159,7 @@ public class BatchEngineImportTaskItemReaderUtil {
 			BatchEngineImportTask batchEngineImportTask, Class<T> itemClass,
 			Map<String, Object> fieldNameValueMap,
 			List<ItemReaderPostAction> itemReaderPostActions,
-			Object[] itemObject)
+			AtomicReference<T> atomicReference)
 		throws Exception {
 
 		Map<String, Serializable> extendedProperties = new HashMap<>();
@@ -185,7 +186,7 @@ public class BatchEngineImportTaskItemReaderUtil {
 		T item = resolvedClass.getDeclaredConstructor(
 		).newInstance();
 
-		itemObject[0] = item;
+		atomicReference.set(item);
 
 		Set<String> batchRestrictFields = _getBatchRestrictFields(
 			batchEngineImportTask);


### PR DESCRIPTION
The change in commit e129541b5d1008ad7ece891df7914a26d394c098 moved the code from convertValue() into _convertValue(), but it also changed how errors were handled.
After that change, when an error happened, the created item could not be seen by the outer method, so BatchEngineImportTaskExecutorException was built with a null item.
Because of that, classExternalReferenceCode was empty in ExportImportReportEntry and the test testExportImportErrorRelatedEntityWithExtensionProvider failed.
This fix passes the created item through an atomic reference to the _convertValue() so the outer method can still access it and include its externalReferenceCode in the error report.
