### PR TITLE
LPD-70657 [Test FIX] export-import-web/main/stagingUseCase.spec.ts > Staging only approved content goes to live

### DIFF
--- a/modules/test/playwright/tests/export-import-web/main/stagingUseCase.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/stagingUseCase.spec.ts
@@ -145,6 +145,10 @@ test('Staging only approved content goes to live', async ({
 	await workflowTasksPage.approve(webContent1.title);
 
 	await pageEditorPage.goto(layout1, stagingSite.friendlyUrlPath);
+	await reloadUntilVisible({
+		myLocator: page.getByText(webcontentContent1, {exact: true}),
+		page,
+	});
 	await expect(
 		page.getByText(webcontentContent1, {exact: true})
 	).toBeVisible();


### PR DESCRIPTION
### LPD: https://liferay.atlassian.net/browse/LPD-70657  

# What is this solving?

Attempting to fix a flaky test. The error reported in CI does not reproduce locally, but a different issue occurs when running the test locally.

# How is it fixed?

Added a `reloadUntilVisible` helper to ensure the target element is visible before proceeding with assertions.

# How to verify?

```sh
npx playwright test -g 'Staging only approved content goes to live'
```

### Tested locally
<img width="1179" height="419" alt="image" src="https://github.com/user-attachments/assets/472cc514-f446-46bb-86ed-c24d2088b0af" />
