### PR TITLE
LPD-70700 Fix siteERC/Id usage depending on Scope

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandler.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandler.java
@@ -378,9 +378,8 @@ public class BatchEnginePortletDataHandler extends BasePortletDataHandler {
 					BatchEngineTaskOperation.CREATE.name(),
 					BatchEnginePortletDataHandlerUtil.buildImportParameters(
 						registration.getExportImportDescriptor(),
-						_groupLocalService.fetchGroup(
-							portletDataContext.getScopeGroupId()),
-						portletDataContext, _stagingGroupHelper),
+						_groupLocalService, portletDataContext,
+						_stagingGroupHelper),
 					registration.getTaskItemDelegateName());
 
 			try (SafeCloseable safeCloseable =
@@ -481,9 +480,8 @@ public class BatchEnginePortletDataHandler extends BasePortletDataHandler {
 				Collections.emptyList(),
 				BatchEnginePortletDataHandlerUtil.buildExportParameters(
 					registration.getExportImportDescriptor(),
-					_groupLocalService.fetchGroup(
-						portletDataContext.getScopeGroupId()),
-					portletDataContext, _stagingGroupHelper),
+					_groupLocalService, portletDataContext,
+					_stagingGroupHelper),
 				registration.getTaskItemDelegateName()),
 			new BatchEngineExportTaskExecutor.Settings() {
 

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandlerUtil.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandlerUtil.java
@@ -15,6 +15,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.petra.string.StringUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -42,7 +43,8 @@ public class BatchEnginePortletDataHandlerUtil {
 	public static Map<String, Serializable> buildExportParameters(
 		ExportImportVulcanBatchEngineTaskItemDelegate.ExportImportDescriptor
 			exportImportDescriptor,
-		Group group, PortletDataContext portletDataContext,
+		GroupLocalService groupLocalService,
+		PortletDataContext portletDataContext,
 		StagingGroupHelper stagingGroupHelper) {
 
 		HashMap<String, Serializable> exportParameters =
@@ -111,7 +113,10 @@ public class BatchEnginePortletDataHandlerUtil {
 				exportImportDescriptor.getParameters(portletDataContext)
 			).build();
 
-		if ((group != null) && !stagingGroupHelper.isCompanyGroup(group)) {
+		Group group = groupLocalService.fetchGroup(
+			portletDataContext.getScopeGroupId());
+
+		if (!_isCompanyScoped(group, stagingGroupHelper)) {
 			exportParameters.put(
 				"siteExternalReferenceCode", group.getExternalReferenceCode());
 
@@ -133,7 +138,8 @@ public class BatchEnginePortletDataHandlerUtil {
 	public static Map<String, Serializable> buildImportParameters(
 		ExportImportVulcanBatchEngineTaskItemDelegate.ExportImportDescriptor
 			exportImportDescriptor,
-		Group group, PortletDataContext portletDataContext,
+		GroupLocalService groupLocalService,
+		PortletDataContext portletDataContext,
 		StagingGroupHelper stagingGroupHelper) {
 
 		HashMap<String, Serializable> importParameters =
@@ -173,13 +179,28 @@ public class BatchEnginePortletDataHandlerUtil {
 				exportImportDescriptor.getParameters(portletDataContext)
 			).build();
 
-		if ((group != null) && !stagingGroupHelper.isCompanyGroup(group)) {
+		Group group = groupLocalService.fetchGroup(
+			portletDataContext.getScopeGroupId());
+
+		if (!_isCompanyScoped(group, stagingGroupHelper)) {
 			importParameters.put(
 				"siteExternalReferenceCode", group.getExternalReferenceCode());
 			importParameters.put("siteId", group.getGroupId());
 		}
 
 		return importParameters;
+	}
+
+	private static boolean _isCompanyScoped(
+		Group group, StagingGroupHelper stagingGroupHelper) {
+
+		if ((group == null) || group.isCompany() ||
+			stagingGroupHelper.isCompanyGroup(group)) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private static final Format _format =

--- a/modules/apps/export-import/export-import-service/src/test/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandlerUtilTest.java
+++ b/modules/apps/export-import/export-import-service/src/test/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandlerUtilTest.java
@@ -10,6 +10,7 @@ import com.liferay.exportimport.kernel.lar.PortletDataHandlerKeys;
 import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngineTaskItemDelegate;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
@@ -73,7 +74,7 @@ public class BatchEnginePortletDataHandlerUtilTest {
 
 		Map<String, Serializable> parameters =
 			BatchEnginePortletDataHandlerUtil.buildExportParameters(
-				_mockExportImportDescriptor(), null,
+				_mockExportImportDescriptor(), _mockGroupLocalService(null),
 				_mockPortletDataContext(endDate, null, null),
 				_getStagingGroupHelper(false));
 
@@ -89,7 +90,7 @@ public class BatchEnginePortletDataHandlerUtilTest {
 
 		Map<String, Serializable> parameters =
 			BatchEnginePortletDataHandlerUtil.buildExportParameters(
-				_mockExportImportDescriptor(), null,
+				_mockExportImportDescriptor(), _mockGroupLocalService(null),
 				_mockPortletDataContext(endDate, null, startDate),
 				_getStagingGroupHelper(false));
 
@@ -107,7 +108,8 @@ public class BatchEnginePortletDataHandlerUtilTest {
 		Map<String, Serializable> parameters =
 			BatchEnginePortletDataHandlerUtil.buildExportParameters(
 				_mockExportImportDescriptor(modelClassName, null, null, null),
-				null, _mockPortletDataContext(), _getStagingGroupHelper(false));
+				_mockGroupLocalService(null), _mockPortletDataContext(),
+				_getStagingGroupHelper(false));
 
 		Assert.assertEquals(modelClassName, parameters.get("modelClassName"));
 	}
@@ -118,8 +120,9 @@ public class BatchEnginePortletDataHandlerUtilTest {
 
 		Map<String, Serializable> parameters =
 			BatchEnginePortletDataHandlerUtil.buildExportParameters(
-				_mockExportImportDescriptor(null, modelName, null, null), null,
-				_mockPortletDataContext(), _getStagingGroupHelper(false));
+				_mockExportImportDescriptor(null, modelName, null, null),
+				_mockGroupLocalService(null), _mockPortletDataContext(),
+				_getStagingGroupHelper(false));
 
 		Assert.assertEquals(modelName, parameters.get("modelName"));
 	}
@@ -130,7 +133,8 @@ public class BatchEnginePortletDataHandlerUtilTest {
 			BatchEnginePortletDataHandlerUtil.buildExportParameters(
 				_mockExportImportDescriptor(
 					null, null, List.of("nestedField1", "nestedField2"), null),
-				null, _mockPortletDataContext(), _getStagingGroupHelper(false));
+				_mockGroupLocalService(null), _mockPortletDataContext(),
+				_getStagingGroupHelper(false));
 
 		Assert.assertEquals(
 			"customFields.attributeType,nestedField1,nestedField2",
@@ -139,7 +143,7 @@ public class BatchEnginePortletDataHandlerUtilTest {
 		parameters = BatchEnginePortletDataHandlerUtil.buildExportParameters(
 			_mockExportImportDescriptor(
 				null, null, List.of("nestedField1", "nestedField2"), null),
-			null,
+			_mockGroupLocalService(null),
 			_mockPortletDataContext(
 				null,
 				HashMapBuilder.put(
@@ -157,8 +161,8 @@ public class BatchEnginePortletDataHandlerUtilTest {
 	public void testBuildExportParametersWithNoDates() {
 		Map<String, Serializable> parameters =
 			BatchEnginePortletDataHandlerUtil.buildExportParameters(
-				_mockExportImportDescriptor(), null, _mockPortletDataContext(),
-				_getStagingGroupHelper(false));
+				_mockExportImportDescriptor(), _mockGroupLocalService(null),
+				_mockPortletDataContext(), _getStagingGroupHelper(false));
 
 		Assert.assertNull(parameters.get("filter"));
 	}
@@ -174,7 +178,8 @@ public class BatchEnginePortletDataHandlerUtilTest {
 					).put(
 						"param2", "value2"
 					).build()),
-				null, _mockPortletDataContext(), _getStagingGroupHelper(false));
+				_mockGroupLocalService(null), _mockPortletDataContext(),
+				_getStagingGroupHelper(false));
 
 		Assert.assertEquals("value1", parameters.get("param1"));
 		Assert.assertEquals("value2", parameters.get("param2"));
@@ -186,7 +191,7 @@ public class BatchEnginePortletDataHandlerUtilTest {
 
 		Map<String, Serializable> parameters =
 			BatchEnginePortletDataHandlerUtil.buildExportParameters(
-				_mockExportImportDescriptor(), null,
+				_mockExportImportDescriptor(), _mockGroupLocalService(null),
 				_mockPortletDataContext(null, null, startDate),
 				_getStagingGroupHelper(false));
 
@@ -202,7 +207,8 @@ public class BatchEnginePortletDataHandlerUtilTest {
 		Map<String, Serializable> parameters =
 			BatchEnginePortletDataHandlerUtil.buildImportParameters(
 				_mockExportImportDescriptor(modelClassName, null, null, null),
-				null, _mockPortletDataContext(), _getStagingGroupHelper(false));
+				_mockGroupLocalService(null), _mockPortletDataContext(),
+				_getStagingGroupHelper(false));
 
 		Assert.assertEquals(modelClassName, parameters.get("modelClassName"));
 	}
@@ -213,8 +219,9 @@ public class BatchEnginePortletDataHandlerUtilTest {
 
 		Map<String, Serializable> parameters =
 			BatchEnginePortletDataHandlerUtil.buildImportParameters(
-				_mockExportImportDescriptor(null, modelName, null, null), null,
-				_mockPortletDataContext(), _getStagingGroupHelper(false));
+				_mockExportImportDescriptor(null, modelName, null, null),
+				_mockGroupLocalService(null), _mockPortletDataContext(),
+				_getStagingGroupHelper(false));
 
 		Assert.assertEquals(modelName, parameters.get("modelName"));
 	}
@@ -226,14 +233,16 @@ public class BatchEnginePortletDataHandlerUtilTest {
 
 		Map<String, Serializable> parameters =
 			BatchEnginePortletDataHandlerUtil.buildExportParameters(
-				_mockExportImportDescriptor(), group, _mockPortletDataContext(),
+				_mockExportImportDescriptor(), _mockGroupLocalService(group),
+				_mockPortletDataContext(null, null, null),
 				_getStagingGroupHelper(true));
 
 		Assert.assertNull(parameters.get("siteExternalReferenceCode"));
 		Assert.assertNull(parameters.get("siteId"));
 
 		parameters = BatchEnginePortletDataHandlerUtil.buildImportParameters(
-			_mockExportImportDescriptor(), group, _mockPortletDataContext(),
+			_mockExportImportDescriptor(), _mockGroupLocalService(group),
+			_mockPortletDataContext(null, null, null),
 			_getStagingGroupHelper(true));
 
 		Assert.assertNull(parameters.get("siteExternalReferenceCode"));
@@ -250,7 +259,8 @@ public class BatchEnginePortletDataHandlerUtilTest {
 
 		Map<String, Serializable> parameters =
 			BatchEnginePortletDataHandlerUtil.buildExportParameters(
-				_mockExportImportDescriptor(), group, _mockPortletDataContext(),
+				_mockExportImportDescriptor(), _mockGroupLocalService(group),
+				_mockPortletDataContext(null, null, null),
 				_getStagingGroupHelper(false));
 
 		Assert.assertEquals(
@@ -259,7 +269,8 @@ public class BatchEnginePortletDataHandlerUtilTest {
 		Assert.assertEquals(parameters.get("siteId"), siteId);
 
 		parameters = BatchEnginePortletDataHandlerUtil.buildImportParameters(
-			_mockExportImportDescriptor(), group, _mockPortletDataContext(),
+			_mockExportImportDescriptor(), _mockGroupLocalService(group),
+			_mockPortletDataContext(null, null, null),
 			_getStagingGroupHelper(false));
 
 		Assert.assertEquals(
@@ -348,6 +359,21 @@ public class BatchEnginePortletDataHandlerUtilTest {
 		).getGroupId();
 
 		return group;
+	}
+
+	private GroupLocalService _mockGroupLocalService(Group group) {
+		GroupLocalService groupLocalService = Mockito.mock(
+			GroupLocalService.class);
+
+		Mockito.doReturn(
+			group
+		).when(
+			groupLocalService
+		).fetchGroup(
+			Mockito.anyLong()
+		);
+
+		return groupLocalService;
 	}
 
 	private PortletDataContext _mockPortletDataContext() {


### PR DESCRIPTION
**What's changed?:**
- Now `siteExternalReferenceCode` and `siteId` parameters are not sent to the Batch Engine execution when the process is being executed from the Export/Import company group to fix an issue that happens when the entity has multiple scopes.

**What's new?:**
- New unit tests have been added for checking the previously failing use cases.

For more information please refer to the following **Jira ticket**: [LPD-70700](https://liferay.atlassian.net/browse/LPD-70700)