### PR TITLE
LPD-71265 | Fix export import teardown

### DIFF
--- a/modules/test/playwright/tests/export-import-web/main/instance.import.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/instance.import.spec.ts
@@ -57,7 +57,7 @@ export const test = mergeTests(
 	wikiPagesTest
 );
 
-test('can export and import custom object entries at instance level', async ({
+test('Can export and import custom object entries at instance level', async ({
 	apiHelpers,
 	companyExportImportPage,
 }) => {
@@ -107,7 +107,7 @@ test('can export and import custom object entries at instance level', async ({
 	);
 });
 
-test('can import account restricted entry when account does and does not exist in enviroment', async ({
+test('Can import account restricted entry when account does and does not exist in environment', async ({
 	apiHelpers,
 	companyExportImportPage,
 }) => {
@@ -230,7 +230,7 @@ test('can import account restricted entry when account does and does not exist i
 	});
 });
 
-test('can import custom and system objects entries at instance level using date filter', async ({
+test('Can import custom and system objects entries at instance level using date filter', async ({
 	apiHelpers,
 	companyExportImportPage,
 	page,
@@ -363,7 +363,7 @@ test('can import custom and system objects entries at instance level using date 
 	});
 });
 
-test('can import custom object entries at instance level with or without permissions based on selection', async ({
+test('Can import custom object entries at instance level with or without permissions based on selection', async ({
 	apiHelpers,
 	companyExportImportPage,
 }) => {
@@ -460,7 +460,7 @@ test('can import custom object entries at instance level with or without permiss
 });
 
 test(
-	'can import custom object entries with current user as creator',
+	'Can import custom object entries with current user as creator',
 	{
 		tag: '@LPD-43217',
 	},
@@ -557,7 +557,7 @@ test(
 );
 
 test(
-	'can import custom object entries with original creator, and creator user does exist in the current environment',
+	'Can import custom object entries with original creator, and creator user does exist in the current environment',
 	{
 		tag: '@LPD-43217',
 	},
@@ -661,7 +661,7 @@ test(
 );
 
 test(
-	'can import custom object entries with original creator, but creator user does not exist in the current environment',
+	'Can import custom object entries with original creator, but creator user does not exist in the current environment',
 	{
 		tag: '@LPD-43217',
 	},
@@ -761,7 +761,7 @@ test(
 );
 
 test(
-	'can import custom object entry values',
+	'Can import custom object entry values',
 	{
 		tag: '@LPD-66167',
 	},
@@ -846,7 +846,7 @@ test(
 	}
 );
 
-test('can import many to many entries', async ({
+test('Can import many to many entries', async ({
 	apiHelpers,
 	companyExportImportPage,
 }) => {
@@ -1016,7 +1016,7 @@ test('can import many to many entries', async ({
 	});
 });
 
-test('can only import custom object entries when their definitions are already in the system', async ({
+test('Can only import custom object entries when their definitions are already in the system', async ({
 	apiHelpers,
 	companyExportImportPage,
 }) => {
@@ -1090,7 +1090,7 @@ test('can only import custom object entries when their definitions are already i
 	);
 });
 
-test('can see corresponding elements at instance level', async ({
+test('Can see corresponding elements at instance level', async ({
 	apiHelpers,
 	companyExportImportPage,
 }) => {
@@ -1249,7 +1249,7 @@ test('Can/not view Import menu item in Application menu depending on permissions
 	).toBeHidden();
 });
 
-test('cannot import a site scoped lar file', async ({
+test('Cannot import a site scoped lar file', async ({
 	companyExportImportPage,
 	exportImportPage,
 }) => {


### PR DESCRIPTION
**Jira ticket**: https://liferay.atlassian.net/browse/LPD-71265

**Description**: Test `Can only import custom object entries when their definitions are already in the system` fails in the second run after posting an objectDefinition but before removing it. This means that there is a `c_test` object definition created that will make the other tests fail.