### PR TITLE
LPD-71435 Make staging test run on export/import changes

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -1102,8 +1102,8 @@
 
     modified.files.includes[staging-playwright-rule][relevant]=\
         **/batch-planner/**/*.java,\
-        **/exportimport/**/*.java,\
         **/export-import/**/*.java,\
+        **/exportimport/**/*.java,\
         **/headless-builder/**/*.java,\
         **/object/object-rest-impl/**/*.java,\
         **/staging/**/*.java
@@ -1118,8 +1118,8 @@
 
     modified.files.includes[staging-rule][relevant]=\
         **/*Staging*.java,\
-        **/exportimport/**/*.java,\
-        **/export-import/**/*.java
+        **/export-import/**/*.java,\
+        **/exportimport/**/*.java
 
     modules.includes.required.test.batch.class.names.includes[staging-rule][relevant][modules-integration-postgresql163]=${test.batch.class.names.includes[headless-staging]}
 


### PR DESCRIPTION
### LPD: https://liferay.atlassian.net/browse/LPD-71435

> [!CAUTION]
> We need to remove the last commit 28d53442afc51ae6afc4dac30f1f8c382f21fc29 to forward it.

The changes we needed were mostly already in place. In principle, updates in `staging-taglib` should already trigger the Playwright tests (`staging-playwright-rule`) we expect. 

The issue we observed in the previous PR https://github.com/liferay-headless/liferay-portal/pull/3250 was unusual because no Java files were modified, so the tests were not triggered.

In this PR I added a missing condition so that any change in the `export/import` area also triggers the `staging-rule` and `staging-playwright-rule`, and I removed a glob pattern that produced no results.