### PR TITLE
LPD-72459 Make test more robust

### DIFF
--- a/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
+++ b/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
@@ -61,6 +61,7 @@ export class PageEditorPage {
 	readonly selectItemMappingButton: Locator;
 	readonly undoButton: Locator;
 	readonly undoHistory: Locator;
+	readonly pageEditor: Locator;
 
 	constructor(page: Page) {
 		this.page = page;
@@ -89,6 +90,7 @@ export class PageEditorPage {
 		this.selectItemMappingButton = page.getByLabel('Select Item');
 		this.undoButton = page.getByTitle('Undo');
 		this.undoHistory = page.locator('.page-editor__undo-history');
+		this.pageEditor = page.locator('.page-editor');
 	}
 
 	async goto(layout: Layout, siteUrl?: Site['friendlyUrlPath']) {
@@ -1804,6 +1806,12 @@ export class PageEditorPage {
 				'Changes have been saved. Page editor will autosave new changes.'
 			)
 			.waitFor({timeout});
+	}
+
+	async waitForPageEditorContent(text: string) {
+		await expect(async () => {
+			await expect(this.pageEditor).toContainText(text);
+		}).toPass({timeout: 30000});
 	}
 
 	getEditable({

--- a/modules/test/playwright/tests/export-import-web/main/stagingUseCase.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/stagingUseCase.spec.ts
@@ -266,10 +266,7 @@ test('Staging only approved content goes to live', async ({
 
 	await pageEditorPage.goto(layout1, stagingSite.friendlyUrlPath);
 
-	const pageViewportLocator = page.locator(
-		'.page-editor__layout-viewport__resizer'
-	);
-	await expect(pageViewportLocator).toContainText(webcontentContent1);
+	await pageEditorPage.waitForPageEditorContent(webcontentContent1);
 
 	await pageEditorPage.goto(layout2, stagingSite.friendlyUrlPath);
 	await expect(


### PR DESCRIPTION
Jira Ticket: https://liferay.atlassian.net/browse/LPD-72459

Replaced `getByText` with `locator() + toContainText` to make the test more robust. This anchors the check to a specific element. 