### PR TITLE
LPD-76339 Technical Task | [POSHI] Investigate java.lang.Exception: TEST_SETUP_ERROR: Element is not present at "//div[contains(@class,'table-list-title') and contains(.,'My-app')]/../..//button[contains(.,'Action')]"...

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineEndpointsToRetrieveASingleElement/CreateGETEndpointThatRetrieveSingleEntry.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineEndpointsToRetrieveASingleElement/CreateGETEndpointThatRetrieveSingleEntry.testcase
@@ -1,6 +1,7 @@
 @component-name = "portal-headless"
 definition {
 
+	property browser.chrome.version = "139.0";
 	property custom.properties = "feature.flag.LPS-178642=true";
 	property portal.acceptance = "quarantine";
 	property portal.release = "true";

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]DefineAPISchemasWithinAnAPIGroup/CreateAPIApplicationSchema.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]DefineAPISchemasWithinAnAPIGroup/CreateAPIApplicationSchema.testcase
@@ -1,6 +1,7 @@
 @component-name = "portal-headless"
 definition {
 
+	property browser.chrome.version = "139.0";
 	property custom.properties = "feature.flag.LPS-178642=true";
 	property portal.acceptance = "quarantine";
 	property portal.release = "true";


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-76339

Some POSHI functional tests have been failing intermittently in CI while passing consistently in local environments. These failures typically occur when tests are executed with Chrome 100, where certain UI elements are not reliably loaded or detected. The issue appears to be influenced by ongoing changes from the Frontend Infrastructure team, as well as other frontend-related updates, which can lead to errors under specific browser conditions.

To improve test stability and reduce flakiness, this pull request explicitly defines a fixed Chrome browser version (139.0) for the affected POSHI test cases. By standardizing the browser version used during execution, we ensure more consistent rendering and interaction behavior across environments, minimizing discrepancies between local and CI runs.

This change does not alter test logic or test coverage; it strictly enhances the reliability and predictability of the test execution environment for critical staging functionalities.