### PR TITLE
LPD-77057 [Categorization] New value on portlet data handlers

### DIFF
--- a/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/constants/ExportImportConstants.java
+++ b/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/constants/ExportImportConstants.java
@@ -12,21 +12,21 @@ public class ExportImportConstants {
 
 	public static final String EXPORT_IMPORT_SCHEMA_VERSION = "4.0.0";
 
-	public static final String SECTION_NAME_CONTENT =
+	public static final String SECTION_KEY_CONTENT =
 		"category.site_administration.content";
 
-	public static final String SECTION_NAME_DESIGN =
+	public static final String SECTION_KEY_DESIGN =
 		"category.site_administration.design";
 
-	public static final String SECTION_NAME_OBJECTS = "objects";
+	public static final String SECTION_KEY_OBJECTS = "objects";
 
-	public static final String SECTION_NAME_OTHERS = "others";
+	public static final String SECTION_KEY_OTHERS = "others";
 
-	public static final String SECTION_NAME_PAGES = "pages";
+	public static final String SECTION_KEY_PAGES = "pages";
 
-	public static final String SECTION_NAME_SITE_BUILDER =
+	public static final String SECTION_KEY_SITE_BUILDER =
 		"category.site_administration.build";
 
-	public static final String SECTION_NAME_SITES = "sites";
+	public static final String SECTION_KEY_SITES = "sites";
 
 }

--- a/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/constants/ExportImportConstants.java
+++ b/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/constants/ExportImportConstants.java
@@ -12,4 +12,21 @@ public class ExportImportConstants {
 
 	public static final String EXPORT_IMPORT_SCHEMA_VERSION = "4.0.0";
 
+	public static final String SECTION_NAME_CONTENT =
+		"category.site_administration.content";
+
+	public static final String SECTION_NAME_DESIGN =
+		"category.site_administration.design";
+
+	public static final String SECTION_NAME_OBJECTS = "objects";
+
+	public static final String SECTION_NAME_OTHERS = "others";
+
+	public static final String SECTION_NAME_PAGES = "pages";
+
+	public static final String SECTION_NAME_SITE_BUILDER =
+		"category.site_administration.build";
+
+	public static final String SECTION_NAME_SITES = "sites";
+
 }

--- a/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/constants/ExportImportConstants.java
+++ b/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/constants/ExportImportConstants.java
@@ -18,6 +18,8 @@ public class ExportImportConstants {
 	public static final String SECTION_KEY_DESIGN =
 		"category.site_administration.design";
 
+	public static final String SECTION_KEY_MULTIPLE = "multiple-sections";
+
 	public static final String SECTION_KEY_OBJECTS = "objects";
 
 	public static final String SECTION_KEY_OTHERS = "others";

--- a/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/vulcan/batch/engine/ExportImportVulcanBatchEngineTaskItemDelegate.java
+++ b/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/vulcan/batch/engine/ExportImportVulcanBatchEngineTaskItemDelegate.java
@@ -5,6 +5,7 @@
 
 package com.liferay.exportimport.vulcan.batch.engine;
 
+import com.liferay.exportimport.constants.ExportImportConstants;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 
@@ -19,23 +20,6 @@ import java.util.Map;
  */
 public interface ExportImportVulcanBatchEngineTaskItemDelegate<T>
 	extends VulcanBatchEngineTaskItemDelegate<T> {
-
-	public static String SECTION_NAME_CONTENT =
-		"category.site_administration.content";
-
-	public static String SECTION_NAME_DESIGN =
-		"category.site_administration.design";
-
-	public static String SECTION_NAME_OBJECTS = "objects";
-
-	public static String SECTION_NAME_OTHERS = "others";
-
-	public static String SECTION_NAME_PAGES = "pages";
-
-	public static String SECTION_NAME_SITE_BUILDER =
-		"category.site_administration.build";
-
-	public static String SECTION_NAME_SITES = "sites";
 
 	public ExportImportDescriptor getExportImportDescriptor();
 
@@ -74,7 +58,7 @@ public interface ExportImportVulcanBatchEngineTaskItemDelegate<T>
 		public Scope getScope();
 
 		public default String getSectionLanguageKey() {
-			return SECTION_NAME_OTHERS;
+			return ExportImportConstants.SECTION_NAME_OTHERS;
 		}
 
 		public default String getTag(Locale locale) {

--- a/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/vulcan/batch/engine/ExportImportVulcanBatchEngineTaskItemDelegate.java
+++ b/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/vulcan/batch/engine/ExportImportVulcanBatchEngineTaskItemDelegate.java
@@ -5,7 +5,6 @@
 
 package com.liferay.exportimport.vulcan.batch.engine;
 
-import com.liferay.exportimport.constants.ExportImportConstants;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 
@@ -58,7 +57,7 @@ public interface ExportImportVulcanBatchEngineTaskItemDelegate<T>
 		public Scope getScope();
 
 		public default String getSectionLanguageKey() {
-			return ExportImportConstants.SECTION_NAME_OTHERS;
+			return null;
 		}
 
 		public default String getTag(Locale locale) {

--- a/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/vulcan/batch/engine/ExportImportVulcanBatchEngineTaskItemDelegate.java
+++ b/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/vulcan/batch/engine/ExportImportVulcanBatchEngineTaskItemDelegate.java
@@ -56,7 +56,7 @@ public interface ExportImportVulcanBatchEngineTaskItemDelegate<T>
 
 		public Scope getScope();
 
-		public default String getSectionLanguageKey() {
+		public default String getSectionKey() {
 			return null;
 		}
 

--- a/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/vulcan/batch/engine/ExportImportVulcanBatchEngineTaskItemDelegate.java
+++ b/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/vulcan/batch/engine/ExportImportVulcanBatchEngineTaskItemDelegate.java
@@ -20,6 +20,17 @@ import java.util.Map;
 public interface ExportImportVulcanBatchEngineTaskItemDelegate<T>
 	extends VulcanBatchEngineTaskItemDelegate<T> {
 
+	public static String SECTION_NAME_CONTENT =
+		"category.site_administration.content";
+
+	public static String SECTION_NAME_DESIGN =
+		"category.site_administration.design";
+
+	public static String SECTION_NAME_OBJECTS = "objects";
+
+	public static String SECTION_NAME_SITE_BUILDER =
+		"category.site_administration.build";
+
 	public ExportImportDescriptor getExportImportDescriptor();
 
 	public interface ExportImportDescriptor {
@@ -55,6 +66,10 @@ public interface ExportImportVulcanBatchEngineTaskItemDelegate<T>
 		public String getResourceClassName();
 
 		public Scope getScope();
+
+		public default String getSectionLanguageKey() {
+			return SECTION_NAME_CONTENT;
+		}
 
 		public default String getTag(Locale locale) {
 			return null;

--- a/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/vulcan/batch/engine/ExportImportVulcanBatchEngineTaskItemDelegate.java
+++ b/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/vulcan/batch/engine/ExportImportVulcanBatchEngineTaskItemDelegate.java
@@ -28,8 +28,14 @@ public interface ExportImportVulcanBatchEngineTaskItemDelegate<T>
 
 	public static String SECTION_NAME_OBJECTS = "objects";
 
+	public static String SECTION_NAME_OTHERS = "others";
+
+	public static String SECTION_NAME_PAGES = "pages";
+
 	public static String SECTION_NAME_SITE_BUILDER =
 		"category.site_administration.build";
+
+	public static String SECTION_NAME_SITES = "sites";
 
 	public ExportImportDescriptor getExportImportDescriptor();
 
@@ -68,7 +74,7 @@ public interface ExportImportVulcanBatchEngineTaskItemDelegate<T>
 		public Scope getScope();
 
 		public default String getSectionLanguageKey() {
-			return SECTION_NAME_CONTENT;
+			return SECTION_NAME_OTHERS;
 		}
 
 		public default String getTag(Locale locale) {

--- a/modules/apps/export-import/export-import-api/src/main/resources/com/liferay/exportimport/constants/packageinfo
+++ b/modules/apps/export-import/export-import-api/src/main/resources/com/liferay/exportimport/constants/packageinfo
@@ -1,1 +1,1 @@
-version 1.3.0
+version 1.4.0

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandler.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandler.java
@@ -173,6 +173,17 @@ public class BatchEnginePortletDataHandler extends BasePortletDataHandler {
 	}
 
 	@Override
+	public String getSectionName() {
+		if (_registrations.isEmpty()) {
+			return null;
+		}
+
+		return _getSoleProperty(
+			ExportImportVulcanBatchEngineTaskItemDelegate.
+				ExportImportDescriptor::getSectionLanguageKey);
+	}
+
+	@Override
 	public String getTag(Locale locale) {
 		return _getSoleProperty(
 			exportImportDescriptor -> exportImportDescriptor.getTag(locale));

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandler.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandler.java
@@ -173,10 +173,10 @@ public class BatchEnginePortletDataHandler extends BasePortletDataHandler {
 	}
 
 	@Override
-	public String getSectionName() {
+	public String getSectionKey() {
 		return _getFirstProperty(
 			ExportImportVulcanBatchEngineTaskItemDelegate.
-				ExportImportDescriptor::getSectionLanguageKey);
+				ExportImportDescriptor::getSectionKey);
 	}
 
 	@Override

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandler.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandler.java
@@ -678,21 +678,6 @@ public class BatchEnginePortletDataHandler extends BasePortletDataHandler {
 		return unsyncByteArrayOutputStream.toByteArray();
 	}
 
-	private <T> T _getFirstProperty(
-		Function
-			<ExportImportVulcanBatchEngineTaskItemDelegate.
-				ExportImportDescriptor,
-			 T> function) {
-
-		if (_registrations.isEmpty()) {
-			return null;
-		}
-
-		Registration registration = _registrations.get(0);
-
-		return function.apply(registration.getExportImportDescriptor());
-	}
-
 	private PortletDataHandlerControl _getPortletDataHandlerControl(
 		Registration registration) {
 
@@ -715,7 +700,9 @@ public class BatchEnginePortletDataHandler extends BasePortletDataHandler {
 			return null;
 		}
 
-		return _getFirstProperty(function);
+		Registration registration = _registrations.get(0);
+
+		return function.apply(registration.getExportImportDescriptor());
 	}
 
 	private long _getUserId() {

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandler.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandler.java
@@ -174,10 +174,6 @@ public class BatchEnginePortletDataHandler extends BasePortletDataHandler {
 
 	@Override
 	public String getSectionName() {
-		if (_registrations.isEmpty()) {
-			return null;
-		}
-
 		return _getFirstProperty(
 			ExportImportVulcanBatchEngineTaskItemDelegate.
 				ExportImportDescriptor::getSectionLanguageKey);

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandler.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandler.java
@@ -15,6 +15,7 @@ import com.liferay.batch.engine.model.BatchEngineExportTask;
 import com.liferay.batch.engine.model.BatchEngineImportTask;
 import com.liferay.batch.engine.service.BatchEngineExportTaskLocalService;
 import com.liferay.batch.engine.service.BatchEngineImportTaskService;
+import com.liferay.exportimport.constants.ExportImportConstants;
 import com.liferay.exportimport.internal.lar.ExportImportDescriptorThreadLocal;
 import com.liferay.exportimport.internal.lar.PortletDataContextImpl;
 import com.liferay.exportimport.internal.lar.PortletDataContextThreadLocal;
@@ -47,6 +48,7 @@ import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.staging.StagingGroupHelper;
 
@@ -62,6 +64,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -174,9 +177,28 @@ public class BatchEnginePortletDataHandler extends BasePortletDataHandler {
 
 	@Override
 	public String getSectionKey() {
-		return _getFirstProperty(
-			ExportImportVulcanBatchEngineTaskItemDelegate.
-				ExportImportDescriptor::getSectionKey);
+		Set<String> sectionKeys = SetUtil.fromList(
+			TransformUtil.transform(
+				_registrations,
+				registration -> {
+					ExportImportVulcanBatchEngineTaskItemDelegate.
+						ExportImportDescriptor exportImportDescriptor =
+							registration.getExportImportDescriptor();
+
+					return exportImportDescriptor.getSectionKey();
+				}));
+
+		if (sectionKeys.isEmpty()) {
+			return ExportImportConstants.SECTION_KEY_OTHERS;
+		}
+
+		if (sectionKeys.size() > 1) {
+			return ExportImportConstants.SECTION_KEY_MULTIPLE;
+		}
+
+		Iterator<String> iterator = sectionKeys.iterator();
+
+		return iterator.next();
 	}
 
 	@Override

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandler.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandler.java
@@ -178,7 +178,7 @@ public class BatchEnginePortletDataHandler extends BasePortletDataHandler {
 			return null;
 		}
 
-		return _getSoleProperty(
+		return _getFirstProperty(
 			ExportImportVulcanBatchEngineTaskItemDelegate.
 				ExportImportDescriptor::getSectionLanguageKey);
 	}
@@ -660,6 +660,21 @@ public class BatchEnginePortletDataHandler extends BasePortletDataHandler {
 		return unsyncByteArrayOutputStream.toByteArray();
 	}
 
+	private <T> T _getFirstProperty(
+		Function
+			<ExportImportVulcanBatchEngineTaskItemDelegate.
+				ExportImportDescriptor,
+			 T> function) {
+
+		if (_registrations.isEmpty()) {
+			return null;
+		}
+
+		Registration registration = _registrations.get(0);
+
+		return function.apply(registration.getExportImportDescriptor());
+	}
+
 	private PortletDataHandlerControl _getPortletDataHandlerControl(
 		Registration registration) {
 
@@ -682,9 +697,7 @@ public class BatchEnginePortletDataHandler extends BasePortletDataHandler {
 			return null;
 		}
 
-		Registration registration = _registrations.get(0);
-
-		return function.apply(registration.getExportImportDescriptor());
+		return _getFirstProperty(function);
 	}
 
 	private long _getUserId() {

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
@@ -1626,31 +1626,30 @@ public class BatchEnginePortletDataHandlerTest {
 
 	@Test
 	@TestInfo("LPD-76858")
-	public void testGetSectionName() throws Exception {
+	public void testGetSectionKey() throws Exception {
 		String portletId = RandomTestUtil.randomString();
-		String sectionLanguageKey = RandomTestUtil.randomString();
+		String sectionKey = RandomTestUtil.randomString();
 
 		try (SafeCloseable safeCloseable1 = _register(
 				new TestExportImportVulcanBatchEngineTaskItemDelegateBuilder(
 				).withPortletId(
 					portletId
-				).withSectionLanguageKey(
-					sectionLanguageKey
+				).withSectionKey(
+					sectionKey
 				).build());
 			SafeCloseable safeCloseable2 = _register(
 				new TestExportImportVulcanBatchEngineTaskItemDelegateBuilder(
 				).withPortletId(
 					portletId
-				).withSectionLanguageKey(
-					sectionLanguageKey
+				).withSectionKey(
+					sectionKey
 				).build())) {
 
 			PortletDataHandler portletDataHandler =
 				_portletDataHandlerProvider.provide(
 					TestPropsValues.getCompanyId(), portletId);
 
-			Assert.assertEquals(
-				sectionLanguageKey, portletDataHandler.getSectionName());
+			Assert.assertEquals(sectionKey, portletDataHandler.getSectionKey());
 		}
 	}
 
@@ -3459,12 +3458,12 @@ public class BatchEnginePortletDataHandlerTest {
 
 		public TestExportImportVulcanBatchEngineTaskItemDelegate(
 			Function<Filter, Page<TestItem>> function, String portletId,
-			Integer rank, String sectionLanguageKey, boolean stagingSupported) {
+			Integer rank, String sectionKey, boolean stagingSupported) {
 
 			_function = function;
 			_portletId = portletId;
 			_rank = rank;
-			_sectionLanguageKey = sectionLanguageKey;
+			_sectionKey = sectionKey;
 			_stagingSupported = stagingSupported;
 		}
 
@@ -3531,8 +3530,8 @@ public class BatchEnginePortletDataHandlerTest {
 				}
 
 				@Override
-				public String getSectionLanguageKey() {
-					return _sectionLanguageKey;
+				public String getSectionKey() {
+					return _sectionKey;
 				}
 
 				@Override
@@ -3625,7 +3624,7 @@ public class BatchEnginePortletDataHandlerTest {
 		private final String _portletId;
 		private final Integer _rank;
 		private final String _resourceClassName = RandomTestUtil.randomString();
-		private final String _sectionLanguageKey;
+		private final String _sectionKey;
 		private final boolean _stagingSupported;
 
 	}
@@ -3639,8 +3638,7 @@ public class BatchEnginePortletDataHandlerTest {
 			}
 
 			return new TestExportImportVulcanBatchEngineTaskItemDelegate(
-				_function, _portletId, _rank, _sectionLanguageKey,
-				_stagingSupported);
+				_function, _portletId, _rank, _sectionKey, _stagingSupported);
 		}
 
 		public TestExportImportVulcanBatchEngineTaskItemDelegateBuilder
@@ -3668,9 +3666,9 @@ public class BatchEnginePortletDataHandlerTest {
 		}
 
 		public TestExportImportVulcanBatchEngineTaskItemDelegateBuilder
-			withSectionLanguageKey(String sectionLanguageKey) {
+			withSectionKey(String sectionKey) {
 
-			_sectionLanguageKey = sectionLanguageKey;
+			_sectionKey = sectionKey;
 
 			return this;
 		}
@@ -3686,7 +3684,7 @@ public class BatchEnginePortletDataHandlerTest {
 		private Function<Filter, Page<TestItem>> _function;
 		private String _portletId;
 		private Integer _rank;
-		private String _sectionLanguageKey;
+		private String _sectionKey;
 		private boolean _stagingSupported;
 
 	}

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
@@ -1630,7 +1630,14 @@ public class BatchEnginePortletDataHandlerTest {
 		String portletId = RandomTestUtil.randomString();
 		String sectionLanguageKey = RandomTestUtil.randomString();
 
-		try (SafeCloseable safeCloseable = _register(
+		try (SafeCloseable safeCloseable1 = _register(
+				new TestExportImportVulcanBatchEngineTaskItemDelegateBuilder(
+				).withPortletId(
+					portletId
+				).withSectionLanguageKey(
+					sectionLanguageKey
+				).build());
+			SafeCloseable safeCloseable2 = _register(
 				new TestExportImportVulcanBatchEngineTaskItemDelegateBuilder(
 				).withPortletId(
 					portletId

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
@@ -1625,6 +1625,29 @@ public class BatchEnginePortletDataHandlerTest {
 	}
 
 	@Test
+	@TestInfo("LPD-76858")
+	public void testGetSectionName() throws Exception {
+		String portletId = RandomTestUtil.randomString();
+		String sectionLanguageKey = RandomTestUtil.randomString();
+
+		try (SafeCloseable safeCloseable = _register(
+				new TestExportImportVulcanBatchEngineTaskItemDelegateBuilder(
+				).withPortletId(
+					portletId
+				).withSectionLanguageKey(
+					sectionLanguageKey
+				).build())) {
+
+			PortletDataHandler portletDataHandler =
+				_portletDataHandlerProvider.provide(
+					TestPropsValues.getCompanyId(), portletId);
+
+			Assert.assertEquals(
+				sectionLanguageKey, portletDataHandler.getSectionName());
+		}
+	}
+
+	@Test
 	@TestInfo("LPD-49421")
 	public void testImportIndividualDeletionsCompanyGroup() throws Exception {
 		Group group = _stagingGroupHelper.fetchCompanyGroup(
@@ -3429,11 +3452,12 @@ public class BatchEnginePortletDataHandlerTest {
 
 		public TestExportImportVulcanBatchEngineTaskItemDelegate(
 			Function<Filter, Page<TestItem>> function, String portletId,
-			Integer rank, boolean stagingSupported) {
+			Integer rank, String sectionLanguageKey, boolean stagingSupported) {
 
 			_function = function;
 			_portletId = portletId;
 			_rank = rank;
+			_sectionLanguageKey = sectionLanguageKey;
 			_stagingSupported = stagingSupported;
 		}
 
@@ -3497,6 +3521,11 @@ public class BatchEnginePortletDataHandlerTest {
 				@Override
 				public Scope getScope() {
 					return Scope.COMPANY;
+				}
+
+				@Override
+				public String getSectionLanguageKey() {
+					return _sectionLanguageKey;
 				}
 
 				@Override
@@ -3589,6 +3618,7 @@ public class BatchEnginePortletDataHandlerTest {
 		private final String _portletId;
 		private final Integer _rank;
 		private final String _resourceClassName = RandomTestUtil.randomString();
+		private final String _sectionLanguageKey;
 		private final boolean _stagingSupported;
 
 	}
@@ -3602,7 +3632,8 @@ public class BatchEnginePortletDataHandlerTest {
 			}
 
 			return new TestExportImportVulcanBatchEngineTaskItemDelegate(
-				_function, _portletId, _rank, _stagingSupported);
+				_function, _portletId, _rank, _sectionLanguageKey,
+				_stagingSupported);
 		}
 
 		public TestExportImportVulcanBatchEngineTaskItemDelegateBuilder
@@ -3630,6 +3661,14 @@ public class BatchEnginePortletDataHandlerTest {
 		}
 
 		public TestExportImportVulcanBatchEngineTaskItemDelegateBuilder
+			withSectionLanguageKey(String sectionLanguageKey) {
+
+			_sectionLanguageKey = sectionLanguageKey;
+
+			return this;
+		}
+
+		public TestExportImportVulcanBatchEngineTaskItemDelegateBuilder
 			withStagingSupported(boolean stagingSupported) {
 
 			_stagingSupported = stagingSupported;
@@ -3640,6 +3679,7 @@ public class BatchEnginePortletDataHandlerTest {
 		private Function<Filter, Page<TestItem>> _function;
 		private String _portletId;
 		private Integer _rank;
+		private String _sectionLanguageKey;
 		private boolean _stagingSupported;
 
 	}

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
@@ -17,6 +17,7 @@ import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.document.library.util.DLURLHelper;
+import com.liferay.exportimport.constants.ExportImportConstants;
 import com.liferay.exportimport.data.handler.base.BaseStagedModelDataHandler;
 import com.liferay.exportimport.kernel.configuration.ExportImportConfigurationSettingsMapFactoryUtil;
 import com.liferay.exportimport.kernel.configuration.constants.ExportImportConfigurationConstants;
@@ -1628,28 +1629,76 @@ public class BatchEnginePortletDataHandlerTest {
 	@TestInfo("LPD-76858")
 	public void testGetSectionKey() throws Exception {
 		String portletId = RandomTestUtil.randomString();
-		String sectionKey = RandomTestUtil.randomString();
 
 		try (SafeCloseable safeCloseable1 = _register(
 				new TestExportImportVulcanBatchEngineTaskItemDelegateBuilder(
 				).withPortletId(
 					portletId
-				).withSectionKey(
-					sectionKey
 				).build());
 			SafeCloseable safeCloseable2 = _register(
 				new TestExportImportVulcanBatchEngineTaskItemDelegateBuilder(
 				).withPortletId(
 					portletId
-				).withSectionKey(
-					sectionKey
 				).build())) {
 
 			PortletDataHandler portletDataHandler =
 				_portletDataHandlerProvider.provide(
 					TestPropsValues.getCompanyId(), portletId);
 
-			Assert.assertEquals(sectionKey, portletDataHandler.getSectionKey());
+			Assert.assertEquals(
+				ExportImportConstants.SECTION_KEY_OTHERS,
+				portletDataHandler.getSectionKey());
+		}
+
+		String sectionKey1 = RandomTestUtil.randomString();
+
+		try (SafeCloseable safeCloseable1 = _register(
+				new TestExportImportVulcanBatchEngineTaskItemDelegateBuilder(
+				).withPortletId(
+					portletId
+				).withSectionKey(
+					sectionKey1
+				).build());
+			SafeCloseable safeCloseable2 = _register(
+				new TestExportImportVulcanBatchEngineTaskItemDelegateBuilder(
+				).withPortletId(
+					portletId
+				).withSectionKey(
+					sectionKey1
+				).build())) {
+
+			PortletDataHandler portletDataHandler =
+				_portletDataHandlerProvider.provide(
+					TestPropsValues.getCompanyId(), portletId);
+
+			Assert.assertEquals(
+				sectionKey1, portletDataHandler.getSectionKey());
+		}
+
+		String sectionKey2 = RandomTestUtil.randomString();
+
+		try (SafeCloseable safeCloseable1 = _register(
+				new TestExportImportVulcanBatchEngineTaskItemDelegateBuilder(
+				).withPortletId(
+					portletId
+				).withSectionKey(
+					sectionKey1
+				).build());
+			SafeCloseable safeCloseable2 = _register(
+				new TestExportImportVulcanBatchEngineTaskItemDelegateBuilder(
+				).withPortletId(
+					portletId
+				).withSectionKey(
+					sectionKey2
+				).build())) {
+
+			PortletDataHandler portletDataHandler =
+				_portletDataHandlerProvider.provide(
+					TestPropsValues.getCompanyId(), portletId);
+
+			Assert.assertEquals(
+				ExportImportConstants.SECTION_KEY_MULTIPLE,
+				portletDataHandler.getSectionKey());
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/DisplayPageTemplateFolderResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/DisplayPageTemplateFolderResourceImpl.java
@@ -5,6 +5,7 @@
 
 package com.liferay.headless.admin.site.internal.resource.v1_0;
 
+import com.liferay.exportimport.constants.ExportImportConstants;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngineTaskItemDelegate;
 import com.liferay.headless.admin.site.dto.v1_0.DisplayPageTemplateFolder;
@@ -105,7 +106,7 @@ public class DisplayPageTemplateFolderResourceImpl
 
 			@Override
 			public String getSectionLanguageKey() {
-				return SECTION_NAME_DESIGN;
+				return ExportImportConstants.SECTION_NAME_DESIGN;
 			}
 
 			@Override

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/DisplayPageTemplateFolderResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/DisplayPageTemplateFolderResourceImpl.java
@@ -104,6 +104,11 @@ public class DisplayPageTemplateFolderResourceImpl
 			}
 
 			@Override
+			public String getSectionLanguageKey() {
+				return SECTION_NAME_DESIGN;
+			}
+
+			@Override
 			public boolean isActive(PortletDataContext portletDataContext) {
 				return FeatureFlagManagerUtil.isEnabled("LPD-35443");
 			}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/DisplayPageTemplateFolderResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/DisplayPageTemplateFolderResourceImpl.java
@@ -105,8 +105,8 @@ public class DisplayPageTemplateFolderResourceImpl
 			}
 
 			@Override
-			public String getSectionLanguageKey() {
-				return ExportImportConstants.SECTION_NAME_DESIGN;
+			public String getSectionKey() {
+				return ExportImportConstants.SECTION_KEY_DESIGN;
 			}
 
 			@Override

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/DisplayPageTemplateResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/DisplayPageTemplateResourceImpl.java
@@ -149,8 +149,8 @@ public class DisplayPageTemplateResourceImpl
 			}
 
 			@Override
-			public String getSectionLanguageKey() {
-				return ExportImportConstants.SECTION_NAME_DESIGN;
+			public String getSectionKey() {
+				return ExportImportConstants.SECTION_KEY_DESIGN;
 			}
 
 			@Override

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/DisplayPageTemplateResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/DisplayPageTemplateResourceImpl.java
@@ -6,6 +6,7 @@
 package com.liferay.headless.admin.site.internal.resource.v1_0;
 
 import com.liferay.client.extension.type.manager.CETManager;
+import com.liferay.exportimport.constants.ExportImportConstants;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngineTaskItemDelegate;
 import com.liferay.fragment.processor.FragmentEntryProcessorRegistry;
@@ -149,7 +150,7 @@ public class DisplayPageTemplateResourceImpl
 
 			@Override
 			public String getSectionLanguageKey() {
-				return SECTION_NAME_DESIGN;
+				return ExportImportConstants.SECTION_NAME_DESIGN;
 			}
 
 			@Override

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/DisplayPageTemplateResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/DisplayPageTemplateResourceImpl.java
@@ -148,6 +148,11 @@ public class DisplayPageTemplateResourceImpl
 			}
 
 			@Override
+			public String getSectionLanguageKey() {
+				return SECTION_NAME_DESIGN;
+			}
+
+			@Override
 			public boolean isActive(PortletDataContext portletDataContext) {
 				return FeatureFlagManagerUtil.isEnabled("LPD-35443");
 			}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/MasterPageResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/MasterPageResourceImpl.java
@@ -6,6 +6,7 @@
 package com.liferay.headless.admin.site.internal.resource.v1_0;
 
 import com.liferay.client.extension.type.manager.CETManager;
+import com.liferay.exportimport.constants.ExportImportConstants;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngineTaskItemDelegate;
 import com.liferay.fragment.processor.FragmentEntryProcessorRegistry;
@@ -127,7 +128,7 @@ public class MasterPageResourceImpl
 
 			@Override
 			public String getSectionLanguageKey() {
-				return SECTION_NAME_DESIGN;
+				return ExportImportConstants.SECTION_NAME_DESIGN;
 			}
 
 			@Override

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/MasterPageResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/MasterPageResourceImpl.java
@@ -126,6 +126,11 @@ public class MasterPageResourceImpl
 			}
 
 			@Override
+			public String getSectionLanguageKey() {
+				return SECTION_NAME_DESIGN;
+			}
+
+			@Override
 			public boolean isActive(PortletDataContext portletDataContext) {
 				return FeatureFlagManagerUtil.isEnabled("LPD-35443");
 			}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/MasterPageResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/MasterPageResourceImpl.java
@@ -127,8 +127,8 @@ public class MasterPageResourceImpl
 			}
 
 			@Override
-			public String getSectionLanguageKey() {
-				return ExportImportConstants.SECTION_NAME_DESIGN;
+			public String getSectionKey() {
+				return ExportImportConstants.SECTION_KEY_DESIGN;
 			}
 
 			@Override

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageTemplateResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageTemplateResourceImpl.java
@@ -6,6 +6,7 @@
 package com.liferay.headless.admin.site.internal.resource.v1_0;
 
 import com.liferay.client.extension.type.manager.CETManager;
+import com.liferay.exportimport.constants.ExportImportConstants;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngineTaskItemDelegate;
 import com.liferay.fragment.processor.FragmentEntryProcessorRegistry;
@@ -148,7 +149,7 @@ public class PageTemplateResourceImpl
 
 			@Override
 			public String getSectionLanguageKey() {
-				return SECTION_NAME_DESIGN;
+				return ExportImportConstants.SECTION_NAME_DESIGN;
 			}
 
 			@Override

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageTemplateResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageTemplateResourceImpl.java
@@ -148,8 +148,8 @@ public class PageTemplateResourceImpl
 			}
 
 			@Override
-			public String getSectionLanguageKey() {
-				return ExportImportConstants.SECTION_NAME_DESIGN;
+			public String getSectionKey() {
+				return ExportImportConstants.SECTION_KEY_DESIGN;
 			}
 
 			@Override

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageTemplateResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageTemplateResourceImpl.java
@@ -147,6 +147,11 @@ public class PageTemplateResourceImpl
 			}
 
 			@Override
+			public String getSectionLanguageKey() {
+				return SECTION_NAME_DESIGN;
+			}
+
+			@Override
 			public boolean isActive(PortletDataContext portletDataContext) {
 				return FeatureFlagManagerUtil.isEnabled("LPD-35443");
 			}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageTemplateSetResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageTemplateSetResourceImpl.java
@@ -101,6 +101,11 @@ public class PageTemplateSetResourceImpl
 			}
 
 			@Override
+			public String getSectionLanguageKey() {
+				return SECTION_NAME_DESIGN;
+			}
+
+			@Override
 			public boolean isActive(PortletDataContext portletDataContext) {
 				return FeatureFlagManagerUtil.isEnabled("LPD-35443");
 			}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageTemplateSetResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageTemplateSetResourceImpl.java
@@ -102,8 +102,8 @@ public class PageTemplateSetResourceImpl
 			}
 
 			@Override
-			public String getSectionLanguageKey() {
-				return ExportImportConstants.SECTION_NAME_DESIGN;
+			public String getSectionKey() {
+				return ExportImportConstants.SECTION_KEY_DESIGN;
 			}
 
 			@Override

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageTemplateSetResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageTemplateSetResourceImpl.java
@@ -5,6 +5,7 @@
 
 package com.liferay.headless.admin.site.internal.resource.v1_0;
 
+import com.liferay.exportimport.constants.ExportImportConstants;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngineTaskItemDelegate;
 import com.liferay.headless.admin.site.dto.v1_0.PageTemplateSet;
@@ -102,7 +103,7 @@ public class PageTemplateSetResourceImpl
 
 			@Override
 			public String getSectionLanguageKey() {
-				return SECTION_NAME_DESIGN;
+				return ExportImportConstants.SECTION_NAME_DESIGN;
 			}
 
 			@Override

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SitePageResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SitePageResourceImpl.java
@@ -6,6 +6,7 @@
 package com.liferay.headless.admin.site.internal.resource.v1_0;
 
 import com.liferay.client.extension.type.manager.CETManager;
+import com.liferay.exportimport.constants.ExportImportConstants;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngineTaskItemDelegate;
 import com.liferay.fragment.processor.FragmentEntryProcessorRegistry;
@@ -221,7 +222,7 @@ public class SitePageResourceImpl
 
 			@Override
 			public String getSectionLanguageKey() {
-				return SECTION_NAME_SITE_BUILDER;
+				return ExportImportConstants.SECTION_NAME_SITE_BUILDER;
 			}
 
 			@Override

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SitePageResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SitePageResourceImpl.java
@@ -221,8 +221,8 @@ public class SitePageResourceImpl
 			}
 
 			@Override
-			public String getSectionLanguageKey() {
-				return ExportImportConstants.SECTION_NAME_SITE_BUILDER;
+			public String getSectionKey() {
+				return ExportImportConstants.SECTION_KEY_SITE_BUILDER;
 			}
 
 			@Override

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SitePageResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SitePageResourceImpl.java
@@ -220,6 +220,11 @@ public class SitePageResourceImpl
 			}
 
 			@Override
+			public String getSectionLanguageKey() {
+				return SECTION_NAME_SITE_BUILDER;
+			}
+
+			@Override
 			public boolean isActive(PortletDataContext portletDataContext) {
 				if (!portletDataContext.isPrivateLayout() &&
 					FeatureFlagManagerUtil.isEnabled("LPD-35443")) {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/UtilityPageResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/UtilityPageResourceImpl.java
@@ -127,6 +127,11 @@ public class UtilityPageResourceImpl
 			}
 
 			@Override
+			public String getSectionLanguageKey() {
+				return SECTION_NAME_SITE_BUILDER;
+			}
+
+			@Override
 			public boolean isActive(PortletDataContext portletDataContext) {
 				return FeatureFlagManagerUtil.isEnabled("LPD-35443");
 			}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/UtilityPageResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/UtilityPageResourceImpl.java
@@ -6,6 +6,7 @@
 package com.liferay.headless.admin.site.internal.resource.v1_0;
 
 import com.liferay.client.extension.type.manager.CETManager;
+import com.liferay.exportimport.constants.ExportImportConstants;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngineTaskItemDelegate;
 import com.liferay.fragment.processor.FragmentEntryProcessorRegistry;
@@ -128,7 +129,7 @@ public class UtilityPageResourceImpl
 
 			@Override
 			public String getSectionLanguageKey() {
-				return SECTION_NAME_SITE_BUILDER;
+				return ExportImportConstants.SECTION_NAME_SITE_BUILDER;
 			}
 
 			@Override

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/UtilityPageResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/UtilityPageResourceImpl.java
@@ -128,8 +128,8 @@ public class UtilityPageResourceImpl
 			}
 
 			@Override
-			public String getSectionLanguageKey() {
-				return ExportImportConstants.SECTION_NAME_SITE_BUILDER;
+			public String getSectionKey() {
+				return ExportImportConstants.SECTION_KEY_SITE_BUILDER;
 			}
 
 			@Override

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
@@ -590,6 +590,11 @@ public class ObjectEntryResourceImpl
 			}
 
 			@Override
+			public String getSectionLanguageKey() {
+				return SECTION_NAME_OBJECTS;
+			}
+
+			@Override
 			public String getTag(Locale locale) {
 				if (!_objectDefinition.isRootNode()) {
 					return null;

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
@@ -5,6 +5,7 @@
 
 package com.liferay.object.rest.internal.resource.v1_0;
 
+import com.liferay.exportimport.constants.ExportImportConstants;
 import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngineTaskItemDelegate;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.exception.ObjectEntryValidationException;
@@ -591,7 +592,7 @@ public class ObjectEntryResourceImpl
 
 			@Override
 			public String getSectionLanguageKey() {
-				return SECTION_NAME_OBJECTS;
+				return ExportImportConstants.SECTION_NAME_OBJECTS;
 			}
 
 			@Override

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
@@ -591,8 +591,8 @@ public class ObjectEntryResourceImpl
 			}
 
 			@Override
-			public String getSectionLanguageKey() {
-				return ExportImportConstants.SECTION_NAME_OBJECTS;
+			public String getSectionKey() {
+				return ExportImportConstants.SECTION_KEY_OBJECTS;
 			}
 
 			@Override

--- a/portal-kernel/src/com/liferay/exportimport/kernel/lar/PortletDataHandler.java
+++ b/portal-kernel/src/com/liferay/exportimport/kernel/lar/PortletDataHandler.java
@@ -233,7 +233,7 @@ public interface PortletDataHandler {
 	 */
 	public String getSchemaVersion();
 
-	public default String getSectionName() {
+	public default String getSectionKey() {
 		return null;
 	}
 

--- a/portal-kernel/src/com/liferay/exportimport/kernel/lar/PortletDataHandler.java
+++ b/portal-kernel/src/com/liferay/exportimport/kernel/lar/PortletDataHandler.java
@@ -233,6 +233,10 @@ public interface PortletDataHandler {
 	 */
 	public String getSchemaVersion();
 
+	public default String getSectionName() {
+		return null;
+	}
+
 	public String getServiceName();
 
 	public default PortletDataHandlerControl[]


### PR DESCRIPTION
Task: [LPD-76858](https://liferay.atlassian.net/browse/LPD-76858)
Technical Task: [LPD-77057](https://liferay.atlassian.net/browse/LPD-77057)

The purpose of this change: we want the portlets on the export-import forms to be displayed under specific sections. This task is about to provide that information on the `PortletDataHandler` level. We will use this in a new API call, so the new UI (Revamp - [LPD-57655](https://liferay.atlassian.net/browse/LPD-57655)) will be able to render the forms.

For the next task ([LPD-76861](https://liferay.atlassian.net/browse/LPD-76861)), I've started creating a [POC](https://github.com/liferay-headless/liferay-portal/compare/master...vendeltoreki:LPD-76861-poc), to see whether we would be able to use the new values in the API call.