### PR TITLE
LPD-77476 Integrate Formik for wizard form management and validation

### DIFF
--- a/modules/apps/export-import/export-import-web/package.json
+++ b/modules/apps/export-import/export-import-web/package.json
@@ -9,6 +9,7 @@
 		"@clayui/modal": "*",
 		"@clayui/multi-step-nav": "*",
 		"classnames": "2.3.1",
+		"formik": "2.1.4",
 		"frontend-js-components-web": "*",
 		"frontend-js-web": "*",
 		"react": "18.2.0"

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/Footer.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/Footer.tsx
@@ -12,10 +12,12 @@ import React from 'react';
 function Footer({
 	actionButton,
 	backURL,
+	continueDisabled,
 	onPrevious,
 }: {
 	actionButton?: React.ReactElement;
 	backURL: string;
+	continueDisabled?: boolean;
 	onPrevious?: () => void;
 }) {
 	return (
@@ -46,7 +48,10 @@ function Footer({
 						{actionButton ? (
 							actionButton
 						) : (
-							<ClayButton type="submit">
+							<ClayButton
+								disabled={continueDisabled}
+								type="submit"
+							>
 								{Liferay.Language.get('continue')}
 							</ClayButton>
 						)}

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/Wizard.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/Wizard.tsx
@@ -39,9 +39,7 @@ export function Wizard({
 	const {actionButton, description, onSubmit, title} = step.props;
 
 	const next = () => {
-		if (stepNumber < totalSteps - 1) {
-			setStepNumber((stepNumber) => stepNumber + 1);
-		}
+		setStepNumber((stepNumber) => Math.min(stepNumber + 1, totalSteps - 1));
 	};
 
 	const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/Wizard.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/Wizard.tsx
@@ -55,17 +55,21 @@ export function Wizard({
 		formikHelpers: FormikHelpers<FormValues>
 	) => {
 		await onSubmit?.(values);
+
 		setFormState((prevState) => ({
 			...prevState,
 			...values,
 		}));
+
+		formikHelpers.setTouched({});
+
 		next();
 	};
 
 	return (
 		<Formik initialValues={formState} onSubmit={handleSubmit}>
 			{(formik) => (
-				<Form>
+				<Form noValidate>
 					<ClayMultiStepNav
 						center
 						className="c-mx-lg-9"

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/Wizard.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/Wizard.tsx
@@ -8,6 +8,7 @@ import {Form, Formik, FormikConfig, FormikHelpers, FormikValues} from 'formik';
 import React, {ReactElement, useState} from 'react';
 
 import Footer from './Footer';
+import {FormikDebug} from './forms/FormikDebug';
 
 interface WizardStepProps {
 	actionButton?: React.ReactElement;
@@ -25,11 +26,13 @@ export function WizardStep({children}: WizardStepProps) {
 export function Wizard({
 	backURL,
 	children,
+	debug = process.env.NODE_ENV === 'development',
 }: {
 	backURL: string;
 	children:
 		| React.ReactElement<WizardStepProps>
 		| React.ReactElement<WizardStepProps>[];
+	debug?: boolean;
 }) {
 	const [stepNumber, setStepNumber] = useState(0);
 	const [formState, setFormState] = useState({});
@@ -124,6 +127,8 @@ export function Wizard({
 								: undefined
 						}
 					/>
+
+					{debug && <FormikDebug />}
 				</Form>
 			)}
 		</Formik>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/Wizard.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/Wizard.tsx
@@ -4,20 +4,16 @@
  */
 
 import ClayMultiStepNav from '@clayui/multi-step-nav';
-import {Form, Formik, FormikHelpers} from 'formik';
+import {Form, Formik, FormikConfig, FormikHelpers, FormikValues} from 'formik';
 import React, {ReactElement, useState} from 'react';
 
 import Footer from './Footer';
-
-type FormValues = {
-	[key: string]: any;
-};
 
 interface WizardStepProps {
 	actionButton?: React.ReactElement;
 	children: React.ReactNode;
 	description: string;
-	onSubmit?: (values: FormValues) => Promise<void>;
+	onSubmit?: FormikConfig<FormikValues>['onSubmit'];
 	title: string;
 }
 
@@ -51,10 +47,10 @@ export function Wizard({
 	};
 
 	const handleSubmit = async (
-		values: FormValues,
-		formikHelpers: FormikHelpers<FormValues>
+		values: FormikValues,
+		formikHelpers: FormikHelpers<FormikValues>
 	) => {
-		await onSubmit?.(values);
+		await onSubmit?.(values, formikHelpers);
 
 		setFormState((prevState) => ({
 			...prevState,

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/Wizard.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/Wizard.tsx
@@ -4,19 +4,24 @@
  */
 
 import ClayMultiStepNav from '@clayui/multi-step-nav';
+import {Form, Formik, FormikHelpers} from 'formik';
 import React, {ReactElement, useState} from 'react';
 
 import Footer from './Footer';
 
-interface WizardStep {
+type FormValues = {
+	[key: string]: any;
+};
+
+interface WizardStepProps {
 	actionButton?: React.ReactElement;
 	children: React.ReactNode;
 	description: string;
-	onSubmit?: () => void;
+	onSubmit?: (values: FormValues) => Promise<void>;
 	title: string;
 }
 
-export function WizardStep({children}: WizardStep) {
+export function WizardStep({children}: WizardStepProps) {
 	return <>{children}</>;
 }
 
@@ -25,73 +30,96 @@ export function Wizard({
 	children,
 }: {
 	backURL: string;
-	children: React.ReactElement<WizardStep> | React.ReactElement<WizardStep>[];
+	children:
+		| React.ReactElement<WizardStepProps>
+		| React.ReactElement<WizardStepProps>[];
 }) {
 	const [stepNumber, setStepNumber] = useState(0);
+	const [formState, setFormState] = useState({});
 
 	const steps = React.Children.toArray(
 		children
-	) as ReactElement<WizardStep>[];
+	) as ReactElement<WizardStepProps>[];
 
 	const totalSteps = steps.length;
 
-	const step = steps[stepNumber] as React.ReactElement<WizardStep>;
+	const step = steps[stepNumber] as React.ReactElement<WizardStepProps>;
 	const {actionButton, description, onSubmit, title} = step.props;
 
 	const next = () => {
 		setStepNumber((stepNumber) => Math.min(stepNumber + 1, totalSteps - 1));
 	};
 
-	const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
-		event.preventDefault();
-		onSubmit?.();
+	const handleSubmit = async (
+		values: FormValues,
+		formikHelpers: FormikHelpers<FormValues>
+	) => {
+		await onSubmit?.(values);
+		setFormState((prevState) => ({
+			...prevState,
+			...values,
+		}));
 		next();
 	};
 
 	return (
-		<form onSubmit={handleSubmit}>
-			<ClayMultiStepNav center className="c-mx-lg-9" indicatorLabel="top">
-				{steps.map((step, index) => {
-					const {title: multiStepTitle} = step.props;
+		<Formik initialValues={formState} onSubmit={handleSubmit}>
+			{(formik) => (
+				<Form>
+					<ClayMultiStepNav
+						center
+						className="c-mx-lg-9"
+						indicatorLabel="top"
+					>
+						{steps.map((step, index) => {
+							const {title: multiStepTitle} = step.props;
 
-					return (
-						<ClayMultiStepNav.Item
-							active={index === stepNumber}
-							key={index}
-							state={stepNumber > index ? 'complete' : undefined}
-						>
-							{index < totalSteps - 1 && (
-								<ClayMultiStepNav.Divider />
-							)}
+							return (
+								<ClayMultiStepNav.Item
+									active={index === stepNumber}
+									key={index}
+									state={
+										stepNumber > index
+											? 'complete'
+											: undefined
+									}
+								>
+									{index < totalSteps - 1 && (
+										<ClayMultiStepNav.Divider />
+									)}
 
-							<ClayMultiStepNav.Indicator
-								label={1 + index}
-								subTitle={multiStepTitle}
-							/>
-						</ClayMultiStepNav.Item>
-					);
-				})}
-			</ClayMultiStepNav>
+									<ClayMultiStepNav.Indicator
+										label={1 + index}
+										subTitle={multiStepTitle}
+									/>
+								</ClayMultiStepNav.Item>
+							);
+						})}
+					</ClayMultiStepNav>
 
-			<header className="mb-1 sheet-header">
-				<div className="mb-1 sheet-title">{title}</div>
+					<header className="mb-1 sheet-header">
+						<div className="mb-1 sheet-title">{title}</div>
 
-				{description && (
-					<p className="sheet-text text-secondary">{description}</p>
-				)}
-			</header>
+						{description && (
+							<p className="sheet-text text-secondary">
+								{description}
+							</p>
+						)}
+					</header>
 
-			{steps[stepNumber]}
+					{step}
 
-			<Footer
-				actionButton={actionButton}
-				backURL={backURL}
-				onPrevious={
-					stepNumber > 0
-						? () => setStepNumber(stepNumber - 1)
-						: undefined
-				}
-			/>
-		</form>
+					<Footer
+						actionButton={actionButton}
+						backURL={backURL}
+						onPrevious={
+							stepNumber > 0
+								? () => setStepNumber(stepNumber - 1)
+								: undefined
+						}
+					/>
+				</Form>
+			)}
+		</Formik>
 	);
 }

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/Wizard.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/Wizard.tsx
@@ -15,6 +15,7 @@ interface WizardStepProps {
 	description: string;
 	onSubmit?: FormikConfig<FormikValues>['onSubmit'];
 	title: string;
+	validate?: FormikConfig<FormikValues>['validate'];
 }
 
 export function WizardStep({children}: WizardStepProps) {
@@ -40,7 +41,7 @@ export function Wizard({
 	const totalSteps = steps.length;
 
 	const step = steps[stepNumber] as React.ReactElement<WizardStepProps>;
-	const {actionButton, description, onSubmit, title} = step.props;
+	const {actionButton, description, onSubmit, title, validate} = step.props;
 
 	const next = () => {
 		setStepNumber((stepNumber) => Math.min(stepNumber + 1, totalSteps - 1));
@@ -63,7 +64,11 @@ export function Wizard({
 	};
 
 	return (
-		<Formik initialValues={formState} onSubmit={handleSubmit}>
+		<Formik
+			initialValues={formState}
+			onSubmit={handleSubmit}
+			validate={validate}
+		>
 			{(formik) => (
 				<Form noValidate>
 					<ClayMultiStepNav

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/Wizard.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/Wizard.tsx
@@ -116,6 +116,7 @@ export function Wizard({
 					<Footer
 						actionButton={actionButton}
 						backURL={backURL}
+						continueDisabled={formik.isSubmitting}
 						onPrevious={
 							stepNumber > 0
 								? () => setStepNumber(stepNumber - 1)

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/FieldText.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/FieldText.tsx
@@ -7,7 +7,7 @@ import {ClayInput} from '@clayui/form';
 import {FieldBase} from 'frontend-js-components-web';
 import React from 'react';
 
-type FieldTextProps = {
+export type FieldTextProps = {
 	component?: 'textarea' | 'input';
 	disabled?: boolean;
 	errorMessage?: string;

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/FormikDebug.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/FormikDebug.tsx
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {FormikConsumer} from 'formik';
+import React from 'react';
+
+export function FormikDebug() {
+	return (
+		<div className="bg-white my-5">
+			<div className="bg-primary font-weight-bold p-2 rounded-top text text-2 text-uppercase text-white">
+				Formik State
+			</div>
+
+			<FormikConsumer>
+				{({
+					validate: _validate,
+					validationSchema: _validationSchema,
+					...rest
+				}) => (
+					<pre className="p-2 text-3">
+						{JSON.stringify(rest, null, 2)}
+					</pre>
+				)}
+			</FormikConsumer>
+		</div>
+	);
+}

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/FormikFields.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/FormikFields.tsx
@@ -3,26 +3,36 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {Field, FieldProps} from 'formik';
+import {Field, FieldProps, FieldValidator} from 'formik';
 import React from 'react';
 
 import FieldText, {FieldTextProps} from './FieldText';
+import {required as requiredValidation} from './validations';
 
 function FormikWrapper({
 	children,
 	name,
+	required,
+	validate,
 }: {
 	children: (props: {
 		errorMessage?: string;
 		field: FieldProps['field'];
 	}) => React.ReactNode;
 	name: string;
+	required?: boolean;
+	validate?: FieldValidator;
 }) {
 	return (
-		<Field name={name}>
+		<Field
+			name={name}
+			validate={
+				validate ? validate : required ? requiredValidation : undefined
+			}
+		>
 			{({field, meta}: FieldProps) =>
 				children({
-					errorMessage: meta.touched ? meta.error : undefined,
+					errorMessage: meta.error,
 					field,
 				})
 			}
@@ -32,7 +42,7 @@ function FormikWrapper({
 
 export function FormikFieldText(props: FieldTextProps) {
 	return (
-		<FormikWrapper name={props.name}>
+		<FormikWrapper name={props.name} required={props.required}>
 			{({errorMessage, field}) => (
 				<FieldText {...props} {...field} errorMessage={errorMessage} />
 			)}

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/FormikFields.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/FormikFields.tsx
@@ -1,0 +1,41 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Field, FieldProps} from 'formik';
+import React from 'react';
+
+import FieldText, {FieldTextProps} from './FieldText';
+
+function FormikWrapper({
+	children,
+	name,
+}: {
+	children: (props: {
+		errorMessage?: string;
+		field: FieldProps['field'];
+	}) => React.ReactNode;
+	name: string;
+}) {
+	return (
+		<Field name={name}>
+			{({field, meta}: FieldProps) =>
+				children({
+					errorMessage: meta.touched ? meta.error : undefined,
+					field,
+				})
+			}
+		</Field>
+	);
+}
+
+export function FormikFieldText(props: FieldTextProps) {
+	return (
+		<FormikWrapper name={props.name}>
+			{({errorMessage, field}) => (
+				<FieldText {...props} {...field} errorMessage={errorMessage} />
+			)}
+		</FormikWrapper>
+	);
+}

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/validations.ts
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/validations.ts
@@ -1,0 +1,11 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {FieldValidator} from 'formik';
+
+const required: FieldValidator = (value) =>
+	!value?.trim() ? Liferay.Language.get('this-field-is-required') : undefined;
+
+export {required};

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/NewExport.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/NewExport.tsx
@@ -46,7 +46,7 @@ export function NewExport({backURL}: {backURL: string}) {
 				description={Liferay.Language.get(
 					'configure-your-export-settings'
 				)}
-				onSubmit={() => {
+				onSubmit={async () => {
 					alert('Export started!');
 				}}
 				title={Liferay.Language.get('settings')}

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/steps/SetupStep.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/steps/SetupStep.tsx
@@ -7,7 +7,7 @@ import ClayLayout from '@clayui/layout';
 import {sub} from 'frontend-js-web';
 import React from 'react';
 
-import FieldText from '../../../components/forms/FieldText';
+import {FormikFieldText} from '../../../components/forms/FormikFields';
 
 export default function SetupStep() {
 	return (
@@ -28,7 +28,7 @@ export default function SetupStep() {
 					</div>
 				</ClayLayout.SheetHeader>
 
-				<FieldText
+				<FormikFieldText
 					label={Liferay.Language.get('file-name')}
 					name="filename"
 					required

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/NewImport.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/NewImport.tsx
@@ -46,7 +46,7 @@ export function NewImport({backURL}: {backURL: string}) {
 				description={Liferay.Language.get(
 					'set-up-your-import-configuration'
 				)}
-				onSubmit={() => {
+				onSubmit={async () => {
 					alert('Import started!');
 				}}
 				title={Liferay.Language.get('settings')}


### PR DESCRIPTION
LPD: https://liferay.atlassian.net/browse/LPD-77476
---

# What is this solving?
This PR integrates **Formik** as the form management library for the Export/Import Revamp Wizard.

Previously, the wizard steps lacked a unified state management and validation strategy. This change introduces a robust architecture to handle:
- Form state persistence across wizard steps.
- Field-level validation.
- Step-level validation (cross-field logic).
- Submission states and UI feedback.

# How is it fixed?
- **Wizard Integration:** Wrapped the `Wizard` component with `<Formik>`. State is now preserved when navigating between steps via `formState` merging.
- **Formik Adapters:** Created `FormikWrapper` and `FormikFieldText` (in `FormikFields.tsx`) to bridge `ClayInput` components with Formik's context.
- **Validation Engine:**
  - Added `validations.ts` with reusable validators (starting with `required`).
  - Implemented logic to support both field-level `validate` prop and form-level validation per step.
- **Typing:** Refactored `Wizard.tsx` to use `FormikConfig` and `FormikValues` for better type safety.
- **Dev Experience:** Added a `FormikDebug` component (visible only in development) to visualize the form state and errors in real-time.
- **UX:** Connected the `Footer` submit button to Formik's `isSubmitting` state to prevent double submissions.

# Screenshoots
<img width="1709" height="988" alt="image" src="https://github.com/user-attachments/assets/e069f7fe-2a15-47df-bc8c-24a9698ec1d4" />
<img width="1707" height="987" alt="image" src="https://github.com/user-attachments/assets/191736a4-ed6e-4b97-aec4-9f78a1075fbf" />
