### PR TITLE
LPD-75473 Import process gets stuck when importing vocabulary and categories at the same time

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -9484,6 +9484,10 @@ ${output.content}</echo>
 		<run-playwright-js-test app.server.type="wildfly" database.type="mariadb" />
 	</target>
 
+	<target name="playwright-js-tomcat101-hypersonic20">
+		<run-playwright-js-test database.type="hypersonic" />
+	</target>
+
 	<target name="playwright-js-tomcat101-mysql84">
 		<run-playwright-js-test database.type="mysql" />
 	</target>

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/service/impl/BatchEngineImportTaskLocalServiceImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/service/impl/BatchEngineImportTaskLocalServiceImpl.java
@@ -156,6 +156,14 @@ public class BatchEngineImportTaskLocalServiceImpl
 		return batchEngineImportTaskPersistence.countByCompanyId(companyId);
 	}
 
+	@Override
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public BatchEngineImportTask updateBatchEngineImportTask(
+		BatchEngineImportTask batchEngineImportTask) {
+
+		return super.updateBatchEngineImportTask(batchEngineImportTask);
+	}
+
 	private void _validateDelimiter(String delimiter)
 		throws BatchEngineImportTaskParametersException {
 

--- a/modules/test/playwright/tests/export-import-web/main/site.import.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/site.import.spec.ts
@@ -10,6 +10,7 @@ import * as path from 'path';
 import {accountSettingsPagesTest} from '../../../fixtures/accountSettingsPagesTest';
 import {accountsPagesTest} from '../../../fixtures/accountsPagesTest';
 import {applicationsMenuPageTest} from '../../../fixtures/applicationsMenuPageTest';
+import {createCategories} from '../../../helpers/CreateCategories';
 import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
 import {depotAdminPageTest} from '../../../fixtures/depotAdminPageTest';
 import {documentLibraryPagesTest} from '../../../fixtures/documentLibraryPages.fixtures';
@@ -76,6 +77,7 @@ export const testWithExportImportAtInstanceLevelFF = mergeTests(
 		'LPD-44771': {enabled: true},
 		'LPD-45276': {enabled: true},
 	}),
+	isolatedSiteTest,
 	loginTest(),
 	styleBookPageTest,
 	uiElementsPageTest
@@ -160,6 +162,61 @@ testWithExportImportAtInstanceLevelFF(
 				textField: objectEntry.textField,
 			})
 		);
+	}
+);
+
+testWithExportImportAtInstanceLevelFF(
+	'Can export and import vocabularies and categories',
+	async ({apiHelpers, exportImportPage, site}) => {
+		const categoryNames = [
+			{name: getRandomString()},
+			{name: getRandomString()},
+		];
+		const vocabularyName = getRandomString();
+
+		const categories: Array<any> = await createCategories({
+			apiHelpers,
+			categoryNames,
+			siteId: site.id,
+			vocabularyName,
+		});
+
+		apiHelpers.data.push({
+			id: categories[0].vocabularyId,
+			type: 'taxonomyVocabulary',
+		});
+
+		await exportImportPage.goToExport(site.friendlyUrlPath);
+
+		const exportFilePath = await exportImportPage.export({
+			portletLabels: [`Categories 3 Items`],
+		});
+
+		const vocabularyContent = await readFileFromZip(
+			`com.liferay.headless.admin.taxonomy.dto.v1_0.TaxonomyVocabulary.json`,
+			exportFilePath
+		);
+
+		const vocabularyJson = JSON.parse(vocabularyContent);
+
+		expect(vocabularyJson.length).toBe(1);
+
+		const categoryContent = await readFileFromZip(
+			`com.liferay.headless.admin.taxonomy.dto.v1_0.TaxonomyCategory.json`,
+			exportFilePath
+		);
+
+		const categoryJson = JSON.parse(categoryContent);
+
+		expect(categoryJson.length).toBe(2);
+
+		expect(
+			await apiHelpers.headlessAdminTaxonomy.deleteTaxonomyVocabulary(categories[0].vocabularyId)
+		).toBeOK();
+
+		await exportImportPage.goToImport(site.friendlyUrlPath);
+
+		await exportImportPage.import({filePath: exportFilePath, taskStatus: 'completedWithErrors'});
 	}
 );
 

--- a/test.properties
+++ b/test.properties
@@ -913,6 +913,7 @@
         modules-integration-solr-mysql84,\
         modules-semantic-versioning,\
         modules-unit,\
+        playwright-js-tomcat101-hypersonic20,\
         playwright-js-tomcat101-postgresql163,\
         semantic-versioning,\
         unit

--- a/test.properties
+++ b/test.properties
@@ -913,7 +913,6 @@
         modules-integration-solr-mysql84,\
         modules-semantic-versioning,\
         modules-unit,\
-        playwright-js-tomcat101-hypersonic20,\
         playwright-js-tomcat101-postgresql163,\
         semantic-versioning,\
         unit

--- a/test.properties
+++ b/test.properties
@@ -4243,6 +4243,9 @@
     # Headless Playwright
     #
 
+    playwright.projects.includes[playwright-js-tomcat101-hypersonic20][headless-playwright]=\
+        ${headless.staging.playwright.projects}
+
     playwright.projects.includes[playwright-js-tomcat101-postgresql163][headless-playwright]=\
         ${headless.playwright.projects},\
         ${headless.staging.playwright.projects}
@@ -4250,6 +4253,7 @@
     test.batch.dist.app.servers[headless-playwright]=tomcat
 
     test.batch.names[headless-playwright]=\
+        playwright-js-tomcat101-hypersonic20,\
         playwright-js-tomcat101-postgresql163
 
     #


### PR DESCRIPTION
[LPD-75473](https://liferay.atlassian.net/browse/LPD-75473)

This fix resolves a deadlock scenario only happening in hypersonic DB. To test this, we created a playwright scenario and added a new CI configuration to force the use of HSQLDB.

cc: @magjed4289