### PR TITLE
LPD-78858 Exclude status column from Import Errors FDS view

### DIFF
--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/frontend/data/set/view/table/ImportErrorsTableFDSView.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/frontend/data/set/view/table/ImportErrorsTableFDSView.java
@@ -42,10 +42,6 @@ public class ImportErrorsTableFDSView extends BaseTableFDSView {
 			"type", "type"
 		).add(
 			"errorMessage", "description"
-		).add(
-			"status", "status",
-			fdsTableSchemaField -> fdsTableSchemaField.setContentRenderer(
-				"label")
 		).build();
 	}
 


### PR DESCRIPTION
### LPD: https://liferay.atlassian.net/browse/LPD-78858  

## What is this solving?
The `status` column is being hidden from the Import Errors report view. This is because currently, all entries in the report are populated with the same status value, making the column redundant for the user.

## Screenshots

### Before PR
<img width="1701" height="658" alt="image" src="https://github.com/user-attachments/assets/1f06d90a-b1e4-44ea-96ab-1e4f2f8b3869" />

### After PR
<img width="1703" height="640" alt="image" src="https://github.com/user-attachments/assets/ba872919-b231-46b3-91c2-93841309c07d" />
