### PR TITLE
LPD-78994 test page priorites with promote content ff enabled

### DIFF
--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutExportImportTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutExportImportTest.java
@@ -962,7 +962,7 @@ public class LayoutExportImportTest extends BaseExportImportTestCase {
 		featureFlags = {@FeatureFlag("LPD-34594"), @FeatureFlag("LPD-35443")}
 	)
 	@Test
-	public void testPromotedPageWithSamePriorityTakesPrecedenceWithPromoteContentFFEnabled()
+	public void testPromotedPageWithSamePriorityTakesPrecedence()
 		throws Exception {
 
 		FeatureFlagTestUtil.invokeFeatureFlagListeners(


### PR DESCRIPTION
Jira Ticket: [LPD-78994](https://liferay.atlassian.net/browse/LPD-78994)

The promotion process applies the pattern used in Page Administration: if a promoted page has the same priority as an existing one, the new page takes precedence, and the existing page's priority is automatically shifted up (moved down in the tree).

This PR updates the existing test to run without the promote content FFs and adds a new test to cover the scenario with the FFs enabled. More details are available in the Jira ticket comments. 