### PR TITLE
LPD-79238 Add ImportReportFDSPropsTransformer and custom status renderer

### DIFF
--- a/modules/apps/export-import/export-import-web/package.json
+++ b/modules/apps/export-import/export-import-web/package.json
@@ -9,6 +9,7 @@
 		"@clayui/loading-indicator": "^3.159.0",
 		"@clayui/modal": "^3.159.0",
 		"@clayui/multi-step-nav": "^3.159.0",
+		"@liferay/frontend-data-set-web": "*",
 		"@liferay/layout-js-components-web": "*",
 		"classnames": "2.3.1",
 		"formik": "2.1.4",

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/frontend/data/set/view/table/ImportErrorsTableFDSView.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/frontend/data/set/view/table/ImportErrorsTableFDSView.java
@@ -45,7 +45,7 @@ public class ImportErrorsTableFDSView extends BaseTableFDSView {
 		).add(
 			"status", "status",
 			fdsTableSchemaField -> fdsTableSchemaField.setContentRenderer(
-				"label")
+				"importReportStatusRenderer")
 		).build();
 	}
 

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/import/view_import_report_entries.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/import/view_import_report_entries.jsp
@@ -43,6 +43,7 @@ GroupDisplayContextHelper groupDisplayContextHelper = new GroupDisplayContextHel
 		apiURL="<%= importReportEntriesDisplayContext.getAPIURL(String.valueOf(backgroundTaskId)) %>"
 		fdsActionDropdownItems="<%= importReportEntriesDisplayContext.getFDSActionDropdownItems() %>"
 		id="<%= stagingGroupHelper.isCompanyGroup(groupDisplayContextHelper.getGroup()) ? ExportImportFDSNames.COMPANY_IMPORT_REPORT_ENTRIES : ExportImportFDSNames.IMPORT_REPORT_ENTRIES %>"
+		propsTransformer="{ImportReportFDSPropsTransformer} from exportimport-web"
 		style="fluid"
 	/>
 </aui:form>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/js/index.ts
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/js/index.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+export {default as ImportReportFDSPropsTransformer} from '../revamp/js/fds/ImportReportFDSPropsTransformer';
 export {NewExport} from '../revamp/js/pages/export/NewExport';
 export {NewImport} from '../revamp/js/pages/import/NewImport';
 export {ViewImportReportEntryDetail} from '../revamp/js/pages/import/report/ViewImportReportEntryDetail';

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/fds/ImportReportFDSPropsTransformer.ts
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/fds/ImportReportFDSPropsTransformer.ts
@@ -1,0 +1,23 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {IInternalRenderer} from '@liferay/frontend-data-set-web';
+
+import ImportReportStatusRenderer from './cell_renderers/ImportReportStatusRenderer';
+
+export default function ImportReportFDSPropsTransformer({...otherProps}) {
+	return {
+		...otherProps,
+		customRenderers: {
+			tableCell: [
+				{
+					component: ImportReportStatusRenderer,
+					name: 'importReportStatusRenderer',
+					type: 'internal',
+				} as IInternalRenderer,
+			],
+		},
+	};
+}

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/fds/cell_renderers/ImportReportStatusRenderer.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/fds/cell_renderers/ImportReportStatusRenderer.tsx
@@ -6,6 +6,11 @@
 import {LabelRenderer} from '@liferay/frontend-data-set-web';
 import React from 'react';
 
+const labelDisplayStyles = {
+	1: 'success',
+	2: 'danger',
+};
+
 export default function ImportReportStatusRenderer({
 	value,
 }: {
@@ -15,23 +20,16 @@ export default function ImportReportStatusRenderer({
 		label_i18n?: string;
 	};
 }) {
-	const getLabelType = (code: number): string => {
-		switch (code) {
-			case 1:
-				return 'success';
-			case 2:
-				return 'danger';
-			default:
-				return 'secondary';
-		}
-	};
+	if (!value) {
+		return null;
+	}
 
-	return value ? (
+	return (
 		<LabelRenderer
 			value={{
-				displayStyle: getLabelType(value.code),
+				displayStyle: labelDisplayStyles[value.code],
 				label: value.label_i18n ?? value.label,
 			}}
 		/>
-	) : null;
+	);
 }

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/fds/cell_renderers/ImportReportStatusRenderer.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/fds/cell_renderers/ImportReportStatusRenderer.tsx
@@ -1,0 +1,37 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import React from 'react';
+
+export default function ImportReportStatusRenderer({
+	value,
+}: {
+	value?: {
+		code: 1 | 2;
+		label: string;
+		label_i18n?: string;
+	};
+}) {
+	const getLabelType = (code: number): string => {
+		switch (code) {
+			case 1:
+				return 'label-success';
+			case 2:
+				return 'label-danger';
+			default:
+				return 'label-secondary';
+		}
+	};
+
+	return value ? (
+		<span className="taglib-workflow-status">
+			<span className="workflow-status">
+				<strong className={`label ${getLabelType(value.code)}`}>
+					{value.label_i18n ?? value.label}
+				</strong>
+			</span>
+		</span>
+	) : null;
+}

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/fds/cell_renderers/ImportReportStatusRenderer.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/fds/cell_renderers/ImportReportStatusRenderer.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import {LabelRenderer} from '@liferay/frontend-data-set-web';
 import React from 'react';
 
 export default function ImportReportStatusRenderer({
@@ -17,21 +18,20 @@ export default function ImportReportStatusRenderer({
 	const getLabelType = (code: number): string => {
 		switch (code) {
 			case 1:
-				return 'label-success';
+				return 'success';
 			case 2:
-				return 'label-danger';
+				return 'danger';
 			default:
-				return 'label-secondary';
+				return 'secondary';
 		}
 	};
 
 	return value ? (
-		<span className="taglib-workflow-status">
-			<span className="workflow-status">
-				<strong className={`label ${getLabelType(value.code)}`}>
-					{value.label_i18n ?? value.label}
-				</strong>
-			</span>
-		</span>
+		<LabelRenderer
+			value={{
+				displayStyle: getLabelType(value.code),
+				label: value.label_i18n ?? value.label,
+			}}
+		/>
 	) : null;
 }

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "748b1f5fe8c960124667f4637b5a5f3af472d22f",
+	"@generated": "10d0277da250ae87043c3c021ece735de2d96fb3",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -11,6 +11,9 @@
 		"module": "es2022",
 		"moduleResolution": "node",
 		"paths": {
+			"@liferay/frontend-data-set-web": [
+				"../../../../../../../frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/index.ts"
+			],
 			"@liferay/layout-js-components-web": [
 				"../../../../../../../layout/layout-js-components-web/src/main/resources/META-INF/resources/js/index.ts"
 			],
@@ -40,6 +43,9 @@
 		"../../../../../../../../global.d.ts"
 	],
 	"references": [
+		{
+			"path": "../../../../../../../frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
 		{
 			"path": "../../../../../../../layout/layout-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
 		},

--- a/modules/apps/export-import/export-import-web/test/tsconfig.json
+++ b/modules/apps/export-import/export-import-web/test/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "3bf2bb70522ac7a7dd3cf62952be0513e568a61c",
+	"@generated": "146024e31d30c40f0fb759a9331fe8c5ba9e9fff",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -11,6 +11,9 @@
 		"module": "es2022",
 		"moduleResolution": "node",
 		"paths": {
+			"@liferay/frontend-data-set-web": [
+				"../../../frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/index.ts"
+			],
 			"@liferay/layout-js-components-web": [
 				"../../../layout/layout-js-components-web/src/main/resources/META-INF/resources/js/index.ts"
 			],
@@ -42,6 +45,9 @@
 		"../src/**/*.tsx"
 	],
 	"references": [
+		{
+			"path": "../../../frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
 		{
 			"path": "../../../layout/layout-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
 		},

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/index.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/index.ts
@@ -12,6 +12,10 @@ export {INTERNAL_CELL_RENDERERS as FDS_INTERNAL_CELL_RENDERERS} from './cell_ren
 
 // @ts-ignore
 
+export {default as LabelRenderer} from './cell_renderers/LabelRenderer';
+
+// @ts-ignore
+
 export {default as StatusRenderer} from './cell_renderers/StatusRenderer';
 
 export {getInternalCellRenderer as getFDSInternalCellRenderer} from './cell_renderers/getInternalCellRenderer';


### PR DESCRIPTION
### LPD: https://liferay.atlassian.net/browse/LPD-79238

# What is this solving?
Replaced the generic status label with a custom ImportReportStatusRenderer. It uses a new FDSPropsTransformer to handle the mapping between status codes and Label display styles.

# How is it fixed?
- Created `ImportReportStatusRenderer` using the shared `LabelRenderer` component from `frontend-data-set-web`.
- Implemented `ImportReportFDSPropsTransformer` to register the custom cell renderer.
- Updated `ImportErrorsTableFDSView.java` to point to the new `importReportStatusRenderer`.
- Exported `LabelRenderer` from `@liferay/frontend-data-set-web` to allow its reuse in other modules.
- Updated `package.json` and `tsconfig.json` to include the necessary dependencies and path mappings.

# Visual changes (optional)
### Before
<img width="1710" height="899" alt="image" src="https://github.com/user-attachments/assets/f430bcdf-49e8-4a43-952f-6a562f4295f7" />

### After
<img width="1709" height="917" alt="image" src="https://github.com/user-attachments/assets/e6d62f67-231a-4f07-9c89-aaad16e8bebe" />
