### PR TITLE
LPD-79367 Hide "Publish Parent Pages by Default" from System Settings

### DIFF
--- a/modules/apps/staging/staging-api/src/main/java/com/liferay/staging/configuration/StagingConfiguration.java
+++ b/modules/apps/staging/staging-api/src/main/java/com/liferay/staging/configuration/StagingConfiguration.java
@@ -7,6 +7,7 @@ package com.liferay.staging.configuration;
 
 import aQute.bnd.annotation.metatype.Meta;
 
+import com.liferay.portal.configuration.metatype.annotations.ExtendedAttributeDefinition;
 import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
 
 /**
@@ -29,6 +30,9 @@ public interface StagingConfiguration {
 	)
 	public boolean publishDisplayedContent();
 
+	@ExtendedAttributeDefinition(
+		visibilityControllerKey = "com.liferay.staging.internal.configuration.admin.display.StagingConfigurationVisibilityController"
+	)
 	@Meta.AD(
 		deflt = "true", description = "publish-parent-layouts-by-default-help",
 		name = "publish-parent-layouts-by-default", required = false

--- a/modules/apps/staging/staging-api/src/main/resources/com/liferay/staging/configuration/packageinfo
+++ b/modules/apps/staging/staging-api/src/main/resources/com/liferay/staging/configuration/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.1
+version 2.0.2

--- a/modules/apps/staging/staging-impl/build.gradle
+++ b/modules/apps/staging/staging-impl/build.gradle
@@ -7,10 +7,12 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:changeset:changeset-api")
+	compileOnly project(":apps:configuration-admin:configuration-admin-api")
 	compileOnly project(":apps:export-import:export-import-api")
 	compileOnly project(":apps:layout:layout-page-template-api")
 	compileOnly project(":apps:portal:portal-instance-lifecycle-api")
 	compileOnly project(":apps:staging:staging-api")
+	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-string")

--- a/modules/apps/staging/staging-impl/src/main/java/com/liferay/staging/internal/configuration/admin/display/StagingConfigurationVisibilityController.java
+++ b/modules/apps/staging/staging-impl/src/main/java/com/liferay/staging/internal/configuration/admin/display/StagingConfigurationVisibilityController.java
@@ -1,0 +1,32 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.staging.internal.configuration.admin.display;
+
+import com.liferay.configuration.admin.display.ConfigurationVisibilityController;
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+
+import java.io.Serializable;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Jorge González
+ */
+@Component(service = ConfigurationVisibilityController.class)
+public class StagingConfigurationVisibilityController
+	implements ConfigurationVisibilityController {
+
+	@Override
+	public boolean isVisible(
+		ExtendedObjectClassDefinition.Scope scope, Serializable scopePK) {
+
+		return !FeatureFlagManagerUtil.isEnabled(
+			CompanyThreadLocal.getCompanyId(), "LPD-35914");
+	}
+
+}


### PR DESCRIPTION
### LPD: https://liferay.atlassian.net/browse/LPD-79367

# What is this solving?
This PR prevents the "publish-parent-layouts-by-default" configuration from being displayed in System Settings when the Promote Content Feature Flag (LPD-35914) is enabled. This ensures the UI remains consistent with the new content promotion flow, avoiding redundant or incompatible configuration options.

# How is it fixed?
- Created `StagingConfigurationVisibilityController` to manage the visibility logic based on the `LPD-35914` feature flag status.
- Registered the visibility controller in `StagingConfiguration` using the `@ExtendedAttributeDefinition` annotation for the `publishParentLayoutsByDefault` attribute.
- Updated `staging-impl/build.gradle` to include necessary dependencies for configuration admin and metatype APIs.

# How to verify?
1. Start Liferay and navigate to **System Settings** > **Staging**.
2. Verify that the "Publish parent layouts by default" setting is visible by default.
3. Enable the Feature Flag `LPD-35914` (Promote Content).
4. Go back to **System Settings** > **Staging** and verify that the setting is now hidden.

# Visual changes
## Before
<img width="3825" height="2104" alt="image" src="https://github.com/user-attachments/assets/6ddde869-320f-4bbf-96c1-fb5edb1caac8" />
<img width="3825" height="2107" alt="image" src="https://github.com/user-attachments/assets/8857db96-758e-4765-9172-d1ca25426af7" />


 ## After
<img width="3824" height="2108" alt="image" src="https://github.com/user-attachments/assets/79570656-d1cb-4543-840a-a311459dd34a" />
<img width="3831" height="2107" alt="image" src="https://github.com/user-attachments/assets/ad451170-fa47-4fb6-8d10-bb3f5b86082f" />
