### PR TITLE
LPD-78913 Only show Pages section if the current group supports it

### DIFF
--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/export/export_templates/edit_export_configuration.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/export/export_templates/edit_export_configuration.jsp
@@ -103,7 +103,7 @@ renderResponse.setTitle((exportImportConfiguration == null) ? LanguageUtil.get(r
 						exportImportConfigurationId="<%= exportImportConfigurationId %>"
 					/>
 
-					<c:if test="<%= !group.isLayoutPrototype() && !group.isCompany() %>">
+					<c:if test="<%= !group.isLayoutPrototype() && !group.isCompany() && GroupCapabilityUtil.isSupportsPages(group) %>">
 						<liferay-staging:select-pages
 							action="<%= Constants.EXPORT %>"
 							exportImportConfigurationId="<%= exportImportConfigurationId %>"


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-78913

# How am I fixing it?

The Export/Import group is a special entity. Since it does not support the export/import of pages there needs to be a check to ensure that the section is not rendered. Regular groups will not see a change in behavior since they do support pages.

If there are any questions or concerns please let me know.