### PR TITLE
LPD-80210 Pages added to Site Template fail to propagate to or appear in Sites created from that template

### DIFF
--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/exportimport/data/handler/StagedGroupStagedModelDataHandler.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/exportimport/data/handler/StagedGroupStagedModelDataHandler.java
@@ -611,7 +611,9 @@ public class StagedGroupStagedModelDataHandler
 				// Portlet data
 
 				if (importPortletControlsMap.get(
-						PortletDataHandlerKeys.PORTLET_DATA)) {
+						PortletDataHandlerKeys.PORTLET_DATA) ||
+					_isPortletImportable(
+						portletDataContext.getCompanyId(), portletId)) {
 
 					_portletImportController.importPortletData(
 						portletDataContext, portletDataElement);
@@ -682,6 +684,20 @@ public class StagedGroupStagedModelDataHandler
 			_portletImportController.importServicePortletPreferences(
 				portletDataContext, serviceElement);
 		}
+	}
+
+	private boolean _isPortletImportable(long companyId, String portletId) {
+		Portlet portlet = _portletLocalService.getPortletById(
+			companyId, portletId);
+
+		PortletDataHandler portletDataHandler =
+			portlet.getPortletDataHandlerInstance();
+
+		if (portletDataHandler == null) {
+			return false;
+		}
+
+		return portletDataHandler.isHidden();
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(


### PR DESCRIPTION
[LPD-80210](https://liferay.atlassian.net/browse/LPD-80210)

This fixes the basic site template propagation scenario:
[com.liferay.exportimport.test.LayoutSetPrototypePropagationTest.testLayoutPropagationWithLinkEnabled](https://github.com/liferay/liferay-portal/blob/9407dc92ea2d645bd2459685ea1fcff4a6bb3e27/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java#L486-L489)

The export of the pages was already happening, because of this code in [PortletExportControllerImpl.exportPortlet()](https://github.com/liferay/liferay-portal/blob/9407dc92ea2d645bd2459685ea1fcff4a6bb3e27/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/controller/PortletExportControllerImpl.java#L347). I added the same condition for the import.
In theory, the "hidden" portlets are the ones that we don't display in the "Contents" section, so these are coincidentally the ones that site templates should still propagate to existing sites, and not just at site creation.