### PR TITLE
LPD-80520 Fix JS error when importing Site Pages without content

### DIFF
--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/js/legacy/main.js
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/js/legacy/main.js
@@ -885,6 +885,11 @@ AUI.add(
 					const instance = this;
 
 					const contentNode = instance.byId('content_' + portletId);
+
+					if (!contentNode) {
+						return;
+					}
+
 					const portletDataNode = instance.byId(
 						'PORTLET_DATA_' + portletId
 					);


### PR DESCRIPTION
# LPD: https://liferay.atlassian.net/browse/LPD-80520

# What is this solving?
The introduction of the "Site Pages" section in the Import/Export UI (following LPD-35914) caused a regression where certain sections do not contain sub-content nodes. The legacy JavaScript was attempting to access these DOM elements without validation, leading to an `Uncaught TypeError: Cannot read properties of null` that broke the rest of the UI rendering.

# How is it fixed?
Added a defensive guard clause in `_setContentLabels` within `main.js` to check if `contentNode` exists before proceeding with label updates. If the node is missing (as is the case with the new Site Pages section), the function returns early, allowing the script to continue execution for the remaining sections.

# How to verify?
### Run the automated test:

```
npx playwright test tests/export-import-web/main/site.import.spec.ts -g 'Can see corresponding elements at site level'
```
### Passed locally

<img width="1258" height="277" alt="image" src="https://github.com/user-attachments/assets/455ff2ff-60b8-494e-bd2d-b1d11bc0121a" />

# Visual changes
## Before
JS execution stops; "Comments, Ratings" are missing from the UI.
<img width="3425" height="1616" alt="image" src="https://github.com/user-attachments/assets/b919285e-521f-4973-95a0-0fc627e8c487" />


## After
UI renders completely; "Comments, Ratings" are visible and no console errors are thrown.
<img width="3431" height="1907" alt="image" src="https://github.com/user-attachments/assets/1c03374a-fe8b-42ee-b276-f7cac1b0f5b4" />
