### PR TITLE
LPD-80621 Site template propagation - propagate pages separately

### DIFF
--- a/modules/test/playwright/tests/layout-set-prototype-web/main/siteTemplatesPropagation.spec.ts
+++ b/modules/test/playwright/tests/layout-set-prototype-web/main/siteTemplatesPropagation.spec.ts
@@ -84,11 +84,17 @@ test('User is able to propagate pages separately on site templates', async ({
 		homePageName,
 		siteId
 	);
-	const widgetPageDataInitial = await apiHelpers.headlessDelivery.getSitePage(
-		pageName,
-		siteId
-	);
 
+	let widgetPageDataInitial: any;
+
+	await expect(async () => {
+		widgetPageDataInitial = await apiHelpers.headlessDelivery.getSitePage(
+			pageName,
+			siteId
+		);
+
+		expect(widgetPageDataInitial).toHaveProperty('friendlyUrlPath');
+	}).toPass();
 
 	await page.goto(
 		`/group/template-${layoutSetPrototype.layoutSetPrototypeId}${widgetPageDataInitial.friendlyUrlPath}`

--- a/modules/test/playwright/tests/layout-set-prototype-web/main/siteTemplatesPropagation.spec.ts
+++ b/modules/test/playwright/tests/layout-set-prototype-web/main/siteTemplatesPropagation.spec.ts
@@ -224,18 +224,13 @@ test(
 
 		// Go to the site when it is available
 
-		await expect
-			.poll(
-				async () => {
-					await page.goto(newSiteURL);
+		await expect(async () => {
+			await page.goto(newSiteURL);
 
-					return page.getByText('Page Not Found Go Back').isVisible();
-				},
-				{
-					timeout: 6000,
-				}
-			)
-			.toBe(false);
+			await expect(page.getByText('Page Not Found Go Back')).toBeHidden();
+		}).toPass({
+			timeout: 6000,
+		});
 
 		await productMenuPage.goToPages();
 

--- a/modules/test/playwright/tests/layout-set-prototype-web/main/siteTemplatesPropagation.spec.ts
+++ b/modules/test/playwright/tests/layout-set-prototype-web/main/siteTemplatesPropagation.spec.ts
@@ -130,10 +130,19 @@ test('User is able to propagate pages separately on site templates', async ({
 
 	const homePageModificationDateAfter = homePageData.dateModified;
 
-	expect(
-		widgetPageModificationDateBefore !== widgetPageModificationDateAfter &&
-			!homePageModificationDateAfter !== homePageModificationDateBefore
-	).toEqual(true);
+	expect
+		.soft(
+			Date.parse(widgetPageModificationDateBefore),
+			'The widget page modification date should be updated after propagating changes from the site template'
+		)
+		.toBeLessThan(Date.parse(widgetPageModificationDateAfter));
+
+	expect
+		.soft(
+			homePageModificationDateBefore,
+			'The home page modification date should remain unchanged, ensuring pages are propagated separately'
+		)
+		.toBe(homePageModificationDateAfter);
 });
 
 test(

--- a/modules/test/playwright/tests/layout-set-prototype-web/main/siteTemplatesPropagation.spec.ts
+++ b/modules/test/playwright/tests/layout-set-prototype-web/main/siteTemplatesPropagation.spec.ts
@@ -80,38 +80,48 @@ test('User is able to propagate pages separately on site templates', async ({
 
 	apiHelpers.data.push({id: siteId, type: 'site'});
 
-	let homePageData = await apiHelpers.headlessDelivery.getSitePage(
+	const homePageDataInitial = await apiHelpers.headlessDelivery.getSitePage(
+		homePageName,
+		siteId
+	);
+	const widgetPageDataInitial = await apiHelpers.headlessDelivery.getSitePage(
+		pageName,
+		siteId
+	);
+
+
+	await page.goto(
+		`/group/template-${layoutSetPrototype.layoutSetPrototypeId}${widgetPageDataInitial.friendlyUrlPath}`
+	);
+	await widgetPagePage.addPortlet('Web Content Display');
+
+	await page.goto(`/web/${siteName}${widgetPageDataInitial.friendlyUrlPath}`);
+
+	const widgetPageDataPhase1 = await apiHelpers.headlessDelivery.getSitePage(
+		pageName,
+		siteId
+	);
+	const homePageDataPhase1 = await apiHelpers.headlessDelivery.getSitePage(
 		homePageName,
 		siteId
 	);
 
-	let widgetPageData = await apiHelpers.headlessDelivery.getSitePage(
-		pageName,
-		siteId
-	);
-
-	const homePageModificationDateBefore = homePageData.dateModified;
-	const widgetPageModificationDateBefore = widgetPageData.dateModified;
-
-	await page.goto(
-		`/group/template-${layoutSetPrototype.layoutSetPrototypeId}${widgetPageData.friendlyUrlPath}`
-	);
-
-	await widgetPagePage.addPortlet('Web Content Display');
-
-	await page.goto(`/web/${siteName}${widgetPageData.friendlyUrlPath}`);
-
-	widgetPageData = await apiHelpers.headlessDelivery.getSitePage(
-		pageName,
-		siteId
-	);
-
-	const widgetPageModificationDateAfter = widgetPageData.dateModified;
+	expect
+		.soft(
+			Date.parse(widgetPageDataPhase1.dateModified),
+			'PHASE 1: Widget page should be updated'
+		)
+		.toBeGreaterThan(Date.parse(widgetPageDataInitial.dateModified));
+	expect
+		.soft(
+			homePageDataPhase1.dateModified,
+			'PHASE 1: Home page should remain unchanged'
+		)
+		.toBe(homePageDataInitial.dateModified);
 
 	await page.goto(
 		`/group/template-${layoutSetPrototype.layoutSetPrototypeId}`
 	);
-
 	await productMenuPage.goToPages();
 	await page.getByText(homePageName).click();
 	await pageEditorPage.addFragment('Basic Components', 'Button');
@@ -119,30 +129,27 @@ test('User is able to propagate pages separately on site templates', async ({
 	await applicationsMenuPage.goToSites();
 	await page.getByText(siteName).click();
 
-	await page.goto(
-		`/group/template-${layoutSetPrototype.layoutSetPrototypeId}${widgetPageData.friendlyUrlPath}`
+	const widgetPageDataPhase2 = await apiHelpers.headlessDelivery.getSitePage(
+		pageName,
+		siteId
 	);
-
-	homePageData = await apiHelpers.headlessDelivery.getSitePage(
+	const homePageDataPhase2 = await apiHelpers.headlessDelivery.getSitePage(
 		homePageName,
 		siteId
 	);
 
-	const homePageModificationDateAfter = homePageData.dateModified;
-
 	expect
 		.soft(
-			Date.parse(widgetPageModificationDateBefore),
-			'The widget page modification date should be updated after propagating changes from the site template'
+			widgetPageDataPhase2.dateModified,
+			'PHASE 2: Widget page should NOT change again'
 		)
-		.toBeLessThan(Date.parse(widgetPageModificationDateAfter));
-
+		.toBe(widgetPageDataPhase1.dateModified);
 	expect
 		.soft(
-			homePageModificationDateBefore,
-			'The home page modification date should remain unchanged, ensuring pages are propagated separately'
+			Date.parse(homePageDataPhase2.dateModified),
+			'PHASE 2: Home page should be updated'
 		)
-		.toBe(homePageModificationDateAfter);
+		.toBeGreaterThan(Date.parse(homePageDataPhase1.dateModified));
 });
 
 test(

--- a/modules/test/playwright/tests/layout-set-prototype-web/main/siteTemplatesPropagation.spec.ts
+++ b/modules/test/playwright/tests/layout-set-prototype-web/main/siteTemplatesPropagation.spec.ts
@@ -103,25 +103,21 @@ test('User is able to propagate pages separately on site templates', async ({
 
 	await page.goto(`/web/${siteName}${widgetPageDataInitial.friendlyUrlPath}`);
 
-	const widgetPageDataPhase1 = await apiHelpers.headlessDelivery.getSitePage(
-		pageName,
-		siteId
-	);
-	const homePageDataPhase1 = await apiHelpers.headlessDelivery.getSitePage(
-		homePageName,
-		siteId
-	);
+	const widgetPageDataWidgetPagePropagation =
+		await apiHelpers.headlessDelivery.getSitePage(pageName, siteId);
+	const homePageDataWidgetPagePropagation =
+		await apiHelpers.headlessDelivery.getSitePage(homePageName, siteId);
 
 	expect
 		.soft(
-			Date.parse(widgetPageDataPhase1.dateModified),
-			'PHASE 1: Widget page should be updated'
+			Date.parse(widgetPageDataWidgetPagePropagation.dateModified),
+			'Widget page changed: Widget page should be updated'
 		)
 		.toBeGreaterThan(Date.parse(widgetPageDataInitial.dateModified));
 	expect
 		.soft(
-			homePageDataPhase1.dateModified,
-			'PHASE 1: Home page should remain unchanged'
+			homePageDataWidgetPagePropagation.dateModified,
+			'Widget page changed: Home page should remain unchanged'
 		)
 		.toBe(homePageDataInitial.dateModified);
 
@@ -135,27 +131,25 @@ test('User is able to propagate pages separately on site templates', async ({
 	await applicationsMenuPage.goToSites();
 	await page.getByText(siteName).click();
 
-	const widgetPageDataPhase2 = await apiHelpers.headlessDelivery.getSitePage(
-		pageName,
-		siteId
-	);
-	const homePageDataPhase2 = await apiHelpers.headlessDelivery.getSitePage(
-		homePageName,
-		siteId
-	);
+	const widgetPageDataHomePagePropagation =
+		await apiHelpers.headlessDelivery.getSitePage(pageName, siteId);
+	const homePageDataHomePagePropagation =
+		await apiHelpers.headlessDelivery.getSitePage(homePageName, siteId);
 
 	expect
 		.soft(
-			widgetPageDataPhase2.dateModified,
-			'PHASE 2: Widget page should NOT change again'
+			widgetPageDataHomePagePropagation.dateModified,
+			'Home page changed: Widget page should NOT change again'
 		)
-		.toBe(widgetPageDataPhase1.dateModified);
+		.toBe(widgetPageDataWidgetPagePropagation.dateModified);
 	expect
 		.soft(
-			Date.parse(homePageDataPhase2.dateModified),
-			'PHASE 2: Home page should be updated'
+			Date.parse(homePageDataHomePagePropagation.dateModified),
+			'Home page changed: Home page should be updated'
 		)
-		.toBeGreaterThan(Date.parse(homePageDataPhase1.dateModified));
+		.toBeGreaterThan(
+			Date.parse(homePageDataWidgetPagePropagation.dateModified)
+		);
 });
 
 test(

--- a/modules/test/playwright/tests/layout-set-prototype-web/main/siteTemplatesPropagation.spec.ts
+++ b/modules/test/playwright/tests/layout-set-prototype-web/main/siteTemplatesPropagation.spec.ts
@@ -180,7 +180,7 @@ test(
 			templateName: siteTemplateName,
 		});
 
-		await apiHelpers.data.push({
+		apiHelpers.data.push({
 			id: layoutSetPrototype.layoutSetPrototypeId,
 			type: 'layoutSetPrototype',
 		});
@@ -218,7 +218,7 @@ test(
 			templateName: siteTemplateName,
 		});
 
-		await apiHelpers.data.push({id: siteId, type: 'site'});
+		apiHelpers.data.push({id: siteId, type: 'site'});
 
 		const newSiteURL = `/web/${siteName}`;
 
@@ -242,7 +242,7 @@ test(
 			.click();
 		await page.getByRole('menuitem', {name: 'Permissions'}).click();
 
-		const permissionsFrameLocator = await page.frameLocator(
+		const permissionsFrameLocator = page.frameLocator(
 			'iframe[title="Permissions"]'
 		);
 

--- a/modules/test/playwright/tests/layout-set-prototype-web/main/siteTemplatesPropagation.spec.ts
+++ b/modules/test/playwright/tests/layout-set-prototype-web/main/siteTemplatesPropagation.spec.ts
@@ -45,10 +45,10 @@ test('User is able to propagate pages separately on site templates', async ({
 	sitesPage,
 	widgetPagePage,
 }) => {
-	const homePageName: string = 'Home';
-	const pageName: string = 'Page-' + getRandomString();
-	const siteTemplateName: string = 'Template-' + getRandomString();
-	const siteName: string = 'Site-' + getRandomString();
+	const homePageName = 'Home';
+	const pageName = `page-${getRandomString()}`;
+	const siteTemplateName = `template-${getRandomString()}`;
+	const siteName = `site-${getRandomString()}`;
 
 	const layoutSetPrototype = await createSiteTemplate({
 		apiHelpers,
@@ -170,7 +170,7 @@ test(
 		productMenuPage,
 		sitesPage,
 	}) => {
-		const siteTemplateName: string = 'template-' + getRandomString();
+		const siteTemplateName = `template-${getRandomString()}`;
 
 		const layoutSetPrototype = await createSiteTemplate({
 			apiHelpers,
@@ -191,7 +191,7 @@ test(
 				layoutSetPrototype.layoutSetPrototypeId
 			);
 
-		const masterPageName: string = 'masterPage-' + getRandomString();
+		const masterPageName = `masterPage-${getRandomString()}`;
 		await apiHelpers.jsonWebServicesLayoutPageTemplateEntry.addLayoutPageTemplateEntry(
 			{
 				groupId: layoutSetPrototypeGroup.groupId,
@@ -202,7 +202,7 @@ test(
 
 		await productMenuPage.goToPages();
 
-		const pageName: string = 'page-' + getRandomString();
+		const pageName = `page-${getRandomString()}`;
 		await pagesAdminPage.createNewPage({
 			draft: false,
 			name: pageName,
@@ -211,7 +211,7 @@ test(
 
 		await applicationsMenuPage.goToSites();
 
-		const siteName: string = 'site-' + getRandomString();
+		const siteName = `site-${getRandomString()}`;
 		const siteId = await sitesPage.createSite({
 			isCustom: true,
 			siteName,


### PR DESCRIPTION
## LPD: https://liferay.atlassian.net/browse/LPD-80621

> [!CAUTION]
> ### ~~Current Status: Behavioral Review~~
> ~~This test `siteTemplatesPropagation.spec.ts@User is able to propagate pages separately on site templates` is currently **failing CI by design**. After refactoring the test to include granular `dateModified` assertions, the test has exposed a potential "over-propagation" issue. Currently, modifying a single page in the template triggers an update for all pages in the linked site. I'll ask in slack to the team to confirm if this isolation is strictly required or if the current global sync is acceptable.~~ 
> This will be fixed by https://liferay.atlassian.net/browse/LPD-80399

# What is this solving?
The goal is to align the Playwright test logic with the original POSHI requirements for partial propagation. The previous implementation had weak assertions that couldn't detect if Liferay was updating more pages than intended.

# How is it fixed?
- **Restored Propagation Logic**: Re-implemented the two-phase validation from the original POSHI test to ensure pages are propagated independently.
- **Granular Assertions**: Replaced generic boolean checks with `expect.soft()` and `Date.parse()` to compare specific modification timestamps.
- **Stability Fixes**: 
   - Added `toPass()` retry logic to `getSitePage` to handle temporary `NOT_FOUND` errors.
    - Replaced `expect.poll` with `toPass()` for more reliable site navigation.

- **Code Quality**: Performed "Source Formatting" (SF) by removing redundant type annotations, adopting template literals, and removing unnecessary `await` calls.

# How to verify?
- Run the Playwright test:
  ```sh
  npx playwright test -g 'User is able to propagate pages separately on site templates'
  ```
**Note**: The test will currently fail during PHASE 1 and PHASE 2 isolation checks, showing that multiple pages are being updated simultaneously.

<img width="1243" height="587" alt="image" src="https://github.com/user-attachments/assets/61e3bfd1-b94d-467d-87d4-0de0c2619a30" />
