### PR TITLE
LPD-80617 Use fetch by ERC instead of UUID, as it is no longer kept between environments

### DIFF
--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutExportImportTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutExportImportTest.java
@@ -300,8 +300,10 @@ public class LayoutExportImportTest extends BaseExportImportTestCase {
 		exportImportLayouts(
 			new long[] {contentLayout.getLayoutId()}, getImportParameterMap());
 
-		Layout importedLayout = _layoutLocalService.fetchLayoutByUuidAndGroupId(
-			contentLayout.getUuid(), importedGroup.getGroupId(), false);
+		Layout importedLayout =
+			_layoutLocalService.fetchLayoutByExternalReferenceCode(
+				contentLayout.getExternalReferenceCode(),
+				importedGroup.getGroupId());
 
 		Layout importedDraftLayout = importedLayout.fetchDraftLayout();
 
@@ -310,9 +312,9 @@ public class LayoutExportImportTest extends BaseExportImportTestCase {
 			importedLayout.getName(), importedDraftLayout.getName());
 
 		Layout importedMasterPageTemplateLayout =
-			_layoutLocalService.fetchLayoutByUuidAndGroupId(
-				masterPageTemplateLayout.getUuid(), importedGroup.getGroupId(),
-				true);
+			_layoutLocalService.fetchLayoutByExternalReferenceCode(
+				masterPageTemplateLayout.getExternalReferenceCode(),
+				importedGroup.getGroupId());
 
 		Layout importedDraftLayoutOfMasterPageTemplate =
 			importedMasterPageTemplateLayout.fetchDraftLayout();


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPD-80617