### PR TITLE
LPD-81247 Technical Task | test-fix for testToMapWithNonexistentCustomFieldAndLazyReferencingEnabled

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/custom/field/test/CustomFieldsUtilTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/custom/field/test/CustomFieldsUtilTest.java
@@ -2753,8 +2753,7 @@ public class CustomFieldsUtilTest {
 		Assert.assertEquals(
 			StringBundler.concat(
 				"The ", ExpandoColumn.class.getName(),
-				" with external reference code ",
-				exportImportReportEntry.getClassExternalReferenceCode(),
+				" with external reference code ", randomName1,
 				" was not found. An empty shell was created."),
 			exportImportReportEntry.getErrorMessage());
 		Assert.assertNull(exportImportReportEntry.getErrorStacktrace());


### PR DESCRIPTION
Test fix needed due to https://liferay.atlassian.net/browse/LPD-77587

After investigating, it turned out that it wasn't flagged on my PR as unique failure, cause this particular test class did not run on relevant