### PR TITLE
LPD-82004 [Test fix] export-import-web/main/stagingUseCase.spec.ts:282:1 › Staging only approved

### DIFF
--- a/modules/test/playwright/pages/journal-content-web/WebContentDisplayPage.ts
+++ b/modules/test/playwright/pages/journal-content-web/WebContentDisplayPage.ts
@@ -162,23 +162,22 @@ export class WebContentDisplayPage {
 			.getByText('Success:The application was added to the page.')
 			.waitFor({state: 'hidden'});
 
-		await this.configurationFrameSelectButton.waitFor();
 		await this.configurationFrameSelectButton.click();
 
 		if (webContentName) {
 			await this.selectWebContentInConfigurationFrame
 				.getByText(webContentName)
-				.waitFor();
-			await this.selectWebContentInConfigurationFrame
-				.getByText(webContentName)
 				.hover();
-			await this.selectWebContentInConfigurationFrame
-				.getByText(webContentName)
-				.click();
 
 			// Wait for the Item Selector's nested iframe to resolve the selection
 
-			await this.configurationFrameChangeButton.waitFor();
+			await clickAndExpectToBeVisible({
+				target: this.configurationFrameChangeButton,
+				trigger:
+					this.selectWebContentInConfigurationFrame.getByText(
+						webContentName
+					),
+			});
 		}
 		else {
 			await this.webContentDisplayOptionsContent.click();
@@ -190,21 +189,14 @@ export class WebContentDisplayPage {
 				.getByText('Success:The application was added to the page.')
 				.waitFor({state: 'hidden'});
 
-			await this.selectWebContentButton.waitFor();
 			await this.selectWebContentButton.click();
-			await this.webContentToSelect.waitFor();
-			await this.webContentToSelect.hover();
-			await this.webContentToSelect.click();
 
-			if (!this.saveButton.isVisible) {
-				await this.webContentToSelect.click();
-			}
+			await clickAndExpectToBeVisible({
+				autoClick: true,
+				target: this.saveButton,
+				trigger: this.webContentToSelect,
+			});
 
-			if (!this.saveButton.isVisible) {
-				await this.webContentToSelect.click();
-			}
-
-			await this.saveButton.click();
 			await this.uiElementsPage.closeClickable.click();
 
 			await this.page
@@ -232,7 +224,7 @@ export class WebContentDisplayPage {
 		await this.page
 			.getByRole('heading', {name: 'Web Content Display'})
 			.hover();
-		await this.selectButton.waitFor();
+
 		await clickAndExpectToBeVisible({
 			target: this.selectWebContentButton,
 			trigger: this.selectButton,
@@ -241,11 +233,11 @@ export class WebContentDisplayPage {
 			target: this.webContentToSelect.getByText(webContentName),
 			trigger: this.selectWebContentButton,
 		});
-		await this.webContentToSelect.getByText(webContentName).hover();
-		await this.webContentToSelect.getByText(webContentName).click();
-		if (!this.saveButton.isVisible) {
-			await this.webContentToSelect.getByLabel(webContentName).click();
-		}
+		await clickAndExpectToBeVisible({
+			target: this.saveButton,
+			trigger: this.webContentToSelect.getByLabel(webContentName),
+		});
+
 		await this.saveButton.click();
 	}
 

--- a/modules/test/playwright/pages/journal-content-web/WebContentDisplayPage.ts
+++ b/modules/test/playwright/pages/journal-content-web/WebContentDisplayPage.ts
@@ -118,7 +118,7 @@ export class WebContentDisplayPage {
 	}
 
 	async goToConfiguration() {
-		await this.webContentDisplay.waitFor({state: 'visible'});
+		await this.webContentDisplay.waitFor();
 		await this.webContentDisplayContent.hover();
 		await this.webContentDisplayContent.click();
 
@@ -135,7 +135,7 @@ export class WebContentDisplayPage {
 			webContentName: '',
 		}
 	) {
-		await this.webContentDisplay.waitFor({state: 'visible'});
+		await this.webContentDisplay.waitFor();
 		await this.webContentDisplayContent.hover();
 		await this.webContentDisplayContent.click();
 
@@ -163,13 +163,13 @@ export class WebContentDisplayPage {
 			.getByText('Success:The application was added to the page.')
 			.waitFor({state: 'hidden'});
 
-		await this.configurationFrameSelectButton.waitFor({state: 'visible'});
+		await this.configurationFrameSelectButton.waitFor();
 		await this.configurationFrameSelectButton.click();
 
 		if (webContentName) {
 			await this.selectWebContentInConfigurationFrame
 				.getByText(webContentName)
-				.waitFor({state: 'visible'});
+				.waitFor();
 			await this.selectWebContentInConfigurationFrame
 				.getByText(webContentName)
 				.hover();
@@ -191,9 +191,9 @@ export class WebContentDisplayPage {
 				.getByText('Success:The application was added to the page.')
 				.waitFor({state: 'hidden'});
 
-			await this.selectWebContentButton.waitFor({state: 'visible'});
+			await this.selectWebContentButton.waitFor();
 			await this.selectWebContentButton.click();
-			await this.webContentToSelect.waitFor({state: 'visible'});
+			await this.webContentToSelect.waitFor();
 			await this.webContentToSelect.hover();
 			await this.webContentToSelect.click();
 
@@ -211,7 +211,7 @@ export class WebContentDisplayPage {
 			await this.page
 				.locator('header')
 				.filter({hasText: 'Web Content Display'})
-				.waitFor({state: 'visible'});
+				.waitFor();
 		}
 
 		await this.saveConfigurationFrameOptions();
@@ -226,14 +226,14 @@ export class WebContentDisplayPage {
 		await this.webContentDisplayAddButton.click();
 		await this.page
 			.getByText('Success:The application was added to the page.')
-			.waitFor({state: 'visible'});
+			.waitFor();
 		await this.page
 			.getByText('Success:The application was added to the page.')
 			.waitFor({state: 'hidden'});
 		await this.page
 			.getByRole('heading', {name: 'Web Content Display'})
 			.hover();
-		await this.selectButton.waitFor({state: 'visible'});
+		await this.selectButton.waitFor();
 		await clickAndExpectToBeVisible({
 			target: this.selectWebContentButton,
 			trigger: this.selectButton,
@@ -264,6 +264,6 @@ export class WebContentDisplayPage {
 				'[id^="portlet_com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_"] header'
 			)
 			.filter({hasText: 'Web Content Display'})
-			.waitFor({state: 'visible'});
+			.waitFor();
 	}
 }

--- a/modules/test/playwright/pages/journal-content-web/WebContentDisplayPage.ts
+++ b/modules/test/playwright/pages/journal-content-web/WebContentDisplayPage.ts
@@ -39,6 +39,9 @@ export class WebContentDisplayPage {
 		this.configurationFrame = page.frameLocator(
 			'iframe[title*="Configuration"]'
 		);
+		this.webContentDisplayConfig = page.frameLocator(
+			'iframe[title*="Web Content Display"]'
+		);
 
 		this.app = page.getByTestId('app-loaded');
 
@@ -59,27 +62,26 @@ export class WebContentDisplayPage {
 		this.scopeOptions = this.configurationFrame.locator(
 			'[id="_com_liferay_portlet_configuration_web_portlet_PortletConfigurationPortlet_scope"]'
 		);
-		this.saveButton = page
-			.frameLocator('iframe[title*="Web Content Display"]')
-			.getByRole('button', {
-				name: 'Save',
-			});
+		this.saveButton = this.webContentDisplayConfig.getByRole('button', {
+			name: 'Save',
+		});
 		this.scopeTab = this.configurationFrame.getByRole('link', {
 			name: 'Scope Deprecated',
 		});
 		this.selectButton = this.app.getByRole('button', {
 			name: 'Select',
 		});
-		this.selectWebContentButton = page
-			.frameLocator('iframe[title*="Web Content Display"]')
-			.getByRole('button', {name: 'Select'});
+		this.selectWebContentButton = this.webContentDisplayConfig.getByRole(
+			'button',
+			{name: 'Select'}
+		);
 		this.selectWebContentInConfigurationFrame =
 			this.configurationFrame.frameLocator(
 				'iframe[title="Select Web Content"]'
 			);
-		this.selectWebContentFrame = page
-			.frameLocator('iframe[title*="Web Content Display"]')
-			.frameLocator('iframe[title="Select Web Content"]');
+		this.selectWebContentFrame = this.webContentDisplayConfig.frameLocator(
+			'iframe[title="Select Web Content"]'
+		);
 		this.uiElementsPage = new UIElementsPage(page);
 		this.webContentDisplay = page
 			.getByText('Select web content to make it visible')
@@ -91,9 +93,6 @@ export class WebContentDisplayPage {
 			.locator('li')
 			.filter({hasText: 'Web Content Display'})
 			.getByLabel('Add Content');
-		this.webContentDisplayConfig = page.frameLocator(
-			'iframe[title*="Web Content Display"]'
-		);
 		this.webContentDisplayContent = page.locator(
 			'[id^="portlet_com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE"]'
 		);

--- a/modules/test/playwright/pages/journal-content-web/WebContentDisplayPage.ts
+++ b/modules/test/playwright/pages/journal-content-web/WebContentDisplayPage.ts
@@ -14,6 +14,7 @@ export class WebContentDisplayPage {
 
 	readonly app: Locator;
 	readonly configurationFrame: FrameLocator;
+	readonly configurationFrameChangeButton: Locator;
 	readonly configurationFrameSelectButton: Locator;
 	readonly configurationOption: Locator;
 	readonly scopeTab: Locator;
@@ -41,6 +42,10 @@ export class WebContentDisplayPage {
 
 		this.app = page.getByTestId('app-loaded');
 
+		this.configurationFrameChangeButton = this.configurationFrame.getByRole(
+			'button',
+			{name: 'Change'}
+		);
 		this.configurationFrameSelectButton = this.configurationFrame.getByRole(
 			'button',
 			{
@@ -171,6 +176,10 @@ export class WebContentDisplayPage {
 			await this.selectWebContentInConfigurationFrame
 				.getByText(webContentName)
 				.click();
+
+			// Wait for the Item Selector's nested iframe to resolve the selection
+
+			await this.configurationFrameChangeButton.waitFor();
 		}
 		else {
 			await this.webContentDisplayOptionsContent.click();

--- a/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
+++ b/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
@@ -52,6 +52,7 @@ export class PageEditorPage {
 
 	readonly editModeButton: Locator;
 	readonly experienceSelector: Locator;
+	readonly dropZone: Locator;
 	readonly languageSelector: Locator;
 	readonly newRuleButton: Locator;
 	readonly publishButton: Locator;
@@ -70,6 +71,7 @@ export class PageEditorPage {
 		this.experienceSelector = page.locator(
 			'.page-editor__experience-selector'
 		);
+		this.dropZone = page.locator('.page-editor__no-fragments-state');
 		this.languageSelector = page
 			.locator('.page-editor__toolbar')
 			.getByLabel('Select a language');

--- a/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
+++ b/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
@@ -71,7 +71,7 @@ export class PageEditorPage {
 		this.experienceSelector = page.locator(
 			'.page-editor__experience-selector'
 		);
-		this.dropZone = page.locator('.page-editor__no-fragments-state');
+		this.dropZone = page.locator('#page-editor');
 		this.languageSelector = page
 			.locator('.page-editor__toolbar')
 			.getByLabel('Select a language');

--- a/modules/test/playwright/tests/export-import-web/main/pages/StagingPage.ts
+++ b/modules/test/playwright/tests/export-import-web/main/pages/StagingPage.ts
@@ -5,6 +5,7 @@
 
 import {Locator, Page, expect} from '@playwright/test';
 
+import {clickAndExpectToBeVisible} from '../../../../utils/clickAndExpectToBeVisible';
 import getRandomString from '../../../../utils/getRandomString';
 
 type StagedPortletsSelection = 'all' | 'none' | string[];
@@ -90,13 +91,15 @@ export class StagingPage {
 	}
 
 	async publishTemplate(templateName: string) {
-		await this.page
-			.locator(`tr`)
-			.filter({hasText: templateName})
-			.getByRole('button')
-			.click();
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: this.page.getByRole('menuitem', {name: 'Publish'}),
+			trigger: this.page
+				.locator(`tr`)
+				.filter({hasText: templateName})
+				.getByRole('button'),
+		});
 
-		await this.page.getByRole('menuitem', {name: 'Publish'}).click();
 		await this.page.getByRole('button', {name: 'Publish to Live'}).click();
 		await expect(
 			this.page

--- a/modules/test/playwright/tests/export-import-web/main/stagingUseCase.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/stagingUseCase.spec.ts
@@ -266,7 +266,7 @@ testWithBatchStagingFF(
 
 		await uiElementsPage.newButton.click();
 
-		await stagingPage.page
+		await page
 			.getByTestId('headerTitle')
 			.filter({hasText: 'New Publish Process'})
 			.waitFor();
@@ -274,9 +274,7 @@ testWithBatchStagingFF(
 		await expect(page.getByRole('button', {name: 'Select'})).toHaveCount(0);
 
 		await expect(
-			stagingPage.page.getByText(
-				/(?=.*Categories \(1\))(?=.*Vocabularies \(1\))/
-			)
+			page.getByText(/(?=.*Categories \(1\))(?=.*Vocabularies \(1\))/)
 		).toBeVisible();
 	}
 );

--- a/modules/test/playwright/tests/export-import-web/main/stagingUseCase.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/stagingUseCase.spec.ts
@@ -302,7 +302,11 @@ test('Staging only approved content goes to live', async ({
 
 	await pageEditorPage.goto(layout1, site.friendlyUrlPath);
 
-	await pageEditorPage.addWidget('Content Management', 'Web Content Display');
+	await pageEditorPage.addWidget(
+		'Content Management',
+		'Web Content Display',
+		pageEditorPage.dropZone
+	);
 
 	await pageEditorPage.publishPage();
 
@@ -313,7 +317,11 @@ test('Staging only approved content goes to live', async ({
 	});
 
 	await pageEditorPage.goto(layout2, site.friendlyUrlPath);
-	await pageEditorPage.addWidget('Content Management', 'Web Content Display');
+	await pageEditorPage.addWidget(
+		'Content Management',
+		'Web Content Display',
+		pageEditorPage.dropZone
+	);
 	await pageEditorPage.publishPage();
 
 	await workflowPage.goto(site.friendlyUrlPath);
@@ -465,7 +473,11 @@ test(
 			name: displayPageTemplateName,
 		});
 		await displayPageTemplatesPage.editTemplate(displayPageTemplateName);
-		await pageEditorPage.addFragment('Basic Components', 'Button');
+		await pageEditorPage.addFragment(
+			'Basic Components',
+			'Button',
+			pageEditorPage.dropZone
+		);
 		await pageEditorPage.mapEditableLink({
 			editableId: 'link',
 			fragmentName: 'Button',
@@ -536,7 +548,11 @@ classTypeIdsJournalArticleAssetRendererFactory=${basicWebcontentStructureId}`,
 			webContentName
 		);
 		await pageEditorPage.goto(layout, site.friendlyUrlPath);
-		await pageEditorPage.addWidget('Content Management', 'Asset Publisher');
+		await pageEditorPage.addWidget(
+			'Content Management',
+			'Asset Publisher',
+			pageEditorPage.dropZone
+		);
 
 		const widgetId = await pageEditorPage.getFragmentId('Asset Publisher');
 

--- a/modules/test/playwright/tests/export-import-web/main/stagingUseCase.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/stagingUseCase.spec.ts
@@ -274,7 +274,9 @@ testWithBatchStagingFF(
 		await expect(page.getByRole('button', {name: 'Select'})).toHaveCount(0);
 
 		await expect(
-			stagingPage.page.getByText('Categories (1), Vocabularies (1)')
+			stagingPage.page.getByText(
+				/(?=.*Categories \(1\))(?=.*Vocabularies \(1\))/
+			)
 		).toBeVisible();
 	}
 );


### PR DESCRIPTION
## LPD: https://liferay.atlassian.net/browse/LPD-82004  

>[!CAUTION]
> ~~**Do not forward until CI checks have passed.**~~

# What is this solving?
The primary goal of this PR is to fix a recurring failure in `export-import-web/main/stagingUseCase.spec.ts > Staging only approved content goes to live` test in CI. The issue was caused by a race condition where the test attempted to save the configuration before the Item Selector's nested iframe had finished resolving the content selection.

# How is it fixed?
- **Resolved Iframe Race Condition**: Introduced a mandatory wait for the `configurationFrameChangeButton` after selecting a web content item. This ensures the selection is fully processed by the nested iframe before the test proceeds.
- **Improved Interaction Stability**: Integrated the `clickAndExpectToBeVisible` utility to manage complex click-and-wait sequences, specifically ensuring the 'Save' button is ready for interaction.
- **General Cleanup**: Performed minor refactors to iframe locator reuse and removed redundant default parameters in `waitFor` calls to improve code maintainability.

# How to verify?

Run the test locally:

```
cd modules/test/playwright
npx playwright test -g 'Staging only approved content goes to live
```