### PR TITLE
LPP-62890 Highlight nestedField issue. NestedFields does not work for Search + Headless

### DIFF
--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/ProductDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/ProductDTOConverter.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 	property = {
 		"application.name=Liferay.Headless.Commerce.Admin.Catalog",
 		"dto.class.name=com.liferay.commerce.product.model.CPDefinition",
-		"version=v1.0"
+		"service.ranking:Integer=" + Integer.MAX_VALUE, "version=v1.0"
 	},
 	service = DTOConverter.class
 )

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/ProductSpecificationDTOConverter.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/dto/v1_0/converter/ProductSpecificationDTOConverter.java
@@ -22,7 +22,11 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alessio Antonio Rendina
  */
 @Component(
-	property = "dto.class.name=com.liferay.commerce.product.model.CPDefinitionSpecificationOptionValue",
+	property = {
+		"application.name=Liferay.Headless.Commerce.Admin.Catalog",
+		"dto.class.name=com.liferay.commerce.product.model.CPDefinitionSpecificationOptionValue",
+		"service.ranking:Integer=" + Integer.MAX_VALUE
+	},
 	service = DTOConverter.class
 )
 public class ProductSpecificationDTOConverter

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/ProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/ProductResourceImpl.java
@@ -267,6 +267,10 @@ public class ProductResourceImpl extends BaseProductResourceImpl {
 			_cpDefinitionService.fetchCPDefinitionByCProductId(id, false);
 
 		if (cpDefinition == null) {
+			cpDefinition = _cpDefinitionService.fetchCPDefinition(id);
+		}
+
+		if (cpDefinition == null) {
 			throw new NoSuchCPDefinitionException(
 				"Unable to find product with ID " + id);
 		}


### PR DESCRIPTION
@4lejandrito ,

As discussed,

https://liferay.atlassian.net/browse/LPP-62890


Reproduction Steps.

1. Deploy commit changes.
2. Start Master
3. Create Minium Site.
3. Create blueprint, add query element `Filter by Exact Terms Match`.
4. Field: `assetCategoryNames`, Value: `brake system`
5. Call `http://localhost:8080/o/search/v1.0/search?nestedFields=embedded,productSpecifications` with following body:
```
{
    "attributes": {
        "search.empty.search": true,
         "search.experiences.blueprint.external.reference.code": "TEST"
    }
}
```
6. Confirm `embedded` returns, but nestedField of `Product` for `productSpecifications` is not returned.
7. Call `http://localhost:8080/o/headless-commerce-admin-catalog/v1.0/products?nestedFields=productSpecifications,skus`
8. Confirm both `productSpecifications` and `skus` which are nestedFields are returned.