### PR TITLE
LPD-82488 Add test-plan skill for generating local test plans

### DIFF
--- a/.claude/skills/test-plan/SKILL.md
+++ b/.claude/skills/test-plan/SKILL.md
@@ -1,7 +1,9 @@
 ---
+
 name: test-plan
 description: Generate a targeted local test plan for branch changes. Use when the user wants to know what tests to run before merging, asks for a test plan, wants to validate their changes locally, or mentions running tests for their branch. This skill analyzes commits on top of master and produces a runnable shell script with unit, integration, playwright, and poshi tests that fit within a 20-minute local run budget.
 allowed-tools: [Read, Glob, Grep, Bash, Agent]
+
 ---
 
 # Test Plan Generator
@@ -52,17 +54,24 @@ For each area that could break, search for test files. Use parallel Agent/Glob c
 Apply this priority order:
 
 **Always include:**
+
 1. Unit tests for directly changed code — fast (~5-15s per class), highest signal
-2. Integration tests that directly test changed functionality
-3. Tests that exercise the core logic change end-to-end
+
+1. Integration tests that directly test changed functionality
+
+1. Tests that exercise the core logic change end-to-end
 
 **Include if budget allows:**
-4. Representative integration tests from affected downstream modules — pick a few that cover different usage patterns rather than running all of them
-5. Playwright tests for affected web modules (~1-3 min per spec)
+
+1. Representative integration tests from affected downstream modules — pick a few that cover different usage patterns rather than running all of them
+
+1. Playwright tests for affected web modules (~1-3 min per spec)
 
 **Include if still within budget:**
-6. Poshi tests (~2-5 min each)
-7. More downstream module tests for broader coverage
+
+1. Poshi tests (~2-5 min each)
+
+1. More downstream module tests for broader coverage
 
 When the change affects many modules (e.g., a framework change), don't try to test every single module. Pick a diverse sample that covers different usage patterns of the changed code.
 

--- a/.claude/skills/test-plan/references/test-organization.md
+++ b/.claude/skills/test-plan/references/test-organization.md
@@ -3,6 +3,7 @@
 ## Module Structure
 
 Standard module layout:
+
 ```
 modules/apps/{module-group}/
 ├── {module}-api/           # API/interfaces (rarely has tests)
@@ -64,14 +65,17 @@ modules/apps/{module-group}/
 ## Mapping Source Changes to Tests
 
 ### Direct mapping (same module)
+
 A change to `modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/util/PingbackMethodImpl.java` maps to:
 - Unit test: `modules/apps/blogs/blogs-service/src/test/java/com/liferay/blogs/internal/util/PingbackMethodImplTest.java`
 
 ### Cross-module mapping (test module)
+
 A change to `modules/apps/blogs/blogs-service/` maps to:
 - Integration tests in: `modules/apps/blogs/blogs-test/src/testIntegration/java/`
 
 ### Using test.properties for broader mapping
+
 Each module group has a `test.properties` at `modules/apps/{module-group}/test.properties` containing:
 
 ```properties
@@ -91,6 +95,7 @@ modules.includes.required.test.batch.class.names.includes[modules-integration-po
 Use `testray.main.component.name` to find related poshi `.testcase` files by searching for matching `@component-name` or `testray.main.component.name` properties inside them.
 
 ### Playwright mapping
+
 Map the module's web component name to its playwright directory:
 - Change in `modules/apps/blogs/blogs-web/` → tests in `modules/test/playwright/tests/blogs-web/`
 - Change in `modules/apps/document-library/document-library-web/` → tests in `modules/test/playwright/tests/document-library-web/`


### PR DESCRIPTION
## Summary
- Adds a Claude Code skill (`test-plan`) that generates a targeted local test plan (runnable shell script) for branch changes
- Includes a reference file documenting how tests are organized in the Liferay Portal codebase (unit, integration, playwright, poshi)
- The skill analyzes commits on top of master and produces a focused test script fitting within a 20-minute local run budget

For [this PR](https://github.com/liferay-headless/liferay-portal/pull/3552) it generated this script:

```bash
#!/bin/bash
#
# Test plan for branch: LPD-57745
# Generated: 2026-03-12
# Estimated time: ~8m / 20m budget
#
# Changes: 1 commit, 188 files changed
# Affected areas: portal-vulcan (DTOConverterRegistry comparator + default property on ~186 DTOConverters)
#
# The core change adds a custom comparator to DTOConverterRegistryImpl that
# prioritizes DTOConverters with a "default=true" OSGi property. All existing
# DTOConverters across the codebase get this property added mechanically.
#

REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
EXIT_CODE=0

# Directly tests the new comparator logic and default property behavior (new test)
"$REPO_ROOT/gradlew" -p "$REPO_ROOT/modules" :apps:portal-vulcan:portal-vulcan-test:testIntegration --tests "com.liferay.portal.vulcan.dto.converter.test.DTOConverterRegistryTest" || EXIT_CODE=1
# Existing integration tests for DTOConverterRegistry - verify no regressions from comparator change
"$REPO_ROOT/gradlew" -p "$REPO_ROOT/modules" :apps:portal-vulcan:portal-vulcan-test:testIntegration --tests "com.liferay.portal.vulcan.batch.engine.test.VulcanBatchEngineTaskItemDelegateAdaptorFactoryTest" || EXIT_CODE=1
# Representative downstream headless test - exercises DTOConverter resolution end-to-end
"$REPO_ROOT/gradlew" -p "$REPO_ROOT/modules" :apps:headless:headless-admin-user:headless-admin-user-test:testIntegration --tests "com.liferay.headless.admin.user.resource.v1_0.test.UserAccountResourceTest" || EXIT_CODE=1
# Another downstream headless test - different module to cover diverse DTOConverter usage
"$REPO_ROOT/gradlew" -p "$REPO_ROOT/modules" :apps:headless:headless-admin-user:headless-admin-user-test:testIntegration --tests "com.liferay.headless.admin.user.resource.v1_0.test.OrganizationResourceTest" || EXIT_CODE=1

exit $EXIT_CODE

```