### PR TITLE
LPD-82880 Fix vocabulary and category deletions not publishable to live via staging

### DIFF
--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/portlet_list/render_controls.jsp
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/portlet_list/render_controls.jsp
@@ -43,11 +43,12 @@ for (int i = 0; i < portletDataHandlerControls.length; i++) {
 					StagedModelType stagedModelType = new StagedModelType(className, portletDataHandlerBoolean.getReferrerClassName());
 
 					long modelAdditionCount = manifestSummary.getModelAdditionCount(stagedModelType);
+					long modelDeletionCount = manifestSummary.getModelDeletionCount(stagedModelType);
 
 					if (modelAdditionCount != 0) {
 						label += (modelAdditionCount > 0) ? " (" + modelAdditionCount + ")" : StringPool.BLANK;
 					}
-					else if (!showAllPortlets) {
+					else if ((modelDeletionCount <= 0) && !showAllPortlets) {
 						continue control;
 					}
 				}


### PR DESCRIPTION
## Summary

Fixes a bug where vocabulary and category deletions cannot be published to the live site when using local staging with **Replicate Individual Deletions**.

- When "Replicate Individual Deletions" is selected in the staging publish process UI, the registration sub-items (Categories, Vocabularies) under the Categories section are not shown — only an empty `Select` dropdown appears
- Because no sub-items are rendered, the form submission does not include them, and deletions are never exported to the live site

## Root Cause

In `render_controls.jsp`, the visibility of individual `PortletDataHandlerBoolean` controls is determined solely by `modelAdditionCount`. When `modelAdditionCount == 0` and `showAllPortlets == false`, the control is skipped via `continue control` — even if the model has pending deletions.

This means that after deleting a vocabulary or category on the staging site, the corresponding controls would never appear in the publish configuration UI because there are zero additions (only deletions exist).

The parent `portlet_list/page.jsp` already correctly accounts for both additions **and** deletions when deciding whether to show a portlet-level entry (line 67):

```java
if ((exportModelCount <= 0) && (modelDeletionCount <= 0) && !showAllPortlets) {
    continue;
}
```

But the child `render_controls.jsp` did not apply the same logic for its sub-items.

## Fix

Added a `modelDeletionCount` check in `render_controls.jsp` so that controls with pending deletions are still rendered even when there are no additions:

```diff
  long modelAdditionCount = manifestSummary.getModelAdditionCount(stagedModelType);
+ long modelDeletionCount = manifestSummary.getModelDeletionCount(stagedModelType);

  if (modelAdditionCount != 0) {
      label += (modelAdditionCount > 0) ? " (" + modelAdditionCount + ")" : StringPool.BLANK;
  }
- else if (!showAllPortlets) {
+ else if ((modelDeletionCount <= 0) && !showAllPortlets) {
      continue control;
  }
```

## Steps to Reproduce

1. Create a new site
2. Enable local staging
3. Create a new vocabulary and a category in it
4. Publish to live
5. Delete the vocabulary on the staging site
6. Create a new publish process and select **Replicate Individual Deletions**
7. Observe the Categories sub-items are missing (empty Select dropdown)

## Test Plan

- [ ] Verify that after deleting a vocabulary/category on staging, the sub-items appear in the publish UI when "Replicate Individual Deletions" is selected
- [ ] Verify that publishing the deletions successfully removes the vocabulary/category from the live site
- [ ] Verify that the normal publish flow (with additions) still works correctly and shows item counts