### PR TITLE
LPD-82879 Limit the random int to 100 (0 <= randomInt < 100) to avoid exceeding the maximum lenght of the field name

### DIFF
--- a/modules/test/playwright/tests/export-import-web/main/site.siteInitializer.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/site.siteInitializer.spec.ts
@@ -273,7 +273,7 @@ testWithClaritySiteInitializerFF(
 							objectDefinition1.externalReferenceCode,
 							{
 								label: {
-									en_US: `objectRelationshipLabel${getRandomInt()}`,
+									en_US: `objectRelationshipLabel${getRandomInt() % 100}`,
 								},
 								name: `objectRelationshipName${getRandomInt() % 100}`,
 								objectDefinitionExternalReferenceCode1:


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPD-82879