### PR TITLE
LPD-8288: Allow batch engine portlet data handler to do the import even if using the 'From Last Publish Date'

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/controller/PortletImportControllerImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/controller/PortletImportControllerImpl.java
@@ -408,7 +408,8 @@ public class PortletImportControllerImpl implements PortletImportController {
 
 		if (ExportImportThreadLocal.isPortletStagingInProcess() &&
 			ExportImportDateUtil.isRangeFromLastPublishDate(
-				portletDataContext)) {
+				portletDataContext) &&
+			!portletDataHandler.isBatch()) {
 
 			String changesetPortletId = ChangesetPortletKeys.CHANGESET;
 


### PR DESCRIPTION
- https://liferay.atlassian.net/browse/LPD-82881

This is part of the fix for /  covered by remoteStaging.spec.ts > Can publish vocabulary deletion from the Global Site using remote staging  