### PR TITLE
LPD-81878 Fix stale transactional cache after REQUIRES_NEW commit

### DIFF
--- a/modules/apps/export-import/export-import-report-api/src/main/java/com/liferay/exportimport/report/service/ExportImportReportEntryLocalService.java
+++ b/modules/apps/export-import/export-import-report-api/src/main/java/com/liferay/exportimport/report/service/ExportImportReportEntryLocalService.java
@@ -59,10 +59,7 @@ public interface ExportImportReportEntryLocalService
 		String modelNameLanguageKey);
 
 	@Indexable(type = IndexableType.REINDEX)
-	@Transactional(
-		isolation = Isolation.PORTAL,
-		rollbackFor = {PortalException.class, SystemException.class}
-	)
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	public ExportImportReportEntry addErrorExportImportReportEntry(
 		long groupId, long companyId, String classExternalReferenceCode,
 		long classNameId, long classPK, long exportImportConfigurationId,

--- a/modules/apps/export-import/export-import-report-api/src/main/resources/com/liferay/exportimport/report/service/packageinfo
+++ b/modules/apps/export-import/export-import-report-api/src/main/resources/com/liferay/exportimport/report/service/packageinfo
@@ -1,1 +1,1 @@
-version 4.1.1
+version 4.1.0

--- a/modules/apps/export-import/export-import-report-service/src/main/java/com/liferay/exportimport/report/service/impl/ExportImportReportEntryLocalServiceImpl.java
+++ b/modules/apps/export-import/export-import-report-service/src/main/java/com/liferay/exportimport/report/service/impl/ExportImportReportEntryLocalServiceImpl.java
@@ -15,13 +15,11 @@ import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.search.Indexable;
 import com.liferay.portal.kernel.search.IndexableType;
-import com.liferay.portal.kernel.transaction.Isolation;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.Transactional;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -82,10 +80,7 @@ public class ExportImportReportEntryLocalServiceImpl
 	}
 
 	@Indexable(type = IndexableType.REINDEX)
-	@Transactional(
-		isolation = Isolation.PORTAL,
-		rollbackFor = {PortalException.class, SystemException.class}
-	)
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	public ExportImportReportEntry addErrorExportImportReportEntry(
 		long groupId, long companyId, String classExternalReferenceCode,
 		long classNameId, long classPK, long exportImportConfigurationId,
@@ -149,7 +144,6 @@ public class ExportImportReportEntryLocalServiceImpl
 	}
 
 	@Override
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ExportImportReportEntry getOrAddErrorExportImportReportEntry(
 		long groupId, long companyId, String classExternalReferenceCode,
 		long classNameId, long classPK, long exportImportConfigurationId,

--- a/modules/apps/export-import/export-import-report-service/src/main/java/com/liferay/exportimport/report/service/impl/ExportImportReportEntryLocalServiceImpl.java
+++ b/modules/apps/export-import/export-import-report-service/src/main/java/com/liferay/exportimport/report/service/impl/ExportImportReportEntryLocalServiceImpl.java
@@ -154,7 +154,7 @@ public class ExportImportReportEntryLocalServiceImpl
 			exportImportReportEntryPersistence.fetchByG_C_C_C_E_T(
 				groupId, companyId, classExternalReferenceCode, classNameId,
 				exportImportConfigurationId,
-				ExportImportReportEntryConstants.TYPE_ERROR);
+				ExportImportReportEntryConstants.TYPE_ERROR, false);
 
 		if (exportImportReportEntry != null) {
 			return exportImportReportEntry;

--- a/modules/apps/export-import/export-import-report-service/src/main/java/com/liferay/exportimport/report/service/impl/ExportImportReportEntryLocalServiceImpl.java
+++ b/modules/apps/export-import/export-import-report-service/src/main/java/com/liferay/exportimport/report/service/impl/ExportImportReportEntryLocalServiceImpl.java
@@ -154,7 +154,7 @@ public class ExportImportReportEntryLocalServiceImpl
 			exportImportReportEntryPersistence.fetchByG_C_C_C_E_T(
 				groupId, companyId, classExternalReferenceCode, classNameId,
 				exportImportConfigurationId,
-				ExportImportReportEntryConstants.TYPE_ERROR, false);
+				ExportImportReportEntryConstants.TYPE_ERROR);
 
 		if (exportImportReportEntry != null) {
 			return exportImportReportEntry;

--- a/modules/apps/export-import/export-import-test-util/bnd.bnd
+++ b/modules/apps/export-import/export-import-test-util/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Export Import Test Utilities
 Bundle-SymbolicName: com.liferay.exportimport.test.util
-Bundle-Version: 10.1.0
+Bundle-Version: 11.0.0
 Export-Package:\
 	com.liferay.exportimport.test.rule,\
 	com.liferay.exportimport.test.util,\

--- a/modules/apps/export-import/export-import-test-util/src/main/resources/com/liferay/exportimport/test/util/lar/packageinfo
+++ b/modules/apps/export-import/export-import-test-util/src/main/resources/com/liferay/exportimport/test/util/lar/packageinfo
@@ -1,1 +1,1 @@
-version 5.0.0
+version 6.0.0

--- a/modules/apps/portal-cache/portal-cache-test-util/src/test/java/com/liferay/portal/cache/test/util/TransactionalPortalCacheTest.java
+++ b/modules/apps/portal-cache/portal-cache-test-util/src/test/java/com/liferay/portal/cache/test/util/TransactionalPortalCacheTest.java
@@ -629,6 +629,108 @@ public class TransactionalPortalCacheTest {
 	}
 
 	@Test
+	public void testTransactionalCacheWithRequiresNewInvalidatesParent() {
+		_setEnableTransactionalCache(true);
+
+		TransactionalPortalCache<String, String> transactionalPortalCache =
+			new TransactionalPortalCache<>(_portalCache, false);
+
+		// Start parent transaction (T1)
+
+		TransactionalPortalCacheUtil.begin();
+
+		// T1 reads KEY_1, gets null (not in cache), then caches a value
+		// simulating a negative cache entry (e.g., "not found" result)
+
+		Assert.assertNull(transactionalPortalCache.get(_KEY_1));
+
+		transactionalPortalCache.put(_KEY_1, _VALUE_1);
+
+		Assert.assertEquals(_VALUE_1, transactionalPortalCache.get(_KEY_1));
+
+		// Start inner transaction (T2) with REQUIRES_NEW semantics
+
+		TransactionalPortalCacheUtil.begin();
+
+		// T2 puts a different value for the same key
+
+		transactionalPortalCache.put(_KEY_1, _VALUE_2);
+
+		Assert.assertEquals(_VALUE_2, transactionalPortalCache.get(_KEY_1));
+
+		// T2 commits — flushes to real cache and invalidates T1's buffer
+
+		TransactionalPortalCacheUtil.commit(false);
+
+		// T1 resumes — T1's stale entry for KEY_1 should have been
+		// invalidated, so T1 should see T2's committed value from the
+		// real cache
+
+		Assert.assertEquals(_VALUE_2, transactionalPortalCache.get(_KEY_1));
+
+		// Also verify a key that only T1 touched is still in T1's buffer
+
+		transactionalPortalCache.put(_KEY_2, _VALUE_1);
+
+		Assert.assertEquals(_VALUE_1, transactionalPortalCache.get(_KEY_2));
+
+		// Commit parent transaction
+
+		TransactionalPortalCacheUtil.commit(false);
+
+		Assert.assertEquals(_VALUE_2, _portalCache.get(_KEY_1));
+	}
+
+	@Test
+	public void testTransactionalCacheWithRequiresNewRemoveInvalidatesParent() {
+		_setEnableTransactionalCache(true);
+
+		TransactionalPortalCache<String, String> transactionalPortalCache =
+			new TransactionalPortalCache<>(_portalCache, false);
+
+		// Populate real cache
+
+		_portalCache.put(_KEY_1, _VALUE_1);
+
+		// Start parent transaction (T1)
+
+		TransactionalPortalCacheUtil.begin();
+
+		// T1 reads KEY_1 from real cache
+
+		Assert.assertEquals(_VALUE_1, transactionalPortalCache.get(_KEY_1));
+
+		// T1 caches its own value for KEY_1
+
+		transactionalPortalCache.put(_KEY_1, _VALUE_2);
+
+		Assert.assertEquals(_VALUE_2, transactionalPortalCache.get(_KEY_1));
+
+		// Start inner transaction (T2)
+
+		TransactionalPortalCacheUtil.begin();
+
+		// T2 removes KEY_1
+
+		transactionalPortalCache.remove(_KEY_1);
+
+		Assert.assertNull(transactionalPortalCache.get(_KEY_1));
+
+		// T2 commits — real cache now has KEY_1 removed, T1's stale entry
+		// should be invalidated
+
+		TransactionalPortalCacheUtil.commit(false);
+
+		// T1 resumes — should NOT see its stale VALUE_2 for KEY_1
+
+		Assert.assertNull(transactionalPortalCache.get(_KEY_1));
+
+		// Commit parent transaction
+
+		TransactionalPortalCacheUtil.commit(false);
+	}
+
+	@Test
 	public void testTransactionalPortalCacheUtilEnabled() {
 		_setEnableTransactionalCache(false);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/cache/transactional/TransactionalPortalCacheUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/cache/transactional/TransactionalPortalCacheUtil.java
@@ -139,6 +139,8 @@ public class TransactionalPortalCacheUtil {
 			uncommittedBuffer.commit(readOnly);
 		}
 
+		_invalidateParentBufferEntries(portalCacheMap);
+
 		portalCacheMap.clear();
 	}
 
@@ -246,6 +248,88 @@ public class TransactionalPortalCacheUtil {
 		}
 
 		return uncommittedBuffer;
+	}
+
+	private static void _invalidateParentBufferEntries(
+		PortalCacheMap committedPortalCacheMap) {
+
+		List<PortalCacheMap> portalCacheMaps = _portalCacheMaps.get();
+
+		if (portalCacheMaps.isEmpty()) {
+			return;
+		}
+
+		PortalCacheMap parentPortalCacheMap = portalCacheMaps.get(
+			portalCacheMaps.size() - 1);
+
+		for (Map.Entry
+				<PortalCache<? extends Serializable, ?>, UncommittedBuffer>
+					entry : committedPortalCacheMap.entrySet()) {
+
+			UncommittedBuffer parentUncommittedBuffer =
+				parentPortalCacheMap.get(entry.getKey());
+
+			if (parentUncommittedBuffer == null) {
+				continue;
+			}
+
+			_invalidateParentUncommittedBuffer(
+				parentUncommittedBuffer, entry.getValue());
+		}
+	}
+
+	private static void _invalidateParentUncommittedBuffer(
+		UncommittedBuffer parentUncommittedBuffer,
+		UncommittedBuffer committedUncommittedBuffer) {
+
+		if (committedUncommittedBuffer instanceof
+				ShardedUncommittedBuffer) {
+
+			if (!(parentUncommittedBuffer instanceof
+					ShardedUncommittedBuffer)) {
+
+				return;
+			}
+
+			ShardedUncommittedBuffer shardedCommittedBuffer =
+				(ShardedUncommittedBuffer)committedUncommittedBuffer;
+			ShardedUncommittedBuffer shardedParentBuffer =
+				(ShardedUncommittedBuffer)parentUncommittedBuffer;
+
+			for (Map.Entry<Long, UncommittedBuffer> shardEntry :
+					shardedCommittedBuffer.
+						_shardedUncommittedBuffers.entrySet()) {
+
+				UncommittedBuffer parentShardBuffer =
+					shardedParentBuffer._shardedUncommittedBuffers.get(
+						shardEntry.getKey());
+
+				if (parentShardBuffer != null) {
+					_invalidateParentUncommittedBuffer(
+						parentShardBuffer, shardEntry.getValue());
+				}
+			}
+		}
+		else if (committedUncommittedBuffer instanceof
+					MVCCUncommittedBuffer) {
+
+			if (!(parentUncommittedBuffer instanceof
+					MVCCUncommittedBuffer)) {
+
+				return;
+			}
+
+			MVCCUncommittedBuffer mvccCommittedBuffer =
+				(MVCCUncommittedBuffer)committedUncommittedBuffer;
+			MVCCUncommittedBuffer mvccParentBuffer =
+				(MVCCUncommittedBuffer)parentUncommittedBuffer;
+
+			for (Serializable key :
+					mvccCommittedBuffer._uncommittedMap.keySet()) {
+
+				mvccParentBuffer._uncommittedMap.remove(key);
+			}
+		}
 	}
 
 	private static boolean _isTransactionalCacheEnabled() {


### PR DESCRIPTION
## Summary

- Fixes a bug where `TransactionalPortalCacheUtil` retains stale entries in a parent transaction's cache buffer after a `REQUIRES_NEW` inner transaction commits
- The inner transaction flushes its writes to the real cache, but the parent's buffer still holds old values (including negative `EmptyResult` entries), causing it to return stale data without falling through to the real cache or database
- After committing the inner buffer, `commit()` now iterates over the committed keys and removes matching entries from the parent's `UncommittedBuffer`, turning stale cached values into cache misses that correctly fall back to the real cache
- Reverts the `useFinderCache=false` workaround in `ExportImportReportEntryLocalServiceImpl` since the infrastructure now handles this

## Test plan

- [ ] Run `TransactionalPortalCacheTest` — includes two new tests (`testTransactionalCacheWithRequiresNewInvalidatesParent` and `testTransactionalCacheWithRequiresNewRemoveInvalidatesParent`) that verify parent buffer invalidation after inner commit
- [ ] Run `ExportImportReportEntryLocalServiceTest` to verify the export-import report entry get-or-add flow works without the `useFinderCache=false` hack
- [ ] Run export/import integration tests that exercise error report entries with content referencing missing groups (triggers the `LayoutReferencesExportImportContentProcessor` loop path)