### PR TITLE
LPD-81551 clear session context after each batch

### DIFF
--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineExportTaskExecutorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineExportTaskExecutorImpl.java
@@ -202,6 +202,10 @@ public class BatchEngineExportTaskExecutorImpl
 		_exportTaskPostActions.close();
 	}
 
+	private void _clearSessionPersistenceContext() {
+		LastSessionRecorderHelperUtil.syncLastSessionState();
+	}
+
 	private InputStream _exportItems(
 			BatchEngineExportTask batchEngineExportTask, Settings settings)
 		throws Exception {
@@ -319,7 +323,7 @@ public class BatchEngineExportTaskExecutorImpl
 							updateBatchEngineExportTask(batchEngineExportTask);
 				}
 
-				clearSessionPersistenceContext();
+				_clearSessionPersistenceContext();
 
 				if (Thread.interrupted()) {
 					throw new InterruptedException();
@@ -584,10 +588,6 @@ public class BatchEngineExportTaskExecutorImpl
 			batchEngineExportTask.getCallbackURL(),
 			batchEngineExportTask.getExecuteStatus(),
 			batchEngineExportTask.getBatchEngineExportTaskId());
-	}
-
-	private void clearSessionPersistenceContext() {
-		LastSessionRecorderHelperUtil.syncLastSessionState();
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(


### PR DESCRIPTION
Jira Ticket: https://liferay.atlassian.net/browse/LPD-81546

This PR fixes a performance issue in the export process where batch export time increases progressively as the export advances.

Based on investigations in the following PRs:
- https://github.com/liferay-headless/liferay-portal/pull/3500
- https://github.com/liferay-headless/liferay-portal/pull/3551

We discovered that the slowdown is caused by the process sharing the same Hibernate session, leading to the session cache continuously growing over time. The proposed fix is to clear the session after each batch.

We [synced with the Infra team](https://liferay.slack.com/archives/C01FP01V5L0/p1773779139641379), and they mentioned that `syncLastSessionState` was introduced for a similar reason. They confirmed that this solution looks appropriate.