### PR TITLE
LPD-80739 sanitize redirect and backURL

### DIFF
--- a/modules/apps/dispatch/dispatch-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/dispatch/dispatch-web/src/main/resources/META-INF/resources/init.jsp
@@ -48,8 +48,10 @@ page import="com.liferay.portal.kernel.util.FastDateFormatFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
+page import="com.liferay.portal.kernel.util.PortalUtil" %><%@
 page import="com.liferay.portal.kernel.util.PropsKeys" %><%@
 page import="com.liferay.portal.kernel.util.PropsUtil" %><%@
+page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.portal.kernel.util.WebKeys" %>
 
 <%@ page import="jakarta.portlet.PortletURL" %>
@@ -67,9 +69,17 @@ page import="java.util.TimeZone" %>
 <portlet:defineObjects />
 
 <%
-String redirect = ParamUtil.getString(request, "redirect");
+String redirect = PortalUtil.escapeRedirect(ParamUtil.getString(request, "redirect", currentURL));
 
-String backURL = ParamUtil.getString(request, "backURL", redirect);
+if (Validator.isNull(redirect)) {
+	redirect = currentURL;
+}
+
+String backURL = PortalUtil.escapeRedirect(ParamUtil.getString(request, "backURL", redirect));
+
+if (Validator.isNull(backURL)) {
+	backURL = redirect;
+}
 
 Format fastDateTimeFormat = FastDateFormatFactoryUtil.getDateTime(FastDateFormatConstants.SHORT, FastDateFormatConstants.LONG, locale, TimeZone.getTimeZone("UTC"));
 %>


### PR DESCRIPTION
Jira Ticket: https://liferay.atlassian.net/browse/LPD-80739

The Job Scheduler portlet used redirect and backURL from the url as link targets. We now validate both with `PortalUtil.escapeRedirect()` so values like `javascript:...` cannot run when users click Back

### Before

https://github.com/user-attachments/assets/9003ee98-08a3-4ab6-8af7-49c3c119bcb1

### After

https://github.com/user-attachments/assets/dde2fa5d-5c35-422c-94ab-23435911c6e3
