### PR TITLE
LPD-83847 Processing batch engine content per item with streaming

### DIFF
--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineImportTaskExecutorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineImportTaskExecutorImpl.java
@@ -555,7 +555,9 @@ public class BatchEngineImportTaskExecutorImpl
 		}
 	}
 
-	private Map<String, Object> _processFieldNameValueMap(Map<String, Object> map) {
+	private Map<String, Object> _processFieldNameValueMap(
+		Map<String, Object> map) {
+
 		for (Map.Entry<String, Object> entry : map.entrySet()) {
 			entry.setValue(_processValue(entry.getValue()));
 		}
@@ -564,7 +566,15 @@ public class BatchEngineImportTaskExecutorImpl
 	}
 
 	private Object _processValue(Object value) {
-		if (value instanceof String valueString) {
+		if (value instanceof List) {
+			List<Object> list = (List<Object>)value;
+
+			list.replaceAll(this::_processValue);
+		}
+		else if (value instanceof Map) {
+			_processFieldNameValueMap((Map<String, Object>)value);
+		}
+		else if (value instanceof String valueString) {
 			for (BatchEngineContentProcessor batchEngineContentProcessor :
 					_batchEngineContentProcessors) {
 
@@ -572,14 +582,6 @@ public class BatchEngineImportTaskExecutorImpl
 			}
 
 			return valueString;
-		}
-		else if (value instanceof Map) {
-			_processFieldNameValueMap((Map<String, Object>)value);
-		}
-		else if (value instanceof List) {
-			List<Object> list = (List<Object>)value;
-
-			list.replaceAll(this::_processValue);
 		}
 
 		return value;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-83847

**What is being fixed:** During batch engine import, `_processInputStream()` reads the entire JSON input stream into a single String in memory via `StringUtil.read(inputStream)` before applying `BatchEngineContentProcessor`s. For large import files (such as liferay.com pages) this causes excessive memory consumption and leads to `OutOfMemoryError`.

**How it is being fixed:** Replacing the `_processInputStream` approach with a per-item `_processFieldNameValueMap` method that applies `BatchEngineContentProcessor`s to individual string values within each item's field map as items are streamed. The method recurses into nested maps and lists to process string values at any depth, using `instanceof` pattern matching and `List.replaceAll` for cleaner code.