### PR TITLE
LPD-84002 Fix "Staging#PublishChildPageWithoutItsParentPage" Poshi test 

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/Staging.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/Staging.testcase
@@ -1255,20 +1255,6 @@ definition {
 
 		JSONStaging.enableLocalStaging(groupName = "Site Name");
 
-		ApplicationsMenu.gotoPortlet(
-			category = "Configuration",
-			panel = "Control Panel",
-			portlet = "System Settings");
-
-		SystemSettings.gotoConfiguration(
-			configurationCategory = "Infrastructure",
-			configurationName = "Staging",
-			configurationScope = "Virtual Instance Scope");
-
-		SystemSettings.configureSystemSetting(
-			enableSetting = "false",
-			settingFieldName = "Publish Parent Pages by Default");
-
 		Navigator.gotoStagedSitePage(
 			pageName = "Staging Test Page",
 			siteName = "Site Name");


### PR DESCRIPTION
**What's changed?** 
- The configuration was removed recently so the test used to fail when trying to enable it. I just removed the segment of the test in which the configuration was set.

Please see the following Jira ticket: [LPD-82574](https://liferay.atlassian.net/browse/LPD-82574)