### PR TITLE
LPD-85630 Remove legacy Headless Site API usage in RESTClientTemplateContextContributorTest

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/template/test/RESTClientTemplateContextContributorTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/template/test/RESTClientTemplateContextContributorTest.java
@@ -64,7 +64,7 @@ public class RESTClientTemplateContextContributorTest {
 				).put(
 					"templateType", "site-initializer"
 				).toString(),
-				"headless-site/v1.0/sites", Http.Method.POST);
+				"headless-admin-site/v1.0/sites", Http.Method.POST);
 
 			HTTPTestUtil.customize(
 			).withoutModulePath(


### PR DESCRIPTION
# What is this trying to solve?
   https://liferay.atlassian.net/browse/LPD-85630

   # How am I fixing it?
   I've updated `RESTClientTemplateContextContributorTest.java` in `portal-vulcan-test` to use the current `headless-admin-site` API instead of the legacy `headless-site` API.

   # How can you verify that it works?
   In `modules/apps/portal-vulcan/portal-vulcan-test`, run:
   `gw testIntegration --tests RESTClientTemplateContextContributorTest.test`