### PR TITLE
LPD-86134: Fix export-import AsahFaro segment entries

### DIFF
--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/exportimport/content/processor/SegmentsEntryExportImportContentProcessor.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/exportimport/content/processor/SegmentsEntryExportImportContentProcessor.java
@@ -19,6 +19,7 @@ import com.liferay.portal.odata.filter.Filter;
 import com.liferay.portal.odata.filter.FilterParser;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.filter.expression.Expression;
+import com.liferay.segments.constants.SegmentsEntryConstants;
 import com.liferay.segments.criteria.Criteria;
 import com.liferay.segments.criteria.CriteriaSerializer;
 import com.liferay.segments.criteria.contributor.SegmentsCriteriaContributor;
@@ -27,8 +28,10 @@ import com.liferay.segments.field.customizer.SegmentsFieldCustomizerRegistry;
 import com.liferay.segments.internal.odata.entity.EntityModelFieldMapper;
 import com.liferay.segments.internal.odata.filter.expression.ExportExpressionVisitorImpl;
 import com.liferay.segments.internal.odata.filter.expression.ImportExpressionVisitorImpl;
+import com.liferay.segments.model.SegmentsEntry;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -52,7 +55,7 @@ public class SegmentsEntryExportImportContentProcessor
 			boolean escapeContent)
 		throws Exception {
 
-		if (Validator.isBlank(content)) {
+		if (Validator.isBlank(content) && _isAsahFaroSource(stagedModel)) {
 			return content;
 		}
 
@@ -73,7 +76,7 @@ public class SegmentsEntryExportImportContentProcessor
 		content = _replaceImportExpandoColumnReferences(
 			portletDataContext.getCompanyId(), content);
 
-		if (Validator.isBlank(content)) {
+		if (Validator.isBlank(content) && _isAsahFaroSource(stagedModel)) {
 			return content;
 		}
 
@@ -86,6 +89,14 @@ public class SegmentsEntryExportImportContentProcessor
 	@Override
 	public void validateContentReferences(long groupId, String content)
 		throws PortalException {
+	}
+
+	private boolean _isAsahFaroSource(StagedModel stagedModel) {
+		SegmentsEntry segmentsEntry = (SegmentsEntry)stagedModel;
+
+		return Objects.equals(
+			SegmentsEntryConstants.SOURCE_ASAH_FARO_BACKEND,
+			segmentsEntry.getSource());
 	}
 
 	private String _replaceExportCriteriaReferences(

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/exportimport/content/processor/SegmentsEntryExportImportContentProcessor.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/exportimport/content/processor/SegmentsEntryExportImportContentProcessor.java
@@ -13,6 +13,7 @@ import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.StagedModel;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.model.adapter.util.ModelAdapterUtil;
 import com.liferay.portal.odata.filter.Filter;
 import com.liferay.portal.odata.filter.FilterParser;
@@ -51,6 +52,10 @@ public class SegmentsEntryExportImportContentProcessor
 			boolean escapeContent)
 		throws Exception {
 
+		if (Validator.isBlank(content)) {
+			return content;
+		}
+
 		Criteria criteria = CriteriaSerializer.deserialize(content);
 
 		content = _replaceExportCriteriaReferences(
@@ -67,6 +72,10 @@ public class SegmentsEntryExportImportContentProcessor
 
 		content = _replaceImportExpandoColumnReferences(
 			portletDataContext.getCompanyId(), content);
+
+		if (Validator.isBlank(content)) {
+			return content;
+		}
 
 		Criteria criteria = CriteriaSerializer.deserialize(content);
 

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/internal/exportimport/data/handler/test/SegmentsEntryStagedModelDataHandlerTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/internal/exportimport/data/handler/test/SegmentsEntryStagedModelDataHandlerTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.segments.exportimport.data.handler.test;
+package com.liferay.segments.internal.exportimport.data.handler.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.expando.kernel.model.ExpandoColumn;

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/internal/exportimport/data/handler/test/SegmentsEntryStagedModelDataHandlerTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/internal/exportimport/data/handler/test/SegmentsEntryStagedModelDataHandlerTest.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.model.StagedModel;
 import com.liferay.portal.kernel.model.Team;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.TeamLocalServiceUtil;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -38,6 +39,7 @@ import com.liferay.portal.model.adapter.util.ModelAdapterUtil;
 import com.liferay.portal.odata.normalizer.Normalizer;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.segments.constants.SegmentsEntryConstants;
 import com.liferay.segments.criteria.Criteria;
 import com.liferay.segments.criteria.CriteriaSerializer;
 import com.liferay.segments.criteria.contributor.SegmentsCriteriaContributor;
@@ -80,6 +82,36 @@ public class SegmentsEntryStagedModelDataHandlerTest
 			(StagedModelRepository<StagedExpandoColumn>)
 				StagedModelRepositoryRegistryUtil.getStagedModelRepository(
 					StagedExpandoColumn.class.getName());
+	}
+
+	@Test
+	@TestInfo("LPD-86134")
+	public void testExportImportAsahFaroSourceSegmentsEntryWithEmptyCriteria()
+		throws Exception {
+
+		initExport();
+
+		_segmentsEntry = SegmentsTestUtil.addSegmentsEntry(
+			stagingGroup.getGroupId(), null);
+
+		_segmentsEntry.setSource(
+			SegmentsEntryConstants.SOURCE_ASAH_FARO_BACKEND);
+
+		StagedModelDataHandlerUtil.exportStagedModel(
+			portletDataContext, _segmentsEntry);
+
+		try (SafeCloseable safeCloseable = initImportWithSafeCloseable()) {
+			SegmentsEntry exportedSegmentsEntry =
+				(SegmentsEntry)readExportedStagedModel(_segmentsEntry);
+
+			StagedModelDataHandlerUtil.importStagedModel(
+				portletDataContext, exportedSegmentsEntry);
+
+			_importedSegmentsEntry = (SegmentsEntry)getStagedModel(
+				_segmentsEntry.getUuid(), liveGroup);
+
+			Assert.assertNull(_importedSegmentsEntry.getCriteriaObj());
+		}
 	}
 
 	@Test

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/internal/exportimport/data/handler/test/SegmentsPortletDataHandlerTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/internal/exportimport/data/handler/test/SegmentsPortletDataHandlerTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.segments.exportimport.data.handler.test;
+package com.liferay.segments.internal.exportimport.data.handler.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.exportimport.kernel.lar.DataLevel;


### PR DESCRIPTION
- https://liferay.atlassian.net/browse/LPD-84210
  - https://liferay.atlassian.net/browse/LPD-86134

Fixes AC segments not being exported-imported because of having empty criteria.