### PR TITLE
LPD-86281 Fix missing feedback when saving Staging configuration

### DIFF
--- a/modules/apps/staging/staging-configuration-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/staging/staging-configuration-web/src/main/resources/META-INF/resources/view.jsp
@@ -233,6 +233,9 @@ BackgroundTask lastCompletedInitialPublicationBackgroundTask = BackgroundTaskMan
 						});
 					}
 				}
+				else {
+					doSubmit();
+				}
 			}
 		</c:if>
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86281

**What is being fixed:** Clicking Save on the Staging configuration page
without changing the staging type produces no feedback. The form is
silently not submitted because the saveGroup() JavaScript function only
calls doSubmit() when the staging type radio selection differs from the
current value.

**How it is being fixed:** An else clause is added so that doSubmit() is
called when the staging type has not changed. This ensures the form
always submits on Save, which lets the server-side code process the
request and display the appropriate success message. This also fixes a
secondary issue where changes to individual portlet checkboxes or
branching options were silently lost if the staging type itself was not
changed.