### PR TITLE
LPD-86428 Disable Claude commit and PR attribution

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  }
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86428

**What is being fixed:** Claude Code, when used by team members in this repository, appends attribution trailers to commits and PR descriptions (e.g. `Co-Authored-By: Claude`, "Generated with Claude Code"). These trailers are noise in the project history and create inconsistency depending on which tool produced the commit.

**How it is being fixed:** Added a project-level `.claude/settings.json` with `attribution.commit` and `attribution.pr` set to empty strings. Claude Code picks up this project-scoped configuration automatically for anyone running it in the repo, so the attribution is suppressed consistently across the team without relying on personal settings.