### PR TITLE
LPD-83788 Export/Import - Elements must meet minimum color contrast ratio thresholds

### DIFF
--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/css/main.scss
@@ -82,7 +82,7 @@
 	}
 
 	.selected-labels {
-		color: #999;
+		color: #595959;
 		font-style: italic;
 		margin-left: 0.5em;
 		margin-right: 0.5em;
@@ -404,7 +404,7 @@ html#{$cadmin-selector} {
 				}
 
 				.selected-labels {
-					color: #999;
+					color: #595959;
 					font-style: italic;
 					margin-left: 0.5em;
 					margin-right: 0.5em;

--- a/modules/apps/staging/staging-processes-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/staging/staging-processes-web/src/main/resources/META-INF/resources/css/main.scss
@@ -75,7 +75,7 @@
 	}
 
 	.selected-labels {
-		color: #999;
+		color: #595959;
 		font-style: italic;
 		margin-left: 0.5em;
 		margin-right: 0.5em;

--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/css/PagesTree.scss
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/css/PagesTree.scss
@@ -77,7 +77,7 @@
 	}
 
 	.selected-labels {
-		color: #999;
+		color: #595959;
 		font-style: italic;
 		margin-left: 0.5em;
 		margin-right: 0.5em;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-83788

Hello we would like a review of our changes related to staging/export/import modules. We adjusted the color for export dialog tree selected labels to meet the minimum color contrast ratio thresholds for WCAG Compliance. Thank you!

cc:@andrea-ale-sbarra