### PR TITLE
LPD-86446 Remove apiHelpers.headlessSite calls for Headless

### DIFF
--- a/modules/test/playwright/helpers/HeadlessAdminSiteApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessAdminSiteApiHelper.ts
@@ -42,7 +42,7 @@ export type TSite = {
 	membershipType?: string;
 	name: string;
 	parentSiteExternalReferenceCode?: string;
-	templateKey?: number;
+	templateKey?: string;
 	templateType?: string;
 };
 

--- a/modules/test/playwright/tests/batch-planner/main/import.spec.ts
+++ b/modules/test/playwright/tests/batch-planner/main/import.spec.ts
@@ -508,11 +508,9 @@ test('Admin users can see all site scopes regardless of site membership', async 
 	let site: Site;
 
 	await test.step('Setup Site, site scoped object and admin user', async () => {
-		site = await apiHelpers.headlessSite.createSite({
+		site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		const objectDefinitionAPIClient =
 			await apiHelpers.buildRestClient(ObjectDefinitionAPI);

--- a/modules/test/playwright/tests/export-import-service/main/remoteStaging.spec.ts
+++ b/modules/test/playwright/tests/export-import-service/main/remoteStaging.spec.ts
@@ -60,11 +60,9 @@ test(
 	}) => {
 		test.slow();
 
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: 'Site Name',
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		const layout = await apiHelpers.jsonWebServicesLayout.addLayout({
 			groupId: site.id,
@@ -74,13 +72,8 @@ test(
 			title: 'Staging Test Page',
 		});
 
-		const remoteSite = await remoteApiHelpers.headlessSite.createSite({
+		const remoteSite = await remoteApiHelpers.headlessAdminSite.postSite({
 			name: 'Remote Site Name',
-		});
-
-		remoteApiHelpers.data.push({
-			id: remoteSite.externalReferenceCode,
-			type: 'site',
 		});
 
 		await apiHelpers.jsonWebServicesStaging.enableRemoteStaging({

--- a/modules/test/playwright/tests/export-import-web/main/site.import.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/site.import.spec.ts
@@ -757,9 +757,11 @@ testWithDeprecationFF(
 			);
 		}
 
-		const site = await virtualInstanceApiHelpers.headlessSite.createSite({
-			name: getRandomString(),
-		});
+		const site = await virtualInstanceApiHelpers.headlessAdminSite.postSite(
+			{
+				name: getRandomString(),
+			}
+		);
 
 		await page.goto(
 			`http://www.able.com:8080/group${site.friendlyUrlPath}${PORTLET_URLS.import}`

--- a/modules/test/playwright/tests/export-import-web/main/site.siteInitializer.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/site.siteInitializer.spec.ts
@@ -62,15 +62,13 @@ const testWithClaritySiteInitializerFF = mergeTests(
 	}, testInfo) => {
 		testInfo.fail(shouldFail);
 
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name,
 			templateKey: name,
 			templateType: 'site-initializer',
 		});
 
 		expect(site.name).toBeDefined();
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		await stagingPage.goto(site.name);
 
@@ -119,15 +117,10 @@ const testWithClaritySiteInitializerFF = mergeTests(
 		let site2: Site;
 
 		await test.step('Create the site 1 from the template', async () => {
-			site1 = await apiHelpers.headlessSite.createSite({
+			site1 = await apiHelpers.headlessAdminSite.postSite({
 				name: getRandomString(),
 				templateKey: name,
 				templateType: 'site-initializer',
-			});
-
-			apiHelpers.data.push({
-				id: site1.externalReferenceCode,
-				type: 'site',
 			});
 		});
 
@@ -140,13 +133,8 @@ const testWithClaritySiteInitializerFF = mergeTests(
 		});
 
 		await test.step('Create the site 2', async () => {
-			site2 = await apiHelpers.headlessSite.createSite({
+			site2 = await apiHelpers.headlessAdminSite.postSite({
 				name: getRandomString(),
-			});
-
-			apiHelpers.data.push({
-				id: site2.externalReferenceCode,
-				type: 'site',
 			});
 		});
 
@@ -307,16 +295,11 @@ testWithClaritySiteInitializerFF(
 			await testWithClaritySiteInitializerFF.step(
 				'Create the site 1 from the template',
 				async () => {
-					site1 = await apiHelpers.headlessSite.createSite({
+					site1 = await apiHelpers.headlessAdminSite.postSite({
 						name: getRandomString(),
 						templateKey:
 							'com.liferay.site.initializer.teaser.showcase',
 						templateType: 'site-initializer',
-					});
-
-					apiHelpers.data.push({
-						id: site1.externalReferenceCode,
-						type: 'site',
 					});
 				}
 			);
@@ -374,13 +357,8 @@ testWithClaritySiteInitializerFF(
 			await testWithClaritySiteInitializerFF.step(
 				'Create the site 2',
 				async () => {
-					site2 = await apiHelpers.headlessSite.createSite({
+					site2 = await apiHelpers.headlessAdminSite.postSite({
 						name: getRandomString(),
-					});
-
-					apiHelpers.data.push({
-						id: site2.externalReferenceCode,
-						type: 'site',
 					});
 				}
 			);

--- a/modules/test/playwright/tests/export-import-web/main/stagingUseCase.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/stagingUseCase.spec.ts
@@ -74,13 +74,8 @@ test(
 			type: 'objectDefinition',
 		});
 
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
-		});
-
-		apiHelpers.data.push({
-			id: site.externalReferenceCode,
-			type: 'site',
 		});
 
 		await apiHelpers.objectEntry.postObjectEntry(
@@ -103,13 +98,8 @@ test(
 	'Taxonomy Categories can be staged through batch',
 	{tag: ['@LPD-76007']},
 	async ({apiHelpers, stagingPage}) => {
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
-		});
-
-		apiHelpers.data.push({
-			id: site.externalReferenceCode,
-			type: 'site',
 		});
 
 		const taxonomyVocabularyAPIClient = await apiHelpers.buildRestClient(
@@ -153,7 +143,7 @@ test(
 			stagedPortlets: [StageableEntities.CATEGORIES],
 		});
 
-		const stagingSite = await apiHelpers.headlessSite.getSite(
+		const stagingSite = await apiHelpers.headlessAdminSite.getSite(
 			`${site.key}-staging`
 		);
 
@@ -208,13 +198,8 @@ test(
 	'Taxonomy Categories display controls on staging page',
 	{tag: ['@LPD-78848']},
 	async ({apiHelpers, page, stagingPage, uiElementsPage}) => {
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
-		});
-
-		apiHelpers.data.push({
-			id: site.externalReferenceCode,
-			type: 'site',
 		});
 
 		await stagingPage.goto(site.key);
@@ -222,7 +207,7 @@ test(
 			stagedPortlets: [StageableEntities.CATEGORIES],
 		});
 
-		const stagingSite = await apiHelpers.headlessSite.getSite(
+		const stagingSite = await apiHelpers.headlessAdminSite.getSite(
 			`${site.key}-staging`
 		);
 
@@ -277,11 +262,9 @@ test('Staging only approved content goes to live', async ({
 	workflowPage,
 	workflowTasksPage,
 }) => {
-	const site = await apiHelpers.headlessSite.createSite({
+	const site = await apiHelpers.headlessAdminSite.postSite({
 		name: `site-${getRandomString()}`,
 	});
-
-	apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 	const layout1 = await apiHelpers.jsonWebServicesLayout.addLayout({
 		groupId: site.id,
@@ -437,11 +420,9 @@ test(
 		pageEditorPage,
 		uiElementsPage,
 	}) => {
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: 'site-' + getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		const layout = await apiHelpers.jsonWebServicesLayout.addLayout({
 			groupId: site.id,
@@ -561,11 +542,9 @@ test(
 	'Non modified referred content cannot publish to live when enable include if modified option',
 	{tag: '@LPS-167777'},
 	async ({apiHelpers, stagingConfigurationPage, stagingPage}) => {
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: 'site-' + getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		await apiHelpers.jsonWebServicesLayout.addLayout({
 			groupId: site.id,
@@ -647,11 +626,9 @@ test(
 		page,
 		webContentDisplayPage,
 	}) => {
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		const document = await apiHelpers.headlessDelivery.postDocument(
 			site.id,
@@ -701,11 +678,9 @@ test('Staging publish template with smoke', async ({
 	webContentDisplayPage,
 	widgetPagePage,
 }) => {
-	const site = await apiHelpers.headlessSite.createSite({
+	const site = await apiHelpers.headlessAdminSite.postSite({
 		name: getRandomString(),
 	});
-
-	apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 	const layout = await apiHelpers.jsonWebServicesLayout.addLayout({
 		groupId: site.id,
@@ -769,11 +744,9 @@ test('A page created in staging is published to live', async ({
 	page,
 	stagingPage,
 }) => {
-	const site = await apiHelpers.headlessSite.createSite({
+	const site = await apiHelpers.headlessAdminSite.postSite({
 		name: 'site-' + getRandomString(),
 	});
-
-	apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 	await stagingPage.goto(site.name);
 	await stagingPage.enableLocalStaging();
@@ -825,11 +798,9 @@ test('Content selection is empty after initial publication to live when using th
 	apiHelpers,
 	stagingPage,
 }) => {
-	const site = await apiHelpers.headlessSite.createSite({
+	const site = await apiHelpers.headlessAdminSite.postSite({
 		name: 'site-' + getRandomString(),
 	});
-
-	apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 	await apiHelpers.headlessAdminSite.createPage(site.externalReferenceCode, {
 		name_i18n: {en_US: getRandomString()},

--- a/modules/test/playwright/tests/staging-configuration-web/main/stagingConfiguration.spec.ts
+++ b/modules/test/playwright/tests/staging-configuration-web/main/stagingConfiguration.spec.ts
@@ -78,11 +78,9 @@ test(
 		page,
 		portletPublishToLivePage,
 	}) => {
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		const layout = await apiHelpers.jsonWebServicesLayout.addLayout({
 			groupId: site.id,
@@ -137,11 +135,9 @@ test(
 		page,
 		portletPublishToLivePage,
 	}) => {
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		const layout = await apiHelpers.jsonWebServicesLayout.addLayout({
 			groupId: site.id,
@@ -194,7 +190,7 @@ test('Check if local staging can be enabled', async ({
 
 	await globalMenuPage.goToControlPanel('Sites');
 
-	const site = await apiHelpers.headlessSite.createSite({
+	const site = await apiHelpers.headlessAdminSite.postSite({
 		name: siteName,
 	});
 
@@ -217,11 +213,9 @@ test(
 		productMenuPage,
 		stagingConfigurationPage,
 	}) => {
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		await globalMenuPage.goToSite(site.name);
 		await productMenuPage.goToPages();
@@ -278,11 +272,9 @@ test(
 		page,
 		portletPublishToLivePage,
 	}) => {
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		const layout = await apiHelpers.jsonWebServicesLayout.addLayout({
 			groupId: site.id,
@@ -397,11 +389,9 @@ testFlagsEnabled(
 		const layoutName = getRandomString();
 		const webContentName = getRandomString();
 
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: siteName,
 		});
-
-		apiHelpers.data.push({id: site.externalReferenceCode, type: 'site'});
 
 		const layout = await apiHelpers.jsonWebServicesLayout.addLayout({
 			groupId: site.id,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86446

### Summary
Standardized Playwright tests by replacing legacy `apiHelpers.headlessSite` with `apiHelpers.headlessAdminSite`.

### Site Cleanup
- Automated: Manual `deleteSite` calls were removed when using `dataApiHelpersTest`, as cleanup is now handled automatically through `ApiHelpers.clearData`.
- Manual: Explicit deletion remains for tests using `apiHelpersTest` (which lacks the automatic registry) or where immediate cleanup is required for state validation.

If you encounter any failures or flakiness related to these changes, please let me know.