### PR TITLE
LPD-86568 Save staging changes when the staging type is unchanged

### DIFF
--- a/modules/apps/staging/staging-configuration-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/staging/staging-configuration-web/src/main/resources/META-INF/resources/view.jsp
@@ -233,6 +233,9 @@ BackgroundTask lastCompletedInitialPublicationBackgroundTask = BackgroundTaskMan
 						});
 					}
 				}
+				else {
+					doSubmit();
+				}
 			}
 		</c:if>
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86568

**What is being fixed:** In Site Administration → Publishing → Staging, clicking the Save button without changing the staging type produced no visible feedback: the form was never submitted, so edits to remote options or staged portlets were silently discarded and the user could not tell whether the action worked or the button was broken.

**How it is being fixed:** The client-side `saveGroup()` handler only submitted the form when the staging type had changed (wrapped in a confirmation modal). When the type was unchanged it fell through silently. The fix submits the form directly in that branch, without a confirmation modal, since no activation or deactivation is happening — the server-side action already emits the appropriate success message (`localStagingModified` / `remoteStagingModified`).