### PR TITLE
LPD-83052 Add ContentSelector for the export/import revamp

### DIFF
--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSection.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSection.tsx
@@ -40,8 +40,6 @@ export default function ContentSection({
 		isSelected(portletContextsValue[context.name], context)
 	);
 
-	const isPresent = !!Object.keys(portletContextsValue).length;
-
 	const handleSelectAll = () => {
 		if (selected) {
 			onChange(undefined);
@@ -63,7 +61,10 @@ export default function ContentSection({
 				<ClayLayout.ContentCol expand={false}>
 					<ClayCheckbox
 						checked={selected}
-						indeterminate={isPresent && !selected}
+						indeterminate={
+							!!Object.keys(portletContextsValue).length &&
+							!selected
+						}
 						onChange={handleSelectAll}
 					/>
 				</ClayLayout.ContentCol>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSection.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSection.tsx
@@ -1,0 +1,106 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ClayCheckbox} from '@clayui/form';
+import ClayLayout from '@clayui/layout';
+import React from 'react';
+
+import {
+	PortletDataHandler,
+	PortletDataHandlerSection as PortletDataHandlerSectionType,
+} from '../../../utils/mockPortletDataHandlerSections';
+import PortletDataControl, {
+	HandlerSelection,
+	getInitialSelection,
+	isSelected,
+} from './PortletDataControl';
+
+export type SectionSelection = Record<string, HandlerSelection>;
+
+interface ContentSectionProps {
+	onChange: (value: SectionSelection | undefined) => void;
+	section: PortletDataHandlerSectionType;
+	value: SectionSelection | undefined;
+}
+
+export default function ContentSection({
+	onChange,
+	section,
+	value,
+}: ContentSectionProps) {
+	const portletContextsValue = value || {};
+
+	const selected = section.portletDataHandlers.every((context) =>
+		isSelected(portletContextsValue[context.name], context)
+	);
+
+	const isPresent = !!Object.keys(portletContextsValue).length;
+
+	const handleSelectAll = () => {
+		if (selected) {
+			onChange(undefined);
+		}
+		else {
+			const newValue: SectionSelection = {};
+
+			section.portletDataHandlers.forEach((context) => {
+				newValue[context.name] = getInitialSelection(context);
+			});
+
+			onChange(newValue);
+		}
+	};
+
+	return (
+		<div className="mb-5 sheet">
+			<ClayLayout.ContentRow padded>
+				<ClayLayout.ContentCol expand={false}>
+					<ClayCheckbox
+						checked={selected}
+						indeterminate={isPresent && !selected}
+						onChange={handleSelectAll}
+					/>
+				</ClayLayout.ContentCol>
+
+				<ClayLayout.ContentCol expand>
+					<div className="font-weight-bold h3 mb-0">
+						{section.name}
+					</div>
+				</ClayLayout.ContentCol>
+			</ClayLayout.ContentRow>
+
+			<div
+				className="overflow-auto pl-4"
+				style={{
+					maxHeight: '400px',
+				}}
+			>
+				{section.portletDataHandlers.map(
+					(context: PortletDataHandler) => (
+						<PortletDataControl
+							control={context}
+							key={context.name}
+							onChange={(controlValue) => {
+								const {[context.name]: _, ...newEntries} =
+									portletContextsValue;
+
+								if (controlValue) {
+									newEntries[context.name] = controlValue;
+								}
+
+								onChange(
+									Object.keys(newEntries).length
+										? (newEntries as SectionSelection)
+										: undefined
+								);
+							}}
+							value={portletContextsValue[context.name]}
+						/>
+					)
+				)}
+			</div>
+		</div>
+	);
+}

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSection.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSection.tsx
@@ -8,14 +8,16 @@ import ClayLayout from '@clayui/layout';
 import React from 'react';
 
 import {
-	PortletDataHandlerBoolean,
-	PortletDataHandlerSection as PortletDataHandlerSectionType,
-} from '../../../utils/mockPortletDataHandlerSections';
-import PortletDataControl, {
 	HandlerSelection,
 	getInitialSelection,
 	isSelected,
-} from './PortletDataControl';
+	updateSelection,
+} from '../../../utils/contentSelection';
+import {
+	PortletDataHandlerBoolean,
+	PortletDataHandlerSection as PortletDataHandlerSectionType,
+} from '../../../utils/mockPortletDataHandlerSections';
+import PortletDataControl from './PortletDataControl';
 
 export type SectionSelection = Record<string, HandlerSelection>;
 
@@ -86,20 +88,15 @@ export default function ContentSection({
 					<PortletDataControl
 						control={context}
 						key={context.name}
-						onChange={(controlValue) => {
-							const {[context.name]: _, ...newEntries} =
-								portletContextsValue;
-
-							if (controlValue) {
-								newEntries[context.name] = controlValue;
-							}
-
+						onChange={(controlValue) =>
 							onChange(
-								Object.keys(newEntries).length
-									? (newEntries as SectionSelection)
-									: undefined
-							);
-						}}
+								updateSelection(
+									portletContextsValue,
+									context.name,
+									controlValue
+								)
+							)
+						}
 						value={portletContextsValue[context.name]}
 					/>
 				))}

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSection.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSection.tsx
@@ -8,7 +8,7 @@ import ClayLayout from '@clayui/layout';
 import React from 'react';
 
 import {
-	PortletDataHandler,
+	PortletDataHandlerBoolean,
 	PortletDataHandlerSection as PortletDataHandlerSectionType,
 } from '../../../utils/mockPortletDataHandlerSections';
 import PortletDataControl, {
@@ -32,7 +32,11 @@ export default function ContentSection({
 }: ContentSectionProps) {
 	const portletContextsValue = value || {};
 
-	const selected = section.portletDataHandlers.every((context) =>
+	const controls = section.portletDataHandlers.map<PortletDataHandlerBoolean>(
+		(handler) => ({...handler, type: 'boolean'})
+	);
+
+	const selected = controls.every((context) =>
 		isSelected(portletContextsValue[context.name], context)
 	);
 
@@ -45,7 +49,7 @@ export default function ContentSection({
 		else {
 			const newValue: SectionSelection = {};
 
-			section.portletDataHandlers.forEach((context) => {
+			controls.forEach((context) => {
 				newValue[context.name] = getInitialSelection(context);
 			});
 
@@ -66,7 +70,7 @@ export default function ContentSection({
 
 				<ClayLayout.ContentCol expand>
 					<div className="font-weight-bold h3 mb-0">
-						{section.name}
+						{section.label}
 					</div>
 				</ClayLayout.ContentCol>
 			</ClayLayout.ContentRow>
@@ -77,29 +81,27 @@ export default function ContentSection({
 					maxHeight: '400px',
 				}}
 			>
-				{section.portletDataHandlers.map(
-					(context: PortletDataHandler) => (
-						<PortletDataControl
-							control={context}
-							key={context.name}
-							onChange={(controlValue) => {
-								const {[context.name]: _, ...newEntries} =
-									portletContextsValue;
+				{controls.map((context) => (
+					<PortletDataControl
+						control={context}
+						key={context.name}
+						onChange={(controlValue) => {
+							const {[context.name]: _, ...newEntries} =
+								portletContextsValue;
 
-								if (controlValue) {
-									newEntries[context.name] = controlValue;
-								}
+							if (controlValue) {
+								newEntries[context.name] = controlValue;
+							}
 
-								onChange(
-									Object.keys(newEntries).length
-										? (newEntries as SectionSelection)
-										: undefined
-								);
-							}}
-							value={portletContextsValue[context.name]}
-						/>
-					)
-				)}
+							onChange(
+								Object.keys(newEntries).length
+									? (newEntries as SectionSelection)
+									: undefined
+							);
+						}}
+						value={portletContextsValue[context.name]}
+					/>
+				))}
 			</div>
 		</div>
 	);

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSelector.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSelector.tsx
@@ -5,6 +5,7 @@
 
 import React from 'react';
 
+import {updateSelection} from '../../../utils/contentSelection';
 import {PortletDataHandlerSection} from '../../../utils/mockPortletDataHandlerSections';
 import ContentSection, {SectionSelection} from './ContentSection';
 
@@ -28,19 +29,15 @@ export default function ContentSelector({
 			{sections.map((section: PortletDataHandlerSection) => (
 				<ContentSection
 					key={section.name}
-					onChange={(sectionValue) => {
-						const {[section.name]: _, ...newValue} = currentValue;
-
-						if (sectionValue) {
-							newValue[section.name] = sectionValue;
-						}
-
+					onChange={(sectionValue) =>
 						onChange(
-							Object.keys(newValue).length
-								? (newValue as ContentSelection)
-								: undefined
-						);
-					}}
+							updateSelection(
+								currentValue,
+								section.name,
+								sectionValue
+							)
+						)
+					}
 					section={section}
 					value={currentValue[section.name]}
 				/>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSelector.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSelector.tsx
@@ -27,12 +27,12 @@ export default function ContentSelector({
 		<div className="mt-4">
 			{sections.map((section: PortletDataHandlerSection) => (
 				<ContentSection
-					key={section.key}
+					key={section.name}
 					onChange={(sectionValue) => {
-						const {[section.key]: _, ...newValue} = currentValue;
+						const {[section.name]: _, ...newValue} = currentValue;
 
 						if (sectionValue) {
-							newValue[section.key] = sectionValue;
+							newValue[section.name] = sectionValue;
 						}
 
 						onChange(
@@ -42,7 +42,7 @@ export default function ContentSelector({
 						);
 					}}
 					section={section}
-					value={currentValue[section.key]}
+					value={currentValue[section.name]}
 				/>
 			))}
 		</div>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSelector.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSelector.tsx
@@ -1,0 +1,50 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import React from 'react';
+
+import {PortletDataHandlerSection} from '../../../utils/mockPortletDataHandlerSections';
+import ContentSection, {SectionSelection} from './ContentSection';
+
+export type ContentSelection = Record<string, SectionSelection>;
+
+interface ContentSelectorProps {
+	onChange: (value: ContentSelection | undefined) => void;
+	sections: PortletDataHandlerSection[];
+	value: ContentSelection | undefined;
+}
+
+export default function ContentSelector({
+	onChange,
+	sections,
+	value,
+}: ContentSelectorProps) {
+	const currentValue = value || {};
+
+	return (
+		<div className="mt-4">
+			{sections.map((section: PortletDataHandlerSection) => (
+				<ContentSection
+					key={section.key}
+					onChange={(sectionValue) => {
+						const {[section.key]: _, ...newValue} = currentValue;
+
+						if (sectionValue) {
+							newValue[section.key] = sectionValue;
+						}
+
+						onChange(
+							Object.keys(newValue).length
+								? (newValue as ContentSelection)
+								: undefined
+						);
+					}}
+					section={section}
+					value={currentValue[section.key]}
+				/>
+			))}
+		</div>
+	);
+}

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/PortletDataControl.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/PortletDataControl.tsx
@@ -7,56 +7,14 @@ import {ClayCheckbox} from '@clayui/form';
 import ClayLayout from '@clayui/layout';
 import React from 'react';
 
+import {
+	HandlerSelection,
+	getInitialSelection,
+	isSelected,
+	updateSelection,
+} from '../../../utils/contentSelection';
 import {PortletDataHandlerControl} from '../../../utils/mockPortletDataHandlerSections';
 import PortletDataControlChoice from './PortletDataControlChoice';
-
-export type HandlerSelection =
-	| {
-			[key: string]: HandlerSelection;
-	  }
-	| string
-	| true;
-
-export function isSelected(
-	value: HandlerSelection | undefined,
-	entry: PortletDataHandlerControl
-): boolean {
-	if (!value) {
-		return false;
-	}
-
-	if (entry.type === 'choice') {
-		return true;
-	}
-
-	if (!entry.controls?.length || typeof value !== 'object') {
-		return true;
-	}
-
-	return entry.controls.every((control) =>
-		isSelected(value[control.name], control)
-	);
-}
-
-export function getInitialSelection(
-	entry: PortletDataHandlerControl
-): HandlerSelection {
-	if (entry.type === 'choice') {
-		return entry.choices[0].name;
-	}
-
-	if (!entry.controls?.length) {
-		return true;
-	}
-
-	const selection: Record<string, HandlerSelection> = {};
-
-	entry.controls.forEach((control) => {
-		selection[control.name] = getInitialSelection(control);
-	});
-
-	return selection;
-}
 
 interface PortletDataControlProps {
 	className?: string;
@@ -117,23 +75,15 @@ export default function PortletDataControl({
 							control={nestedControl}
 							key={nestedControl.name}
 							level={level + 1}
-							onChange={(controlValue) => {
-								const {
-									[nestedControl.name]: _,
-									...newSelection
-								} = currentSelection;
-
-								if (controlValue) {
-									newSelection[nestedControl.name] =
-										controlValue;
-								}
-
+							onChange={(controlValue) =>
 								onChange(
-									Object.keys(newSelection).length
-										? (newSelection as HandlerSelection)
-										: undefined
-								);
-							}}
+									updateSelection(
+										currentSelection,
+										nestedControl.name,
+										controlValue
+									)
+								)
+							}
 							value={currentSelection[nestedControl.name]}
 						/>
 					)

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/PortletDataControl.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/PortletDataControl.tsx
@@ -1,0 +1,140 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ClayCheckbox} from '@clayui/form';
+import ClayLayout from '@clayui/layout';
+import React from 'react';
+
+import {PortletDataControl as PortletDataControlType} from '../../../utils/mockPortletDataHandlerSections';
+import PortletDataControlChoice from './PortletDataControlChoice';
+
+export type HandlerSelection =
+	| {
+			[key: string]: HandlerSelection;
+	  }
+	| string
+	| true;
+
+export function isSelected(
+	value: HandlerSelection | undefined,
+	entry: PortletDataControlType
+): boolean {
+	if (!value) {
+		return false;
+	}
+
+	if (!entry.controls?.length || typeof value !== 'object') {
+		return true;
+	}
+
+	return entry.controls.every((control) =>
+		isSelected(value[control.name], control)
+	);
+}
+
+export function getInitialSelection(
+	entry: PortletDataControlType
+): HandlerSelection {
+	if (entry.type === 'choice' && entry.options) {
+		return entry.options[0].value;
+	}
+
+	if (!entry.controls?.length) {
+		return true;
+	}
+
+	const selection: Record<string, HandlerSelection> = {};
+
+	entry.controls.forEach((control) => {
+		selection[control.name] = getInitialSelection(control);
+	});
+
+	return selection;
+}
+
+interface PortletDataControlProps {
+	className?: string;
+	control: PortletDataControlType;
+	level?: number;
+	onChange: (value: HandlerSelection | undefined) => void;
+	value: HandlerSelection | undefined;
+}
+
+export default function PortletDataControl({
+	className = 'mb-2',
+	control,
+	level = 0,
+	onChange,
+	value,
+}: PortletDataControlProps) {
+	if (control.type === 'choice') {
+		return (
+			<PortletDataControlChoice
+				className="mt-2 pl-2"
+				control={control}
+				onChange={(_, newValue) => onChange(newValue)}
+				value={typeof value === 'string' ? value : ''}
+			/>
+		);
+	}
+
+	const isPresent = !!value;
+	const selected = isSelected(value, control);
+	const currentSelection = typeof value === 'object' ? value : {};
+
+	return (
+		<ClayLayout.ContentRow className={className}>
+			<ClayLayout.ContentCol className="pr-2" expand={false}>
+				<ClayCheckbox
+					checked={selected}
+					indeterminate={isPresent && !selected}
+					onChange={() =>
+						onChange(
+							selected ? undefined : getInitialSelection(control)
+						)
+					}
+				/>
+			</ClayLayout.ContentCol>
+
+			<ClayLayout.ContentCol expand>
+				<div className="align-items-center d-flex justify-content-between">
+					<span
+						className={`small ${level === 0 ? 'font-weight-semi-bold' : ''}`}
+					>
+						{control.label}
+					</span>
+				</div>
+
+				{control.controls &&
+					control.controls.map((nestedControl) => (
+						<PortletDataControl
+							className="mt-2"
+							control={nestedControl}
+							key={nestedControl.name}
+							level={level + 1}
+							onChange={(controlValue) => {
+								const {
+									[nestedControl.name]: _,
+									...newSelection
+								} = currentSelection;
+
+								if (controlValue) {
+									newSelection[nestedControl.name] =
+										controlValue;
+								}
+
+								onChange(
+									Object.keys(newSelection).length
+										? (newSelection as HandlerSelection)
+										: undefined
+								);
+							}}
+							value={currentSelection[nestedControl.name]}
+						/>
+					))}
+			</ClayLayout.ContentCol>
+		</ClayLayout.ContentRow>
+	);
+}

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/PortletDataControl.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/PortletDataControl.tsx
@@ -111,8 +111,8 @@ export default function PortletDataControl({
 					</span>
 				</div>
 
-				{control.controls &&
-					control.controls.map((nestedControl) => (
+				{control.controls?.map((nestedControl) =>
+					nestedControl.type === 'choice' && !selected ? null : (
 						<PortletDataControl
 							className="mt-2"
 							control={nestedControl}
@@ -137,7 +137,8 @@ export default function PortletDataControl({
 							}}
 							value={currentSelection[nestedControl.name]}
 						/>
-					))}
+					)
+				)}
 			</ClayLayout.ContentCol>
 		</ClayLayout.ContentRow>
 	);

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/PortletDataControl.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/PortletDataControl.tsx
@@ -84,7 +84,6 @@ export default function PortletDataControl({
 		);
 	}
 
-	const isPresent = !!value;
 	const selected = isSelected(value, control);
 	const currentSelection = typeof value === 'object' ? value : {};
 
@@ -93,7 +92,7 @@ export default function PortletDataControl({
 			<ClayLayout.ContentCol className="pr-2" expand={false}>
 				<ClayCheckbox
 					checked={selected}
-					indeterminate={isPresent && !selected}
+					indeterminate={!!value && !selected}
 					onChange={() =>
 						onChange(
 							selected ? undefined : getInitialSelection(control)

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/PortletDataControl.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/PortletDataControl.tsx
@@ -7,7 +7,7 @@ import {ClayCheckbox} from '@clayui/form';
 import ClayLayout from '@clayui/layout';
 import React from 'react';
 
-import {PortletDataControl as PortletDataControlType} from '../../../utils/mockPortletDataHandlerSections';
+import {PortletDataHandlerControl} from '../../../utils/mockPortletDataHandlerSections';
 import PortletDataControlChoice from './PortletDataControlChoice';
 
 export type HandlerSelection =
@@ -19,10 +19,14 @@ export type HandlerSelection =
 
 export function isSelected(
 	value: HandlerSelection | undefined,
-	entry: PortletDataControlType
+	entry: PortletDataHandlerControl
 ): boolean {
 	if (!value) {
 		return false;
+	}
+
+	if (entry.type === 'choice') {
+		return true;
 	}
 
 	if (!entry.controls?.length || typeof value !== 'object') {
@@ -35,10 +39,10 @@ export function isSelected(
 }
 
 export function getInitialSelection(
-	entry: PortletDataControlType
+	entry: PortletDataHandlerControl
 ): HandlerSelection {
-	if (entry.type === 'choice' && entry.options) {
-		return entry.options[0].value;
+	if (entry.type === 'choice') {
+		return entry.choices[0].name;
 	}
 
 	if (!entry.controls?.length) {
@@ -56,7 +60,7 @@ export function getInitialSelection(
 
 interface PortletDataControlProps {
 	className?: string;
-	control: PortletDataControlType;
+	control: PortletDataHandlerControl;
 	level?: number;
 	onChange: (value: HandlerSelection | undefined) => void;
 	value: HandlerSelection | undefined;

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/PortletDataControl.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/PortletDataControl.tsx
@@ -78,7 +78,7 @@ export default function PortletDataControl({
 			<PortletDataControlChoice
 				className="mt-2 pl-2"
 				control={control}
-				onChange={(_, newValue) => onChange(newValue)}
+				onChange={onChange}
 				value={typeof value === 'string' ? value : ''}
 			/>
 		);

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/PortletDataControlChoice.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/PortletDataControlChoice.tsx
@@ -12,7 +12,7 @@ import FieldSelectWithOption from '../FieldSelectWithOption';
 interface PortletDataControlChoiceProps {
 	className?: string;
 	control: PortletDataHandlerChoice;
-	onChange: (fieldId: string, value: string) => void;
+	onChange: (value: string) => void;
 	value: string;
 }
 
@@ -29,7 +29,7 @@ export default function PortletDataControlChoice({
 			label={control.label}
 			name={control.name}
 			onChange={(event) => {
-				onChange(control.name, event.target.value);
+				onChange(event.target.value);
 			}}
 			options={control.choices.map(({label, name}) => ({
 				label,

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/PortletDataControlChoice.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/PortletDataControlChoice.tsx
@@ -1,0 +1,38 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import classnames from 'classnames';
+import React from 'react';
+
+import {PortletDataControl} from '../../../utils/mockPortletDataHandlerSections';
+import FieldSelectWithOption from '../FieldSelectWithOption';
+
+interface PortletDataControlChoiceProps {
+	className?: string;
+	control: NonNullable<PortletDataControl>;
+	onChange: (fieldId: string, value: string) => void;
+	value: string;
+}
+
+export default function PortletDataControlChoice({
+	className = 'ml-1',
+	control,
+	onChange,
+	value,
+}: PortletDataControlChoiceProps) {
+	return (
+		<FieldSelectWithOption
+			className="w-auto"
+			formGroupProps={{className: classnames('mb-0', className)}}
+			label={control.label}
+			name={control.name}
+			onChange={(event) => {
+				onChange(control.name, event.target.value);
+			}}
+			options={control.options || []}
+			value={value}
+		/>
+	);
+}

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/PortletDataControlChoice.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/PortletDataControlChoice.tsx
@@ -6,12 +6,12 @@
 import classnames from 'classnames';
 import React from 'react';
 
-import {PortletDataControl} from '../../../utils/mockPortletDataHandlerSections';
+import {PortletDataHandlerChoice} from '../../../utils/mockPortletDataHandlerSections';
 import FieldSelectWithOption from '../FieldSelectWithOption';
 
 interface PortletDataControlChoiceProps {
 	className?: string;
-	control: NonNullable<PortletDataControl>;
+	control: PortletDataHandlerChoice;
 	onChange: (fieldId: string, value: string) => void;
 	value: string;
 }
@@ -31,7 +31,10 @@ export default function PortletDataControlChoice({
 			onChange={(event) => {
 				onChange(control.name, event.target.value);
 			}}
-			options={control.options || []}
+			options={control.choices.map(({label, name}) => ({
+				label,
+				value: name,
+			}))}
 			value={value}
 		/>
 	);

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/formik/FormikFieldContentSelector.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/formik/FormikFieldContentSelector.tsx
@@ -1,0 +1,35 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {useFormikContext} from 'formik';
+import React from 'react';
+
+import {PortletDataHandlerSection} from '../../../utils/mockPortletDataHandlerSections';
+import ContentSelector, {
+	ContentSelection,
+} from '../content_selector/ContentSelector';
+
+interface FormikFieldContentSelectorProps {
+	name: string;
+	sections: PortletDataHandlerSection[];
+}
+
+export function FormikFieldContentSelector({
+	name,
+	sections,
+}: FormikFieldContentSelectorProps) {
+	const {setFieldValue, values} =
+		useFormikContext<Record<string, ContentSelection | undefined>>();
+
+	const value = values[name];
+
+	return (
+		<ContentSelector
+			onChange={(newValue) => setFieldValue(name, newValue)}
+			sections={sections}
+			value={value}
+		/>
+	);
+}

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/formik/index.ts
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/formik/index.ts
@@ -4,6 +4,7 @@
  */
 
 export {FormikDebug} from './FormikDebug';
+export {FormikFieldContentSelector} from './FormikFieldContentSelector';
 export {FormikFieldFileSelector} from './FormikFieldFileSelector';
 export {FormikFieldMultiCheckbox} from './FormikFieldMultiCheckbox';
 export {FormikFieldText} from './FormikFieldText';

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/NewExport.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/NewExport.tsx
@@ -100,8 +100,6 @@ export function NewExport({
 						contentSelection: values.contentSelection,
 						flatValues,
 					});
-
-					alert('Export started!');
 				}}
 				title={Liferay.Language.get('settings')}
 			>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/NewExport.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/NewExport.tsx
@@ -10,6 +10,7 @@ import React from 'react';
 
 import {Wizard, WizardStep} from '../../components/Wizard';
 import {DateFilterValues} from '../../components/date_filter';
+import {flattenContentSelection} from '../../utils/flattenContentSelection';
 import {
 	PortletDataHandlerSection,
 	mockPortletDataHandlerSections,
@@ -88,7 +89,18 @@ export function NewExport({
 				description={Liferay.Language.get(
 					'configure-your-export-settings'
 				)}
-				onSubmit={async () => {
+				onSubmit={async (values) => {
+					const flatValues = flattenContentSelection({
+						contentSelection: values.contentSelection,
+						sections,
+					});
+
+					// eslint-disable-next-line no-console
+					console.log({
+						contentSelection: values.contentSelection,
+						flatValues,
+					});
+
 					alert('Export started!');
 				}}
 				title={Liferay.Language.get('settings')}

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/NewExport.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/NewExport.tsx
@@ -63,11 +63,15 @@ export function NewExport({
 				description={Liferay.Language.get(
 					'select-and-filter-the-data-you-want-to-include-in-your-export'
 				)}
+				initialValues={{
+					contentSelection: undefined,
+				}}
 				title={Liferay.Language.get('data-selection')}
 			>
 				<DataSelectionStep
 					itemsCount={0}
 					onApplyFilter={handleApplyFilter}
+					sections={sections}
 				/>
 			</WizardStep>
 

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/NewExport.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/NewExport.tsx
@@ -10,11 +10,23 @@ import React from 'react';
 
 import {Wizard, WizardStep} from '../../components/Wizard';
 import {DateFilterValues} from '../../components/date_filter';
+import {
+	PortletDataHandlerSection,
+	mockPortletDataHandlerSections,
+} from '../../utils/mockPortletDataHandlerSections';
 import DataSelectionStep from './steps/DataSelectionStep';
 import SettingsStep from './steps/SettingsStep';
 import SetupStep from './steps/SetupStep';
 
-export function NewExport({backURL}: {backURL: string}) {
+interface NewExportProps {
+	backURL: string;
+	sections?: PortletDataHandlerSection[];
+}
+
+export function NewExport({
+	backURL,
+	sections = mockPortletDataHandlerSections,
+}: NewExportProps) {
 	const handleApplyFilter = (filterValues: DateFilterValues) => {
 
 		// eslint-disable-next-line no-console
@@ -44,7 +56,7 @@ export function NewExport({backURL}: {backURL: string}) {
 					return errors;
 				}}
 			>
-				<SetupStep />
+				<SetupStep sections={sections} />
 			</WizardStep>
 
 			<WizardStep

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/steps/DataSelectionStep.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/steps/DataSelectionStep.tsx
@@ -7,13 +7,17 @@ import ClayLayout from '@clayui/layout';
 import React from 'react';
 
 import DateFilter, {DateFilterValues} from '../../../components/date_filter';
+import {FormikFieldContentSelector} from '../../../components/forms/formik';
+import {PortletDataHandlerSection} from '../../../utils/mockPortletDataHandlerSections';
 
 export default function DataSelectionStep({
 	itemsCount = 0,
 	onApplyFilter,
+	sections,
 }: {
 	itemsCount?: number;
 	onApplyFilter?: (filterValues: DateFilterValues) => void;
+	sections: PortletDataHandlerSection[];
 }) {
 	return (
 		<>
@@ -24,9 +28,10 @@ export default function DataSelectionStep({
 				/>
 			</ClayLayout.Sheet>
 
-			<ClayLayout.Sheet>
-				{Liferay.Language.get('portlets')}
-			</ClayLayout.Sheet>
+			<FormikFieldContentSelector
+				name="contentSelection"
+				sections={sections}
+			/>
 		</>
 	);
 }

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/steps/SetupStep.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/steps/SetupStep.tsx
@@ -11,9 +11,13 @@ import {
 	FormikFieldMultiCheckbox,
 	FormikFieldText,
 } from '../../../components/forms/formik';
-import {mockPortletDataHandlerSections} from '../../../utils/mockPortletDataHandlerSections';
+import {PortletDataHandlerSection} from '../../../utils/mockPortletDataHandlerSections';
 
-export default function SetupStep() {
+interface SetupStepProps {
+	sections: PortletDataHandlerSection[];
+}
+
+export default function SetupStep({sections}: SetupStepProps) {
 	return (
 		<>
 			<ClayLayout.Sheet>
@@ -62,15 +66,13 @@ export default function SetupStep() {
 					aria-describedby="selectedSectionIds-description"
 					aria-labelledby="selectedSectionIds-label"
 					name="selectedSectionIds"
-					options={mockPortletDataHandlerSections.map(
-						({name, portletEntries}) => ({
-							description: portletEntries
-								.map(({portletTitle}) => portletTitle)
-								.join(', '),
-							label: name,
-							value: name,
-						})
-					)}
+					options={sections.map(({name, portletDataHandlers}) => ({
+						description: portletDataHandlers
+							.map(({label}) => label)
+							.join(', '),
+						label: name,
+						value: name,
+					}))}
 				/>
 			</ClayLayout.Sheet>
 		</>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/steps/SetupStep.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/steps/SetupStep.tsx
@@ -11,7 +11,7 @@ import {
 	FormikFieldMultiCheckbox,
 	FormikFieldText,
 } from '../../../components/forms/formik';
-import {mockPorletDataHandlerSections} from '../../../utils/mockPorletDataHandlerSections';
+import {mockPortletDataHandlerSections} from '../../../utils/mockPortletDataHandlerSections';
 
 export default function SetupStep() {
 	return (
@@ -62,7 +62,7 @@ export default function SetupStep() {
 					aria-describedby="selectedSectionIds-description"
 					aria-labelledby="selectedSectionIds-label"
 					name="selectedSectionIds"
-					options={mockPorletDataHandlerSections.map(
+					options={mockPortletDataHandlerSections.map(
 						({name, portletEntries}) => ({
 							description: portletEntries
 								.map(({portletTitle}) => portletTitle)

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/steps/SetupStep.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/steps/SetupStep.tsx
@@ -66,13 +66,15 @@ export default function SetupStep({sections}: SetupStepProps) {
 					aria-describedby="selectedSectionIds-description"
 					aria-labelledby="selectedSectionIds-label"
 					name="selectedSectionIds"
-					options={sections.map(({name, portletDataHandlers}) => ({
-						description: portletDataHandlers
-							.map(({label}) => label)
-							.join(', '),
-						label: name,
-						value: name,
-					}))}
+					options={sections.map(
+						({label: sectionLabel, name, portletDataHandlers}) => ({
+							description: portletDataHandlers
+								.map(({label}) => label)
+								.join(', '),
+							label: sectionLabel,
+							value: name,
+						})
+					)}
 				/>
 			</ClayLayout.Sheet>
 		</>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/contentSelection.ts
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/contentSelection.ts
@@ -1,0 +1,65 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {PortletDataHandlerControl} from './mockPortletDataHandlerSections';
+
+export type HandlerSelection =
+	| {
+			[key: string]: HandlerSelection;
+	  }
+	| string
+	| true;
+
+export function isSelected(
+	value: HandlerSelection | undefined,
+	entry: PortletDataHandlerControl
+): boolean {
+	if (!value) {
+		return false;
+	}
+
+	if (entry.type === 'choice') {
+		return true;
+	}
+
+	if (!entry.controls?.length || typeof value !== 'object') {
+		return true;
+	}
+
+	return entry.controls.every((control) =>
+		isSelected(value[control.name], control)
+	);
+}
+
+export function getInitialSelection(
+	entry: PortletDataHandlerControl
+): HandlerSelection {
+	if (entry.type === 'choice') {
+		return entry.choices[0].name;
+	}
+
+	if (!entry.controls?.length) {
+		return true;
+	}
+
+	const selection: Record<string, HandlerSelection> = {};
+
+	entry.controls.forEach((control) => {
+		selection[control.name] = getInitialSelection(control);
+	});
+
+	return selection;
+}
+
+export function updateSelection<V>(
+	current: Record<string, V>,
+	key: string,
+	value: V | undefined
+): Record<string, V> | undefined {
+	const {[key]: _, ...rest} = current;
+	const next: Record<string, V> = value ? {...rest, [key]: value} : rest;
+
+	return Object.keys(next).length ? next : undefined;
+}

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/flattenContentSelection.ts
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/flattenContentSelection.ts
@@ -1,0 +1,79 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ContentSelection} from '../components/forms/content_selector/ContentSelector';
+import {HandlerSelection} from '../components/forms/content_selector/PortletDataControl';
+import {
+	PortletDataControl,
+	PortletDataHandlerSection,
+} from './mockPortletDataHandlerSections';
+
+interface FlattenContentSelectionInput {
+	additionalFields?: Record<string, string>;
+	contentSelection?: ContentSelection;
+	sections: PortletDataHandlerSection[];
+}
+
+export function flattenContentSelection({
+	additionalFields = {},
+	contentSelection = {},
+	sections,
+}: FlattenContentSelectionInput) {
+	const flatValues: Record<string, string> = {...additionalFields};
+	const checkboxNames: string[] = [];
+
+	const collectCheckboxNames = (controls: PortletDataControl[]) => {
+		controls.forEach((control) => {
+			if (control.type === 'boolean') {
+				checkboxNames.push(control.name);
+			}
+
+			if (control.controls) {
+				collectCheckboxNames(control.controls);
+			}
+		});
+	};
+
+	sections.forEach((section) => {
+		section.portletDataHandlers.forEach((handler) => {
+			checkboxNames.push(handler.name);
+
+			if (handler.controls) {
+				collectCheckboxNames(handler.controls);
+			}
+		});
+	});
+
+	const processSelection = (value: HandlerSelection, name: string) => {
+		flatValues[name] = 'on';
+
+		if (typeof value === 'object') {
+			Object.entries(value).forEach(([childName, childValue]) => {
+				if (typeof childValue === 'object' || childValue === true) {
+					processSelection(childValue as HandlerSelection, childName);
+				}
+				else if (typeof childValue === 'string') {
+					flatValues[childName] = childValue;
+				}
+			});
+		}
+	};
+
+	Object.values(contentSelection).forEach((sectionValue) => {
+		if (sectionValue) {
+			Object.entries(sectionValue).forEach(
+				([handlerName, handlerValue]) => {
+					processSelection(handlerValue, handlerName);
+				}
+			);
+		}
+	});
+
+	if (checkboxNames.length) {
+		flatValues.checkboxNames = checkboxNames.join(',');
+	}
+
+	return flatValues;
+}

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/flattenContentSelection.ts
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/flattenContentSelection.ts
@@ -4,7 +4,7 @@
  */
 
 import {ContentSelection} from '../components/forms/content_selector/ContentSelector';
-import {HandlerSelection} from '../components/forms/content_selector/PortletDataControl';
+import {HandlerSelection} from './contentSelection';
 import {
 	PortletDataHandlerControl,
 	PortletDataHandlerSection,

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/flattenContentSelection.ts
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/flattenContentSelection.ts
@@ -6,7 +6,7 @@
 import {ContentSelection} from '../components/forms/content_selector/ContentSelector';
 import {HandlerSelection} from '../components/forms/content_selector/PortletDataControl';
 import {
-	PortletDataControl,
+	PortletDataHandlerControl,
 	PortletDataHandlerSection,
 } from './mockPortletDataHandlerSections';
 
@@ -24,14 +24,14 @@ export function flattenContentSelection({
 	const flatValues: Record<string, string> = {...additionalFields};
 	const checkboxNames: string[] = [];
 
-	const collectCheckboxNames = (controls: PortletDataControl[]) => {
+	const collectCheckboxNames = (controls: PortletDataHandlerControl[]) => {
 		controls.forEach((control) => {
 			if (control.type === 'boolean') {
 				checkboxNames.push(control.name);
-			}
 
-			if (control.controls) {
-				collectCheckboxNames(control.controls);
+				if (control.controls) {
+					collectCheckboxNames(control.controls);
+				}
 			}
 		});
 	};

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/mockPortletDataHandlerSections.ts
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/mockPortletDataHandlerSections.ts
@@ -3,106 +3,167 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-export const mockPortletDataHandlerSections: {
+export interface PortletDataControl {
+	controls?: PortletDataControl[];
+	label: string;
 	name: string;
-	portletEntries: {
-		portletDescription: string;
-		portletId: string;
-		portletTitle: string;
-	}[];
-}[] = [
+	options?: {label: string; value: string}[];
+	type: 'boolean' | 'choice';
+}
+
+export interface PortletDataHandler {
+	controls?: PortletDataControl[];
+	label: string;
+	name: string;
+	type: 'boolean';
+}
+
+export interface PortletDataHandlerSection {
+	id: string;
+	key: string;
+	name: string;
+	portletDataHandlers: PortletDataHandler[];
+}
+
+export const mockPortletDataHandlerSections: PortletDataHandlerSection[] = [
 	{
+		id: 'category.site_administration.design',
+		key: 'category.site_administration.design',
 		name: 'Design',
-		portletEntries: [
+		portletDataHandlers: [
 			{
-				portletDescription: 'Configuration for themes',
-				portletId: 'theme-settings',
-				portletTitle: 'Theme Settings',
+				label: 'Theme Settings',
+				name: 'THEME_REFERENCE',
+				type: 'boolean',
 			},
 			{
-				portletDescription: 'Configuration for templates',
-				portletId: 'template-settings',
-				portletTitle: 'Template Settings',
+				label: 'Logo',
+				name: 'LOGO',
+				type: 'boolean',
 			},
 			{
-				portletDescription: 'Site logo settings',
-				portletId: 'logo',
-				portletTitle: 'Logo',
-			},
-			{
-				portletDescription: 'UI fragments',
-				portletId: 'fragments',
-				portletTitle: 'Fragments',
-			},
-			{
-				portletDescription: 'General templates',
-				portletId: 'templates',
-				portletTitle: 'Templates',
-			},
-			{
-				portletDescription: 'Templates for specific pages',
-				portletId: 'page-templates',
-				portletTitle: 'Page Templates',
+				label: 'Fragments',
+				name: 'PORTLET_DATA_com_liferay_fragment_web_portlet_FragmentPortlet',
+				type: 'boolean',
 			},
 		],
 	},
 	{
+		id: 'category.site_administration.build',
+		key: 'category.site_administration.build',
 		name: 'Site Builder',
-		portletEntries: [
+		portletDataHandlers: [
 			{
-				portletDescription: 'Individual page configurations',
-				portletId: 'page-settings',
-				portletTitle: 'Page Settings',
-			},
-			{
-				portletDescription: 'Management of static content pages',
-				portletId: 'static-pages',
-				portletTitle: 'Static Pages',
-			},
-			{
-				portletDescription: '404, login, and other utility pages',
-				portletId: 'utility-pages',
-				portletTitle: 'Utility Pages',
-			},
-			{
-				portletDescription: 'Grouped content collections',
-				portletId: 'collections',
-				portletTitle: 'Collections',
+				label: 'Pages',
+				name: 'PORTLET_DATA_com_liferay_layout_admin_web_portlet_GroupPagesPortlet',
+				type: 'boolean',
 			},
 		],
 	},
 	{
+		id: 'category.site_administration.content',
+		key: 'category.site_administration.content',
 		name: 'Content & Data',
-		portletEntries: [
+		portletDataHandlers: [
 			{
-				portletDescription: 'Articles and web assets',
-				portletId: 'web-content',
-				portletTitle: 'Web Content',
+				controls: [
+					{
+						label: 'Web Content',
+						name: '_journal_web-content',
+						type: 'boolean',
+					},
+					{
+						controls: [
+							{
+								label: 'Referenced Content Behavior',
+								name: '_journal_referenced-content-behavior',
+								options: [
+									{
+										label: 'Include Always',
+										value: 'include-always',
+									},
+									{
+										label: 'Include If Modified',
+										value: 'include-if-modified',
+									},
+								],
+								type: 'choice',
+							},
+						],
+						label: 'Referenced Content',
+						name: '_journal_referenced-content',
+						type: 'boolean',
+					},
+					{
+						label: 'Version History',
+						name: '_journal_version-history',
+						type: 'boolean',
+					},
+				],
+				label: 'Web Content',
+				name: 'PORTLET_DATA_com_liferay_journal_web_portlet_JournalPortlet',
+				type: 'boolean',
 			},
 			{
-				portletDescription: 'Blog posts and entries',
-				portletId: 'blogs',
-				portletTitle: 'Blogs',
-			},
-			{
-				portletDescription: 'File repository and media library',
-				portletId: 'documents-media',
-				portletTitle: 'Documents and Media',
-			},
-			{
-				portletDescription: 'User input forms and surveys',
-				portletId: 'forms',
-				portletTitle: 'Forms',
-			},
-		],
-	},
-	{
-		name: 'Objects',
-		portletEntries: [
-			{
-				portletDescription: 'Custom object data entries',
-				portletId: 'object-entries',
-				portletTitle: 'Object Entries',
+				controls: [
+					{
+						label: 'Repositories',
+						name: '_document_library_repositories',
+						type: 'boolean',
+					},
+					{
+						label: 'Folders',
+						name: '_document_library_folders',
+						type: 'boolean',
+					},
+					{
+						controls: [
+							{
+								label: 'Previews and Thumbnails',
+								name: '_document_library_previews-and-thumbnails',
+								type: 'boolean',
+							},
+							{
+								controls: [
+									{
+										label: 'Referenced Content Behavior',
+										name: '_document_library_referenced-content-behavior',
+										options: [
+											{
+												label: 'Include Always',
+												value: 'include-always',
+											},
+											{
+												label: 'Include If Modified',
+												value: 'include-if-modified',
+											},
+										],
+										type: 'choice',
+									},
+								],
+								label: 'Referenced Content',
+								name: '_document_library_referenced-content',
+								type: 'boolean',
+							},
+						],
+						label: 'Documents',
+						name: '_document_library_documents',
+						type: 'boolean',
+					},
+					{
+						label: 'Document Types',
+						name: '_document_library_document-types',
+						type: 'boolean',
+					},
+					{
+						label: 'Shortcuts',
+						name: '_document_library_shortcuts',
+						type: 'boolean',
+					},
+				],
+				label: 'Documents and Media',
+				name: 'PORTLET_DATA_com_liferay_document_library_web_portlet_DLAdminPortlet',
+				type: 'boolean',
 			},
 		],
 	},

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/mockPortletDataHandlerSections.ts
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/mockPortletDataHandlerSections.ts
@@ -3,67 +3,64 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-export interface PortletDataControl {
-	controls?: PortletDataControl[];
-	label: string;
-	name: string;
-	options?: {label: string; value: string}[];
-	type: 'boolean' | 'choice';
-}
-
-export interface PortletDataHandler {
-	controls?: PortletDataControl[];
+export interface PortletDataHandlerBoolean {
+	controls?: PortletDataHandlerControl[];
 	label: string;
 	name: string;
 	type: 'boolean';
 }
 
+export interface PortletDataHandlerChoice {
+	choices: {label: string; name: string}[];
+	label: string;
+	name: string;
+	type: 'choice';
+}
+
+export type PortletDataHandlerControl =
+	| PortletDataHandlerBoolean
+	| PortletDataHandlerChoice;
+
+export type PortletDataHandler = Omit<PortletDataHandlerBoolean, 'type'>;
+
 export interface PortletDataHandlerSection {
-	id: string;
-	key: string;
+	label: string;
 	name: string;
 	portletDataHandlers: PortletDataHandler[];
 }
 
 export const mockPortletDataHandlerSections: PortletDataHandlerSection[] = [
 	{
-		id: 'category.site_administration.design',
-		key: 'category.site_administration.design',
-		name: 'Design',
+		label: 'Design',
+		name: 'category.site_administration.design',
 		portletDataHandlers: [
 			{
 				label: 'Theme Settings',
 				name: 'THEME_REFERENCE',
-				type: 'boolean',
 			},
 			{
 				label: 'Logo',
 				name: 'LOGO',
-				type: 'boolean',
 			},
 			{
 				label: 'Fragments',
 				name: 'PORTLET_DATA_com_liferay_fragment_web_portlet_FragmentPortlet',
-				type: 'boolean',
 			},
 		],
 	},
 	{
-		id: 'category.site_administration.build',
-		key: 'category.site_administration.build',
-		name: 'Site Builder',
+		label: 'Site Builder',
+		name: 'category.site_administration.build',
 		portletDataHandlers: [
 			{
 				label: 'Pages',
 				name: 'PORTLET_DATA_com_liferay_layout_admin_web_portlet_GroupPagesPortlet',
-				type: 'boolean',
 			},
 		],
 	},
 	{
-		id: 'category.site_administration.content',
-		key: 'category.site_administration.content',
-		name: 'Content & Data',
+		label: 'Content & Data',
+		name: 'category.site_administration.content',
 		portletDataHandlers: [
 			{
 				controls: [
@@ -75,18 +72,18 @@ export const mockPortletDataHandlerSections: PortletDataHandlerSection[] = [
 					{
 						controls: [
 							{
-								label: 'Referenced Content Behavior',
-								name: '_journal_referenced-content-behavior',
-								options: [
+								choices: [
 									{
 										label: 'Include Always',
-										value: 'include-always',
+										name: 'include-always',
 									},
 									{
 										label: 'Include If Modified',
-										value: 'include-if-modified',
+										name: 'include-if-modified',
 									},
 								],
+								label: 'Referenced Content Behavior',
+								name: '_journal_referenced-content-behavior',
 								type: 'choice',
 							},
 						],
@@ -102,7 +99,6 @@ export const mockPortletDataHandlerSections: PortletDataHandlerSection[] = [
 				],
 				label: 'Web Content',
 				name: 'PORTLET_DATA_com_liferay_journal_web_portlet_JournalPortlet',
-				type: 'boolean',
 			},
 			{
 				controls: [
@@ -126,18 +122,18 @@ export const mockPortletDataHandlerSections: PortletDataHandlerSection[] = [
 							{
 								controls: [
 									{
-										label: 'Referenced Content Behavior',
-										name: '_document_library_referenced-content-behavior',
-										options: [
+										choices: [
 											{
 												label: 'Include Always',
-												value: 'include-always',
+												name: 'include-always',
 											},
 											{
 												label: 'Include If Modified',
-												value: 'include-if-modified',
+												name: 'include-if-modified',
 											},
 										],
+										label: 'Referenced Content Behavior',
+										name: '_document_library_referenced-content-behavior',
 										type: 'choice',
 									},
 								],
@@ -163,7 +159,6 @@ export const mockPortletDataHandlerSections: PortletDataHandlerSection[] = [
 				],
 				label: 'Documents and Media',
 				name: 'PORTLET_DATA_com_liferay_document_library_web_portlet_DLAdminPortlet',
-				type: 'boolean',
 			},
 		],
 	},

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/mockPortletDataHandlerSections.ts
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/mockPortletDataHandlerSections.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-export const mockPorletDataHandlerSections: {
+export const mockPortletDataHandlerSections: {
 	name: string;
 	portletEntries: {
 		portletDescription: string;

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/www/package.json
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/www/package.json
@@ -16,7 +16,7 @@
 		"classnames": "2.3.1",
 		"next": "15.5.10",
 		"node-html-parser": "^7.0.1",
-		"prettier": "^3.0.0",
+		"prettier": "3.2.5",
 		"react": "18.2.0",
 		"react-dom": "18.2.0",
 		"rehype-mdx-code-props": "^3.0.1",

--- a/modules/frontend-sdk/node-scripts/package.json
+++ b/modules/frontend-sdk/node-scripts/package.json
@@ -46,7 +46,7 @@
 		"liferay-theme-tasks": "11.5.6",
 		"micromatch": "4.0.2",
 		"minimist": "^1.2.8",
-		"prettier": "^3.2.5",
+		"prettier": "3.2.5",
 		"react-test-renderer": "18.2.0",
 		"react-test-renderer-16.12.0": "npm:react-test-renderer@16.12.0",
 		"regenerator-runtime": "0.11.1",

--- a/modules/package.json
+++ b/modules/package.json
@@ -27,6 +27,7 @@
 	"private": true,
 	"resolutions": {
 		"@types/html-minifier-terser": "5.1.0",
+		"prettier": "3.2.5",
 		"ua-parser-js": "^0.7.30"
 	},
 	"scripts": {

--- a/modules/package.json
+++ b/modules/package.json
@@ -1,4 +1,7 @@
 {
+	"dependencies": {
+		"prettier": "3.2.5"
+	},
 	"devDependencies": {
 		"@liferay/eslint-plugin": "1.9.1",
 		"@liferay/prettier-plugin": "1.1.5",
@@ -27,7 +30,6 @@
 	"private": true,
 	"resolutions": {
 		"@types/html-minifier-terser": "5.1.0",
-		"prettier": "3.2.5",
 		"ua-parser-js": "^0.7.30"
 	},
 	"scripts": {

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -7,7 +7,7 @@
   resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.4.4.tgz#2856c55443d3d461693f32d2b96fb6ea92e1ffa9"
   integrity sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==
 
-"@ampproject/remapping@^2.2.0", "@ampproject/remapping@^2.3.0":
+"@ampproject/remapping@^2.3.0":
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.3.0.tgz#ed441b6fa600072520ce18b43d2c8cc8caecc7f4"
   integrity sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==
@@ -489,7 +489,7 @@
   dependencies:
     "@babel/highlight" "^7.10.4"
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.25.9", "@babel/code-frame@^7.26.0", "@babel/code-frame@^7.27.1", "@babel/code-frame@^7.28.6", "@babel/code-frame@^7.5.5", "@babel/code-frame@^7.8.3":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.28.6", "@babel/code-frame@^7.5.5", "@babel/code-frame@^7.8.3":
   version "7.28.6"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.28.6.tgz#72499312ec58b1e2245ba4a4f550c132be4982f7"
   integrity sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==
@@ -498,7 +498,7 @@
     js-tokens "^4.0.0"
     picocolors "^1.1.1"
 
-"@babel/compat-data@^7.20.5", "@babel/compat-data@^7.22.6", "@babel/compat-data@^7.24.7", "@babel/compat-data@^7.27.2", "@babel/compat-data@^7.27.7", "@babel/compat-data@^7.28.6":
+"@babel/compat-data@^7.20.5", "@babel/compat-data@^7.24.7", "@babel/compat-data@^7.27.7", "@babel/compat-data@^7.28.6":
   version "7.28.6"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.28.6.tgz#103f466803fa0f059e82ccac271475470570d74c"
   integrity sha512-2lfu57JtzctfIrcGMz992hyLlByuzgIk58+hhGCxjKZ3rWI82NnVLjXcaTqkI2NvlcvOskZaiZ5kjUALo3Lpxg==
@@ -546,7 +546,7 @@
     json5 "^2.2.3"
     semver "^6.3.1"
 
-"@babel/generator@^7.12.11", "@babel/generator@^7.12.5", "@babel/generator@^7.25.9", "@babel/generator@^7.26.0", "@babel/generator@^7.28.3", "@babel/generator@^7.28.6", "@babel/generator@^7.7.2":
+"@babel/generator@^7.12.11", "@babel/generator@^7.12.5", "@babel/generator@^7.28.6", "@babel/generator@^7.7.2":
   version "7.28.6"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.28.6.tgz#48dcc65d98fcc8626a48f72b62e263d25fc3c3f1"
   integrity sha512-lOoVRwADj8hjf7al89tvQ2a1lf53Z+7tiXMgpZJL3maQPDxh0DgLMN62B2MKUOFcoodBHLMbDM6WAbKgNy5Suw==
@@ -557,22 +557,14 @@
     "@jridgewell/trace-mapping" "^0.3.28"
     jsesc "^3.0.2"
 
-"@babel/helper-annotate-as-pure@^7.18.6", "@babel/helper-annotate-as-pure@^7.24.7", "@babel/helper-annotate-as-pure@^7.25.9", "@babel/helper-annotate-as-pure@^7.27.1", "@babel/helper-annotate-as-pure@^7.27.3":
+"@babel/helper-annotate-as-pure@^7.18.6", "@babel/helper-annotate-as-pure@^7.27.1", "@babel/helper-annotate-as-pure@^7.27.3":
   version "7.27.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz#f31fd86b915fc4daf1f3ac6976c59be7084ed9c5"
   integrity sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==
   dependencies:
     "@babel/types" "^7.27.3"
 
-"@babel/helper-builder-binary-assignment-operator-visitor@^7.24.7":
-  version "7.24.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.24.7.tgz"
-  integrity sha512-xZeCVVdwb4MsDBkkyZ64tReWYrLRHlMN72vP7Bdm3OUOuyFZExhsHUUnuWnm2/XOlAJzR0LfPpB56WXZn0X/lA==
-  dependencies:
-    "@babel/traverse" "^7.24.7"
-    "@babel/types" "^7.24.7"
-
-"@babel/helper-compilation-targets@^7.13.0", "@babel/helper-compilation-targets@^7.20.7", "@babel/helper-compilation-targets@^7.22.6", "@babel/helper-compilation-targets@^7.24.7", "@babel/helper-compilation-targets@^7.25.9", "@babel/helper-compilation-targets@^7.27.1", "@babel/helper-compilation-targets@^7.27.2", "@babel/helper-compilation-targets@^7.28.6":
+"@babel/helper-compilation-targets@^7.13.0", "@babel/helper-compilation-targets@^7.20.7", "@babel/helper-compilation-targets@^7.24.7", "@babel/helper-compilation-targets@^7.27.1", "@babel/helper-compilation-targets@^7.27.2", "@babel/helper-compilation-targets@^7.28.6":
   version "7.28.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz#32c4a3f41f12ed1532179b108a4d746e105c2b25"
   integrity sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==
@@ -583,7 +575,7 @@
     lru-cache "^5.1.1"
     semver "^6.3.1"
 
-"@babel/helper-create-class-features-plugin@^7.18.6", "@babel/helper-create-class-features-plugin@^7.21.0", "@babel/helper-create-class-features-plugin@^7.24.7", "@babel/helper-create-class-features-plugin@^7.25.9", "@babel/helper-create-class-features-plugin@^7.28.6":
+"@babel/helper-create-class-features-plugin@^7.18.6", "@babel/helper-create-class-features-plugin@^7.21.0", "@babel/helper-create-class-features-plugin@^7.28.6":
   version "7.28.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.6.tgz#611ff5482da9ef0db6291bcd24303400bca170fb"
   integrity sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==
@@ -596,7 +588,7 @@
     "@babel/traverse" "^7.28.6"
     semver "^6.3.1"
 
-"@babel/helper-create-regexp-features-plugin@^7.18.6", "@babel/helper-create-regexp-features-plugin@^7.24.7", "@babel/helper-create-regexp-features-plugin@^7.27.1", "@babel/helper-create-regexp-features-plugin@^7.28.5":
+"@babel/helper-create-regexp-features-plugin@^7.18.6", "@babel/helper-create-regexp-features-plugin@^7.27.1", "@babel/helper-create-regexp-features-plugin@^7.28.5":
   version "7.28.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.28.5.tgz#7c1ddd64b2065c7f78034b25b43346a7e19ed997"
   integrity sha512-N1EhvLtHzOvj7QQOUCCS3NrPJP8c5W6ZXCHDn7Yialuy1iu4r5EmIYkXlKNqT99Ciw+W0mDqWoR6HWMZlFP3hw==
@@ -619,7 +611,7 @@
     resolve "^1.14.2"
     semver "^6.1.2"
 
-"@babel/helper-define-polyfill-provider@^0.6.1", "@babel/helper-define-polyfill-provider@^0.6.2", "@babel/helper-define-polyfill-provider@^0.6.5":
+"@babel/helper-define-polyfill-provider@^0.6.1", "@babel/helper-define-polyfill-provider@^0.6.5":
   version "0.6.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.5.tgz#742ccf1cb003c07b48859fc9fa2c1bbe40e5f753"
   integrity sha512-uJnGFcPsWQK8fvjgGP5LZUZZsYGIoPeRjSF5PGwrelYgq7Q15/Ft9NGFp1zglwgIv//W0uG4BevRuSJRyylZPg==
@@ -630,34 +622,12 @@
     lodash.debounce "^4.0.8"
     resolve "^1.22.10"
 
-"@babel/helper-environment-visitor@^7.24.7":
-  version "7.24.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.24.7.tgz"
-  integrity sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==
-  dependencies:
-    "@babel/types" "^7.24.7"
-
-"@babel/helper-function-name@^7.24.7":
-  version "7.24.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.24.7.tgz"
-  integrity sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==
-  dependencies:
-    "@babel/template" "^7.24.7"
-    "@babel/types" "^7.24.7"
-
 "@babel/helper-globals@^7.28.0":
   version "7.28.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-globals/-/helper-globals-7.28.0.tgz#b9430df2aa4e17bc28665eadeae8aa1d985e6674"
   integrity sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==
 
-"@babel/helper-hoist-variables@^7.24.7":
-  version "7.24.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.24.7.tgz"
-  integrity sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ==
-  dependencies:
-    "@babel/types" "^7.24.7"
-
-"@babel/helper-member-expression-to-functions@^7.25.9", "@babel/helper-member-expression-to-functions@^7.28.5":
+"@babel/helper-member-expression-to-functions@^7.28.5":
   version "7.28.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.28.5.tgz#f3e07a10be37ed7a63461c63e6929575945a6150"
   integrity sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==
@@ -665,7 +635,7 @@
     "@babel/traverse" "^7.28.5"
     "@babel/types" "^7.28.5"
 
-"@babel/helper-module-imports@^7.12.13", "@babel/helper-module-imports@^7.16.7", "@babel/helper-module-imports@^7.24.7", "@babel/helper-module-imports@^7.25.9", "@babel/helper-module-imports@^7.27.1", "@babel/helper-module-imports@^7.28.6":
+"@babel/helper-module-imports@^7.12.13", "@babel/helper-module-imports@^7.16.7", "@babel/helper-module-imports@^7.28.6":
   version "7.28.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz#60632cbd6ffb70b22823187201116762a03e2d5c"
   integrity sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==
@@ -673,7 +643,7 @@
     "@babel/traverse" "^7.28.6"
     "@babel/types" "^7.28.6"
 
-"@babel/helper-module-transforms@^7.12.1", "@babel/helper-module-transforms@^7.24.7", "@babel/helper-module-transforms@^7.26.0", "@babel/helper-module-transforms@^7.27.1", "@babel/helper-module-transforms@^7.28.3", "@babel/helper-module-transforms@^7.28.6":
+"@babel/helper-module-transforms@^7.12.1", "@babel/helper-module-transforms@^7.27.1", "@babel/helper-module-transforms@^7.28.3", "@babel/helper-module-transforms@^7.28.6":
   version "7.28.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz#9312d9d9e56edc35aeb6e95c25d4106b50b9eb1e"
   integrity sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==
@@ -682,7 +652,7 @@
     "@babel/helper-validator-identifier" "^7.28.5"
     "@babel/traverse" "^7.28.6"
 
-"@babel/helper-optimise-call-expression@^7.25.9", "@babel/helper-optimise-call-expression@^7.27.1":
+"@babel/helper-optimise-call-expression@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz#c65221b61a643f3e62705e5dd2b5f115e35f9200"
   integrity sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==
@@ -694,12 +664,12 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz#2f75a831269d4f677de49986dff59927533cf375"
   integrity sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==
 
-"@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.13.0", "@babel/helper-plugin-utils@^7.14.5", "@babel/helper-plugin-utils@^7.18.6", "@babel/helper-plugin-utils@^7.20.2", "@babel/helper-plugin-utils@^7.22.5", "@babel/helper-plugin-utils@^7.24.7", "@babel/helper-plugin-utils@^7.25.9", "@babel/helper-plugin-utils@^7.27.1", "@babel/helper-plugin-utils@^7.28.6", "@babel/helper-plugin-utils@^7.8.0", "@babel/helper-plugin-utils@^7.8.3":
+"@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.13.0", "@babel/helper-plugin-utils@^7.14.5", "@babel/helper-plugin-utils@^7.18.6", "@babel/helper-plugin-utils@^7.20.2", "@babel/helper-plugin-utils@^7.24.7", "@babel/helper-plugin-utils@^7.27.1", "@babel/helper-plugin-utils@^7.28.6", "@babel/helper-plugin-utils@^7.8.0", "@babel/helper-plugin-utils@^7.8.3":
   version "7.28.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz#6f13ea251b68c8532e985fd532f28741a8af9ac8"
   integrity sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==
 
-"@babel/helper-remap-async-to-generator@^7.24.7", "@babel/helper-remap-async-to-generator@^7.27.1":
+"@babel/helper-remap-async-to-generator@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.27.1.tgz#4601d5c7ce2eb2aea58328d43725523fcd362ce6"
   integrity sha512-7fiA521aVw8lSPeI4ZOD3vRFkoqkJcS+z4hFo82bFSH/2tNd6eJ5qCVMS5OzDmZh/kaHQeBaeyxK6wljcPtveA==
@@ -708,7 +678,7 @@
     "@babel/helper-wrap-function" "^7.27.1"
     "@babel/traverse" "^7.27.1"
 
-"@babel/helper-replace-supers@^7.24.7", "@babel/helper-replace-supers@^7.25.9", "@babel/helper-replace-supers@^7.27.1", "@babel/helper-replace-supers@^7.28.6":
+"@babel/helper-replace-supers@^7.27.1", "@babel/helper-replace-supers@^7.28.6":
   version "7.28.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.28.6.tgz#94aa9a1d7423a00aead3f204f78834ce7d53fe44"
   integrity sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==
@@ -717,15 +687,7 @@
     "@babel/helper-optimise-call-expression" "^7.27.1"
     "@babel/traverse" "^7.28.6"
 
-"@babel/helper-simple-access@^7.24.7":
-  version "7.24.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.24.7.tgz"
-  integrity sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==
-  dependencies:
-    "@babel/traverse" "^7.24.7"
-    "@babel/types" "^7.24.7"
-
-"@babel/helper-skip-transparent-expression-wrappers@^7.20.0", "@babel/helper-skip-transparent-expression-wrappers@^7.24.7", "@babel/helper-skip-transparent-expression-wrappers@^7.25.9", "@babel/helper-skip-transparent-expression-wrappers@^7.27.1":
+"@babel/helper-skip-transparent-expression-wrappers@^7.20.0", "@babel/helper-skip-transparent-expression-wrappers@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz#62bb91b3abba8c7f1fec0252d9dbea11b3ee7a56"
   integrity sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==
@@ -733,19 +695,12 @@
     "@babel/traverse" "^7.27.1"
     "@babel/types" "^7.27.1"
 
-"@babel/helper-split-export-declaration@^7.24.7":
-  version "7.24.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.7.tgz"
-  integrity sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==
-  dependencies:
-    "@babel/types" "^7.24.7"
-
-"@babel/helper-string-parser@^7.25.9", "@babel/helper-string-parser@^7.27.1":
+"@babel/helper-string-parser@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz#54da796097ab19ce67ed9f88b47bb2ec49367687"
   integrity sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==
 
-"@babel/helper-validator-identifier@^7.24.7", "@babel/helper-validator-identifier@^7.25.9", "@babel/helper-validator-identifier@^7.27.1", "@babel/helper-validator-identifier@^7.28.5":
+"@babel/helper-validator-identifier@^7.24.7", "@babel/helper-validator-identifier@^7.28.5":
   version "7.28.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz#010b6938fab7cb7df74aa2bbc06aa503b8fe5fb4"
   integrity sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==
@@ -755,7 +710,7 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz#fa52f5b1e7db1ab049445b421c4471303897702f"
   integrity sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==
 
-"@babel/helper-wrap-function@^7.24.7", "@babel/helper-wrap-function@^7.27.1":
+"@babel/helper-wrap-function@^7.27.1":
   version "7.28.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.28.6.tgz#4e349ff9222dab69a93a019cc296cdd8442e279a"
   integrity sha512-z+PwLziMNBeSQJonizz2AGnndLsP2DeGHIxDAn+wdHOGuo4Fo1x1HBPPXeE9TAOPHNNWQKCSlA2VZyYyyibDnQ==
@@ -764,7 +719,7 @@
     "@babel/traverse" "^7.28.6"
     "@babel/types" "^7.28.6"
 
-"@babel/helpers@^7.12.5", "@babel/helpers@^7.26.0", "@babel/helpers@^7.28.4", "@babel/helpers@^7.28.6":
+"@babel/helpers@^7.12.5", "@babel/helpers@^7.28.6":
   version "7.28.6"
   resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.28.6.tgz#fca903a313ae675617936e8998b814c415cbf5d7"
   integrity sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==
@@ -782,7 +737,7 @@
     js-tokens "^4.0.0"
     picocolors "^1.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.12.11", "@babel/parser@^7.12.7", "@babel/parser@^7.14.7", "@babel/parser@^7.20.7", "@babel/parser@^7.24.4", "@babel/parser@^7.25.9", "@babel/parser@^7.26.0", "@babel/parser@^7.27.2", "@babel/parser@^7.28.3", "@babel/parser@^7.28.4", "@babel/parser@^7.28.5", "@babel/parser@^7.28.6", "@babel/parser@^7.4.4", "@babel/parser@^7.7.0":
+"@babel/parser@^7.1.0", "@babel/parser@^7.12.11", "@babel/parser@^7.12.7", "@babel/parser@^7.14.7", "@babel/parser@^7.20.7", "@babel/parser@^7.24.4", "@babel/parser@^7.28.6", "@babel/parser@^7.4.4", "@babel/parser@^7.7.0":
   version "7.28.6"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.28.6.tgz#f01a8885b7fa1e56dd8a155130226cd698ef13fd"
   integrity sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==
@@ -1003,7 +958,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-syntax-jsx@^7.24.7", "@babel/plugin-syntax-jsx@^7.27.1", "@babel/plugin-syntax-jsx@^7.28.6":
+"@babel/plugin-syntax-jsx@^7.27.1", "@babel/plugin-syntax-jsx@^7.28.6":
   version "7.28.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz#f8ca28bbd84883b5fea0e447c635b81ba73997ee"
   integrity sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==
@@ -1066,7 +1021,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
-"@babel/plugin-syntax-typescript@^7.25.9", "@babel/plugin-syntax-typescript@^7.28.6", "@babel/plugin-syntax-typescript@^7.7.2":
+"@babel/plugin-syntax-typescript@^7.28.6", "@babel/plugin-syntax-typescript@^7.7.2":
   version "7.28.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz#c7b2ddf1d0a811145b1de800d1abd146af92e3a2"
   integrity sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==
@@ -1765,11 +1720,6 @@
     pirates "^4.0.6"
     source-map-support "^0.5.16"
 
-"@babel/regjsgen@^0.8.0":
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@babel/regjsgen/-/regjsgen-0.8.0.tgz"
-  integrity sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==
-
 "@babel/runtime-corejs3@^7.20.7", "@babel/runtime-corejs3@^7.22.15", "@babel/runtime-corejs3@^7.26.10", "@babel/runtime-corejs3@^7.27.1":
   version "7.28.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.28.4.tgz#c25be39c7997ce2f130d70b9baecb8ed94df93fa"
@@ -1777,12 +1727,12 @@
   dependencies:
     core-js-pure "^3.43.0"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.15.4", "@babel/runtime@^7.16.3", "@babel/runtime@^7.17.8", "@babel/runtime@^7.18.3", "@babel/runtime@^7.28.4", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.1", "@babel/runtime@^7.5.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.15.4", "@babel/runtime@^7.16.3", "@babel/runtime@^7.17.8", "@babel/runtime@^7.18.3", "@babel/runtime@^7.28.4", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.1", "@babel/runtime@^7.5.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.28.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.28.6.tgz#d267a43cb1836dc4d182cce93ae75ba954ef6d2b"
   integrity sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==
 
-"@babel/template@^7.12.7", "@babel/template@^7.24.7", "@babel/template@^7.25.9", "@babel/template@^7.27.2", "@babel/template@^7.28.6", "@babel/template@^7.3.3":
+"@babel/template@^7.12.7", "@babel/template@^7.28.6", "@babel/template@^7.3.3":
   version "7.28.6"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.28.6.tgz#0e7e56ecedb78aeef66ce7972b082fce76a23e57"
   integrity sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==
@@ -1791,7 +1741,7 @@
     "@babel/parser" "^7.28.6"
     "@babel/types" "^7.28.6"
 
-"@babel/traverse@^7.1.6", "@babel/traverse@^7.12.11", "@babel/traverse@^7.12.9", "@babel/traverse@^7.13.0", "@babel/traverse@^7.24.7", "@babel/traverse@^7.25.9", "@babel/traverse@^7.27.1", "@babel/traverse@^7.28.0", "@babel/traverse@^7.28.3", "@babel/traverse@^7.28.4", "@babel/traverse@^7.28.5", "@babel/traverse@^7.28.6", "@babel/traverse@^7.7.0", "@babel/traverse@^7.7.2":
+"@babel/traverse@^7.1.6", "@babel/traverse@^7.12.11", "@babel/traverse@^7.12.9", "@babel/traverse@^7.13.0", "@babel/traverse@^7.27.1", "@babel/traverse@^7.28.0", "@babel/traverse@^7.28.5", "@babel/traverse@^7.28.6", "@babel/traverse@^7.7.0", "@babel/traverse@^7.7.2":
   version "7.28.6"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.28.6.tgz#871ddc79a80599a5030c53b1cc48cbe3a5583c2e"
   integrity sha512-fgWX62k02qtjqdSNTAGxmKYY/7FSL9WAS1o2Hu5+I5m9T0yxZzr4cnrfXQ/MX0rIifthCSs6FKTlzYbJcPtMNg==
@@ -1804,7 +1754,7 @@
     "@babel/types" "^7.28.6"
     debug "^4.3.1"
 
-"@babel/types@^7.0.0", "@babel/types@^7.12.11", "@babel/types@^7.12.7", "@babel/types@^7.2.0", "@babel/types@^7.20.7", "@babel/types@^7.24.7", "@babel/types@^7.25.9", "@babel/types@^7.26.0", "@babel/types@^7.27.1", "@babel/types@^7.27.3", "@babel/types@^7.28.2", "@babel/types@^7.28.4", "@babel/types@^7.28.5", "@babel/types@^7.28.6", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.7.0":
+"@babel/types@^7.0.0", "@babel/types@^7.12.11", "@babel/types@^7.12.7", "@babel/types@^7.2.0", "@babel/types@^7.20.7", "@babel/types@^7.27.1", "@babel/types@^7.27.3", "@babel/types@^7.28.2", "@babel/types@^7.28.5", "@babel/types@^7.28.6", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.7.0":
   version "7.28.6"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.28.6.tgz#c3e9377f1b155005bcc4c46020e7e394e13089df"
   integrity sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==
@@ -3580,7 +3530,7 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@floating-ui/core@^1.7.3", "@floating-ui/core@^1.7.5":
+"@floating-ui/core@^1.7.5":
   version "1.7.5"
   resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.7.5.tgz#d4af157a03330af5a60e69da7a4692507ada0622"
   integrity sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==
@@ -3611,7 +3561,7 @@
     "@floating-ui/utils" "^0.2.8"
     tabbable "^6.0.0"
 
-"@floating-ui/utils@^0.2.10", "@floating-ui/utils@^0.2.11", "@floating-ui/utils@^0.2.8":
+"@floating-ui/utils@^0.2.11", "@floating-ui/utils@^0.2.8":
   version "0.2.11"
   resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.11.tgz#a269e055e40e2f45873bae9d1a2fdccbd314ea3f"
   integrity sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==
@@ -4159,11 +4109,6 @@
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz#7a0ee601f60f99a20c7c7c5ff0c80388c1189bd6"
   integrity sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==
-
-"@jridgewell/set-array@^1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.2.1.tgz#558fb6472ed16a4c850b889530e6b36438c49280"
-  integrity sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==
 
 "@jridgewell/source-map@^0.3.3":
   version "0.3.6"
@@ -7181,7 +7126,7 @@
   dependencies:
     "@types/color-name" "^1.1.0"
 
-"@types/color-name@^1.1.0", "@types/color-name@^1.1.1":
+"@types/color-name@^1.1.0":
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.5.tgz#3a3510c4e3661f7707c5ae9c67d726986e6e147d"
   integrity sha512-j2K5UJqGTxeesj6oQuGpMgifpT5k9HprgQd8D1Y0lOFqKHl3PJu5GMeS4Y5EgjS55AE6OQxf8mPED9uaGbf4Cg==
@@ -8426,7 +8371,7 @@ acorn@^7.1.1, acorn@^7.4.0, acorn@^7.4.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-acorn@^8.11.0, acorn@^8.14.0, acorn@^8.15.0, acorn@^8.2.4, acorn@^8.4.1, acorn@^8.5.0, acorn@^8.8.2:
+acorn@^8.11.0, acorn@^8.14.0, acorn@^8.15.0, acorn@^8.2.4, acorn@^8.4.1, acorn@^8.5.0:
   version "8.16.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.16.0.tgz#4ce79c89be40afe7afe8f3adb902a1f1ce9ac08a"
   integrity sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==
@@ -9135,7 +9080,7 @@ autoprefixer@^9.7.4, autoprefixer@^9.8.6:
     postcss "^7.0.32"
     postcss-value-parser "^4.1.0"
 
-available-typed-arrays@^1.0.5, available-typed-arrays@^1.0.7:
+available-typed-arrays@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz#a5cc375d6a03c2efc87a553f3e0b1522def14846"
   integrity sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==
@@ -9970,7 +9915,7 @@ browserslist-config-clay-components@^2.0.3:
   resolved "https://registry.yarnpkg.com/browserslist-config-clay-components/-/browserslist-config-clay-components-2.1.12.tgz"
   integrity sha1-MPpfYABkVLrbYewKDYN/aTZfDM4=
 
-browserslist@^4.12.0, browserslist@^4.23.0, browserslist@^4.24.0, browserslist@^4.28.0, browserslist@^4.28.1, browserslist@^4.8.3:
+browserslist@^4.12.0, browserslist@^4.24.0, browserslist@^4.28.0, browserslist@^4.28.1:
   version "4.28.1"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.28.1.tgz#7f534594628c53c63101079e27e40de490456a95"
   integrity sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==
@@ -10200,7 +10145,7 @@ call-bind-apply-helpers@^1.0.0, call-bind-apply-helpers@^1.0.1, call-bind-apply-
     es-errors "^1.3.0"
     function-bind "^1.1.2"
 
-call-bind@^1.0.0, call-bind@^1.0.2, call-bind@^1.0.5, call-bind@^1.0.7, call-bind@^1.0.8:
+call-bind@^1.0.2, call-bind@^1.0.5, call-bind@^1.0.7, call-bind@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.8.tgz#0736a9660f537e3388826f440d5ec45f744eaa4c"
   integrity sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==
@@ -10305,7 +10250,7 @@ camelcase@^6.2.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
-caniuse-lite@^1.0.30001020, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001579, caniuse-lite@^1.0.30001669, caniuse-lite@^1.0.30001759:
+caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001579, caniuse-lite@^1.0.30001759:
   version "1.0.30001766"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001766.tgz#b6f6b55cb25a2d888d9393104d14751c6a7d6f7a"
   integrity sha512-4C0lfJ0/YPjJQHagaE9x2Elb69CIqEPZeG0anQt9SIvIoOH4a4uaRl73IavyO+0qZh6MDLH//DrXThEYKHkmYA==
@@ -11184,7 +11129,7 @@ core-js-compat@^3.31.0, core-js-compat@^3.36.1, core-js-compat@^3.43.0, core-js-
   dependencies:
     browserslist "^4.28.0"
 
-core-js-pure@^3.23.3, core-js-pure@^3.30.2, core-js-pure@^3.43.0:
+core-js-pure@^3.23.3, core-js-pure@^3.43.0:
   version "3.47.0"
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.47.0.tgz#1104df8a3b6eb9189fcc559b5a65b90f66e7e887"
   integrity sha512-BcxeDbzUrRnXGYIVAGFtcGQVNpFcUhVjr6W7F8XktvQW2iJP9e66GP6xdKotCRFlrxBvNIBrhwKteRXqMV86Nw==
@@ -12186,7 +12131,7 @@ define-lazy-prop@^3.0.0:
   resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz#dbb19adfb746d7fc6d734a06b72f4a00d021255f"
   integrity sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==
 
-define-properties@^1.1.2, define-properties@^1.1.3, define-properties@^1.1.4, define-properties@^1.2.0, define-properties@^1.2.1:
+define-properties@^1.1.2, define-properties@^1.1.3, define-properties@^1.2.0, define-properties@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.2.1.tgz"
   integrity sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==
@@ -12655,7 +12600,7 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-electron-to-chromium@^1.5.263, electron-to-chromium@^1.5.41:
+electron-to-chromium@^1.5.263:
   version "1.5.267"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz#5d84f2df8cdb6bfe7e873706bb21bd4bfb574dc7"
   integrity sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==
@@ -12826,7 +12771,7 @@ error@^7.0.0:
   dependencies:
     string-template "~0.2.1"
 
-es-abstract@^1.18.0-next.1, es-abstract@^1.18.0-next.2, es-abstract@^1.22.1, es-abstract@^1.22.3, es-abstract@^1.23.2, es-abstract@^1.23.5, es-abstract@^1.23.6, es-abstract@^1.23.9, es-abstract@^1.24.0, es-abstract@^1.5.1:
+es-abstract@^1.22.1, es-abstract@^1.22.3, es-abstract@^1.23.2, es-abstract@^1.23.5, es-abstract@^1.23.6, es-abstract@^1.23.9, es-abstract@^1.24.0:
   version "1.24.1"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.24.1.tgz#f0c131ed5ea1bb2411134a8dd94def09c46c7899"
   integrity sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==
@@ -12950,7 +12895,7 @@ es-shim-unscopables@^1.0.2:
   dependencies:
     hasown "^2.0.2"
 
-es-to-primitive@^1.2.1, es-to-primitive@^1.3.0:
+es-to-primitive@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.3.0.tgz#96c89c82cc49fd8794a24835ba3e1ff87f214e18"
   integrity sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==
@@ -14389,7 +14334,7 @@ get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-intrinsic@^1.0.2, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3, get-intrinsic@^1.2.0, get-intrinsic@^1.2.1, get-intrinsic@^1.2.4, get-intrinsic@^1.2.5, get-intrinsic@^1.2.6, get-intrinsic@^1.2.7, get-intrinsic@^1.3.0:
+get-intrinsic@^1.1.3, get-intrinsic@^1.2.1, get-intrinsic@^1.2.4, get-intrinsic@^1.2.5, get-intrinsic@^1.2.6, get-intrinsic@^1.2.7, get-intrinsic@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
   integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
@@ -14674,11 +14619,6 @@ global@^4.4.0:
   dependencies:
     min-document "^2.19.0"
     process "^0.11.10"
-
-globals@^11.1.0:
-  version "11.12.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz"
-  integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
 globals@^13.6.0, globals@^13.9.0:
   version "13.24.0"
@@ -15136,7 +15076,7 @@ has-ansi@^2.0.0:
   dependencies:
     ansi-regex "^2.0.0"
 
-has-bigints@^1.0.1, has-bigints@^1.0.2:
+has-bigints@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.1.0.tgz#28607e965ac967e03cd2a2c70a2636a1edad49fe"
   integrity sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==
@@ -15184,7 +15124,7 @@ has-symbol-support-x@^1.4.1:
   resolved "https://registry.yarnpkg.com/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz#1409f98bc00247da45da67cee0a36f282ff26455"
   integrity sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==
 
-has-symbols@^1.0.1, has-symbols@^1.0.2, has-symbols@^1.0.3, has-symbols@^1.1.0:
+has-symbols@^1.0.3, has-symbols@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.1.0.tgz#fc9c6a783a084951d0b971fe1018de813707a338"
   integrity sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==
@@ -15196,7 +15136,7 @@ has-to-string-tag-x@^1.2.0:
   dependencies:
     has-symbol-support-x "^1.4.1"
 
-has-tostringtag@^1.0.0, has-tostringtag@^1.0.2:
+has-tostringtag@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.2.tgz#2cdc42d40bef2e5b4eeab7c01a73c54ce7ab5abc"
   integrity sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==
@@ -15957,11 +15897,6 @@ indent-string@^4.0.0:
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz"
   integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
 
-indexes-of@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/indexes-of/-/indexes-of-1.0.1.tgz"
-  integrity sha1-8w9xbI4r00bHtn0985FVZqfAVgc=
-
 infer-owner@^1.0.3, infer-owner@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/infer-owner/-/infer-owner-1.0.4.tgz#c4cefcaa8e51051c2a40ba2ce8a3d27295af9467"
@@ -16022,7 +15957,7 @@ internal-ip@^4.3.0:
     default-gateway "^4.2.0"
     ipaddr.js "^1.9.0"
 
-internal-slot@^1.0.3, internal-slot@^1.0.4, internal-slot@^1.1.0:
+internal-slot@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.1.0.tgz#1eac91762947d2f7056bc838d93e13b2e9604961"
   integrity sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==
@@ -16152,7 +16087,7 @@ is-arguments@^1.0.4, is-arguments@^1.1.1:
     call-bound "^1.0.2"
     has-tostringtag "^1.0.2"
 
-is-array-buffer@^3.0.1, is-array-buffer@^3.0.2, is-array-buffer@^3.0.4, is-array-buffer@^3.0.5:
+is-array-buffer@^3.0.2, is-array-buffer@^3.0.4, is-array-buffer@^3.0.5:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/is-array-buffer/-/is-array-buffer-3.0.5.tgz#65742e1e687bd2cc666253068fd8707fe4d44280"
   integrity sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==
@@ -16177,7 +16112,7 @@ is-async-function@^2.0.0:
     has-tostringtag "^1.0.2"
     safe-regex-test "^1.1.0"
 
-is-bigint@^1.0.1, is-bigint@^1.1.0:
+is-bigint@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-bigint/-/is-bigint-1.1.0.tgz#dda7a3445df57a42583db4228682eba7c4170672"
   integrity sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==
@@ -16198,7 +16133,7 @@ is-binary-path@~2.1.0:
   dependencies:
     binary-extensions "^2.0.0"
 
-is-boolean-object@^1.1.0, is-boolean-object@^1.2.1:
+is-boolean-object@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.2.2.tgz#7067f47709809a393c71ff5bb3e135d8a9215d9e"
   integrity sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==
@@ -16216,7 +16151,7 @@ is-buffer@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.4.tgz"
   integrity sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==
 
-is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.2.3, is-callable@^1.2.7:
+is-callable@^1.2.7:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz"
   integrity sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==
@@ -16228,7 +16163,7 @@ is-ci@^2.0.0:
   dependencies:
     ci-info "^2.0.0"
 
-is-core-module@^2.16.0, is-core-module@^2.16.1, is-core-module@^2.2.0:
+is-core-module@^2.16.1, is-core-module@^2.2.0:
   version "2.16.1"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.16.1.tgz#2a98801a849f43e2add644fbb6bc6229b19a4ef4"
   integrity sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==
@@ -16258,7 +16193,7 @@ is-data-view@^1.0.1, is-data-view@^1.0.2:
     get-intrinsic "^1.2.6"
     is-typed-array "^1.1.13"
 
-is-date-object@^1.0.1, is-date-object@^1.0.5, is-date-object@^1.1.0:
+is-date-object@^1.0.5, is-date-object@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.1.0.tgz#ad85541996fc7aa8b2729701d27b7319f95d82f7"
   integrity sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==
@@ -16447,7 +16382,7 @@ is-installed-globally@^0.3.1:
     global-dirs "^2.0.1"
     is-path-inside "^3.0.1"
 
-is-map@^2.0.1, is-map@^2.0.2, is-map@^2.0.3:
+is-map@^2.0.2, is-map@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/is-map/-/is-map-2.0.3.tgz#ede96b7fe1e270b3c4465e3a465658764926d62e"
   integrity sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==
@@ -16457,7 +16392,7 @@ is-negated-glob@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-negated-glob/-/is-negated-glob-1.0.0.tgz"
   integrity sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=
 
-is-negative-zero@^2.0.1, is-negative-zero@^2.0.3:
+is-negative-zero@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.3.tgz#ced903a027aca6381b777a5743069d7376a49747"
   integrity sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==
@@ -16467,7 +16402,7 @@ is-npm@^4.0.0:
   resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-4.0.0.tgz#c90dd8380696df87a7a6d823c20d0b12bbe3c84d"
   integrity sha512-96ECIfh9xtDDlPylNPXhzjsykHsMJZ18ASpaWzQyBr4YRTcVjUvzaHayDAES2oU/3KpljhHUjtSRNiDwi0F0ig==
 
-is-number-object@^1.0.4, is-number-object@^1.1.1:
+is-number-object@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.1.1.tgz#144b21e95a1bc148205dcc2814a9134ec41b2541"
   integrity sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==
@@ -16607,7 +16542,7 @@ is-retry-allowed@^1.0.0, is-retry-allowed@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz#d778488bd0a4666a3be8a1482b9f2baafedea8b4"
   integrity sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==
 
-is-set@^2.0.1, is-set@^2.0.2, is-set@^2.0.3:
+is-set@^2.0.2, is-set@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/is-set/-/is-set-2.0.3.tgz#8ab209ea424608141372ded6e0cb200ef1d9d01d"
   integrity sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==
@@ -16634,7 +16569,7 @@ is-stream@^4.0.1:
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-4.0.1.tgz"
   integrity sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==
 
-is-string@^1.0.5, is-string@^1.0.7, is-string@^1.1.1:
+is-string@^1.0.7, is-string@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.1.1.tgz#92ea3f3d5c5b6e039ca8677e5ac8d07ea773cbb9"
   integrity sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==
@@ -16642,7 +16577,7 @@ is-string@^1.0.5, is-string@^1.0.7, is-string@^1.1.1:
     call-bound "^1.0.3"
     has-tostringtag "^1.0.2"
 
-is-symbol@^1.0.2, is-symbol@^1.0.3, is-symbol@^1.0.4, is-symbol@^1.1.1:
+is-symbol@^1.0.3, is-symbol@^1.0.4, is-symbol@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.1.1.tgz#f47761279f532e2b05a7024a7506dbbedacd0634"
   integrity sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==
@@ -16651,7 +16586,7 @@ is-symbol@^1.0.2, is-symbol@^1.0.3, is-symbol@^1.0.4, is-symbol@^1.1.1:
     has-symbols "^1.1.0"
     safe-regex-test "^1.1.0"
 
-is-typed-array@^1.1.10, is-typed-array@^1.1.13, is-typed-array@^1.1.14, is-typed-array@^1.1.15, is-typed-array@^1.1.3:
+is-typed-array@^1.1.13, is-typed-array@^1.1.14, is-typed-array@^1.1.15, is-typed-array@^1.1.3:
   version "1.1.15"
   resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.15.tgz#4bfb4a45b61cee83a5a46fba778e4e8d59c0ce0b"
   integrity sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==
@@ -16685,7 +16620,7 @@ is-valid-glob@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-valid-glob/-/is-valid-glob-1.0.0.tgz"
   integrity sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=
 
-is-weakmap@^2.0.1, is-weakmap@^2.0.2:
+is-weakmap@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/is-weakmap/-/is-weakmap-2.0.2.tgz#bf72615d649dfe5f699079c54b83e47d1ae19cfd"
   integrity sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==
@@ -16697,7 +16632,7 @@ is-weakref@^1.0.2, is-weakref@^1.1.1:
   dependencies:
     call-bound "^1.0.3"
 
-is-weakset@^2.0.1, is-weakset@^2.0.3:
+is-weakset@^2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-weakset/-/is-weakset-2.0.4.tgz#c9f5deb0bc1906c6d6f1027f284ddf459249daca"
   integrity sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==
@@ -17608,11 +17543,6 @@ jsesc@^3.0.2, jsesc@~3.1.0:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-3.1.0.tgz#74d335a234f67ed19907fdadfac7ccf9d409825d"
   integrity sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==
 
-jsesc@~0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz"
-  integrity sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=
-
 json-buffer@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898"
@@ -17756,7 +17686,7 @@ klaw@^3.0.0:
   dependencies:
     graceful-fs "^4.1.9"
 
-kleur@^3.0.2, kleur@^3.0.3:
+kleur@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
@@ -19311,11 +19241,6 @@ miller-rabin@^4.0.0:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
-mime-db@1.44.0:
-  version "1.44.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.44.0.tgz"
-  integrity sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==
-
 mime-db@1.52.0, "mime-db@>= 1.40.0 < 2":
   version "1.52.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
@@ -19630,7 +19555,7 @@ nan@^2.12.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.20.0.tgz"
   integrity sha512-bk3gXBZDGILuuo/6sKtr0DQmSThYHLtNCdSdXk9YkxD/jK6X2vmCyyXBBxyqZ4XcnzTyYEAThfX3DCEnLf6igw==
 
-nanoid@^3.3.1, nanoid@^3.3.11, nanoid@^3.3.6, nanoid@^3.3.8:
+nanoid@^3.3.1, nanoid@^3.3.11, nanoid@^3.3.6:
   version "3.3.11"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
   integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
@@ -19836,12 +19761,7 @@ node-libs-browser@^2.2.1:
     util "^0.11.0"
     vm-browserify "^1.0.1"
 
-node-modules-regexp@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz"
-  integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
-
-node-releases@^2.0.18, node-releases@^2.0.27:
+node-releases@^2.0.27:
   version "2.0.27"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.27.tgz#eedca519205cf20f650f61d56b070db111231e4e"
   integrity sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==
@@ -20003,7 +19923,7 @@ object-hash@^2.0.1:
   resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.2.0.tgz"
   integrity sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==
 
-object-inspect@^1.13.3, object-inspect@^1.13.4, object-inspect@^1.9.0:
+object-inspect@^1.13.3, object-inspect@^1.13.4:
   version "1.13.4"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.4.tgz#8375265e21bc20d0fa582c22e1b13485d6e00213"
   integrity sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==
@@ -20761,7 +20681,7 @@ picocolors@^0.2.1:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-0.2.1.tgz#570670f793646851d1ba135996962abad587859f"
   integrity sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==
 
-picocolors@^1.0.0, picocolors@^1.1.0, picocolors@^1.1.1:
+picocolors@^1.0.0, picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
@@ -21125,20 +21045,10 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha512-s/46sYeylUfHNjI+sA/78FAHlmIuKqI9wNnzEOGehAlUUYeObv5C2mOinXBjyUyWmJ2SfcS2/ydApH4hTF4WXQ==
 
-prettier@3.2.5:
+prettier@3.2.5, "prettier@>=2.2.1 <=2.3.0", prettier@^3.2.5, prettier@^3.5.3:
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.2.5.tgz"
   integrity sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==
-
-"prettier@>=2.2.1 <=2.3.0":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.0.tgz#b6a5bf1284026ae640f17f7ff5658a7567fc0d18"
-  integrity sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==
-
-prettier@^3.2.5, prettier@^3.5.3:
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.8.1.tgz#edf48977cf991558f4fcbd8a3ba6015ba2a3a173"
-  integrity sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==
 
 pretty-error@^2.1.1:
   version "2.1.2"
@@ -21600,7 +21510,7 @@ rc@1.2.8, rc@^1.0.1, rc@^1.1.6, rc@^1.2.8:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
 
-"react-18@npm:react@18.2.0":
+"react-18@npm:react@18.2.0", react@18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz"
   integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
@@ -21709,15 +21619,7 @@ react-docgen@^8.0.2:
     prop-types "^15.6.2"
     scheduler "^0.18.0"
 
-"react-dom-18@npm:react-dom@18.2.0":
-  version "18.2.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz"
-  integrity sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==
-  dependencies:
-    loose-envify "^1.1.0"
-    scheduler "^0.23.0"
-
-react-dom@18.2.0:
+"react-dom-18@npm:react-dom@18.2.0", react-dom@18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz"
   integrity sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==
@@ -22061,13 +21963,6 @@ react-transition-group@^4.3.0, react-transition-group@^4.4.1:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react@18.2.0:
-  version "18.2.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz"
-  integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
-  dependencies:
-    loose-envify "^1.1.0"
-
 react@^16.8.3:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
@@ -22329,7 +22224,7 @@ refractor@^5.0.0:
     hastscript "^9.0.0"
     parse-entities "^4.0.0"
 
-regenerate-unicode-properties@^10.1.0, regenerate-unicode-properties@^10.2.2:
+regenerate-unicode-properties@^10.2.2:
   version "10.2.2"
   resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.2.tgz#aa113812ba899b630658c7623466be71e1f86f66"
   integrity sha512-m03P+zhBeQd1RGnYxrGyDAPpWX/epKirLrp8e3qevZdVkKtnCrjjWczIbYc8+xd6vcTStVlqfycTx1KR4LOr0g==
@@ -22351,18 +22246,6 @@ regenerator-runtime@^0.13.7:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
   integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
 
-regenerator-runtime@^0.14.0:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz"
-  integrity sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==
-
-regenerator-transform@^0.15.2:
-  version "0.15.2"
-  resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.15.2.tgz"
-  integrity sha512-hfMp2BoF0qOk3uc5V20ALGDS2ddjQaLrdl7xrGXvAIow7qeWRM2VA2HuCHkUKk9slq3VwEwLNK3DFBqDfPGYtg==
-  dependencies:
-    "@babel/runtime" "^7.8.4"
-
 regex-cache@^0.4.2:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/regex-cache/-/regex-cache-0.4.4.tgz#75bdc58a2a1496cec48a12835bc54c8d562336dd"
@@ -22378,7 +22261,7 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
 
-regexp.prototype.flags@^1.3.1, regexp.prototype.flags@^1.5.0, regexp.prototype.flags@^1.5.3, regexp.prototype.flags@^1.5.4:
+regexp.prototype.flags@^1.5.0, regexp.prototype.flags@^1.5.3, regexp.prototype.flags@^1.5.4:
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz#1ad6c62d44a259007e55b3970e00f746efbcaa19"
   integrity sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==
@@ -22394,18 +22277,6 @@ regexpp@^3.1.0, regexpp@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
   integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
-
-regexpu-core@^5.3.1:
-  version "5.3.2"
-  resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-5.3.2.tgz"
-  integrity sha512-RAM5FlZz+Lhmo7db9L298p2vHP5ZywrVXmVXpmAD9GuL5MPH6t9ROw1iA/wfHkQ76Qe7AaPF0nGuim96/IrQMQ==
-  dependencies:
-    "@babel/regjsgen" "^0.8.0"
-    regenerate "^1.4.2"
-    regenerate-unicode-properties "^10.1.0"
-    regjsparser "^0.9.1"
-    unicode-match-property-ecmascript "^2.0.0"
-    unicode-match-property-value-ecmascript "^2.1.0"
 
 regexpu-core@^6.3.1:
   version "6.4.0"
@@ -22459,13 +22330,6 @@ regjsparser@^0.13.0:
   integrity sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==
   dependencies:
     jsesc "~3.1.0"
-
-regjsparser@^0.9.1:
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.9.1.tgz"
-  integrity sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==
-  dependencies:
-    jsesc "~0.5.0"
 
 rehype-dom-parse@5.0.2:
   version "5.0.2"
@@ -23444,7 +23308,7 @@ set-function-length@^1.2.2:
     gopd "^1.0.1"
     has-property-descriptors "^1.0.2"
 
-set-function-name@^2.0.0, set-function-name@^2.0.1, set-function-name@^2.0.2:
+set-function-name@^2.0.1, set-function-name@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/set-function-name/-/set-function-name-2.0.2.tgz#16a705c5a0dc2f5e638ca96d8a8cd4e1c2b90985"
   integrity sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==
@@ -23647,7 +23511,7 @@ signal-exit@^4.0.1, signal-exit@^4.1.0:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
-sisteransi@^1.0.0, sisteransi@^1.0.5:
+sisteransi@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
   integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
@@ -24079,7 +23943,7 @@ string-template@~0.2.1:
   resolved "https://registry.yarnpkg.com/string-template/-/string-template-0.2.1.tgz#42932e598a352d01fc22ec3367d9d84eec6c9add"
   integrity sha512-Yptehjogou2xm4UJbxJ4CxgZx12HBfeystp0y3x7s4Dj32ltVVG1Gg8YhKjHZkHicuKpZX/ffilA8505VbUbpw==
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -24096,15 +23960,6 @@ string-width@^1.0.1, string-width@^1.0.2:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^3.0.0, string-width@^3.1.0:
   version "3.1.0"
@@ -24177,7 +24032,7 @@ string.prototype.trim@^1.2.10:
     es-object-atoms "^1.0.0"
     has-property-descriptors "^1.0.2"
 
-string.prototype.trimend@^1.0.4, string.prototype.trimend@^1.0.9:
+string.prototype.trimend@^1.0.9:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz#62e2731272cd285041b36596054e9f66569b6942"
   integrity sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==
@@ -24187,7 +24042,7 @@ string.prototype.trimend@^1.0.4, string.prototype.trimend@^1.0.9:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
-string.prototype.trimstart@^1.0.4, string.prototype.trimstart@^1.0.8:
+string.prototype.trimstart@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz#7ee834dda8c7c17eff3118472bb35bfedaa34dde"
   integrity sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==
@@ -24233,7 +24088,7 @@ stringify-entities@^4.0.0:
     character-entities-html4 "^2.0.0"
     character-entities-legacy "^3.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -24260,13 +24115,6 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -25365,7 +25213,7 @@ uglify-js@^3.1.4:
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.19.3.tgz#82315e9bbc6f2b25888858acd1fff8441035b77f"
   integrity sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==
 
-unbox-primitive@^1.0.0, unbox-primitive@^1.1.0:
+unbox-primitive@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.1.0.tgz#8d9d2c9edeea8460c7f35033a88867944934d1e2"
   integrity sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==
@@ -25441,7 +25289,7 @@ unicode-match-property-ecmascript@^2.0.0:
     unicode-canonical-property-names-ecmascript "^2.0.0"
     unicode-property-aliases-ecmascript "^2.0.0"
 
-unicode-match-property-value-ecmascript@^2.1.0, unicode-match-property-value-ecmascript@^2.2.1:
+unicode-match-property-value-ecmascript@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.1.tgz#65a7adfad8574c219890e219285ce4c64ed67eaa"
   integrity sha512-JQ84qTuMg4nVkx8ga4A16a1epI9H6uTXAknqxkGF/aFfRLw1xC/Bp24HNLaZhHSkWd3+84t8iXnp1J0kYcZHhg==
@@ -25507,11 +25355,6 @@ union-value@^2.0.1:
   dependencies:
     get-value "^3.0.1"
     set-value "^3.0.0"
-
-uniq@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz"
-  integrity sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=
 
 unique-filename@^1.1.1:
   version "1.1.1"
@@ -25740,7 +25583,7 @@ upath@^1.1.1:
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.2.tgz"
   integrity sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==
 
-update-browserslist-db@^1.1.1, update-browserslist-db@^1.2.0:
+update-browserslist-db@^1.2.0:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz#64d76db58713136acbeb4c49114366cc6cc2e80d"
   integrity sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==
@@ -25772,7 +25615,7 @@ upper-case@^1.1.1:
   resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598"
   integrity sha512-WRbjgmYzgXkCV7zNVpy5YgrHgbBv126rMALQQMrmzOVC4GM2waQ9x7xtm8VU+1yF2kWyPzI9zbZ48n4vSxwfSA==
 
-uri-js@^4.2.2, uri-js@^4.4.1:
+uri-js@^4.2.2:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz"
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
@@ -26625,7 +26468,7 @@ which-module@^2.0.0:
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
-which-typed-array@^1.1.11, which-typed-array@^1.1.16, which-typed-array@^1.1.19, which-typed-array@^1.1.2, which-typed-array@^1.1.9:
+which-typed-array@^1.1.16, which-typed-array@^1.1.19, which-typed-array@^1.1.2, which-typed-array@^1.1.9:
   version "1.1.20"
   resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.20.tgz#3fdb7adfafe0ea69157b1509f3a1cd892bd1d122"
   integrity sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -21045,10 +21045,20 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha512-s/46sYeylUfHNjI+sA/78FAHlmIuKqI9wNnzEOGehAlUUYeObv5C2mOinXBjyUyWmJ2SfcS2/ydApH4hTF4WXQ==
 
-prettier@3.2.5, "prettier@>=2.2.1 <=2.3.0", prettier@^3.2.5, prettier@^3.5.3:
+prettier@3.2.5:
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.2.5.tgz"
   integrity sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==
+
+"prettier@>=2.2.1 <=2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.0.tgz#b6a5bf1284026ae640f17f7ff5658a7567fc0d18"
+  integrity sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==
+
+prettier@^3.5.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.8.3.tgz#560f2de55bf01b4c0503bc629d5df99b9a1d09b0"
+  integrity sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==
 
 pretty-error@^2.1.1:
   version "2.1.2"


### PR DESCRIPTION
## Issue https://liferay.atlassian.net/browse/LPD-83052

## Summary

Adds a **BASIC VERSION** of `ContentSelector`, a nested-checkbox selector for the Export/Import revamp, wired into the New Export wizard. Selection is flattened into the legacy form payload on submit.

### Components
- `content_selector/` — `ContentSelector`, `ContentSection`, `PortletDataControl`, `PortletDataControlChoice`.
- `PortletDataControlChoice` renders only when its Boolean parent is checked (design-agreed pattern: choices are dependent on the parent Boolean and never have siblings).
- `FormikFieldContentSelector` wrapper + formik barrel entry.

### Utils
- `utils/contentSelection.ts` — central state shape (`HandlerSelection`) and pure helpers: `isSelected`, `getInitialSelection`, `updateSelection`. Consumed by every component in the feature and by `flattenContentSelection`.
- `utils/flattenContentSelection.ts` — walks the full `sections` tree so `checkboxNames` lists every boolean (required by `PortletRequestImpl._processCheckbox` to mark unchecked ones as `false`); `additionalFields` merges arbitrary params (`groupId`, `privateLayout`, …).
- `utils/mockPortletDataHandlerSections.ts` — fixture aligned with the backend schema. Types modelled as a discriminated union: `PortletDataHandlerControl = PortletDataHandlerBoolean | PortletDataHandlerChoice`, with `PortletDataHandler = Omit<PortletDataHandlerBoolean, 'type'>` for root entries (the API does not provide `type` there; it's injected at the `ContentSection` boundary). Sections carry `name` (identifier) and `label` (display string).

### Wiring
- Mock imported only in `NewExport`; every consumer takes `sections` as a required prop.

## Screenshot:
<img width="1445" height="1293" alt="image" src="https://github.com/user-attachments/assets/0f8ac386-be8f-48b7-8b1a-890ca892f16e" />
