### PR TITLE
LPD-86581 Route polymorphic deletion rows through a dedicated carrier path

### DIFF
--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/reader/BatchEngineImportTaskItemReaderUtil.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/reader/BatchEngineImportTaskItemReaderUtil.java
@@ -7,6 +7,7 @@ package com.liferay.batch.engine.internal.reader;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -16,6 +17,7 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 
 import com.liferay.batch.engine.BatchEngineTaskContentType;
+import com.liferay.batch.engine.BatchEngineTaskOperation;
 import com.liferay.batch.engine.action.ItemReaderPostAction;
 import com.liferay.batch.engine.exception.BatchEngineImportTaskExecutorException;
 import com.liferay.batch.engine.model.BatchEngineImportTask;
@@ -61,8 +63,10 @@ public class BatchEngineImportTaskItemReaderUtil {
 		T item = null;
 
 		try {
-			Class<? extends T> resolvedClass = _resolveClass(
-				fieldNameValueMap, itemClass);
+			Class<? extends T> resolvedClass =
+				_isPolymorphicDeletion(batchEngineImportTask, itemClass) ?
+					_getDeletionSubtypeClass(itemClass) :
+						_resolveClass(fieldNameValueMap, itemClass);
 
 			Constructor<? extends T> constructor =
 				resolvedClass.getDeclaredConstructor();
@@ -226,6 +230,21 @@ public class BatchEngineImportTaskItemReaderUtil {
 		return fields;
 	}
 
+	private static <T> Class<? extends T> _getDeletionSubtypeClass(
+		Class<T> itemClass) {
+
+		JsonSubTypes jsonSubTypes = itemClass.getAnnotation(JsonSubTypes.class);
+
+		if ((jsonSubTypes == null) || (jsonSubTypes.value().length == 0)) {
+			throw new IllegalStateException(
+				StringBundler.concat(
+					"Polymorphic class ", itemClass.getName(),
+					" has no @JsonSubTypes;"));
+		}
+
+		return (Class<? extends T>)jsonSubTypes.value()[0].value();
+	}
+
 	private static ObjectMapper _getObjectMapper(
 			BatchEngineImportTask batchEngineImportTask, Field field,
 			Object value)
@@ -293,6 +312,24 @@ public class BatchEngineImportTaskItemReaderUtil {
 		}
 
 		return true;
+	}
+
+	private static boolean _isPolymorphicDeletion(
+		BatchEngineImportTask batchEngineImportTask, Class<?> itemClass) {
+
+		if (itemClass.getAnnotation(JsonTypeInfo.class) == null) {
+			return false;
+		}
+
+		BatchEngineTaskOperation batchEngineTaskOperation =
+			BatchEngineTaskOperation.valueOf(
+				batchEngineImportTask.getOperation());
+
+		if (batchEngineTaskOperation == BatchEngineTaskOperation.DELETE) {
+			return true;
+		}
+
+		return false;
 	}
 
 	private static void _processFieldNameValueMap(

--- a/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/dto/v1_0/ChildTestEntity1.java
+++ b/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/dto/v1_0/ChildTestEntity1.java
@@ -198,6 +198,22 @@ public class ChildTestEntity1 extends TestEntity implements Serializable {
 			sb.append(documentId);
 		}
 
+		String externalReferenceCode = getExternalReferenceCode();
+
+		if (externalReferenceCode != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"externalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(externalReferenceCode));
+
+			sb.append("\"");
+		}
+
 		Long id = getId();
 
 		if (id != null) {
@@ -431,4 +447,4 @@ public class ChildTestEntity1 extends TestEntity implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1490710173
+// LIFERAY-REST-BUILDER-HASH:283054578

--- a/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/dto/v1_0/ChildTestEntity2.java
+++ b/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/dto/v1_0/ChildTestEntity2.java
@@ -198,6 +198,22 @@ public class ChildTestEntity2 extends TestEntity implements Serializable {
 			sb.append(documentId);
 		}
 
+		String externalReferenceCode = getExternalReferenceCode();
+
+		if (externalReferenceCode != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"externalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(externalReferenceCode));
+
+			sb.append("\"");
+		}
+
 		Long id = getId();
 
 		if (id != null) {
@@ -431,4 +447,4 @@ public class ChildTestEntity2 extends TestEntity implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:34301248
+// LIFERAY-REST-BUILDER-HASH:353612751

--- a/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/dto/v1_0/ChildTestEntity3.java
+++ b/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/dto/v1_0/ChildTestEntity3.java
@@ -136,6 +136,22 @@ public class ChildTestEntity3 extends TestEntity implements Serializable {
 			sb.append(documentId);
 		}
 
+		String externalReferenceCode = getExternalReferenceCode();
+
+		if (externalReferenceCode != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"externalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(externalReferenceCode));
+
+			sb.append("\"");
+		}
+
 		Long id = getId();
 
 		if (id != null) {
@@ -369,4 +385,4 @@ public class ChildTestEntity3 extends TestEntity implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1983856151
+// LIFERAY-REST-BUILDER-HASH:-1211902042

--- a/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/dto/v1_0/TestEntity.java
+++ b/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/dto/v1_0/TestEntity.java
@@ -241,6 +241,47 @@ public abstract class TestEntity implements Serializable {
 	private Supplier<Long> _documentIdSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema
+	public String getExternalReferenceCode() {
+		if (_externalReferenceCodeSupplier != null) {
+			externalReferenceCode = _externalReferenceCodeSupplier.get();
+
+			_externalReferenceCodeSupplier = null;
+		}
+
+		return externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		this.externalReferenceCode = externalReferenceCode;
+
+		_externalReferenceCodeSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setExternalReferenceCode(
+		UnsafeSupplier<String, Exception> externalReferenceCodeUnsafeSupplier) {
+
+		_externalReferenceCodeSupplier = () -> {
+			try {
+				return externalReferenceCodeUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String externalReferenceCode;
+
+	@JsonIgnore
+	private Supplier<String> _externalReferenceCodeSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
 	public Long getId() {
 		if (_idSupplier != null) {
 			id = _idSupplier.get();
@@ -712,6 +753,22 @@ public abstract class TestEntity implements Serializable {
 			sb.append(documentId);
 		}
 
+		String externalReferenceCode = getExternalReferenceCode();
+
+		if (externalReferenceCode != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"externalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(externalReferenceCode));
+
+			sb.append("\"");
+		}
+
 		Long id = getId();
 
 		if (id != null) {
@@ -985,4 +1042,4 @@ public abstract class TestEntity implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:2122153770
+// LIFERAY-REST-BUILDER-HASH:-633467060

--- a/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/TestEntityResource.java
+++ b/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/TestEntityResource.java
@@ -57,6 +57,10 @@ public interface TestEntityResource {
 			Boolean permanent, String callbackURL, Object object)
 		throws Exception;
 
+	public void deleteTestEntityByExternalReferenceCode(
+			String externalReferenceCode)
+		throws Exception;
+
 	public Page<TestEntity> getTestEntitiesPage(
 			com.liferay.portal.kernel.search.filter.Filter filter)
 		throws Exception;
@@ -195,4 +199,4 @@ public interface TestEntityResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:953012982
+// LIFERAY-REST-BUILDER-HASH:1436564411

--- a/modules/util/portal-tools-rest-builder-test-client-js/src/apis/TestEntityAPI.ts
+++ b/modules/util/portal-tools-rest-builder-test-client-js/src/apis/TestEntityAPI.ts
@@ -85,6 +85,59 @@ export class TestEntityAPI {
 
 		/**
 		 * 
+				 * @param externalReferenceCode
+		 * @param headers Optional custom request headers
+		 */
+		public async deleteTestEntityByExternalReferenceCode(
+						externalReferenceCode: string,
+			headers?: {[name: string]: string},
+		): Promise<{
+				body?: any;
+			response: Response;
+		}> {
+
+			const path = this._basePath + "/test/v1.0/test-entities/by-external-reference-code/{externalReferenceCode}"
+						.replace("{externalReferenceCode}",encodeURIComponent(externalReferenceCode))
+				;
+
+			const queryParameters: any = {};
+
+						if (externalReferenceCode === null || externalReferenceCode === undefined) {
+							throw new Error("Required parameter externalReferenceCode was null or undefined when calling deleteTestEntityByExternalReferenceCode.");
+						}
+
+			const queryString = Object.keys(queryParameters).length ?
+				"?" + new URLSearchParams(queryParameters).toString() :
+					"";
+
+			const response = await fetch(path + queryString, {
+				headers:
+					Object.assign({}, this._defaultHeaders
+						,{
+								Accept: "application/json"
+						}
+					,headers || {}
+					),
+				method: "DELETE",
+			});
+
+			if (response.ok) {
+				const contentType = response.headers.get("content-type") || "";
+
+					if (contentType.includes("application/json")) {
+						return {body: await response.json(), response};
+					}
+					else {
+						return {body: await response.text(), response};
+					}
+			}
+			else {
+				throw new Error("HTTP Error " + response.status + ": " + response.statusText + ". " + await response.text());
+			}
+		}
+
+		/**
+		 * 
 				 * @param filter
 		 * @param headers Optional custom request headers
 		 */

--- a/modules/util/portal-tools-rest-builder-test-client-js/src/models/TestEntity.ts
+++ b/modules/util/portal-tools-rest-builder-test-client-js/src/models/TestEntity.ts
@@ -16,6 +16,7 @@
 			"dateModified"?: Date;
 			"description"?: string;
 			"documentId"?: number;
+			"externalReferenceCode"?: string;
 			"id"?: number;
 			"jsonProperty"?: string;
 			"name"?: string;
@@ -52,6 +53,11 @@
 			baseName: "documentId",
 			name: "documentId",
 			type: "number",
+		},
+		{
+			baseName: "externalReferenceCode",
+			name: "externalReferenceCode",
+			type: "string",
 		},
 		{
 			baseName: "id",

--- a/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/dto/v1_0/TestEntity.java
+++ b/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/dto/v1_0/TestEntity.java
@@ -111,6 +111,27 @@ public abstract class TestEntity implements Cloneable, Serializable {
 
 	protected Long documentId;
 
+	public String getExternalReferenceCode() {
+		return externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		this.externalReferenceCode = externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(
+		UnsafeSupplier<String, Exception> externalReferenceCodeUnsafeSupplier) {
+
+		try {
+			externalReferenceCode = externalReferenceCodeUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String externalReferenceCode;
+
 	public Long getId() {
 		return id;
 	}
@@ -370,4 +391,4 @@ public abstract class TestEntity implements Cloneable, Serializable {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1512172249
+// LIFERAY-REST-BUILDER-HASH:1709442815

--- a/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/TestEntityResource.java
+++ b/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/TestEntityResource.java
@@ -50,6 +50,15 @@ public interface TestEntityResource {
 			Boolean permanent, String callbackURL, Object object)
 		throws Exception;
 
+	public void deleteTestEntityByExternalReferenceCode(
+			String externalReferenceCode)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			deleteTestEntityByExternalReferenceCodeHttpResponse(
+				String externalReferenceCode)
+		throws Exception;
+
 	public Page<TestEntity> getTestEntitiesPage(String filterString)
 		throws Exception;
 
@@ -446,6 +455,114 @@ public interface TestEntityResource {
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
 						"/o/test/v1.0/test-entities/batch");
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public void deleteTestEntityByExternalReferenceCode(
+				String externalReferenceCode)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				deleteTestEntityByExternalReferenceCodeHttpResponse(
+					externalReferenceCode);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return;
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				deleteTestEntityByExternalReferenceCodeHttpResponse(
+					String externalReferenceCode)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.DELETE);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/test/v1.0/test-entities/by-external-reference-code/{externalReferenceCode}");
+
+			httpInvoker.path("externalReferenceCode", externalReferenceCode);
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -1839,4 +1956,4 @@ public interface TestEntityResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-826106989
+// LIFERAY-REST-BUILDER-HASH:41082852

--- a/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/serdes/v1_0/ChildTestEntity1SerDes.java
+++ b/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/serdes/v1_0/ChildTestEntity1SerDes.java
@@ -123,6 +123,20 @@ public class ChildTestEntity1SerDes {
 			sb.append(childTestEntity1.getDocumentId());
 		}
 
+		if (childTestEntity1.getExternalReferenceCode() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"externalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(childTestEntity1.getExternalReferenceCode()));
+
+			sb.append("\"");
+		}
+
 		if (childTestEntity1.getId() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -306,6 +320,15 @@ public class ChildTestEntity1SerDes {
 				"documentId", String.valueOf(childTestEntity1.getDocumentId()));
 		}
 
+		if (childTestEntity1.getExternalReferenceCode() == null) {
+			map.put("externalReferenceCode", null);
+		}
+		else {
+			map.put(
+				"externalReferenceCode",
+				String.valueOf(childTestEntity1.getExternalReferenceCode()));
+		}
+
 		if (childTestEntity1.getId() == null) {
 			map.put("id", null);
 		}
@@ -412,6 +435,11 @@ public class ChildTestEntity1SerDes {
 			else if (Objects.equals(jsonParserFieldName, "documentId")) {
 				return false;
 			}
+			else if (Objects.equals(
+						jsonParserFieldName, "externalReferenceCode")) {
+
+				return false;
+			}
 			else if (Objects.equals(jsonParserFieldName, "id")) {
 				return false;
 			}
@@ -477,6 +505,14 @@ public class ChildTestEntity1SerDes {
 				if (jsonParserFieldValue != null) {
 					childTestEntity1.setDocumentId(
 						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "externalReferenceCode")) {
+
+				if (jsonParserFieldValue != null) {
+					childTestEntity1.setExternalReferenceCode(
+						(String)jsonParserFieldValue);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "id")) {
@@ -616,4 +652,4 @@ public class ChildTestEntity1SerDes {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1955755204
+// LIFERAY-REST-BUILDER-HASH:-1780652226

--- a/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/serdes/v1_0/ChildTestEntity2SerDes.java
+++ b/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/serdes/v1_0/ChildTestEntity2SerDes.java
@@ -123,6 +123,20 @@ public class ChildTestEntity2SerDes {
 			sb.append(childTestEntity2.getDocumentId());
 		}
 
+		if (childTestEntity2.getExternalReferenceCode() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"externalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(childTestEntity2.getExternalReferenceCode()));
+
+			sb.append("\"");
+		}
+
 		if (childTestEntity2.getId() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -306,6 +320,15 @@ public class ChildTestEntity2SerDes {
 				"documentId", String.valueOf(childTestEntity2.getDocumentId()));
 		}
 
+		if (childTestEntity2.getExternalReferenceCode() == null) {
+			map.put("externalReferenceCode", null);
+		}
+		else {
+			map.put(
+				"externalReferenceCode",
+				String.valueOf(childTestEntity2.getExternalReferenceCode()));
+		}
+
 		if (childTestEntity2.getId() == null) {
 			map.put("id", null);
 		}
@@ -412,6 +435,11 @@ public class ChildTestEntity2SerDes {
 			else if (Objects.equals(jsonParserFieldName, "documentId")) {
 				return false;
 			}
+			else if (Objects.equals(
+						jsonParserFieldName, "externalReferenceCode")) {
+
+				return false;
+			}
 			else if (Objects.equals(jsonParserFieldName, "id")) {
 				return false;
 			}
@@ -477,6 +505,14 @@ public class ChildTestEntity2SerDes {
 				if (jsonParserFieldValue != null) {
 					childTestEntity2.setDocumentId(
 						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "externalReferenceCode")) {
+
+				if (jsonParserFieldValue != null) {
+					childTestEntity2.setExternalReferenceCode(
+						(String)jsonParserFieldValue);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "id")) {
@@ -616,4 +652,4 @@ public class ChildTestEntity2SerDes {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-928705764
+// LIFERAY-REST-BUILDER-HASH:-299393257

--- a/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/serdes/v1_0/ChildTestEntity3SerDes.java
+++ b/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/serdes/v1_0/ChildTestEntity3SerDes.java
@@ -109,6 +109,20 @@ public class ChildTestEntity3SerDes {
 			sb.append(childTestEntity3.getDocumentId());
 		}
 
+		if (childTestEntity3.getExternalReferenceCode() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"externalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(childTestEntity3.getExternalReferenceCode()));
+
+			sb.append("\"");
+		}
+
 		if (childTestEntity3.getId() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -284,6 +298,15 @@ public class ChildTestEntity3SerDes {
 				"documentId", String.valueOf(childTestEntity3.getDocumentId()));
 		}
 
+		if (childTestEntity3.getExternalReferenceCode() == null) {
+			map.put("externalReferenceCode", null);
+		}
+		else {
+			map.put(
+				"externalReferenceCode",
+				String.valueOf(childTestEntity3.getExternalReferenceCode()));
+		}
+
 		if (childTestEntity3.getId() == null) {
 			map.put("id", null);
 		}
@@ -387,6 +410,11 @@ public class ChildTestEntity3SerDes {
 			else if (Objects.equals(jsonParserFieldName, "documentId")) {
 				return false;
 			}
+			else if (Objects.equals(
+						jsonParserFieldName, "externalReferenceCode")) {
+
+				return false;
+			}
 			else if (Objects.equals(jsonParserFieldName, "id")) {
 				return false;
 			}
@@ -447,6 +475,14 @@ public class ChildTestEntity3SerDes {
 				if (jsonParserFieldValue != null) {
 					childTestEntity3.setDocumentId(
 						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "externalReferenceCode")) {
+
+				if (jsonParserFieldValue != null) {
+					childTestEntity3.setExternalReferenceCode(
+						(String)jsonParserFieldValue);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "id")) {
@@ -586,4 +622,4 @@ public class ChildTestEntity3SerDes {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1080431968
+// LIFERAY-REST-BUILDER-HASH:179202052

--- a/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/serdes/v1_0/TestEntitySerDes.java
+++ b/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/serdes/v1_0/TestEntitySerDes.java
@@ -122,6 +122,15 @@ public class TestEntitySerDes {
 			map.put("documentId", String.valueOf(testEntity.getDocumentId()));
 		}
 
+		if (testEntity.getExternalReferenceCode() == null) {
+			map.put("externalReferenceCode", null);
+		}
+		else {
+			map.put(
+				"externalReferenceCode",
+				String.valueOf(testEntity.getExternalReferenceCode()));
+		}
+
 		if (testEntity.getId() == null) {
 			map.put("id", null);
 		}
@@ -223,6 +232,11 @@ public class TestEntitySerDes {
 			else if (Objects.equals(jsonParserFieldName, "documentId")) {
 				return false;
 			}
+			else if (Objects.equals(
+						jsonParserFieldName, "externalReferenceCode")) {
+
+				return false;
+			}
 			else if (Objects.equals(jsonParserFieldName, "id")) {
 				return false;
 			}
@@ -311,6 +325,14 @@ public class TestEntitySerDes {
 				if (jsonParserFieldValue != null) {
 					testEntity.setDocumentId(
 						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "externalReferenceCode")) {
+
+				if (jsonParserFieldValue != null) {
+					testEntity.setExternalReferenceCode(
+						(String)jsonParserFieldValue);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "id")) {
@@ -448,4 +470,4 @@ public class TestEntitySerDes {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:612167682
+// LIFERAY-REST-BUILDER-HASH:1962982168

--- a/modules/util/portal-tools-rest-builder-test-impl/rest-openapi.yaml
+++ b/modules/util/portal-tools-rest-builder-test-impl/rest-openapi.yaml
@@ -338,6 +338,8 @@ components:
                 documentId:
                     format: int64
                     type: integer
+                externalReferenceCode:
+                    type: string
                 id:
                     format: int64
                     readOnly: true
@@ -2636,6 +2638,23 @@ paths:
                         application/xml:
                             schema:
                                 $ref: "#/components/schemas/TestEntity"
+            tags: ["TestEntity"]
+    "/test-entities/by-external-reference-code/{externalReferenceCode}":
+        delete:
+            operationId: deleteTestEntityByExternalReferenceCode
+            parameters:
+                -   in: path
+                    name: externalReferenceCode
+                    required: true
+                    schema:
+                        type: string
+            responses:
+                200:
+                    content:
+                        application/json: {}
+                        application/xml: {}
+                    description:
+                        "OK"
             tags: ["TestEntity"]
     "/test-entities/count":
         get:

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/graphql/mutation/v1_0/Mutation.java
@@ -1592,6 +1592,21 @@ public class Mutation {
 	}
 
 	@GraphQLField
+	public boolean deleteTestEntityByExternalReferenceCode(
+			@GraphQLName("externalReferenceCode") String externalReferenceCode)
+		throws Exception {
+
+		_applyVoidComponentServiceObjects(
+			_testEntityResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			testEntityResource ->
+				testEntityResource.deleteTestEntityByExternalReferenceCode(
+					externalReferenceCode));
+
+		return true;
+	}
+
+	@GraphQLField
 	public TestEntity patchTestEntity(
 			@GraphQLName("testEntityId") Long testEntityId,
 			@GraphQLName("optionalParameter") Long optionalParameter,
@@ -2126,4 +2141,4 @@ public class Mutation {
 		_vulcanBatchEngineImportTaskResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-531622753
+// LIFERAY-REST-BUILDER-HASH:-364271703

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/graphql/query/v1_0/Query.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/graphql/query/v1_0/Query.java
@@ -990,7 +990,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {testEntity(testEntityId: ___){dateCreated, dateModified, description, documentId, id, jsonProperty, name, nestedTestEntity, self, stringTestEntities, stringTestEntity, testEntities, type}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {testEntity(testEntityId: ___){dateCreated, dateModified, description, documentId, externalReferenceCode, id, jsonProperty, name, nestedTestEntity, self, stringTestEntities, stringTestEntity, testEntities, type}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField
 	public TestEntity testEntity(@GraphQLName("testEntityId") Long testEntityId)
@@ -2150,4 +2150,4 @@ public class Query {
 	private com.liferay.portal.kernel.model.User _user;
 
 }
-// LIFERAY-REST-BUILDER-HASH:708482390
+// LIFERAY-REST-BUILDER-HASH:-1568869523

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -582,6 +582,11 @@ public class ServletDataImpl implements ServletData {
 							TestEntityResourceImpl.class,
 							"deleteTestEntityBatch"));
 					put(
+						"mutation#deleteTestEntityByExternalReferenceCode",
+						new ObjectValuePair<>(
+							TestEntityResourceImpl.class,
+							"deleteTestEntityByExternalReferenceCode"));
+					put(
 						"mutation#patchTestEntity",
 						new ObjectValuePair<>(
 							TestEntityResourceImpl.class, "patchTestEntity"));
@@ -940,4 +945,4 @@ public class ServletDataImpl implements ServletData {
 		_testEntityAddressResourceComponentServiceObjects;
 
 }
-// LIFERAY-REST-BUILDER-HASH:593829650
+// LIFERAY-REST-BUILDER-HASH:-1712790753

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseTestEntityResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseTestEntityResourceImpl.java
@@ -169,6 +169,36 @@ public abstract class BaseTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
+	 * curl -X 'DELETE' 'http://localhost:8080/o/test/v1.0/test-entities/by-external-reference-code/{externalReferenceCode}'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "externalReferenceCode"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "TestEntity")}
+	)
+	@jakarta.ws.rs.DELETE
+	@jakarta.ws.rs.Path(
+		"/test-entities/by-external-reference-code/{externalReferenceCode}"
+	)
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public void deleteTestEntityByExternalReferenceCode(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("externalReferenceCode")
+			String externalReferenceCode)
+		throws Exception {
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
 	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/test-entities'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
@@ -246,7 +276,7 @@ public abstract class BaseTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PATCH' 'http://localhost:8080/o/test/v1.0/test-entities/{testEntityId}' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "documentId": ___, "jsonProperty": ___, "name": ___, "nestedTestEntity": ___, "self": ___, "stringTestEntities": ___, "stringTestEntity": ___, "testEntities": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PATCH' 'http://localhost:8080/o/test/v1.0/test-entities/{testEntityId}' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "documentId": ___, "externalReferenceCode": ___, "jsonProperty": ___, "name": ___, "nestedTestEntity": ___, "self": ___, "stringTestEntities": ___, "stringTestEntity": ___, "testEntities": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -295,6 +325,11 @@ public abstract class BaseTestEntityResourceImpl
 
 		if (testEntity.getDocumentId() != null) {
 			existingTestEntity.setDocumentId(testEntity.getDocumentId());
+		}
+
+		if (testEntity.getExternalReferenceCode() != null) {
+			existingTestEntity.setExternalReferenceCode(
+				testEntity.getExternalReferenceCode());
 		}
 
 		if (testEntity.getJsonProperty() != null) {
@@ -407,7 +442,7 @@ public abstract class BaseTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/test-entities' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "documentId": ___, "jsonProperty": ___, "name": ___, "nestedTestEntity": ___, "self": ___, "stringTestEntities": ___, "stringTestEntity": ___, "testEntities": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/test-entities' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "documentId": ___, "externalReferenceCode": ___, "jsonProperty": ___, "name": ___, "nestedTestEntity": ___, "self": ___, "stringTestEntities": ___, "stringTestEntity": ___, "testEntities": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.tags.Tags(
 		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "TestEntity")}
@@ -514,7 +549,7 @@ public abstract class BaseTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/test/v1.0/test-entities/{testEntityId}' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "documentId": ___, "jsonProperty": ___, "name": ___, "nestedTestEntity": ___, "self": ___, "stringTestEntities": ___, "stringTestEntity": ___, "testEntities": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/test/v1.0/test-entities/{testEntityId}' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "documentId": ___, "externalReferenceCode": ___, "jsonProperty": ___, "name": ___, "nestedTestEntity": ___, "self": ___, "stringTestEntities": ___, "stringTestEntity": ___, "testEntities": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -604,7 +639,7 @@ public abstract class BaseTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/test/v1.0/test-entities/{testEntityId}/status' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "documentId": ___, "jsonProperty": ___, "name": ___, "nestedTestEntity": ___, "self": ___, "stringTestEntities": ___, "stringTestEntity": ___, "testEntities": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/test/v1.0/test-entities/{testEntityId}/status' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "documentId": ___, "externalReferenceCode": ___, "jsonProperty": ___, "name": ___, "nestedTestEntity": ___, "self": ___, "stringTestEntities": ___, "stringTestEntity": ___, "testEntities": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -679,11 +714,32 @@ public abstract class BaseTestEntityResourceImpl
 
 		UnsafeFunction<TestEntity, TestEntity, Exception>
 			testEntityUnsafeFunction = testEntity -> {
-				deleteTestEntity(
-					testEntity.getId(),
-					_parseBoolean((String)parameters.get("permanent")));
+				if (testEntity.getId() != null) {
+					try {
+						deleteTestEntity(
+							testEntity.getId(),
+							_parseBoolean((String)parameters.get("permanent")));
 
-				return testEntity;
+						return testEntity;
+					}
+					catch (Exception exception) {
+						if (testEntity.getExternalReferenceCode() != null) {
+							deleteTestEntityByExternalReferenceCode(
+								testEntity.getExternalReferenceCode());
+
+							return testEntity;
+						}
+					}
+				}
+				else if (testEntity.getExternalReferenceCode() != null) {
+					deleteTestEntityByExternalReferenceCode(
+						testEntity.getExternalReferenceCode());
+
+					return testEntity;
+				}
+
+				throw new UnsupportedOperationException(
+					"Unable to delete by external reference code or ID");
 			};
 
 		if (contextBatchUnsafeBiConsumer != null) {
@@ -1417,4 +1473,4 @@ public abstract class BaseTestEntityResourceImpl
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1843325977
+// LIFERAY-REST-BUILDER-HASH:-1282794480

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/TestEntityResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/TestEntityResourceImpl.java
@@ -24,6 +24,7 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -119,7 +120,7 @@ public class TestEntityResourceImpl extends BaseTestEntityResourceImpl {
 	public TestEntity postTestEntity(TestEntity testEntity) {
 		testEntity.setDateCreated(new Date());
 		testEntity.setDateModified(new Date());
-		testEntity.setId((long)_testEntities.size());
+		testEntity.setId(_nextId.getAndIncrement());
 
 		_testEntities.add(testEntity);
 
@@ -149,16 +150,24 @@ public class TestEntityResourceImpl extends BaseTestEntityResourceImpl {
 	public TestEntity putTestEntity(
 		Long testEntityId, Long optionalParameter, TestEntity testEntity) {
 
-		TestEntity oldTestEntity = _testEntities.set(
-			Math.toIntExact(testEntityId), testEntity);
+		for (int i = 0; i < _testEntities.size(); i++) {
+			TestEntity oldTestEntity = _testEntities.get(i);
 
-		testEntity.setDateCreated(oldTestEntity.getDateCreated());
-		testEntity.setDateModified(oldTestEntity.getDateModified());
-		testEntity.setId(oldTestEntity.getId());
+			if (Objects.equals(oldTestEntity.getId(), testEntityId)) {
+				testEntity.setDateCreated(oldTestEntity.getDateCreated());
+				testEntity.setDateModified(oldTestEntity.getDateModified());
+				testEntity.setId(oldTestEntity.getId());
 
-		return testEntity;
+				_testEntities.set(i, testEntity);
+
+				return testEntity;
+			}
+		}
+
+		throw new IndexOutOfBoundsException();
 	}
 
+	private static final AtomicLong _nextId = new AtomicLong(1);
 	private static final List<TestEntity> _testEntities = new ArrayList<>();
 
 	@Reference

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/TestEntityResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/TestEntityResourceImpl.java
@@ -60,6 +60,29 @@ public class TestEntityResourceImpl extends BaseTestEntityResourceImpl {
 	}
 
 	@Override
+	public void deleteTestEntityByExternalReferenceCode(
+			String externalReferenceCode)
+		throws Exception {
+
+		Iterator<TestEntity> testEntityIterator = _testEntities.iterator();
+
+		while (testEntityIterator.hasNext()) {
+			TestEntity testEntity = testEntityIterator.next();
+
+			if (Objects.equals(
+					testEntity.getExternalReferenceCode(),
+					externalReferenceCode)) {
+
+				testEntityIterator.remove();
+
+				return;
+			}
+		}
+
+		throw new NoSuchModelException();
+	}
+
+	@Override
 	public EntityModel getEntityModel(MultivaluedMap multivaluedMap) {
 		return new TestEntityEntityModel();
 	}

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseTestEntityResourceTestCase.java
@@ -214,6 +214,7 @@ public abstract class BaseTestEntityResourceTestCase {
 		TestEntity testEntity = randomTestEntity();
 
 		testEntity.setDescription(regex);
+		testEntity.setExternalReferenceCode(regex);
 		testEntity.setJsonProperty(regex);
 		testEntity.setName(regex);
 		testEntity.setSelf(regex);
@@ -225,6 +226,7 @@ public abstract class BaseTestEntityResourceTestCase {
 		testEntity = TestEntitySerDes.toDTO(json);
 
 		Assert.assertEquals(regex, testEntity.getDescription());
+		Assert.assertEquals(regex, testEntity.getExternalReferenceCode());
 		Assert.assertEquals(regex, testEntity.getJsonProperty());
 		Assert.assertEquals(regex, testEntity.getName());
 		Assert.assertEquals(regex, testEntity.getSelf());
@@ -332,11 +334,40 @@ public abstract class BaseTestEntityResourceTestCase {
 		TestEntity testEntity1 = testDeleteTestEntityBatch_addTestEntity();
 
 		testDeleteTestEntityBatch_deleteTestEntity(
+			202, testEntity1.getExternalReferenceCode(), null);
+
+		assertHttpResponseStatusCode(
+			404,
+			testEntityResource.getTestEntityHttpResponse(testEntity1.getId()));
+
+		testEntity1 = testDeleteTestEntityBatch_addTestEntity();
+
+		testDeleteTestEntityBatch_deleteTestEntity(
 			202, null, testEntity1.getId());
 
 		assertHttpResponseStatusCode(
 			404,
 			testEntityResource.getTestEntityHttpResponse(testEntity1.getId()));
+
+		testEntity1 = testDeleteTestEntityBatch_addTestEntity();
+		TestEntity testEntity2 = testDeleteTestEntityBatch_addTestEntity();
+
+		testDeleteTestEntityBatch_deleteTestEntity(
+			202, testEntity2.getExternalReferenceCode(), testEntity1.getId());
+
+		assertHttpResponseStatusCode(
+			404,
+			testEntityResource.getTestEntityHttpResponse(testEntity1.getId()));
+		assertHttpResponseStatusCode(
+			200,
+			testEntityResource.getTestEntityHttpResponse(testEntity2.getId()));
+
+		testDeleteTestEntityBatch_deleteTestEntity(
+			202, testEntity2.getExternalReferenceCode(), testEntity1.getId());
+
+		assertHttpResponseStatusCode(
+			404,
+			testEntityResource.getTestEntityHttpResponse(testEntity2.getId()));
 	}
 
 	protected TestEntity testDeleteTestEntityBatch_addTestEntity()
@@ -364,6 +395,86 @@ public abstract class BaseTestEntityResourceTestCase {
 		waitForFinish(
 			"COMPLETED",
 			JSONFactoryUtil.createJSONObject(httpResponse.getContent()));
+	}
+
+	@Test
+	public void testDeleteTestEntityByExternalReferenceCode() throws Exception {
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		TestEntity testEntity =
+			testDeleteTestEntityByExternalReferenceCode_addTestEntity();
+
+		assertHttpResponseStatusCode(
+			204,
+			testEntityResource.
+				deleteTestEntityByExternalReferenceCodeHttpResponse(
+					testEntity.getExternalReferenceCode()));
+	}
+
+	protected TestEntity
+			testDeleteTestEntityByExternalReferenceCode_addTestEntity()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testGraphQLDeleteTestEntityByExternalReferenceCode()
+		throws Exception {
+
+		// No namespace
+
+		TestEntity testEntity1 =
+			testGraphQLDeleteTestEntityByExternalReferenceCode_addTestEntity();
+
+		Assert.assertTrue(
+			JSONUtil.getValueAsBoolean(
+				invokeGraphQLMutation(
+					new GraphQLField(
+						"deleteTestEntityByExternalReferenceCode",
+						new HashMap<String, Object>() {
+							{
+								put(
+									"externalReferenceCode",
+									"\"" +
+										testEntity1.getExternalReferenceCode() +
+											"\"");
+							}
+						})),
+				"JSONObject/data",
+				"Object/deleteTestEntityByExternalReferenceCode"));
+
+		// Using the namespace test_v1_0
+
+		TestEntity testEntity2 =
+			testGraphQLDeleteTestEntityByExternalReferenceCode_addTestEntity();
+
+		Assert.assertTrue(
+			JSONUtil.getValueAsBoolean(
+				invokeGraphQLMutation(
+					new GraphQLField(
+						"test_v1_0",
+						new GraphQLField(
+							"deleteTestEntityByExternalReferenceCode",
+							new HashMap<String, Object>() {
+								{
+									put(
+										"externalReferenceCode",
+										"\"" +
+											testEntity2.
+												getExternalReferenceCode() +
+													"\"");
+								}
+							}))),
+				"JSONObject/data", "JSONObject/test_v1_0",
+				"Object/deleteTestEntityByExternalReferenceCode"));
+	}
+
+	protected TestEntity
+			testGraphQLDeleteTestEntityByExternalReferenceCode_addTestEntity()
+		throws Exception {
+
+		return testGraphQLTestEntity_addTestEntity();
 	}
 
 	@Test
@@ -911,6 +1022,8 @@ public abstract class BaseTestEntityResourceTestCase {
 				description = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
 				documentId = RandomTestUtil.randomLong();
+				externalReferenceCode = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
 				id = RandomTestUtil.randomLong();
 				jsonProperty = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
@@ -934,6 +1047,8 @@ public abstract class BaseTestEntityResourceTestCase {
 				description = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
 				documentId = RandomTestUtil.randomLong();
+				externalReferenceCode = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
 				id = RandomTestUtil.randomLong();
 				jsonProperty = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
@@ -957,6 +1072,8 @@ public abstract class BaseTestEntityResourceTestCase {
 				description = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
 				documentId = RandomTestUtil.randomLong();
+				externalReferenceCode = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
 				id = RandomTestUtil.randomLong();
 				jsonProperty = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
@@ -1068,11 +1185,41 @@ public abstract class BaseTestEntityResourceTestCase {
 			testBatchEngineDeleteImportTask_addTestEntity();
 
 		testBatchEngineDeleteImportTask_deleteTestEntity(
+			200, testEntity1.getExternalReferenceCode(), null);
+
+		assertHttpResponseStatusCode(
+			404,
+			testEntityResource.getTestEntityHttpResponse(testEntity1.getId()));
+
+		testEntity1 = testBatchEngineDeleteImportTask_addTestEntity();
+
+		testBatchEngineDeleteImportTask_deleteTestEntity(
 			200, null, testEntity1.getId());
 
 		assertHttpResponseStatusCode(
 			404,
 			testEntityResource.getTestEntityHttpResponse(testEntity1.getId()));
+
+		testEntity1 = testBatchEngineDeleteImportTask_addTestEntity();
+		TestEntity testEntity2 =
+			testBatchEngineDeleteImportTask_addTestEntity();
+
+		testBatchEngineDeleteImportTask_deleteTestEntity(
+			200, testEntity2.getExternalReferenceCode(), testEntity1.getId());
+
+		assertHttpResponseStatusCode(
+			404,
+			testEntityResource.getTestEntityHttpResponse(testEntity1.getId()));
+		assertHttpResponseStatusCode(
+			200,
+			testEntityResource.getTestEntityHttpResponse(testEntity2.getId()));
+
+		testBatchEngineDeleteImportTask_deleteTestEntity(
+			200, testEntity2.getExternalReferenceCode(), testEntity1.getId());
+
+		assertHttpResponseStatusCode(
+			404,
+			testEntityResource.getTestEntityHttpResponse(testEntity2.getId()));
 	}
 
 	protected TestEntity testBatchEngineDeleteImportTask_addTestEntity()
@@ -1335,6 +1482,16 @@ public abstract class BaseTestEntityResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals(
+					"externalReferenceCode", additionalAssertFieldName)) {
+
+				if (testEntity.getExternalReferenceCode() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("jsonProperty", additionalAssertFieldName)) {
 				if (testEntity.getJsonProperty() == null) {
 					valid = false;
@@ -1483,6 +1640,8 @@ public abstract class BaseTestEntityResourceTestCase {
 	protected List<GraphQLField> getGraphQLFields() throws Exception {
 		List<GraphQLField> graphQLFields = new ArrayList<>();
 
+		graphQLFields.add(new GraphQLField("externalReferenceCode"));
+
 		graphQLFields.add(new GraphQLField("id"));
 
 		for (java.lang.reflect.Field field :
@@ -1581,6 +1740,19 @@ public abstract class BaseTestEntityResourceTestCase {
 				if (!Objects.deepEquals(
 						testEntity1.getDocumentId(),
 						testEntity2.getDocumentId())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"externalReferenceCode", additionalAssertFieldName)) {
+
+				if (!Objects.deepEquals(
+						testEntity1.getExternalReferenceCode(),
+						testEntity2.getExternalReferenceCode())) {
 
 					return false;
 				}
@@ -1935,6 +2107,52 @@ public abstract class BaseTestEntityResourceTestCase {
 				"Invalid entity field " + entityFieldName);
 		}
 
+		if (entityFieldName.equals("externalReferenceCode")) {
+			Object object = testEntity.getExternalReferenceCode();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
 		if (entityFieldName.equals("id")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
@@ -2155,6 +2373,8 @@ public abstract class BaseTestEntityResourceTestCase {
 				testEntity.setDescription(
 					StringUtil.toLowerCase(RandomTestUtil.randomString()));
 				testEntity.setDocumentId(RandomTestUtil.randomLong());
+				testEntity.setExternalReferenceCode(
+					StringUtil.toLowerCase(RandomTestUtil.randomString()));
 				testEntity.setId(RandomTestUtil.randomLong());
 				testEntity.setJsonProperty(
 					StringUtil.toLowerCase(RandomTestUtil.randomString()));
@@ -2178,6 +2398,8 @@ public abstract class BaseTestEntityResourceTestCase {
 				testEntity.setDescription(
 					StringUtil.toLowerCase(RandomTestUtil.randomString()));
 				testEntity.setDocumentId(RandomTestUtil.randomLong());
+				testEntity.setExternalReferenceCode(
+					StringUtil.toLowerCase(RandomTestUtil.randomString()));
 				testEntity.setId(RandomTestUtil.randomLong());
 				testEntity.setJsonProperty(
 					StringUtil.toLowerCase(RandomTestUtil.randomString()));
@@ -2201,6 +2423,8 @@ public abstract class BaseTestEntityResourceTestCase {
 				testEntity.setDescription(
 					StringUtil.toLowerCase(RandomTestUtil.randomString()));
 				testEntity.setDocumentId(RandomTestUtil.randomLong());
+				testEntity.setExternalReferenceCode(
+					StringUtil.toLowerCase(RandomTestUtil.randomString()));
 				testEntity.setId(RandomTestUtil.randomLong());
 				testEntity.setJsonProperty(
 					StringUtil.toLowerCase(RandomTestUtil.randomString()));
@@ -2486,4 +2710,4 @@ public abstract class BaseTestEntityResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-31913864
+// LIFERAY-REST-BUILDER-HASH:1033368029

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/TestEntityResourceTest.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/TestEntityResourceTest.java
@@ -42,13 +42,6 @@ public class TestEntityResourceTest extends BaseTestEntityResourceTestCase {
 	@Ignore
 	@Override
 	@Test
-	public void testBatchEngineDeleteImportTask() throws Exception {
-		super.testBatchEngineDeleteImportTask();
-	}
-
-	@Ignore
-	@Override
-	@Test
 	public void testDeleteTestEntityBatch() throws Exception {
 		super.testDeleteTestEntityBatch();
 	}
@@ -286,6 +279,14 @@ public class TestEntityResourceTest extends BaseTestEntityResourceTestCase {
 
 	@Override
 	protected TestEntity testDeleteTestEntity_addTestEntity() throws Exception {
+		return testGetTestEntitiesPage_addTestEntity(randomTestEntity());
+	}
+
+	@Override
+	protected TestEntity
+			testDeleteTestEntityByExternalReferenceCode_addTestEntity()
+		throws Exception {
+
 		return testGetTestEntitiesPage_addTestEntity(randomTestEntity());
 	}
 


### PR DESCRIPTION
## Summary

Jira: [LPD-86581](https://liferay.atlassian.net/browse/LPD-86581)

### Issue
Batch imports of type `DELETE` targeting a polymorphic headless DTO
(annotated with `@JsonTypeInfo` + `@JsonSubTypes`) were failing with
`InvalidTypeIdException`. DELETE rows carry only `externalReferenceCode`
and no discriminator field, so Jackson's discriminator-based class
resolution had nothing to work with.

### Fix
`BatchEngineImportTaskItemReaderUtil.convertValue` now recognizes the
polymorphic-DELETE case and bypasses `_resolveClass`, using the first
`@JsonSubTypes` entry as a carrier. Delete dispatch is keyed on the
model class (not the DTO subtype) and delete handlers only read
`getExternalReferenceCode()` / `getId()`, which live on the shared
abstract base — so any concrete subtype is a valid carrier.
`_resolveClass` is left as a pure discriminator-driven resolver for
`CREATE` and `UPDATE`.

### Test coverage
Extended the REST Builder dummy modules so `TestEntity` (the existing
polymorphic dummy with `ChildTestEntity1/2/3`) carries an
`externalReferenceCode` and exposes a delete-by-ERC endpoint. The
auto-generated `testBatchEngineDeleteImportTask` in
`TestEntityResourceTest` was un-`@Ignore`d and now exercises the
carrier path end-to-end: it submits DELETE rows against the abstract
polymorphic `TestEntity` class with payloads containing only
`externalReferenceCode` and/or `id`. Without the fix, the batch engine
throws `InvalidTypeIdException`; with the fix, the batch completes as
expected.

Also hardened the dummy `TestEntityResourceImpl` id scheme
(`AtomicLong` counter instead of list size) so ids never collide after
deletes.

## Test plan
- [ ] `./gradlew :util:portal-tools-rest-builder-test-test:testIntegration --tests "com.liferay.portal.tools.rest.builder.test.resource.v1_0.test.TestEntityResourceTest"` passes
- [ ] Regression check: revert the `_isPolymorphicDeletion` branch locally, rerun `testBatchEngineDeleteImportTask`, confirm it fails with `InvalidTypeIdException`