### PR TITLE
LPD-87008 | Match new custom task export filename without timestamp suffix

### DIFF
--- a/modules/test/playwright/tests/export-import-web/main/instance.export.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/instance.export.spec.ts
@@ -385,7 +385,7 @@ test('can export new default and custom task name', async ({
 	});
 
 	expect(customExportFilePath).toMatch(
-		new RegExp(`^${getTempDir()}${taskName}-`)
+		new RegExp(`^${getTempDir()}${taskName}\\.lar$`)
 	);
 });
 


### PR DESCRIPTION
## Jira
[LPD-87008](https://liferay.atlassian.net/browse/LPD-87008) — addresses the acceptance failure tracked in [LPD-86967](https://liferay.atlassian.net/browse/LPD-86967).

## Description
The custom-task-name LAR export is now named without a timestamp suffix (e.g. `CustomTaskName.lar` instead of `CustomTaskName-<timestamp>.lar`). This PR updates the expected-filename regex in `tests/export-import-web/main/instance.export.spec.ts` to match the new naming.

## Test
From `modules/test/playwright/`:

` npx playwright test --project='export-import-web.main' tests/export-import-web/main/instance.export.spec.ts `

The relevant test is `can export new default and custom task name` (line 348).

## Before
`can export new default and custom task name` failed at the filename regex assertion:

- Expected pattern: `/^.*/tmp/CustomTaskName-/`
- Received string: `.../tmp/CustomTaskName.lar`

## After
The regex is updated to match the new filename without the timestamp.

Spec result locally on a clean bundle: **10/10 passed (1.7m)**.