### PR TITLE
LPD-87300 Add UnsyncBufferedReader petra io location to avoid REST Builder errors after bumping the com.liferay.portal.tools.java.parser version (1.0.57 -> 1.0.58)

### DIFF
--- a/modules/util/portal-tools-rest-builder/bnd.bnd
+++ b/modules/util/portal-tools-rest-builder/bnd.bnd
@@ -13,6 +13,7 @@ Main-Class: com.liferay.portal.tools.rest.builder.RESTBuilder
 	@com.liferay.petra.function-*.jar!/com/liferay/petra/function/transform/TransformUtil.class,\
 	@com.liferay.petra.io-*.jar!/com/liferay/petra/io/StreamUtil.class,\
 	@com.liferay.petra.io-*.jar!/com/liferay/petra/io/unsync/BoundaryCheckerUtil.class,\
+	@com.liferay.petra.io-*.jar!/com/liferay/petra/io/unsync/UnsyncBufferedReader.class,\
 	@com.liferay.petra.io-*.jar!/com/liferay/petra/io/unsync/UnsyncByteArrayOutputStream.class,\
 	@com.liferay.petra.io-*.jar!/com/liferay/petra/io/unsync/UnsyncStringReader.class,\
 	@com.liferay.petra.lang-*.jar!/com/liferay/petra/lang/CentralizedThreadLocal.class,\


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPD-87300