### PR TITLE
LPD-85155 optimize batch export pagination by avoiding offset queries

### DIFF
--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineExportTaskExecutorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineExportTaskExecutorImpl.java
@@ -213,7 +213,7 @@ public class BatchEngineExportTaskExecutorImpl
 	}
 
 	private Filter _createCursorFilter(
-		Filter originalFilter, long lastEntryClassPK) {
+		long lastEntryClassPK, Filter originalFilter) {
 
 		BooleanFilter booleanFilter = new BooleanFilter();
 
@@ -296,23 +296,12 @@ public class BatchEngineExportTaskExecutorImpl
 			Sort[] sorts = _getSorts(
 				batchEngineTaskItemDelegate, parameters, user);
 
-			boolean cursorPaginationActive = false;
-
-			if (_USE_EXPORT_CURSOR_PAGINATION &&
-				_isSearchCursorPaginationEnabled(sorts)) {
-
-				cursorPaginationActive = true;
-			}
-
-			int batchIndex = 1;
-
-			long readStartTimeNs = System.nanoTime();
+			boolean cursorPaginationActive = _isSearchCursorPaginationEnabled(
+				sorts);
 
 			Page<?> page = batchEngineTaskItemDelegate.read(
 				filter, Pagination.of(1, exportBatchSize), sorts,
 				filteredParameters, (String)parameters.get("search"));
-
-			long readTimeMs = (System.nanoTime() - readStartTimeNs) / 1_000_000;
 
 			batchEngineExportTask.setTotalItemsCount(
 				Math.toIntExact(page.getTotalCount()));
@@ -335,12 +324,7 @@ public class BatchEngineExportTaskExecutorImpl
 					}
 				}
 
-				long writeStartTimeNs = System.nanoTime();
-
 				batchEngineExportTaskItemWriter.write(items);
-
-				long writeTimeMs =
-					(System.nanoTime() - writeStartTimeNs) / 1_000_000;
 
 				batchEngineExportTask.setProcessedItemsCount(
 					batchEngineExportTask.getProcessedItemsCount() +
@@ -366,24 +350,7 @@ public class BatchEngineExportTaskExecutorImpl
 							updateBatchEngineExportTask(batchEngineExportTask);
 				}
 
-				long syncLastSessionStartTimeNs = System.nanoTime();
-
 				_clearSessionPersistenceContext();
-
-				long syncLastSessionTimeMs =
-					(System.nanoTime() - syncLastSessionStartTimeNs) /
-						1_000_000;
-
-				System.out.println(
-					String.format(
-						"{\"event\":\"batchExportMetrics\",\"batchIndex\":" +
-							"%d,\"readTimeMs\":%d,\"writeTimeMs\":%d," +
-								"\"syncLastSessionTimeMs\":%d," +
-									"\"itemCount\":%d,\"processedItemsCount\":" +
-										"%d}",
-						batchIndex, readTimeMs, writeTimeMs,
-						syncLastSessionTimeMs, items.size(),
-						batchEngineExportTask.getProcessedItemsCount()));
 
 				if (Thread.interrupted()) {
 					throw new InterruptedException();
@@ -406,26 +373,18 @@ public class BatchEngineExportTaskExecutorImpl
 					}
 				}
 
+				Filter readFilter = filter;
+				Pagination pagination = Pagination.of(
+					(int)page.getPage() + 1, exportBatchSize);
+
 				if (cursorPaginationActive) {
-					readStartTimeNs = System.nanoTime();
-
-					page = batchEngineTaskItemDelegate.read(
-						_createCursorFilter(filter, lastItemId),
-						Pagination.of(1, exportBatchSize), sorts,
-						filteredParameters, (String)parameters.get("search"));
-				}
-				else {
-					readStartTimeNs = System.nanoTime();
-
-					page = batchEngineTaskItemDelegate.read(
-						filter,
-						Pagination.of((int)page.getPage() + 1, exportBatchSize),
-						sorts, filteredParameters,
-						(String)parameters.get("search"));
+					readFilter = _createCursorFilter(lastItemId, filter);
+					pagination = Pagination.of(1, exportBatchSize);
 				}
 
-				readTimeMs = (System.nanoTime() - readStartTimeNs) / 1_000_000;
-				batchIndex++;
+				page = batchEngineTaskItemDelegate.read(
+					readFilter, pagination, sorts, filteredParameters,
+					(String)parameters.get("search"));
 
 				items = page.getItems();
 			}
@@ -568,16 +527,6 @@ public class BatchEngineExportTaskExecutorImpl
 		return filteredParameters;
 	}
 
-	private Long _getFirstItemId(Collection<?> items) {
-		if (items.isEmpty()) {
-			return null;
-		}
-
-		return _getItemId(
-			items.iterator(
-			).next());
-	}
-
 	private Long _getItemId(Object item) {
 		try {
 			Method method = item.getClass(
@@ -592,7 +541,9 @@ public class BatchEngineExportTaskExecutorImpl
 			}
 
 			if (id instanceof Number) {
-				return ((Number)id).longValue();
+				Number number = (Number)id;
+
+				return number.longValue();
 			}
 		}
 		catch (Exception exception) {
@@ -733,8 +684,6 @@ public class BatchEngineExportTaskExecutorImpl
 			batchEngineExportTask.getExecuteStatus(),
 			batchEngineExportTask.getBatchEngineExportTaskId());
 	}
-
-	private static final boolean _USE_EXPORT_CURSOR_PAGINATION = true;
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		BatchEngineExportTaskExecutorImpl.class);

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineExportTaskExecutorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineExportTaskExecutorImpl.java
@@ -35,8 +35,12 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.module.configuration.ConfigurationException;
+import com.liferay.portal.kernel.search.BooleanClauseOccur;
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.search.filter.RangeTermFilter;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
@@ -60,6 +64,8 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
+
+import java.lang.reflect.Method;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -206,6 +212,24 @@ public class BatchEngineExportTaskExecutorImpl
 		LastSessionRecorderHelperUtil.syncLastSessionState();
 	}
 
+	private Filter _createCursorFilter(
+		Filter originalFilter, long lastEntryClassPK) {
+
+		BooleanFilter booleanFilter = new BooleanFilter();
+
+		if (originalFilter != null) {
+			booleanFilter.add(originalFilter, BooleanClauseOccur.MUST);
+		}
+
+		booleanFilter.add(
+			new RangeTermFilter(
+				Field.ENTRY_CLASS_PK, false, false,
+				String.valueOf(lastEntryClassPK), null),
+			BooleanClauseOccur.MUST);
+
+		return booleanFilter;
+	}
+
 	private InputStream _exportItems(
 			BatchEngineExportTask batchEngineExportTask, Settings settings)
 		throws Exception {
@@ -272,6 +296,9 @@ public class BatchEngineExportTaskExecutorImpl
 			Sort[] sorts = _getSorts(
 				batchEngineTaskItemDelegate, parameters, user);
 
+			boolean cursorPaginationActive =
+				_USE_EXPORT_CURSOR_PAGINATION &&
+					_isSearchCursorPaginationEnabled(sorts);
 			Page<?> page = batchEngineTaskItemDelegate.read(
 				filter, Pagination.of(1, exportBatchSize), sorts,
 				filteredParameters, (String)parameters.get("search"));
@@ -336,11 +363,29 @@ public class BatchEngineExportTaskExecutorImpl
 					break;
 				}
 
-				page = batchEngineTaskItemDelegate.read(
-					filter,
-					Pagination.of((int)page.getPage() + 1, exportBatchSize),
-					sorts, filteredParameters,
-					(String)parameters.get("search"));
+				Long lastItemId = null;
+
+				if (cursorPaginationActive) {
+					lastItemId = _getLastItemId(items);
+
+					if (lastItemId == null) {
+						cursorPaginationActive = false;
+					}
+				}
+
+				if (cursorPaginationActive) {
+					page = batchEngineTaskItemDelegate.read(
+						_createCursorFilter(filter, lastItemId),
+						Pagination.of(1, exportBatchSize), sorts, filteredParameters,
+						(String)parameters.get("search"));
+				}
+				else {
+					page = batchEngineTaskItemDelegate.read(
+						filter, Pagination.of(
+							(int)page.getPage() + 1, exportBatchSize), sorts,
+						filteredParameters,
+						(String)parameters.get("search"));
+				}
 
 				items = page.getItems();
 			}
@@ -483,6 +528,53 @@ public class BatchEngineExportTaskExecutorImpl
 		return filteredParameters;
 	}
 
+	private Long _getFirstItemId(Collection<?> items) {
+		if (items.isEmpty()) {
+			return null;
+		}
+
+		return _getItemId(items.iterator().next());
+	}
+
+	private Long _getItemId(Object item) {
+		try {
+			Method method = item.getClass().getMethod("getId");
+
+			Object id = method.invoke(item);
+
+			if (id instanceof Long) {
+				return (Long)id;
+			}
+
+			if (id instanceof Number) {
+				return ((Number)id).longValue();
+			}
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Unable to extract ID from " + item.getClass(),
+					exception);
+			}
+		}
+
+		return null;
+	}
+
+	private Long _getLastItemId(Collection<?> items) {
+		if (items.isEmpty()) {
+			return null;
+		}
+
+		Object lastItem = null;
+
+		for (Object item : items) {
+			lastItem = item;
+		}
+
+		return _getItemId(lastItem);
+	}
+
 	private Map<String, Serializable> _getParameters(
 		BatchEngineExportTask batchEngineExportTask) {
 
@@ -556,6 +648,10 @@ public class BatchEngineExportTaskExecutorImpl
 		return zipOutputStream;
 	}
 
+	private boolean _isSearchCursorPaginationEnabled(Sort[] sorts) {
+		return sorts == null;
+	}
+
 	private Map<String, List<String>> _toMultivaluedMap(
 		Map<String, Serializable> parameterMap) {
 
@@ -589,6 +685,8 @@ public class BatchEngineExportTaskExecutorImpl
 			batchEngineExportTask.getExecuteStatus(),
 			batchEngineExportTask.getBatchEngineExportTaskId());
 	}
+
+	private static final boolean _USE_EXPORT_CURSOR_PAGINATION = true;
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		BatchEngineExportTaskExecutorImpl.class);

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineExportTaskExecutorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineExportTaskExecutorImpl.java
@@ -299,9 +299,16 @@ public class BatchEngineExportTaskExecutorImpl
 			boolean cursorPaginationActive =
 				_USE_EXPORT_CURSOR_PAGINATION &&
 					_isSearchCursorPaginationEnabled(sorts);
+
+			int batchIndex = 1;
+
+			long readStartTimeNs = System.nanoTime();
+
 			Page<?> page = batchEngineTaskItemDelegate.read(
 				filter, Pagination.of(1, exportBatchSize), sorts,
 				filteredParameters, (String)parameters.get("search"));
+
+			long readTimeMs = (System.nanoTime() - readStartTimeNs) / 1_000_000;
 
 			batchEngineExportTask.setTotalItemsCount(
 				Math.toIntExact(page.getTotalCount()));
@@ -324,7 +331,12 @@ public class BatchEngineExportTaskExecutorImpl
 					}
 				}
 
+				long writeStartTimeNs = System.nanoTime();
+
 				batchEngineExportTaskItemWriter.write(items);
+
+				long writeTimeMs = (System.nanoTime() - writeStartTimeNs) /
+					1_000_000;
 
 				batchEngineExportTask.setProcessedItemsCount(
 					batchEngineExportTask.getProcessedItemsCount() +
@@ -350,7 +362,24 @@ public class BatchEngineExportTaskExecutorImpl
 							updateBatchEngineExportTask(batchEngineExportTask);
 				}
 
+				long syncLastSessionStartTimeNs = System.nanoTime();
+
 				_clearSessionPersistenceContext();
+
+				long syncLastSessionTimeMs =
+					(System.nanoTime() - syncLastSessionStartTimeNs) /
+						1_000_000;
+
+				System.out.println(
+					String.format(
+						"{\"event\":\"batchExportMetrics\",\"batchIndex\":" +
+							"%d,\"readTimeMs\":%d,\"writeTimeMs\":%d," +
+								"\"syncLastSessionTimeMs\":%d," +
+									"\"itemCount\":%d,\"processedItemsCount\":" +
+										"%d}",
+						batchIndex, readTimeMs, writeTimeMs,
+						syncLastSessionTimeMs, items.size(),
+						batchEngineExportTask.getProcessedItemsCount()));
 
 				if (Thread.interrupted()) {
 					throw new InterruptedException();
@@ -374,18 +403,25 @@ public class BatchEngineExportTaskExecutorImpl
 				}
 
 				if (cursorPaginationActive) {
+					readStartTimeNs = System.nanoTime();
+
 					page = batchEngineTaskItemDelegate.read(
 						_createCursorFilter(filter, lastItemId),
 						Pagination.of(1, exportBatchSize), sorts, filteredParameters,
 						(String)parameters.get("search"));
 				}
 				else {
+					readStartTimeNs = System.nanoTime();
+
 					page = batchEngineTaskItemDelegate.read(
 						filter, Pagination.of(
 							(int)page.getPage() + 1, exportBatchSize), sorts,
 						filteredParameters,
 						(String)parameters.get("search"));
 				}
+
+				readTimeMs = (System.nanoTime() - readStartTimeNs) / 1_000_000;
+				batchIndex++;
 
 				items = page.getItems();
 			}
@@ -686,7 +722,7 @@ public class BatchEngineExportTaskExecutorImpl
 			batchEngineExportTask.getBatchEngineExportTaskId());
 	}
 
-	private static final boolean _USE_EXPORT_CURSOR_PAGINATION = true;
+	private static final boolean _USE_EXPORT_CURSOR_PAGINATION = false;
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		BatchEngineExportTaskExecutorImpl.class);

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineExportTaskExecutorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineExportTaskExecutorImpl.java
@@ -296,9 +296,13 @@ public class BatchEngineExportTaskExecutorImpl
 			Sort[] sorts = _getSorts(
 				batchEngineTaskItemDelegate, parameters, user);
 
-			boolean cursorPaginationActive =
-				_USE_EXPORT_CURSOR_PAGINATION &&
-					_isSearchCursorPaginationEnabled(sorts);
+			boolean cursorPaginationActive = false;
+
+			if (_USE_EXPORT_CURSOR_PAGINATION &&
+				_isSearchCursorPaginationEnabled(sorts)) {
+
+				cursorPaginationActive = true;
+			}
 
 			int batchIndex = 1;
 
@@ -335,8 +339,8 @@ public class BatchEngineExportTaskExecutorImpl
 
 				batchEngineExportTaskItemWriter.write(items);
 
-				long writeTimeMs = (System.nanoTime() - writeStartTimeNs) /
-					1_000_000;
+				long writeTimeMs =
+					(System.nanoTime() - writeStartTimeNs) / 1_000_000;
 
 				batchEngineExportTask.setProcessedItemsCount(
 					batchEngineExportTask.getProcessedItemsCount() +
@@ -407,16 +411,16 @@ public class BatchEngineExportTaskExecutorImpl
 
 					page = batchEngineTaskItemDelegate.read(
 						_createCursorFilter(filter, lastItemId),
-						Pagination.of(1, exportBatchSize), sorts, filteredParameters,
-						(String)parameters.get("search"));
+						Pagination.of(1, exportBatchSize), sorts,
+						filteredParameters, (String)parameters.get("search"));
 				}
 				else {
 					readStartTimeNs = System.nanoTime();
 
 					page = batchEngineTaskItemDelegate.read(
-						filter, Pagination.of(
-							(int)page.getPage() + 1, exportBatchSize), sorts,
-						filteredParameters,
+						filter,
+						Pagination.of((int)page.getPage() + 1, exportBatchSize),
+						sorts, filteredParameters,
 						(String)parameters.get("search"));
 				}
 
@@ -569,12 +573,17 @@ public class BatchEngineExportTaskExecutorImpl
 			return null;
 		}
 
-		return _getItemId(items.iterator().next());
+		return _getItemId(
+			items.iterator(
+			).next());
 	}
 
 	private Long _getItemId(Object item) {
 		try {
-			Method method = item.getClass().getMethod("getId");
+			Method method = item.getClass(
+			).getMethod(
+				"getId"
+			);
 
 			Object id = method.invoke(item);
 
@@ -589,8 +598,7 @@ public class BatchEngineExportTaskExecutorImpl
 		catch (Exception exception) {
 			if (_log.isDebugEnabled()) {
 				_log.debug(
-					"Unable to extract ID from " + item.getClass(),
-					exception);
+					"Unable to extract ID from " + item.getClass(), exception);
 			}
 		}
 
@@ -685,7 +693,11 @@ public class BatchEngineExportTaskExecutorImpl
 	}
 
 	private boolean _isSearchCursorPaginationEnabled(Sort[] sorts) {
-		return sorts == null;
+		if (sorts == null) {
+			return true;
+		}
+
+		return false;
 	}
 
 	private Map<String, List<String>> _toMultivaluedMap(
@@ -722,7 +734,7 @@ public class BatchEngineExportTaskExecutorImpl
 			batchEngineExportTask.getBatchEngineExportTaskId());
 	}
 
-	private static final boolean _USE_EXPORT_CURSOR_PAGINATION = false;
+	private static final boolean _USE_EXPORT_CURSOR_PAGINATION = true;
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		BatchEngineExportTaskExecutorImpl.class);

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BaseBatchEngineTaskExecutorTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BaseBatchEngineTaskExecutorTest.java
@@ -117,6 +117,8 @@ public class BaseBatchEngineTaskExecutorTest {
 				new TestBlogPostingBatchEngineTaskItemDelegate(),
 				new HashMapDictionary<String, String>());
 
+		batchReadDurations.clear();
+
 		initialCount = getBlogEntriesCount();
 	}
 
@@ -238,7 +240,9 @@ public class BaseBatchEngineTaskExecutorTest {
 
 			long siteId = GetterUtil.getLong(parameters.get("siteId"));
 
-			return _search(
+			long startTime = System.currentTimeMillis();
+
+			Page<BlogPosting> page = _search(
 				booleanQuery -> {
 				},
 				filter, search, pagination,
@@ -255,6 +259,10 @@ public class BaseBatchEngineTaskExecutorTest {
 					_blogsEntryService.getEntry(
 						GetterUtil.getLong(
 							document.get(Field.ENTRY_CLASS_PK)))));
+
+			batchReadDurations.add(System.currentTimeMillis() - startTime);
+
+			return page;
 		}
 
 		@Override
@@ -466,6 +474,7 @@ public class BaseBatchEngineTaskExecutorTest {
 	protected static final int ROWS_COUNT = 18;
 
 	protected Date baseDate;
+	protected final List<Long> batchReadDurations = new ArrayList<>();
 
 	@Inject
 	protected BlogsEntryLocalService blogsEntryLocalService;

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineExportTaskExecutorPerformanceTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineExportTaskExecutorPerformanceTest.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineExportTaskExecutorPerformanceTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineExportTaskExecutorPerformanceTest.java
@@ -12,7 +12,6 @@ import com.liferay.batch.engine.model.BatchEngineExportTask;
 import com.liferay.batch.engine.service.BatchEngineExportTaskLocalService;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.TestInfo;
-import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -31,14 +30,13 @@ import org.junit.runner.RunWith;
 /**
  * @author Jose Luis Navarro
  */
-@DataGuard(scope = DataGuard.Scope.METHOD)
 @RunWith(Arquillian.class)
 public class BatchEngineExportTaskExecutorPerformanceTest
 	extends BaseBatchEngineTaskExecutorTest {
 
 	@Test
 	@TestInfo("LPD-85155")
-	public void testExportBlogPostingsPerformance() throws Exception {
+	public void testExportBlogPostings() throws Exception {
 		Group group = GroupTestUtil.addGroup();
 
 		for (int i = 0; i < 3000; i++) {

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineExportTaskExecutorPerformanceTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineExportTaskExecutorPerformanceTest.java
@@ -12,6 +12,7 @@ import com.liferay.batch.engine.model.BatchEngineExportTask;
 import com.liferay.batch.engine.service.BatchEngineExportTaskLocalService;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.performance.PerformanceTimer;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -39,30 +40,36 @@ public class BatchEngineExportTaskExecutorPerformanceTest
 	public void testExportBlogPostings() throws Exception {
 		Group group = GroupTestUtil.addGroup();
 
-		for (int i = 0; i < 3000; i++) {
-			blogsEntryLocalService.addEntry(
-				user.getUserId(), "headline" + i, "alternativeHeadline" + i,
-				null, "articleBody" + i, new Date(baseDate.getTime()), false,
-				false, null, null, null, null,
-				ServiceContextTestUtil.getServiceContext(
-					TestPropsValues.getCompanyId(), group.getGroupId(),
-					user.getUserId()));
-		}
+		_addBlogsEntries(group, 0, _EXPORT_BATCH_SIZE);
 
 		batchReadDurations.clear();
 
-		BatchEngineExportTask batchEngineExportTask =
-			_batchEngineExportTaskLocalService.addBatchEngineExportTask(
-				null, user.getCompanyId(), user.getUserId(), null,
-				BlogPosting.class.getName(), "JSON",
-				BatchEngineTaskExecuteStatus.INITIAL.name(),
-				Arrays.asList("headline", "id"),
-				HashMapBuilder.<String, Serializable>put(
-					"siteId", group.getGroupId()
-				).build(),
-				null);
+		_executeExportTask(group);
 
-		_batchEngineExportTaskExecutor.execute(batchEngineExportTask);
+		long baselineBatchReadTime = batchReadDurations.get(0);
+
+		_addBlogsEntries(group, _EXPORT_BATCH_SIZE, _ROW_COUNT);
+
+		batchReadDurations.clear();
+
+		try (PerformanceTimer performanceTimer = new PerformanceTimer(
+				BatchEngineExportTaskExecutorPerformanceTest.class,
+				baselineBatchReadTime * (_ROW_COUNT / _EXPORT_BATCH_SIZE) * 3,
+				"exportBlogPostings")) {
+
+			_executeExportTask(group);
+		}
+
+		long totalBatchReadTime = 0;
+
+		for (long batchReadDuration : batchReadDurations) {
+			totalBatchReadTime += batchReadDuration;
+		}
+
+		Assert.assertTrue(
+			totalBatchReadTime <=
+				(baselineBatchReadTime * (_ROW_COUNT / _EXPORT_BATCH_SIZE) *
+					2));
 
 		int batchCount = batchReadDurations.size();
 
@@ -84,6 +91,39 @@ public class BatchEngineExportTaskExecutorPerformanceTest
 
 		Assert.assertTrue(last5Average <= (first5Average * 2));
 	}
+
+	private void _addBlogsEntries(Group group, int start, int end)
+		throws Exception {
+
+		for (int i = start; i < end; i++) {
+			blogsEntryLocalService.addEntry(
+				user.getUserId(), "headline" + i, "alternativeHeadline" + i,
+				null, "articleBody" + i, new Date(baseDate.getTime()), false,
+				false, null, null, null, null,
+				ServiceContextTestUtil.getServiceContext(
+					TestPropsValues.getCompanyId(), group.getGroupId(),
+					user.getUserId()));
+		}
+	}
+
+	private void _executeExportTask(Group group) throws Exception {
+		BatchEngineExportTask batchEngineExportTask =
+			_batchEngineExportTaskLocalService.addBatchEngineExportTask(
+				null, user.getCompanyId(), user.getUserId(), null,
+				BlogPosting.class.getName(), "JSON",
+				BatchEngineTaskExecuteStatus.INITIAL.name(),
+				Arrays.asList("headline", "id"),
+				HashMapBuilder.<String, Serializable>put(
+					"siteId", group.getGroupId()
+				).build(),
+				null);
+
+		_batchEngineExportTaskExecutor.execute(batchEngineExportTask);
+	}
+
+	private static final int _EXPORT_BATCH_SIZE = 100;
+
+	private static final int _ROW_COUNT = 3000;
 
 	@Inject
 	private BatchEngineExportTaskExecutor _batchEngineExportTaskExecutor;

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineExportTaskExecutorPerformanceTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineExportTaskExecutorPerformanceTest.java
@@ -1,0 +1,97 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.batch.engine.internal.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.batch.engine.BatchEngineExportTaskExecutor;
+import com.liferay.batch.engine.BatchEngineTaskExecuteStatus;
+import com.liferay.batch.engine.model.BatchEngineExportTask;
+import com.liferay.batch.engine.service.BatchEngineExportTaskLocalService;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.DataGuard;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.test.rule.Inject;
+
+import java.io.Serializable;
+
+import java.util.Arrays;
+import java.util.Date;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jose Luis Navarro
+ */
+@DataGuard(scope = DataGuard.Scope.METHOD)
+@RunWith(Arquillian.class)
+public class BatchEngineExportTaskExecutorPerformanceTest
+	extends BaseBatchEngineTaskExecutorTest {
+
+	@Test
+	@TestInfo("LPD-85155")
+	public void testExportBlogPostingsPerformance() throws Exception {
+		Group group = GroupTestUtil.addGroup();
+
+		for (int i = 0; i < 3000; i++) {
+			blogsEntryLocalService.addEntry(
+				user.getUserId(), "headline" + i, "alternativeHeadline" + i,
+				null, "articleBody" + i, new Date(baseDate.getTime()), false,
+				false, null, null, null, null,
+				ServiceContextTestUtil.getServiceContext(
+					TestPropsValues.getCompanyId(), group.getGroupId(),
+					user.getUserId()));
+		}
+
+		batchReadDurations.clear();
+
+		BatchEngineExportTask batchEngineExportTask =
+			_batchEngineExportTaskLocalService.addBatchEngineExportTask(
+				null, user.getCompanyId(), user.getUserId(), null,
+				BlogPosting.class.getName(), "JSON",
+				BatchEngineTaskExecuteStatus.INITIAL.name(),
+				Arrays.asList("headline", "id"),
+				HashMapBuilder.<String, Serializable>put(
+					"siteId", group.getGroupId()
+				).build(),
+				null);
+
+		_batchEngineExportTaskExecutor.execute(batchEngineExportTask);
+
+		int batchCount = batchReadDurations.size();
+
+		long first5Average = 0;
+
+		for (int i = 0; i < 5; i++) {
+			first5Average += batchReadDurations.get(i);
+		}
+
+		first5Average = first5Average / 5;
+
+		long last5Average = 0;
+
+		for (int i = batchCount - 5; i < batchCount; i++) {
+			last5Average += batchReadDurations.get(i);
+		}
+
+		last5Average = last5Average / 5;
+
+		Assert.assertTrue(last5Average <= (first5Average * 2));
+	}
+
+	@Inject
+	private BatchEngineExportTaskExecutor _batchEngineExportTaskExecutor;
+
+	@Inject
+	private BatchEngineExportTaskLocalService
+		_batchEngineExportTaskLocalService;
+
+}

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineExportTaskExecutorTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineExportTaskExecutorTest.java
@@ -27,14 +27,12 @@ import com.liferay.petra.io.unsync.UnsyncBufferedReader;
 import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
-import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.spring.orm.LastSessionRecorderHelper;
 import com.liferay.portal.kernel.spring.orm.LastSessionRecorderHelperUtil;
 import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.DataGuard;
-import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -101,57 +99,6 @@ public class BatchEngineExportTaskExecutorTest
 		_parameters = HashMapBuilder.<String, Serializable>put(
 			"siteId", TestPropsValues.getGroupId()
 		).build();
-	}
-
-	@Test
-	@TestInfo("LPD-85155")
-	public void testExportBlogPostingsPerformance() throws Exception {
-		Group group = GroupTestUtil.addGroup();
-
-		for (int i = 0; i < 3000; i++) {
-			blogsEntryLocalService.addEntry(
-				user.getUserId(), "headline" + i, "alternativeHeadline" + i,
-				null, "articleBody" + i, new Date(baseDate.getTime()), false,
-				false, null, null, null, null,
-				ServiceContextTestUtil.getServiceContext(
-					TestPropsValues.getCompanyId(), group.getGroupId(),
-					user.getUserId()));
-		}
-
-		batchReadDurations.clear();
-
-		_batchEngineExportTask =
-			_batchEngineExportTaskLocalService.addBatchEngineExportTask(
-				null, user.getCompanyId(), user.getUserId(), null,
-				BlogPosting.class.getName(), "JSON",
-				BatchEngineTaskExecuteStatus.INITIAL.name(),
-				Arrays.asList("headline", "id"),
-				HashMapBuilder.<String, Serializable>put(
-					"siteId", group.getGroupId()
-				).build(),
-				null);
-
-		_batchEngineExportTaskExecutor.execute(_batchEngineExportTask);
-
-		int batchCount = batchReadDurations.size();
-
-		long first5Average = 0;
-
-		for (int i = 0; i < 5; i++) {
-			first5Average += batchReadDurations.get(i);
-		}
-
-		first5Average = first5Average / 5;
-
-		long last5Average = 0;
-
-		for (int i = batchCount - 5; i < batchCount; i++) {
-			last5Average += batchReadDurations.get(i);
-		}
-
-		last5Average = last5Average / 5;
-
-		Assert.assertTrue(last5Average <= (first5Average * 2));
 	}
 
 	@Test

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineExportTaskExecutorTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineExportTaskExecutorTest.java
@@ -25,7 +25,6 @@ import com.liferay.object.service.ObjectFieldLocalServiceUtil;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.petra.io.unsync.UnsyncBufferedReader;
 import com.liferay.petra.string.CharPool;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
@@ -215,68 +214,6 @@ public class BatchEngineExportTaskExecutorTest
 	}
 
 	@Test
-	@TestInfo("LPD-85155")
-	public void testExportBlogPostingsWithMultipleBatches()
-		throws Exception {
-
-		Group group = GroupTestUtil.addGroup();
-
-		for (int i = 0; i < 3000; i++) {
-			blogsEntryLocalService.addEntry(
-				user.getUserId(), "headline" + i, "alternativeHeadline" + i,
-				null, "articleBody" + i, new Date(baseDate.getTime()), false,
-				false, null, null, null, null,
-				ServiceContextTestUtil.getServiceContext(
-					TestPropsValues.getCompanyId(), group.getGroupId(),
-					user.getUserId()));
-		}
-
-		batchReadDurations.clear();
-
-		_batchEngineExportTask =
-			_batchEngineExportTaskLocalService.addBatchEngineExportTask(
-				null, user.getCompanyId(), user.getUserId(), null,
-				BlogPosting.class.getName(), "JSON",
-				BatchEngineTaskExecuteStatus.INITIAL.name(),
-				Arrays.asList("headline", "id"),
-				HashMapBuilder.<String, Serializable>put(
-					"siteId", group.getGroupId()
-				).build(),
-				null);
-
-		_batchEngineExportTaskExecutor.execute(_batchEngineExportTask);
-
-		int batchCount = batchReadDurations.size();
-
-		Assert.assertTrue(
-			"Expected at least 20 batches but got " + batchCount,
-			batchCount >= 20);
-
-		long first10Average = 0;
-
-		for (int i = 0; i < 10; i++) {
-			first10Average += batchReadDurations.get(i);
-		}
-
-		first10Average = first10Average / 10;
-
-		long last10Average = 0;
-
-		for (int i = batchCount - 10; i < batchCount; i++) {
-			last10Average += batchReadDurations.get(i);
-		}
-
-		last10Average = last10Average / 10;
-
-		Assert.assertTrue(
-			StringBundler.concat(
-				"Read time degradation detected: first 10 batches average ",
-				first10Average, "ms, last 10 batches average ", last10Average,
-				"ms. Last 10 should not be more than 2x the first 10"),
-			last10Average <= (first10Average * 2));
-	}
-
-	@Test
 	public void testExportBlogPostingsToJSONLFileWithEmptyFieldNames()
 		throws Exception {
 
@@ -400,6 +337,57 @@ public class BatchEngineExportTaskExecutorTest
 
 				return null;
 			});
+	}
+
+	@Test
+	@TestInfo("LPD-85155")
+	public void testExportBlogPostingsWithMultipleBatches() throws Exception {
+		Group group = GroupTestUtil.addGroup();
+
+		for (int i = 0; i < 3000; i++) {
+			blogsEntryLocalService.addEntry(
+				user.getUserId(), "headline" + i, "alternativeHeadline" + i,
+				null, "articleBody" + i, new Date(baseDate.getTime()), false,
+				false, null, null, null, null,
+				ServiceContextTestUtil.getServiceContext(
+					TestPropsValues.getCompanyId(), group.getGroupId(),
+					user.getUserId()));
+		}
+
+		batchReadDurations.clear();
+
+		_batchEngineExportTask =
+			_batchEngineExportTaskLocalService.addBatchEngineExportTask(
+				null, user.getCompanyId(), user.getUserId(), null,
+				BlogPosting.class.getName(), "JSON",
+				BatchEngineTaskExecuteStatus.INITIAL.name(),
+				Arrays.asList("headline", "id"),
+				HashMapBuilder.<String, Serializable>put(
+					"siteId", group.getGroupId()
+				).build(),
+				null);
+
+		_batchEngineExportTaskExecutor.execute(_batchEngineExportTask);
+
+		int batchCount = batchReadDurations.size();
+
+		long first5Average = 0;
+
+		for (int i = 0; i < 5; i++) {
+			first5Average += batchReadDurations.get(i);
+		}
+
+		first5Average = first5Average / 5;
+
+		long last5Average = 0;
+
+		for (int i = batchCount - 5; i < batchCount; i++) {
+			last5Average += batchReadDurations.get(i);
+		}
+
+		last5Average = last5Average / 5;
+
+		Assert.assertTrue(last5Average <= (first5Average * 2));
 	}
 
 	@Test

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineExportTaskExecutorTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineExportTaskExecutorTest.java
@@ -25,14 +25,17 @@ import com.liferay.object.service.ObjectFieldLocalServiceUtil;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.petra.io.unsync.UnsyncBufferedReader;
 import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.spring.orm.LastSessionRecorderHelper;
 import com.liferay.portal.kernel.spring.orm.LastSessionRecorderHelperUtil;
 import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.DataGuard;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -209,6 +212,68 @@ public class BatchEngineExportTaskExecutorTest
 				blogPosting.getId()
 			},
 			_parameters);
+	}
+
+	@Test
+	@TestInfo("LPD-85155")
+	public void testExportBlogPostingsWithMultipleBatches()
+		throws Exception {
+
+		Group group = GroupTestUtil.addGroup();
+
+		for (int i = 0; i < 3000; i++) {
+			blogsEntryLocalService.addEntry(
+				user.getUserId(), "headline" + i, "alternativeHeadline" + i,
+				null, "articleBody" + i, new Date(baseDate.getTime()), false,
+				false, null, null, null, null,
+				ServiceContextTestUtil.getServiceContext(
+					TestPropsValues.getCompanyId(), group.getGroupId(),
+					user.getUserId()));
+		}
+
+		batchReadDurations.clear();
+
+		_batchEngineExportTask =
+			_batchEngineExportTaskLocalService.addBatchEngineExportTask(
+				null, user.getCompanyId(), user.getUserId(), null,
+				BlogPosting.class.getName(), "JSON",
+				BatchEngineTaskExecuteStatus.INITIAL.name(),
+				Arrays.asList("headline", "id"),
+				HashMapBuilder.<String, Serializable>put(
+					"siteId", group.getGroupId()
+				).build(),
+				null);
+
+		_batchEngineExportTaskExecutor.execute(_batchEngineExportTask);
+
+		int batchCount = batchReadDurations.size();
+
+		Assert.assertTrue(
+			"Expected at least 20 batches but got " + batchCount,
+			batchCount >= 20);
+
+		long first10Average = 0;
+
+		for (int i = 0; i < 10; i++) {
+			first10Average += batchReadDurations.get(i);
+		}
+
+		first10Average = first10Average / 10;
+
+		long last10Average = 0;
+
+		for (int i = batchCount - 10; i < batchCount; i++) {
+			last10Average += batchReadDurations.get(i);
+		}
+
+		last10Average = last10Average / 10;
+
+		Assert.assertTrue(
+			StringBundler.concat(
+				"Read time degradation detected: first 10 batches average ",
+				first10Average, "ms, last 10 batches average ", last10Average,
+				"ms. Last 10 should not be more than 2x the first 10"),
+			last10Average <= (first10Average * 2));
 	}
 
 	@Test

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineExportTaskExecutorTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineExportTaskExecutorTest.java
@@ -104,6 +104,57 @@ public class BatchEngineExportTaskExecutorTest
 	}
 
 	@Test
+	@TestInfo("LPD-85155")
+	public void testExportBlogPostingsPerformance() throws Exception {
+		Group group = GroupTestUtil.addGroup();
+
+		for (int i = 0; i < 3000; i++) {
+			blogsEntryLocalService.addEntry(
+				user.getUserId(), "headline" + i, "alternativeHeadline" + i,
+				null, "articleBody" + i, new Date(baseDate.getTime()), false,
+				false, null, null, null, null,
+				ServiceContextTestUtil.getServiceContext(
+					TestPropsValues.getCompanyId(), group.getGroupId(),
+					user.getUserId()));
+		}
+
+		batchReadDurations.clear();
+
+		_batchEngineExportTask =
+			_batchEngineExportTaskLocalService.addBatchEngineExportTask(
+				null, user.getCompanyId(), user.getUserId(), null,
+				BlogPosting.class.getName(), "JSON",
+				BatchEngineTaskExecuteStatus.INITIAL.name(),
+				Arrays.asList("headline", "id"),
+				HashMapBuilder.<String, Serializable>put(
+					"siteId", group.getGroupId()
+				).build(),
+				null);
+
+		_batchEngineExportTaskExecutor.execute(_batchEngineExportTask);
+
+		int batchCount = batchReadDurations.size();
+
+		long first5Average = 0;
+
+		for (int i = 0; i < 5; i++) {
+			first5Average += batchReadDurations.get(i);
+		}
+
+		first5Average = first5Average / 5;
+
+		long last5Average = 0;
+
+		for (int i = batchCount - 5; i < batchCount; i++) {
+			last5Average += batchReadDurations.get(i);
+		}
+
+		last5Average = last5Average / 5;
+
+		Assert.assertTrue(last5Average <= (first5Average * 2));
+	}
+
+	@Test
 	public void testExportBlogPostingsToCSVFileWithEmptyFieldNames()
 		throws Exception {
 
@@ -337,57 +388,6 @@ public class BatchEngineExportTaskExecutorTest
 
 				return null;
 			});
-	}
-
-	@Test
-	@TestInfo("LPD-85155")
-	public void testExportBlogPostingsWithMultipleBatches() throws Exception {
-		Group group = GroupTestUtil.addGroup();
-
-		for (int i = 0; i < 3000; i++) {
-			blogsEntryLocalService.addEntry(
-				user.getUserId(), "headline" + i, "alternativeHeadline" + i,
-				null, "articleBody" + i, new Date(baseDate.getTime()), false,
-				false, null, null, null, null,
-				ServiceContextTestUtil.getServiceContext(
-					TestPropsValues.getCompanyId(), group.getGroupId(),
-					user.getUserId()));
-		}
-
-		batchReadDurations.clear();
-
-		_batchEngineExportTask =
-			_batchEngineExportTaskLocalService.addBatchEngineExportTask(
-				null, user.getCompanyId(), user.getUserId(), null,
-				BlogPosting.class.getName(), "JSON",
-				BatchEngineTaskExecuteStatus.INITIAL.name(),
-				Arrays.asList("headline", "id"),
-				HashMapBuilder.<String, Serializable>put(
-					"siteId", group.getGroupId()
-				).build(),
-				null);
-
-		_batchEngineExportTaskExecutor.execute(_batchEngineExportTask);
-
-		int batchCount = batchReadDurations.size();
-
-		long first5Average = 0;
-
-		for (int i = 0; i < 5; i++) {
-			first5Average += batchReadDurations.get(i);
-		}
-
-		first5Average = first5Average / 5;
-
-		long last5Average = 0;
-
-		for (int i = batchCount - 5; i < batchCount; i++) {
-			last5Average += batchReadDurations.get(i);
-		}
-
-		last5Average = last5Average / 5;
-
-		Assert.assertTrue(last5Average <= (first5Average * 2));
 	}
 
 	@Test


### PR DESCRIPTION
Jira Ticket: https://liferay.atlassian.net/jira/software/c/projects/LPD/boards/626?assignee=712020%3A2de6b052-0fdc-4f34-8b53-9bede77e739d&selectedIssue=LPD-85154

With offset pagination each new batch forces the search engine to skip more and more rows before returning the page.

Batch 1: skip 0, return 100
Batch 40: skip 3900, return 100
Batch 60: skip 5900, return 100
That increasing skip work is why run gets slower as start/end grows.

With the cursor style approach each query remains:

start=0, end=100
plus ENTRY_CLASS_PK > lastSeenId

So the engine fetches the next 100 directly instead of repeatedly rescanning and discarding thousands of earlier hits which keeps query cost much flatter across batches.


## Cursor pagination disabled
```
{"event":"batchExportMetrics","batchIndex":1,"readTimeMs":60,"writeTimeMs":121,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":100}
{"event":"batchExportMetrics","batchIndex":2,"readTimeMs":50,"writeTimeMs":66,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":200}
{"event":"batchExportMetrics","batchIndex":3,"readTimeMs":51,"writeTimeMs":61,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":300}
{"event":"batchExportMetrics","batchIndex":4,"readTimeMs":56,"writeTimeMs":61,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":400}
{"event":"batchExportMetrics","batchIndex":5,"readTimeMs":55,"writeTimeMs":50,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":500}
{"event":"batchExportMetrics","batchIndex":6,"readTimeMs":95,"writeTimeMs":54,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":600}
{"event":"batchExportMetrics","batchIndex":7,"readTimeMs":79,"writeTimeMs":55,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":700}
{"event":"batchExportMetrics","batchIndex":8,"readTimeMs":71,"writeTimeMs":72,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":800}
{"event":"batchExportMetrics","batchIndex":9,"readTimeMs":80,"writeTimeMs":54,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":900}
{"event":"batchExportMetrics","batchIndex":10,"readTimeMs":89,"writeTimeMs":104,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":1000}
{"event":"batchExportMetrics","batchIndex":11,"readTimeMs":126,"writeTimeMs":69,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":1100}
{"event":"batchExportMetrics","batchIndex":12,"readTimeMs":128,"writeTimeMs":52,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":1200}
{"event":"batchExportMetrics","batchIndex":13,"readTimeMs":131,"writeTimeMs":59,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":1300}
{"event":"batchExportMetrics","batchIndex":14,"readTimeMs":137,"writeTimeMs":68,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":1400}
{"event":"batchExportMetrics","batchIndex":15,"readTimeMs":180,"writeTimeMs":49,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":1500}
{"event":"batchExportMetrics","batchIndex":16,"readTimeMs":147,"writeTimeMs":55,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":1600}
{"event":"batchExportMetrics","batchIndex":17,"readTimeMs":133,"writeTimeMs":45,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":1700}
{"event":"batchExportMetrics","batchIndex":18,"readTimeMs":135,"writeTimeMs":47,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":1800}
{"event":"batchExportMetrics","batchIndex":19,"readTimeMs":156,"writeTimeMs":63,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":1900}
{"event":"batchExportMetrics","batchIndex":20,"readTimeMs":132,"writeTimeMs":49,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":2000}
{"event":"batchExportMetrics","batchIndex":21,"readTimeMs":188,"writeTimeMs":46,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":2100}
{"event":"batchExportMetrics","batchIndex":22,"readTimeMs":206,"writeTimeMs":49,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":2200}
{"event":"batchExportMetrics","batchIndex":23,"readTimeMs":219,"writeTimeMs":72,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":2300}
{"event":"batchExportMetrics","batchIndex":24,"readTimeMs":226,"writeTimeMs":56,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":2400}
{"event":"batchExportMetrics","batchIndex":25,"readTimeMs":193,"writeTimeMs":48,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":2500}
{"event":"batchExportMetrics","batchIndex":26,"readTimeMs":190,"writeTimeMs":54,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":2600}
{"event":"batchExportMetrics","batchIndex":27,"readTimeMs":195,"writeTimeMs":64,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":2700}
{"event":"batchExportMetrics","batchIndex":28,"readTimeMs":187,"writeTimeMs":47,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":2800}
{"event":"batchExportMetrics","batchIndex":29,"readTimeMs":188,"writeTimeMs":45,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":2900}
{"event":"batchExportMetrics","batchIndex":30,"readTimeMs":195,"writeTimeMs":47,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":3000}
{"event":"batchExportMetrics","batchIndex":31,"readTimeMs":252,"writeTimeMs":71,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":3100}
{"event":"batchExportMetrics","batchIndex":32,"readTimeMs":267,"writeTimeMs":52,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":3200}
{"event":"batchExportMetrics","batchIndex":33,"readTimeMs":308,"writeTimeMs":45,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":3300}
{"event":"batchExportMetrics","batchIndex":34,"readTimeMs":256,"writeTimeMs":58,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":3400}
{"event":"batchExportMetrics","batchIndex":35,"readTimeMs":253,"writeTimeMs":43,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":3500}
{"event":"batchExportMetrics","batchIndex":36,"readTimeMs":251,"writeTimeMs":48,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":3600}
{"event":"batchExportMetrics","batchIndex":37,"readTimeMs":257,"writeTimeMs":57,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":3700}
{"event":"batchExportMetrics","batchIndex":38,"readTimeMs":255,"writeTimeMs":61,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":3800}
{"event":"batchExportMetrics","batchIndex":39,"readTimeMs":262,"writeTimeMs":45,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":3900}
{"event":"batchExportMetrics","batchIndex":40,"readTimeMs":326,"writeTimeMs":52,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":4000}
{"event":"batchExportMetrics","batchIndex":41,"readTimeMs":312,"writeTimeMs":74,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":4100}
{"event":"batchExportMetrics","batchIndex":42,"readTimeMs":308,"writeTimeMs":53,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":4200}
{"event":"batchExportMetrics","batchIndex":43,"readTimeMs":325,"writeTimeMs":53,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":4300}
{"event":"batchExportMetrics","batchIndex":44,"readTimeMs":315,"writeTimeMs":58,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":4400}
{"event":"batchExportMetrics","batchIndex":45,"readTimeMs":324,"writeTimeMs":51,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":4500}
{"event":"batchExportMetrics","batchIndex":46,"readTimeMs":329,"writeTimeMs":56,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":4600}
{"event":"batchExportMetrics","batchIndex":47,"readTimeMs":351,"writeTimeMs":68,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":4700}
{"event":"batchExportMetrics","batchIndex":48,"readTimeMs":322,"writeTimeMs":46,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":4800}
{"event":"batchExportMetrics","batchIndex":49,"readTimeMs":322,"writeTimeMs":48,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":4900}
{"event":"batchExportMetrics","batchIndex":50,"readTimeMs":310,"writeTimeMs":52,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":5000}
{"event":"batchExportMetrics","batchIndex":51,"readTimeMs":373,"writeTimeMs":52,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":5100}
{"event":"batchExportMetrics","batchIndex":52,"readTimeMs":384,"writeTimeMs":55,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":5200}
{"event":"batchExportMetrics","batchIndex":53,"readTimeMs":369,"writeTimeMs":54,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":5300}
{"event":"batchExportMetrics","batchIndex":54,"readTimeMs":385,"writeTimeMs":59,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":5400}
{"event":"batchExportMetrics","batchIndex":55,"readTimeMs":381,"writeTimeMs":72,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":5500}
{"event":"batchExportMetrics","batchIndex":56,"readTimeMs":384,"writeTimeMs":61,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":5600}
{"event":"batchExportMetrics","batchIndex":57,"readTimeMs":396,"writeTimeMs":48,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":5700}
{"event":"batchExportMetrics","batchIndex":58,"readTimeMs":385,"writeTimeMs":63,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":5800}
{"event":"batchExportMetrics","batchIndex":59,"readTimeMs":419,"writeTimeMs":46,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":5900}
{"event":"batchExportMetrics","batchIndex":60,"readTimeMs":445,"writeTimeMs":65,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":6000}
```

## Cursor pagination enabled

```
{"event":"batchExportMetrics","batchIndex":1,"readTimeMs":517,"writeTimeMs":253,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":100}
{"event":"batchExportMetrics","batchIndex":2,"readTimeMs":180,"writeTimeMs":280,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":200}
{"event":"batchExportMetrics","batchIndex":3,"readTimeMs":237,"writeTimeMs":172,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":300}
{"event":"batchExportMetrics","batchIndex":4,"readTimeMs":123,"writeTimeMs":149,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":400}
{"event":"batchExportMetrics","batchIndex":5,"readTimeMs":107,"writeTimeMs":128,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":500}
{"event":"batchExportMetrics","batchIndex":6,"readTimeMs":101,"writeTimeMs":191,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":600}
{"event":"batchExportMetrics","batchIndex":7,"readTimeMs":116,"writeTimeMs":138,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":700}
{"event":"batchExportMetrics","batchIndex":8,"readTimeMs":102,"writeTimeMs":135,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":800}
{"event":"batchExportMetrics","batchIndex":9,"readTimeMs":92,"writeTimeMs":130,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":900}
{"event":"batchExportMetrics","batchIndex":10,"readTimeMs":98,"writeTimeMs":163,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":1000}
{"event":"batchExportMetrics","batchIndex":11,"readTimeMs":91,"writeTimeMs":121,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":1100}
{"event":"batchExportMetrics","batchIndex":12,"readTimeMs":86,"writeTimeMs":109,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":1200}
{"event":"batchExportMetrics","batchIndex":13,"readTimeMs":85,"writeTimeMs":107,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":1300}
{"event":"batchExportMetrics","batchIndex":14,"readTimeMs":80,"writeTimeMs":99,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":1400}
{"event":"batchExportMetrics","batchIndex":15,"readTimeMs":81,"writeTimeMs":109,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":1500}
{"event":"batchExportMetrics","batchIndex":16,"readTimeMs":74,"writeTimeMs":100,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":1600}
{"event":"batchExportMetrics","batchIndex":17,"readTimeMs":92,"writeTimeMs":95,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":1700}
{"event":"batchExportMetrics","batchIndex":18,"readTimeMs":77,"writeTimeMs":95,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":1800}
{"event":"batchExportMetrics","batchIndex":19,"readTimeMs":74,"writeTimeMs":90,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":1900}
{"event":"batchExportMetrics","batchIndex":20,"readTimeMs":69,"writeTimeMs":90,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":2000}
{"event":"batchExportMetrics","batchIndex":21,"readTimeMs":95,"writeTimeMs":95,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":2100}
{"event":"batchExportMetrics","batchIndex":22,"readTimeMs":76,"writeTimeMs":91,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":2200}
{"event":"batchExportMetrics","batchIndex":23,"readTimeMs":75,"writeTimeMs":95,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":2300}
{"event":"batchExportMetrics","batchIndex":24,"readTimeMs":76,"writeTimeMs":96,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":2400}
{"event":"batchExportMetrics","batchIndex":25,"readTimeMs":72,"writeTimeMs":88,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":2500}
{"event":"batchExportMetrics","batchIndex":26,"readTimeMs":80,"writeTimeMs":118,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":2600}
{"event":"batchExportMetrics","batchIndex":27,"readTimeMs":88,"writeTimeMs":110,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":2700}
{"event":"batchExportMetrics","batchIndex":28,"readTimeMs":81,"writeTimeMs":87,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":2800}
{"event":"batchExportMetrics","batchIndex":29,"readTimeMs":76,"writeTimeMs":94,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":2900}
{"event":"batchExportMetrics","batchIndex":30,"readTimeMs":110,"writeTimeMs":92,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":3000}
{"event":"batchExportMetrics","batchIndex":31,"readTimeMs":74,"writeTimeMs":95,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":3100}
{"event":"batchExportMetrics","batchIndex":32,"readTimeMs":145,"writeTimeMs":115,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":3200}
{"event":"batchExportMetrics","batchIndex":33,"readTimeMs":89,"writeTimeMs":97,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":3300}
{"event":"batchExportMetrics","batchIndex":34,"readTimeMs":81,"writeTimeMs":94,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":3400}
{"event":"batchExportMetrics","batchIndex":35,"readTimeMs":73,"writeTimeMs":103,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":3500}
{"event":"batchExportMetrics","batchIndex":36,"readTimeMs":72,"writeTimeMs":93,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":3600}
{"event":"batchExportMetrics","batchIndex":37,"readTimeMs":90,"writeTimeMs":96,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":3700}
{"event":"batchExportMetrics","batchIndex":38,"readTimeMs":75,"writeTimeMs":97,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":3800}
{"event":"batchExportMetrics","batchIndex":39,"readTimeMs":71,"writeTimeMs":93,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":3900}
{"event":"batchExportMetrics","batchIndex":40,"readTimeMs":72,"writeTimeMs":99,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":4000}
{"event":"batchExportMetrics","batchIndex":41,"readTimeMs":73,"writeTimeMs":89,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":4100}
{"event":"batchExportMetrics","batchIndex":42,"readTimeMs":74,"writeTimeMs":125,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":4200}
{"event":"batchExportMetrics","batchIndex":43,"readTimeMs":81,"writeTimeMs":92,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":4300}
{"event":"batchExportMetrics","batchIndex":44,"readTimeMs":76,"writeTimeMs":103,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":4400}
{"event":"batchExportMetrics","batchIndex":45,"readTimeMs":79,"writeTimeMs":97,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":4500}
{"event":"batchExportMetrics","batchIndex":46,"readTimeMs":72,"writeTimeMs":91,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":4600}
{"event":"batchExportMetrics","batchIndex":47,"readTimeMs":77,"writeTimeMs":122,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":4700}
{"event":"batchExportMetrics","batchIndex":48,"readTimeMs":104,"writeTimeMs":103,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":4800}
{"event":"batchExportMetrics","batchIndex":49,"readTimeMs":67,"writeTimeMs":91,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":4900}
{"event":"batchExportMetrics","batchIndex":50,"readTimeMs":80,"writeTimeMs":106,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":5000}
{"event":"batchExportMetrics","batchIndex":51,"readTimeMs":75,"writeTimeMs":102,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":5100}
{"event":"batchExportMetrics","batchIndex":52,"readTimeMs":76,"writeTimeMs":103,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":5200}
{"event":"batchExportMetrics","batchIndex":53,"readTimeMs":76,"writeTimeMs":116,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":5300}
{"event":"batchExportMetrics","batchIndex":54,"readTimeMs":72,"writeTimeMs":88,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":5400}
{"event":"batchExportMetrics","batchIndex":55,"readTimeMs":67,"writeTimeMs":91,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":5500}
{"event":"batchExportMetrics","batchIndex":56,"readTimeMs":69,"writeTimeMs":109,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":5600}
{"event":"batchExportMetrics","batchIndex":57,"readTimeMs":72,"writeTimeMs":151,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":5700}
{"event":"batchExportMetrics","batchIndex":58,"readTimeMs":89,"writeTimeMs":129,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":5800}
{"event":"batchExportMetrics","batchIndex":59,"readTimeMs":74,"writeTimeMs":102,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":5900}
{"event":"batchExportMetrics","batchIndex":60,"readTimeMs":72,"writeTimeMs":92,"syncLastSessionTimeMs":0,"itemCount":100,"processedItemsCount":6000}
```

### Options and tradeoffs
Option A: cursor only if sorts == null
Use cursor when there’s no user sort. If there is a sort, use offset pagination. Pro: user sort is honored on the offset path. Con: big exports with a sort stay slow (deep offset).

*Sort is explicitly provided as a query parameter. Otherwise `_getSorts` returns `null` and no sorting is applied*

Option B: force PK sort when cursor is on
Always sort by PK (asc) for cursor reads so entryClassPK > lastId stays correct, even if the task had a sort. Pro: fast paging for large exports. Con: export order may not match the user’s sort

### To Do:
- [x] remove _USE_EXPORT_CURSOR_PAGINATION boolean
- [x] remove logs