### PR TITLE
LPD-87411 Embed UnsyncBufferedReader from petra.io in REST Builder fat jar

### DIFF
--- a/modules/util/portal-tools-rest-builder/bnd.bnd
+++ b/modules/util/portal-tools-rest-builder/bnd.bnd
@@ -14,6 +14,7 @@ Main-Class: com.liferay.portal.tools.rest.builder.RESTBuilder
 	@com.liferay.petra.io-*.jar!/com/liferay/petra/io/StreamUtil.class,\
 	@com.liferay.petra.io-*.jar!/com/liferay/petra/io/unsync/BoundaryCheckerUtil.class,\
 	@com.liferay.petra.io-*.jar!/com/liferay/petra/io/unsync/UnsyncByteArrayOutputStream.class,\
+	@com.liferay.petra.io-*.jar!/com/liferay/petra/io/unsync/UnsyncBufferedReader.class,\
 	@com.liferay.petra.io-*.jar!/com/liferay/petra/io/unsync/UnsyncStringReader.class,\
 	@com.liferay.petra.lang-*.jar!/com/liferay/petra/lang/CentralizedThreadLocal.class,\
 	@com.liferay.petra.string-*.jar!/com/liferay/petra/string/CharPool.class,\


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87411

**What is being fixed:** When an external workspace pins the REST Builder
tool to a specific version, the `buildREST` task fails with
`NoClassDefFoundError: com/liferay/petra/io/unsync/UnsyncBufferedReader`
because the class is missing from the published fat jar. The fat jar
embeds specific classes from `petra.io` via `-includeresource` in
`bnd.bnd`, but `UnsyncBufferedReader` — used by `JavaParser._getLines()`
— was never included in the list.

**How it is being fixed:** Added `UnsyncBufferedReader.class` to the
`-includeresource` directive in `bnd.bnd` alongside the other
`com.liferay.petra.io.unsync` classes already embedded there. This
ensures the class is bundled into the distributed jar without requiring
consumers to declare `petra.io` as a separate dependency.