### PR TITLE
LPD-87411 Embed UnsyncBufferedReader from petra.io in REST Builder fat jar

### DIFF
--- a/modules/util/portal-tools-rest-builder/bnd.bnd
+++ b/modules/util/portal-tools-rest-builder/bnd.bnd
@@ -13,6 +13,7 @@ Main-Class: com.liferay.portal.tools.rest.builder.RESTBuilder
 	@com.liferay.petra.function-*.jar!/com/liferay/petra/function/transform/TransformUtil.class,\
 	@com.liferay.petra.io-*.jar!/com/liferay/petra/io/StreamUtil.class,\
 	@com.liferay.petra.io-*.jar!/com/liferay/petra/io/unsync/BoundaryCheckerUtil.class,\
+	@com.liferay.petra.io-*.jar!/com/liferay/petra/io/unsync/UnsyncBufferedReader.class,\
 	@com.liferay.petra.io-*.jar!/com/liferay/petra/io/unsync/UnsyncByteArrayOutputStream.class,\
 	@com.liferay.petra.io-*.jar!/com/liferay/petra/io/unsync/UnsyncStringReader.class,\
 	@com.liferay.petra.lang-*.jar!/com/liferay/petra/lang/CentralizedThreadLocal.class,\


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87411

**What is being fixed:** The REST Builder fat jar was missing
`UnsyncBufferedReader` from `com.liferay.petra.io`, causing a
`NoClassDefFoundError` at runtime when that class was needed during REST
Builder execution.

**How it is being fixed:** The `UnsyncBufferedReader.class` entry is added
to the `-includeresource` directive in `bnd.bnd`, embedding it in the fat
jar alongside the other `petra.io` unsync classes that were already present
(`BoundaryCheckerUtil`, `UnsyncByteArrayOutputStream`, `UnsyncStringReader`).