### PR TITLE
LPD-87731 Make MCP server cluster-safe via stateless transport

### DIFF
--- a/modules/apps/mcp/mcp-server-test/src/testIntegration/java/com/liferay/mcp/server/test/MCPServerServletTest.java
+++ b/modules/apps/mcp/mcp-server-test/src/testIntegration/java/com/liferay/mcp/server/test/MCPServerServletTest.java
@@ -13,6 +13,7 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -21,7 +22,9 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
@@ -197,6 +200,59 @@ public class MCPServerServletTest {
 		mcpSyncClient.closeGracefully();
 	}
 
+	@Test
+	public void testServiceWithoutSession() throws Exception {
+		Http.Options options = new Http.Options();
+
+		options.addHeader("Authorization", _getAuthorization());
+		options.setLocation("http://localhost:8080/o/mcp");
+
+		_http.URLtoString(options);
+
+		Http.Response response = options.getResponse();
+
+		Assert.assertEquals("text/event-stream", response.getContentType());
+		Assert.assertEquals(200, response.getResponseCode());
+
+		options = new Http.Options();
+
+		options.addHeader("Accept", "application/json, text/event-stream");
+		options.addHeader("Authorization", _getAuthorization());
+		options.addHeader("Content-Type", ContentTypes.APPLICATION_JSON);
+		options.setBody(
+			JSONUtil.put(
+				"id", 1
+			).put(
+				"jsonrpc", "2.0"
+			).put(
+				"method", "initialize"
+			).put(
+				"params",
+				JSONUtil.put(
+					"capabilities", JSONFactoryUtil.createJSONObject()
+				).put(
+					"clientInfo",
+					JSONUtil.put(
+						"name", "test-client"
+					).put(
+						"version", "1.0.0"
+					)
+				).put(
+					"protocolVersion", "2025-11-25"
+				)
+			).toString(),
+			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
+		options.setLocation("http://localhost:8080/o/mcp");
+		options.setPost(true);
+
+		_http.URLtoString(options);
+
+		response = options.getResponse();
+
+		Assert.assertEquals(200, response.getResponseCode());
+		Assert.assertNull(response.getHeader("Mcp-Session-Id"));
+	}
+
 	@FeatureFlag("LPD-86164")
 	@Test
 	public void testServiceWithProfile() throws Exception {
@@ -348,6 +404,9 @@ public class MCPServerServletTest {
 			).build()
 		).build();
 	}
+
+	@Inject
+	private Http _http;
 
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;

--- a/modules/apps/mcp/mcp-server/src/main/java/com/liferay/mcp/server/internal/servlet/MCPServerServlet.java
+++ b/modules/apps/mcp/mcp-server/src/main/java/com/liferay/mcp/server/internal/servlet/MCPServerServlet.java
@@ -33,10 +33,9 @@ import com.liferay.portal.kernel.util.Validator;
 import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.json.jackson2.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.server.McpServer;
-import io.modelcontextprotocol.server.McpServerFeatures;
-import io.modelcontextprotocol.server.McpSyncServer;
-import io.modelcontextprotocol.server.McpSyncServerExchange;
-import io.modelcontextprotocol.server.transport.HttpServletStreamableServerTransportProvider;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures;
+import io.modelcontextprotocol.server.McpStatelessSyncServer;
+import io.modelcontextprotocol.server.transport.HttpServletStatelessServerTransport;
 import io.modelcontextprotocol.spec.McpSchema;
 
 import jakarta.servlet.GenericServlet;
@@ -56,6 +55,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.osgi.service.component.annotations.Component;
@@ -160,10 +160,10 @@ public class MCPServerServlet extends HttpServlet {
 		String baseURL, long companyId, String authorization,
 		MCPServerProfile mcpServerProfile) {
 
-		HttpServletStreamableServerTransportProvider
-			httpServletStreamableServerTransportProvider =
-				HttpServletStreamableServerTransportProvider.builder(
-				).mcpEndpoint(
+		HttpServletStatelessServerTransport
+			httpServletStatelessServerTransport =
+				HttpServletStatelessServerTransport.builder(
+				).messageEndpoint(
 					(mcpServerProfile != null) ?
 						"/mcp/" + mcpServerProfile._name : "/mcp"
 				).contextExtractor(
@@ -177,8 +177,8 @@ public class MCPServerServlet extends HttpServlet {
 						).build())
 				).build();
 
-		List<McpServerFeatures.SyncToolSpecification> syncToolSpecifications =
-			new ArrayList<>();
+		List<McpStatelessServerFeatures.SyncToolSpecification>
+			syncToolSpecifications = new ArrayList<>();
 
 		if (mcpServerProfile != null) {
 			Map<String, String> openAPIJSONStringCache = new HashMap<>();
@@ -186,33 +186,35 @@ public class MCPServerServlet extends HttpServlet {
 			syncToolSpecifications.addAll(
 				TransformUtil.transformToList(
 					mcpServerProfile._endpoints,
-					endpoint -> new McpServerFeatures.SyncToolSpecification(
-						OpenAPIUtil.getTool(
-							endpoint,
-							openAPIJSONStringCache.computeIfAbsent(
-								OpenAPIUtil.getOpenAPIURL(endpoint),
-								key -> _getOpenAPIJSONString(
-									baseURL, authorization, key))),
-						(mcpSyncServerExchange, callToolRequest) -> {
-							OpenAPIUtil.HttpCallArguments httpCallArguments =
-								OpenAPIUtil.getHttpCallArguments(
-									callToolRequest.arguments(), baseURL,
-									endpoint);
+					endpoint ->
+						new McpStatelessServerFeatures.SyncToolSpecification(
+							OpenAPIUtil.getTool(
+								endpoint,
+								openAPIJSONStringCache.computeIfAbsent(
+									OpenAPIUtil.getOpenAPIURL(endpoint),
+									key -> _getOpenAPIJSONString(
+										baseURL, authorization, key))),
+							(mcpTransportContext, callToolRequest) -> {
+								OpenAPIUtil.HttpCallArguments
+									httpCallArguments =
+										OpenAPIUtil.getHttpCallArguments(
+											callToolRequest.arguments(),
+											baseURL, endpoint);
 
-							return _call(
-								httpCallArguments.getBody(),
-								httpCallArguments.getURL(),
-								mcpSyncServerExchange,
-								httpCallArguments.getMethod());
-						})));
+								return _call(
+									httpCallArguments.getBody(),
+									httpCallArguments.getURL(),
+									mcpTransportContext,
+									httpCallArguments.getMethod());
+							})));
 		}
 		else {
 			JSONObject toolsJSONObject = _getToolsJSONObject(baseURL);
 
 			syncToolSpecifications.add(
-				new McpServerFeatures.SyncToolSpecification(
+				new McpStatelessServerFeatures.SyncToolSpecification(
 					_getTool("call-http-endpoint", toolsJSONObject),
-					(mcpSyncServerExchange, callToolRequest) -> {
+					(mcpTransportContext, callToolRequest) -> {
 						Map<String, Object> arguments =
 							callToolRequest.arguments();
 
@@ -224,30 +226,30 @@ public class MCPServerServlet extends HttpServlet {
 
 						return _call(
 							String.valueOf(arguments.get("payload")),
-							baseURL + path, mcpSyncServerExchange,
+							baseURL + path, mcpTransportContext,
 							String.valueOf(arguments.get("method")));
 					}));
 			syncToolSpecifications.add(
-				new McpServerFeatures.SyncToolSpecification(
+				new McpStatelessServerFeatures.SyncToolSpecification(
 					_getTool("get-openapi", toolsJSONObject),
-					(mcpSyncServerExchange, callToolRequest) -> _call(
+					(mcpTransportContext, callToolRequest) -> _call(
 						null,
 						String.valueOf(
 							callToolRequest.arguments(
 							).get(
 								"url"
 							)),
-						mcpSyncServerExchange, "GET")));
+						mcpTransportContext, "GET")));
 			syncToolSpecifications.add(
-				new McpServerFeatures.SyncToolSpecification(
+				new McpStatelessServerFeatures.SyncToolSpecification(
 					_getTool("get-openapis", toolsJSONObject),
-					(mcpSyncServerExchange, callToolRequest) -> _call(
-						null, baseURL + "/openapi", mcpSyncServerExchange,
+					(mcpTransportContext, callToolRequest) -> _call(
+						null, baseURL + "/openapi", mcpTransportContext,
 						"GET")));
 		}
 
-		McpSyncServer mcpSyncServer = McpServer.sync(
-			httpServletStreamableServerTransportProvider
+		McpStatelessSyncServer mcpStatelessSyncServer = McpServer.sync(
+			httpServletStatelessServerTransport
 		).capabilities(
 			McpSchema.ServerCapabilities.builder(
 			).tools(
@@ -265,7 +267,7 @@ public class MCPServerServlet extends HttpServlet {
 
 			@Override
 			public void destroy() {
-				mcpSyncServer.closeGracefully();
+				mcpStatelessSyncServer.closeGracefully();
 			}
 
 			@Override
@@ -274,7 +276,23 @@ public class MCPServerServlet extends HttpServlet {
 					ServletResponse servletResponse)
 				throws IOException, ServletException {
 
-				httpServletStreamableServerTransportProvider.service(
+				HttpServletRequest httpServletRequest =
+					(HttpServletRequest)servletRequest;
+
+				if (Objects.equals(httpServletRequest.getMethod(), "GET")) {
+					HttpServletResponse httpServletResponse =
+						(HttpServletResponse)servletResponse;
+
+					httpServletResponse.setStatus(HttpServletResponse.SC_OK);
+					httpServletResponse.setContentType("text/event-stream");
+					httpServletResponse.setHeader("Cache-Control", "no-cache");
+
+					httpServletResponse.flushBuffer();
+
+					return;
+				}
+
+				httpServletStatelessServerTransport.service(
 					servletRequest, servletResponse);
 			}
 
@@ -282,8 +300,8 @@ public class MCPServerServlet extends HttpServlet {
 	}
 
 	private McpSchema.CallToolResult _call(
-		String body, String location,
-		McpSyncServerExchange mcpSyncServerExchange, String method) {
+		String body, String location, McpTransportContext mcpTransportContext,
+		String method) {
 
 		Http.Options options = new Http.Options();
 
@@ -291,9 +309,6 @@ public class MCPServerServlet extends HttpServlet {
 			options.setBody(
 				body, ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 		}
-
-		McpTransportContext mcpTransportContext =
-			mcpSyncServerExchange.transportContext();
 
 		Object liferayAIHubCellOnBehalfOf = mcpTransportContext.get(
 			"liferayAIHubCellOnBehalfOf");
@@ -467,7 +482,7 @@ public class MCPServerServlet extends HttpServlet {
 		return servletKey;
 	}
 
-	private List<McpServerFeatures.SyncPromptSpecification>
+	private List<McpStatelessServerFeatures.SyncPromptSpecification>
 		_getSyncPromptSpecifications(long companyId) {
 
 		ObjectDefinition objectDefinition =
@@ -488,12 +503,12 @@ public class MCPServerServlet extends HttpServlet {
 			objectEntry -> {
 				Map<String, Serializable> values = objectEntry.getValues();
 
-				return new McpServerFeatures.SyncPromptSpecification(
+				return new McpStatelessServerFeatures.SyncPromptSpecification(
 					new McpSchema.Prompt(
 						(String)values.get("name"),
 						(String)values.get("description"),
 						Collections.emptyList()),
-					(mcpSyncServerExchange, request) ->
+					(mcpTransportContext, request) ->
 						new McpSchema.GetPromptResult(
 							(String)values.get("description"),
 							List.of(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87731

**What is being fixed:** The MCP server's Streamable HTTP transport kept sessions in a per-JVM `ConcurrentHashMap`, so requests routed to a different cluster node by a non-sticky load balancer were rejected with HTTP 404 "Session not found". This affects real Liferay PaaS deployments — Neil Griffin reported it against DXP 2025.q4.3 with VS Code Copilot, where tool calls failed intermittently while the same client worked against `localhost:8080`. The upstream Java SDK does not yet expose a `SessionStore` SPI (modelcontextprotocol/java-sdk#274), so externalizing the session map is not currently an option. See the parent story LPD-66843 for full context.

**How it is being fixed:** The server is switched from `HttpServletStreamableServerTransportProvider` to `HttpServletStatelessServerTransport`, eliminating per-JVM session state entirely. The MCP server only declares `tools` and `prompts` capabilities and uses no sampling, elicitation, ping, or notifications, so the trade-offs of stateless mode cost nothing today. Tool and prompt specifications are migrated from `McpServerFeatures` to `McpStatelessServerFeatures`, and `_call` now receives `McpTransportContext` directly instead of unwrapping it from a `McpSyncServerExchange`. The inner servlet short-circuits GET requests to the message endpoint with an empty `text/event-stream` 200 response so streamable clients do not throw a transport exception when probing for the absent notification channel. The per-tenant servlet cache, profile routing, and header propagation are unchanged. All three existing integration tests in `MCPServerServletTest` continue to pass.