### PR TITLE
LPD-87938 LPD-65220 Add company-scoped configuration to enable/disable the MCP server

### DIFF
--- a/modules/apps/mcp/mcp-server-test/src/testIntegration/java/com/liferay/mcp/server/test/MCPServerServletTest.java
+++ b/modules/apps/mcp/mcp-server-test/src/testIntegration/java/com/liferay/mcp/server/test/MCPServerServletTest.java
@@ -36,22 +36,35 @@ import io.modelcontextprotocol.spec.McpSchema;
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
 import java.util.Base64;
 import java.util.Collections;
+import java.util.Dictionary;
+import java.util.Hashtable;
 import java.util.List;
 
 import org.hamcrest.CoreMatchers;
 
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+
 import org.skyscreamer.jsonassert.JSONAssert;
 
 /**
  * @author Alejandro Tardín
+ * @author Beni Herrero
  */
 @FeatureFlag("LPD-63311")
 @RunWith(Arquillian.class)
@@ -61,6 +74,43 @@ public class MCPServerServletTest {
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_updateMCPServerConfiguration(true);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		Configuration[] configurations = _configurationAdmin.listConfigurations(
+			"(service.factoryPid=" + _MCP_SERVER_CONFIGURATION_PID + ")");
+
+		if (configurations != null) {
+			for (Configuration configuration : configurations) {
+				configuration.delete();
+			}
+		}
+	}
+
+	@Test
+	public void testServiceWhenMCPServerConfigurationIsDisabled()
+		throws Exception {
+
+		_updateMCPServerConfiguration(false);
+
+		HttpResponse<Void> httpResponse = HttpClient.newHttpClient(
+		).send(
+			HttpRequest.newBuilder(
+			).header(
+				"Authorization", _getAuthorization()
+			).uri(
+				URI.create("http://localhost:8080/o/mcp")
+			).build(),
+			HttpResponse.BodyHandlers.discarding()
+		);
+
+		Assert.assertEquals(404, httpResponse.statusCode());
+	}
 
 	@FeatureFlag("LPD-86164")
 	@Test
@@ -348,6 +398,28 @@ public class MCPServerServletTest {
 			).build()
 		).build();
 	}
+
+	private void _updateMCPServerConfiguration(boolean enabled)
+		throws Exception {
+
+		Configuration configuration =
+			_configurationAdmin.getFactoryConfiguration(
+				_MCP_SERVER_CONFIGURATION_PID,
+				String.valueOf(TestPropsValues.getCompanyId()), "?");
+
+		Dictionary<String, Object> properties = new Hashtable<>();
+
+		properties.put("companyId", TestPropsValues.getCompanyId());
+		properties.put("enabled", enabled);
+
+		configuration.update(properties);
+	}
+
+	private static final String _MCP_SERVER_CONFIGURATION_PID =
+		"com.liferay.mcp.server.internal.configuration.MCPServerConfiguration";
+
+	@Inject
+	private ConfigurationAdmin _configurationAdmin;
 
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;

--- a/modules/apps/mcp/mcp-server/bnd.bnd
+++ b/modules/apps/mcp/mcp-server/bnd.bnd
@@ -1,3 +1,4 @@
+Bundle-Localization: content/Language
 Bundle-Name: Liferay MCP Server
 Bundle-SymbolicName: com.liferay.mcp.server
 Bundle-Version: 0.0.13

--- a/modules/apps/mcp/mcp-server/build.gradle
+++ b/modules/apps/mcp/mcp-server/build.gradle
@@ -7,12 +7,16 @@ dependencies {
 	compileInclude group: "org.yaml", name: "snakeyaml", version: "2.3"
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.18.6"
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.18.6"
+	compileOnly group: "com.liferay", name: "biz.aQute.bnd.annotation", version: "4.2.0.LIFERAY-PATCHED-2"
 	compileOnly group: "com.liferay.jakarta.portlet", name: "com.liferay.jakarta.portlet-api", version: "4.0.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "jakarta.servlet", name: "jakarta.servlet-api", version: "6.0.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly project(":apps:configuration-admin:configuration-admin-api")
 	compileOnly project(":apps:object:object-api")
+	compileOnly project(":apps:portal-configuration:portal-configuration-module-configuration-api")
+	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-string")

--- a/modules/apps/mcp/mcp-server/src/main/java/com/liferay/mcp/server/internal/configuration/MCPServerConfiguration.java
+++ b/modules/apps/mcp/mcp-server/src/main/java/com/liferay/mcp/server/internal/configuration/MCPServerConfiguration.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/apps/mcp/mcp-server/src/main/java/com/liferay/mcp/server/internal/configuration/MCPServerConfiguration.java
+++ b/modules/apps/mcp/mcp-server/src/main/java/com/liferay/mcp/server/internal/configuration/MCPServerConfiguration.java
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.mcp.server.internal.configuration;
+
+import aQute.bnd.annotation.metatype.Meta;
+
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+
+/**
+ * @author Beni Herrero
+ */
+@ExtendedObjectClassDefinition(
+	category = "mcp-server", scope = ExtendedObjectClassDefinition.Scope.COMPANY
+)
+@Meta.OCD(
+	description = "mcp-server-configuration-description",
+	id = "com.liferay.mcp.server.internal.configuration.MCPServerConfiguration",
+	localization = "content/Language", name = "mcp-server-configuration-name"
+)
+public interface MCPServerConfiguration {
+
+	@Meta.AD(deflt = "false", name = "enabled", required = false)
+	public boolean enabled();
+
+}

--- a/modules/apps/mcp/mcp-server/src/main/java/com/liferay/mcp/server/internal/configuration/admin/category/MCPServerConfigurationCategory.java
+++ b/modules/apps/mcp/mcp-server/src/main/java/com/liferay/mcp/server/internal/configuration/admin/category/MCPServerConfigurationCategory.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/apps/mcp/mcp-server/src/main/java/com/liferay/mcp/server/internal/configuration/admin/category/MCPServerConfigurationCategory.java
+++ b/modules/apps/mcp/mcp-server/src/main/java/com/liferay/mcp/server/internal/configuration/admin/category/MCPServerConfigurationCategory.java
@@ -1,0 +1,33 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.mcp.server.internal.configuration.admin.category;
+
+import com.liferay.configuration.admin.category.ConfigurationCategory;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Beni Herrero
+ */
+@Component(service = ConfigurationCategory.class)
+public class MCPServerConfigurationCategory implements ConfigurationCategory {
+
+	@Override
+	public String getCategoryIcon() {
+		return "server";
+	}
+
+	@Override
+	public String getCategoryKey() {
+		return "mcp-server";
+	}
+
+	@Override
+	public String getCategorySection() {
+		return "platform";
+	}
+
+}

--- a/modules/apps/mcp/mcp-server/src/main/java/com/liferay/mcp/server/internal/servlet/MCPServerServlet.java
+++ b/modules/apps/mcp/mcp-server/src/main/java/com/liferay/mcp/server/internal/servlet/MCPServerServlet.java
@@ -131,6 +131,12 @@ public class MCPServerServlet extends HttpServlet {
 
 		long companyId = _portal.getCompanyId(httpServletRequest);
 
+		if (!FeatureFlagManagerUtil.isEnabled(companyId, "LPD-63311")) {
+			httpServletResponse.setStatus(HttpServletResponse.SC_NOT_FOUND);
+
+			return;
+		}
+
 		MCPServerConfiguration mcpServerConfiguration;
 
 		try {
@@ -146,9 +152,7 @@ public class MCPServerServlet extends HttpServlet {
 			return;
 		}
 
-		if (!FeatureFlagManagerUtil.isEnabled(companyId, "LPD-63311") ||
-			!mcpServerConfiguration.enabled()) {
-
+		if (!mcpServerConfiguration.enabled()) {
 			httpServletResponse.setStatus(HttpServletResponse.SC_NOT_FOUND);
 
 			return;

--- a/modules/apps/mcp/mcp-server/src/main/java/com/liferay/mcp/server/internal/servlet/MCPServerServlet.java
+++ b/modules/apps/mcp/mcp-server/src/main/java/com/liferay/mcp/server/internal/servlet/MCPServerServlet.java
@@ -7,6 +7,7 @@ package com.liferay.mcp.server.internal.servlet;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import com.liferay.mcp.server.internal.configuration.MCPServerConfiguration;
 import com.liferay.mcp.server.internal.constants.MCPServerConstants;
 import com.liferay.mcp.server.internal.util.OpenAPIUtil;
 import com.liferay.object.model.ObjectDefinition;
@@ -16,6 +17,7 @@ import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONException;
@@ -23,6 +25,7 @@ import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Http;
@@ -128,7 +131,24 @@ public class MCPServerServlet extends HttpServlet {
 
 		long companyId = _portal.getCompanyId(httpServletRequest);
 
-		if (!FeatureFlagManagerUtil.isEnabled(companyId, "LPD-63311")) {
+		MCPServerConfiguration mcpServerConfiguration;
+
+		try {
+			mcpServerConfiguration =
+				_configurationProvider.getCompanyConfiguration(
+					MCPServerConfiguration.class, companyId);
+		}
+		catch (ConfigurationException configurationException) {
+			_log.error(configurationException);
+
+			httpServletResponse.setStatus(HttpServletResponse.SC_NOT_FOUND);
+
+			return;
+		}
+
+		if (!FeatureFlagManagerUtil.isEnabled(companyId, "LPD-63311") ||
+			!mcpServerConfiguration.enabled()) {
+
 			httpServletResponse.setStatus(HttpServletResponse.SC_NOT_FOUND);
 
 			return;
@@ -535,6 +555,9 @@ public class MCPServerServlet extends HttpServlet {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		MCPServerServlet.class);
+
+	@Reference
+	private ConfigurationProvider _configurationProvider;
 
 	@Reference
 	private Http _http;

--- a/modules/apps/mcp/mcp-server/src/main/resources/content/Language.properties
+++ b/modules/apps/mcp/mcp-server/src/main/resources/content/Language.properties
@@ -1,0 +1,3 @@
+category.mcp-server=MCP Server
+mcp-server-configuration-description=Configure the MCP Server settings.
+mcp-server-configuration-name=MCP Server


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87938

**What is being fixed:** The MCP server had no admin-facing toggle to
enable or disable it. The only gate was a dev-time feature flag
(LPD-63311), which is not suitable for production control by
administrators.

**How it is being fixed:** A company-scoped OSGi configuration interface
(MCPServerConfiguration) is added with a single enabled boolean that
defaults to false. A matching ConfigurationCategory registers an "MCP
Server" entry under System Settings → Platform. The servlet checks both
the existing feature flag and the new configuration flag before
processing any request, so an admin can enable or disable the server per
virtual instance without touching feature flags.