### PR TITLE
LPD-88691 Add extension and size to FileEntry in expected_openapi.json

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/resources/com/liferay/headless/builder/resource/test/dependencies/expected_openapi.json
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/resources/com/liferay/headless/builder/resource/test/dependencies/expected_openapi.json
@@ -33,6 +33,10 @@
 						"readOnly": true,
 						"type": "string"
 					},
+					"extension": {
+						"readOnly": true,
+						"type": "string"
+					},
 					"externalReferenceCode": {
 						"type": "string"
 					},
@@ -77,6 +81,10 @@
 					},
 					"scope": {
 						"$ref": "#/components/schemas/Scope"
+					},
+					"size": {
+						"readOnly": true,
+						"type": "string"
 					},
 					"thumbnailURL": {
 						"description": "optional field that specifies the thumbnail of the file to be used, can be embedded with nestedFields (the format of the nested field must be `<attachment field name>.thumbnailURL`)",


### PR DESCRIPTION
Hi guys! This PR was done by Claude as part of some investigation we are doing, it intends to fix a test. I'm leaving here the output Claude gave:

https://liferay.atlassian.net/browse/LPD-88691

## Failing Test

`com.liferay.headless.builder.resource.test.HeadlessBuilderOpenAPIResourceTest`

`modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderOpenAPIResourceTest.java`

```
test: java.lang.AssertionError: components.schemas.FileEntry.properties Unexpected: extension  ; components.schemas.FileEntry.properties Unexpected: size   at org.skyscreamer.jsonassert.JSONAssert.assertEqu
```

## Root Cause

Commit `43b91a257ff4` ("LPD-83178 Add new field to FileEntry (yaml)") added the `extension` and `size` properties to `components.schemas.FileEntry` in `object-rest-impl/rest-openapi.yaml`, but the test's `expected_openapi.json` resource was not regenerated, so `JSONAssert.assertEquals` reported both fields as Unexpected on `FileEntry.properties`.

## Fix

Add the matching `extension` and `size` entries (both `readOnly` strings, alphabetically placed) to the FileEntry schema inside the test resource so the expected document mirrors the runtime OpenAPI document produced after `LPD-83178`.

- `modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/resources/com/liferay/headless/builder/resource/test/dependencies/expected_openapi.json`
