### PR TITLE
LPD-88869 Add extension and size to FileEntry expected schema

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/resources/com/liferay/headless/builder/resource/test/dependencies/expected_openapi.json
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/resources/com/liferay/headless/builder/resource/test/dependencies/expected_openapi.json
@@ -33,6 +33,10 @@
 						"readOnly": true,
 						"type": "string"
 					},
+					"extension": {
+						"readOnly": true,
+						"type": "string"
+					},
 					"externalReferenceCode": {
 						"type": "string"
 					},
@@ -77,6 +81,10 @@
 					},
 					"scope": {
 						"$ref": "#/components/schemas/Scope"
+					},
+					"size": {
+						"readOnly": true,
+						"type": "string"
 					},
 					"thumbnailURL": {
 						"description": "optional field that specifies the thumbnail of the file to be used, can be embedded with nestedFields (the format of the nested field must be `<attachment field name>.thumbnailURL`)",


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88868

## Failing Test

`com.liferay.headless.builder.resource.test.HeadlessBuilderOpenAPIResourceTest`

`modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderOpenAPIResourceTest.java`

```
java.lang.AssertionError: components.schemas.FileEntry.properties Unexpected: extension  ; components.schemas.FileEntry.properties Unexpected: size
	at org.skyscreamer.jsonassert.JSONAssert.assertEquals(JSONAssert.java:222)
	at com.liferay.headless.builder.resource.test.HeadlessBuilderOpenAPIResourceTest.test(HeadlessBuilderOpenAPIResourceTest.java:431)
```

## Root Cause

Commit `43b91a257ff4` ("LPD-83178 Add new field to FileEntry (yaml)") added `extension` and `size` properties to the `FileEntry` schema in `modules/apps/object/object-rest-impl/rest-openapi.yaml` to satisfy LPD-83178 ("Missing fields in the info panel for files"). The test's `expected_openapi.json` still asserts the previous schema, so the new properties surface as `Unexpected`.

## Fix

Add `extension` and `size` (each `readOnly: true`, `type: string`) to the `FileEntry.properties` block of `expected_openapi.json` so the assertion mirrors the current OpenAPI contract. With this change, the test passes locally.

- `modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/resources/com/liferay/headless/builder/resource/test/dependencies/expected_openapi.json`