### PR TITLE
LPD-88802 surface expando locale warnings as import report entries

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -81,7 +81,7 @@ cd <module-root> && <gradlew> test --tests <TestClassName>
 
 # Portal core
 ant test-unit
-ant test-unit -Dtest.class=SomeTest
+ant test-class -Dtest.class=SomeTest
 ant test-package -Dtest.package=com.liferay.portal.kernel.util
 
 # Frontend

--- a/.claude/rules/breaking-changes.md
+++ b/.claude/rules/breaking-changes.md
@@ -1,0 +1,58 @@
+# Breaking Changes
+
+Liferay reports Java API breaking changes via commit messages so they can be extracted and published. Before assuming a change is breaking, ask bnd — it is the source of truth.
+
+## When To Apply
+
+Any change to a public Java type in `portal-kernel`, `portal-impl`, or any OSGi module. Examples that may or may not be breaking depending on context: changing a method return type, removing or renaming a public method, changing a parameter list, removing a public constant, narrowing a class or method's visibility.
+
+## Step 1 — Run Baseline
+
+This determines whether the change is actually breaking and what version bump is required.
+
+- In the API module:
+
+	```bash
+	gw baseline
+	```
+
+- At `portal-kernel`:
+
+	```bash
+	ant -Dbaseline.jar.report.level=persist clean jar
+	```
+
+Both commands write the new version directly into `packageinfo` and `bnd.bnd` when a bump is required. Check `git status` afterwards:
+
+- If neither file was modified, the change is not breaking from bnd's perspective. Stop. No commit message edit needed.
+- If either file was modified, the bump has already been applied. Continue to Step 2.
+
+## Step 2 — Enrich The Commit Message
+
+Add a `# breaking` block to the commit that introduces the change. Commit with `git commit --cleanup=verbatim` so the `#` headers are not stripped.
+
+Template (the `## Alternatives` section is optional and should be omitted when there is no meaningful alternative):
+
+````
+<Jira ticket> <Subject as usual>
+
+# breaking
+
+## What <full/path/from/repo/root/File.java>
+
+<Concrete description: name the class, method, signature change, removed constant, etc.>
+
+## Why
+
+<Motivation: the requirement or constraint that made the break necessary.>
+
+## Alternatives
+
+<Optional. If callers have a migration path other than adopting the new signature, describe it here.>
+
+----
+````
+
+## Amendments
+
+If a breaking-change commit message is wrong or missing after the fact, do not rewrite history. Append an entry to `readme/BREAKING_CHANGES_AMENDMENTS.md` instead, following the format used in that file.

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PortletDataContextImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PortletDataContextImpl.java
@@ -32,6 +32,7 @@ import com.liferay.exportimport.kernel.lar.StagedModelType;
 import com.liferay.exportimport.kernel.lar.UserIdStrategy;
 import com.liferay.exportimport.kernel.xstream.XStreamAlias;
 import com.liferay.exportimport.kernel.xstream.XStreamConverter;
+import com.liferay.exportimport.report.service.ExportImportReportEntryLocalServiceUtil;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
@@ -1954,8 +1955,37 @@ public class PortletDataContextImpl implements PortletDataContext {
 					(Map<String, Serializable>)getZipEntryAsObject(expandoPath);
 
 				if (expandoBridgeAttributes != null) {
-					ExpandoUtil.fillMissingDefaultLocaleValues(
-						expandoBridgeAttributes);
+					List<String> warningMessages =
+						ExpandoUtil.fillMissingDefaultLocaleValues(
+							expandoBridgeAttributes);
+
+					if (!warningMessages.isEmpty()) {
+						String externalReferenceCode = null;
+
+						if (classedModel instanceof
+								ExternalReferenceCodeModel) {
+
+							ExternalReferenceCodeModel
+								externalReferenceCodeModel =
+									(ExternalReferenceCodeModel)classedModel;
+
+							externalReferenceCode =
+								externalReferenceCodeModel.
+									getExternalReferenceCode();
+						}
+
+						ExportImportReportEntryLocalServiceUtil.
+							getOrAddErrorExportImportReportEntry(
+								getGroupId(), getCompanyId(),
+								externalReferenceCode,
+								ExportImportClassedModelUtil.getClassNameId(
+									classedModel),
+								ExportImportClassedModelUtil.getClassPK(
+									classedModel),
+								GetterUtil.getLong(getExportImportProcessId()),
+								StringUtil.merge(warningMessages, "\n"), null,
+								clazz.getName());
+					}
 
 					serviceContext.setExpandoBridgeAttributes(
 						expandoBridgeAttributes);

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/PortletDataContextExpandoLocaleWarningTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/PortletDataContextExpandoLocaleWarningTest.java
@@ -1,0 +1,276 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.exportimport.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.expando.kernel.model.ExpandoBridge;
+import com.liferay.exportimport.kernel.configuration.constants.ExportImportConfigurationConstants;
+import com.liferay.exportimport.kernel.lar.PortletDataContext;
+import com.liferay.exportimport.kernel.lar.StagedModelType;
+import com.liferay.exportimport.kernel.model.ExportImportConfiguration;
+import com.liferay.exportimport.kernel.service.ExportImportConfigurationLocalService;
+import com.liferay.exportimport.report.constants.ExportImportReportEntryConstants;
+import com.liferay.exportimport.report.model.ExportImportReportEntry;
+import com.liferay.exportimport.report.service.ExportImportReportEntryLocalService;
+import com.liferay.exportimport.test.util.ExportImportTestUtil;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.StagedModel;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleThreadLocal;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.xml.Element;
+import com.liferay.portal.kernel.xml.SAXReaderUtil;
+import com.liferay.portal.kernel.zip.ZipWriter;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.io.Serializable;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jose Luis Navarro
+ */
+@RunWith(Arquillian.class)
+public class PortletDataContextExpandoLocaleWarningTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_originalSiteDefaultLocale = LocaleThreadLocal.getSiteDefaultLocale();
+	}
+
+	@After
+	public void tearDown() {
+		LocaleThreadLocal.setSiteDefaultLocale(_originalSiteDefaultLocale);
+	}
+
+	@Test
+	public void testReportEntryAddedWhenDefaultLocaleMissing()
+		throws Exception {
+
+		LocaleThreadLocal.setSiteDefaultLocale(LocaleUtil.GERMANY);
+
+		PortletDataContext portletDataContext =
+			ExportImportTestUtil.getImportPortletDataContext(
+				_group.getGroupId());
+
+		portletDataContext.setZipWriter(
+			(ZipWriter)portletDataContext.getZipReader());
+
+		ExportImportConfiguration exportImportConfiguration =
+			_addDraftExportImportConfiguration();
+
+		portletDataContext.setExportImportProcessId(
+			String.valueOf(
+				exportImportConfiguration.getExportImportConfigurationId()));
+
+		String expandoPath = _addExpandoZipEntry(
+			portletDataContext,
+			HashMapBuilder.<String, Serializable>put(
+				"greeting",
+				(Serializable)HashMapBuilder.<Locale, String>put(
+					LocaleUtil.US, "Hello"
+				).build()
+			).build());
+
+		Element element = SAXReaderUtil.createElement("staged-model");
+
+		element.addAttribute("expando-path", expandoPath);
+
+		try {
+			portletDataContext.createServiceContext(
+				element,
+				new TestStagedModel(
+					RandomTestUtil.randomString(),
+					RandomTestUtil.randomLong()));
+
+			List<ExportImportReportEntry> exportImportReportEntries =
+				_exportImportReportEntryLocalService.
+					getExportImportReportEntries(
+						TestPropsValues.getCompanyId(),
+						exportImportConfiguration.
+							getExportImportConfigurationId());
+
+			Assert.assertEquals(
+				exportImportReportEntries.toString(), 1,
+				exportImportReportEntries.size());
+
+			ExportImportReportEntry exportImportReportEntry =
+				exportImportReportEntries.get(0);
+
+			Assert.assertEquals(
+				ExportImportReportEntryConstants.TYPE_ERROR,
+				exportImportReportEntry.getType());
+
+			String errorMessage = exportImportReportEntry.getErrorMessage();
+
+			Assert.assertTrue(errorMessage, errorMessage.contains("greeting"));
+		}
+		finally {
+			_exportImportConfigurationLocalService.
+				deleteExportImportConfiguration(exportImportConfiguration);
+		}
+	}
+
+	private ExportImportConfiguration _addDraftExportImportConfiguration()
+		throws Exception {
+
+		return _exportImportConfigurationLocalService.
+			addDraftExportImportConfiguration(
+				_group.getCreatorUserId(), RandomTestUtil.randomString(),
+				ExportImportConfigurationConstants.TYPE_IMPORT_LAYOUT,
+				Collections.emptyMap());
+	}
+
+	private String _addExpandoZipEntry(
+		PortletDataContext portletDataContext,
+		Map<String, Serializable> expandoBridgeAttributes) {
+
+		String expandoPath =
+			"/expando/test-" + RandomTestUtil.randomString() + ".xml";
+
+		portletDataContext.addZipEntry(expandoPath, expandoBridgeAttributes);
+
+		return expandoPath;
+	}
+
+	@Inject
+	private ExportImportConfigurationLocalService
+		_exportImportConfigurationLocalService;
+
+	@Inject
+	private ExportImportReportEntryLocalService
+		_exportImportReportEntryLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	private Locale _originalSiteDefaultLocale;
+
+	private static class TestStagedModel
+		implements ExternalReferenceCodeModel, StagedModel {
+
+		public TestStagedModel(String externalReferenceCode, long primaryKey) {
+			_externalReferenceCode = externalReferenceCode;
+			_primaryKey = primaryKey;
+		}
+
+		@Override
+		public Object clone() {
+			return null;
+		}
+
+		@Override
+		public long getCompanyId() {
+			return 0;
+		}
+
+		@Override
+		public Date getCreateDate() {
+			return null;
+		}
+
+		@Override
+		public ExpandoBridge getExpandoBridge() {
+			return null;
+		}
+
+		@Override
+		public String getExternalReferenceCode() {
+			return _externalReferenceCode;
+		}
+
+		@Override
+		public Class<?> getModelClass() {
+			return TestStagedModel.class;
+		}
+
+		@Override
+		public String getModelClassName() {
+			return TestStagedModel.class.getName();
+		}
+
+		@Override
+		public Date getModifiedDate() {
+			return null;
+		}
+
+		@Override
+		public Serializable getPrimaryKeyObj() {
+			return _primaryKey;
+		}
+
+		@Override
+		public StagedModelType getStagedModelType() {
+			return new StagedModelType(
+				PortalUtil.getClassNameId(TestStagedModel.class.getName()),
+				PortalUtil.getClassNameId(TestStagedModel.class.getName()));
+		}
+
+		@Override
+		public String getUuid() {
+			return null;
+		}
+
+		@Override
+		public void setCompanyId(long companyId) {
+		}
+
+		@Override
+		public void setCreateDate(Date date) {
+		}
+
+		@Override
+		public void setExternalReferenceCode(String externalReferenceCode) {
+		}
+
+		@Override
+		public void setModifiedDate(Date date) {
+		}
+
+		@Override
+		public void setPrimaryKeyObj(Serializable primaryKeyObj) {
+		}
+
+		@Override
+		public void setUuid(String uuid) {
+		}
+
+		private final String _externalReferenceCode;
+		private final long _primaryKey;
+
+	}
+
+}

--- a/portal-kernel/src/com/liferay/expando/kernel/util/ExpandoUtil.java
+++ b/portal-kernel/src/com/liferay/expando/kernel/util/ExpandoUtil.java
@@ -46,11 +46,13 @@ import java.util.TimeZone;
  */
 public class ExpandoUtil {
 
-	public static void fillMissingDefaultLocaleValues(
+	public static List<String> fillMissingDefaultLocaleValues(
 		Map<String, Serializable> expandoBridgeAttributes) {
 
+		List<String> warningMessages = new ArrayList<>();
+
 		if (expandoBridgeAttributes == null) {
-			return;
+			return warningMessages;
 		}
 
 		Locale siteDefaultLocale = LocaleUtil.getSiteDefault();
@@ -89,20 +91,25 @@ public class ExpandoUtil {
 				if (_hasLocalizedExpandoValue(localeEntry.getValue())) {
 					localizedMap.put(siteDefaultLocale, localeEntry.getValue());
 
+					String warningMessage = StringBundler.concat(
+						"Using value from locale ",
+						LocaleUtil.toLanguageId(localeEntry.getKey()),
+						" for expando attribute \"", entry.getKey(),
+						"\" because default locale ", siteDefaultLanguageId,
+						" has no value");
+
+					warningMessages.add(warningMessage);
+
 					if (_log.isWarnEnabled()) {
-						_log.warn(
-							StringBundler.concat(
-								"Using value from locale ",
-								LocaleUtil.toLanguageId(localeEntry.getKey()),
-								" for expando attribute \"", entry.getKey(),
-								"\" because default locale ",
-								siteDefaultLanguageId, " has no value"));
+						_log.warn(warningMessage);
 					}
 
 					break;
 				}
 			}
 		}
+
+		return warningMessages;
 	}
 
 	public static Map<String, Serializable> getExpandoBridgeAttributes(

--- a/portal-kernel/test/unit/com/liferay/expando/kernel/util/ExpandoUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/expando/kernel/util/ExpandoUtilTest.java
@@ -11,7 +11,6 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LogEntry;
 import com.liferay.portal.test.log.LoggerTestUtil;
-import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.io.Serializable;
 
@@ -22,19 +21,12 @@ import java.util.Map;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
 
 /**
  * @author Petteri Karttunen
  */
 public class ExpandoUtilTest {
-
-	@ClassRule
-	@Rule
-	public static final LiferayUnitTestRule liferayUnitTestRule =
-		LiferayUnitTestRule.INSTANCE;
 
 	@Before
 	public void setUp() {
@@ -49,6 +41,18 @@ public class ExpandoUtilTest {
 	}
 
 	@Test
+	public void testFillMissingDefaultLocaleValues() {
+		Map<Locale, String> localizedMap = HashMapBuilder.put(
+			LocaleUtil.GERMANY, "Hallo"
+		).build();
+
+		ExpandoUtil.fillMissingDefaultLocaleValues(
+			_attributesOf("greeting", (Serializable)localizedMap));
+
+		Assert.assertEquals("Hallo", localizedMap.get(LocaleUtil.US));
+	}
+
+	@Test
 	public void testFillMissingDefaultLocaleValuesWithDefaultPresent() {
 		Map<Locale, String> localizedMap = HashMapBuilder.put(
 			LocaleUtil.GERMANY, "Hallo"
@@ -56,11 +60,15 @@ public class ExpandoUtilTest {
 			LocaleUtil.US, "Hello"
 		).build();
 
-		ExpandoUtil.fillMissingDefaultLocaleValues(
-			_attributesOf("greeting", (Serializable)localizedMap));
+		List<String> warningMessages =
+			ExpandoUtil.fillMissingDefaultLocaleValues(
+				_attributesOf("greeting", (Serializable)localizedMap));
 
 		Assert.assertEquals("Hello", localizedMap.get(LocaleUtil.US));
 		Assert.assertEquals("Hallo", localizedMap.get(LocaleUtil.GERMANY));
+
+		Assert.assertTrue(
+			warningMessages.toString(), warningMessages.isEmpty());
 	}
 
 	@Test
@@ -72,14 +80,17 @@ public class ExpandoUtilTest {
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				ExpandoUtil.class.getName(), LoggerTestUtil.WARN)) {
 
-			ExpandoUtil.fillMissingDefaultLocaleValues(
-				_attributesOf("greeting", (Serializable)localizedMap));
+			List<String> warningMessages =
+				ExpandoUtil.fillMissingDefaultLocaleValues(
+					_attributesOf("greeting", (Serializable)localizedMap));
 
 			Assert.assertArrayEquals(
 				new String[] {"Hallo", "Welt"},
 				localizedMap.get(LocaleUtil.US));
 
 			_assertLog(logCapture, "greeting", LocaleUtil.GERMANY);
+			_assertWarningMessages(
+				warningMessages, "greeting", LocaleUtil.GERMANY);
 		}
 	}
 
@@ -92,12 +103,15 @@ public class ExpandoUtilTest {
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				ExpandoUtil.class.getName(), LoggerTestUtil.WARN)) {
 
-			ExpandoUtil.fillMissingDefaultLocaleValues(
-				_attributesOf("greeting", (Serializable)localizedMap));
+			List<String> warningMessages =
+				ExpandoUtil.fillMissingDefaultLocaleValues(
+					_attributesOf("greeting", (Serializable)localizedMap));
 
 			Assert.assertEquals("Hallo", localizedMap.get(LocaleUtil.US));
 
 			_assertLog(logCapture, "greeting", LocaleUtil.GERMANY);
+			_assertWarningMessages(
+				warningMessages, "greeting", LocaleUtil.GERMANY);
 		}
 	}
 
@@ -115,6 +129,20 @@ public class ExpandoUtilTest {
 		Assert.assertTrue(message, message.contains(name));
 		Assert.assertTrue(
 			message, message.contains(LocaleUtil.toLanguageId(locale)));
+	}
+
+	private void _assertWarningMessages(
+		List<String> warningMessages, String name, Locale locale) {
+
+		Assert.assertEquals(
+			warningMessages.toString(), 1, warningMessages.size());
+
+		String warningMessage = warningMessages.get(0);
+
+		Assert.assertTrue(warningMessage, warningMessage.contains(name));
+		Assert.assertTrue(
+			warningMessage,
+			warningMessage.contains(LocaleUtil.toLanguageId(locale)));
 	}
 
 	private Map<String, Serializable> _attributesOf(


### PR DESCRIPTION
Jira Ticket: https://liferay.atlassian.net/browse/LPD-87238

- Dropped @ClassRule LiferayUnitTestRule from ExpandoUtilTest, the test wasn't  
  being picked up in CI: https://testray.liferay.com/#/project/35392/cases/470018880         
 - Fixed an issue in .claude/CLAUDE.md                            
 - Kept the warn log in fillMissingDefaultLocaleValuesWithWarnings. LayoutUtil
  (headless-admin-site REST API) does not produce a report entry so the log is still the only signal there
- Added breaking changes rule

https://github.com/user-attachments/assets/7e01e53a-cb50-4674-8c8f-e04007d23424

