### PR TITLE
LPD-88913 Add cadmin class to Publish to Live modal

### DIFF
--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/menu/staging_actions.jspf
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/menu/staging_actions.jspf
@@ -239,7 +239,6 @@
 						event.preventDefault();
 
 						Liferay.Util.openModal({
-							containerProps: {},
 							id: '<portlet:namespace />publishLatestChangesDialog',
 							iframeBodyCssClass: 'dialog-with-footer',
 							onClose: () => {

--- a/modules/test/playwright/tests/staging-configuration-web/main/stagingConfiguration.spec.ts
+++ b/modules/test/playwright/tests/staging-configuration-web/main/stagingConfiguration.spec.ts
@@ -68,7 +68,7 @@ export const testFlagsEnabled = mergeTests(
 
 test(
 	'Verify there is advanced staging configuration checkbox with description in Instance Setting,the configuration checkbox can be enabled',
-	{tag: ['@LPS-189238']},
+	{tag: ['@LPS-189238', '@LPD-88913']},
 	async ({
 		apiHelpers,
 		exportImportStagingInstanceSettingsPage,
@@ -109,6 +109,14 @@ test(
 				page,
 			});
 			await portletPublishToLivePage.publishToLiveButton.click();
+
+			await test.step('LPD-88913 - Publish to Live modal must keep the cadmin wrapper', async () => {
+				await expect(
+					page.locator(
+						'div.cadmin > [id$="publishLatestChangesDialog"]'
+					)
+				).toBeVisible();
+			});
 
 			await expect(
 				portletPublishToLivePage.publishToLiveIframe.getByRole('link', {


### PR DESCRIPTION
## Summary

- Restores the `cadmin` class wrapper on the "Publish to Live" modal in
  `staging_actions.jspf` by removing the explicit `containerProps: {}`
  that was overriding the default in
  `frontend-js-components-web/Modal.tsx`. Empty `containerProps`
  short-circuits the destructuring default (`{className: 'cadmin'}`)
  JS only applies the default when the prop is `undefined`, not when
  it is `{}`.
- Adds a Playwright assertion (wrapped in `test.step`, tagged
  `@LPD-88913`) to an existing test in `stagingConfiguration.spec.ts`
  that already opens this modal. Reusing the existing setup avoids a
  separate CI run for one CSS class check; the step name makes the
  intent obvious in failure output.
- Scope is intentionally **atomic** limited to the customer-reported
  call site (LPP-63828). The same underlying issue exists in other
  modals across the portal, but that broader concern is out of scope
  for this PR and will be discussed with the Frontend Infrastructure
  team as a follow-up.

<img width="2000" height="1564" alt="staging_actions_jspf_L239_publishToLive" src="https://github.com/user-attachments/assets/662c8eaf-3348-47ae-bb53-aeb23c9c2b5e" />


Fixes [LPD-88913](https://liferay.atlassian.net/browse/LPD-88913) (linked from [LPP-63828](https://liferay.atlassian.net/browse/LPP-63828)).

## Test plan

- [ ] CI passes the new `@LPD-88913` Playwright assertion in
  `stagingConfiguration.spec.ts`.
- [x] Local manual check: enable local staging, navigate to a staged
  page, click "Publish to Live", inspect the modal in DevTools and
  confirm `<div class="cadmin">` wraps `modal-backdrop` +
  `liferay-modal`.
- [x] Tested locally - assertion passes:
<img width="3425" height="1801" alt="image" src="https://github.com/user-attachments/assets/11254fe7-83ff-400c-a318-3c533bac9745" />

- [x] Regression check confirmed locally: temporarily re-adding
  `containerProps: {}` to the JSP and redeploying makes the new test
  fail at the step `LPD-88913 - Publish to Live modal must keep the cadmin wrapper`.