### PR TITLE
LPD-85261 Headless APIs ignore milliseconds in date values

### DIFF
--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/writer/ColumnValuesExtractor.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/writer/ColumnValuesExtractor.java
@@ -5,8 +5,6 @@
 
 package com.liferay.batch.engine.internal.writer;
 
-import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
-
 import com.liferay.batch.engine.csv.ColumnDescriptor;
 import com.liferay.batch.engine.csv.ColumnDescriptorProvider;
 import com.liferay.petra.function.UnsafeFunction;
@@ -25,6 +23,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
 import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -33,6 +32,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TimeZone;
 
 /**
  * @author Shuyang Zhou
@@ -228,7 +228,10 @@ public class ColumnValuesExtractor {
 
 		if (ItemClassIndexUtil.isSingleColumnAdoptableValue(fieldClass)) {
 			if (ItemClassIndexUtil.isDate(fieldClass)) {
-				DateFormat dateFormat = new ISO8601DateFormat();
+				DateFormat dateFormat = new SimpleDateFormat(
+					"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+
+				dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
 
 				return new UnsafeFunction
 					<Object, Object, ReflectiveOperationException>() {

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/writer/ColumnValuesExtractor.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/writer/ColumnValuesExtractor.java
@@ -5,6 +5,8 @@
 
 package com.liferay.batch.engine.internal.writer;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import com.liferay.batch.engine.csv.ColumnDescriptor;
 import com.liferay.batch.engine.csv.ColumnDescriptorProvider;
 import com.liferay.petra.function.UnsafeFunction;
@@ -17,13 +19,13 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.CSVUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.ObjectValuePair;
+import com.liferay.portal.vulcan.jackson.databind.ObjectMapperProviderUtil;
 
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
 import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -32,7 +34,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TimeZone;
 
 /**
  * @author Shuyang Zhou
@@ -228,10 +229,10 @@ public class ColumnValuesExtractor {
 
 		if (ItemClassIndexUtil.isSingleColumnAdoptableValue(fieldClass)) {
 			if (ItemClassIndexUtil.isDate(fieldClass)) {
-				DateFormat dateFormat = new SimpleDateFormat(
-					"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+				ObjectMapper objectMapper =
+					ObjectMapperProviderUtil.getBatchEngineObjectMapper();
 
-				dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+				DateFormat dateFormat = objectMapper.getDateFormat();
 
 				return new UnsafeFunction
 					<Object, Object, ReflectiveOperationException>() {

--- a/modules/apps/batch-engine/batch-engine-service/src/test/java/com/liferay/batch/engine/internal/writer/BaseBatchEngineExportTaskItemWriterImplTestCase.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/test/java/com/liferay/batch/engine/internal/writer/BaseBatchEngineExportTaskItemWriterImplTestCase.java
@@ -26,6 +26,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 
 import org.junit.Before;
 
@@ -283,10 +284,15 @@ public abstract class BaseBatchEngineExportTaskItemWriterImplTestCase {
 
 	protected static final List<String> columnFieldNames = Arrays.asList(
 		"createDate", "description", "id", "map", "name_en", "name_hr");
-	protected static final DateFormat dateFormat = new SimpleDateFormat(
-		"yyyy-MM-dd'T'HH:mm:ssX");
+	protected static final DateFormat dateFormat;
 	protected static final List<String> jsonFieldNames = Arrays.asList(
 		"childItem", "createDate", "description", "id", "map", "name");
+
+	static {
+		dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+
+		dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+	}
 
 	protected Map<String, ObjectValuePair<Field, Method>>
 		fieldNameObjectValuePairs = ItemClassIndexUtil.index(Item.class);

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BaseBatchEngineTaskExecutorTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BaseBatchEngineTaskExecutorTest.java
@@ -68,6 +68,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -476,10 +477,18 @@ public class BaseBatchEngineTaskExecutorTest {
 	@Inject
 	protected BlogsEntryLocalService blogsEntryLocalService;
 
-	protected final DateFormat dateFormat = new SimpleDateFormat(
-		"yyyy-MM-dd'T'HH:mm:ssX");
+	protected final DateFormat dateFormat = _createDateFormat();
 	protected int initialCount;
 	protected User user;
+
+	private DateFormat _createDateFormat() {
+		DateFormat dateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+
+		dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+		return dateFormat;
+	}
 
 	private ServiceRegistration<?>
 		_batchEngineTaskItemDelegateServiceRegistration;

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineExportTaskExecutorTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineExportTaskExecutorTest.java
@@ -27,6 +27,7 @@ import com.liferay.petra.io.unsync.UnsyncBufferedReader;
 import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.spring.orm.LastSessionRecorderHelper;
 import com.liferay.portal.kernel.spring.orm.LastSessionRecorderHelperUtil;
 import com.liferay.portal.kernel.test.AssertUtils;
@@ -53,6 +54,9 @@ import java.io.Serializable;
 
 import java.sql.Blob;
 
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -61,6 +65,7 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.zip.ZipInputStream;
@@ -179,6 +184,43 @@ public class BatchEngineExportTaskExecutorTest
 		_assertExportedValues(
 			blogsEntries, fieldNames,
 			_readRowValuesList(_csvFilterFunction, batchEngineExportTask));
+	}
+
+	@Test
+	@TestInfo("LPD-85261")
+	public void testExportBlogPostingsToJSONFileWithDateCreated()
+		throws Exception {
+
+		BlogsEntry blogsEntry = blogsEntryLocalService.addEntry(
+			user.getUserId(), "headline", "alternativeHeadline", null,
+			"articleBody", new Date(baseDate.getTime()), false, false, null,
+			null, null, null,
+			ServiceContextTestUtil.getServiceContext(
+				TestPropsValues.getCompanyId(), TestPropsValues.getGroupId(),
+				user.getUserId()));
+
+		_exportBlogPostings("JSON", Arrays.asList("dateCreated"), _parameters);
+
+		BatchEngineExportTask batchEngineExportTask =
+			_batchEngineExportTaskLocalService.getBatchEngineExportTask(
+				_batchEngineExportTask.getBatchEngineExportTaskId());
+
+		JSONArray jsonArray = JSONFactoryUtil.createJSONArray(
+			StringUtil.read(
+				_getZipInputStream(
+					_batchEngineExportTaskLocalService.openContentInputStream(
+						batchEngineExportTask.getBatchEngineExportTaskId()))));
+
+		JSONObject jsonObject = jsonArray.getJSONObject(initialCount);
+
+		DateFormat dateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+
+		dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+		Assert.assertEquals(
+			blogsEntry.getCreateDate(),
+			dateFormat.parse(jsonObject.getString("dateCreated")));
 	}
 
 	@Test

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/jackson/databind/ObjectMapperProviderUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/jackson/databind/ObjectMapperProviderUtil.java
@@ -25,6 +25,10 @@ import com.liferay.portal.vulcan.jaxrs.serializer.JSONArrayStdSerializer;
 import com.liferay.portal.vulcan.jaxrs.serializer.JSONObjectStdSerializer;
 import com.liferay.portal.vulcan.jaxrs.serializer.UnsafeSupplierJsonSerializer;
 
+import java.text.SimpleDateFormat;
+
+import java.util.TimeZone;
+
 /**
  * @author Alejandro Tardín
  */
@@ -55,7 +59,13 @@ public class ObjectMapperProviderUtil {
 								new UnsafeSupplierJsonSerializer());
 						}
 					});
-				setDateFormat(new ISO8601DateFormat());
+
+				SimpleDateFormat dateFormat = new SimpleDateFormat(
+					"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+
+				dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+				setDateFormat(dateFormat);
 				setSerializationInclusion(JsonInclude.Include.NON_NULL);
 			}
 		};

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/jackson/databind/ObjectMapperProviderUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/jackson/databind/ObjectMapperProviderUtil.java
@@ -25,6 +25,7 @@ import com.liferay.portal.vulcan.jaxrs.serializer.JSONArrayStdSerializer;
 import com.liferay.portal.vulcan.jaxrs.serializer.JSONObjectStdSerializer;
 import com.liferay.portal.vulcan.jaxrs.serializer.UnsafeSupplierJsonSerializer;
 
+import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
 import java.util.TimeZone;
@@ -60,12 +61,13 @@ public class ObjectMapperProviderUtil {
 						}
 					});
 
-				SimpleDateFormat dateFormat = new SimpleDateFormat(
+				DateFormat dateFormat = new SimpleDateFormat(
 					"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
 
 				dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
 
 				setDateFormat(dateFormat);
+
 				setSerializationInclusion(JsonInclude.Include.NON_NULL);
 			}
 		};


### PR DESCRIPTION
[LPD-85261](https://liferay.atlassian.net/browse/LPD-85261)

Use milliseconds only in batch processing. The API will still use the `ISO8601DateFormat` and work the same way for the other calls. We decided to go with this approach to avoid breaking the API for existing users.

cc: @peerkar , @4lejandrito 