### PR TITLE
LPD-89022 Pass account entry id when populating object entry tree

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -10662,34 +10662,11 @@ public class DefaultObjectEntryManagerImplTest
 			AccountEntry accountEntry, String externalReferenceCodeSuffix)
 		throws Exception {
 
-		Tree tree = TreeTestUtil.createObjectEntryTree(
-			externalReferenceCodeSuffix, objectDefinitionLocalService,
-			_objectEntryLocalService, objectFieldLocalService,
-			_objectRelationshipLocalService,
+		return TreeTestUtil.createObjectEntryTree(
+			accountEntry.getAccountEntryId(), externalReferenceCodeSuffix,
+			objectDefinitionLocalService, _objectEntryLocalService,
+			objectFieldLocalService, _objectRelationshipLocalService,
 			_rootObjectDefinition.getObjectDefinitionId());
-
-		Node node = tree.getRootNode();
-
-		com.liferay.object.model.ObjectEntry serviceBuilderObjectEntry =
-			_objectEntryLocalService.getObjectEntry(node.getPrimaryKey());
-
-		_objectEntryLocalService.updateObjectEntry(
-			adminUser.getUserId(), serviceBuilderObjectEntry.getPrimaryKey(),
-			serviceBuilderObjectEntry.getObjectEntryFolderId(),
-			HashMapBuilder.<String, Serializable>put(
-				() -> {
-					ObjectField objectField =
-						objectFieldLocalService.getObjectField(
-							_rootObjectDefinition.
-								getAccountEntryRestrictedObjectFieldId());
-
-					return objectField.getName();
-				},
-				accountEntry.getAccountEntryId()
-			).build(),
-			ServiceContextTestUtil.getServiceContext());
-
-		return tree;
 	}
 
 	private ObjectFieldSetting _createObjectFieldSetting(

--- a/modules/apps/object/object-test-util/src/main/java/com/liferay/object/test/util/TreeTestUtil.java
+++ b/modules/apps/object/object-test-util/src/main/java/com/liferay/object/test/util/TreeTestUtil.java
@@ -200,7 +200,7 @@ public class TreeTestUtil {
 	}
 
 	public static Tree createObjectEntryTree(
-			String externalReferenceCodeSuffix,
+			Long accountEntryId, String externalReferenceCodeSuffix,
 			ObjectDefinitionLocalService objectDefinitionLocalService,
 			ObjectEntryLocalService objectEntryLocalService,
 			ObjectFieldLocalService objectFieldLocalService,
@@ -222,14 +222,20 @@ public class TreeTestUtil {
 		Queue<String> externalReferenceCodes = new ArrayDeque<>(
 			Arrays.asList("A", "AA", "AB", "AAA", "AAB"));
 
+		HashMapBuilder.HashMapWrapper<String, Serializable> rootValuesBuilder =
+			HashMapBuilder.<String, Serializable>put(
+				"externalReferenceCode",
+				externalReferenceCodes.poll() + externalReferenceCodeSuffix);
+
+		_putAccountEntryRestrictedValue(
+			accountEntryId, objectDefinitionLocalService,
+			objectFieldLocalService, rootNode.getPrimaryKey(),
+			rootValuesBuilder);
+
 		ObjectEntry rootObjectEntry = objectEntryLocalService.addObjectEntry(
 			0, TestPropsValues.getUserId(), rootNode.getPrimaryKey(),
 			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-			null,
-			HashMapBuilder.<String, Serializable>put(
-				"externalReferenceCode",
-				externalReferenceCodes.poll() + externalReferenceCodeSuffix
-			).build(),
+			null, rootValuesBuilder.build(),
 			ServiceContextTestUtil.getServiceContext());
 
 		Map<Long, Long> objectEntryIds = HashMapBuilder.put(
@@ -239,11 +245,7 @@ public class TreeTestUtil {
 		while (iterator.hasNext()) {
 			Node node = iterator.next();
 
-			ObjectEntry objectEntry = objectEntryLocalService.addObjectEntry(
-				0, TestPropsValues.getUserId(), node.getPrimaryKey(),
-				ObjectEntryFolderConstants.
-					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-				null,
+			HashMapBuilder.HashMapWrapper<String, Serializable> valuesBuilder =
 				HashMapBuilder.<String, Serializable>put(
 					"externalReferenceCode",
 					externalReferenceCodes.poll() + externalReferenceCodeSuffix
@@ -267,7 +269,17 @@ public class TreeTestUtil {
 
 						return objectEntryIds.get(parentNode.getPrimaryKey());
 					}
-				).build(),
+				);
+
+			_putAccountEntryRestrictedValue(
+				accountEntryId, objectDefinitionLocalService,
+				objectFieldLocalService, node.getPrimaryKey(), valuesBuilder);
+
+			ObjectEntry objectEntry = objectEntryLocalService.addObjectEntry(
+				0, TestPropsValues.getUserId(), node.getPrimaryKey(),
+				ObjectEntryFolderConstants.
+					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+				null, valuesBuilder.build(),
 				ServiceContextTestUtil.getServiceContext());
 
 			objectEntryIds.put(
@@ -280,6 +292,21 @@ public class TreeTestUtil {
 
 		return objectEntryTreeFactory.create(
 			rootObjectEntry.getObjectEntryId());
+	}
+
+	public static Tree createObjectEntryTree(
+			String externalReferenceCodeSuffix,
+			ObjectDefinitionLocalService objectDefinitionLocalService,
+			ObjectEntryLocalService objectEntryLocalService,
+			ObjectFieldLocalService objectFieldLocalService,
+			ObjectRelationshipLocalService objectRelationshipLocalService,
+			long rootObjectDefinitionId)
+		throws PortalException {
+
+		return createObjectEntryTree(
+			null, externalReferenceCodeSuffix, objectDefinitionLocalService,
+			objectEntryLocalService, objectFieldLocalService,
+			objectRelationshipLocalService, rootObjectDefinitionId);
 	}
 
 	public static void deleteObjectDefinitionHierarchy(
@@ -452,6 +479,35 @@ public class TreeTestUtil {
 				node.getPrimaryKey());
 
 		return objectDefinition.getShortName();
+	}
+
+	private static void _putAccountEntryRestrictedValue(
+			Long accountEntryId,
+			ObjectDefinitionLocalService objectDefinitionLocalService,
+			ObjectFieldLocalService objectFieldLocalService,
+			long objectDefinitionId,
+			HashMapBuilder.HashMapWrapper<String, Serializable> valuesBuilder)
+		throws PortalException {
+
+		if (accountEntryId == null) {
+			return;
+		}
+
+		ObjectDefinition objectDefinition =
+			objectDefinitionLocalService.getObjectDefinition(
+				objectDefinitionId);
+
+		long accountEntryRestrictedObjectFieldId =
+			objectDefinition.getAccountEntryRestrictedObjectFieldId();
+
+		if (accountEntryRestrictedObjectFieldId <= 0) {
+			return;
+		}
+
+		ObjectField objectField = objectFieldLocalService.getObjectField(
+			accountEntryRestrictedObjectFieldId);
+
+		valuesBuilder.put(objectField.getName(), accountEntryId);
 	}
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89022

## Failing Test

`com.liferay.object.rest.internal.manager.v1_0.test.DefaultObjectEntryManagerImplTest`

`modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java`

```
com.liferay.object.exception.ObjectEntryValuesException$Required:
No value was provided for required object field "r_oneToManyRelationshipName2_accountEntryId"
    at com.liferay.object.test.util.TreeTestUtil.createObjectEntryTree(TreeTestUtil.java:225)
    at com.liferay.object.rest.internal.manager.v1_0.test.DefaultObjectEntryManagerImplTest._createObjectEntryTree(DefaultObjectEntryManagerImplTest.java:10665)
```

## Root Cause

Commit `00c1afcc8e102` ("LPD-86683 Update account entry restricted object field to be required") made the relationship field to AccountEntry required at creation time on account-entry-restricted object definitions. The shared helper `TreeTestUtil.createObjectEntryTree` did not pass an accountEntryId, so adding the root entry now fails the required-value check.

## Fix

Adds an overload of `TreeTestUtil.createObjectEntryTree` that accepts an `accountEntryId` and writes it into each entry's account-entry-restricted field, and routes the affected test's `_createObjectEntryTree` helper through the new overload (the second `updateObjectEntry` call that used to set the field becomes redundant). The pre-existing 6-arg overload is preserved for non-restricted callers.

- `modules/apps/object/object-test-util/src/main/java/com/liferay/object/test/util/TreeTestUtil.java`
- `modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java`