### PR TITLE
LPD-89090 Reject export submissions without a file name

### DIFF
--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/ExportLayoutsMVCActionCommand.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/ExportLayoutsMVCActionCommand.java
@@ -13,7 +13,6 @@ import com.liferay.exportimport.kernel.lar.ExportImportHelper;
 import com.liferay.exportimport.kernel.model.ExportImportConfiguration;
 import com.liferay.exportimport.kernel.service.ExportImportConfigurationLocalService;
 import com.liferay.exportimport.kernel.service.ExportImportService;
-import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
@@ -130,10 +129,6 @@ public class ExportLayoutsMVCActionCommand extends BaseMVCActionCommand {
 
 		String taskName = ParamUtil.getString(actionRequest, "name");
 
-		if (Validator.isNull(taskName)) {
-			taskName = _language.get(actionRequest.getLocale(), "export");
-		}
-
 		return _exportImportConfigurationLocalService.
 			addDraftExportImportConfiguration(
 				themeDisplay.getUserId(), taskName,
@@ -181,9 +176,6 @@ public class ExportLayoutsMVCActionCommand extends BaseMVCActionCommand {
 
 	@Reference
 	private ExportImportService _exportImportService;
-
-	@Reference
-	private Language _language;
 
 	@Reference
 	private Portal _portal;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89090

## Failing Test

`export-import-web/main/site.export.spec.ts > cannot export at site level without file name`

`modules/test/playwright/tests/export-import-web/main/site.export.spec.ts`

```
Error: Timed out 15000ms waiting for expect(locator).toBeVisible()
Locator: getByRole('alert').filter({ hasText: 'Please enter a file with a valid file name.' })
Expected: visible
Received: <element(s) not found>
  at modules/test/playwright/tests/export-import-web/main/site.export.spec.ts:75:5
```

## Root Cause

The Playwright test was added under LPD-76875 to assert that submitting an export without a file name surfaces the alert "Please enter a file with a valid file name." (rendered server-side via `LARFileNameException` → `<liferay-ui:error>`). The matching code change documented under LPD-76875 — commit `445803f71dc` "Validator not needed as the name will be mandatory in UI", which removes the silent default-name fallback in `ExportLayoutsMVCActionCommand.getExportImportConfiguration` — never reached master. With the fallback still in place, the empty `name` parameter was silently replaced by the localized `"Export"` string, `DLValidatorUtil.isValidName` always passed, no exception was thrown, and the alert never rendered. The test has therefore been failing on every routine since it was added.

## Fix

Remove the empty-name fallback so the empty `taskName` flows through to `ExportImportLocalServiceImpl.exportLayoutsAsFileInBackground`, where `DLValidatorUtil.isValidName("")` returns false and `LARFileNameException` is thrown. The existing JSP error tag (`<liferay-ui:error exception="<%= LARFileNameException.class %>" message="please-enter-a-file-with-a-valid-file-name" />`) renders the expected alert. This mirrors exactly what commit `445803f71dc` did under LPD-76875.

- `modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/ExportLayoutsMVCActionCommand.java`

## Why are there no tests?

The Playwright test that this change targets — `cannot export at site level without file name` in `modules/test/playwright/tests/export-import-web/main/site.export.spec.ts` — already exists in the codebase and was failing on every routine. After this change it passes locally; no new test is needed.