### PR TITLE
LPD-88399 Add File Summary component to Import wizard

### DIFF
--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/FileSelector.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/FileSelector.tsx
@@ -12,6 +12,7 @@ import ClayAlert from '@clayui/alert';
 import {ButtonWithIcon} from '@clayui/core';
 import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
+import {formatStorage} from 'frontend-js-web';
 
 import DragZone from './forms/DragZone';
 
@@ -117,7 +118,7 @@ export default function FileSelector({
 							</p>
 
 							<p className="mb-1">
-								{Liferay.Util.formatStorage(file.size, {
+								{formatStorage(file.size, {
 									addSpaceBeforeSuffix: true,
 								})}
 							</p>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/NewImport.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/NewImport.tsx
@@ -20,7 +20,9 @@ export function NewImport({
 	backURL: string;
 	importPreviewAPIURL: string;
 }) {
-	const [importPreview, setImportPreview] = useState<ImportPreview | undefined>();
+	const [importPreview, setImportPreview] = useState<
+		ImportPreview | undefined
+	>();
 
 	return (
 		<Wizard backURL={backURL}>
@@ -33,8 +35,7 @@ export function NewImport({
 					name: '',
 				}}
 				isStepValid={(values) =>
-					values.fileSelector instanceof File &&
-					!!values.name.trim()
+					values.fileSelector instanceof File && !!values.name.trim()
 				}
 				title={Liferay.Language.get('setup')}
 			>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/NewImport.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/NewImport.tsx
@@ -5,24 +5,13 @@
 
 import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
-import React, {createContext, useContext} from 'react';
+import React, {useState} from 'react';
 
 import {Wizard, WizardStep} from '../../components/Wizard';
+import {ImportPreview} from '../../types/exportImportPreview';
 import DataSelectionStep from './steps/DataSelectionStep';
 import FileSelectionStep from './steps/FileSelectionStep';
 import SettingsStep, {SETTINGS_STEP_INITIAL_VALUES} from './steps/SettingsStep';
-
-interface WizardContextValue {
-	importPreviewAPIURL: string;
-}
-
-export const WizardContext = createContext<WizardContextValue>({
-	importPreviewAPIURL: '',
-});
-
-export function useWizard() {
-	return useContext(WizardContext);
-}
 
 export function NewImport({
 	backURL,
@@ -31,57 +20,60 @@ export function NewImport({
 	backURL: string;
 	importPreviewAPIURL: string;
 }) {
+	const [importPreview, setImportPreview] = useState<ImportPreview | undefined>();
+
 	return (
-		<WizardContext.Provider value={{importPreviewAPIURL}}>
-			<Wizard backURL={backURL}>
-				<WizardStep
-					description={Liferay.Language.get(
-						'name-your-import-process-and-upload-your-file'
-					)}
-					initialValues={{
-						fileSelector: undefined,
-						name: '',
-					}}
-					isStepValid={(values) =>
-						values.fileSelector instanceof File &&
-						!!values.name.trim()
-					}
-					title={Liferay.Language.get('setup')}
-				>
-					<FileSelectionStep />
-				</WizardStep>
+		<Wizard backURL={backURL}>
+			<WizardStep
+				description={Liferay.Language.get(
+					'name-your-import-process-and-upload-your-file'
+				)}
+				initialValues={{
+					fileSelector: undefined,
+					name: '',
+				}}
+				isStepValid={(values) =>
+					values.fileSelector instanceof File &&
+					!!values.name.trim()
+				}
+				title={Liferay.Language.get('setup')}
+			>
+				<FileSelectionStep
+					importPreviewAPIURL={importPreviewAPIURL}
+					setImportPreview={setImportPreview}
+				/>
+			</WizardStep>
 
-				<WizardStep
-					description={Liferay.Language.get(
-						'select-the-data-from-your-file-that-you-would-like-to-import'
-					)}
-					title={Liferay.Language.get('data-selection')}
-				>
-					<DataSelectionStep />
-				</WizardStep>
+			<WizardStep
+				description={Liferay.Language.get(
+					'select-the-data-from-your-file-that-you-would-like-to-import'
+				)}
+				title={Liferay.Language.get('data-selection')}
+			>
+				<DataSelectionStep importPreview={importPreview} />
+			</WizardStep>
 
-				<WizardStep
-					actionButton={
-						<ClayButton type="submit">
-							<span className="inline-item inline-item-before">
-								<ClayIcon className="mr-1" symbol="import" />
-							</span>
+			<WizardStep
+				actionButton={
+					<ClayButton type="submit">
+						<span className="inline-item inline-item-before">
+							<ClayIcon className="mr-1" symbol="import" />
+						</span>
 
-							{Liferay.Language.get('import')}
-						</ClayButton>
-					}
-					description={Liferay.Language.get(
-						'set-up-your-import-configuration'
-					)}
-					initialValues={SETTINGS_STEP_INITIAL_VALUES}
-					onSubmit={async () => {
-						alert('Import started!');
-					}}
-					title={Liferay.Language.get('settings')}
-				>
-					<SettingsStep />
-				</WizardStep>
-			</Wizard>
-		</WizardContext.Provider>
+						{Liferay.Language.get('import')}
+					</ClayButton>
+				}
+				description={Liferay.Language.get(
+					'set-up-your-import-configuration'
+				)}
+				initialValues={SETTINGS_STEP_INITIAL_VALUES}
+				onSubmit={async () => {
+					alert('Import started!');
+				}}
+				title={Liferay.Language.get('settings')}
+			>
+				<SettingsStep />
+			</WizardStep>
+		</Wizard>
 	);
 }

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/steps/DataSelectionStep.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/steps/DataSelectionStep.tsx
@@ -6,12 +6,21 @@
 import ClayLayout from '@clayui/layout';
 import React from 'react';
 
-export default function DataSelectionStep() {
+import {ImportPreview} from '../../../types/exportImportPreview';
+import FileSummary from './FileSummary';
+
+export default function DataSelectionStep({
+	importPreview,
+}: {
+	importPreview?: ImportPreview;
+}) {
+	if (!importPreview) {
+		return null;
+	}
+
 	return (
 		<>
-			<ClayLayout.Sheet>
-				{Liferay.Language.get('file-summary')}
-			</ClayLayout.Sheet>
+			<FileSummary importPreview={importPreview} />
 
 			<ClayLayout.Sheet>
 				{Liferay.Language.get('Portlets')}

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/steps/FileSelectionStep.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/steps/FileSelectionStep.tsx
@@ -10,11 +10,16 @@ import React, {useEffect, useRef, useState} from 'react';
 import {FormikFieldText} from '../../../components/forms/formik';
 import {FormikFieldFileSelector} from '../../../components/forms/formik/FormikFieldFileSelector';
 import {postImportPreview} from '../../../services/postImportPreview';
-import {useWizard} from '../NewImport';
+import {ImportPreview} from '../../../types/exportImportPreview';
 
-export default function FileSelectionStep() {
+export default function FileSelectionStep({
+	importPreviewAPIURL,
+	setImportPreview,
+}: {
+	importPreviewAPIURL: string;
+	setImportPreview: (importPreview?: ImportPreview) => void;
+}) {
 	const [progress, setProgress] = useState<number>();
-	const {importPreviewAPIURL} = useWizard();
 
 	const {setFieldValue, values} = useFormikContext<{
 		fileSelector?: File;
@@ -34,15 +39,26 @@ export default function FileSelectionStep() {
 		if (currentFile instanceof File && !values.name) {
 			setFieldValue('name', currentFile.name.replace(/\.lar$/i, ''));
 		}
-	}, [values.fileSelector, values.name, setFieldValue]);
 
-	const postPreview = (file: File, signal?: AbortSignal) =>
-		postImportPreview({
+		if (!currentFile) {
+			setImportPreview(undefined);
+		}
+	}, [values.fileSelector, values.name, setFieldValue, setImportPreview]);
+
+	const handleUpload = async (file: File, signal?: AbortSignal) => {
+		const result = await postImportPreview({
 			file,
 			onProgress: setProgress,
 			signal,
 			url: importPreviewAPIURL,
 		});
+
+		if (result.data) {
+			setImportPreview(result.data);
+		}
+
+		return result;
+	};
 
 	return (
 		<>
@@ -93,7 +109,7 @@ export default function FileSelectionStep() {
 					aria-labelledby="fileSelector-label"
 					name="fileSelector"
 					progress={progress}
-					uploadRequest={postPreview}
+					uploadRequest={handleUpload}
 					validExtensions=".lar"
 				/>
 			</ClayLayout.Sheet>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/steps/FileSummary.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/steps/FileSummary.tsx
@@ -25,11 +25,11 @@ function MetadataItem({
 				<ClayIcon symbol={icon} />
 			</span>
 
-			<div className="ml-3">
-				<div className="font-weight-semi-bold">{label}</div>
+			<dl className="mb-0 ml-3">
+				<dt className="font-weight-semi-bold">{label}</dt>
 
-				<div className="text-secondary">{value}</div>
-			</div>
+				<dd className="mb-0 text-secondary">{value}</dd>
+			</dl>
 		</div>
 	);
 }

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/steps/FileSummary.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/steps/FileSummary.tsx
@@ -5,7 +5,7 @@
 
 import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
-import {dateUtils} from 'frontend-js-web';
+import {dateUtils, formatStorage} from 'frontend-js-web';
 import React from 'react';
 
 import {ImportPreview} from '../../../types/exportImportPreview';
@@ -82,7 +82,7 @@ export default function FileSummary({
 						label={Liferay.Language.get('size')}
 						value={
 							typeof fileSize === 'number'
-								? Liferay.Util.formatStorage(fileSize, {
+								? formatStorage(fileSize, {
 										addSpaceBeforeSuffix: true,
 									})
 								: '—'

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/steps/FileSummary.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/steps/FileSummary.tsx
@@ -1,0 +1,95 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayIcon from '@clayui/icon';
+import ClayLayout from '@clayui/layout';
+import {dateUtils} from 'frontend-js-web';
+import React from 'react';
+
+import {ImportPreview} from '../../../types/exportImportPreview';
+
+function MetadataItem({
+	icon,
+	label,
+	value,
+}: {
+	icon: string;
+	label: string;
+	value: string;
+}) {
+	return (
+		<div className="align-items-start border d-flex p-3 rounded">
+			<span className="sticker sticker-secondary sticker-sm">
+				<ClayIcon symbol={icon} />
+			</span>
+
+			<div className="ml-3">
+				<div className="font-weight-semi-bold">{label}</div>
+
+				<div className="text-secondary">{value}</div>
+			</div>
+		</div>
+	);
+}
+
+export default function FileSummary({
+	importPreview,
+}: {
+	importPreview: ImportPreview;
+}) {
+	const {author, exportDate, fileName, fileSize} = importPreview;
+
+	return (
+		<ClayLayout.Sheet>
+			<ClayLayout.SheetHeader className="mb-1">
+				<div className="mb-2 sheet-title">
+					{Liferay.Language.get('file-summary')}
+				</div>
+
+				{fileName && (
+					<div className="sheet-text text-3 text-secondary">
+						{fileName}
+					</div>
+				)}
+			</ClayLayout.SheetHeader>
+
+			<ClayLayout.Row>
+				<ClayLayout.Col md={4}>
+					<MetadataItem
+						icon="export"
+						label={Liferay.Language.get('exported')}
+						value={
+							exportDate
+								? dateUtils.fromNow(new Date(exportDate))
+								: '—'
+						}
+					/>
+				</ClayLayout.Col>
+
+				<ClayLayout.Col md={4}>
+					<MetadataItem
+						icon="user"
+						label={Liferay.Language.get('author')}
+						value={author ?? '—'}
+					/>
+				</ClayLayout.Col>
+
+				<ClayLayout.Col md={4}>
+					<MetadataItem
+						icon="paperclip"
+						label={Liferay.Language.get('size')}
+						value={
+							typeof fileSize === 'number'
+								? Liferay.Util.formatStorage(fileSize, {
+										addSpaceBeforeSuffix: true,
+									})
+								: '—'
+						}
+					/>
+				</ClayLayout.Col>
+			</ClayLayout.Row>
+		</ClayLayout.Sheet>
+	);
+}

--- a/modules/apps/export-import/export-import-web/test/revamp/js/pages/import/NewImport.test.tsx
+++ b/modules/apps/export-import/export-import-web/test/revamp/js/pages/import/NewImport.test.tsx
@@ -11,6 +11,18 @@ import React from 'react';
 
 import {NewImport} from '../../../../../src/main/resources/META-INF/resources/revamp/js/pages/import/NewImport';
 
+jest.mock('frontend-js-web', () => {
+	const actual = jest.requireActual('frontend-js-web');
+
+	return {
+		...actual,
+		dateUtils: {
+			...actual.dateUtils,
+			fromNow: jest.fn(() => '5 days ago'),
+		},
+	};
+});
+
 jest.mock(
 	'../../../../../src/main/resources/META-INF/resources/revamp/js/services/postImportPreview',
 	() => ({
@@ -187,5 +199,27 @@ describe('NewImport', () => {
 		await user.clear(nameInput);
 
 		expect(nameInput).toHaveValue('');
+	});
+
+	it('forwards the upload metadata to the FileSummary card on the Data Selection step', async () => {
+		renderComponent();
+
+		await user.type(screen.getByLabelText(/^name/i), 'My import');
+
+		await uploadFile('site.lar');
+
+		await waitFor(() => {
+			expect(
+				screen.getByRole('button', {name: /continue/i})
+			).toBeEnabled();
+		});
+
+		await user.click(screen.getByRole('button', {name: /continue/i}));
+
+		expect(screen.getByText('file-summary')).toBeInTheDocument();
+		expect(screen.getAllByText('site.lar').length).toBeGreaterThan(0);
+		expect(screen.getByText('Test User')).toBeInTheDocument();
+		expect(screen.getByText('5 days ago')).toBeInTheDocument();
+		expect(screen.getByText('4 B')).toBeInTheDocument();
 	});
 });

--- a/modules/apps/export-import/export-import-web/test/revamp/js/pages/import/NewImport.test.tsx
+++ b/modules/apps/export-import/export-import-web/test/revamp/js/pages/import/NewImport.test.tsx
@@ -35,7 +35,7 @@ jest.mock(
 					exportDate: '2000-07-27T00:00:00Z',
 					fileEntryId: 1,
 					fileName: 'site.lar',
-					fileSize: 4,
+					fileSize: 4096,
 					portletDataHandlerSections: [],
 				},
 				error: null,
@@ -76,12 +76,6 @@ const uploadFile = async (fileName = 'site.lar') => {
 };
 
 describe('NewImport', () => {
-	beforeAll(() => {
-		global.Liferay.Util.formatStorage = jest.fn(
-			(bytes: number) => `${bytes} B`
-		);
-	});
-
 	beforeEach(() => {
 		user = userEvent.setup();
 	});
@@ -220,6 +214,6 @@ describe('NewImport', () => {
 		expect(screen.getAllByText('site.lar').length).toBeGreaterThan(0);
 		expect(screen.getByText('Test User')).toBeInTheDocument();
 		expect(screen.getByText('5 days ago')).toBeInTheDocument();
-		expect(screen.getByText('4 B')).toBeInTheDocument();
+		expect(screen.getByText('4 KB')).toBeInTheDocument();
 	});
 });

--- a/modules/apps/export-import/export-import-web/test/revamp/js/pages/import/steps/FileSummary.test.tsx
+++ b/modules/apps/export-import/export-import-web/test/revamp/js/pages/import/steps/FileSummary.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {render, screen, within} from '@testing-library/react';
+import React from 'react';
+
+import FileSummary from '../../../../../../src/main/resources/META-INF/resources/revamp/js/pages/import/steps/FileSummary';
+import {ImportPreview} from '../../../../../../src/main/resources/META-INF/resources/revamp/js/types/exportImportPreview';
+
+jest.mock('frontend-js-web', () => {
+	const actual = jest.requireActual('frontend-js-web');
+
+	return {
+		...actual,
+		dateUtils: {
+			...actual.dateUtils,
+			fromNow: jest.fn(() => '5 days ago'),
+		},
+	};
+});
+
+const baseImportPreview: ImportPreview = {
+	additionCount: 0,
+	author: 'Jane Doe',
+	deletionCount: 0,
+	exportDate: '2026-05-01T00:00:00Z',
+	fileEntryId: 1,
+	fileName: 'site.lar',
+	fileSize: 1024,
+	portletDataHandlerSections: [],
+};
+
+const valueOf = (label: string) =>
+	within(screen.getByText(label).parentElement as HTMLElement).getByText(
+		(_, element) => element?.classList.contains('text-secondary') ?? false
+	);
+
+describe('FileSummary', () => {
+	beforeAll(() => {
+		global.Liferay.Util.formatStorage = jest.fn(
+			(bytes: number) => `${bytes} B`
+		);
+	});
+
+	it('renders the file name in the sheet header', () => {
+		render(<FileSummary importPreview={baseImportPreview} />);
+
+		expect(screen.getByText('site.lar')).toBeInTheDocument();
+	});
+
+	it('renders author, relative export date, and formatted file size', () => {
+		render(<FileSummary importPreview={baseImportPreview} />);
+
+		expect(valueOf('author')).toHaveTextContent('Jane Doe');
+		expect(valueOf('exported')).toHaveTextContent('5 days ago');
+		expect(valueOf('size')).toHaveTextContent('1024 B');
+	});
+
+	it('falls back to em-dash when author is null', () => {
+		render(
+			<FileSummary
+				importPreview={{
+					...baseImportPreview,
+					author: null as unknown as string,
+				}}
+			/>
+		);
+
+		expect(valueOf('author')).toHaveTextContent('—');
+	});
+
+	it('falls back to em-dash when exportDate is empty', () => {
+		render(
+			<FileSummary
+				importPreview={{...baseImportPreview, exportDate: ''}}
+			/>
+		);
+
+		expect(valueOf('exported')).toHaveTextContent('—');
+	});
+
+	it('falls back to em-dash when fileSize is null', () => {
+		render(
+			<FileSummary
+				importPreview={{
+					...baseImportPreview,
+					fileSize: null as unknown as number,
+				}}
+			/>
+		);
+
+		expect(valueOf('size')).toHaveTextContent('—');
+	});
+
+	it('renders 0 B (not em-dash) when fileSize is 0', () => {
+		render(
+			<FileSummary importPreview={{...baseImportPreview, fileSize: 0}} />
+		);
+
+		expect(valueOf('size')).toHaveTextContent('0 B');
+	});
+
+	it('omits the file name node in the header when fileName is empty', () => {
+		const {container} = render(
+			<FileSummary importPreview={{...baseImportPreview, fileName: ''}} />
+		);
+
+		expect(screen.getByText('file-summary')).toBeInTheDocument();
+		expect(
+			container.querySelectorAll('.sheet-text.text-3.text-secondary')
+		).toHaveLength(0);
+	});
+});

--- a/modules/apps/export-import/export-import-web/test/revamp/js/pages/import/steps/FileSummary.test.tsx
+++ b/modules/apps/export-import/export-import-web/test/revamp/js/pages/import/steps/FileSummary.test.tsx
@@ -36,12 +36,6 @@ const valueOf = (label: string) =>
 	screen.getByText(label).nextElementSibling as HTMLElement;
 
 describe('FileSummary', () => {
-	beforeAll(() => {
-		global.Liferay.Util.formatStorage = jest.fn(
-			(bytes: number) => `${bytes} B`
-		);
-	});
-
 	it('renders the file name in the sheet header', () => {
 		render(<FileSummary importPreview={baseImportPreview} />);
 
@@ -53,7 +47,7 @@ describe('FileSummary', () => {
 
 		expect(valueOf('author')).toHaveTextContent('Jane Doe');
 		expect(valueOf('exported')).toHaveTextContent('5 days ago');
-		expect(valueOf('size')).toHaveTextContent('1024 B');
+		expect(valueOf('size')).toHaveTextContent('1 KB');
 	});
 
 	it('falls back to em-dash when author is null', () => {
@@ -92,12 +86,12 @@ describe('FileSummary', () => {
 		expect(valueOf('size')).toHaveTextContent('—');
 	});
 
-	it('renders 0 B (not em-dash) when fileSize is 0', () => {
+	it('renders 0 KB (not em-dash) when fileSize is 0', () => {
 		render(
 			<FileSummary importPreview={{...baseImportPreview, fileSize: 0}} />
 		);
 
-		expect(valueOf('size')).toHaveTextContent('0 B');
+		expect(valueOf('size')).toHaveTextContent('0 KB');
 	});
 
 	it('omits the file name node in the header when fileName is empty', () => {

--- a/modules/apps/export-import/export-import-web/test/revamp/js/pages/import/steps/FileSummary.test.tsx
+++ b/modules/apps/export-import/export-import-web/test/revamp/js/pages/import/steps/FileSummary.test.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {render, screen, within} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
 import React from 'react';
 
 import FileSummary from '../../../../../../src/main/resources/META-INF/resources/revamp/js/pages/import/steps/FileSummary';
@@ -33,9 +33,7 @@ const baseImportPreview: ImportPreview = {
 };
 
 const valueOf = (label: string) =>
-	within(screen.getByText(label).parentElement as HTMLElement).getByText(
-		(_, element) => element?.classList.contains('text-secondary') ?? false
-	);
+	screen.getByText(label).nextElementSibling as HTMLElement;
 
 describe('FileSummary', () => {
 	beforeAll(() => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88399

On top of [#3720](https://github.com/liferay-headless/liferay-portal/pull/3720) (LPD-77057, LPD-86880, LPD-88071)

## What is being added

A new `FileSummary` card on the Data Selection step of the new Import wizard. Once the user uploads a LAR file in the previous step, the card surfaces the most relevant metadata — name, author, export date (relative time), and size — so they can confirm what they are about to import before picking the data.

## How it is being added

`NewImport` keeps the full `ImportPreview` returned by the import-preview REST endpoint as React state. The setter is drilled to `FileSelectionStep`, which calls it after a successful upload and clears it when the user removes the file. `DataSelectionStep` reads the value and early-returns until it exists, then renders the new `FileSummary` component — a sheet with three `MetadataItem` tiles. Author and size fall back to an em-dash when missing; the exported date uses `dateUtils.fromNow` from `frontend-js-web` to honor the Liferay locale.

<img width="1980" height="907" alt="image" src="https://github.com/user-attachments/assets/ede9b958-cc2f-4ba5-b6b8-c8d95d5b2a8e" />
