### PR TITLE
LPD-89138 Remove Poshi ExportImportSmoke; covered by Playwright

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/exportimport/ExportImport.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/exportimport/ExportImport.testcase
@@ -1232,45 +1232,6 @@ definition {
 		}
 	}
 
-	@description = "Verify is possible export/import a Smoke template."
-	@priority = 4
-	test ExportImportSmoke {
-		property app.server.types = "jboss,tomcat,weblogic,wildfly";
-		property database.types = "db2,hypersonic,mariadb,mysql,oracle,postgresql,sqlserver";
-		property portal.acceptance = "true";
-		property test.liferay.virtual.instance = "false";
-		property test.run.type = "single";
-
-		task ("Given: User exports default site") {
-			LAR.exportSiteCP(siteScopeName = "Guest");
-
-			var key_larFileName = ${larFileName};
-			var larFileName = LAR.getLarFileName();
-
-			LAR.downloadLar();
-		}
-
-		task ("When: Adds a new site then import the LAR file") {
-			HeadlessSite.addSite(siteName = "Site Name");
-
-			for (var layoutUtilityPageName : list "404 Error,500 Error") {
-				JSONLayoututilitypage.deleteLayoutUtilityPage(
-					groupName = "Site Name",
-					layoutUtilityPageName = ${layoutUtilityPageName});
-			}
-
-			LAR.importSiteCP(
-				larFileName = ${larFileName},
-				siteName = "Site Name");
-		}
-
-		task ("Then: Import should be successful without error message on console") {
-			AssertConsoleTextNotPresent(value1 = "java.lang.StringIndexOutOfBoundsException");
-
-			AssertConsoleTextNotPresent(value1 = "java.lang.NullPointerException");
-		}
-	}
-
 	@description = "Verify is possible export/import theme settings."
 	@priority = 3
 	test ExportImportThemeSettings {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89138

**What is being fixed:** The Poshi acceptance test `LocalFile.ExportImport#ExportImportSmoke` was failing with `InvalidArgumentException: File not found: bundles/poshi/Export-<timestamp>.lar`. The cause is LPD-76875, which split the export attachment into a timestamped `sourceFileName` (present in the URL slug, e.g. `Export-20260421235741943.lar`) and a user-facing `title` (sent via `Content-Disposition`, e.g. `Export.lar`). The Poshi macro `LAR.getLarFileName()` reads the URL slug, but Chrome saves the file under the title, so the subsequent upload step looks for a file that does not exist on disk.

**How it is being fixed:** Deleting the Poshi smoke test rather than patching the macro. The underlying behavior — exporting a site and importing the resulting LAR into another scope — is already covered by Playwright at `modules/test/playwright/tests/export-import-web/main/site.import.spec.ts` ("Can import a lar file selecting some items to import" for the Guest round-trip and "Can import the default site on a new instance twice" for the default-site-into-new-instance flow) and at `modules/test/playwright/tests/export-import-web/main/site.siteInitializer.spec.ts` (cross-site import including utility-page deletion and an exportable-items equality assertion). Playwright's native `download.suggestedFilename()` consumes the actual saved filename, so this class of mismatch cannot reproduce there. Per the team's direction to migrate Poshi to Playwright, deletion is the correct outcome.