### PR TITLE
LPD-89166 use mutable values map in testDeleteImportTask

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ImportTaskResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ImportTaskResourceTest.java
@@ -34,8 +34,6 @@ import com.liferay.portal.test.rule.Inject;
 
 import java.io.Serializable;
 
-import java.util.Collections;
-
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -618,12 +616,14 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 
 		ObjectEntry objectEntry1 = ObjectEntryTestUtil.addObjectEntry(
 			groupId, objectDefinition,
-			Collections.singletonMap(
-				OBJECT_FIELD_NAME_TEXT_1, RandomTestUtil.randomString()));
+			HashMapBuilder.<String, Serializable>put(
+				OBJECT_FIELD_NAME_TEXT_1, RandomTestUtil.randomString()
+			).build());
 		ObjectEntry objectEntry2 = ObjectEntryTestUtil.addObjectEntry(
 			groupId, objectDefinition,
-			Collections.singletonMap(
-				OBJECT_FIELD_NAME_TEXT_1, RandomTestUtil.randomString()));
+			HashMapBuilder.<String, Serializable>put(
+				OBJECT_FIELD_NAME_TEXT_1, RandomTestUtil.randomString()
+			).build());
 
 		HttpInvoker.HttpResponse httpResponse =
 			importTaskResource.deleteImportTaskHttpResponse(
@@ -656,13 +656,15 @@ public class ImportTaskResourceTest extends BaseTaskResourceTestCase {
 
 		objectEntry1 = ObjectEntryTestUtil.addObjectEntry(
 			groupId, objectDefinition,
-			Collections.singletonMap(
-				OBJECT_FIELD_NAME_TEXT_1, RandomTestUtil.randomString()));
+			HashMapBuilder.<String, Serializable>put(
+				OBJECT_FIELD_NAME_TEXT_1, RandomTestUtil.randomString()
+			).build());
 
 		objectEntry2 = ObjectEntryTestUtil.addObjectEntry(
 			groupId, objectDefinition,
-			Collections.singletonMap(
-				OBJECT_FIELD_NAME_TEXT_1, RandomTestUtil.randomString()));
+			HashMapBuilder.<String, Serializable>put(
+				OBJECT_FIELD_NAME_TEXT_1, RandomTestUtil.randomString()
+			).build());
 
 		httpResponse = importTaskResource.deleteImportTaskHttpResponse(
 			"com.liferay.object.rest.dto.v1_0.ObjectEntry", null, null, null,


### PR DESCRIPTION
Jira Ticket: https://liferay.atlassian.net/browse/LPD-88023

The test was passing an immutable map to `addObjectEntry`, which now mutates it. Switched to a mutable `HashMapBuilder` map.  