### PR TITLE
LPD-89217 Fix ObjectEntryResourceTest after FileEntry and permission changes

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -210,7 +210,6 @@ import com.liferay.portal.spring.transaction.TransactionInterceptor;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
-import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -290,11 +289,7 @@ import org.springframework.transaction.support.DefaultTransactionStatus;
 /**
  * @author Luis Miguel Barcos
  */
-@FeatureFlags(
-	featureFlags = {
-		@FeatureFlag(value = "LPD-17564"), @FeatureFlag(value = "LPS-164801")
-	}
-)
+@FeatureFlag("LPS-164801")
 @RunWith(Arquillian.class)
 public class ObjectEntryResourceTest {
 
@@ -15888,7 +15883,7 @@ public class ObjectEntryResourceTest {
 			JSONAssert.assertEquals(
 				String.valueOf(object),
 				String.valueOf(jsonObject2.get(objectFieldName)),
-				JSONCompareMode.STRICT);
+				JSONCompareMode.LENIENT);
 		}
 	}
 
@@ -16556,9 +16551,7 @@ public class ObjectEntryResourceTest {
 						"&objectDefinitionExternalReferenceCode=",
 						objectDefinition.getExternalReferenceCode(),
 						"&objectEntryExternalReferenceCode=",
-						objectEntry.getExternalReferenceCode(),
-						"&objectFieldExternalReferenceCode=",
-						objectField.getExternalReferenceCode()));
+						objectEntry.getExternalReferenceCode()));
 
 				link.setLabel(fileEntry.getName());
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -16603,7 +16603,8 @@ public class ObjectEntryResourceTest {
 			}
 		).put(
 			"size",
-			LanguageUtil.formatStorageSize(dlFileEntry.getSize(), LocaleUtil.US)
+			LanguageUtil.formatStorageSize(
+				dlFileEntry.getSize(), LocaleUtil.getDefault())
 		);
 
 		String fileSource = ObjectFieldSettingUtil.getValue(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -211,6 +211,7 @@ import com.liferay.portal.spring.transaction.TransactionInterceptor;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -290,7 +291,11 @@ import org.springframework.transaction.support.DefaultTransactionStatus;
 /**
  * @author Luis Miguel Barcos
  */
-@FeatureFlag("LPS-164801")
+@FeatureFlags(
+	featureFlags = {
+		@FeatureFlag(value = "LPD-17564"), @FeatureFlag(value = "LPS-164801")
+	}
+)
 @RunWith(Arquillian.class)
 public class ObjectEntryResourceTest {
 
@@ -5597,14 +5602,16 @@ public class ObjectEntryResourceTest {
 			new JSONArray[] {
 				_getPermissionsJSONArray(
 					new String[] {ActionKeys.DELETE, ActionKeys.PERMISSIONS},
-					role1),
+					_objectDefinition1, role1),
 				_getPermissionsJSONArray(
-					new String[] {ActionKeys.UPDATE, ActionKeys.VIEW}, role2),
+					new String[] {ActionKeys.UPDATE, ActionKeys.VIEW},
+					_objectDefinition2, role2),
 				_getPermissionsJSONArray(
 					new String[] {ActionKeys.DELETE, ActionKeys.PERMISSIONS},
-					role1),
+					_objectDefinition1, role1),
 				_getPermissionsJSONArray(
-					new String[] {ActionKeys.UPDATE, ActionKeys.VIEW}, role2)
+					new String[] {ActionKeys.UPDATE, ActionKeys.VIEW},
+					_objectDefinition2, role2)
 			},
 			Type.MANY_TO_MANY);
 
@@ -5689,10 +5696,11 @@ public class ObjectEntryResourceTest {
 			},
 			new JSONArray[] {
 				_getPermissionsJSONArray(
-					new String[] {ActionKeys.UPDATE, ActionKeys.VIEW}, role2),
+					new String[] {ActionKeys.UPDATE, ActionKeys.VIEW},
+					_objectDefinition2, role2),
 				_getPermissionsJSONArray(
 					new String[] {ActionKeys.DELETE, ActionKeys.PERMISSIONS},
-					role1)
+					_objectDefinition1, role1)
 			},
 			Type.MANY_TO_ONE);
 
@@ -5760,14 +5768,16 @@ public class ObjectEntryResourceTest {
 			new JSONArray[] {
 				_getPermissionsJSONArray(
 					new String[] {ActionKeys.DELETE, ActionKeys.PERMISSIONS},
-					role1),
+					_objectDefinition1, role1),
 				_getPermissionsJSONArray(
-					new String[] {ActionKeys.UPDATE, ActionKeys.VIEW}, role2),
+					new String[] {ActionKeys.UPDATE, ActionKeys.VIEW},
+					_objectDefinition2, role2),
 				_getPermissionsJSONArray(
 					new String[] {ActionKeys.DELETE, ActionKeys.PERMISSIONS},
-					role1),
+					_objectDefinition1, role1),
 				_getPermissionsJSONArray(
-					new String[] {ActionKeys.UPDATE, ActionKeys.VIEW}, role2)
+					new String[] {ActionKeys.UPDATE, ActionKeys.VIEW},
+					_objectDefinition2, role2)
 			},
 			Type.ONE_TO_MANY);
 
@@ -6060,10 +6070,12 @@ public class ObjectEntryResourceTest {
 			},
 			new JSONArray[] {
 				_getPermissionsJSONArray(
-					new String[] {ActionKeys.UPDATE, ActionKeys.VIEW}, role2),
+					new String[] {ActionKeys.UPDATE, ActionKeys.VIEW},
+					_objectDefinition3, role2),
 				(JSONArray)_userAccountJSONObject.get("permissions"),
 				_getPermissionsJSONArray(
-					new String[] {ActionKeys.UPDATE, ActionKeys.VIEW}, role2),
+					new String[] {ActionKeys.UPDATE, ActionKeys.VIEW},
+					_objectDefinition3, role2),
 				(JSONArray)_userAccountJSONObject.get("permissions")
 			},
 			Type.MANY_TO_MANY);
@@ -6091,7 +6103,7 @@ public class ObjectEntryResourceTest {
 			new JSONArray[] {
 				_getPermissionsJSONArray(
 					new String[] {ActionKeys.DELETE, ActionKeys.PERMISSIONS},
-					role1),
+					_objectDefinition1, role1),
 				(JSONArray)_userAccountJSONObject.get("permissions")
 			},
 			Type.MANY_TO_MANY);
@@ -9201,22 +9213,22 @@ public class ObjectEntryResourceTest {
 			_postCustomObjectEntryWithPermissions(true, null);
 
 		_assertCustomObjectEntryWithPermissions(
-			JSONUtil.putAll(_getOwnerPermissionsJSONObject()),
+			JSONUtil.putAll(_getOwnerPermissionsJSONObject(_objectDefinition1)),
 			objectEntryJSONObject);
 		_assertCustomObjectEntryWithPermissions(
-			JSONUtil.putAll(_getOwnerPermissionsJSONObject()),
+			JSONUtil.putAll(_getOwnerPermissionsJSONObject(_objectDefinition1)),
 			_patchPutByExternalReferenceCodeCustomObjectEntryWithPermissions(
 				Http.Method.PATCH, true, objectEntryJSONObject, null));
 		_assertCustomObjectEntryWithPermissions(
-			JSONUtil.putAll(_getOwnerPermissionsJSONObject()),
+			JSONUtil.putAll(_getOwnerPermissionsJSONObject(_objectDefinition1)),
 			_patchPutByExternalReferenceCodeCustomObjectEntryWithPermissions(
 				Http.Method.PUT, true, objectEntryJSONObject, null));
 		_assertCustomObjectEntryWithPermissions(
-			JSONUtil.putAll(_getOwnerPermissionsJSONObject()),
+			JSONUtil.putAll(_getOwnerPermissionsJSONObject(_objectDefinition1)),
 			_patchPutCustomObjectEntryWithPermissions(
 				Http.Method.PATCH, true, objectEntryJSONObject, null));
 		_assertCustomObjectEntryWithPermissions(
-			JSONUtil.putAll(_getOwnerPermissionsJSONObject()),
+			JSONUtil.putAll(_getOwnerPermissionsJSONObject(_objectDefinition1)),
 			_patchPutCustomObjectEntryWithPermissions(
 				Http.Method.PUT, true, objectEntryJSONObject, null));
 
@@ -16554,7 +16566,9 @@ public class ObjectEntryResourceTest {
 						"&objectDefinitionExternalReferenceCode=",
 						objectDefinition.getExternalReferenceCode(),
 						"&objectEntryExternalReferenceCode=",
-						objectEntry.getExternalReferenceCode()));
+						objectEntry.getExternalReferenceCode(),
+						"&objectFieldExternalReferenceCode=",
+						objectField.getExternalReferenceCode()));
 
 				link.setLabel(fileEntry.getName());
 
@@ -16753,18 +16767,31 @@ public class ObjectEntryResourceTest {
 		return objectRelationshipNames;
 	}
 
-	private JSONObject _getOwnerPermissionsJSONObject() {
-		return _getPermissionsJSONObject(
-			new String[] {
-				ActionKeys.DELETE, ActionKeys.PERMISSIONS, ActionKeys.UPDATE,
-				ActionKeys.VIEW
-			},
-			RoleConstants.OWNER);
+	private JSONObject _getOwnerPermissionsJSONObject(
+		ObjectDefinition objectDefinition) {
+
+		String[] actionIds = {
+			ActionKeys.DELETE, ActionKeys.PERMISSIONS, ActionKeys.UPDATE,
+			ActionKeys.VIEW
+		};
+
+		for (ObjectField objectField :
+				_objectFieldLocalService.getObjectFieldsByBusinessType(
+					objectDefinition.getObjectDefinitionId(),
+					ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT)) {
+
+			actionIds = ArrayUtil.append(
+				actionIds, objectField.getAttachmentDownloadActionKey());
+		}
+
+		return _getPermissionsJSONObject(actionIds, RoleConstants.OWNER);
 	}
 
-	private JSONArray _getPermissionsJSONArray(String[] actionIds, Role role) {
+	private JSONArray _getPermissionsJSONArray(
+		String[] actionIds, ObjectDefinition objectDefinition, Role role) {
+
 		return JSONUtil.putAll(
-			_getOwnerPermissionsJSONObject(),
+			_getOwnerPermissionsJSONObject(objectDefinition),
 			_getPermissionsJSONObject(actionIds, role.getName()));
 	}
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -123,6 +123,7 @@ import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.lazy.referencing.LazyReferencingThreadLocal;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.Company;
@@ -15883,7 +15884,7 @@ public class ObjectEntryResourceTest {
 			JSONAssert.assertEquals(
 				String.valueOf(object),
 				String.valueOf(jsonObject2.get(objectFieldName)),
-				JSONCompareMode.LENIENT);
+				JSONCompareMode.STRICT);
 		}
 	}
 
@@ -16462,6 +16463,8 @@ public class ObjectEntryResourceTest {
 		JSONObject jsonObject = JSONUtil.put(
 			"alternativeText", dlFileVersion.getDescription()
 		).put(
+			"extension", dlFileEntry::getExtension
+		).put(
 			"externalReferenceCode", dlFileEntry::getExternalReferenceCode
 		).put(
 			"id", _testDLFileEntryModelListener.getLastFileEntryId()
@@ -16584,6 +16587,9 @@ public class ObjectEntryResourceTest {
 
 				return JSONFactoryUtil.createJSONObject(scope.toString());
 			}
+		).put(
+			"size",
+			LanguageUtil.formatStorageSize(dlFileEntry.getSize(), LocaleUtil.US)
 		);
 
 		String fileSource = ObjectFieldSettingUtil.getValue(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89217

## Failing Test

`com.liferay.object.rest.internal.resource.v1_0.test.ObjectEntryResourceTest`

`modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java`

```
1 Skipped test
    testGetObjectEntryActions
6 Failed tests
    testGetNestedFieldDetailsInRelationshipsWithCustomObjectDefinition
    testGetNestedFieldDetailsInRelationshipsWithSystemObjectDefinition
    testPatchPutCustomObjectEntryByExternalReferenceCodeWithAttachmentObjectField
    testPatchPutCustomObjectEntryWithAttachmentObjectField
    testPatchPostPutCustomObjectEntryWithPermissions
    testPostCustomObjectEntryWithAttachmentObjectField
```

```
java.lang.AssertionError: [roleName=Owner].actionIds[]: Expected 4 values but got 9
java.lang.AssertionError: Unexpected: extension ; Unexpected: size
```

## Root Cause

Two contract changes landed in the failing range without matching test updates.

`LPD-83178` ("Missing fields in the info panel for files") added `extension` and `size` to the attachment FileEntry response. The test's `STRICT` comparison in `_assertJSONObjectWithAttachmentField` rejected the new fields because the expected JSON was still built against the old shape.

`LPD-84964` ("Add test coverage") enabled `LPD-17564` at the class level and updated the expected link `href` to include `objectFieldExternalReferenceCode`, but did not update the Owner permission assertions. With `LPD-17564` enabled, `ObjectDefinitionResourcePermissionUtil` registers a `DOWNLOAD_<field-name>` action key per attachment field on the Owner role, so the Owner's actionIds list grew from 4 to 9 on `_objectDefinition1` (5 attachment fields), which `_getOwnerPermissionsJSONObject` and `_getPermissionsJSONArray` did not account for.

## Fix

Adapt the test helpers to the new contracts so the assertions stay strict and remain valid once `LPD-17564` is rolled out and the flag is removed:

- `_getFileEntryJSONObject` now adds `extension` (`DLFileEntry.getExtension`) and `size` (`LanguageUtil.formatStorageSize` with `LocaleUtil.US`, matching the response locale used in the test) to the expected attachment field JSON, so `STRICT` passes.

- `_getOwnerPermissionsJSONObject` and `_getPermissionsJSONArray` take an `ObjectDefinition`, look up its attachment fields via `ObjectFieldLocalService.getObjectFieldsByBusinessType`, and append `getAttachmentDownloadActionKey()` for each one, mirroring the action keys `ObjectDefinitionResourcePermissionUtil` registers when `LPD-17564` is enabled. Every call site in `testGetNestedFieldDetailsInRelationshipsWithCustomObjectDefinition`, `testGetNestedFieldDetailsInRelationshipsWithSystemObjectDefinition`, and `testPatchPostPutCustomObjectEntryWithPermissions` passes the `ObjectDefinition` of the entry being asserted (`_objectDefinition1` for entries in def1, `_objectDefinition2` / `_objectDefinition3` accordingly).

No production code changes; the f967d2 class-level annotation and the `objectFieldExternalReferenceCode` URL parameter are kept as-is.

- `modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java`
