### PR TITLE
LPD-89227 Fix Staging gotoTemplatePage selector after LPD-36105 GA

### DIFF
--- a/modules/test/playwright/tests/export-import-web/main/pages/StagingPage.ts
+++ b/modules/test/playwright/tests/export-import-web/main/pages/StagingPage.ts
@@ -214,7 +214,7 @@ export class StagingPage {
 
 	async gotoTemplatePage() {
 		await this.page
-			.getByText('Staging Open Applications')
+			.getByTestId('headerOptions')
 			.getByLabel('Options')
 			.click();
 		await this.page


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89227

## Failing Test

`export-import-web/main/stagingUseCase.spec.ts > Staging publish template with smoke`

`modules/test/playwright/tests/export-import-web/main/stagingUseCase.spec.ts:677`

```
Test timeout of 90000ms exceeded.
Error: locator.click: Test timeout of 90000ms exceeded.
Call log:
  - waiting for getByText('Staging Open Applications').getByLabel('Options')
    at export-import-web/main/pages/StagingPage.ts:219
```

## Root Cause

Commit `6947315c` ("LPD-86396 Remove LPD-36105 FF") promoted feature flag `LPD-36105` to GA, dropping the legacy `ApplicationsMenu` React component in favor of the new `GlobalMenu`. The previous selector `getByText('Staging Open Applications')` matched a parent of the legacy `sr-only` div whose visible text included `"Open Applications Menu"`; the new `GlobalMenu` exposes that string only as an `aria-label`, which `getByText` does not consider, so the locator never resolves and the click times out at 90s.

## Fix

Scope the selector to `data-qa-id="headerOptions"` — the page-level Options menu in the Control Menu, which contains the `Publish Templates` configuration icon menu item that the test ultimately needs to click. This matches the pattern already used elsewhere in the playwright suite (`JournalStructuresPage.ts`, `UsersAndOrganizationsPage.ts`, `DocumentLibraryPage.ts`, etc.).

- `modules/test/playwright/tests/export-import-web/main/pages/StagingPage.ts`