### PR TITLE
LPD-89337 Strip timestamp from getLarFileName

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/LAR.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/LAR.macro
@@ -710,7 +710,11 @@ definition {
 
 		var portalURL = JSONCompany.getPortalURL();
 
-		var larFileName = RegexUtil.replace(${valueName}, "${portalURL}/documents/portlet_file_entry/[0-9]*/([a-zA-z0-9_.-]*)[(0-9KB)]*", 1);
+		var sourceFileName = RegexUtil.replace(${valueName}, "${portalURL}/documents/portlet_file_entry/[0-9]*/([a-zA-z0-9_.-]*)[(0-9KB)]*", 1);
+
+		var titleName = RegexUtil.replace(${sourceFileName}, "(.*)-[0-9]+\.lar", 1);
+
+		var larFileName = "${titleName}.lar";
 
 		echo("lar file name ${larFileName}");
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89337

## Failing Test

`LocalFile.SitesExportImport#ExportImportSiteWithMappedImage`

`portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/site/SitesExportImport.testcase`

```
org.openqa.selenium.InvalidArgumentException: invalid argument: File not found : /opt/dev/projects/github/liferay-portal/bundles/poshi/Export-20260507204941345.lar   (Session info: chrome=139.0.7258.6
```

## Root Cause

LPD-76875 (commits `1a7c604e1467` "Calculate sourceFileName with timestamp and title with user input only", `b9bf72deae36` "Pass query string that would make use the title", `dd244a2b2fd2` "Handle title in download via WebServerServlet instead of URL path") split the LAR file's `sourceFileName` (with timestamp, persisted on disk and reflected in the file-entry URL) from its `title` (without timestamp, served by `WebServerServlet` as the `Content-Disposition` filename when `useTitle=true`). After that change the browser saves the file under the title (`Export.lar`), but `LAR.getLarFileName()` continued to parse the URL and returned the source filename (`Export-<timestamp>.lar`), so the subsequent `selenium.uploadTempFile` looked for a file that did not exist on disk.

## Fix

Update `LAR.getLarFileName()` to strip the `-<timestamp>` suffix from the captured source filename, producing the title which matches what the browser actually saved. Verified locally: before the fix the macro echoed `lar file name Export-<timestamp>.lar` and the upload failed with the original trace; after the fix it echoes `lar file name Export.lar` matching `files: [Export.lar]` and the upload succeeds.

- `portal-web/test/functional/com/liferay/portalweb/macros/LAR.macro`