### PR TITLE
LPD-89368 Set user password before authenticating ExportPreviewResourceTest

### DIFF
--- a/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ExportPreviewResourceTest.java
+++ b/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ExportPreviewResourceTest.java
@@ -71,9 +71,14 @@ public class ExportPreviewResourceTest
 
 		_user = UserTestUtil.addUser(testCompany);
 
+		String password = RandomTestUtil.randomString();
+
+		_userLocalService.updatePassword(
+			_user.getUserId(), password, password, false, true);
+
 		_exportPreviewResource = ExportPreviewResource.builder(
 		).authentication(
-			_user.getEmailAddress(), RandomTestUtil.randomString()
+			_user.getEmailAddress(), password
 		).endpoint(
 			testCompany.getVirtualHostname(), 8080, "http"
 		).locale(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89368

## Failing Test

`com.liferay.exportimport.rest.resource.v1_0.test.ExportPreviewResourceTest`

`modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ExportPreviewResourceTest.java`

```
java.lang.AssertionError: expected:<404> but was:<401>
	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.failNotEquals(Assert.java:835)
	at org.junit.Assert.assertEquals(Assert.java:647)
	at org.junit.Assert.assertEquals(Assert.java:633)
	at com.liferay.exportimport.rest.resource.v1_0.test.BaseExportPreviewResourceTestCase.assertHttpResponseStatusCode(BaseExportPreviewResourceTestCase.java:245)
	at com.liferay.exportimport.rest.resource.v1_0.test.ExportPreviewResourceTest.testGetAssetLibraryExportPreview(ExportPreviewResourceTest.java:100)
```

The same `404 vs 401` failure also occurs in `testGetExportPreview` and `testGetSiteExportPreview`.

## Root Cause

The test was added in commit `eab7ed3fae8ad` ("LPD-86880 Add integration tests") and has never passed on the team routine. The `setUp` builds an HTTP client authenticated as `_user` with a freshly generated `RandomTestUtil.randomString()` as the password — but `UserTestUtil.addUser(testCompany)` creates the user with an autogenerated password (it never accepts the test's random string), so the credentials never match. Every request from `_exportPreviewResource` therefore fails authentication with `401` before reaching the resource that would have returned the expected `404` for a user without permission.

## Fix

Update the user's password to a known value before authenticating, mirroring the fix applied to the sibling `ImportPreviewResourceTest` in LPD-89392. This exercises the negative-path coverage the test intends and preserves the original `404` assertions.

- `modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ExportPreviewResourceTest.java`
