### PR TITLE
LPD-89392 Set user password before authenticating to assert HTTP 403

### DIFF
--- a/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ImportPreviewResourceTest.java
+++ b/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ImportPreviewResourceTest.java
@@ -95,9 +95,14 @@ public class ImportPreviewResourceTest
 
 		_user = UserTestUtil.addUser(testCompany);
 
+		String password = RandomTestUtil.randomString();
+
+		_userLocalService.updatePassword(
+			_user.getUserId(), password, password, false, true);
+
 		_importPreviewResource = ImportPreviewResource.builder(
 		).authentication(
-			_user.getEmailAddress(), RandomTestUtil.randomString()
+			_user.getEmailAddress(), password
 		).endpoint(
 			testCompany.getVirtualHostname(), 8080, "http"
 		).locale(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89392

## Failing Test

`com.liferay.exportimport.rest.resource.v1_0.test.ImportPreviewResourceTest`

`modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ImportPreviewResourceTest.java`

```
java.lang.AssertionError: expected:<403> but was:<401>
	at com.liferay.exportimport.rest.resource.v1_0.test.BaseImportPreviewResourceTestCase.assertHttpResponseStatusCode(BaseImportPreviewResourceTestCase.java:316)
	at com.liferay.exportimport.rest.resource.v1_0.test.ImportPreviewResourceTest.testPostSiteImportPreview(ImportPreviewResourceTest.java:182)
```

(Same trace for `testPostImportPreview` and `testPostAssetLibraryImportPreview`.)

## Root Cause

Commit `bbf1d2542ecaa` ("LPD-88071 Add integration tests") built `ImportPreviewResource` with the newly added user's email and a `RandomTestUtil.randomString()` as the password — credentials that do not match the user. The server therefore returns 401 (Unauthorized) for invalid auth instead of the 403 (Forbidden) the test expects for permission denial. The test has never passed since it was added.

## Fix

Generate a known password, set it on the user via `UserLocalService.updatePassword`, and pass that password to the `ImportPreviewResource` builder so authentication succeeds and the resource enforces permissions, returning the asserted 403.

- `modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ImportPreviewResourceTest.java`