### PR TITLE
  LPD-89806 Honor web.server.host in REST action hrefs

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/UriInfoUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/UriInfoUtil.java
@@ -47,20 +47,13 @@ public class UriInfoUtil {
 
 		UriBuilder uriBuilder = getBaseUriBuilder(uriInfo);
 
-		uriBuilder.host(PortalUtil.getForwardedHost(httpServletRequest));
-
-		int port = PortalUtil.getForwardedPort(httpServletRequest);
-
 		boolean secure = PortalUtil.isSecure(httpServletRequest);
 
-		if (((port != Http.HTTP_PORT) && !secure) ||
-			((port != Http.HTTPS_PORT) && secure)) {
+		uriBuilder.host(PortalUtil.getForwardedHost(httpServletRequest));
 
-			uriBuilder.port(port);
-		}
-		else {
-			uriBuilder.port(-1);
-		}
+		_setPort(
+			uriBuilder, PortalUtil.getForwardedPort(httpServletRequest),
+			secure);
 
 		if (secure) {
 			uriBuilder.scheme(Http.HTTPS);
@@ -333,6 +326,19 @@ public class UriInfoUtil {
 		return false;
 	}
 
+	private static void _setPort(
+		UriBuilder uriBuilder, int port, boolean secure) {
+
+		if (((port != Http.HTTP_PORT) && !secure) ||
+			((port != Http.HTTPS_PORT) && secure)) {
+
+			uriBuilder.port(port);
+		}
+		else {
+			uriBuilder.port(_NO_PORT);
+		}
+	}
+
 	private static UriBuilder _updateUriBuilder(UriBuilder uriBuilder) {
 		if (!Validator.isBlank(PortalUtil.getPathContext())) {
 			URI uri = uriBuilder.build();
@@ -350,6 +356,8 @@ public class UriInfoUtil {
 
 		return uriBuilder;
 	}
+
+	private static final int _NO_PORT = -1;
 
 	private static volatile Field _uriBuilderHostField;
 

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/UriInfoUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/UriInfoUtil.java
@@ -8,6 +8,7 @@ package com.liferay.portal.vulcan.util;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -348,6 +349,27 @@ public class UriInfoUtil {
 			if (!path.startsWith(PortalUtil.getPathContext())) {
 				uriBuilder.replacePath(PortalUtil.getPathContext(path));
 			}
+		}
+
+		String webServerHost = PropsUtil.get(PropsKeys.WEB_SERVER_HOST);
+
+		if (Validator.isNotNull(webServerHost)) {
+			boolean secure = _isSecure();
+
+			uriBuilder.host(webServerHost);
+
+			_setPort(
+				uriBuilder,
+				GetterUtil.getInteger(
+					PropsUtil.get(
+						secure ? PropsKeys.WEB_SERVER_HTTPS_PORT :
+							PropsKeys.WEB_SERVER_HTTP_PORT),
+					secure ? Http.HTTPS_PORT : Http.HTTP_PORT),
+				secure);
+
+			uriBuilder.scheme(secure ? Http.HTTPS : Http.HTTP);
+
+			return uriBuilder;
 		}
 
 		if (Validator.isNotNull(_getHost(uriBuilder)) && _isSecure()) {

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/UriInfoUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/UriInfoUtil.java
@@ -374,18 +374,19 @@ public class UriInfoUtil {
 		if (Validator.isNotNull(host)) {
 			boolean secure = _isSecure();
 
+			int defaultPort = secure ? Http.HTTPS_PORT : Http.HTTP_PORT;
+			String portPropsKey = secure ? PropsKeys.WEB_SERVER_HTTPS_PORT :
+				PropsKeys.WEB_SERVER_HTTP_PORT;
+			String scheme = secure ? Http.HTTPS : Http.HTTP;
+
 			uriBuilder.host(host);
 
 			_setPort(
 				uriBuilder,
-				GetterUtil.getInteger(
-					PropsUtil.get(
-						secure ? PropsKeys.WEB_SERVER_HTTPS_PORT :
-							PropsKeys.WEB_SERVER_HTTP_PORT),
-					secure ? Http.HTTPS_PORT : Http.HTTP_PORT),
+				GetterUtil.getInteger(PropsUtil.get(portPropsKey), defaultPort),
 				secure);
 
-			uriBuilder.scheme(secure ? Http.HTTPS : Http.HTTP);
+			uriBuilder.scheme(scheme);
 
 			return uriBuilder;
 		}

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/UriInfoUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/UriInfoUtil.java
@@ -8,6 +8,9 @@ package com.liferay.portal.vulcan.util;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.Portal;
@@ -302,6 +305,17 @@ public class UriInfoUtil {
 		};
 	}
 
+	private static String _getCompanyVirtualHostname() {
+		Company company = CompanyLocalServiceUtil.fetchCompany(
+			CompanyThreadLocal.getCompanyId());
+
+		if (company == null) {
+			return null;
+		}
+
+		return company.getVirtualHostname();
+	}
+
 	private static String _getHost(UriBuilder uriBuilder) {
 		try {
 			if (_uriBuilderHostField == null) {
@@ -351,12 +365,16 @@ public class UriInfoUtil {
 			}
 		}
 
-		String webServerHost = PropsUtil.get(PropsKeys.WEB_SERVER_HOST);
+		String host = _getCompanyVirtualHostname();
 
-		if (Validator.isNotNull(webServerHost)) {
+		if (Validator.isNull(host)) {
+			host = PropsUtil.get(PropsKeys.WEB_SERVER_HOST);
+		}
+
+		if (Validator.isNotNull(host)) {
 			boolean secure = _isSecure();
 
-			uriBuilder.host(webServerHost);
+			uriBuilder.host(host);
 
 			_setPort(
 				uriBuilder,

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/UriInfoUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/UriInfoUtil.java
@@ -365,10 +365,10 @@ public class UriInfoUtil {
 			}
 		}
 
-		String host = _getCompanyVirtualHostname();
+		String host = PropsUtil.get(PropsKeys.WEB_SERVER_HOST);
 
 		if (Validator.isNull(host)) {
-			host = PropsUtil.get(PropsKeys.WEB_SERVER_HOST);
+			host = _getCompanyVirtualHostname();
 		}
 
 		if (Validator.isNotNull(host)) {

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/test/java/com/liferay/portal/vulcan/util/UriInfoUtilTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/test/java/com/liferay/portal/vulcan/util/UriInfoUtilTest.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.vulcan.util;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.Http;
@@ -21,6 +22,7 @@ import java.net.URI;
 
 import org.apache.cxf.jaxrs.impl.UriBuilderImpl;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -53,6 +55,13 @@ public class UriInfoUtilTest {
 		);
 
 		_setProtocol(null);
+	}
+
+	@After
+	public void tearDown() {
+		PropsUtil.set(PropsKeys.WEB_SERVER_HOST, null);
+		PropsUtil.set(PropsKeys.WEB_SERVER_HTTP_PORT, null);
+		PropsUtil.set(PropsKeys.WEB_SERVER_HTTPS_PORT, null);
 	}
 
 	@Test
@@ -122,6 +131,123 @@ public class UriInfoUtilTest {
 			pathContext + path);
 	}
 
+	@Test
+	public void testGetBaseUriBuilderWebServerHostHttpCustomPort()
+		throws Exception {
+
+		int httpPort = RandomTestUtil.randomInt(
+			_PORT_MIN_INCLUSIVE, _PORT_MAX_INCLUSIVE);
+
+		PropsUtil.set(PropsKeys.WEB_SERVER_HOST, _WEB_SERVER_HOST);
+		PropsUtil.set(PropsKeys.WEB_SERVER_PROTOCOL, Http.HTTP);
+		PropsUtil.set(PropsKeys.WEB_SERVER_HTTP_PORT, String.valueOf(httpPort));
+
+		Assert.assertSame(_uriBuilder, UriInfoUtil.getBaseUriBuilder(_uriInfo));
+
+		Assert.assertEquals(
+			new URI(
+				StringBundler.concat(
+					Http.HTTP_WITH_SLASH, _WEB_SERVER_HOST, StringPool.COLON,
+					httpPort, _PATH)),
+			_uriBuilder.build());
+	}
+
+	@Test
+	public void testGetBaseUriBuilderWebServerHostHttpDefaultPort()
+		throws Exception {
+
+		PropsUtil.set(PropsKeys.WEB_SERVER_HOST, _WEB_SERVER_HOST);
+		PropsUtil.set(PropsKeys.WEB_SERVER_PROTOCOL, Http.HTTP);
+		PropsUtil.set(
+			PropsKeys.WEB_SERVER_HTTP_PORT, String.valueOf(Http.HTTP_PORT));
+
+		Assert.assertSame(_uriBuilder, UriInfoUtil.getBaseUriBuilder(_uriInfo));
+
+		Assert.assertEquals(
+			new URI(Http.HTTP_WITH_SLASH + _WEB_SERVER_HOST + _PATH),
+			_uriBuilder.build());
+	}
+
+	@Test
+	public void testGetBaseUriBuilderWebServerHostHttpsCustomPort()
+		throws Exception {
+
+		int httpsPort = RandomTestUtil.randomInt(
+			_PORT_MIN_INCLUSIVE, _PORT_MAX_INCLUSIVE);
+
+		PropsUtil.set(PropsKeys.WEB_SERVER_HOST, _WEB_SERVER_HOST);
+		PropsUtil.set(PropsKeys.WEB_SERVER_PROTOCOL, Http.HTTPS);
+		PropsUtil.set(
+			PropsKeys.WEB_SERVER_HTTPS_PORT, String.valueOf(httpsPort));
+
+		Assert.assertSame(_uriBuilder, UriInfoUtil.getBaseUriBuilder(_uriInfo));
+
+		Assert.assertEquals(
+			new URI(
+				StringBundler.concat(
+					Http.HTTPS_WITH_SLASH, _WEB_SERVER_HOST, StringPool.COLON,
+					httpsPort, _PATH)),
+			_uriBuilder.build());
+	}
+
+	@Test
+	public void testGetBaseUriBuilderWebServerHostHttpsDefaultPort()
+		throws Exception {
+
+		PropsUtil.set(PropsKeys.WEB_SERVER_HOST, _WEB_SERVER_HOST);
+		PropsUtil.set(PropsKeys.WEB_SERVER_PROTOCOL, Http.HTTPS);
+		PropsUtil.set(
+			PropsKeys.WEB_SERVER_HTTPS_PORT, String.valueOf(Http.HTTPS_PORT));
+
+		Assert.assertSame(_uriBuilder, UriInfoUtil.getBaseUriBuilder(_uriInfo));
+
+		Assert.assertEquals(
+			new URI(Http.HTTPS_WITH_SLASH + _WEB_SERVER_HOST + _PATH),
+			_uriBuilder.build());
+	}
+
+	@Test
+	public void testGetBaseUriBuilderWebServerHostNullPreservesUriInfoHost()
+		throws Exception {
+
+		int spoofedPort = RandomTestUtil.randomInt(
+			_PORT_MIN_INCLUSIVE, _PORT_MAX_INCLUSIVE);
+
+		_uriBuilder.host(_SPOOFED_HOST);
+		_uriBuilder.port(spoofedPort);
+
+		Assert.assertSame(_uriBuilder, UriInfoUtil.getBaseUriBuilder(_uriInfo));
+
+		Assert.assertEquals(
+			new URI(
+				StringBundler.concat(
+					_SPOOFED_HOST, StringPool.COLON, spoofedPort, _PATH)),
+			_uriBuilder.build());
+	}
+
+	@Test
+	public void testGetBaseUriBuilderWebServerHostOverridesSpoofedHost()
+		throws Exception {
+
+		int spoofedPort = RandomTestUtil.randomInt(
+			_PORT_MIN_INCLUSIVE, _PORT_MAX_INCLUSIVE);
+
+		PropsUtil.set(PropsKeys.WEB_SERVER_HOST, _WEB_SERVER_HOST);
+		PropsUtil.set(PropsKeys.WEB_SERVER_PROTOCOL, Http.HTTPS);
+		PropsUtil.set(
+			PropsKeys.WEB_SERVER_HTTPS_PORT, String.valueOf(Http.HTTPS_PORT));
+
+		_uriBuilder.host(_SPOOFED_HOST);
+		_uriBuilder.port(spoofedPort);
+		_uriBuilder.scheme(Http.HTTP);
+
+		Assert.assertSame(_uriBuilder, UriInfoUtil.getBaseUriBuilder(_uriInfo));
+
+		Assert.assertEquals(
+			new URI(Http.HTTPS_WITH_SLASH + _WEB_SERVER_HOST + _PATH),
+			_uriBuilder.build());
+	}
+
 	private void _assertUriBuilder(
 			int buildTimes, String path, int replacePathTimes, int schemeTimes,
 			UriBuilder uriBuilder, UriInfo uriInfo, String uriString)
@@ -172,11 +298,21 @@ public class UriInfoUtilTest {
 		PropsUtil.set(PropsKeys.WEB_SERVER_PROTOCOL, protocol);
 	}
 
+	private static final String _PATH = "/test-path";
+
+	private static final int _PORT_MAX_INCLUSIVE = 65535;
+
+	private static final int _PORT_MIN_INCLUSIVE = 1025;
+
+	private static final String _SPOOFED_HOST = "internal-host";
+
+	private static final String _WEB_SERVER_HOST = "example.com";
+
 	private final Portal _portal = Mockito.mock(Portal.class);
 	private final UriBuilder _uriBuilder = Mockito.spy(
 		new UriBuilderImpl(
 		).path(
-			"/test-path"
+			_PATH
 		));
 	private final UriInfo _uriInfo = Mockito.mock(UriInfo.class);
 

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/test/java/com/liferay/portal/vulcan/util/UriInfoUtilTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/test/java/com/liferay/portal/vulcan/util/UriInfoUtilTest.java
@@ -7,6 +7,10 @@ package com.liferay.portal.vulcan.util;
 
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.Portal;
@@ -48,6 +52,12 @@ public class UriInfoUtilTest {
 
 		portalUtil.setPortal(_portal);
 
+		_originalCompanyLocalService = ReflectionTestUtil.getFieldValue(
+			CompanyLocalServiceUtil.class, "_service");
+
+		ReflectionTestUtil.setFieldValue(
+			CompanyLocalServiceUtil.class, "_service", _companyLocalService);
+
 		Mockito.when(
 			_uriInfo.getBaseUriBuilder()
 		).thenReturn(
@@ -59,9 +69,77 @@ public class UriInfoUtilTest {
 
 	@After
 	public void tearDown() {
+		ReflectionTestUtil.setFieldValue(
+			CompanyLocalServiceUtil.class, "_service",
+			_originalCompanyLocalService);
+
 		PropsUtil.set(PropsKeys.WEB_SERVER_HOST, null);
 		PropsUtil.set(PropsKeys.WEB_SERVER_HTTP_PORT, null);
 		PropsUtil.set(PropsKeys.WEB_SERVER_HTTPS_PORT, null);
+	}
+
+	@Test
+	public void testGetBaseUriBuilderCompanyVirtualHostnameHttpCustomPort()
+		throws Exception {
+
+		int httpPort = RandomTestUtil.randomInt(
+			_PORT_MIN_INCLUSIVE, _PORT_MAX_INCLUSIVE);
+
+		_stubCompanyVirtualHostname(_COMPANY_VIRTUAL_HOSTNAME);
+
+		PropsUtil.set(PropsKeys.WEB_SERVER_HTTP_PORT, String.valueOf(httpPort));
+		PropsUtil.set(PropsKeys.WEB_SERVER_PROTOCOL, Http.HTTP);
+
+		Assert.assertSame(_uriBuilder, UriInfoUtil.getBaseUriBuilder(_uriInfo));
+
+		Assert.assertEquals(
+			new URI(
+				StringBundler.concat(
+					Http.HTTP_WITH_SLASH, _COMPANY_VIRTUAL_HOSTNAME,
+					StringPool.COLON, httpPort, _PATH)),
+			_uriBuilder.build());
+	}
+
+	@Test
+	public void testGetBaseUriBuilderCompanyVirtualHostnameOverridesSpoofedHost()
+		throws Exception {
+
+		int spoofedPort = RandomTestUtil.randomInt(
+			_PORT_MIN_INCLUSIVE, _PORT_MAX_INCLUSIVE);
+
+		_stubCompanyVirtualHostname(_COMPANY_VIRTUAL_HOSTNAME);
+
+		PropsUtil.set(
+			PropsKeys.WEB_SERVER_HTTPS_PORT, String.valueOf(Http.HTTPS_PORT));
+		PropsUtil.set(PropsKeys.WEB_SERVER_PROTOCOL, Http.HTTPS);
+
+		_uriBuilder.host(_SPOOFED_HOST);
+		_uriBuilder.port(spoofedPort);
+		_uriBuilder.scheme(Http.HTTP);
+
+		Assert.assertSame(_uriBuilder, UriInfoUtil.getBaseUriBuilder(_uriInfo));
+
+		Assert.assertEquals(
+			new URI(Http.HTTPS_WITH_SLASH + _COMPANY_VIRTUAL_HOSTNAME + _PATH),
+			_uriBuilder.build());
+	}
+
+	@Test
+	public void testGetBaseUriBuilderCompanyVirtualHostnameOverridesWebServerHost()
+		throws Exception {
+
+		_stubCompanyVirtualHostname(_COMPANY_VIRTUAL_HOSTNAME);
+
+		PropsUtil.set(PropsKeys.WEB_SERVER_HOST, _WEB_SERVER_HOST);
+		PropsUtil.set(
+			PropsKeys.WEB_SERVER_HTTP_PORT, String.valueOf(Http.HTTP_PORT));
+		PropsUtil.set(PropsKeys.WEB_SERVER_PROTOCOL, Http.HTTP);
+
+		Assert.assertSame(_uriBuilder, UriInfoUtil.getBaseUriBuilder(_uriInfo));
+
+		Assert.assertEquals(
+			new URI(Http.HTTP_WITH_SLASH + _COMPANY_VIRTUAL_HOSTNAME + _PATH),
+			_uriBuilder.build());
 	}
 
 	@Test
@@ -139,8 +217,8 @@ public class UriInfoUtilTest {
 			_PORT_MIN_INCLUSIVE, _PORT_MAX_INCLUSIVE);
 
 		PropsUtil.set(PropsKeys.WEB_SERVER_HOST, _WEB_SERVER_HOST);
-		PropsUtil.set(PropsKeys.WEB_SERVER_PROTOCOL, Http.HTTP);
 		PropsUtil.set(PropsKeys.WEB_SERVER_HTTP_PORT, String.valueOf(httpPort));
+		PropsUtil.set(PropsKeys.WEB_SERVER_PROTOCOL, Http.HTTP);
 
 		Assert.assertSame(_uriBuilder, UriInfoUtil.getBaseUriBuilder(_uriInfo));
 
@@ -298,6 +376,25 @@ public class UriInfoUtilTest {
 		PropsUtil.set(PropsKeys.WEB_SERVER_PROTOCOL, protocol);
 	}
 
+	private void _stubCompanyVirtualHostname(String virtualHostname) {
+		Company company = Mockito.mock(Company.class);
+
+		Mockito.when(
+			company.getVirtualHostname()
+		).thenReturn(
+			virtualHostname
+		);
+
+		Mockito.when(
+			_companyLocalService.fetchCompany(Mockito.anyLong())
+		).thenReturn(
+			company
+		);
+	}
+
+	private static final String _COMPANY_VIRTUAL_HOSTNAME =
+		"tenant.example.com";
+
 	private static final String _PATH = "/test-path";
 
 	private static final int _PORT_MAX_INCLUSIVE = 65535;
@@ -308,6 +405,9 @@ public class UriInfoUtilTest {
 
 	private static final String _WEB_SERVER_HOST = "example.com";
 
+	private final CompanyLocalService _companyLocalService = Mockito.mock(
+		CompanyLocalService.class);
+	private CompanyLocalService _originalCompanyLocalService;
 	private final Portal _portal = Mockito.mock(Portal.class);
 	private final UriBuilder _uriBuilder = Mockito.spy(
 		new UriBuilderImpl(

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/test/java/com/liferay/portal/vulcan/util/UriInfoUtilTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/test/java/com/liferay/portal/vulcan/util/UriInfoUtilTest.java
@@ -101,6 +101,24 @@ public class UriInfoUtilTest {
 	}
 
 	@Test
+	public void testGetBaseUriBuilderCompanyVirtualHostnameNullFallsBackToWebServerHost()
+		throws Exception {
+
+		_stubCompanyVirtualHostname(null);
+
+		PropsUtil.set(PropsKeys.WEB_SERVER_HOST, _WEB_SERVER_HOST);
+		PropsUtil.set(
+			PropsKeys.WEB_SERVER_HTTP_PORT, String.valueOf(Http.HTTP_PORT));
+		PropsUtil.set(PropsKeys.WEB_SERVER_PROTOCOL, Http.HTTP);
+
+		Assert.assertSame(_uriBuilder, UriInfoUtil.getBaseUriBuilder(_uriInfo));
+
+		Assert.assertEquals(
+			new URI(Http.HTTP_WITH_SLASH + _WEB_SERVER_HOST + _PATH),
+			_uriBuilder.build());
+	}
+
+	@Test
 	public void testGetBaseUriBuilderCompanyVirtualHostnameOverridesSpoofedHost()
 		throws Exception {
 
@@ -210,6 +228,27 @@ public class UriInfoUtilTest {
 	}
 
 	@Test
+	public void testGetBaseUriBuilderWebServerHostEmptyStringPreservesUriInfoHost()
+		throws Exception {
+
+		int spoofedPort = RandomTestUtil.randomInt(
+			_PORT_MIN_INCLUSIVE, _PORT_MAX_INCLUSIVE);
+
+		PropsUtil.set(PropsKeys.WEB_SERVER_HOST, StringPool.BLANK);
+
+		_uriBuilder.host(_SPOOFED_HOST);
+		_uriBuilder.port(spoofedPort);
+
+		Assert.assertSame(_uriBuilder, UriInfoUtil.getBaseUriBuilder(_uriInfo));
+
+		Assert.assertEquals(
+			new URI(
+				StringBundler.concat(
+					_SPOOFED_HOST, StringPool.COLON, spoofedPort, _PATH)),
+			_uriBuilder.build());
+	}
+
+	@Test
 	public void testGetBaseUriBuilderWebServerHostHttpCustomPort()
 		throws Exception {
 
@@ -285,25 +324,6 @@ public class UriInfoUtilTest {
 	}
 
 	@Test
-	public void testGetBaseUriBuilderWebServerHostNullPreservesUriInfoHost()
-		throws Exception {
-
-		int spoofedPort = RandomTestUtil.randomInt(
-			_PORT_MIN_INCLUSIVE, _PORT_MAX_INCLUSIVE);
-
-		_uriBuilder.host(_SPOOFED_HOST);
-		_uriBuilder.port(spoofedPort);
-
-		Assert.assertSame(_uriBuilder, UriInfoUtil.getBaseUriBuilder(_uriInfo));
-
-		Assert.assertEquals(
-			new URI(
-				StringBundler.concat(
-					_SPOOFED_HOST, StringPool.COLON, spoofedPort, _PATH)),
-			_uriBuilder.build());
-	}
-
-	@Test
 	public void testGetBaseUriBuilderWebServerHostOverridesSpoofedHost()
 		throws Exception {
 
@@ -323,6 +343,25 @@ public class UriInfoUtilTest {
 
 		Assert.assertEquals(
 			new URI(Http.HTTPS_WITH_SLASH + _WEB_SERVER_HOST + _PATH),
+			_uriBuilder.build());
+	}
+
+	@Test
+	public void testGetBaseUriBuilderWebServerHostUnsetPreservesUriInfoHost()
+		throws Exception {
+
+		int spoofedPort = RandomTestUtil.randomInt(
+			_PORT_MIN_INCLUSIVE, _PORT_MAX_INCLUSIVE);
+
+		_uriBuilder.host(_SPOOFED_HOST);
+		_uriBuilder.port(spoofedPort);
+
+		Assert.assertSame(_uriBuilder, UriInfoUtil.getBaseUriBuilder(_uriInfo));
+
+		Assert.assertEquals(
+			new URI(
+				StringBundler.concat(
+					_SPOOFED_HOST, StringPool.COLON, spoofedPort, _PATH)),
 			_uriBuilder.build());
 	}
 

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/test/java/com/liferay/portal/vulcan/util/UriInfoUtilTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/test/java/com/liferay/portal/vulcan/util/UriInfoUtilTest.java
@@ -235,9 +235,9 @@ public class UriInfoUtilTest {
 		throws Exception {
 
 		PropsUtil.set(PropsKeys.WEB_SERVER_HOST, _WEB_SERVER_HOST);
-		PropsUtil.set(PropsKeys.WEB_SERVER_PROTOCOL, Http.HTTP);
 		PropsUtil.set(
 			PropsKeys.WEB_SERVER_HTTP_PORT, String.valueOf(Http.HTTP_PORT));
+		PropsUtil.set(PropsKeys.WEB_SERVER_PROTOCOL, Http.HTTP);
 
 		Assert.assertSame(_uriBuilder, UriInfoUtil.getBaseUriBuilder(_uriInfo));
 
@@ -254,9 +254,9 @@ public class UriInfoUtilTest {
 			_PORT_MIN_INCLUSIVE, _PORT_MAX_INCLUSIVE);
 
 		PropsUtil.set(PropsKeys.WEB_SERVER_HOST, _WEB_SERVER_HOST);
-		PropsUtil.set(PropsKeys.WEB_SERVER_PROTOCOL, Http.HTTPS);
 		PropsUtil.set(
 			PropsKeys.WEB_SERVER_HTTPS_PORT, String.valueOf(httpsPort));
+		PropsUtil.set(PropsKeys.WEB_SERVER_PROTOCOL, Http.HTTPS);
 
 		Assert.assertSame(_uriBuilder, UriInfoUtil.getBaseUriBuilder(_uriInfo));
 
@@ -273,9 +273,9 @@ public class UriInfoUtilTest {
 		throws Exception {
 
 		PropsUtil.set(PropsKeys.WEB_SERVER_HOST, _WEB_SERVER_HOST);
-		PropsUtil.set(PropsKeys.WEB_SERVER_PROTOCOL, Http.HTTPS);
 		PropsUtil.set(
 			PropsKeys.WEB_SERVER_HTTPS_PORT, String.valueOf(Http.HTTPS_PORT));
+		PropsUtil.set(PropsKeys.WEB_SERVER_PROTOCOL, Http.HTTPS);
 
 		Assert.assertSame(_uriBuilder, UriInfoUtil.getBaseUriBuilder(_uriInfo));
 
@@ -311,9 +311,9 @@ public class UriInfoUtilTest {
 			_PORT_MIN_INCLUSIVE, _PORT_MAX_INCLUSIVE);
 
 		PropsUtil.set(PropsKeys.WEB_SERVER_HOST, _WEB_SERVER_HOST);
-		PropsUtil.set(PropsKeys.WEB_SERVER_PROTOCOL, Http.HTTPS);
 		PropsUtil.set(
 			PropsKeys.WEB_SERVER_HTTPS_PORT, String.valueOf(Http.HTTPS_PORT));
+		PropsUtil.set(PropsKeys.WEB_SERVER_PROTOCOL, Http.HTTPS);
 
 		_uriBuilder.host(_SPOOFED_HOST);
 		_uriBuilder.port(spoofedPort);

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/test/java/com/liferay/portal/vulcan/util/UriInfoUtilTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/test/java/com/liferay/portal/vulcan/util/UriInfoUtilTest.java
@@ -101,24 +101,6 @@ public class UriInfoUtilTest {
 	}
 
 	@Test
-	public void testGetBaseUriBuilderCompanyVirtualHostnameNullFallsBackToWebServerHost()
-		throws Exception {
-
-		_stubCompanyVirtualHostname(null);
-
-		PropsUtil.set(PropsKeys.WEB_SERVER_HOST, _WEB_SERVER_HOST);
-		PropsUtil.set(
-			PropsKeys.WEB_SERVER_HTTP_PORT, String.valueOf(Http.HTTP_PORT));
-		PropsUtil.set(PropsKeys.WEB_SERVER_PROTOCOL, Http.HTTP);
-
-		Assert.assertSame(_uriBuilder, UriInfoUtil.getBaseUriBuilder(_uriInfo));
-
-		Assert.assertEquals(
-			new URI(Http.HTTP_WITH_SLASH + _WEB_SERVER_HOST + _PATH),
-			_uriBuilder.build());
-	}
-
-	@Test
 	public void testGetBaseUriBuilderCompanyVirtualHostnameOverridesSpoofedHost()
 		throws Exception {
 
@@ -139,24 +121,6 @@ public class UriInfoUtilTest {
 
 		Assert.assertEquals(
 			new URI(Http.HTTPS_WITH_SLASH + _COMPANY_VIRTUAL_HOSTNAME + _PATH),
-			_uriBuilder.build());
-	}
-
-	@Test
-	public void testGetBaseUriBuilderCompanyVirtualHostnameOverridesWebServerHost()
-		throws Exception {
-
-		_stubCompanyVirtualHostname(_COMPANY_VIRTUAL_HOSTNAME);
-
-		PropsUtil.set(PropsKeys.WEB_SERVER_HOST, _WEB_SERVER_HOST);
-		PropsUtil.set(
-			PropsKeys.WEB_SERVER_HTTP_PORT, String.valueOf(Http.HTTP_PORT));
-		PropsUtil.set(PropsKeys.WEB_SERVER_PROTOCOL, Http.HTTP);
-
-		Assert.assertSame(_uriBuilder, UriInfoUtil.getBaseUriBuilder(_uriInfo));
-
-		Assert.assertEquals(
-			new URI(Http.HTTP_WITH_SLASH + _COMPANY_VIRTUAL_HOSTNAME + _PATH),
 			_uriBuilder.build());
 	}
 
@@ -324,6 +288,24 @@ public class UriInfoUtilTest {
 	}
 
 	@Test
+	public void testGetBaseUriBuilderWebServerHostOverridesCompanyVirtualHostname()
+		throws Exception {
+
+		_stubCompanyVirtualHostname(_COMPANY_VIRTUAL_HOSTNAME);
+
+		PropsUtil.set(PropsKeys.WEB_SERVER_HOST, _WEB_SERVER_HOST);
+		PropsUtil.set(
+			PropsKeys.WEB_SERVER_HTTP_PORT, String.valueOf(Http.HTTP_PORT));
+		PropsUtil.set(PropsKeys.WEB_SERVER_PROTOCOL, Http.HTTP);
+
+		Assert.assertSame(_uriBuilder, UriInfoUtil.getBaseUriBuilder(_uriInfo));
+
+		Assert.assertEquals(
+			new URI(Http.HTTP_WITH_SLASH + _WEB_SERVER_HOST + _PATH),
+			_uriBuilder.build());
+	}
+
+	@Test
 	public void testGetBaseUriBuilderWebServerHostOverridesSpoofedHost()
 		throws Exception {
 
@@ -343,6 +325,23 @@ public class UriInfoUtilTest {
 
 		Assert.assertEquals(
 			new URI(Http.HTTPS_WITH_SLASH + _WEB_SERVER_HOST + _PATH),
+			_uriBuilder.build());
+	}
+
+	@Test
+	public void testGetBaseUriBuilderWebServerHostUnsetFallsBackToCompanyVirtualHostname()
+		throws Exception {
+
+		_stubCompanyVirtualHostname(_COMPANY_VIRTUAL_HOSTNAME);
+
+		PropsUtil.set(
+			PropsKeys.WEB_SERVER_HTTP_PORT, String.valueOf(Http.HTTP_PORT));
+		PropsUtil.set(PropsKeys.WEB_SERVER_PROTOCOL, Http.HTTP);
+
+		Assert.assertSame(_uriBuilder, UriInfoUtil.getBaseUriBuilder(_uriInfo));
+
+		Assert.assertEquals(
+			new URI(Http.HTTP_WITH_SLASH + _COMPANY_VIRTUAL_HOSTNAME + _PATH),
 			_uriBuilder.build());
 	}
 


### PR DESCRIPTION
What is being fixed:
REST action href values generated by Vulcan endpoints currently derive their host, port, and scheme from the inbound request’s Host header rather than the externally-configured `web.server.* properties. `In deployments behind load balancers, reverse proxies, or SSL-terminating gateways, this can result in REST responses exposing internal hostnames or ports instead of the publicly-reachable address.

How it is being fixed:
Updating `UriInfoUtil._updateUriBuilder `so that, whenever `web.server.host` is configured, the UriBuilder host, port, and scheme are overridden using `web.server.host`, `web.server.protocol`, and the corresponding `web.server.http.port / web.server.https.port` values. This aligns the behavior with the sibling `getBaseUriBuilder(HttpServletRequest, UriInfo) `overload, which already respects these settings through `PortalUtil.getForwardedHost(...)` and `getForwardedPort(...)`.
