### PR TITLE
LPD-89862 Move SiteParamConverterProviderTest base URL out of <clinit>

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/param/converter/provider/test/SiteParamConverterProviderTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/param/converter/provider/test/SiteParamConverterProviderTest.java
@@ -19,7 +19,6 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
@@ -62,6 +61,10 @@ public class SiteParamConverterProviderTest {
 
 	@Before
 	public void setUp() {
+		_testBaseURL =
+			"http://localhost:" + _portal.getPortalServerPort(false) +
+				"/o/test-vulcan/";
+
 		Bundle bundle = FrameworkUtil.getBundle(
 			SiteParamConverterProviderTest.class);
 
@@ -93,7 +96,7 @@ public class SiteParamConverterProviderTest {
 				_CLASS_NAME_WEB_APPLICATION_EXCEPTION_MAPPER,
 				LoggerTestUtil.ERROR)) {
 
-			URLConnectionUtil.read(_TEST_BASE_URL + "0/name");
+			URLConnectionUtil.read(_testBaseURL + "0/name");
 		}
 	}
 
@@ -111,7 +114,7 @@ public class SiteParamConverterProviderTest {
 				LoggerTestUtil.ERROR)) {
 
 			URLConnectionUtil.read(
-				_TEST_BASE_URL + company.getGroupId() + "/name");
+				_testBaseURL + company.getGroupId() + "/name");
 		}
 	}
 
@@ -131,15 +134,15 @@ public class SiteParamConverterProviderTest {
 		Assert.assertEquals(
 			expectedGroupName,
 			URLConnectionUtil.read(
-				_TEST_BASE_URL + group.getExternalReferenceCode() + "/name"));
+				_testBaseURL + group.getExternalReferenceCode() + "/name"));
 		Assert.assertEquals(
 			expectedGroupName,
 			URLConnectionUtil.read(
-				_TEST_BASE_URL + group.getGroupId() + "/name"));
+				_testBaseURL + group.getGroupId() + "/name"));
 		Assert.assertEquals(
 			expectedGroupName,
 			URLConnectionUtil.read(
-				_TEST_BASE_URL + group.getGroupKey() + "/name"));
+				_testBaseURL + group.getGroupKey() + "/name"));
 	}
 
 	public static class TestApplication extends Application {
@@ -165,13 +168,10 @@ public class SiteParamConverterProviderTest {
 		"com.liferay.portal.vulcan.internal.jaxrs.exception.mapper." +
 			"WebApplicationExceptionMapper";
 
-	private static final String _TEST_BASE_URL =
-		"http://localhost:" + PortalUtil.getPortalServerPort(false) +
-			"/o/test-vulcan/";
-
 	@Inject
 	private Portal _portal;
 
 	private ServiceRegistration<Application> _serviceRegistration;
+	private String _testBaseURL;
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89862

## Failing Test

`com.liferay.portal.vulcan.internal.jaxrs.param.converter.provider.test.SiteParamConverterProviderTest`

`modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/param/converter/provider/test/SiteParamConverterProviderTest.java`

```
initializationError: java.lang.ExceptionInInitializerError
    at java.base/java.lang.Class.forName0(Native Method)
    at java.base/java.lang.Class.forName(Class.java:467)
    at com.liferay.arquillian.extension.junit.bridge.junit.Arquillian.run(Arquillian.java:102)
    ...
Caused by: java.lang.NullPointerException: Cannot invoke "com.liferay.portal.kernel.util.Portal.getPortalServerPort(boolean)" because "com.liferay.portal.kernel.util.PortalUtil._portal" is null
    at com.liferay.portal.kernel.util.PortalUtil.getPortalServerPort(PortalUtil.java:1140)
    at com.liferay.portal.vulcan.internal.jaxrs.param.converter.provider.test.SiteParamConverterProviderTest.<clinit>(SiteParamConverterProviderTest.java:169)
```

## Root Cause

Commit `3257296d2aaff` ("LPD-87965 Replace hardcoded 8080 in hand-maintained tests") moved the base URL from a compile-time `String` constant to a `static final` initializer that calls `PortalUtil.getPortalServerPort(false)`. Arquillian loads the test class on the client JVM first to discover `@Test` methods, and on that side `PortalUtil._portal` has never been wired, so `<clinit>` raises `ExceptionInInitializerError`.

## Fix

Drop the static field and build the URL inside `setUp` instead. The setup method runs inside the OSGi container where `PortalUtil._portal` is populated, so the lookup succeeds and every test in the class can resolve the URL again.

- `modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/jaxrs/param/converter/provider/test/SiteParamConverterProviderTest.java`