### PR TITLE
LPD-89873 Update OpenAPI fixtures for OpenAPIResourceTest

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi.json
@@ -88,6 +88,9 @@
 						"format": "date-time",
 						"type": "string"
 					},
+					"emailAddress": {
+						"type": "string"
+					},
 					"externalReferenceCode": {
 						"description": "The collaborator external reference code.",
 						"readOnly": true,
@@ -132,6 +135,41 @@
 				},
 				"xml": {
 					"name": "Collaborator"
+				}
+			},
+			"CollaboratorBrief": {
+				"properties": {
+					"actionIds": {
+						"description": "The sharing actions granted to the user making the request (e.g. VIEW, UPDATE).",
+						"items": {
+							"description": "The sharing actions granted to the user making the request (e.g. VIEW, UPDATE).",
+							"type": "string"
+						},
+						"readOnly": true,
+						"type": "array"
+					},
+					"dateExpired": {
+						"description": "The date when the sharing access expires, or null if it never expires.",
+						"format": "date-time",
+						"readOnly": true,
+						"type": "string"
+					},
+					"share": {
+						"description": "Whether the user making the request can reshare this asset with others.",
+						"readOnly": true,
+						"type": "boolean"
+					},
+					"x-class-name": {
+						"default": "com.liferay.object.rest.dto.v1_0.CollaboratorBrief",
+						"readOnly": true,
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": {
+				},
+				"xml": {
+					"name": "CollaboratorBrief"
 				}
 			},
 			"Comment": {
@@ -321,6 +359,10 @@
 						"readOnly": true,
 						"type": "string"
 					},
+					"extension": {
+						"readOnly": true,
+						"type": "string"
+					},
 					"externalReferenceCode": {
 						"type": "string"
 					},
@@ -365,6 +407,10 @@
 					},
 					"scope": {
 						"$ref": "#/components/schemas/Scope"
+					},
+					"size": {
+						"readOnly": true,
+						"type": "string"
 					},
 					"thumbnailURL": {
 						"description": "optional field that specifies the thumbnail of the file to be used, can be embedded with nestedFields (the format of the nested field must be `<attachment field name>.thumbnailURL`)",
@@ -453,6 +499,19 @@
 				},
 				"xml": {
 					"name": "ListEntry"
+				}
+			},
+			"MultipartBody": {
+				"properties": {
+					"values": {
+						"additionalProperties": {
+							"type": "string"
+						},
+						"type": "object"
+					}
+				},
+				"type": "object",
+				"x-filterable": {
 				}
 			},
 			"Object1": {
@@ -2546,6 +2605,30 @@
 					"name": "Permission"
 				}
 			},
+			"PostObjectEntryTranslationRequestBody": {
+				"properties": {
+					"file": {
+						"description": "File",
+						"format": "binary",
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": {
+				}
+			},
+			"PostScopeScopeKeyByExternalReferenceCodeTranslationRequestBody": {
+				"properties": {
+					"file": {
+						"description": "File",
+						"format": "binary",
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": {
+				}
+			},
 			"Scope": {
 				"properties": {
 					"externalReferenceCode": {
@@ -2662,6 +2745,35 @@
 				},
 				"xml": {
 					"name": "TaxonomyCategoryBrief"
+				}
+			},
+			"TranslationResponse": {
+				"properties": {
+					"failureMessagesJSON": {
+						"items": {
+							"type": "string"
+						},
+						"readOnly": true,
+						"type": "array"
+					},
+					"successMessages": {
+						"items": {
+							"type": "string"
+						},
+						"readOnly": true,
+						"type": "array"
+					},
+					"x-class-name": {
+						"default": "com.liferay.object.rest.dto.v1_0.TranslationResponse",
+						"readOnly": true,
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": {
+				},
+				"xml": {
+					"name": "TranslationResponse"
 				}
 			},
 			"UserGroupBrief": {
@@ -6147,6 +6259,163 @@
 				]
 			}
 		},
+		"/{object1Id}/collaborators/by-email-address/{emailAddress}": {
+			"delete": {
+				"description": "Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.",
+				"operationId": "deleteObject1CollaboratorByEmailAddress",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object1Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "emailAddress",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+							},
+							"application/xml": {
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"get": {
+				"description": "Retrieves the collaborator for an object entry.",
+				"operationId": "getObject1CollaboratorByEmailAddress",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object1Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "emailAddress",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "fields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "nestedFields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "restrictFields",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"put": {
+				"description": "Add or update a collaborator received in the request.",
+				"operationId": "putObject1CollaboratorByEmailAddress",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object1Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "emailAddress",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						}
+					}
+				},
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			}
+		},
 		"/{object1Id}/collaborators/by-type/{type}/{collaboratorId}": {
 			"delete": {
 				"description": "Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.",
@@ -7112,6 +7381,48 @@
 					"default": {
 						"content": {
 							"application/zip": {
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Object1"
+				]
+			},
+			"post": {
+				"operationId": "postObject1Translation",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object1Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"multipart/form-data": {
+							"schema": {
+								"$ref": "#/components/schemas/PostObjectEntryTranslationRequestBody"
+							}
+						}
+					}
+				},
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/TranslationResponse"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/TranslationResponse"
+								}
 							}
 						},
 						"description": "default response"

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions.json
@@ -88,6 +88,9 @@
 						"format": "date-time",
 						"type": "string"
 					},
+					"emailAddress": {
+						"type": "string"
+					},
 					"externalReferenceCode": {
 						"description": "The collaborator external reference code.",
 						"readOnly": true,
@@ -132,6 +135,41 @@
 				},
 				"xml": {
 					"name": "Collaborator"
+				}
+			},
+			"CollaboratorBrief": {
+				"properties": {
+					"actionIds": {
+						"description": "The sharing actions granted to the user making the request (e.g. VIEW, UPDATE).",
+						"items": {
+							"description": "The sharing actions granted to the user making the request (e.g. VIEW, UPDATE).",
+							"type": "string"
+						},
+						"readOnly": true,
+						"type": "array"
+					},
+					"dateExpired": {
+						"description": "The date when the sharing access expires, or null if it never expires.",
+						"format": "date-time",
+						"readOnly": true,
+						"type": "string"
+					},
+					"share": {
+						"description": "Whether the user making the request can reshare this asset with others.",
+						"readOnly": true,
+						"type": "boolean"
+					},
+					"x-class-name": {
+						"default": "com.liferay.object.rest.dto.v1_0.CollaboratorBrief",
+						"readOnly": true,
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": {
+				},
+				"xml": {
+					"name": "CollaboratorBrief"
 				}
 			},
 			"Comment": {
@@ -321,6 +359,10 @@
 						"readOnly": true,
 						"type": "string"
 					},
+					"extension": {
+						"readOnly": true,
+						"type": "string"
+					},
 					"externalReferenceCode": {
 						"type": "string"
 					},
@@ -365,6 +407,10 @@
 					},
 					"scope": {
 						"$ref": "#/components/schemas/Scope"
+					},
+					"size": {
+						"readOnly": true,
+						"type": "string"
 					},
 					"thumbnailURL": {
 						"description": "optional field that specifies the thumbnail of the file to be used, can be embedded with nestedFields (the format of the nested field must be `<attachment field name>.thumbnailURL`)",
@@ -425,6 +471,19 @@
 				},
 				"xml": {
 					"name": "Link"
+				}
+			},
+			"MultipartBody": {
+				"properties": {
+					"values": {
+						"additionalProperties": {
+							"type": "string"
+						},
+						"type": "object"
+					}
+				},
+				"type": "object",
+				"x-filterable": {
 				}
 			},
 			"Object1": {
@@ -1090,6 +1149,30 @@
 					"name": "Permission"
 				}
 			},
+			"PostObjectEntryTranslationRequestBody": {
+				"properties": {
+					"file": {
+						"description": "File",
+						"format": "binary",
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": {
+				}
+			},
+			"PostScopeScopeKeyByExternalReferenceCodeTranslationRequestBody": {
+				"properties": {
+					"file": {
+						"description": "File",
+						"format": "binary",
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": {
+				}
+			},
 			"Scope": {
 				"properties": {
 					"externalReferenceCode": {
@@ -1206,6 +1289,35 @@
 				},
 				"xml": {
 					"name": "TaxonomyCategoryBrief"
+				}
+			},
+			"TranslationResponse": {
+				"properties": {
+					"failureMessagesJSON": {
+						"items": {
+							"type": "string"
+						},
+						"readOnly": true,
+						"type": "array"
+					},
+					"successMessages": {
+						"items": {
+							"type": "string"
+						},
+						"readOnly": true,
+						"type": "array"
+					},
+					"x-class-name": {
+						"default": "com.liferay.object.rest.dto.v1_0.TranslationResponse",
+						"readOnly": true,
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": {
+				},
+				"xml": {
+					"name": "TranslationResponse"
 				}
 			},
 			"UserGroupBrief": {
@@ -3307,6 +3419,163 @@
 				]
 			}
 		},
+		"/{object1Id}/collaborators/by-email-address/{emailAddress}": {
+			"delete": {
+				"description": "Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.",
+				"operationId": "deleteObject1CollaboratorByEmailAddress",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object1Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "emailAddress",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+							},
+							"application/xml": {
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"get": {
+				"description": "Retrieves the collaborator for an object entry.",
+				"operationId": "getObject1CollaboratorByEmailAddress",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object1Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "emailAddress",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "fields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "nestedFields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "restrictFields",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"put": {
+				"description": "Add or update a collaborator received in the request.",
+				"operationId": "putObject1CollaboratorByEmailAddress",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object1Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "emailAddress",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						}
+					}
+				},
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			}
+		},
 		"/{object1Id}/collaborators/by-type/{type}/{collaboratorId}": {
 			"delete": {
 				"description": "Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.",
@@ -3690,6 +3959,48 @@
 					"default": {
 						"content": {
 							"application/zip": {
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Object1"
+				]
+			},
+			"post": {
+				"operationId": "postObject1Translation",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object1Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"multipart/form-data": {
+							"schema": {
+								"$ref": "#/components/schemas/PostObjectEntryTranslationRequestBody"
+							}
+						}
+					}
+				},
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/TranslationResponse"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/TranslationResponse"
+								}
 							}
 						},
 						"description": "default response"

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions_object_action.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions_object_action.json
@@ -88,6 +88,9 @@
 						"format": "date-time",
 						"type": "string"
 					},
+					"emailAddress": {
+						"type": "string"
+					},
 					"externalReferenceCode": {
 						"description": "The collaborator external reference code.",
 						"readOnly": true,
@@ -132,6 +135,41 @@
 				},
 				"xml": {
 					"name": "Collaborator"
+				}
+			},
+			"CollaboratorBrief": {
+				"properties": {
+					"actionIds": {
+						"description": "The sharing actions granted to the user making the request (e.g. VIEW, UPDATE).",
+						"items": {
+							"description": "The sharing actions granted to the user making the request (e.g. VIEW, UPDATE).",
+							"type": "string"
+						},
+						"readOnly": true,
+						"type": "array"
+					},
+					"dateExpired": {
+						"description": "The date when the sharing access expires, or null if it never expires.",
+						"format": "date-time",
+						"readOnly": true,
+						"type": "string"
+					},
+					"share": {
+						"description": "Whether the user making the request can reshare this asset with others.",
+						"readOnly": true,
+						"type": "boolean"
+					},
+					"x-class-name": {
+						"default": "com.liferay.object.rest.dto.v1_0.CollaboratorBrief",
+						"readOnly": true,
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": {
+				},
+				"xml": {
+					"name": "CollaboratorBrief"
 				}
 			},
 			"Comment": {
@@ -321,6 +359,10 @@
 						"readOnly": true,
 						"type": "string"
 					},
+					"extension": {
+						"readOnly": true,
+						"type": "string"
+					},
 					"externalReferenceCode": {
 						"type": "string"
 					},
@@ -365,6 +407,10 @@
 					},
 					"scope": {
 						"$ref": "#/components/schemas/Scope"
+					},
+					"size": {
+						"readOnly": true,
+						"type": "string"
 					},
 					"thumbnailURL": {
 						"description": "optional field that specifies the thumbnail of the file to be used, can be embedded with nestedFields (the format of the nested field must be `<attachment field name>.thumbnailURL`)",
@@ -425,6 +471,19 @@
 				},
 				"xml": {
 					"name": "Link"
+				}
+			},
+			"MultipartBody": {
+				"properties": {
+					"values": {
+						"additionalProperties": {
+							"type": "string"
+						},
+						"type": "object"
+					}
+				},
+				"type": "object",
+				"x-filterable": {
 				}
 			},
 			"Object1": {
@@ -1114,6 +1173,30 @@
 					"name": "Permission"
 				}
 			},
+			"PostObjectEntryTranslationRequestBody": {
+				"properties": {
+					"file": {
+						"description": "File",
+						"format": "binary",
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": {
+				}
+			},
+			"PostScopeScopeKeyByExternalReferenceCodeTranslationRequestBody": {
+				"properties": {
+					"file": {
+						"description": "File",
+						"format": "binary",
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": {
+				}
+			},
 			"Scope": {
 				"properties": {
 					"externalReferenceCode": {
@@ -1230,6 +1313,35 @@
 				},
 				"xml": {
 					"name": "TaxonomyCategoryBrief"
+				}
+			},
+			"TranslationResponse": {
+				"properties": {
+					"failureMessagesJSON": {
+						"items": {
+							"type": "string"
+						},
+						"readOnly": true,
+						"type": "array"
+					},
+					"successMessages": {
+						"items": {
+							"type": "string"
+						},
+						"readOnly": true,
+						"type": "array"
+					},
+					"x-class-name": {
+						"default": "com.liferay.object.rest.dto.v1_0.TranslationResponse",
+						"readOnly": true,
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": {
+				},
+				"xml": {
+					"name": "TranslationResponse"
 				}
 			},
 			"UserGroupBrief": {
@@ -3360,6 +3472,163 @@
 				]
 			}
 		},
+		"/{object1Id}/collaborators/by-email-address/{emailAddress}": {
+			"delete": {
+				"description": "Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.",
+				"operationId": "deleteObject1CollaboratorByEmailAddress",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object1Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "emailAddress",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+							},
+							"application/xml": {
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"get": {
+				"description": "Retrieves the collaborator for an object entry.",
+				"operationId": "getObject1CollaboratorByEmailAddress",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object1Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "emailAddress",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "fields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "nestedFields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "restrictFields",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"put": {
+				"description": "Add or update a collaborator received in the request.",
+				"operationId": "putObject1CollaboratorByEmailAddress",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object1Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "emailAddress",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						}
+					}
+				},
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			}
+		},
 		"/{object1Id}/collaborators/by-type/{type}/{collaboratorId}": {
 			"delete": {
 				"description": "Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.",
@@ -3772,6 +4041,48 @@
 					"default": {
 						"content": {
 							"application/zip": {
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Object1"
+				]
+			},
+			"post": {
+				"operationId": "postObject1Translation",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object1Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"multipart/form-data": {
+							"schema": {
+								"$ref": "#/components/schemas/PostObjectEntryTranslationRequestBody"
+							}
+						}
+					}
+				},
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/TranslationResponse"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/TranslationResponse"
+								}
 							}
 						},
 						"description": "default response"

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_categorization_disabled.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_categorization_disabled.json
@@ -88,6 +88,9 @@
 						"format": "date-time",
 						"type": "string"
 					},
+					"emailAddress": {
+						"type": "string"
+					},
 					"externalReferenceCode": {
 						"description": "The collaborator external reference code.",
 						"readOnly": true,
@@ -132,6 +135,41 @@
 				},
 				"xml": {
 					"name": "Collaborator"
+				}
+			},
+			"CollaboratorBrief": {
+				"properties": {
+					"actionIds": {
+						"description": "The sharing actions granted to the user making the request (e.g. VIEW, UPDATE).",
+						"items": {
+							"description": "The sharing actions granted to the user making the request (e.g. VIEW, UPDATE).",
+							"type": "string"
+						},
+						"readOnly": true,
+						"type": "array"
+					},
+					"dateExpired": {
+						"description": "The date when the sharing access expires, or null if it never expires.",
+						"format": "date-time",
+						"readOnly": true,
+						"type": "string"
+					},
+					"share": {
+						"description": "Whether the user making the request can reshare this asset with others.",
+						"readOnly": true,
+						"type": "boolean"
+					},
+					"x-class-name": {
+						"default": "com.liferay.object.rest.dto.v1_0.CollaboratorBrief",
+						"readOnly": true,
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": {
+				},
+				"xml": {
+					"name": "CollaboratorBrief"
 				}
 			},
 			"Comment": {
@@ -309,6 +347,19 @@
 					},
 					"term": {
 						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": {
+				}
+			},
+			"MultipartBody": {
+				"properties": {
+					"values": {
+						"additionalProperties": {
+							"type": "string"
+						},
+						"type": "object"
 					}
 				},
 				"type": "object",
@@ -793,6 +844,30 @@
 					"name": "Permission"
 				}
 			},
+			"PostObjectEntryTranslationRequestBody": {
+				"properties": {
+					"file": {
+						"description": "File",
+						"format": "binary",
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": {
+				}
+			},
+			"PostScopeScopeKeyByExternalReferenceCodeTranslationRequestBody": {
+				"properties": {
+					"file": {
+						"description": "File",
+						"format": "binary",
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": {
+				}
+			},
 			"Scope": {
 				"properties": {
 					"externalReferenceCode": {
@@ -855,6 +930,35 @@
 				},
 				"xml": {
 					"name": "Status"
+				}
+			},
+			"TranslationResponse": {
+				"properties": {
+					"failureMessagesJSON": {
+						"items": {
+							"type": "string"
+						},
+						"readOnly": true,
+						"type": "array"
+					},
+					"successMessages": {
+						"items": {
+							"type": "string"
+						},
+						"readOnly": true,
+						"type": "array"
+					},
+					"x-class-name": {
+						"default": "com.liferay.object.rest.dto.v1_0.TranslationResponse",
+						"readOnly": true,
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": {
+				},
+				"xml": {
+					"name": "TranslationResponse"
 				}
 			},
 			"UserGroupBrief": {
@@ -2956,6 +3060,163 @@
 				]
 			}
 		},
+		"/{object9Id}/collaborators/by-email-address/{emailAddress}": {
+			"delete": {
+				"description": "Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.",
+				"operationId": "deleteObject9CollaboratorByEmailAddress",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object9Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "emailAddress",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+							},
+							"application/xml": {
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"get": {
+				"description": "Retrieves the collaborator for an object entry.",
+				"operationId": "getObject9CollaboratorByEmailAddress",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object9Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "emailAddress",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "fields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "nestedFields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "restrictFields",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"put": {
+				"description": "Add or update a collaborator received in the request.",
+				"operationId": "putObject9CollaboratorByEmailAddress",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object9Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "emailAddress",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						}
+					}
+				},
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			}
+		},
 		"/{object9Id}/collaborators/by-type/{type}/{collaboratorId}": {
 			"delete": {
 				"description": "Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.",
@@ -3339,6 +3600,48 @@
 					"default": {
 						"content": {
 							"application/zip": {
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Object9"
+				]
+			},
+			"post": {
+				"operationId": "postObject9Translation",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object9Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"multipart/form-data": {
+							"schema": {
+								"$ref": "#/components/schemas/PostObjectEntryTranslationRequestBody"
+							}
+						}
+					}
+				},
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/TranslationResponse"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/TranslationResponse"
+								}
 							}
 						},
 						"description": "default response"

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_related.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_related.json
@@ -88,6 +88,9 @@
 						"format": "date-time",
 						"type": "string"
 					},
+					"emailAddress": {
+						"type": "string"
+					},
 					"externalReferenceCode": {
 						"description": "The collaborator external reference code.",
 						"readOnly": true,
@@ -132,6 +135,41 @@
 				},
 				"xml": {
 					"name": "Collaborator"
+				}
+			},
+			"CollaboratorBrief": {
+				"properties": {
+					"actionIds": {
+						"description": "The sharing actions granted to the user making the request (e.g. VIEW, UPDATE).",
+						"items": {
+							"description": "The sharing actions granted to the user making the request (e.g. VIEW, UPDATE).",
+							"type": "string"
+						},
+						"readOnly": true,
+						"type": "array"
+					},
+					"dateExpired": {
+						"description": "The date when the sharing access expires, or null if it never expires.",
+						"format": "date-time",
+						"readOnly": true,
+						"type": "string"
+					},
+					"share": {
+						"description": "Whether the user making the request can reshare this asset with others.",
+						"readOnly": true,
+						"type": "boolean"
+					},
+					"x-class-name": {
+						"default": "com.liferay.object.rest.dto.v1_0.CollaboratorBrief",
+						"readOnly": true,
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": {
+				},
+				"xml": {
+					"name": "CollaboratorBrief"
 				}
 			},
 			"Comment": {
@@ -321,6 +359,10 @@
 						"readOnly": true,
 						"type": "string"
 					},
+					"extension": {
+						"readOnly": true,
+						"type": "string"
+					},
 					"externalReferenceCode": {
 						"type": "string"
 					},
@@ -365,6 +407,10 @@
 					},
 					"scope": {
 						"$ref": "#/components/schemas/Scope"
+					},
+					"size": {
+						"readOnly": true,
+						"type": "string"
 					},
 					"thumbnailURL": {
 						"description": "optional field that specifies the thumbnail of the file to be used, can be embedded with nestedFields (the format of the nested field must be `<attachment field name>.thumbnailURL`)",
@@ -453,6 +499,19 @@
 				},
 				"xml": {
 					"name": "ListEntry"
+				}
+			},
+			"MultipartBody": {
+				"properties": {
+					"values": {
+						"additionalProperties": {
+							"type": "string"
+						},
+						"type": "object"
+					}
+				},
+				"type": "object",
+				"x-filterable": {
 				}
 			},
 			"Object1": {
@@ -3622,6 +3681,30 @@
 					"name": "Permission"
 				}
 			},
+			"PostObjectEntryTranslationRequestBody": {
+				"properties": {
+					"file": {
+						"description": "File",
+						"format": "binary",
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": {
+				}
+			},
+			"PostScopeScopeKeyByExternalReferenceCodeTranslationRequestBody": {
+				"properties": {
+					"file": {
+						"description": "File",
+						"format": "binary",
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": {
+				}
+			},
 			"Scope": {
 				"properties": {
 					"externalReferenceCode": {
@@ -3738,6 +3821,35 @@
 				},
 				"xml": {
 					"name": "TaxonomyCategoryBrief"
+				}
+			},
+			"TranslationResponse": {
+				"properties": {
+					"failureMessagesJSON": {
+						"items": {
+							"type": "string"
+						},
+						"readOnly": true,
+						"type": "array"
+					},
+					"successMessages": {
+						"items": {
+							"type": "string"
+						},
+						"readOnly": true,
+						"type": "array"
+					},
+					"x-class-name": {
+						"default": "com.liferay.object.rest.dto.v1_0.TranslationResponse",
+						"readOnly": true,
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": {
+				},
+				"xml": {
+					"name": "TranslationResponse"
 				}
 			},
 			"UserGroupBrief": {
@@ -7915,6 +8027,163 @@
 				]
 			}
 		},
+		"/{object2Id}/collaborators/by-email-address/{emailAddress}": {
+			"delete": {
+				"description": "Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.",
+				"operationId": "deleteObject2CollaboratorByEmailAddress",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object2Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "emailAddress",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+							},
+							"application/xml": {
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"get": {
+				"description": "Retrieves the collaborator for an object entry.",
+				"operationId": "getObject2CollaboratorByEmailAddress",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object2Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "emailAddress",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "fields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "nestedFields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "restrictFields",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"put": {
+				"description": "Add or update a collaborator received in the request.",
+				"operationId": "putObject2CollaboratorByEmailAddress",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object2Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "emailAddress",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						}
+					}
+				},
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			}
+		},
 		"/{object2Id}/collaborators/by-type/{type}/{collaboratorId}": {
 			"delete": {
 				"description": "Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.",
@@ -9171,6 +9440,48 @@
 					"default": {
 						"content": {
 							"application/zip": {
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Object2"
+				]
+			},
+			"post": {
+				"operationId": "postObject2Translation",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object2Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"multipart/form-data": {
+							"schema": {
+								"$ref": "#/components/schemas/PostObjectEntryTranslationRequestBody"
+							}
+						}
+					}
+				},
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/TranslationResponse"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/TranslationResponse"
+								}
 							}
 						},
 						"description": "default response"

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_site.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_site.json
@@ -88,6 +88,9 @@
 						"format": "date-time",
 						"type": "string"
 					},
+					"emailAddress": {
+						"type": "string"
+					},
 					"externalReferenceCode": {
 						"description": "The collaborator external reference code.",
 						"readOnly": true,
@@ -132,6 +135,41 @@
 				},
 				"xml": {
 					"name": "Collaborator"
+				}
+			},
+			"CollaboratorBrief": {
+				"properties": {
+					"actionIds": {
+						"description": "The sharing actions granted to the user making the request (e.g. VIEW, UPDATE).",
+						"items": {
+							"description": "The sharing actions granted to the user making the request (e.g. VIEW, UPDATE).",
+							"type": "string"
+						},
+						"readOnly": true,
+						"type": "array"
+					},
+					"dateExpired": {
+						"description": "The date when the sharing access expires, or null if it never expires.",
+						"format": "date-time",
+						"readOnly": true,
+						"type": "string"
+					},
+					"share": {
+						"description": "Whether the user making the request can reshare this asset with others.",
+						"readOnly": true,
+						"type": "boolean"
+					},
+					"x-class-name": {
+						"default": "com.liferay.object.rest.dto.v1_0.CollaboratorBrief",
+						"readOnly": true,
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": {
+				},
+				"xml": {
+					"name": "CollaboratorBrief"
 				}
 			},
 			"Comment": {
@@ -309,6 +347,19 @@
 					},
 					"term": {
 						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": {
+				}
+			},
+			"MultipartBody": {
+				"properties": {
+					"values": {
+						"additionalProperties": {
+							"type": "string"
+						},
+						"type": "object"
 					}
 				},
 				"type": "object",
@@ -819,6 +870,30 @@
 					"name": "Permission"
 				}
 			},
+			"PostObjectEntryTranslationRequestBody": {
+				"properties": {
+					"file": {
+						"description": "File",
+						"format": "binary",
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": {
+				}
+			},
+			"PostScopeScopeKeyByExternalReferenceCodeTranslationRequestBody": {
+				"properties": {
+					"file": {
+						"description": "File",
+						"format": "binary",
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": {
+				}
+			},
 			"Scope": {
 				"properties": {
 					"externalReferenceCode": {
@@ -935,6 +1010,35 @@
 				},
 				"xml": {
 					"name": "TaxonomyCategoryBrief"
+				}
+			},
+			"TranslationResponse": {
+				"properties": {
+					"failureMessagesJSON": {
+						"items": {
+							"type": "string"
+						},
+						"readOnly": true,
+						"type": "array"
+					},
+					"successMessages": {
+						"items": {
+							"type": "string"
+						},
+						"readOnly": true,
+						"type": "array"
+					},
+					"x-class-name": {
+						"default": "com.liferay.object.rest.dto.v1_0.TranslationResponse",
+						"readOnly": true,
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"x-filterable": {
+				},
+				"xml": {
+					"name": "TranslationResponse"
 				}
 			},
 			"UserGroupBrief": {
@@ -1992,6 +2096,187 @@
 				]
 			}
 		},
+		"/scopes/{scopeKey}/by-external-reference-code/{externalReferenceCode}/collaborators/by-email-address/{emailAddress}": {
+			"delete": {
+				"description": "Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.",
+				"operationId": "deleteScopeScopeKeyByExternalReferenceCodeCollaboratorByEmailAddress",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "externalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "emailAddress",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+							},
+							"application/xml": {
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"get": {
+				"description": "Retrieves the collaborator for an object entry.",
+				"operationId": "getScopeScopeKeyByExternalReferenceCodeCollaboratorByEmailAddress",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "externalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "emailAddress",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "fields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "nestedFields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "restrictFields",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"put": {
+				"description": "Add or update a collaborator received in the request.",
+				"operationId": "putScopeScopeKeyByExternalReferenceCodeCollaboratorByEmailAddress",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "externalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "emailAddress",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						}
+					}
+				},
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			}
+		},
 		"/scopes/{scopeKey}/by-external-reference-code/{externalReferenceCode}/collaborators/by-type/{type}/{collaboratorId}": {
 			"delete": {
 				"description": "Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.",
@@ -2855,6 +3140,56 @@
 				"tags": [
 					"Object8"
 				]
+			},
+			"post": {
+				"operationId": "postScopeScopeKeyByExternalReferenceCodeTranslation",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "scopeKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "externalReferenceCode",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"multipart/form-data": {
+							"schema": {
+								"$ref": "#/components/schemas/PostScopeScopeKeyByExternalReferenceCodeTranslationRequestBody"
+							}
+						}
+					}
+				},
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/TranslationResponse"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/TranslationResponse"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Object8"
+				]
 			}
 		},
 		"/scopes/{scopeKey}/by-external-reference-code/{externalReferenceCode}/translations/{languageId}": {
@@ -3540,6 +3875,163 @@
 				]
 			}
 		},
+		"/{object8Id}/collaborators/by-email-address/{emailAddress}": {
+			"delete": {
+				"description": "Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.",
+				"operationId": "deleteObject8CollaboratorByEmailAddress",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object8Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "emailAddress",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+							},
+							"application/xml": {
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"get": {
+				"description": "Retrieves the collaborator for an object entry.",
+				"operationId": "getObject8CollaboratorByEmailAddress",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object8Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "emailAddress",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "fields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "nestedFields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "restrictFields",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			},
+			"put": {
+				"description": "Add or update a collaborator received in the request.",
+				"operationId": "putObject8CollaboratorByEmailAddress",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object8Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "path",
+						"name": "emailAddress",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/Collaborator"
+							}
+						}
+					}
+				},
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Collaborator"
+								}
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Collaborator"
+				]
+			}
+		},
 		"/{object8Id}/collaborators/by-type/{type}/{collaboratorId}": {
 			"delete": {
 				"description": "Deletes the collaborator for an object entry and returns a 204 if the operation succeeds.",
@@ -3923,6 +4415,48 @@
 					"default": {
 						"content": {
 							"application/zip": {
+							}
+						},
+						"description": "default response"
+					}
+				},
+				"tags": [
+					"Object8"
+				]
+			},
+			"post": {
+				"operationId": "postObject8Translation",
+				"parameters": [
+					{
+						"in": "path",
+						"name": "object8Id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"multipart/form-data": {
+							"schema": {
+								"$ref": "#/components/schemas/PostObjectEntryTranslationRequestBody"
+							}
+						}
+					}
+				},
+				"responses": {
+					"default": {
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/TranslationResponse"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/TranslationResponse"
+								}
 							}
 						},
 						"description": "default response"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89873

## Failing Test

`com.liferay.object.rest.internal.resource.v1_0.test.OpenAPIResourceTest`

`modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/OpenAPIResourceTest.java`

```
2 Failed tests     testGetOpenAPIWithActions      testGetOpenAPI

java.lang.AssertionError: components.schemas.Collaborator.properties
Unexpected: emailAddress
 ; components.schemas.FileEntry.properties
Unexpected: extension
 ; components.schemas.FileEntry.properties
Unexpected: size
 ; components.schemas
Unexpected: CollaboratorBrief
 ; components.schemas
Unexpected: MultipartBody
 ; components.schemas
Unexpected: PostObjectEntryTranslationRequestBody
 ; components.schemas
Unexpected: PostScopeScopeKeyByExternalReferenceCodeTranslationRequestBody
 ; components.schemas
Unexpected: TranslationResponse
 ; paths./{object1Id}/translations
Unexpected: post
 ; paths
Unexpected: /{object1Id}/collaborators/by-email-address/{emailAddress}
```

## Root Cause

The test compares the live OpenAPI JSON for an `ObjectDefinition` against a checked-in fixture using `JSONCompareMode.STRICT`. Several intentional API additions landed in `modules/apps/object/object-rest-impl/rest-openapi.yaml` over time without updating these fixtures:

- `LPD-66045` added the `CollaboratorBrief` schema.
- `LPD-78457` added the `/{objectId}/collaborators/by-email-address/{emailAddress}` endpoint and `emailAddress` on `Collaborator`.
- `LPD-83178` added `extension` and `size` to `FileEntry`.
- `LPD-72778` and related work added translation endpoints (`PostObjectEntryTranslationRequestBody`, `PostScopeScopeKeyByExternalReferenceCodeTranslationRequestBody`, `TranslationResponse`, `/translations` POST).
- `MultipartBody` followed from common file-upload scaffolding.

Each addition is legitimate; the fixture simply lagged behind, so `testGetOpenAPI` and `testGetOpenAPIWithActions` have been failing continuously in the master routine since at least 2026-03-17.

## Fix

Regenerate the expected OpenAPI JSON fixtures from the current live OpenAPI output. The diff is purely additive — no previously expected schema or path is missing from the regenerated fixtures. After the update, all four `OpenAPIResourceTest` methods pass locally.

- `modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi.json`
- `modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions.json`
- `modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions_object_action.json`
- `modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_categorization_disabled.json`
- `modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_related.json`
- `modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_site.json`