### PR TITLE
LPD-89909 Seed MCP server profile object definition in test setUp

### DIFF
--- a/modules/apps/mcp/mcp-server-test/build.gradle
+++ b/modules/apps/mcp/mcp-server-test/build.gradle
@@ -4,6 +4,7 @@ dependencies {
 	testIntegrationImplementation group: "io.modelcontextprotocol.sdk", name: "mcp-json-jackson2", version: "1.0.1"
 	testIntegrationImplementation group: "org.json", name: "json", version: "20231013"
 	testIntegrationImplementation group: "org.skyscreamer", name: "jsonassert", version: "1.5.0"
+	testIntegrationImplementation project(":apps:batch-engine:batch-engine-test-util")
 	testIntegrationImplementation project(":apps:object:object-api")
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationImplementation project(":apps:portal-vulcan:portal-vulcan-api")

--- a/modules/apps/mcp/mcp-server-test/src/testIntegration/java/com/liferay/mcp/server/test/MCPServerServletTest.java
+++ b/modules/apps/mcp/mcp-server-test/src/testIntegration/java/com/liferay/mcp/server/test/MCPServerServletTest.java
@@ -8,6 +8,7 @@ package com.liferay.mcp.server.test;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.batch.engine.test.util.BatchEngineTestUtil;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
@@ -79,6 +80,13 @@ public class MCPServerServletTest {
 	@Before
 	public void setUp() throws Exception {
 		_updateMCPServerConfiguration(true);
+
+		BatchEngineTestUtil.processBatchEngineUnits(
+			"com.liferay.mcp.server", MCPServerServletTest.class,
+			new String[] {
+				".com.liferay.mcp.server.internal.batch.01.object.definition",
+				".com.liferay.mcp.server.internal.batch.02.object.definition"
+			});
 	}
 
 	@After


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89909

## Failing Test

`com.liferay.mcp.server.test.MCPServerServletTest`

`modules/apps/mcp/mcp-server-test/src/testIntegration/java/com/liferay/mcp/server/test/MCPServerServletTest.java`

```
2 Failed tests
    testServiceWithProfile
    testServiceWithModifiedProfile

java.lang.NullPointerException: Cannot invoke "com.liferay.object.model.ObjectDefinition.getObjectDefinitionId()" because "objectDefinition" is null
	at com.liferay.mcp.server.test.MCPServerServletTest._addObjectEntry(MCPServerServletTest.java:387)
	at com.liferay.mcp.server.test.MCPServerServletTest.testServiceWithProfile(MCPServerServletTest.java:302)
```

## Root Cause

Commit `d09ca4d14b4d8` ("LPD-86164 Add MCP server profiles and OpenAPI-driven tool generation") introduced `02-object-definition.batch-engine-data.json` with `"featureFlag": "LPD-86164"` in its `parameters`. The batch engine processes the bundle's batches when the MCP server module deploys; because LPD-86164 is off at that point, the `L_MCP_SERVER_PROFILE` object definition is never created. The test enables LPD-86164 at runtime through `@FeatureFlag`, but by then the batch is already marked processed, so `fetchObjectDefinitionByExternalReferenceCode("L_MCP_SERVER_PROFILE", ...)` returns `null` and `_addObjectEntry` throws an NPE.

## Fix

Reprocess the 01 and 02 batches in `setUp` after `@FeatureFlag` has enabled LPD-86164 for the test, mirroring the seeding pattern in `FrontendDataSetTestUtil.initialize`. `BatchEngineTestUtil.processBatchEngineUnits` deletes the bundle's `.processed` markers and re-runs the batch units, so the `L_MCP_SERVER_PROFILE` and `L_MCP_SERVER_PROMPT` object definitions are created with the flag now on.

- `modules/apps/mcp/mcp-server-test/build.gradle`
- `modules/apps/mcp/mcp-server-test/src/testIntegration/java/com/liferay/mcp/server/test/MCPServerServletTest.java`