### PR TITLE
LPD-83781 show completed with errors status when import items fail

### DIFF
--- a/modules/apps/asset/asset-tags-test/src/testIntegration/java/com/liferay/asset/tags/exportimport/data/handler/test/AssetTagsPortletDataHandlerTest.java
+++ b/modules/apps/asset/asset-tags-test/src/testIntegration/java/com/liferay/asset/tags/exportimport/data/handler/test/AssetTagsPortletDataHandlerTest.java
@@ -27,10 +27,16 @@ import com.liferay.exportimport.kernel.staging.constants.StagingConstants;
 import com.liferay.exportimport.report.constants.ExportImportReportEntryConstants;
 import com.liferay.exportimport.report.model.ExportImportReportEntry;
 import com.liferay.exportimport.report.service.ExportImportReportEntryLocalService;
+import com.liferay.exportimport.test.util.ExportImportTestUtil;
 import com.liferay.exportimport.test.util.lar.BasePortletDataHandlerTestCase;
+import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.backgroundtask.BackgroundTask;
+import com.liferay.portal.kernel.backgroundtask.BackgroundTaskManagerUtil;
+import com.liferay.portal.kernel.backgroundtask.constants.BackgroundTaskConstants;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.service.GroupServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -50,7 +56,9 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import java.io.File;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -115,6 +123,71 @@ public class AssetTagsPortletDataHandlerTest
 							" already exists") &&
 					(exportImportReportEntry.getType() ==
 						ExportImportReportEntryConstants.TYPE_ERROR)));
+	}
+
+	@FeatureFlag("LPD-17564")
+	@Test
+	public void testAssetTagImportCompletedWithErrors() throws Exception {
+		AssetTag assetTag = _addTag();
+
+		Layout layout = LayoutTestUtil.addTypePortletLayout(stagingGroup);
+
+		Map<String, String[]> parameterMap = HashMapBuilder.put(
+			PortletDataHandlerKeys.PORTLET_DATA,
+			new String[] {Boolean.TRUE.toString()}
+		).put(
+			PortletDataHandlerKeys.PORTLET_DATA + "_" +
+				AssetTagsAdminPortletKeys.ASSET_TAGS_ADMIN,
+			new String[] {Boolean.TRUE.toString()}
+		).build();
+
+		ExportImportConfiguration exportImportConfiguration =
+			_exportImportConfigurationLocalService.
+				addDraftExportImportConfiguration(
+					TestPropsValues.getUserId(),
+					ExportImportConfigurationConstants.TYPE_EXPORT_PORTLET,
+					ExportImportConfigurationSettingsMapFactoryUtil.
+						buildExportPortletSettingsMap(
+							TestPropsValues.getUser(), layout.getPlid(),
+							stagingGroup.getGroupId(),
+							AssetTagsAdminPortletKeys.ASSET_TAGS_ADMIN,
+							parameterMap, StringPool.BLANK));
+
+		File larFile = _exportImportLocalService.exportPortletInfoAsFile(
+			exportImportConfiguration);
+
+		assetTag.setExternalReferenceCode(RandomTestUtil.randomString());
+
+		_assetTagLocalService.updateAssetTag(assetTag);
+
+		exportImportConfiguration =
+			_exportImportConfigurationLocalService.
+				addDraftExportImportConfiguration(
+					TestPropsValues.getUserId(),
+					ExportImportConfigurationConstants.TYPE_IMPORT_PORTLET,
+					ExportImportConfigurationSettingsMapFactoryUtil.
+						buildImportPortletSettingsMap(
+							TestPropsValues.getUser(), layout.getPlid(),
+							stagingGroup.getGroupId(),
+							AssetTagsAdminPortletKeys.ASSET_TAGS_ADMIN,
+							parameterMap));
+
+		long backgroundTaskId =
+			_exportImportLocalService.importPortletInfoInBackground(
+				TestPropsValues.getUserId(), exportImportConfiguration,
+				larFile);
+
+		ExportImportTestUtil.retryAssert(
+			1, TimeUnit.SECONDS, 5, TimeUnit.SECONDS,
+			() -> {
+				BackgroundTask backgroundTask =
+					BackgroundTaskManagerUtil.getBackgroundTask(
+						backgroundTaskId);
+
+				Assert.assertEquals(
+					BackgroundTaskConstants.STATUS_COMPLETED_WITH_ERRORS,
+					backgroundTask.getStatus());
+			});
 	}
 
 	@FeatureFlag("LPD-17564")

--- a/modules/apps/export-import/export-import-report-api/bnd.bnd
+++ b/modules/apps/export-import/export-import-report-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Export Import Report API
 Bundle-SymbolicName: com.liferay.exportimport.report.api
-Bundle-Version: 8.0.0
+Bundle-Version: 8.1.0
 Export-Package:\
 	com.liferay.exportimport.report.constants,\
 	com.liferay.exportimport.report.exception,\

--- a/modules/apps/export-import/export-import-report-api/src/main/java/com/liferay/exportimport/report/service/ExportImportReportEntryLocalService.java
+++ b/modules/apps/export-import/export-import-report-api/src/main/java/com/liferay/exportimport/report/service/ExportImportReportEntryLocalService.java
@@ -239,6 +239,10 @@ public interface ExportImportReportEntryLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getExportImportReportEntriesCount();
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int getExportImportReportEntriesCount(
+		long companyId, long exportImportConfigurationId);
+
 	/**
 	 * Returns the export import report entry with the primary key.
 	 *
@@ -302,4 +306,4 @@ public interface ExportImportReportEntryLocalService
 		ExportImportReportEntry exportImportReportEntry);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1609212277
+// LIFERAY-SERVICE-BUILDER-HASH:-1818811699

--- a/modules/apps/export-import/export-import-report-api/src/main/java/com/liferay/exportimport/report/service/ExportImportReportEntryLocalServiceUtil.java
+++ b/modules/apps/export-import/export-import-report-api/src/main/java/com/liferay/exportimport/report/service/ExportImportReportEntryLocalServiceUtil.java
@@ -274,6 +274,13 @@ public class ExportImportReportEntryLocalServiceUtil {
 		return getService().getExportImportReportEntriesCount();
 	}
 
+	public static int getExportImportReportEntriesCount(
+		long companyId, long exportImportConfigurationId) {
+
+		return getService().getExportImportReportEntriesCount(
+			companyId, exportImportConfigurationId);
+	}
+
 	/**
 	 * Returns the export import report entry with the primary key.
 	 *
@@ -372,4 +379,4 @@ public class ExportImportReportEntryLocalServiceUtil {
 			ExportImportReportEntryLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1145355427
+// LIFERAY-SERVICE-BUILDER-HASH:-1063489840

--- a/modules/apps/export-import/export-import-report-api/src/main/java/com/liferay/exportimport/report/service/ExportImportReportEntryLocalServiceWrapper.java
+++ b/modules/apps/export-import/export-import-report-api/src/main/java/com/liferay/exportimport/report/service/ExportImportReportEntryLocalServiceWrapper.java
@@ -318,6 +318,15 @@ public class ExportImportReportEntryLocalServiceWrapper
 			getExportImportReportEntriesCount();
 	}
 
+	@Override
+	public int getExportImportReportEntriesCount(
+		long companyId, long exportImportConfigurationId) {
+
+		return _exportImportReportEntryLocalService.
+			getExportImportReportEntriesCount(
+				companyId, exportImportConfigurationId);
+	}
+
 	/**
 	 * Returns the export import report entry with the primary key.
 	 *
@@ -446,4 +455,4 @@ public class ExportImportReportEntryLocalServiceWrapper
 		_exportImportReportEntryLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:233950841
+// LIFERAY-SERVICE-BUILDER-HASH:601233165

--- a/modules/apps/export-import/export-import-report-api/src/main/resources/com/liferay/exportimport/report/service/packageinfo
+++ b/modules/apps/export-import/export-import-report-api/src/main/resources/com/liferay/exportimport/report/service/packageinfo
@@ -1,1 +1,1 @@
-version 4.1.0
+version 4.2.0

--- a/modules/apps/export-import/export-import-report-service/src/main/java/com/liferay/exportimport/report/service/impl/ExportImportReportEntryLocalServiceImpl.java
+++ b/modules/apps/export-import/export-import-report-service/src/main/java/com/liferay/exportimport/report/service/impl/ExportImportReportEntryLocalServiceImpl.java
@@ -122,6 +122,14 @@ public class ExportImportReportEntryLocalServiceImpl
 	}
 
 	@Override
+	public int getExportImportReportEntriesCount(
+		long companyId, long exportImportConfigurationId) {
+
+		return exportImportReportEntryPersistence.countByC_E(
+			companyId, exportImportConfigurationId);
+	}
+
+	@Override
 	public ExportImportReportEntry getOrAddEmptyExportImportReportEntry(
 		long groupId, long companyId, String classExternalReferenceCode,
 		long classNameId, long exportImportConfigurationId,

--- a/modules/apps/export-import/export-import-report-test/src/testIntegration/java/com/liferay/exportimport/report/service/test/ExportImportReportEntryLocalServiceTest.java
+++ b/modules/apps/export-import/export-import-report-test/src/testIntegration/java/com/liferay/exportimport/report/service/test/ExportImportReportEntryLocalServiceTest.java
@@ -206,6 +206,7 @@ public class ExportImportReportEntryLocalServiceTest {
 			RandomTestUtil.randomLong(), TestPropsValues.getCompanyId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
 			exportImportConfigurationId, RandomTestUtil.randomString());
+
 		_exportImportReportEntryLocalService.addEmptyExportImportReportEntry(
 			RandomTestUtil.randomLong(), TestPropsValues.getCompanyId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
@@ -217,6 +218,7 @@ public class ExportImportReportEntryLocalServiceTest {
 			RandomTestUtil.randomLong(), company.getCompanyId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
 			exportImportConfigurationId, RandomTestUtil.randomString());
+
 		_exportImportReportEntryLocalService.addEmptyExportImportReportEntry(
 			RandomTestUtil.randomLong(), company.getCompanyId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomLong(),

--- a/modules/apps/export-import/export-import-report-test/src/testIntegration/java/com/liferay/exportimport/report/service/test/ExportImportReportEntryLocalServiceTest.java
+++ b/modules/apps/export-import/export-import-report-test/src/testIntegration/java/com/liferay/exportimport/report/service/test/ExportImportReportEntryLocalServiceTest.java
@@ -192,6 +192,47 @@ public class ExportImportReportEntryLocalServiceTest {
 	}
 
 	@Test
+	public void testGetExportImportReportEntriesCount() throws Exception {
+		long exportImportConfigurationId = RandomTestUtil.randomLong();
+
+		Assert.assertEquals(
+			0,
+			_exportImportReportEntryLocalService.
+				getExportImportReportEntriesCount(
+					TestPropsValues.getCompanyId(),
+					exportImportConfigurationId));
+
+		_exportImportReportEntryLocalService.addEmptyExportImportReportEntry(
+			RandomTestUtil.randomLong(), TestPropsValues.getCompanyId(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
+			exportImportConfigurationId, RandomTestUtil.randomString());
+		_exportImportReportEntryLocalService.addEmptyExportImportReportEntry(
+			RandomTestUtil.randomLong(), TestPropsValues.getCompanyId(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
+			RandomTestUtil.randomLong(), RandomTestUtil.randomString());
+
+		Company company = CompanyTestUtil.addCompany();
+
+		_exportImportReportEntryLocalService.addEmptyExportImportReportEntry(
+			RandomTestUtil.randomLong(), company.getCompanyId(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
+			exportImportConfigurationId, RandomTestUtil.randomString());
+		_exportImportReportEntryLocalService.addEmptyExportImportReportEntry(
+			RandomTestUtil.randomLong(), company.getCompanyId(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
+			RandomTestUtil.randomLong(), RandomTestUtil.randomString());
+
+		Assert.assertEquals(
+			1,
+			_exportImportReportEntryLocalService.
+				getExportImportReportEntriesCount(
+					TestPropsValues.getCompanyId(),
+					exportImportConfigurationId));
+
+		_companyLocalService.deleteCompany(company);
+	}
+
+	@Test
 	public void testGetOrAddEmptyExportImportReportEntry() throws Exception {
 		int count =
 			_exportImportReportEntryLocalService.

--- a/modules/apps/export-import/export-import-report-test/src/testIntegration/java/com/liferay/exportimport/report/service/test/ExportImportReportEntryLocalServiceTest.java
+++ b/modules/apps/export-import/export-import-report-test/src/testIntegration/java/com/liferay/exportimport/report/service/test/ExportImportReportEntryLocalServiceTest.java
@@ -12,7 +12,6 @@ import com.liferay.exportimport.report.model.ExportImportReportEntry;
 import com.liferay.exportimport.report.service.ExportImportReportEntryLocalService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Company;
-import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -23,6 +22,7 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import java.util.List;
 
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -38,6 +38,11 @@ public class ExportImportReportEntryLocalServiceTest {
 	@Rule
 	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
 		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_company = CompanyTestUtil.addCompany();
+	}
 
 	@Test
 	@TestInfo("LPD-77587")
@@ -169,14 +174,12 @@ public class ExportImportReportEntryLocalServiceTest {
 			RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
 			RandomTestUtil.randomLong(), RandomTestUtil.randomString());
 
-		Company company = CompanyTestUtil.addCompany();
-
 		_exportImportReportEntryLocalService.addEmptyExportImportReportEntry(
-			RandomTestUtil.randomLong(), company.getCompanyId(),
+			RandomTestUtil.randomLong(), _company.getCompanyId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
 			exportImportConfigurationId, RandomTestUtil.randomString());
 		_exportImportReportEntryLocalService.addEmptyExportImportReportEntry(
-			RandomTestUtil.randomLong(), company.getCompanyId(),
+			RandomTestUtil.randomLong(), _company.getCompanyId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
 			RandomTestUtil.randomLong(), RandomTestUtil.randomString());
 
@@ -187,8 +190,6 @@ public class ExportImportReportEntryLocalServiceTest {
 		Assert.assertEquals(
 			exportImportReportEntries.toString(), 1,
 			exportImportReportEntries.size());
-
-		_companyLocalService.deleteCompany(company);
 	}
 
 	@Test
@@ -212,15 +213,13 @@ public class ExportImportReportEntryLocalServiceTest {
 			RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
 			RandomTestUtil.randomLong(), RandomTestUtil.randomString());
 
-		Company company = CompanyTestUtil.addCompany();
-
 		_exportImportReportEntryLocalService.addEmptyExportImportReportEntry(
-			RandomTestUtil.randomLong(), company.getCompanyId(),
+			RandomTestUtil.randomLong(), _company.getCompanyId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
 			exportImportConfigurationId, RandomTestUtil.randomString());
 
 		_exportImportReportEntryLocalService.addEmptyExportImportReportEntry(
-			RandomTestUtil.randomLong(), company.getCompanyId(),
+			RandomTestUtil.randomLong(), _company.getCompanyId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
 			RandomTestUtil.randomLong(), RandomTestUtil.randomString());
 
@@ -230,8 +229,6 @@ public class ExportImportReportEntryLocalServiceTest {
 				getExportImportReportEntriesCount(
 					TestPropsValues.getCompanyId(),
 					exportImportConfigurationId));
-
-		_companyLocalService.deleteCompany(company);
 	}
 
 	@Test
@@ -507,8 +504,7 @@ public class ExportImportReportEntryLocalServiceTest {
 			updateExportImportReportEntry(exportImportReportEntry);
 	}
 
-	@Inject
-	private CompanyLocalService _companyLocalService;
+	private static Company _company;
 
 	@Inject
 	private ExportImportReportEntryLocalService

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/background/task/LayoutImportBackgroundTaskExecutor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/background/task/LayoutImportBackgroundTaskExecutor.java
@@ -111,8 +111,7 @@ public class LayoutImportBackgroundTaskExecutor
 			_exportImportReportEntryLocalService.
 				getExportImportReportEntriesCount(
 					exportImportConfiguration.getCompanyId(),
-					exportImportConfiguration.
-						getExportImportConfigurationId());
+					exportImportConfiguration.getExportImportConfigurationId());
 
 		if (count > 0) {
 			return BackgroundTaskResult.COMPLETED_WITH_ERRORS;

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/background/task/LayoutImportBackgroundTaskExecutor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/background/task/LayoutImportBackgroundTaskExecutor.java
@@ -8,9 +8,7 @@ package com.liferay.exportimport.internal.background.task;
 import com.liferay.exportimport.kernel.exception.ExportImportIOException;
 import com.liferay.exportimport.kernel.model.ExportImportConfiguration;
 import com.liferay.exportimport.kernel.service.ExportImportLocalService;
-import com.liferay.exportimport.report.model.ExportImportReportEntryTable;
 import com.liferay.exportimport.report.service.ExportImportReportEntryLocalService;
-import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTask;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskExecutor;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskResult;
@@ -109,20 +107,12 @@ public class LayoutImportBackgroundTaskExecutor
 			}
 		}
 
-		int count = _exportImportReportEntryLocalService.dslQueryCount(
-			DSLQueryFactoryUtil.count(
-			).from(
-				ExportImportReportEntryTable.INSTANCE
-			).where(
-				ExportImportReportEntryTable.INSTANCE.companyId.eq(
-					exportImportConfiguration.getCompanyId()
-				).and(
-					ExportImportReportEntryTable.INSTANCE.
-						exportImportConfigurationId.eq(
-							exportImportConfiguration.
-								getExportImportConfigurationId())
-				)
-			));
+		int count =
+			_exportImportReportEntryLocalService.
+				getExportImportReportEntriesCount(
+					exportImportConfiguration.getCompanyId(),
+					exportImportConfiguration.
+						getExportImportConfigurationId());
 
 		if (count > 0) {
 			return BackgroundTaskResult.COMPLETED_WITH_ERRORS;

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/background/task/PortletImportBackgroundTaskExecutor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/background/task/PortletImportBackgroundTaskExecutor.java
@@ -113,8 +113,7 @@ public class PortletImportBackgroundTaskExecutor
 			_exportImportReportEntryLocalService.
 				getExportImportReportEntriesCount(
 					exportImportConfiguration.getCompanyId(),
-					exportImportConfiguration.
-						getExportImportConfigurationId());
+					exportImportConfiguration.getExportImportConfigurationId());
 
 		if (count > 0) {
 			return BackgroundTaskResult.COMPLETED_WITH_ERRORS;

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/background/task/PortletImportBackgroundTaskExecutor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/background/task/PortletImportBackgroundTaskExecutor.java
@@ -9,6 +9,9 @@ import com.liferay.exportimport.internal.background.task.display.PortletExportIm
 import com.liferay.exportimport.kernel.exception.ExportImportIOException;
 import com.liferay.exportimport.kernel.model.ExportImportConfiguration;
 import com.liferay.exportimport.kernel.service.ExportImportLocalService;
+import com.liferay.exportimport.report.model.ExportImportReportEntryTable;
+import com.liferay.exportimport.report.service.ExportImportReportEntryLocalService;
+import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTask;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskExecutor;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskResult;
@@ -108,6 +111,25 @@ public class PortletImportBackgroundTaskExecutor
 			}
 		}
 
+		int count = _exportImportReportEntryLocalService.dslQueryCount(
+			DSLQueryFactoryUtil.count(
+			).from(
+				ExportImportReportEntryTable.INSTANCE
+			).where(
+				ExportImportReportEntryTable.INSTANCE.companyId.eq(
+					exportImportConfiguration.getCompanyId()
+				).and(
+					ExportImportReportEntryTable.INSTANCE.
+						exportImportConfigurationId.eq(
+							exportImportConfiguration.
+								getExportImportConfigurationId())
+				)
+			));
+
+		if (count > 0) {
+			return BackgroundTaskResult.COMPLETED_WITH_ERRORS;
+		}
+
 		return BackgroundTaskResult.SUCCESS;
 	}
 
@@ -120,6 +142,10 @@ public class PortletImportBackgroundTaskExecutor
 
 	@Reference
 	private ExportImportLocalService _exportImportLocalService;
+
+	@Reference
+	private ExportImportReportEntryLocalService
+		_exportImportReportEntryLocalService;
 
 	private class PortletImportCallable implements Callable<Void> {
 

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/background/task/PortletImportBackgroundTaskExecutor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/background/task/PortletImportBackgroundTaskExecutor.java
@@ -9,9 +9,7 @@ import com.liferay.exportimport.internal.background.task.display.PortletExportIm
 import com.liferay.exportimport.kernel.exception.ExportImportIOException;
 import com.liferay.exportimport.kernel.model.ExportImportConfiguration;
 import com.liferay.exportimport.kernel.service.ExportImportLocalService;
-import com.liferay.exportimport.report.model.ExportImportReportEntryTable;
 import com.liferay.exportimport.report.service.ExportImportReportEntryLocalService;
-import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTask;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskExecutor;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskResult;
@@ -111,20 +109,12 @@ public class PortletImportBackgroundTaskExecutor
 			}
 		}
 
-		int count = _exportImportReportEntryLocalService.dslQueryCount(
-			DSLQueryFactoryUtil.count(
-			).from(
-				ExportImportReportEntryTable.INSTANCE
-			).where(
-				ExportImportReportEntryTable.INSTANCE.companyId.eq(
-					exportImportConfiguration.getCompanyId()
-				).and(
-					ExportImportReportEntryTable.INSTANCE.
-						exportImportConfigurationId.eq(
-							exportImportConfiguration.
-								getExportImportConfigurationId())
-				)
-			));
+		int count =
+			_exportImportReportEntryLocalService.
+				getExportImportReportEntriesCount(
+					exportImportConfiguration.getCompanyId(),
+					exportImportConfiguration.
+						getExportImportConfigurationId());
 
 		if (count > 0) {
 			return BackgroundTaskResult.COMPLETED_WITH_ERRORS;

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/controller/PortletImportControllerImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/controller/PortletImportControllerImpl.java
@@ -279,6 +279,8 @@ public class PortletImportControllerImpl implements PortletImportController {
 			ExportImportConfiguration exportImportConfiguration, File file)
 		throws Exception {
 
+		ExportImportThreadLocal.setExportImportConfigurationId(
+			exportImportConfiguration.getExportImportConfigurationId());
 		ExportImportThreadLocal.setPortletImportInProcess(true);
 
 		PortletDataContext portletDataContext = null;

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/controller/PortletImportControllerImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/controller/PortletImportControllerImpl.java
@@ -327,6 +327,9 @@ public class PortletImportControllerImpl implements PortletImportController {
 
 			throw throwable;
 		}
+		finally {
+			ExportImportThreadLocal.setExportImportConfigurationId(0);
+		}
 	}
 
 	@Override

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/ViewImportReportEntriesMVCRenderCommand.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/ViewImportReportEntriesMVCRenderCommand.java
@@ -16,6 +16,7 @@ import org.osgi.service.component.annotations.Component;
 @Component(
 	property = {
 		"jakarta.portlet.name=" + ExportImportPortletKeys.COMPANY_IMPORT,
+		"jakarta.portlet.name=" + ExportImportPortletKeys.EXPORT_IMPORT,
 		"jakarta.portlet.name=" + ExportImportPortletKeys.IMPORT,
 		"mvc.command.name=/export_import/view_import_report_entries"
 	},

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/ViewImportReportEntryDetailMVCRenderCommand.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/ViewImportReportEntryDetailMVCRenderCommand.java
@@ -16,6 +16,7 @@ import org.osgi.service.component.annotations.Component;
 @Component(
 	property = {
 		"jakarta.portlet.name=" + ExportImportPortletKeys.COMPANY_IMPORT,
+		"jakarta.portlet.name=" + ExportImportPortletKeys.EXPORT_IMPORT,
 		"jakarta.portlet.name=" + ExportImportPortletKeys.IMPORT,
 		"mvc.command.name=/export_import/view_import_report_entry_detail"
 	},

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/import_portlet_processes.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/import_portlet_processes.jsp
@@ -107,12 +107,12 @@ else {
 						markupView="lexicon"
 						showWhenSingleIcon="<%= true %>"
 					>
-						<c:if test="<%= backgroundTask.getStatus() != BackgroundTaskConstants.STATUS_SUCCESSFUL %>">
-							<liferay-ui:icon
-								label="<%= true %>"
-								message="view-report-entries"
-								url="<%= viewReportEntriesURL %>"
-							/>
+						<c:if test="<%= (backgroundTask.getStatus() == BackgroundTaskConstants.STATUS_COMPLETED_WITH_ERRORS) || (backgroundTask.getStatus() == BackgroundTaskConstants.STATUS_FAILED) %>">
+							<li>
+								<a class="dropdown-item" href="<%= viewReportEntriesURL %>">
+									<liferay-ui:message key="view-report-entries" />
+								</a>
+							</li>
 						</c:if>
 
 						<liferay-ui:icon-delete

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/import_portlet_processes.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/import_portlet_processes.jsp
@@ -96,12 +96,25 @@ else {
 						<portlet:param name="backgroundTaskId" value="<%= String.valueOf(backgroundTask.getBackgroundTaskId()) %>" />
 					</liferay-portlet:actionURL>
 
+					<liferay-portlet:renderURL portletName="<%= PortletKeys.EXPORT_IMPORT %>" var="viewReportEntriesURL">
+						<portlet:param name="mvcRenderCommandName" value="/export_import/view_import_report_entries" />
+						<portlet:param name="backgroundTaskId" value="<%= String.valueOf(backgroundTask.getBackgroundTaskId()) %>" />
+					</liferay-portlet:renderURL>
+
 					<liferay-ui:icon-menu
 						direction="left-side"
 						icon="<%= StringPool.BLANK %>"
 						markupView="lexicon"
 						showWhenSingleIcon="<%= true %>"
 					>
+						<c:if test="<%= backgroundTask.getStatus() != BackgroundTaskConstants.STATUS_SUCCESSFUL %>">
+							<liferay-ui:icon
+								label="<%= true %>"
+								message="view-report-entries"
+								url="<%= viewReportEntriesURL %>"
+							/>
+						</c:if>
+
 						<liferay-ui:icon-delete
 							label="<%= true %>"
 							message='<%= ((completionDate != null) && completionDate.before(new Date())) ? "clear" : "cancel" %>'

--- a/modules/test/playwright/tests/export-import-web/main/cms.tagsImportReport.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/cms.tagsImportReport.spec.ts
@@ -1,0 +1,87 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
+import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
+import {tagsPagesTest} from '../../asset-tags-admin-web/main/fixtures/tagsAdminPagesTest';
+import {portletExportImportPageTest} from './fixtures/portletExportImportPageTest';
+
+const test = mergeTests(
+	apiHelpersTest,
+	featureFlagsTest({'LPD-17564': {enabled: true}}),
+	isolatedSiteTest,
+	loginTest(),
+	portletExportImportPageTest,
+	tagsPagesTest
+);
+
+test('Can view report entries from Tags Export/Import after import with errors', async ({
+	apiHelpers,
+	page,
+	portletExportImportPage,
+	site,
+	tagsAdminPage,
+}) => {
+	const tagName = 'tag1';
+
+	const tag = await apiHelpers.headlessAdminTaxonomy.postSiteKeyword({
+		name: tagName,
+		siteId: site.id,
+	});
+
+	await tagsAdminPage.goto(site.friendlyUrlPath);
+
+	await clickAndExpectToBeVisible({
+		autoClick: true,
+		target: page
+			.locator('.dropdown-menu')
+			.getByRole('menuitem', {name: 'Export / Import'}),
+		trigger: page.getByLabel('Options'),
+	});
+
+	const {filePath} = await portletExportImportPage.exportLARFile({
+		fileNamePattern: /.*\.portlet\.lar/,
+	});
+
+	await apiHelpers.headlessAdminTaxonomy.deleteKeyword({id: tag.id});
+
+	await apiHelpers.headlessAdminTaxonomy.postSiteKeyword({
+		name: tagName,
+		siteId: site.id,
+	});
+
+	await tagsAdminPage.goto(site.friendlyUrlPath);
+
+	await clickAndExpectToBeVisible({
+		autoClick: true,
+		target: page
+			.locator('.dropdown-menu')
+			.getByRole('menuitem', {name: 'Export / Import'}),
+		trigger: page.getByLabel('Options'),
+	});
+
+	await portletExportImportPage.importLARFile({
+		filePath,
+		taskStatus: 'completedWithErrors',
+	});
+
+	await clickAndExpectToBeVisible({
+		target: portletExportImportPage.viewReportEntriesMenuItem,
+		trigger: portletExportImportPage.taskActionsMenu,
+	});
+
+	await portletExportImportPage.viewReportEntriesMenuItem.click();
+
+	await expect(
+		portletExportImportPage.frame.getByRole('link', {
+			name: 'Report Entries',
+		})
+	).toBeVisible();
+});

--- a/modules/test/playwright/tests/export-import-web/main/pages/PortletExportImportPage.ts
+++ b/modules/test/playwright/tests/export-import-web/main/pages/PortletExportImportPage.ts
@@ -7,6 +7,13 @@ import {FrameLocator, Locator, Page, expect} from '@playwright/test';
 
 import {getTempDir} from '../../../../utils/temp';
 
+type taskStatus = 'completedWithErrors' | 'success';
+
+const taskStatusTexts: Record<taskStatus, string> = {
+	completedWithErrors: 'Completed with errors',
+	success: 'Successful',
+};
+
 export class PortletExportImportPage {
 	readonly frame: FrameLocator;
 	readonly page: Page;
@@ -14,6 +21,8 @@ export class PortletExportImportPage {
 	readonly exportButton: Locator;
 	readonly exportDeletionsButton: Locator;
 	readonly importDeletionsButton: Locator;
+	readonly taskActionsMenu: Locator;
+	readonly viewReportEntriesMenuItem: Locator;
 
 	constructor(page: Page) {
 		this.frame = page.frameLocator('iframe[title="Export \\/ Import"]');
@@ -26,6 +35,13 @@ export class PortletExportImportPage {
 		this.importDeletionsButton = this.frame.getByLabel(
 			'Replicate Individual Deletions'
 		);
+		this.taskActionsMenu = this.frame
+			.locator('[data-qa-id="row"]')
+			.first()
+			.getByRole('button');
+		this.viewReportEntriesMenuItem = this.frame.getByRole('menuitem', {
+			name: 'View Report Entries',
+		});
 	}
 
 	async exportLARFile({
@@ -62,9 +78,11 @@ export class PortletExportImportPage {
 	async importLARFile({
 		filePath,
 		includeDeletions = false,
+		taskStatus = 'success',
 	}: {
 		filePath: string;
 		includeDeletions?: boolean;
+		taskStatus?: taskStatus;
 	}): Promise<void> {
 		await this.frame.getByRole('link', {name: 'Import'}).click();
 
@@ -78,7 +96,9 @@ export class PortletExportImportPage {
 		await this.frame.getByRole('button', {name: 'Import'}).click();
 
 		await expect(
-			this.frame.getByRole('cell', {name: 'Successful'}).first()
+			this.frame
+				.getByRole('cell', {name: taskStatusTexts[taskStatus]})
+				.first()
 		).toBeVisible();
 	}
 }


### PR DESCRIPTION
Jira Ticket: https://liferay.atlassian.net/browse/LPD-83781

 - Mark layout/portlet imports as `COMPLETED_WITH_ERRORS` when any report entries are produced, and surface a "View Report Entries" action for those tasks. 
  - Add `getExportImportReportEntriesCount(companyId, configId)` service method. Route both import executors through it instead of an inlined DSL count.                                                          

<img width="1906" height="933" alt="Screenshot From 2026-05-05 12-14-19" src="https://github.com/user-attachments/assets/53c73b01-6691-4eee-8816-8240020096c6" />
