### PR TITLE
LPD-90077 Add format-source rule for phrasing messages as a single thought

### DIFF
--- a/.claude/skills/format-source/SKILL.md
+++ b/.claude/skills/format-source/SKILL.md
@@ -425,3 +425,25 @@ Update the call sites at the same time.
 -_removeStaleFoos(deletedIdsMap);
 +_deleteStaleFoos(deletedIdsMap);
 ```
+
+### Rule 20: Phrase Messages as a Single Thought
+
+**Why:** Rewriting a two-clause log or exception message as "<action> because <reason>" reads as one continuous thought, surfaces the action up front instead of burying it after a semicolon, and avoids splitting the message at a punctuation seam.
+
+**Examples:**
+
+```diff
+ _log.warn(
+ 	StringBundler.concat(
+-		"Attribute \"", name,
+-		"\" has no value for scope ", primaryScope,
+-		"; using value from scope ", fallbackScope));
++		"Using value from scope ", fallbackScope,
++		" for attribute \"", name,
++		"\" because scope ", primaryScope, " has no value"));
+```
+
+```diff
+-_log.info("SQL server version is too stale; upgraded to " + version);
++_log.info("Upgraded SQL server version to " + version + " because it is too stale");
+```


### PR DESCRIPTION
## Summary

- Add Rule 20 to the `format-source` skill: phrase log/exception messages as a single thought (`<action> because <reason>`) instead of two clauses split by a semicolon.
- Derived from commit [`8bec977`](https://github.com/liferay/liferay-portal/commit/8bec977753ee5ff595793bd9a0475d4339e7b6c6) (LPD-85139 Rephrase).

Jira: [LPD-90077](https://liferay.atlassian.net/browse/LPD-90077)

## Test plan

- [x] Manually apply the rule to the parent of `8bec977` and verify the result matches the commit.