### PR TITLE
LPD-90280 baseline

### DIFF
--- a/modules/apps/export-import/export-import-api/bnd.bnd
+++ b/modules/apps/export-import/export-import-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Export Import API
 Bundle-SymbolicName: com.liferay.exportimport.api
-Bundle-Version: 17.0.1
+Bundle-Version: 17.1.0
 Export-Package:\
 	com.liferay.exportimport.attachment,\
 	com.liferay.exportimport.configuration,\

--- a/modules/apps/export-import/export-import-api/src/main/resources/com/liferay/exportimport/constants/packageinfo
+++ b/modules/apps/export-import/export-import-api/src/main/resources/com/liferay/exportimport/constants/packageinfo
@@ -1,1 +1,1 @@
-version 1.3.0
+version 1.4.0

--- a/modules/apps/export-import/export-import-api/src/main/resources/com/liferay/exportimport/vulcan/batch/engine/packageinfo
+++ b/modules/apps/export-import/export-import-api/src/main/resources/com/liferay/exportimport/vulcan/batch/engine/packageinfo
@@ -1,1 +1,1 @@
-version 8.0.0
+version 8.1.0

--- a/modules/apps/export-import/export-import-rest-api/src/main/resources/com/liferay/exportimport/rest/dto/v1_0/packageinfo
+++ b/modules/apps/export-import/export-import-rest-api/src/main/resources/com/liferay/exportimport/rest/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 3.0.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90280

## Failing Test

`modules-semantic-versioning[modules/apps/export-import]`

`modules/apps/export-import/export-import-api`, `modules/apps/export-import/export-import-rest-api`

```
* com.liferay.exportimport.constants                 MINOR      1.3.0      1.3.0      1.4.0      VERSION INCREASE REQUIRED
* com.liferay.exportimport.vulcan.batch.engine       MINOR      8.0.0      8.0.0      8.1.0      VERSION INCREASE REQUIRED
[Baseline Warning] Bundle Version Change Recommended: 17.1.0

* com.liferay.exportimport.rest.dto.v1_0             MAJOR      2.1.0      2.1.0      3.0.0      VERSION INCREASE REQUIRED
```

## Root Cause

Several merges between `c3e6af76` (last pass) and `a37e8eb2` (first fail) added new exported members without bumping the corresponding package versions. `LPD-77057` added `ExportImportConstants.SECTION_KEY_*` constants and `ExportImportDescriptor.getSectionKey()`. `LPD-86880` / `LPD-88071` added new DTOs (`Choice`, `ExportPreview`, `ImportPreview`) under `com.liferay.exportimport.rest.dto.v1_0`. The bnd baseline check rejects each of these as a semantic-versioning violation.

## Fix

Bump the affected package versions and the API bundle version to the values that bnd's baseline tool recommends. No product behavior changes — only the version metadata that the baseline check enforces.

- `modules/apps/export-import/export-import-api/bnd.bnd`
- `modules/apps/export-import/export-import-api/src/main/resources/com/liferay/exportimport/constants/packageinfo`
- `modules/apps/export-import/export-import-api/src/main/resources/com/liferay/exportimport/vulcan/batch/engine/packageinfo`
- `modules/apps/export-import/export-import-rest-api/src/main/resources/com/liferay/exportimport/rest/dto/v1_0/packageinfo`