### PR TITLE
LPD-90494 Bump portal-vulcan-api versions for new ExceptionMapperUtil class

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Vulcan API
 Bundle-SymbolicName: com.liferay.portal.vulcan.api
-Bundle-Version: 48.6.3
+Bundle-Version: 48.7.0
 Export-Package:\
 	com.liferay.portal.vulcan.accept.language,\
 	com.liferay.portal.vulcan.aggregation,\

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/jaxrs/exception/mapper/packageinfo
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/jaxrs/exception/mapper/packageinfo
@@ -1,1 +1,1 @@
-version 5.0.0
+version 5.1.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90494

## Failing Test

`modules-semantic-versioning[modules/apps/portal-vulcan]`

`modules/apps/portal-vulcan/portal-vulcan-api/build/reports/baseline/baseline.log`

```
PACKAGE_NAME                                       DELTA      CUR_VER    BASE_VER   REC_VER    WARNINGS
* com.liferay.portal.vulcan.jaxrs.exception.mapper  MINOR      5.0.0      5.0.0      5.1.0      VERSION INCREASE REQUIRED
+   class      com.liferay.portal.vulcan.jaxrs.exception.mapper.ExceptionMapperUtil
+   method     <init>()
+   method     getType(java.lang.String) (static)
[Baseline Warning] Bundle Version Change Recommended: 48.7.0
```

## Root Cause

Commit `88ec39783f84` ("LPD-86255 Extract exception type normalization into ExceptionMapperUtil") added a new public class `ExceptionMapperUtil` to the exported package `com.liferay.portal.vulcan.jaxrs.exception.mapper`, but left the package version at 5.0.0. Per OSGi semantic versioning, adding a new public type to an exported package is a MINOR change and requires a version bump.

## Fix

Bump the `com.liferay.portal.vulcan.jaxrs.exception.mapper` package version from 5.0.0 to 5.1.0 and the bundle version from 48.6.3 to 48.7.0 to reflect the MINOR API addition. Verified locally with `gradlew :apps:portal-vulcan:portal-vulcan-api:baseline`.

- `modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd`
- `modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/jaxrs/exception/mapper/packageinfo`