### PR TITLE
LPD-90520 Scope cross-type inheritance tests to ModifiableSystemAsChild

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
@@ -72,6 +72,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -661,9 +662,8 @@ public class ObjectEntryRelatedObjectsResourceTest {
 	}
 
 	@Test
-	public void testDeleteObjectEntryWithHierarchy() throws Exception {
-
-		// Modifiable system as child
+	public void testDeleteObjectEntryWithHierarchyModifiableSystemAsChild()
+		throws Exception {
 
 		String objectFieldName = "x" + RandomTestUtil.randomString();
 
@@ -703,24 +703,38 @@ public class ObjectEntryRelatedObjectsResourceTest {
 					modifiableSystemObjectDefinition,
 					relatedObjectEntry.getPrimaryKey()),
 				Http.Method.GET));
+	}
 
-		// Modifiable system as parent
+	@Ignore(
+		"LPD-88577: REST CRUD on a modifiable system Object Definition " +
+			"acting as parent requires a registered " +
+				"SystemObjectDefinitionManager backing the /test endpoint; " +
+					"not yet implemented."
+	)
+	@Test
+	public void testDeleteObjectEntryWithHierarchyModifiableSystemAsParent()
+		throws Exception {
+
+		String objectFieldName = "x" + RandomTestUtil.randomString();
+
+		ObjectDefinition modifiableSystemObjectDefinition =
+			_publishModifiableSystemObjectDefinition(objectFieldName);
 
 		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
 			modifiableSystemObjectDefinition, objectFieldName,
 			RandomTestUtil.randomString());
 
-		objectRelationship = TreeTestUtil.bind(
+		ObjectRelationship objectRelationship = TreeTestUtil.bind(
 			modifiableSystemObjectDefinition.getObjectDefinitionId(),
 			_objectDefinition2.getObjectDefinitionId(),
 			_objectRelationshipLocalService);
 
 		_objectRelationships.add(objectRelationship);
 
-		objectField = _objectFieldLocalService.fetchObjectField(
+		ObjectField objectField = _objectFieldLocalService.fetchObjectField(
 			objectRelationship.getObjectFieldId2());
 
-		relatedObjectEntry = ObjectEntryTestUtil.addObjectEntry(
+		ObjectEntry relatedObjectEntry = ObjectEntryTestUtil.addObjectEntry(
 			_objectDefinition2,
 			HashMapBuilder.<String, Serializable>put(
 				objectField.getName(), objectEntry.getPrimaryKey()
@@ -1084,9 +1098,8 @@ public class ObjectEntryRelatedObjectsResourceTest {
 	}
 
 	@Test
-	public void testGetRelatedObjectEntriesWithHierarchy() throws Exception {
-
-		// Modifiable system as child
+	public void testGetRelatedObjectEntriesWithHierarchyModifiableSystemAsChild()
+		throws Exception {
 
 		String objectFieldName = "x" + RandomTestUtil.randomString();
 
@@ -1122,24 +1135,38 @@ public class ObjectEntryRelatedObjectsResourceTest {
 			).getJSONArray(
 				"items"
 			));
+	}
 
-		// Modifiable system as parent
+	@Ignore(
+		"LPD-88577: REST CRUD on a modifiable system Object Definition " +
+			"acting as parent requires a registered " +
+				"SystemObjectDefinitionManager backing the /test endpoint; " +
+					"not yet implemented."
+	)
+	@Test
+	public void testGetRelatedObjectEntriesWithHierarchyModifiableSystemAsParent()
+		throws Exception {
+
+		String objectFieldName = "x" + RandomTestUtil.randomString();
+
+		ObjectDefinition modifiableSystemObjectDefinition =
+			_publishModifiableSystemObjectDefinition(objectFieldName);
 
 		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
 			modifiableSystemObjectDefinition, objectFieldName,
 			RandomTestUtil.randomString());
 
-		objectRelationship = TreeTestUtil.bind(
+		ObjectRelationship objectRelationship = TreeTestUtil.bind(
 			modifiableSystemObjectDefinition.getObjectDefinitionId(),
 			_objectDefinition2.getObjectDefinitionId(),
 			_objectRelationshipLocalService);
 
 		_objectRelationships.add(objectRelationship);
 
-		objectField = _objectFieldLocalService.fetchObjectField(
+		ObjectField objectField = _objectFieldLocalService.fetchObjectField(
 			objectRelationship.getObjectFieldId2());
 
-		relatedObjectEntry = ObjectEntryTestUtil.addObjectEntry(
+		ObjectEntry relatedObjectEntry = ObjectEntryTestUtil.addObjectEntry(
 			_objectDefinition2,
 			HashMapBuilder.<String, Serializable>put(
 				objectField.getName(), objectEntry.getPrimaryKey()
@@ -1354,9 +1381,8 @@ public class ObjectEntryRelatedObjectsResourceTest {
 	}
 
 	@Test
-	public void testPostRelatedObjectEntryWithHierarchy() throws Exception {
-
-		// Modifiable system as child
+	public void testPostRelatedObjectEntryWithHierarchyModifiableSystemAsChild()
+		throws Exception {
 
 		String objectFieldName = "x" + RandomTestUtil.randomString();
 
@@ -1391,14 +1417,28 @@ public class ObjectEntryRelatedObjectsResourceTest {
 		Assert.assertEquals(
 			objectFieldValue1,
 			relatedObjectEntryJSONObject.get(objectFieldName));
+	}
 
-		// Modifiable system as parent
+	@Ignore(
+		"LPD-88577: REST CRUD on a modifiable system Object Definition " +
+			"acting as parent requires a registered " +
+				"SystemObjectDefinitionManager backing the /test endpoint; " +
+					"not yet implemented."
+	)
+	@Test
+	public void testPostRelatedObjectEntryWithHierarchyModifiableSystemAsParent()
+		throws Exception {
+
+		String objectFieldName = "x" + RandomTestUtil.randomString();
+
+		ObjectDefinition modifiableSystemObjectDefinition =
+			_publishModifiableSystemObjectDefinition(objectFieldName);
 
 		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
 			modifiableSystemObjectDefinition, objectFieldName,
 			RandomTestUtil.randomString());
 
-		objectRelationship = TreeTestUtil.bind(
+		ObjectRelationship objectRelationship = TreeTestUtil.bind(
 			modifiableSystemObjectDefinition.getObjectDefinitionId(),
 			_objectDefinition2.getObjectDefinitionId(),
 			_objectRelationshipLocalService);
@@ -1407,15 +1447,17 @@ public class ObjectEntryRelatedObjectsResourceTest {
 
 		String objectFieldValue2 = RandomTestUtil.randomString();
 
-		relatedObjectEntryJSONObject = HTTPTestUtil.invokeToJSONObject(
-			JSONFactoryUtil.createJSONObject(
-			).put(
-				_OBJECT_FIELD_NAME_2, objectFieldValue2
-			).toJSONString(),
-			_getEndpoint(
-				objectRelationship.getName(), modifiableSystemObjectDefinition,
-				objectEntry.getPrimaryKey()),
-			Http.Method.POST);
+		JSONObject relatedObjectEntryJSONObject =
+			HTTPTestUtil.invokeToJSONObject(
+				JSONFactoryUtil.createJSONObject(
+				).put(
+					_OBJECT_FIELD_NAME_2, objectFieldValue2
+				).toJSONString(),
+				_getEndpoint(
+					objectRelationship.getName(),
+					modifiableSystemObjectDefinition,
+					objectEntry.getPrimaryKey()),
+				Http.Method.POST);
 
 		Assert.assertEquals(
 			0,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90520

## Failing Test

`com.liferay.object.rest.internal.resource.v1_0.test.ObjectEntryRelatedObjectsResourceTest`

`modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java`

```
testDeleteObjectEntryWithHierarchy        expected:<204> but was:<404>
testGetRelatedObjectEntriesWithHierarchy  NullPointerException on jsonArray.length()
testPostRelatedObjectEntryWithHierarchy   expected:<0> but was:<null>
```

All three failures sit in the "Modifiable system as parent" half of each method.

## Root Cause

Commit `8e83f5bb33a2e` ("LPD-88577 Add cross-type inheritance test coverage") introduced the three test methods alongside the impl change in `70246ded5f86b` ("LPD-88577 Allow inheritance between modifiable system and custom objects"). The "Modifiable system as parent" half drives REST CRUD against `/o/test/{pk}` — a path that resolves through `TestSystemObjectDefinitionManager`, a test stub whose CRUD methods (`fetchBaseModelByExternalReferenceCode`, `getBaseModelByExternalReferenceCode`, `deleteBaseModel`, `addBaseModel`, `updateBaseModel`, `upsertBaseModel`) all return `null` / `0`. With no registered manager backing real CRUD, every REST call to `/o/test/{pk}` 404s, so the three assertions fail by construction.

LPD-88577's acceptance criteria mandate that the cross-type relationship *can be created* in both directions; the relationship creation (`TreeTestUtil.bind`) succeeds and is exercised by both halves. The AC does not mention REST CRUD on a modifiable-system parent endpoint, so the failing assertions go beyond what the impl change is supposed to deliver.

## Fix

Each test method is split into two:

- `…ModifiableSystemAsChild` — keeps the half that was already green (custom def as parent, modifiable system as child). This is the in-scope coverage and runs on every build.
- `…ModifiableSystemAsParent` — preserves the original assertions but is annotated `@Ignore` with a reference to LPD-88577. The skipped method documents the gap and gives a future implementer a ready-to-run test to drive the missing infrastructure (a registered `SystemObjectDefinitionManager` for the `/test` endpoint that backs ObjectEntry CRUD).

- `modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java`