### PR TITLE
LPD-90662 Replace hardcoded 8080 with the dynamic port in tests

### DIFF
--- a/modules/apps/captcha/captcha-test/src/testIntegration/java/com/liferay/captcha/test/util/CaptchaTestUtil.java
+++ b/modules/apps/captcha/captcha-test/src/testIntegration/java/com/liferay/captcha/test/util/CaptchaTestUtil.java
@@ -5,6 +5,7 @@
 
 package com.liferay.captcha.test.util;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
@@ -12,6 +13,7 @@ import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.WebKeys;
 
@@ -91,7 +93,9 @@ public class CaptchaTestUtil {
 			TestPropsValues.getCompanyId());
 
 		themeDisplay.setPortalURL(
-			"http://" + company.getVirtualHostname() + ":8080");
+			StringBundler.concat(
+				"http://", company.getVirtualHostname(), ":",
+				PortalUtil.getPortalServerPort(false)));
 
 		themeDisplay.setScopeGroupId(TestPropsValues.getGroupId());
 		themeDisplay.setSiteGroupId(TestPropsValues.getGroupId());

--- a/modules/apps/consent-management-platform/consent-management-platform-integration-test/src/testIntegration/java/com/liferay/consent/management/platform/integration/internal/servlet/taglib/test/ConsentManagementPlatformTopHeadDynamicIncludeTest.java
+++ b/modules/apps/consent-management-platform/consent-management-platform-integration-test/src/testIntegration/java/com/liferay/consent/management/platform/integration/internal/servlet/taglib/test/ConsentManagementPlatformTopHeadDynamicIncludeTest.java
@@ -14,6 +14,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.URLUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
@@ -60,7 +61,10 @@ public class ConsentManagementPlatformTopHeadDynamicIncludeTest {
 			).build());
 
 		Matcher matcher = _pattern.matcher(
-			URLUtil.toString(new URL("http://localhost:8080")));
+			URLUtil.toString(
+				new URL(
+					"http://localhost:" +
+						PortalUtil.getPortalServerPort(false))));
 
 		Assert.assertTrue(matcher.find());
 

--- a/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ExportPreviewResourceTest.java
+++ b/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ExportPreviewResourceTest.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
@@ -77,7 +78,8 @@ public class ExportPreviewResourceTest
 		).authentication(
 			_user.getEmailAddress(), password
 		).endpoint(
-			testCompany.getVirtualHostname(), 8080, "http"
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
 		).locale(
 			LocaleUtil.getDefault()
 		).build();

--- a/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ImportPreviewResourceTest.java
+++ b/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ImportPreviewResourceTest.java
@@ -42,6 +42,7 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
@@ -101,7 +102,8 @@ public class ImportPreviewResourceTest
 		).authentication(
 			_user.getEmailAddress(), password
 		).endpoint(
-			testCompany.getVirtualHostname(), 8080, "http"
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
 		).locale(
 			LocaleUtil.getDefault()
 		).build();

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/internal/batch/engine/action/test/util/ExportImportTaskResourceTestUtil.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/internal/batch/engine/action/test/util/ExportImportTaskResourceTestUtil.java
@@ -156,9 +156,10 @@ public class ExportImportTaskResourceTestUtil {
 		httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
 
 		String path = StringBundler.concat(
-			"http://", host, ":8080/o/headless-batch-engine/v1.0/import-task/",
-			className, "?createStrategy=", createStrategy,
-			"&importCreatorStrategy=", importCreatorStrategy);
+			"http://", host, ":", PortalUtil.getPortalServerPort(false),
+			"/o/headless-batch-engine/v1.0/import-task/", className,
+			"?createStrategy=", createStrategy, "&importCreatorStrategy=",
+			importCreatorStrategy);
 
 		if (MapUtil.isNotEmpty(parameters)) {
 			for (Map.Entry<String, String> entry : parameters.entrySet()) {
@@ -195,8 +196,10 @@ public class ExportImportTaskResourceTestUtil {
 				_invoke(
 					host,
 					StringBundler.concat(
-						"http://", host, ":8080/o/headless-batch-engine/v1.0",
-						"/import-task/by-external-reference-code/",
+						"http://", host, ":",
+						PortalUtil.getPortalServerPort(false),
+						"/o/headless-batch-engine/v1.0/import-task",
+						"/by-external-reference-code/",
 						externalReferenceCode)));
 
 			if (Objects.equals(

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-test/src/testIntegration/java/com/liferay/headless/batch/engine/resource/v1_0/test/ExportImportTaskResourceCreatorInfoTest.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-test/src/testIntegration/java/com/liferay/headless/batch/engine/resource/v1_0/test/ExportImportTaskResourceCreatorInfoTest.java
@@ -441,8 +441,9 @@ public class ExportImportTaskResourceCreatorInfoTest {
 
 		httpInvoker.path(
 			StringBundler.concat(
-				"http://", host, ":8080/o/headless-batch-engine/v1.0",
-				"/import-task/com.liferay.object.admin.rest.dto.v1_0.",
+				"http://", host, ":", PortalUtil.getPortalServerPort(false),
+				"/o/headless-batch-engine/v1.0/import-task",
+				"/com.liferay.object.admin.rest.dto.v1_0.",
 				"ObjectDefinition?createStrategy=", createStrategy,
 				"&importCreatorStrategy=", importCreatorStrategy));
 
@@ -468,8 +469,10 @@ public class ExportImportTaskResourceCreatorInfoTest {
 				_invoke(
 					host,
 					StringBundler.concat(
-						"http://", host, ":8080/o/headless-batch-engine/v1.0",
-						"/import-task/by-external-reference-code/",
+						"http://", host, ":",
+						PortalUtil.getPortalServerPort(false),
+						"/o/headless-batch-engine/v1.0/import-task",
+						"/by-external-reference-code/",
 						externalReferenceCode)));
 
 			if (Objects.equals(

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderOpenAPIResourceTest.java
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/java/com/liferay/headless/builder/resource/test/HeadlessBuilderOpenAPIResourceTest.java
@@ -437,7 +437,11 @@ public class HeadlessBuilderOpenAPIResourceTest extends BaseTestCase {
 				new String(
 					FileUtil.getBytes(
 						getClass(), "dependencies/expected_openapi.json")),
-				"${BASE_URL}", "c/" + _API_BASE_URL),
+				new String[] {"${BASE_URL}", "${PORT}"},
+				new String[] {
+					"c/" + _API_BASE_URL,
+					String.valueOf(PortalUtil.getPortalServerPort(false))
+				}),
 			jsonObject.toString(), JSONCompareMode.STRICT);
 	}
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/resources/com/liferay/headless/builder/resource/test/dependencies/expected_openapi.json
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testIntegration/resources/com/liferay/headless/builder/resource/test/dependencies/expected_openapi.json
@@ -785,7 +785,7 @@
 	},
 	"servers": [
 		{
-			"url": "http://localhost:8080/o/${BASE_URL}/"
+			"url": "http://localhost:${PORT}/o/${BASE_URL}/"
 		}
 	]
 }

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/FormStructureResourceTest.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/FormStructureResourceTest.java
@@ -39,7 +39,8 @@ public class FormStructureResourceTest
 		FormStructureResource formStructureResource =
 			FormStructureResource.builder(
 			).endpoint(
-				testCompany.getVirtualHostname(), 8080, "http"
+				testCompany.getVirtualHostname(),
+				_portal.getPortalServerPort(false), "http"
 			).build();
 
 		AssertUtils.assertFailure(

--- a/modules/apps/login/login-test/src/testIntegration/java/com/liferay/login/internal/portlet/action/test/LoginActionTest.java
+++ b/modules/apps/login/login-test/src/testIntegration/java/com/liferay/login/internal/portlet/action/test/LoginActionTest.java
@@ -43,6 +43,7 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -121,8 +122,9 @@ public class LoginActionTest {
 				location.contains(
 					StringBundler.concat(
 						"_com_liferay_login_web_portlet_LoginPortlet_redirect=",
-						"http%3A%2F%2F", _company.getVirtualHostname(),
-						"%3A8080", HtmlUtil.escapeURL(contextPath),
+						"http%3A%2F%2F", _company.getVirtualHostname(), "%3A",
+						PortalUtil.getPortalServerPort(false),
+						HtmlUtil.escapeURL(contextPath),
 						"%2Fweb%2Fguest%2Fhome")));
 		}
 	}
@@ -171,8 +173,9 @@ public class LoginActionTest {
 				query.contains(
 					StringBundler.concat(
 						"_com_liferay_login_web_portlet_LoginPortlet_redirect=",
-						"http%3A%2F%2F", _company.getVirtualHostname(),
-						"%3A8080%2Fweb%2Fguest%2Fhome")));
+						"http%3A%2F%2F", _company.getVirtualHostname(), "%3A",
+						PortalUtil.getPortalServerPort(false),
+						"%2Fweb%2Fguest%2Fhome")));
 		}
 	}
 
@@ -232,7 +235,8 @@ public class LoginActionTest {
 
 			URL url = new URL(
 				StringBundler.concat(
-					"http://", _company.getVirtualHostname(), ":8080/web",
+					"http://", _company.getVirtualHostname(), ":",
+					PortalUtil.getPortalServerPort(false), "/web",
 					_group.getFriendlyURL(), layout.getFriendlyURL()));
 
 			HttpURLConnection httpURLConnection =
@@ -266,8 +270,9 @@ public class LoginActionTest {
 
 		URL url = new URL(
 			StringBundler.concat(
-				"http://", _company.getVirtualHostname(),
-				":8080/c/portal/login?p_l_id=", TestPropsValues.getPlid(),
+				"http://", _company.getVirtualHostname(), ":",
+				PortalUtil.getPortalServerPort(false),
+				"/c/portal/login?p_l_id=", TestPropsValues.getPlid(),
 				"&windowState=exclusive"));
 
 		HttpURLConnection httpURLConnection =

--- a/modules/apps/login/login-test/src/testIntegration/java/com/liferay/login/internal/portlet/action/test/UpdatePasswordActionTest.java
+++ b/modules/apps/login/login-test/src/testIntegration/java/com/liferay/login/internal/portlet/action/test/UpdatePasswordActionTest.java
@@ -43,6 +43,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.ScopeUtil;
 import com.liferay.portal.kernel.util.URLUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -197,16 +198,17 @@ public class UpdatePasswordActionTest {
 		if (usePlid) {
 			url = new URL(
 				StringBundler.concat(
-					"http://", _company.getVirtualHostname(),
-					":8080/c/portal/update_password?p_l_id=",
-					_layout1.getPlid(), "&ticketId=", ticketId, "&ticketId=",
-					ticketKey));
+					"http://", _company.getVirtualHostname(), ":",
+					PortalUtil.getPortalServerPort(false),
+					"/c/portal/update_password?p_l_id=", _layout1.getPlid(),
+					"&ticketId=", ticketId, "&ticketId=", ticketKey));
 		}
 		else {
 			url = new URL(
 				StringBundler.concat(
-					"http://", _company.getVirtualHostname(),
-					":8080/c/portal/update_password?ticketId=", ticketId,
+					"http://", _company.getVirtualHostname(), ":",
+					PortalUtil.getPortalServerPort(false),
+					"/c/portal/update_password?ticketId=", ticketId,
 					"&ticketId=", ticketKey));
 		}
 

--- a/modules/apps/mcp/mcp-server-test/src/testIntegration/java/com/liferay/mcp/server/test/MCPServerServletTest.java
+++ b/modules/apps/mcp/mcp-server-test/src/testIntegration/java/com/liferay/mcp/server/test/MCPServerServletTest.java
@@ -106,7 +106,9 @@ public class MCPServerServletTest {
 			).header(
 				"Authorization", _getAuthorization()
 			).uri(
-				URI.create("http://localhost:8080/o/mcp")
+				URI.create(
+					"http://localhost:" +
+						PortalUtil.getPortalServerPort(false) + "/o/mcp")
 			).build(),
 			HttpResponse.BodyHandlers.discarding()
 		);
@@ -254,7 +256,9 @@ public class MCPServerServletTest {
 		Http.Options options = new Http.Options();
 
 		options.addHeader("Authorization", _getAuthorization());
-		options.setLocation("http://localhost:8080/o/mcp");
+		options.setLocation(
+			"http://localhost:" + PortalUtil.getPortalServerPort(false) +
+				"/o/mcp");
 
 		_http.URLtoString(options);
 
@@ -291,7 +295,9 @@ public class MCPServerServletTest {
 				)
 			).toString(),
 			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
-		options.setLocation("http://localhost:8080/o/mcp");
+		options.setLocation(
+			"http://localhost:" + PortalUtil.getPortalServerPort(false) +
+				"/o/mcp");
 		options.setPost(true);
 
 		_http.URLtoString(options);

--- a/modules/apps/oauth-client/oauth-client-admin-web-test/src/testIntegration/java/com/liferay/oauth/client/admin/web/internal/servlet/test/OAuth2WellKnownAuthorizationServerServletTest.java
+++ b/modules/apps/oauth-client/oauth-client-admin-web-test/src/testIntegration/java/com/liferay/oauth/client/admin/web/internal/servlet/test/OAuth2WellKnownAuthorizationServerServletTest.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -71,8 +72,9 @@ public class OAuth2WellKnownAuthorizationServerServletTest {
 			TestPropsValues.getCompanyId());
 
 		String urlString = StringBundler.concat(
-			Http.HTTP_WITH_SLASH, company.getVirtualHostname(),
-			":8080/o/.well-known/oauth-authorization-server/");
+			Http.HTTP_WITH_SLASH, company.getVirtualHostname(), ":",
+			PortalUtil.getPortalServerPort(false),
+			"/o/.well-known/oauth-authorization-server/");
 
 		options.setLocation(urlString);
 

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/BaseClientTestCase.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/BaseClientTestCase.java
@@ -8,6 +8,7 @@ package com.liferay.oauth2.provider.client.test;
 import com.liferay.oauth2.provider.model.OAuth2Authorization;
 import com.liferay.oauth2.provider.service.OAuth2AuthorizationLocalService;
 import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.json.JSONObjectImpl;
 import com.liferay.portal.kernel.cookies.constants.CookiesConstants;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -20,6 +21,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.DigesterUtil;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.test.rule.Inject;
@@ -141,7 +143,9 @@ public abstract class BaseClientTestCase {
 
 			return client.target(
 				uriBuilder.uri(
-					"http://" + company.getVirtualHostname() + ":8080"));
+					StringBundler.concat(
+						"http://", company.getVirtualHostname(), ":",
+						PortalUtil.getPortalServerPort(false))));
 		}
 		catch (PortalException portalException) {
 			throw new RuntimeException(portalException);

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryPerformanceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryPerformanceTest.java
@@ -44,6 +44,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropertiesUtil;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.Validator;
@@ -271,7 +272,8 @@ public class ObjectEntryPerformanceTest {
 
 	private String _getPath(String pathSuffix) {
 		return StringBundler.concat(
-			"http://", _VIRTUAL_HOST_NAME, ":8080", pathSuffix);
+			"http://", _VIRTUAL_HOST_NAME, ":",
+			PortalUtil.getPortalServerPort(false), pathSuffix);
 	}
 
 	private HttpInvoker.HttpResponse _invoke(

--- a/modules/apps/portal-remote/portal-remote-cors-test/src/testIntegration/java/com/liferay/portal/remote/cors/client/test/BaseCORSClientTestCase.java
+++ b/modules/apps/portal-remote/portal-remote-cors-test/src/testIntegration/java/com/liferay/portal/remote/cors/client/test/BaseCORSClientTestCase.java
@@ -136,8 +136,10 @@ public abstract class BaseCORSClientTestCase {
 		ProcessChannel<String[]> processChannel = processExecutor.execute(
 			builder.build(),
 			new AllowRestrictedHeadersCallable(
-				"http://localhost:8080/api/jsonws" + urlString, allowedOrigin,
-				method, true));
+				StringBundler.concat(
+					"http://localhost:", PortalUtil.getPortalServerPort(false),
+					"/api/jsonws", urlString),
+				allowedOrigin, method, true));
 
 		Future<String[]> future = processChannel.getProcessNoticeableFuture();
 

--- a/modules/apps/portal-remote/portal-remote-cors-test/src/testIntegration/java/com/liferay/portal/remote/cors/client/test/PortalConfigurationCORSClientTest.java
+++ b/modules/apps/portal-remote/portal-remote-cors-test/src/testIntegration/java/com/liferay/portal/remote/cors/client/test/PortalConfigurationCORSClientTest.java
@@ -10,6 +10,7 @@ import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.cookies.constants.CookiesConstants;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -196,7 +197,9 @@ public class PortalConfigurationCORSClientTest extends BaseCORSClientTestCase {
 
 		UriBuilder uriBuilder = runtimeDelegate.createUriBuilder();
 
-		return client.target(uriBuilder.uri("http://localhost:8080"));
+		return client.target(
+			uriBuilder.uri(
+				"http://localhost:" + PortalUtil.getPortalServerPort(false)));
 	}
 
 	private WebTarget _getWebTarget(String... paths) {

--- a/modules/apps/portal-remote/portal-remote-json-web-service-web-test/src/testIntegration/java/com/liferay/portal/remote/json/web/service/web/client/test/JSONWebServiceTrackerTest.java
+++ b/modules/apps/portal-remote/portal-remote-json-web-service-web-test/src/testIntegration/java/com/liferay/portal/remote/json/web/service/web/client/test/JSONWebServiceTrackerTest.java
@@ -11,6 +11,7 @@ import com.liferay.portal.kernel.jsonwebservice.JSONWebService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.URLUtil;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -67,7 +68,9 @@ public class JSONWebServiceTrackerTest {
 
 	@Test
 	public void testWebServiceContextAppearsInTheSummary() throws IOException {
-		URL url = new URL("http://localhost:8080/api/jsonws");
+		URL url = new URL(
+			"http://localhost:" + PortalUtil.getPortalServerPort(false) +
+				"/api/jsonws");
 
 		String body = URLUtil.toString(url);
 
@@ -83,8 +86,8 @@ public class JSONWebServiceTrackerTest {
 
 		URL url = new URL(
 			StringBundler.concat(
-				"http://localhost:8080/api/jsonws/test.testweb/sum/a/", a,
-				"/b/", b));
+				"http://localhost:", PortalUtil.getPortalServerPort(false),
+				"/api/jsonws/test.testweb/sum/a/", a, "/b/", b));
 
 		Assert.assertEquals(
 			a + b, GetterUtil.getInteger(URLUtil.toString(url)));

--- a/modules/apps/portal-security/portal-security-auto-login-test/src/testIntegration/java/com/liferay/portal/security/auto/login/test/UpdatePasswordActionTest.java
+++ b/modules/apps/portal-security/portal-security-auto-login-test/src/testIntegration/java/com/liferay/portal/security/auto/login/test/UpdatePasswordActionTest.java
@@ -31,6 +31,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Constants;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.URLUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.struts.Action;
@@ -89,9 +90,9 @@ public class UpdatePasswordActionTest {
 
 		URL url = new URL(
 			StringBundler.concat(
-				"http://localhost:8080/c/portal/update_password?languageId=",
-				user.getLanguageId(), "&ticketId=", _ticketId, "&ticketKey=",
-				_ticketKey));
+				"http://localhost:", PortalUtil.getPortalServerPort(false),
+				"/c/portal/update_password?languageId=", user.getLanguageId(),
+				"&ticketId=", _ticketId, "&ticketKey=", _ticketKey));
 
 		String content = URLUtil.toString(url);
 

--- a/modules/apps/portal-security/portal-security-content-security-policy-test/src/testIntegration/java/com/liferay/portal/security/content/security/policy/test/ContentSecurityPolicyFilterTest.java
+++ b/modules/apps/portal-security/portal-security-content-security-policy-test/src/testIntegration/java/com/liferay/portal/security/content/security/policy/test/ContentSecurityPolicyFilterTest.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.security.content.security.policy.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.service.CompanyLocalService;
@@ -13,6 +14,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.HtmlUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -52,7 +54,8 @@ public class ContentSecurityPolicyFilterTest {
 						false, null, "", false)) {
 
 			HttpURLConnection httpURLConnection = _openHttpURLConnection(
-				"http://localhost:8080/html/common/null.html");
+				"http://localhost:" + PortalUtil.getPortalServerPort(false) +
+					"/html/common/null.html");
 
 			Map<String, List<String>> headerFields =
 				httpURLConnection.getHeaderFields();
@@ -75,7 +78,9 @@ public class ContentSecurityPolicyFilterTest {
 						false, null, "", false)) {
 
 			HttpURLConnection httpURLConnection = _openHttpURLConnection(
-				"http://" + company.getVirtualHostname() + ":8080/web/guest");
+				StringBundler.concat(
+					"http://", company.getVirtualHostname(), ":",
+					PortalUtil.getPortalServerPort(false), "/web/guest"));
 
 			Map<String, List<String>> headerFields =
 				httpURLConnection.getHeaderFields();
@@ -92,7 +97,9 @@ public class ContentSecurityPolicyFilterTest {
 						false, null, "", true)) {
 
 			HttpURLConnection httpURLConnection = _openHttpURLConnection(
-				"http://" + company.getVirtualHostname() + ":8080/web/guest");
+				StringBundler.concat(
+					"http://", company.getVirtualHostname(), ":",
+					PortalUtil.getPortalServerPort(false), "/web/guest"));
 
 			Map<String, List<String>> headerFields =
 				httpURLConnection.getHeaderFields();
@@ -110,7 +117,9 @@ public class ContentSecurityPolicyFilterTest {
 						true, null, "", false)) {
 
 			HttpURLConnection httpURLConnection = _openHttpURLConnection(
-				"http://" + company.getVirtualHostname() + ":8080/web/guest");
+				StringBundler.concat(
+					"http://", company.getVirtualHostname(), ":",
+					PortalUtil.getPortalServerPort(false), "/web/guest"));
 
 			Map<String, List<String>> headerFields =
 				httpURLConnection.getHeaderFields();
@@ -133,7 +142,9 @@ public class ContentSecurityPolicyFilterTest {
 						true, null, policy, false)) {
 
 			HttpURLConnection httpURLConnection = _openHttpURLConnection(
-				"http://" + company.getVirtualHostname() + ":8080/web/guest");
+				StringBundler.concat(
+					"http://", company.getVirtualHostname(), ":",
+					PortalUtil.getPortalServerPort(false), "/web/guest"));
 
 			Assert.assertEquals(
 				httpURLConnection.getHeaderField("Content-Security-Policy"),
@@ -148,7 +159,9 @@ public class ContentSecurityPolicyFilterTest {
 						true, null, policy, true)) {
 
 			HttpURLConnection httpURLConnection = _openHttpURLConnection(
-				"http://" + company.getVirtualHostname() + ":8080/web/guest");
+				StringBundler.concat(
+					"http://", company.getVirtualHostname(), ":",
+					PortalUtil.getPortalServerPort(false), "/web/guest"));
 
 			Assert.assertEquals(
 				httpURLConnection.getHeaderField(
@@ -168,7 +181,9 @@ public class ContentSecurityPolicyFilterTest {
 						true, null, policy, false)) {
 
 			HttpURLConnection httpURLConnection = _openHttpURLConnection(
-				"http://" + company.getVirtualHostname() + ":8080/web/guest");
+				StringBundler.concat(
+					"http://", company.getVirtualHostname(), ":",
+					PortalUtil.getPortalServerPort(false), "/web/guest"));
 
 			Map<String, List<String>> headerFields =
 				httpURLConnection.getHeaderFields();
@@ -214,7 +229,9 @@ public class ContentSecurityPolicyFilterTest {
 						policy, false)) {
 
 			HttpURLConnection httpURLConnection = _openHttpURLConnection(
-				"http://" + company.getVirtualHostname() + ":8080/web/guest");
+				StringBundler.concat(
+					"http://", company.getVirtualHostname(), ":",
+					PortalUtil.getPortalServerPort(false), "/web/guest"));
 
 			Map<String, List<String>> headerFields =
 				httpURLConnection.getHeaderFields();

--- a/modules/apps/portal/portal-character-encoding-test/src/testIntegration/java/com/liferay/portal/character/encoding/test/CharacterEncodingTest.java
+++ b/modules/apps/portal/portal-character-encoding-test/src/testIntegration/java/com/liferay/portal/character/encoding/test/CharacterEncodingTest.java
@@ -9,6 +9,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.io.unsync.UnsyncBufferedReader;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.character.encoding.test.servlet.filter.CharacterEncodingFilter;
+import com.liferay.portal.kernel.util.PortalUtil;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -52,7 +53,8 @@ public class CharacterEncodingTest {
 	private String _testCharacterEncoding(boolean addCharacterEncoding)
 		throws IOException {
 
-		URL url = new URL("http://localhost:8080");
+		URL url = new URL(
+			"http://localhost:" + PortalUtil.getPortalServerPort(false));
 
 		HttpURLConnection httpURLConnection =
 			(HttpURLConnection)url.openConnection();

--- a/modules/apps/portal/portal-error-code-test/src/testIntegration/java/com/liferay/portal/error/code/test/PortalErrorCodeTest.java
+++ b/modules/apps/portal/portal-error-code-test/src/testIntegration/java/com/liferay/portal/error/code/test/PortalErrorCodeTest.java
@@ -7,6 +7,7 @@ package com.liferay.portal.error.code.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.URLUtil;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LogEntry;
@@ -39,7 +40,11 @@ public class PortalErrorCodeTest {
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				"portal_web.docroot.errors.code_jsp", LoggerTestUtil.WARN)) {
 
-			URLUtil.toString(new URL("http://localhost:8080/errors/code.jsp"));
+			URLUtil.toString(
+				new URL(
+					"http://localhost:" +
+						PortalUtil.getPortalServerPort(false) +
+							"/errors/code.jsp"));
 
 			List<LogEntry> logEntries = logCapture.getLogEntries();
 

--- a/modules/apps/portal/portal-events-test/src/testIntegration/java/com/liferay/portal/events/test/ServicePreActionTest.java
+++ b/modules/apps/portal/portal-events-test/src/testIntegration/java/com/liferay/portal/events/test/ServicePreActionTest.java
@@ -128,8 +128,13 @@ public class ServicePreActionTest {
 					"SERVLET_SERVICE_EVENTS_PRE_ERROR_PAGE",
 					"/portal/portlet_error.jsp")) {
 
-			_testErrorPage(true, false, false, "http://localhost:8080");
-			_testErrorPage(true, false, false, "http://localhost:8080/c");
+			_testErrorPage(
+				true, false, false,
+				"http://localhost:" + _portal.getPortalServerPort(false));
+			_testErrorPage(
+				true, false, false,
+				"http://localhost:" + _portal.getPortalServerPort(false) +
+					"/c");
 		}
 	}
 
@@ -144,8 +149,13 @@ public class ServicePreActionTest {
 					"SERVLET_SERVICE_EVENTS_PRE_ERROR_PAGE",
 					"/portal/portlet_error.jsp")) {
 
-			_testErrorPage(false, true, false, "http://localhost:8080");
-			_testErrorPage(false, true, false, "http://localhost:8080/c");
+			_testErrorPage(
+				false, true, false,
+				"http://localhost:" + _portal.getPortalServerPort(false));
+			_testErrorPage(
+				false, true, false,
+				"http://localhost:" + _portal.getPortalServerPort(false) +
+					"/c");
 		}
 	}
 
@@ -156,8 +166,13 @@ public class ServicePreActionTest {
 					"SERVLET_SERVICE_EVENTS_PRE",
 					new String[] {TestLifecycleAction.class.getName()})) {
 
-			_testErrorPage(false, false, false, "http://localhost:8080");
-			_testErrorPage(false, false, false, "http://localhost:8080/c");
+			_testErrorPage(
+				false, false, false,
+				"http://localhost:" + _portal.getPortalServerPort(false));
+			_testErrorPage(
+				false, false, false,
+				"http://localhost:" + _portal.getPortalServerPort(false) +
+					"/c");
 		}
 	}
 
@@ -170,8 +185,13 @@ public class ServicePreActionTest {
 					"SERVLET_SERVICE_EVENTS_PRE",
 					new String[] {TestLifecycleAction.class.getName()})) {
 
-			_testErrorPage(false, false, true, "http://localhost:8080");
-			_testErrorPage(false, false, true, "http://localhost:8080/c");
+			_testErrorPage(
+				false, false, true,
+				"http://localhost:" + _portal.getPortalServerPort(false));
+			_testErrorPage(
+				false, false, true,
+				"http://localhost:" + _portal.getPortalServerPort(false) +
+					"/c");
 		}
 	}
 

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/EnterpriseDatabaseTest.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/EnterpriseDatabaseTest.java
@@ -94,7 +94,7 @@ public class EnterpriseDatabaseTest extends BaseLicenseTestCase {
 
 		assertPortalLicenseRegistered();
 
-		String response = hitHomePage("localhost", 8080);
+		String response = hitHomePage("localhost", getLocalPort());
 
 		for (DBType dbType : _DB_TYPES) {
 			Assert.assertTrue(

--- a/modules/apps/portal/portal-virtual-host-test/src/testIntegration/java/com/liferay/portal/virtual/host/test/CompanyVirtualHostTest.java
+++ b/modules/apps/portal/portal-virtual-host-test/src/testIntegration/java/com/liferay/portal/virtual/host/test/CompanyVirtualHostTest.java
@@ -14,6 +14,7 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import org.junit.Assert;
@@ -54,7 +55,8 @@ public class CompanyVirtualHostTest extends BaseVirtualHostTestCase {
 					body.contains(layout.getName(LocaleUtil.getDefault())));
 			},
 			StringBundler.concat(
-				"http://", company1.getVirtualHostname(), ":8080/web",
+				"http://", company1.getVirtualHostname(), ":",
+				PortalUtil.getPortalServerPort(false), "/web",
 				group.getFriendlyURL()));
 
 		assertURLtoString(
@@ -63,7 +65,8 @@ public class CompanyVirtualHostTest extends BaseVirtualHostTestCase {
 				Assert.assertTrue(body.contains(company2.getVirtualHostname()));
 			},
 			StringBundler.concat(
-				"http://", company2.getVirtualHostname(), ":8080/web",
+				"http://", company2.getVirtualHostname(), ":",
+				PortalUtil.getPortalServerPort(false), "/web",
 				group.getFriendlyURL()));
 	}
 

--- a/modules/apps/portal/portal-virtual-host-test/src/testIntegration/java/com/liferay/portal/virtual/host/test/SiteVirtualHostTest.java
+++ b/modules/apps/portal/portal-virtual-host-test/src/testIntegration/java/com/liferay/portal/virtual/host/test/SiteVirtualHostTest.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.TreeMapBuilder;
 import com.liferay.portal.test.rule.Inject;
@@ -209,7 +210,8 @@ public class SiteVirtualHostTest extends BaseVirtualHostTestCase {
 					body.contains(layout.getName(LocaleUtil.getDefault())));
 			},
 			StringBundler.concat(
-				"http://", virtualHostName, ":8080/web",
+				"http://", virtualHostName, ":",
+				PortalUtil.getPortalServerPort(false), "/web",
 				group.getFriendlyURL()));
 	}
 

--- a/modules/apps/static/portal-k8s-agent/portal-k8s-agent-test/src/testIntegration/java/com/liferay/portal/k8s/agent/internal/test/RoutesPortalK8sConfigMapModifierTest.java
+++ b/modules/apps/static/portal-k8s-agent/portal-k8s-agent-test/src/testIntegration/java/com/liferay/portal/k8s/agent/internal/test/RoutesPortalK8sConfigMapModifierTest.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.service.VirtualHostLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.test.rule.Inject;
@@ -127,7 +128,7 @@ public class RoutesPortalK8sConfigMapModifierTest {
 
 		Assert.assertTrue(Files.exists(lxcDXPMainDomainPath));
 		Assert.assertEquals(
-			hostname + ":8080",
+			hostname + ":" + PortalUtil.getPortalServerPort(false),
 			new String(Files.readAllBytes(lxcDXPMainDomainPath)));
 
 		VirtualHost virtualHost = _virtualHostLocalService.createVirtualHost(
@@ -153,13 +154,21 @@ public class RoutesPortalK8sConfigMapModifierTest {
 
 		if (hostname.compareTo(virtualHostHostname) > 0) {
 			Assert.assertEquals(
-				virtualHostHostname + ":8080", lxcDXPDomains.get(0));
-			Assert.assertEquals(hostname + ":8080", lxcDXPDomains.get(1));
+				virtualHostHostname + ":" +
+					PortalUtil.getPortalServerPort(false),
+				lxcDXPDomains.get(0));
+			Assert.assertEquals(
+				hostname + ":" + PortalUtil.getPortalServerPort(false),
+				lxcDXPDomains.get(1));
 		}
 		else {
-			Assert.assertEquals(hostname + ":8080", lxcDXPDomains.get(0));
 			Assert.assertEquals(
-				virtualHostHostname + ":8080", lxcDXPDomains.get(1));
+				hostname + ":" + PortalUtil.getPortalServerPort(false),
+				lxcDXPDomains.get(0));
+			Assert.assertEquals(
+				virtualHostHostname + ":" +
+					PortalUtil.getPortalServerPort(false),
+				lxcDXPDomains.get(1));
 		}
 
 		// Ext init

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-jsp-compiler-test/src/testIntegration/java/com/liferay/portal/osgi/web/servlet/jsp/compiler/test/JspPrecompileTest.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-jsp-compiler-test/src/testIntegration/java/com/liferay/portal/osgi/web/servlet/jsp/compiler/test/JspPrecompileTest.java
@@ -377,9 +377,9 @@ public class JspPrecompileTest {
 
 		URL url = new URL(
 			StringBundler.concat(
-				"http://localhost:8080/web", _group.getFriendlyURL(),
-				"?p_p_id=", JspPrecompilePortlet.PORTLET_NAME,
-				StringPool.AMPERSAND,
+				"http://localhost:", PortalUtil.getPortalServerPort(false),
+				"/web", _group.getFriendlyURL(), "?p_p_id=",
+				JspPrecompilePortlet.PORTLET_NAME, StringPool.AMPERSAND,
 				JspPrecompilePortlet.getJspFileNameParameterName(), "=/",
 				jspFileName));
 

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-jsp-compiler-test/src/testIntegration/java/com/liferay/portal/osgi/web/servlet/jsp/compiler/test/TagFileCompileTest.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-jsp-compiler-test/src/testIntegration/java/com/liferay/portal/osgi/web/servlet/jsp/compiler/test/TagFileCompileTest.java
@@ -93,9 +93,10 @@ public class TagFileCompileTest {
 
 			URL url = new URL(
 				StringBundler.concat(
-					"http://localhost:8080/web",
-					testGroupAutoCloseable._group.getFriendlyURL(), "?p_p_id=",
-					JspPrecompilePortlet.PORTLET_NAME, StringPool.AMPERSAND,
+					"http://localhost:", PortalUtil.getPortalServerPort(false),
+					"/web", testGroupAutoCloseable._group.getFriendlyURL(),
+					"?p_p_id=", JspPrecompilePortlet.PORTLET_NAME,
+					StringPool.AMPERSAND,
 					JspPrecompilePortlet.getJspFileNameParameterName(), "=/",
 					_TAG_TEST_JSP_FILE_NAME));
 

--- a/modules/apps/websocket/websocket-whiteboard-test/src/testIntegration/java/com/liferay/websocket/whiteboard/test/WebSocketEndpointTest.java
+++ b/modules/apps/websocket/websocket-whiteboard-test/src/testIntegration/java/com/liferay/websocket/whiteboard/test/WebSocketEndpointTest.java
@@ -7,6 +7,7 @@ package com.liferay.websocket.whiteboard.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.websocket.whiteboard.test.encode.client.EncodeWebSocketClient;
 import com.liferay.websocket.whiteboard.test.encode.data.Example;
@@ -112,7 +113,9 @@ public class WebSocketEndpointTest {
 		BinaryWebSocketClient binaryWebSocketClient = new BinaryWebSocketClient(
 			synchronousQueue);
 
-		URI uri = new URI("ws://localhost:8080/o/websocket/test");
+		URI uri = new URI(
+			"ws://localhost:" + PortalUtil.getPortalServerPort(false) +
+				"/o/websocket/test");
 
 		webSocketContainer.connectToServer(binaryWebSocketClient, uri);
 
@@ -134,7 +137,9 @@ public class WebSocketEndpointTest {
 		TextWebSocketClient textWebSocketClient = new TextWebSocketClient(
 			synchronousQueue);
 
-		URI uri = new URI("ws://localhost:8080/o/websocket/test");
+		URI uri = new URI(
+			"ws://localhost:" + PortalUtil.getPortalServerPort(false) +
+				"/o/websocket/test");
 
 		webSocketContainer.connectToServer(textWebSocketClient, uri);
 
@@ -153,7 +158,9 @@ public class WebSocketEndpointTest {
 		EncodeWebSocketClient encodeWebSocketClient = new EncodeWebSocketClient(
 			synchronousQueue);
 
-		URI uri = new URI("ws://localhost:8080/o/websocket/decoder");
+		URI uri = new URI(
+			"ws://localhost:" + PortalUtil.getPortalServerPort(false) +
+				"/o/websocket/decoder");
 
 		webSocketContainer.connectToServer(encodeWebSocketClient, uri);
 

--- a/modules/dxp/apps/saml/saml-test/src/testIntegration/java/com/liferay/saml/internal/servlet/filter/test/SamlSameSiteLaxCookiesFilterTest.java
+++ b/modules/dxp/apps/saml/saml-test/src/testIntegration/java/com/liferay/saml/internal/servlet/filter/test/SamlSameSiteLaxCookiesFilterTest.java
@@ -10,6 +10,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.CompanyProviderClassTestRule;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -105,17 +106,26 @@ public class SamlSameSiteLaxCookiesFilterTest {
 
 	@Test
 	public void testACSSameSiteLaxCookiesSupport() throws Exception {
-		_execute(new URL("http://localhost:8080/c/portal/saml/acs"));
+		_execute(
+			new URL(
+				"http://localhost:" + PortalUtil.getPortalServerPort(false) +
+					"/c/portal/saml/acs"));
 	}
 
 	@Test
 	public void testSLOSameSiteLaxCookies() throws Exception {
-		_execute(new URL("http://localhost:8080/c/portal/saml/slo"));
+		_execute(
+			new URL(
+				"http://localhost:" + PortalUtil.getPortalServerPort(false) +
+					"/c/portal/saml/slo"));
 	}
 
 	@Test
 	public void testSSOSameSiteLaxCookies() throws Exception {
-		_execute(new URL("http://localhost:8080/c/portal/saml/sso"));
+		_execute(
+			new URL(
+				"http://localhost:" + PortalUtil.getPortalServerPort(false) +
+					"/c/portal/saml/sso"));
 	}
 
 	protected static SamlProviderConfigurationHelper

--- a/modules/dxp/apps/saml/saml-test/src/testIntegration/java/com/liferay/saml/internal/servlet/filter/test/SpSessionTerminationSamlPortalFilterTest.java
+++ b/modules/dxp/apps/saml/saml-test/src/testIntegration/java/com/liferay/saml/internal/servlet/filter/test/SpSessionTerminationSamlPortalFilterTest.java
@@ -15,6 +15,7 @@ import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -64,7 +65,8 @@ public class SpSessionTerminationSamlPortalFilterTest {
 				TestPropsValues.getCompanyId());
 
 			URL url = new URL(
-				"http://" + company.getVirtualHostname() + ":8080");
+				"http://" + company.getVirtualHostname() + ":" +
+					PortalUtil.getPortalServerPort(false));
 
 			HttpURLConnection httpURLConnection =
 				(HttpURLConnection)url.openConnection();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90662

## What is being fixed

Integration tests that opened live HTTP connections embedded "http://localhost:8080" or similar literals, which only worked when Tomcat happened to listen on 8080. On a worktree that binds Tomcat to a different port, every one of those tests failed with "Connection refused".

## How it is being fixed

Each affected call site now derives the port at runtime from `PortalUtil.getPortalServerPort(false)`, so the same suite runs against whatever port the bundle uses.

## Why are there no tests?

This PR itself modifies existing integration tests; those tests are the verification — they failed on non-8080 setups before and pass after the change. No additional test target exists.