### PR TITLE
LPD-90758 Point ExportImportPortlet view template to export_import.jsp

### DIFF
--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/web/internal/portlet/test/ExportImportPortletTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/web/internal/portlet/test/ExportImportPortletTest.java
@@ -1,0 +1,68 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.exportimport.web.internal.portlet.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.portlet.bridges.mvc.constants.MVCRenderConstants;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderRequest;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderResponse;
+import com.liferay.portal.kernel.theme.PortletDisplay;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portlet.test.MockLiferayPortletContext;
+
+import jakarta.portlet.Portlet;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alejandro Tardín
+ */
+@RunWith(Arquillian.class)
+public class ExportImportPortletTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testRenderWithoutMVCRenderCommand() throws Exception {
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			new MockLiferayPortletRenderRequest();
+
+		String path = "/export_import.jsp";
+
+		mockLiferayPortletRenderRequest.setAttribute(
+			MVCRenderConstants.
+				PORTLET_CONTEXT_OVERRIDE_REQUEST_ATTIBUTE_NAME_PREFIX + path,
+			new MockLiferayPortletContext(path));
+
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		mockLiferayPortletRenderRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
+
+		PortletDisplay portletDisplay = new PortletDisplay();
+
+		portletDisplay.setThemeDisplay(themeDisplay);
+
+		_portlet.render(
+			mockLiferayPortletRenderRequest,
+			new MockLiferayPortletRenderResponse());
+	}
+
+	@Inject(
+		filter = "component.name=com.liferay.exportimport.web.internal.portlet.ExportImportPortlet"
+	)
+	private Portlet _portlet;
+
+}

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/ExportImportPortlet.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/ExportImportPortlet.java
@@ -41,7 +41,7 @@ import org.osgi.service.component.annotations.Reference;
 		"jakarta.portlet.expiration-cache=0",
 		"jakarta.portlet.init-param.mvc-action-command-package-prefix=com.liferay.exportimport.web.portlet.action",
 		"jakarta.portlet.init-param.template-path=/META-INF/resources/",
-		"jakarta.portlet.init-param.view-template=/view.jsp",
+		"jakarta.portlet.init-param.view-template=/export_import.jsp",
 		"jakarta.portlet.name=" + ExportImportPortletKeys.EXPORT_IMPORT,
 		"jakarta.portlet.resource-bundle=content.Language",
 		"jakarta.portlet.security-role-ref=administrator",


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90758

## What is being fixed

The hidden `ExportImportPortlet` declared `/view.jsp` as its default view template, but that JSP was removed by LPS-143562 in 2021. Whenever the portlet was rendered without an MVC render command — for example when placed on a Content Page or instantiated by the CMS site initializer — `MVCPortlet` dispatched to the missing path and threw `jakarta.portlet.PortletException: Path /view.jsp is not accessible`, leaving a portlet-error placeholder on the page and noise in the logs.

## How it is being fixed

`jakarta.portlet.init-param.view-template` now points at `/export_import.jsp`, which is the same JSP that `ExportImportMVCRenderCommand` returns for the explicit `/export_import/export_import` command. The default render path therefore matches every other entry point into this portlet. A new integration test `ExportImportPortletTest` reproduces the original failure by rendering the portlet without an MVC render command and asserting it no longer throws.