### PR TITLE
LPD-90969 Fix test adding the comments field

### DIFF
--- a/modules/apps/batch-planner/batch-planner-rest-test/src/testIntegration/java/com/liferay/batch/planner/rest/resource/v1_0/test/FieldResourceTest.java
+++ b/modules/apps/batch-planner/batch-planner-rest-test/src/testIntegration/java/com/liferay/batch/planner/rest/resource/v1_0/test/FieldResourceTest.java
@@ -124,6 +124,7 @@ public class FieldResourceTest extends BaseFieldResourceTestCase {
 
 		assertEqualsIgnoringOrder(
 			ListUtil.fromArray(
+				_toField(null, "comments", false, "array", null),
 				_toField(null, "defaultLanguageId", false, "string", null),
 				_toField(null, "displayDate", false, "string", null),
 				_toField(null, "expirationDate", false, "string", null),


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90969

## Failing Test

`com.liferay.batch.planner.rest.resource.v1_0.test.FieldResourceTest`

`modules/apps/batch-planner/batch-planner-rest-test/src/testIntegration/java/com/liferay/batch/planner/rest/resource/v1_0/test/FieldResourceTest.java`

```
testGetPlanInternalClassNameKeyFieldsPage: java.lang.AssertionError: expected:<22> but was:<23>
  at org.junit.Assert.fail(Assert.java:89)
  at org.junit.Assert.failNotEquals(Assert.java:835)
  at org.junit.Assert.assertEquals(Assert.java:647)
  at com.liferay.batch.planner.rest.resource.v1_0.test.BaseFieldResourceTestCase.assertEqualsIgnoringOrder(BaseFieldResourceTestCase.java:309)
  at com.liferay.batch.planner.rest.resource.v1_0.test.FieldResourceTest.testGetPlanInternalClassNameKeyFieldsPage(FieldResourceTest.java:125)
```

## Root Cause

Commit `f48b6f6a094f5` ("LPD-65254 Add comments property to ObjectEntry schema") added a new `comments` property to the `ObjectEntry` schema in `modules/apps/object/object-rest-impl/rest-openapi.yaml` so comments can be exported and imported alongside object entries. The new property is neither `readOnly` nor `writeOnly`, so it surfaces through the batch planner `Field` listing endpoint, raising the response size from 22 to 23 fields and breaking the test's hardcoded size assertion.

## Fix

The `LPD-65254` story explicitly added `comments` to the export/import contract of `ObjectEntry`, so the new field is the intended behavior and the test is what needs updating. Add `comments` to the expected list in `testGetPlanInternalClassNameKeyFieldsPage` with the same shape the batch engine returns it (`type=array`, no `anyOfGroup`, not required) so the assertion matches the current schema. This mirrors the precedent set by commit `470f7b1525639` (`LPD-63787 Fix test adding the removedBy field`).

- `modules/apps/batch-planner/batch-planner-rest-test/src/testIntegration/java/com/liferay/batch/planner/rest/resource/v1_0/test/FieldResourceTest.java`