### PR TITLE
LPD-89912 Fix export test to match server rejection of empty file names

### DIFF
--- a/modules/test/playwright/tests/export-import-web/main/site.export.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/site.export.spec.ts
@@ -59,14 +59,20 @@ test('can export at site level with custom export task name', async ({
 });
 
 test(
-	'Can successfully export without file name by falling back to default',
+	'cannot export at site level without file name',
 	{tag: '@LPD-76875'},
 	async ({exportImportPage}) => {
 		await exportImportPage.goToExport();
 
-		const exportFilePath = await exportImportPage.export({taskName: ''});
+		await exportImportPage.newExportButton.click();
 
-		expect(exportFilePath).toMatch(/\/Export\.lar$/);
+		await exportImportPage.exportButton.click();
+
+		await expect(
+			exportImportPage.page.getByRole('alert').filter({
+				hasText: 'Please enter a file with a valid file name.',
+			})
+		).toBeVisible();
 	}
 );
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91069

## What is being fixed

The Playwright test "Can successfully export without file name by falling back to default" has been failing in CI since commit `b2045ac` (LPD-89090) intentionally removed the server-side fallback that converted an empty export file name to "Export". Without that fallback, submitting an export with an empty name now returns a validation error instead of creating a successful task.

## How it is being fixed

The test is reverted to its pre-LPD-88406 form: "cannot export at site level without file name". Rather than calling `exportImportPage.export({taskName: ''})` and expecting a row with status "Successful", the test now clicks the export buttons directly and asserts the "Please enter a file with a valid file name." validation alert. This matches the current server-side behavior introduced by `b2045ac`.