### PR TITLE
LPD-80406 Refresh after embedded search to avoid indexer race

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/Staging.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/Staging.testcase
@@ -1202,6 +1202,8 @@ definition {
 
 		SearchPage.searchEmbedded(searchTerm = "Category Name");
 
+		Refresh();
+
 		SearchResults.viewSearchResults(
 			searchAssetTitle = "WC WebContent Title",
 			searchAssetType = "Web Content");
@@ -1215,6 +1217,8 @@ definition {
 			siteName = "Site Name");
 
 		SearchPage.searchEmbedded(searchTerm = "Category Name");
+
+		Refresh();
 
 		SearchResults.viewSearchResults(
 			searchAssetTitle = "WC WebContent Title",


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-80406

## What is being fixed

`LocalFile.Staging#PublishContentPageWithCategory` has been failing on the headless team's master routine since 2026-02-24 with `ElementNotFoundPoshiRunnerException` on `SearchPage#RESULT_TITLE_SPECIFIC` after running an embedded search for a category-tagged Web Content. The locator and the `subtext-item` markup it targets are still produced by `portal-search-web`'s `portlet_display_template_list.ftl`, and Magdalena Jedraszak's prior triage on the same ticket confirms the result row appears once the Search page is refreshed. The failure is therefore a post-publish indexer lag, not a stale assertion.

## How it is being fixed

Refresh the Search page after each embedded search and before the `SearchResults.viewSearchResults` assertion, both on the staging side and on the live side after `Staging.publishCustomPublication()`. This matches the existing convention in the same file at lines 2253 and 2281 for the asset publisher path, which also runs a publish-then-assert step. The refresh lets the asserted index state replace the transient post-publish empty result without changing what the test asserts.

## Why are there no tests?

The change is itself a Poshi test fix; it modifies an existing test assertion path. No new tests are added.