### PR TITLE
LPD-91529 Tolerate millisecond batch-export dates in object export test

### DIFF
--- a/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/SupportExportObjectEntriesAtInstancelevel.testcase
+++ b/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/SupportExportObjectEntriesAtInstancelevel.testcase
@@ -129,10 +129,23 @@ definition {
 					property = "$.items..${fieldName}",
 					response = ${response});
 
-				BatchEngine.assertExportedFileContainsCorrectObject(
-					expectedValue = ${expectedValue},
-					fileName = "export.batch-engine-data.json",
-					jsonObject = "$.items..${fieldName}");
+				if ((${fieldName} == "dateCreated") || (${fieldName} == "dateModified")) {
+					var fileContent = TestCase.getTempFileContent(fileName = "export.batch-engine-data.json");
+
+					var actualValue = JSONUtil.getWithJSONPath(${fileContent}, "$.items..${fieldName}");
+
+					var actualValue = StringUtil.regexReplaceAll(${actualValue}, "\.\d{1,3}Z", "Z");
+
+					TestUtils.assertEquals(
+						actual = ${actualValue},
+						expected = ${expectedValue});
+				}
+				else {
+					BatchEngine.assertExportedFileContainsCorrectObject(
+						expectedValue = ${expectedValue},
+						fileName = "export.batch-engine-data.json",
+						jsonObject = "$.items..${fieldName}");
+				}
 			}
 
 			BatchEngine.assertExportedFileContainsCorrectObject(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91529

## Failing Test

`LocalFile.SupportExportObjectEntriesAtInstancelevel#CanExportSystemObjectItems`

`modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/SupportExportObjectEntriesAtInstancelevel.testcase`

```
java.lang.Exception: FAILED: expected '2026-05-20T00:00:56Z', actual was '2026-05-20T00:00:56.876Z'
```

## Root Cause

Commit `78d0868` ("LPD-85261 Use milliseconds in date formats") intentionally diverged the two Jackson serializers behind this assertion — `ObjectMapperProviderUtil.getBatchEngineObjectMapper()` switched to `yyyy-MM-dd'T'HH:mm:ss.SSS'Z'`, while `getObjectMapper()` (which the headless Account API hangs off of) still uses `ISO8601DateFormat` without milliseconds. The batch-engine integration tests were updated for the new format (`5709071`, `8ae131e`, `52063fd`), but this Poshi test was not, so its string equality between the API response and the exported file stops holding the moment the export grows a `.SSS` suffix.

## Fix

When iterating over the asserted field list, treat `dateCreated` and `dateModified` separately. Pull the exported value through `JSONUtil.getWithJSONPath`, strip the millisecond suffix with `StringUtil.regexReplaceAll`, then assert against the API value. The non-date fields keep the existing `BatchEngine.assertExportedFileContainsCorrectObject` call. The assertion now reflects the precision both serializers actually share, so the regression is gone without weakening the per-field coverage the test was already providing.

- `modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/SupportExportObjectEntriesAtInstancelevel.testcase`