### PR TITLE
LPD-91683 Tolerate millisecond precision in batch export date assertions

### DIFF
--- a/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/SupportExportObjectEntriesAtSiteLevel.testcase
+++ b/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/SupportExportObjectEntriesAtSiteLevel.testcase
@@ -125,9 +125,9 @@ definition {
 			var response = ObjectDefinitionAPI.getObjectEntries(
 				en_US_plural_label = "students",
 				scopeKey = "true");
-			var totalFieldsList = "creator,dateCreated,dateModified,externalReferenceCode,id,keywords,name,scopeKey,status";
+			var nonDateFieldsList = "creator,externalReferenceCode,id,keywords,name,scopeKey,status";
 
-			for (var fieldName : list ${totalFieldsList}) {
+			for (var fieldName : list ${nonDateFieldsList}) {
 				var expectedValue = JSONPathUtil.getProperty(
 					property = "$.items..[0]${fieldName}",
 					response = ${response});
@@ -136,6 +136,26 @@ definition {
 					expectedValue = ${expectedValue},
 					fileName = "export.json",
 					jsonObject = "$..[0]${fieldName}");
+			}
+
+			// The batch export serializes dates with millisecond precision
+			// (LPD-85261), while the headless REST response still drops them,
+			// so compare the seconds-precision prefix instead of the full value.
+
+			var dateFieldsList = "dateCreated,dateModified";
+			var exportFileContent = TestCase.getTempFileContent(fileName = "export.json");
+
+			for (var fieldName : list ${dateFieldsList}) {
+				var expectedValue = JSONPathUtil.getProperty(
+					property = "$.items..[0]${fieldName}",
+					response = ${response});
+
+				var expectedValuePrefix = StringUtil.replace(${expectedValue}, "Z", "");
+				var actualValue = JSONUtil.getWithJSONPath(${exportFileContent}, "$..[0]${fieldName}");
+
+				TestUtils.assertContain(
+					actual = ${actualValue},
+					expected = ${expectedValuePrefix});
 			}
 		}
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91683

## Failing Test

`LocalFile.SupportExportObjectEntriesAtSiteLevel#CanDownloadFileWithAllFieldsSelected`

`modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/SupportExportObjectEntriesAtSiteLevel.testcase`

```
java.lang.Exception: FAILED: expected '2026-05-20T23:51:50Z', actual was '2026-05-20T23:51:50.366Z'
```

## Root Cause

Commit `78d0868` ("LPD-85261 Use milliseconds in date formats") deliberately switched the batch-engine `ObjectMapper` in `ObjectMapperProviderUtil` to `yyyy-MM-dd'T'HH:mm:ss.SSS'Z'`, but the general vulcan `ObjectMapper` still uses `ISO8601DateFormat()` (no milliseconds). The test compares the exported value against the REST API value on the same field, so the two sides now disagree on precision.

## Fix

Split the assertion list so `dateCreated` and `dateModified` are checked separately. For those, the REST API value has its trailing `Z` stripped and the export value is asserted to contain that prefix, which tolerates the additional `.SSS` precision. Non-date fields keep the full equality check.

- `modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/SupportExportObjectEntriesAtSiteLevel.testcase`

## Why are there no tests?

This PR fixes an existing Poshi test rather than adding a new one; the regression is in test logic that no longer matches the documented contract change from LPD-85261.