### PR TITLE
LPD-91930 Normalize date precision in export field assertions

### DIFF
--- a/modules/apps/batch-engine/batch-engine-test/src/testFunctional/macros/BatchEngine.macro
+++ b/modules/apps/batch-engine/batch-engine-test/src/testFunctional/macros/BatchEngine.macro
@@ -42,6 +42,9 @@ definition {
 			var actualValue = ListUtil.sort(${actualValue});
 		}
 
+		var actualValue = StringUtil.regexReplaceFirst(${actualValue}, "\.\d+Z$", "Z");
+		var expectedValue = StringUtil.regexReplaceFirst(${expectedValue}, "\.\d+Z$", "Z");
+
 		TestUtils.assertEquals(
 			actual = ${actualValue},
 			expected = ${expectedValue});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91930

## What is being fixed

Two Poshi tests (`SupportExportObjectEntriesAtSiteLevel#CanDownloadFileWithAllFieldsSelected` and `SupportExportObjectEntriesAtInstancelevel#CanExportSystemObjectItems`) fail in CI with traces like:

    java.lang.Exception: FAILED: expected '2026-05-23T23:50:49Z', actual was '2026-05-23T23:50:49.408Z'

Both iterate `totalFieldsList` containing `dateCreated` and `dateModified`, extract each value from a fresh `GET /o/c/<plural>` REST response, and string-compare it against the value in the exported JSON file. The REST API serializes `Date` through Jackson's `ISO8601DateFormat()` (no milliseconds: `2026-05-23T23:50:49Z`), while the batch engine export uses `SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")` (with milliseconds: `2026-05-23T23:50:49.408Z`).

The divergence is intentional: the REST API prioritizes a clean public contract for human-facing clients, while the batch engine preserves full precision so export-import round trips do not lose data. The two paths encode the same instant; the test was asserting a contract narrower than the real one.

## How it is being fixed

Strip any fractional-second suffix (`\.\d+Z$`) from both expected and actual values inside `BatchEngine.assertExportedFileContainsCorrectObject` before equality. Three lines added to the macro; no caller signature changes.

The transformation is a no-op for non-date values: the 23 existing callers pass literal `expectedValue`s such as `"Math"`, `"POST,DELETE,PUT"`, `"com.liferay.object.rest.dto.v1_0.ObjectEntry"`, version strings, IDs, and JSON-path captures — none ends in `.\d+Z`, so the regex match never triggers for them. End-anchoring the regex (`$`) further reduces the chance of accidental future matches.

Product code is intentionally not touched. The two date formats serve distinct purposes that should remain divergent.

## Why are there no tests?

The change is a Poshi macro under `testFunctional/`. No production code is modified, so no new unit/integration coverage applies. Verified locally against a fresh bundle: `SupportExportObjectEntriesAtInstancelevel#CanExportSystemObjectItems` (originally red in Testray) now passes end-to-end; the other 5 testcases that consume the macro (24 call sites in total, covering names, operation enums, class names, version strings, IDs, and JSON-path captures) pass unchanged.