### PR TITLE
LPD-92652 Fix the unit tests broken by using getPortalServerPort

### DIFF
--- a/portal-impl/test/unit/com/liferay/portal/util/PortalImplEscapeRedirectTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/util/PortalImplEscapeRedirectTest.java
@@ -5,7 +5,6 @@
 
 package com.liferay.portal.util;
 
-import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.VirtualHost;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.redirect.RedirectURLSettings;
@@ -17,7 +16,6 @@ import com.liferay.portal.kernel.service.VirtualHostLocalServiceWrapper;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PrefsPropsUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsValues;
@@ -80,9 +78,7 @@ public class PortalImplEscapeRedirectTest {
 		ServiceContext serviceContext = new ServiceContext();
 
 		serviceContext.setPortalURL(
-			StringBundler.concat(
-				"https://", _HOSTNAME_PORTAL_DOMAIN, ":",
-				PortalUtil.getPortalServerPort(false)));
+			"https://" + _HOSTNAME_PORTAL_DOMAIN + ":1234");
 
 		ServiceContextThreadLocal.pushServiceContext(serviceContext);
 	}
@@ -107,46 +103,41 @@ public class PortalImplEscapeRedirectTest {
 
 		// Allow request host header
 
-		String portalURL = StringBundler.concat(
-			"https://", _HOSTNAME_PORTAL_DOMAIN, ":",
-			PortalUtil.getPortalServerPort(false));
-
-		Assert.assertEquals(portalURL, _portalImpl.escapeRedirect(portalURL));
+		Assert.assertEquals(
+			"https://" + _HOSTNAME_PORTAL_DOMAIN + ":1234",
+			_portalImpl.escapeRedirect(
+				"https://" + _HOSTNAME_PORTAL_DOMAIN + ":1234"));
 
 		// Allow virtual host
 
-		portalURL = StringBundler.concat(
-			"https://", _HOSTNAME_VIRTUAL_HOST, ":",
-			PortalUtil.getPortalServerPort(false));
-
-		Assert.assertEquals(portalURL, _portalImpl.escapeRedirect(portalURL));
+		Assert.assertEquals(
+			"https://" + _HOSTNAME_VIRTUAL_HOST + ":1234",
+			_portalImpl.escapeRedirect(
+				"https://" + _HOSTNAME_VIRTUAL_HOST + ":1234"));
 
 		// Allowed domains
 
 		Assert.assertEquals(
 			"http://localhost", _portalImpl.escapeRedirect("http://localhost"));
 
-		portalURL =
-			"https://localhost:" + PortalUtil.getPortalServerPort(false) +
-				"/a/b;c=d?e=f&g=h#x=y";
-
-		Assert.assertEquals(portalURL, _portalImpl.escapeRedirect(portalURL));
+		Assert.assertEquals(
+			"https://localhost:1234/a/b;c=d?e=f&g=h#x=y",
+			_portalImpl.escapeRedirect(
+				"https://localhost:1234/a/b;c=d?e=f&g=h#x=y"));
 
 		Assert.assertEquals(
 			"http://google.com",
 			_portalImpl.escapeRedirect("http://google.com"));
 
-		String url =
-			"https://google.com:" + PortalUtil.getPortalServerPort(false) +
-				"/a/b;c=d?e=f&g=h#x=y";
-
-		Assert.assertEquals(url, _portalImpl.escapeRedirect(url));
+		Assert.assertEquals(
+			"https://google.com:1234/a/b;c=d?e=f&g=h#x=y",
+			_portalImpl.escapeRedirect(
+				"https://google.com:1234/a/b;c=d?e=f&g=h#x=y"));
 
 		Assert.assertNull(_portalImpl.escapeRedirect("http://liferay.com"));
 		Assert.assertNull(
 			_portalImpl.escapeRedirect(
-				"https://liferay.com:" + PortalUtil.getPortalServerPort(false) +
-					"/a/b;c=d?e=f&g=h#x=y"));
+				"https://liferay.com:1234/a/b;c=d?e=f&g=h#x=y"));
 
 		// Disabled domains
 
@@ -198,12 +189,10 @@ public class PortalImplEscapeRedirectTest {
 				"http://localhost",
 				_portalImpl.escapeRedirect("http://localhost"));
 
-			String portalURL =
-				"https://localhost:" + PortalUtil.getPortalServerPort(false) +
-					"/a/b;c=d?e=f&g=h#x=y";
-
 			Assert.assertEquals(
-				portalURL, _portalImpl.escapeRedirect(portalURL));
+				"https://localhost:1234/a/b;c=d?e=f&g=h#x=y",
+				_portalImpl.escapeRedirect(
+					"https://localhost:1234/a/b;c=d?e=f&g=h#x=y"));
 
 			Set<String> computerAddresses = _portalImpl.getComputerAddresses();
 
@@ -220,9 +209,7 @@ public class PortalImplEscapeRedirectTest {
 			Assert.assertNull(_portalImpl.escapeRedirect("http://liferay.com"));
 			Assert.assertNull(
 				_portalImpl.escapeRedirect(
-					"https://liferay.com:" +
-						PortalUtil.getPortalServerPort(false) +
-							"/a/b;c=d?e=f&g=h#x=y"));
+					"https://liferay.com:1234/a/b;c=d?e=f&g=h#x=y"));
 			Assert.assertNull(
 				_portalImpl.escapeRedirect("http://127.0.0.1suffix"));
 			Assert.assertNull(
@@ -321,37 +308,33 @@ public class PortalImplEscapeRedirectTest {
 			"http://test.liferay.com",
 			_portalImpl.escapeRedirect("http://test.liferay.com"));
 
-		String portalURL =
-			"https://test.liferay.com:" +
-				PortalUtil.getPortalServerPort(false) + "/a/b;c=d?e=f&g=h#x=y";
-
-		Assert.assertEquals(portalURL, _portalImpl.escapeRedirect(portalURL));
+		Assert.assertEquals(
+			"https://test.liferay.com:1234/a/b;c=d?e=f&g=h#x=y",
+			_portalImpl.escapeRedirect(
+				"https://test.liferay.com:1234/a/b;c=d?e=f&g=h#x=y"));
 
 		Assert.assertEquals(
 			"http://second.test.liferay.com",
 			_portalImpl.escapeRedirect("http://second.test.liferay.com"));
 
-		portalURL =
-			"https://second.test.liferay.com:" +
-				PortalUtil.getPortalServerPort(false) + "/a;c=d?e=f&g=h#x=y";
-
-		Assert.assertEquals(portalURL, _portalImpl.escapeRedirect(portalURL));
+		Assert.assertEquals(
+			"https://second.test.liferay.com:1234/a;c=d?e=f&g=h#x=y",
+			_portalImpl.escapeRedirect(
+				"https://second.test.liferay.com:1234/a;c=d?e=f&g=h#x=y"));
 
 		Assert.assertEquals(
 			"http://google.com",
 			_portalImpl.escapeRedirect("http://google.com"));
 
-		String url =
-			"https://google.com:" + PortalUtil.getPortalServerPort(false) +
-				"/a/b;c=d?e=f&g=h#x=y";
-
-		Assert.assertEquals(url, _portalImpl.escapeRedirect(url));
+		Assert.assertEquals(
+			"https://google.com:1234/a/b;c=d?e=f&g=h#x=y",
+			_portalImpl.escapeRedirect(
+				"https://google.com:1234/a/b;c=d?e=f&g=h#x=y"));
 
 		Assert.assertNull(_portalImpl.escapeRedirect("http://liferay.com"));
 		Assert.assertNull(
 			_portalImpl.escapeRedirect(
-				"https://liferay.com:" + PortalUtil.getPortalServerPort(false) +
-					"/a/b;c=d?e=f&g=h#x=y"));
+				"https://liferay.com:1234/a/b;c=d?e=f&g=h#x=y"));
 		Assert.assertNull(
 			_portalImpl.escapeRedirect("http://test.liferay.comsuffix"));
 		Assert.assertNull(

--- a/portal-impl/test/unit/com/liferay/portal/util/PortalImplUnitTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/util/PortalImplUnitTest.java
@@ -325,7 +325,7 @@ public class PortalImplUnitTest {
 		MockHttpServletRequest mockHttpServletRequest =
 			new MockHttpServletRequest();
 
-		int portalServerPort = _portalImpl.getPortalServerPort(false);
+		int portalServerPort = 1234;
 
 		mockHttpServletRequest.setServerPort(portalServerPort);
 
@@ -352,12 +352,10 @@ public class PortalImplUnitTest {
 				new MockHttpServletRequest();
 
 			mockHttpServletRequest.addHeader("X-Forwarded-Custom-Port", 8081);
-			mockHttpServletRequest.setServerPort(
-				_portalImpl.getPortalServerPort(false));
+			mockHttpServletRequest.setServerPort(1234);
 
 			Assert.assertEquals(
-				_portalImpl.getPortalServerPort(false),
-				_portalImpl.getForwardedPort(mockHttpServletRequest));
+				1234, _portalImpl.getForwardedPort(mockHttpServletRequest));
 		}
 		finally {
 			setPropsValuesValue(
@@ -383,12 +381,10 @@ public class PortalImplUnitTest {
 				new MockHttpServletRequest();
 
 			mockHttpServletRequest.addHeader("X-Forwarded-Port", 8081);
-			mockHttpServletRequest.setServerPort(
-				_portalImpl.getPortalServerPort(false));
+			mockHttpServletRequest.setServerPort(1234);
 
 			Assert.assertEquals(
-				_portalImpl.getPortalServerPort(false),
-				_portalImpl.getForwardedPort(mockHttpServletRequest));
+				1234, _portalImpl.getForwardedPort(mockHttpServletRequest));
 		}
 		finally {
 			setPropsValuesValue(
@@ -411,8 +407,7 @@ public class PortalImplUnitTest {
 				new MockHttpServletRequest();
 
 			mockHttpServletRequest.addHeader("X-Forwarded-Port", "8081");
-			mockHttpServletRequest.setServerPort(
-				_portalImpl.getPortalServerPort(false));
+			mockHttpServletRequest.setServerPort(1234);
 
 			Assert.assertEquals(
 				8081, _portalImpl.getForwardedPort(mockHttpServletRequest));
@@ -443,9 +438,8 @@ public class PortalImplUnitTest {
 		_setUpPortalImpl(StringPool.BLANK);
 
 		_assertGetLayoutSetFriendlyURL(
-			"/web/test-group",
-			"http://liferay.com:" + _portalImpl.getPortalServerPort(false),
-			false, new TreeMap<>());
+			"/web/test-group", "http://liferay.com:1234", false,
+			new TreeMap<>());
 	}
 
 	@Test
@@ -455,9 +449,8 @@ public class PortalImplUnitTest {
 		_setUpPortalImpl(StringPool.BLANK);
 
 		_assertGetLayoutSetFriendlyURL(
-			"/group/test-group",
-			"http://liferay.com:" + _portalImpl.getPortalServerPort(false),
-			true, new TreeMap<>());
+			"/group/test-group", "http://liferay.com:1234", true,
+			new TreeMap<>());
 	}
 
 	@Test
@@ -467,9 +460,8 @@ public class PortalImplUnitTest {
 		_setUpPortalImpl(StringPool.BLANK, true);
 
 		_assertGetLayoutSetFriendlyURL(
-			"/user/test-group",
-			"http://liferay.com:" + _portalImpl.getPortalServerPort(false),
-			true, new TreeMap<>());
+			"/user/test-group", "http://liferay.com:1234", true,
+			new TreeMap<>());
 	}
 
 	@Test
@@ -479,9 +471,7 @@ public class PortalImplUnitTest {
 		_setUpPortalImpl(StringPool.BLANK);
 
 		_assertGetLayoutSetFriendlyURL(
-			"/web/test-group",
-			"http://liferay.com:" + _portalImpl.getPortalServerPort(false),
-			false,
+			"/web/test-group", "http://liferay.com:1234", false,
 			TreeMapBuilder.put(
 				"test.com", StringPool.BLANK
 			).build());
@@ -493,8 +483,7 @@ public class PortalImplUnitTest {
 
 		_setUpPortalImpl(StringPool.BLANK);
 
-		String portalURL = _portalImpl.getPortalURL(
-			"test.com", _portalImpl.getPortalServerPort(false), false);
+		String portalURL = _portalImpl.getPortalURL("test.com", 1234, false);
 
 		_assertGetLayoutSetFriendlyURL(
 			portalURL, portalURL, false,
@@ -511,9 +500,7 @@ public class PortalImplUnitTest {
 
 		_assertGetLayoutSetFriendlyURL(
 			"/context-path/web/test-group",
-			"http://liferay.com:" + _portalImpl.getPortalServerPort(false) +
-				"/context-path",
-			false,
+			"http://liferay.com:1234/context-path", false,
 			TreeMapBuilder.put(
 				"test.com", StringPool.BLANK
 			).build());
@@ -525,8 +512,7 @@ public class PortalImplUnitTest {
 
 		_setUpPortalImpl("context-path");
 
-		String portalURL = _portalImpl.getPortalURL(
-			"test.com", _portalImpl.getPortalServerPort(false), false);
+		String portalURL = _portalImpl.getPortalURL("test.com", 1234, false);
 
 		String portalURLWithContextPath = portalURL + "/context-path";
 
@@ -551,10 +537,8 @@ public class PortalImplUnitTest {
 			_setUpPortalImpl(StringPool.BLANK);
 
 			_assertGetLayoutSetFriendlyURL(
-				"/test-group",
-				"http://liferay.com:" + _portalImpl.getPortalServerPort(false) +
-					"",
-				false, new TreeMap<>());
+				"/test-group", "http://liferay.com:1234", false,
+				new TreeMap<>());
 		}
 		finally {
 			setPropsValuesValue(
@@ -578,9 +562,7 @@ public class PortalImplUnitTest {
 
 			_assertGetLayoutSetFriendlyURL(
 				"/context-path/test-group",
-				"http://liferay.com:" + _portalImpl.getPortalServerPort(false) +
-					"/context-path",
-				false, new TreeMap<>());
+				"http://liferay.com:1234/context-path", false, new TreeMap<>());
 		}
 		finally {
 			setPropsValuesValue(
@@ -603,9 +585,8 @@ public class PortalImplUnitTest {
 			_setUpPortalImpl(StringPool.BLANK);
 
 			_assertGetLayoutSetFriendlyURL(
-				"/group/test-group",
-				"http://liferay.com:" + _portalImpl.getPortalServerPort(false),
-				true, new TreeMap<>());
+				"/group/test-group", "http://liferay.com:1234", true,
+				new TreeMap<>());
 		}
 		finally {
 			setPropsValuesValue(
@@ -628,9 +609,8 @@ public class PortalImplUnitTest {
 			_setUpPortalImpl(StringPool.BLANK, true);
 
 			_assertGetLayoutSetFriendlyURL(
-				"/user/test-group",
-				"http://liferay.com:" + _portalImpl.getPortalServerPort(false),
-				true, new TreeMap<>());
+				"/user/test-group", "http://liferay.com:1234", true,
+				new TreeMap<>());
 		}
 		finally {
 			setPropsValuesValue(
@@ -653,9 +633,7 @@ public class PortalImplUnitTest {
 			_setUpPortalImpl(StringPool.BLANK);
 
 			_assertGetLayoutSetFriendlyURL(
-				"/test-group",
-				"http://liferay.com:" + _portalImpl.getPortalServerPort(false),
-				false,
+				"/test-group", "http://liferay.com:1234", false,
 				TreeMapBuilder.put(
 					"test.com", StringPool.BLANK
 				).build());
@@ -681,9 +659,8 @@ public class PortalImplUnitTest {
 			_setUpPortalImpl(StringPool.BLANK);
 
 			_assertGetLayoutSetFriendlyURL(
-				"/web/test-group",
-				"http://liferay.com:" + _portalImpl.getPortalServerPort(false),
-				false, new TreeMap<>());
+				"/web/test-group", "http://liferay.com:1234", false,
+				new TreeMap<>());
 		}
 		finally {
 			setPropsValuesValue(
@@ -1023,7 +1000,7 @@ public class PortalImplUnitTest {
 		themeDisplay.setRefererGroupId(0);
 		themeDisplay.setRefererPlid(0);
 		themeDisplay.setSecure(false);
-		themeDisplay.setServerPort(_portalImpl.getPortalServerPort(false));
+		themeDisplay.setServerPort(1234);
 		themeDisplay.setURLPortal(portalURL);
 
 		Assert.assertEquals(

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/util/HtmlUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/util/HtmlUtilTest.java
@@ -90,8 +90,7 @@ public class HtmlUtilTest {
 				"data:text/html;base64," +
 					"PHNjcmlwdD5hbGVydCgndGVzdDMnKTwvc2NyaXB0Pg"));
 
-		String portalURL =
-			"http://localhost:" + PortalUtil.getPortalServerPort(false);
+		String portalURL = "http://localhost:1234";
 
 		Assert.assertEquals(portalURL, HtmlUtil.escapeHREF(portalURL));
 
@@ -163,8 +162,7 @@ public class HtmlUtilTest {
 			HtmlUtil.escapeJSLink(
 				"%00javascript://localhost:800/123%0aalert(document.domain)"));
 
-		String portalURL =
-			"http://localhost:" + PortalUtil.getPortalServerPort(false);
+		String portalURL = "http://localhost:1234";
 
 		Assert.assertEquals(portalURL, HtmlUtil.escapeJSLink(portalURL));
 		Assert.assertEquals(

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/util/URLCodecTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/util/URLCodecTest.java
@@ -87,10 +87,7 @@ public class URLCodecTest {
 
 		// LPS-62628
 
-		_testDecodeURL(
-			"http://localhost:" + PortalUtil.getPortalServerPort(false) +
-				"/?id=%'",
-			false);
+		_testDecodeURL("http://localhost:1234/?id=%'", false);
 	}
 
 	@Test


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92652

## What is being fixed

LPD-89060 replaced the hardcoded 8080 port literal with `PortalUtil.getPortalServerPort(false)` in four unit tests:

- PortalImplUnitTest
- PortalImplEscapeRedirectTest
- HtmlUtilTest
- URLCodecTest

`PortalUtil._portal` is null in the unit test environment, so every call threw `NullPointerException`.

## How it is being fixed

These tests do not depend on the real server port: the value is either irrelevant test data that the code under test echoes back, or a port the test itself sets on the request and theme display. They now use a fixed port literal directly instead of calling `getPortalServerPort`, so no portal stub or property override is needed. The literal is `1234` rather than `8080` to make clear the value is arbitrary test data and to avoid mixing it up with the real default server port, which should no longer be hardcoded in tests.

## Why are there no tests?

The PR fixes existing tests and adds no new behavior, so no new tests are warranted.