### PR TITLE
LPD-92133 Apply unique suffix on friendly URL collision in publish

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/model/listener/LayoutFriendlyURLModelListener.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/model/listener/LayoutFriendlyURLModelListener.java
@@ -7,6 +7,8 @@ package com.liferay.layout.internal.model.listener;
 
 import com.liferay.batch.engine.thread.local.BatchEngineThreadLocal;
 import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
+import com.liferay.friendly.url.model.FriendlyURLEntry;
+import com.liferay.friendly.url.model.FriendlyURLEntryLocalization;
 import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
 import com.liferay.layout.friendly.url.LayoutFriendlyURLEntryHelper;
 import com.liferay.portal.kernel.exception.ModelListenerException;
@@ -14,6 +16,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.LayoutFriendlyURL;
 import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.portal.kernel.service.LayoutFriendlyURLLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.staging.StagingGroupHelper;
@@ -68,15 +71,36 @@ public class LayoutFriendlyURLModelListener
 		}
 
 		try {
+			long classNameId = _layoutFriendlyURLEntryHelper.getClassNameId(
+				layoutFriendlyURL.isPrivateLayout());
+
+			String urlTitle = layoutFriendlyURL.getFriendlyURL();
+
+			String uniqueUrlTitle = _toUniqueUrlTitle(
+				layoutFriendlyURL, classNameId, urlTitle);
+
 			_friendlyURLEntryLocalService.addFriendlyURLEntry(
-				layoutFriendlyURL.getGroupId(),
-				_layoutFriendlyURLEntryHelper.getClassNameId(
-					layoutFriendlyURL.isPrivateLayout()),
+				layoutFriendlyURL.getGroupId(), classNameId,
 				layoutFriendlyURL.getPlid(),
 				Collections.singletonMap(
-					layoutFriendlyURL.getLanguageId(),
-					layoutFriendlyURL.getFriendlyURL()),
+					layoutFriendlyURL.getLanguageId(), uniqueUrlTitle),
 				serviceContext);
+
+			if (!uniqueUrlTitle.equals(urlTitle) &&
+				!Boolean.TRUE.equals(_suppressUniqueResolution.get())) {
+
+				_suppressUniqueResolution.set(Boolean.TRUE);
+
+				try {
+					layoutFriendlyURL.setFriendlyURL(uniqueUrlTitle);
+
+					_layoutFriendlyURLLocalService.updateLayoutFriendlyURL(
+						layoutFriendlyURL);
+				}
+				finally {
+					_suppressUniqueResolution.remove();
+				}
+			}
 		}
 		catch (PortalException portalException) {
 			throw new ModelListenerException(portalException);
@@ -88,11 +112,67 @@ public class LayoutFriendlyURLModelListener
 		}
 	}
 
+	private String _toUniqueUrlTitle(
+		LayoutFriendlyURL layoutFriendlyURL, long classNameId,
+		String urlTitle) {
+
+		// Skip the lookup on the recursive update triggered by our own
+		// LayoutFriendlyURL persistence below.
+
+		if (Boolean.TRUE.equals(_suppressUniqueResolution.get())) {
+			return urlTitle;
+		}
+
+		String uniqueUrlTitle = urlTitle;
+
+		for (int i = 1;; i++) {
+			FriendlyURLEntryLocalization friendlyURLEntryLocalization =
+				_friendlyURLEntryLocalService.fetchFriendlyURLEntryLocalization(
+					layoutFriendlyURL.getGroupId(), classNameId,
+					uniqueUrlTitle);
+
+			if ((friendlyURLEntryLocalization == null) ||
+				(friendlyURLEntryLocalization.getClassPK() ==
+					layoutFriendlyURL.getPlid())) {
+
+				return uniqueUrlTitle;
+			}
+
+			// A localization whose owning FriendlyURLEntry is no longer the
+			// main entry of its layout is a stale redirect; release it so the
+			// current layout can claim the URL.
+
+			FriendlyURLEntry currentFriendlyURLEntry =
+				_friendlyURLEntryLocalService.fetchMainFriendlyURLEntry(
+					classNameId, friendlyURLEntryLocalization.getClassPK());
+
+			if ((currentFriendlyURLEntry == null) ||
+				(currentFriendlyURLEntry.getFriendlyURLEntryId() !=
+					friendlyURLEntryLocalization.getFriendlyURLEntryId())) {
+
+				_friendlyURLEntryLocalService.
+					deleteFriendlyURLLocalizationEntry(
+						friendlyURLEntryLocalization.getFriendlyURLEntryId(),
+						friendlyURLEntryLocalization.getLanguageId());
+
+				return uniqueUrlTitle;
+			}
+
+			uniqueUrlTitle = urlTitle + i;
+		}
+	}
+
+	private static final ThreadLocal<Boolean> _suppressUniqueResolution =
+		new ThreadLocal<>();
+
 	@Reference
 	private FriendlyURLEntryLocalService _friendlyURLEntryLocalService;
 
 	@Reference
 	private LayoutFriendlyURLEntryHelper _layoutFriendlyURLEntryHelper;
+
+	@Reference
+	private LayoutFriendlyURLLocalService _layoutFriendlyURLLocalService;
 
 	@Reference
 	private StagingGroupHelper _stagingGroupHelper;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92179

## Failing Test

`com.liferay.staging.test.StagingLayoutFriendlyURLTest#testLayoutFriendlyURL`

`modules/apps/staging/staging-test/src/testIntegration/java/com/liferay/staging/test/StagingLayoutFriendlyURLTest.java`

```
testLayoutFriendlyURL: org.junit.ComparisonFailure: expected:</t[est1]> but was:</t[iipw8xy]>
	at org.junit.Assert.assertEquals(Assert.java:117)
	at org.junit.Assert.assertEquals(Assert.java:146)
	at com.liferay.staging.test.StagingLayoutFriendlyURLTest.testLayoutFriendlyURL(StagingLayoutFriendlyURLTest.java:88)
```

## Root Cause

Commit `8c52863` ("LPD-79715 Removing promote content ff from code") removed the LPD-35914 feature-flag gates that kept the legacy staging-publish path active, making the batch-engine layout-import path permanent on master. That path drives the layout update through LayoutFriendlyURL persistence which fires LayoutFriendlyURLModelListener; the listener called addFriendlyURLEntry unconditionally, so the moment a staging friendly URL collided with one already used on the live group, DuplicateFriendlyURLEntryException was thrown, the per-item transaction rolled back, the batch-engine swallowed the error (its import strategy isn't ON_ERROR_FAIL), and the live layout silently kept its original auto-generated URL while the publish reported success.

## Fix

In LayoutFriendlyURLModelListener._addFriendlyURLEntry, resolve the URL title before calling addFriendlyURLEntry: walk uniqueUrlTitle = urlTitle + i until either no localization exists, the existing localization already belongs to the current layout, or the existing localization is stale (its owning FriendlyURLEntry is no longer the main entry of its layout). Stale localizations are deleted so the current layout can reclaim the URL when the collision is resolved. When the uniqueUrlTitle differs from the input, the LayoutFriendlyURL entity is updated to match (guarded by a ThreadLocal to prevent recursive resolution).

- `modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/model/listener/LayoutFriendlyURLModelListener.java`