### PR TITLE
LPD-92206 Update Configuration.path move-boxes locators for ClayDualListBox

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Configuration.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Configuration.path
@@ -55,12 +55,12 @@
 </tr>
 <tr>
 	<td>MOVE_AVAILABLE_TO_CURRENT</td>
-	<td>xpath=(//*[contains(@id,'${key_configuration}')] | //div[*[contains(@class,'${key_configuration}')]])//button[@title='Move selected items from Available to In Use.']</td>
+	<td>//button[@aria-label='Move selected items from Available to In Use.']</td>
 	<td></td>
 </tr>
 <tr>
 	<td>MOVE_CURRENT_TO_AVAILABLE</td>
-	<td>xpath=(//*[contains(@id,'${key_configuration}')] | //div[*[contains(@class,'${key_configuration}')]])//button[@title='Move selected items from In Use to Available.']</td>
+	<td>//button[@aria-label='Move selected items from In Use to Available.']</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92206

## Failing Test

`LocalFile.StagingUsecase#AssertAssetPriorityNotBeResetAfterPublication`

`portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/StagingUsecase.testcase`

```
java.lang.Exception: Element is not present at "xpath=(//*[contains(@id,'metadataContent')] | //div[*[contains(@class,'metadataContent')]])//button[@title='Move selected items from Available to In Use.']"
```

## Root Cause

Commit `b2129c56a3038` ("LPD-54241 - Remove input-move-boxes component and use ClayDualListBox") deliberately replaced the legacy `Liferay.InputMoveBoxes` JS widget with the React `ClayDualListBox` component. The new component exposes the move buttons via `@aria-label` instead of `@title` and no longer renders a `metadataContent` wrapper, so the legacy XPath in `Configuration.path` can no longer match.

The same fix was applied to `Button.path`'s equivalent locators in `7b6afce6baeca` ("LPD-74177 Update broken tests"); `Configuration.path` was missed and has kept this test (and `AssetPublisherUseCase`'s metadata assertions) failing on the headless team routine since 2025-04-29.

## Fix

Update the two move-boxes locators in `Configuration.path` to match the ClayDualListBox DOM by targeting `@aria-label` and dropping the obsolete `metadataContent` scoping. This mirrors what LPD-74177 did to `Button.path` for the same UI element.

- `portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Configuration.path`