### PR TITLE
LPD-92249 Expect collaborator removal when its ticket is deleted

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/CollaboratorResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/CollaboratorResourceTest.java
@@ -631,6 +631,15 @@ public class CollaboratorResourceTest {
 				"/collaborators/by-email-address/", emailAddress),
 			Http.Method.PUT);
 
+		jsonObject = HTTPTestUtil.invokeToJSONObject(
+			null,
+			StringBundler.concat(
+				_objectDefinition.getRESTContextPath(), StringPool.SLASH,
+				objectEntry.getObjectEntryId(), "/collaborators"),
+			Http.Method.GET);
+
+		Assert.assertEquals(4, jsonObject.getInt("totalCount"));
+
 		Ticket ticket = _fetchTicketByEmailAddress(
 			objectEntry.getModelClassName(), objectEntry.getObjectEntryId(),
 			emailAddress);
@@ -644,7 +653,7 @@ public class CollaboratorResourceTest {
 				objectEntry.getObjectEntryId(), "/collaborators"),
 			Http.Method.GET);
 
-		Assert.assertEquals(4, jsonObject.getInt("totalCount"));
+		Assert.assertEquals(3, jsonObject.getInt("totalCount"));
 	}
 
 	@Test


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92249

## Failing Test

`com.liferay.object.rest.internal.resource.v1_0.test.CollaboratorResourceTest`

`modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/CollaboratorResourceTest.java`

```
testGetObjectEntryCollaboratorsPage: java.lang.AssertionError: expected:<4> but was:<3>
  at org.junit.Assert.fail(Assert.java:89)
  at org.junit.Assert.failNotEquals(Assert.java:835)
  at org.junit.Assert.assertEquals(Assert.java:647)
```

## Root Cause

Commit `16ae36b2335d` ("LPD-89500 create TicketModelListener to delete sharing entries same as UserGroupModelListener and UserModelListener") added a `TicketModelListener` whose `onBeforeRemove` cascade-deletes the `SharingEntry` rows that point to a ticket. The test creates an email collaborator (which generates an invitation ticket plus its sharing entry), deletes that ticket, and then expected the collaborator to remain, so the total count was asserted to stay at 4 when it now drops to 3.

## Fix

Adapt the test to the new cascade-delete contract: assert the email collaborator is listed (total count 4) while its invitation ticket exists, then assert it is removed (total count 3) once the ticket is deleted.

- `modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/CollaboratorResourceTest.java`