### PR TITLE
LPD-92255 Enter a file name before exporting the mapped image site

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/site/SitesExportImport.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/site/SitesExportImport.testcase
@@ -352,6 +352,11 @@ definition {
 
 			LexiconEntry.gotoAdd();
 
+			Type(
+				inputFieldId = "ExportPortlet_name",
+				locator1 = "TextInput#INPUT_ID",
+				value1 = "Test Site Name");
+
 			LAR.exportWithAssertionOnSuccess();
 
 			LAR.downloadLar();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92255

## Failing Test

`LocalFile.SitesExportImport#ExportImportSiteWithMappedImage`

`portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/site/SitesExportImport.testcase`

```
com.liferay.poshi.runner.exception.ElementNotFoundPoshiRunnerException: Element is not present at "//tr[1]/td[2]//div[contains(@class,'h5')] | //span[contains(@data-qa-id,'processResult')]"
	at LAR.exportWithAssertionOnSuccess(.../macros/LAR.macro:693)
	at SitesExportImport.ExportImportSiteWithMappedImage(.../SitesExportImport.testcase:355)
```

## Root Cause

Commit `b2045ac` ("LPD-89090 Reject export submissions without a file name") removed the fallback in `ExportLayoutsMVCActionCommand` that substituted a localized "Export" default for an empty export name, completing the LPD-76875 contract that makes the export file name mandatory in the UI. The test clicked **Export** without entering a Title, so the server threw `LARFileNameException` ("Please enter a file with a valid file name"), the export never ran, and the "Successful" process result row never rendered.

## Fix

Enter a file name into the export form before submitting, matching the existing `_exportSite` / `exportExportTemplateCP` convention (`Type` into `ExportPortlet_name`). With a valid name the export proceeds, the process row shows "Successful", and the downstream import/assert steps run as before.

- `portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/site/SitesExportImport.testcase`
