### PR TITLE
LPD-92262 Increase com.liferay.portal.vulcan.util to version 12.4.0

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/util/packageinfo
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/util/packageinfo
@@ -1,1 +1,1 @@
-version 12.3.0
+version 12.4.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92262

## Failing Test

`modules-semantic-versioning[modules/apps/portal-vulcan]`

`modules/apps/portal-vulcan/portal-vulcan-api`

```
baseline:  > modules/apps/portal-vulcan/portal-vulcan-api/build/reports/baseline/baseline.log

  PACKAGE_NAME                       DELTA   CUR_VER  BASE_VER  REC_VER  WARNINGS
* com.liferay.portal.vulcan.util     MINOR   12.3.0   12.3.0    12.4.0   VERSION INCREASE REQUIRED
    <   class    com.liferay.portal.vulcan.util.ActionUtil
        +   method   addAction(java.lang.String,java.lang.Class,java.lang.Long,java.lang.String,java.lang.Object,java.lang.Long,java.lang.String,java.lang.Long,java.util.Map,jakarta.ws.rs.core.UriInfo)
            +   access   static
            +   return   java.util.Map
```

## Root Cause

The package `com.liferay.portal.vulcan.util` declares version `12.3.0`, but its public API exceeds what the released baseline artifact `com.liferay.portal.vulcan.api-48.6.2` records for that version, so the bnd baseline check requires a MINOR increase to `12.4.0`.

The flagged method, `ActionUtil.addAction(String, Class, Long, String, Object, Long, String, Long, Map, UriInfo)`, is not itself the defect: it was added back in 2023 by commit `1283d4e` ("LPS-189508 Adding support for custom url template params"), which correctly bumped the package version `11.3.0` → `11.4.0` at the same time.

The check flipped from passing to failing on 2026-04-28 with no change to `portal-vulcan` source — across that boundary the package version stayed `12.3.0` and the method was neither added nor removed. The trigger was the release commit `4b07d80` ("artifact:ignore portal-vulcan-api 48.6.2 prep next", 2026-04-26), which bumped `Bundle-Version` `48.6.2` → `48.6.3`. From that point the baseline compares the current source against the published `48.6.2` artifact, whose `com.liferay.portal.vulcan.util` package (at `12.3.0`) carries less API than the current source at the same version. In other words, version `12.3.0` (last set by `4588982`, "LPD-74573 baseline", 2026-01-27) was consumed by the `48.6.2` release while the package API had grown, and the release surfaced the missing version bump.

## Fix

Increment the `com.liferay.portal.vulcan.util` package version from `12.3.0` to `12.4.0`, the value recommended by the baseline report for a MINOR API addition. This is the version that `./gradlew baseline` (via its `syncVersions` step) writes, and with it `./gradlew baseline` for `portal-vulcan-api` passes.

- `modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/util/packageinfo`
