### PR TITLE
LPD-75473 Fix HSQLDB deadlock during batch engine task updates

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -9850,6 +9850,10 @@ ${output.content}</echo>
 		<run-playwright-js-test app.server.type="wildfly" database.type="mariadb" />
 	</target>
 
+	<target name="playwright-js-tomcat101-hypersonic20">
+		<run-playwright-js-test database.type="hypersonic" />
+	</target>
+
 	<target name="playwright-js-tomcat101-mysql84">
 		<run-playwright-js-test database.type="mysql" />
 	</target>

--- a/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/service/BatchEngineExportTaskLocalService.java
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/service/BatchEngineExportTaskLocalService.java
@@ -343,8 +343,9 @@ public interface BatchEngineExportTaskLocalService
 	 * @return the batch engine export task that was updated
 	 */
 	@Indexable(type = IndexableType.REINDEX)
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	public BatchEngineExportTask updateBatchEngineExportTask(
 		BatchEngineExportTask batchEngineExportTask);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:753350967
+// LIFERAY-SERVICE-BUILDER-HASH:-587742894

--- a/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/service/BatchEngineImportTaskLocalService.java
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/service/BatchEngineImportTaskLocalService.java
@@ -352,8 +352,9 @@ public interface BatchEngineImportTaskLocalService
 	 * @return the batch engine import task that was updated
 	 */
 	@Indexable(type = IndexableType.REINDEX)
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	public BatchEngineImportTask updateBatchEngineImportTask(
 		BatchEngineImportTask batchEngineImportTask);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-964169574
+// LIFERAY-SERVICE-BUILDER-HASH:1324455093

--- a/modules/apps/batch-engine/batch-engine-api/src/main/resources/com/liferay/batch/engine/service/packageinfo
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/resources/com/liferay/batch/engine/service/packageinfo
@@ -1,1 +1,1 @@
-version 6.1.0
+version 6.1.1

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/service/impl/BatchEngineExportTaskLocalServiceImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/service/impl/BatchEngineExportTaskLocalServiceImpl.java
@@ -108,4 +108,12 @@ public class BatchEngineExportTaskLocalServiceImpl
 		return batchEngineExportTaskPersistence.countByCompanyId(companyId);
 	}
 
+	@Override
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public BatchEngineExportTask updateBatchEngineExportTask(
+		BatchEngineExportTask batchEngineExportTask) {
+
+		return super.updateBatchEngineExportTask(batchEngineExportTask);
+	}
+
 }

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/service/impl/BatchEngineImportTaskLocalServiceImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/service/impl/BatchEngineImportTaskLocalServiceImpl.java
@@ -156,6 +156,14 @@ public class BatchEngineImportTaskLocalServiceImpl
 		return batchEngineImportTaskPersistence.countByCompanyId(companyId);
 	}
 
+	@Override
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public BatchEngineImportTask updateBatchEngineImportTask(
+		BatchEngineImportTask batchEngineImportTask) {
+
+		return super.updateBatchEngineImportTask(batchEngineImportTask);
+	}
+
 	private void _validateDelimiter(String delimiter)
 		throws BatchEngineImportTaskParametersException {
 

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BaseBatchEngineTaskServiceTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BaseBatchEngineTaskServiceTest.java
@@ -12,10 +12,20 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.transaction.Propagation;
+import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -50,10 +60,66 @@ public class BaseBatchEngineTaskServiceTest {
 		CompanyLocalServiceUtil.deleteCompany(company);
 	}
 
+	protected void assertConcurrentRunnables(
+			CheckedRunnable runnable1, CheckedRunnable runnable2)
+		throws Exception {
+
+		AtomicReference<Throwable> throwableReference = new AtomicReference<>();
+
+		ExecutorService executorService = Executors.newFixedThreadPool(2);
+
+		Future<?> future1 = executorService.submit(
+			() -> {
+				try {
+					runnable1.run();
+				}
+				catch (Throwable throwable) {
+					throwableReference.compareAndSet(null, throwable);
+				}
+			});
+
+		Future<?> future2 = executorService.submit(
+			() -> {
+				try {
+					runnable2.run();
+				}
+				catch (Throwable throwable) {
+					throwableReference.compareAndSet(null, throwable);
+				}
+			});
+
+		try {
+			future1.get(10, TimeUnit.SECONDS);
+			future2.get(10, TimeUnit.SECONDS);
+		}
+		catch (TimeoutException timeoutException) {
+			throw new AssertionError(timeoutException);
+		}
+		finally {
+			future1.cancel(true);
+			future2.cancel(true);
+
+			executorService.shutdownNow();
+		}
+
+		Assert.assertNull(throwableReference.get());
+	}
+
+	protected static final TransactionConfig REQUIRED_TRANSACTION_CONFIG =
+		TransactionConfig.Factory.create(
+			Propagation.REQUIRED, new Class<?>[] {Exception.class});
+
 	protected static Company company;
 	protected static User companyAdminUser;
 	protected static Company defaultCompany;
 	protected static User omniadminUser;
 	protected static User user;
+
+	@FunctionalInterface
+	protected interface CheckedRunnable {
+
+		public void run() throws Throwable;
+
+	}
 
 }

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BaseBatchEngineTaskServiceTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BaseBatchEngineTaskServiceTest.java
@@ -15,6 +15,7 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -42,6 +43,11 @@ public class BaseBatchEngineTaskServiceTest {
 		companyAdminUser = UserTestUtil.addCompanyAdminUser(company);
 
 		user = UserTestUtil.addUser(company);
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		CompanyLocalServiceUtil.deleteCompany(company);
 	}
 
 	protected static Company company;

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BatchEngineExportTaskServiceTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BatchEngineExportTaskServiceTest.java
@@ -274,13 +274,13 @@ public class BatchEngineExportTaskServiceTest
 			_batchEngineExportTaskLocalService.addBatchEngineExportTask(
 				null, omniadminUser.getCompanyId(), omniadminUser.getUserId(),
 				null, BlogPosting.class.getName(), "JSON",
-				BatchEngineTaskExecuteStatus.COMPLETED.name(),
+				BatchEngineTaskExecuteStatus.INITIAL.name(),
 				Collections.emptyList(), null, null);
 		BatchEngineExportTask batchEngineExportTask2 =
 			_batchEngineExportTaskLocalService.addBatchEngineExportTask(
 				null, omniadminUser.getCompanyId(), omniadminUser.getUserId(),
 				null, BlogPosting.class.getName(), "JSON",
-				BatchEngineTaskExecuteStatus.COMPLETED.name(),
+				BatchEngineTaskExecuteStatus.INITIAL.name(),
 				Collections.emptyList(), null, null);
 
 		CountDownLatch countDownLatch1 = new CountDownLatch(1);

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BatchEngineExportTaskServiceTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BatchEngineExportTaskServiceTest.java
@@ -17,6 +17,7 @@ import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.test.rule.Inject;
 
@@ -24,6 +25,7 @@ import java.io.Serializable;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 
 import org.hamcrest.CoreMatchers;
 
@@ -266,13 +268,70 @@ public class BatchEngineExportTaskServiceTest
 				QueryUtil.ALL_POS));
 	}
 
+	@Test
+	public void testUpdateBatchEngineExportTask() throws Exception {
+		BatchEngineExportTask batchEngineExportTask1 =
+			_batchEngineExportTaskLocalService.addBatchEngineExportTask(
+				null, omniadminUser.getCompanyId(), omniadminUser.getUserId(),
+				null, BlogPosting.class.getName(), "JSON",
+				BatchEngineTaskExecuteStatus.COMPLETED.name(),
+				Collections.emptyList(), null, null);
+		BatchEngineExportTask batchEngineExportTask2 =
+			_batchEngineExportTaskLocalService.addBatchEngineExportTask(
+				null, omniadminUser.getCompanyId(), omniadminUser.getUserId(),
+				null, BlogPosting.class.getName(), "JSON",
+				BatchEngineTaskExecuteStatus.COMPLETED.name(),
+				Collections.emptyList(), null, null);
+
+		CountDownLatch countDownLatch1 = new CountDownLatch(1);
+		CountDownLatch countDownLatch2 = new CountDownLatch(1);
+
+		assertConcurrentRunnables(
+			() -> TransactionInvokerUtil.invoke(
+				REQUIRED_TRANSACTION_CONFIG,
+				() -> {
+					batchEngineExportTask1.setExecuteStatus(
+						BatchEngineTaskExecuteStatus.COMPLETED.name());
+
+					_batchEngineExportTaskLocalService.
+						updateBatchEngineExportTask(batchEngineExportTask1);
+
+					countDownLatch1.countDown();
+
+					countDownLatch2.await();
+
+					return null;
+				}),
+			() -> {
+				countDownLatch1.await();
+
+				try {
+					TransactionInvokerUtil.invoke(
+						REQUIRED_TRANSACTION_CONFIG,
+						() -> {
+							batchEngineExportTask2.setExecuteStatus(
+								BatchEngineTaskExecuteStatus.COMPLETED.name());
+
+							_batchEngineExportTaskLocalService.
+								updateBatchEngineExportTask(
+									batchEngineExportTask2);
+
+							return null;
+						});
+				}
+				finally {
+					countDownLatch2.countDown();
+				}
+			});
+	}
+
 	private BatchEngineExportTask _addBatchEngineExportTask(User user)
 		throws Exception {
 
 		return _batchEngineExportTaskLocalService.addBatchEngineExportTask(
 			null, user.getCompanyId(), user.getUserId(), null,
 			BlogPosting.class.getName(), "JSON",
-			BatchEngineTaskExecuteStatus.INITIAL.name(),
+			BatchEngineTaskExecuteStatus.COMPLETED.name(),
 			Collections.emptyList(),
 			HashMapBuilder.<String, Serializable>put(
 				"siteId", TestPropsValues.getGroupId()

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BatchEngineImportTaskServiceTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BatchEngineImportTaskServiceTest.java
@@ -266,14 +266,14 @@ public class BatchEngineImportTaskServiceTest
 			_batchEngineImportTaskLocalService.addBatchEngineImportTask(
 				null, omniadminUser.getCompanyId(), omniadminUser.getUserId(),
 				10, null, BlogPosting.class.getName(), new byte[0], "JSON",
-				BatchEngineTaskExecuteStatus.COMPLETED.name(), null,
+				BatchEngineTaskExecuteStatus.INITIAL.name(), null,
 				BatchEngineImportTaskConstants.IMPORT_STRATEGY_ON_ERROR_FAIL,
 				BatchEngineTaskOperation.CREATE.name(), new HashMap<>(), null);
 		BatchEngineImportTask batchEngineImportTask2 =
 			_batchEngineImportTaskLocalService.addBatchEngineImportTask(
 				null, omniadminUser.getCompanyId(), omniadminUser.getUserId(),
 				10, null, BlogPosting.class.getName(), new byte[0], "JSON",
-				BatchEngineTaskExecuteStatus.COMPLETED.name(), null,
+				BatchEngineTaskExecuteStatus.INITIAL.name(), null,
 				BatchEngineImportTaskConstants.IMPORT_STRATEGY_ON_ERROR_FAIL,
 				BatchEngineTaskOperation.CREATE.name(), new HashMap<>(), null);
 

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BatchEngineImportTaskServiceTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BatchEngineImportTaskServiceTest.java
@@ -18,10 +18,12 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
 import com.liferay.portal.test.rule.Inject;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 
 import org.hamcrest.CoreMatchers;
 
@@ -258,13 +260,72 @@ public class BatchEngineImportTaskServiceTest
 				QueryUtil.ALL_POS));
 	}
 
+	@Test
+	public void testUpdateBatchEngineImportTask() throws Exception {
+		BatchEngineImportTask batchEngineImportTask1 =
+			_batchEngineImportTaskLocalService.addBatchEngineImportTask(
+				null, omniadminUser.getCompanyId(), omniadminUser.getUserId(),
+				10, null, BlogPosting.class.getName(), new byte[0], "JSON",
+				BatchEngineTaskExecuteStatus.COMPLETED.name(), null,
+				BatchEngineImportTaskConstants.IMPORT_STRATEGY_ON_ERROR_FAIL,
+				BatchEngineTaskOperation.CREATE.name(), new HashMap<>(), null);
+		BatchEngineImportTask batchEngineImportTask2 =
+			_batchEngineImportTaskLocalService.addBatchEngineImportTask(
+				null, omniadminUser.getCompanyId(), omniadminUser.getUserId(),
+				10, null, BlogPosting.class.getName(), new byte[0], "JSON",
+				BatchEngineTaskExecuteStatus.COMPLETED.name(), null,
+				BatchEngineImportTaskConstants.IMPORT_STRATEGY_ON_ERROR_FAIL,
+				BatchEngineTaskOperation.CREATE.name(), new HashMap<>(), null);
+
+		CountDownLatch countDownLatch1 = new CountDownLatch(1);
+		CountDownLatch countDownLatch2 = new CountDownLatch(1);
+
+		assertConcurrentRunnables(
+			() -> TransactionInvokerUtil.invoke(
+				REQUIRED_TRANSACTION_CONFIG,
+				() -> {
+					batchEngineImportTask1.setExecuteStatus(
+						BatchEngineTaskExecuteStatus.COMPLETED.name());
+
+					_batchEngineImportTaskLocalService.
+						updateBatchEngineImportTask(batchEngineImportTask1);
+
+					countDownLatch1.countDown();
+
+					countDownLatch2.await();
+
+					return null;
+				}),
+			() -> {
+				countDownLatch1.await();
+
+				try {
+					TransactionInvokerUtil.invoke(
+						REQUIRED_TRANSACTION_CONFIG,
+						() -> {
+							batchEngineImportTask2.setExecuteStatus(
+								BatchEngineTaskExecuteStatus.COMPLETED.name());
+
+							_batchEngineImportTaskLocalService.
+								updateBatchEngineImportTask(
+									batchEngineImportTask2);
+
+							return null;
+						});
+				}
+				finally {
+					countDownLatch2.countDown();
+				}
+			});
+	}
+
 	private BatchEngineImportTask _addBatchEngineImportTask(User user)
 		throws Exception {
 
 		return _batchEngineImportTaskLocalService.addBatchEngineImportTask(
 			null, user.getCompanyId(), user.getUserId(), 10, null,
 			BlogPosting.class.getName(), new byte[0], "JSON",
-			BatchEngineTaskExecuteStatus.INITIAL.name(), null,
+			BatchEngineTaskExecuteStatus.COMPLETED.name(), null,
 			BatchEngineImportTaskConstants.IMPORT_STRATEGY_ON_ERROR_FAIL,
 			BatchEngineTaskOperation.CREATE.name(), new HashMap<>(), null);
 	}

--- a/modules/apps/batch-engine/test.properties
+++ b/modules/apps/batch-engine/test.properties
@@ -6,6 +6,10 @@ modified.files.includes[relevant][batch-engine-java-rule]=\
 modules.includes.required.test.batch.class.names.includes[batch-engine-java-rule][relevant][modules-integration-db-partition-postgresql163]=\
     apps/batch-engine/**/BatchEngineUnitProcessorImplDBPartitionTest.java
 
+modules.includes.required.test.batch.class.names.includes[modules-integration-hypersonic20][relevant][batch-engine-java-rule]=\
+    apps/batch-engine/**/BatchEngineExportTaskServiceTest.java,\
+    apps/batch-engine/**/BatchEngineImportTaskServiceTest.java
+
 modules.includes.required.test.batch.class.names.includes[modules-integration-postgresql163][relevant][batch-engine-java-rule]=\
     apps/batch-engine/**/*Test.java,\
     util/portal-tools-rest-builder-test-test/**/exportimport/test/*Test.java
@@ -17,6 +21,7 @@ relevant.rule.names=batch-engine-java-rule
 
 test.batch.names[relevant][batch-engine-java-rule]=\
     modules-integration-db-partition-postgresql163,\
+    modules-integration-hypersonic20,\
     modules-integration-postgresql163,\
     modules-unit
 

--- a/modules/test/playwright/tests/export-import-web/main/site.import.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/site.import.spec.ts
@@ -95,24 +95,6 @@ const testWithDeprecationFF = mergeTests(
 	uiElementsPageTest
 );
 
-export const testWithExportImportAtInstanceLevelFF = mergeTests(
-	companyExportImportPageTest,
-	dataApiHelpersTest,
-	depotAdminPageTest,
-	exportImportPagesTest,
-	featureFlagsTest({
-		'LPD-17564': {enabled: true},
-		'LPD-35443': {enabled: true},
-		'LPD-44307': {enabled: true},
-		'LPD-44771': {enabled: true},
-		'LPD-45276': {enabled: true},
-	}),
-	isolatedSiteTest,
-	loginTest(),
-	styleBookPageTest,
-	uiElementsPageTest
-);
-
 const testWithObjectExportImportFF = mergeTests(
 	assetCategoriesPagesTest,
 	dataApiHelpersTest,

--- a/modules/test/playwright/tests/export-import-web/main/site.import.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/site.import.spec.ts
@@ -25,6 +25,7 @@ import {uiElementsPageTest} from '../../../fixtures/uiElementsTest';
 import {usersAndOrganizationsPagesTest} from '../../../fixtures/usersAndOrganizationsPagesTest';
 import {wikiPagesTest} from '../../../fixtures/wikiPagesTest';
 import {DataApiHelpers} from '../../../helpers/ApiHelpers';
+import {createCategories} from '../../../helpers/CreateCategories';
 import {liferayConfig} from '../../../liferay.config';
 import {HomePage} from '../../../pages/portal-web/HomePage';
 import {getRandomInt} from '../../../utils/getRandomInt';
@@ -34,6 +35,7 @@ import {openFieldset} from '../../../utils/openFieldset';
 import {performLoginViaApi} from '../../../utils/performLogin';
 import {PORTLET_URLS} from '../../../utils/portletUrls';
 import {readFileFromZip} from '../../../utils/zip';
+import {assetCategoriesPagesTest} from '../../asset-categories-admin-web/main/fixtures/assetCategoriesAdminPagesTest';
 import {companyExportImportPageTest} from './fixtures/companyExportImportPagesTest';
 import {exportImportPagesTest} from './fixtures/exportImportPagesTest';
 import {stagingPageTest} from './fixtures/stagingPageTest';
@@ -91,6 +93,109 @@ const testWithDeprecationFF = mergeTests(
 	}),
 	loginTest(),
 	uiElementsPageTest
+);
+
+export const testWithExportImportAtInstanceLevelFF = mergeTests(
+	companyExportImportPageTest,
+	dataApiHelpersTest,
+	depotAdminPageTest,
+	exportImportPagesTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+		'LPD-35443': {enabled: true},
+		'LPD-44307': {enabled: true},
+		'LPD-44771': {enabled: true},
+		'LPD-45276': {enabled: true},
+	}),
+	isolatedSiteTest,
+	loginTest(),
+	styleBookPageTest,
+	uiElementsPageTest
+);
+
+const testWithObjectExportImportFF = mergeTests(
+	assetCategoriesPagesTest,
+	dataApiHelpersTest,
+	exportImportPagesTest,
+	featureFlagsTest({'LPD-35443': {enabled: true}}),
+	isolatedSiteTest,
+	loginTest()
+);
+
+testWithObjectExportImportFF(
+	'Can export and import vocabularies and categories',
+	{tag: '@LPD-75473'},
+	async ({apiHelpers, assetCategoriesAdminPage, exportImportPage, site}) => {
+		const categoryNames = [
+			{name: getRandomString()},
+			{name: getRandomString()},
+		];
+		const vocabularyName = getRandomString();
+
+		const categories: Array<any> = await createCategories({
+			apiHelpers,
+			categoryNames,
+			siteId: site.id,
+			vocabularyName,
+		});
+
+		apiHelpers.data.push({
+			id: categories[0].vocabularyId,
+			type: 'taxonomyVocabulary',
+		});
+
+		await exportImportPage.goToExport(site.friendlyUrlPath);
+
+		const exportFilePath = await exportImportPage.export({
+			portletLabels: [`Categories 3 Items`],
+		});
+
+		const content1 = await readFileFromZip(
+			'TaxonomyVocabularyResourceImpl.json',
+			exportFilePath
+		);
+
+		expect(JSON.parse(content1).length).toBe(1);
+
+		const content2 = await readFileFromZip(
+			'TaxonomyCategoryResourceImpl.json',
+			exportFilePath
+		);
+
+		expect(JSON.parse(content2).length).toBe(2);
+
+		expect(
+			await apiHelpers.headlessAdminTaxonomy.deleteTaxonomyVocabulary(
+				categories[0].vocabularyId
+			)
+		).toBeOK();
+
+		await assetCategoriesAdminPage.goto(site.friendlyUrlPath);
+
+		await expect(
+			assetCategoriesAdminPage.page.getByRole('menuitem', {
+				exact: true,
+				name: vocabularyName,
+			})
+		).not.toBeVisible();
+
+		await exportImportPage.goToImport(site.friendlyUrlPath);
+
+		await exportImportPage.import({
+			filePath: exportFilePath,
+			taskStatus: 'success',
+		});
+
+		await assetCategoriesAdminPage.goto(site.friendlyUrlPath);
+
+		await assetCategoriesAdminPage.gotoVocabulary(vocabularyName);
+
+		for (const {name} of categoryNames) {
+			await expect(
+				assetCategoriesAdminPage.page.getByRole('row', {name})
+			).toBeVisible();
+		}
+	}
 );
 
 test('Can export and import custom object entries at site level', async ({

--- a/test.properties
+++ b/test.properties
@@ -4200,7 +4200,8 @@
         **/portal-security/portal-security-ldap-impl/**/*Test.java
 
     test.batch.class.names.includes[modules-integration-hypersonic20][headless]=\
-        **/batch-engine/**/src/testIntegration/**/BatchEngineTaskDeadlockTest.java
+        **/batch-engine/**/src/testIntegration/**/BatchEngineExportTaskServiceTest.java,\
+        **/batch-engine/**/src/testIntegration/**/BatchEngineImportTaskServiceTest.java
 
     test.batch.class.names.includes[modules-integration-*][headless]=\
         **/batch-engine/**/src/testIntegration/**/*Test.java,\

--- a/test.properties
+++ b/test.properties
@@ -912,6 +912,7 @@
         modules-integration-solr-mysql84,\
         modules-semantic-versioning,\
         modules-unit,\
+        playwright-js-tomcat101-hypersonic20,\
         playwright-js-tomcat101-postgresql163,\
         semantic-versioning,\
         unit
@@ -4161,6 +4162,9 @@
     # Headless
     #
 
+    headless.hypersonic.playwright.projects=\
+        export-import-web.main
+
     headless.playwright.projects=\
         batch-planner.main,\
         dispatch-web.main,\
@@ -4448,6 +4452,9 @@
     # Headless Playwright
     #
 
+    playwright.projects.includes[playwright-js-tomcat101-hypersonic20][headless-playwright]=\
+        ${headless.hypersonic.playwright.projects}
+
     playwright.projects.includes[playwright-js-tomcat101-postgresql163][headless-playwright]=\
         ${headless.playwright.projects},\
         ${headless.staging.playwright.projects}
@@ -4455,6 +4462,7 @@
     test.batch.dist.app.servers[headless-playwright]=tomcat
 
     test.batch.names[headless-playwright]=\
+        playwright-js-tomcat101-hypersonic20,\
         playwright-js-tomcat101-postgresql163
 
     #

--- a/test.properties
+++ b/test.properties
@@ -4199,6 +4199,9 @@
         **/layout/layout-page-template-test/**/*Test.java,\
         **/portal-security/portal-security-ldap-impl/**/*Test.java
 
+    test.batch.class.names.includes[modules-integration-hypersonic20][headless]=\
+        **/batch-engine/**/src/testIntegration/**/BatchEngineTaskDeadlockTest.java
+
     test.batch.class.names.includes[modules-integration-*][headless]=\
         **/batch-engine/**/src/testIntegration/**/*Test.java,\
         **/batch-planner/**/src/testIntegration/**/*Test.java,\
@@ -4235,6 +4238,7 @@
     test.batch.names[headless]=\
         functional-tomcat101-postgresql163,\
         js-unit,\
+        modules-integration-hypersonic20,\
         modules-integration-postgresql163,\
         modules-unit,\
         playwright-js-tomcat101-postgresql163


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-75473

## What is being fixed

HSQLDB uses table-level write locks, so two concurrent transactions
updating different batch engine tasks deadlock: each holds its own lock
and waits for the other's. The symptom is that importing vocabularies
and categories simultaneously causes the import process to hang
indefinitely.

## How it is being fixed

`updateBatchEngineExportTask` and `updateBatchEngineImportTask` in their
respective `LocalServiceImpl` classes are now annotated with
`@Transactional(propagation = Propagation.REQUIRES_NEW)`. Each update
runs in its own short-lived transaction that acquires, writes, and
immediately releases the table lock, eliminating the deadlock window.

An integration test in `BatchEngineExportTaskServiceTest` and
`BatchEngineImportTaskServiceTest` reproduces the deadlock directly by
running two concurrent transactions on different tasks with coordinated
latches. A Playwright test verifies the end-to-end vocabulary and
category export/import flow.

`BaseBatchEngineTaskServiceTest` now deletes its test company in
`@AfterClass`, which cascade-deletes all associated batch tasks and
fixes a slow bundle shutdown observed on MySQL.

CI is wired to run the integration tests on HSQLDB
(`modules-integration-hypersonic20`) and the Playwright test on a
Hypersonic-backed environment (`playwright-js-tomcat101-hypersonic20`).