### PR TITLE
LPD-92279 Provide a file name when exporting a site in Poshi

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/LAR.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/LAR.macro
@@ -121,12 +121,14 @@ definition {
 
 	@summary = "Default summary"
 	macro _exportSite(larFileName = null) {
-		if (isSet(larFileName)) {
-			Type(
-				inputFieldId = "ExportPortlet_name",
-				locator1 = "TextInput#INPUT_ID",
-				value1 = ${larFileName});
+		if (!(isSet(larFileName))) {
+			var larFileName = "Export Process";
 		}
+
+		Type(
+			inputFieldId = "ExportPortlet_name",
+			locator1 = "TextInput#INPUT_ID",
+			value1 = ${larFileName});
 
 		LAR.exportWithAssertionOnSuccess();
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92279

## Failing Test

`LocalFile.ExportImport#ExportContentThenPublish`

`portal-web/test/functional/com/liferay/portalweb/tests/enduser/exportimport/ExportImport.testcase`

```
com.liferay.poshi.runner.exception.ElementNotFoundPoshiRunnerException: Element is not present at "//tr[1]/td[2]//div[contains(@class,'h5')] | //span[contains(@data-qa-id,'processResult')]"
```

## Root Cause

The legacy Custom Export form requires a process name (Title). Submitting it empty triggers a server-side `LARFileNameException` ("Please enter a file with a valid file name"), so no export process is created. `LAR.exportSiteCP` is called by all of its call sites without a `larFileName`, so `_exportSite` never typed a name; the export was rejected before any process appeared, leaving the success-status locator `ExportImport#CURRENT_AND_PREVIOUS_STATUS_1` with nothing to match. The introducing change predates this checkout's squashed history root, so the exact commit cannot be pinned.

## Fix

`_exportSite` now types a default file name when the caller does not provide one, so the required Title field is populated, the export runs, and the success status the assertion checks is rendered. Verified locally against a worktree portal with the legacy export UI (`feature.flag.LPD-57655=false`, as the failing routine runs): the test passes (`BUILD SUCCESSFUL`).

- `portal-web/test/functional/com/liferay/portalweb/macros/LAR.macro`

## Why are there no tests?

This is a test-only change: it repairs an existing Poshi functional test macro. There is no product code path to add coverage for.
