### PR TITLE
LPD-90963 Fix malformed Blob assertion in testCreateDraft template

### DIFF
--- a/modules/apps/change-tracking/change-tracking-store-test/src/testIntegration/java/com/liferay/change/tracking/store/service/persistence/test/CTSContentPersistenceTest.java
+++ b/modules/apps/change-tracking/change-tracking-store-test/src/testIntegration/java/com/liferay/change/tracking/store/service/persistence/test/CTSContentPersistenceTest.java
@@ -36,7 +36,6 @@ import java.io.Serializable;
 import java.sql.Blob;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -169,10 +168,8 @@ public class CTSContentPersistenceTest {
 			existingCTSContent.getVersion(), newCTSContent.getVersion());
 		Blob existingData = existingCTSContent.getData();
 
-		Assert.assertTrue(
-			Arrays.equals(
-				existingData.getBytes(1, (int)existingData.length()),
-				newDataBytes));
+		Assert.assertArrayEquals(
+			existingData.getBytes(1, (int)existingData.length()), newDataBytes);
 		Assert.assertEquals(
 			existingCTSContent.getSize(), newCTSContent.getSize());
 		Assert.assertEquals(
@@ -585,4 +582,4 @@ public class CTSContentPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:65518857
+// LIFERAY-SERVICE-BUILDER-HASH:257230465

--- a/modules/apps/document-library/document-library-content-test/src/testIntegration/java/com/liferay/document/library/content/service/persistence/test/DLContentPersistenceTest.java
+++ b/modules/apps/document-library/document-library-content-test/src/testIntegration/java/com/liferay/document/library/content/service/persistence/test/DLContentPersistenceTest.java
@@ -36,7 +36,6 @@ import java.io.Serializable;
 import java.sql.Blob;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -169,10 +168,8 @@ public class DLContentPersistenceTest {
 			existingDLContent.getVersion(), newDLContent.getVersion());
 		Blob existingData = existingDLContent.getData();
 
-		Assert.assertTrue(
-			Arrays.equals(
-				existingData.getBytes(1, (int)existingData.length()),
-				newDataBytes));
+		Assert.assertArrayEquals(
+			existingData.getBytes(1, (int)existingData.length()), newDataBytes);
 		Assert.assertEquals(
 			existingDLContent.getSize(), newDLContent.getSize());
 	}
@@ -563,4 +560,4 @@ public class DLContentPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1694078217
+// LIFERAY-SERVICE-BUILDER-HASH:1214941025

--- a/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/model/ERCVersionedEntryLazyBlobBlobModel.java
+++ b/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/model/ERCVersionedEntryLazyBlobBlobModel.java
@@ -1,0 +1,53 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.tools.service.builder.test.model;
+
+import java.sql.Blob;
+
+/**
+ * The Blob model class for lazy loading the lazyBlob column in ERCVersionedEntry.
+ *
+ * @author Brian Wing Shun Chan
+ * @see ERCVersionedEntry
+ * @generated
+ */
+public class ERCVersionedEntryLazyBlobBlobModel {
+
+	public ERCVersionedEntryLazyBlobBlobModel() {
+	}
+
+	public ERCVersionedEntryLazyBlobBlobModel(long ercVersionedEntryId) {
+		_ercVersionedEntryId = ercVersionedEntryId;
+	}
+
+	public ERCVersionedEntryLazyBlobBlobModel(
+		long ercVersionedEntryId, Blob lazyBlobBlob) {
+
+		_ercVersionedEntryId = ercVersionedEntryId;
+		_lazyBlobBlob = lazyBlobBlob;
+	}
+
+	public long getErcVersionedEntryId() {
+		return _ercVersionedEntryId;
+	}
+
+	public void setErcVersionedEntryId(long ercVersionedEntryId) {
+		_ercVersionedEntryId = ercVersionedEntryId;
+	}
+
+	public Blob getLazyBlobBlob() {
+		return _lazyBlobBlob;
+	}
+
+	public void setLazyBlobBlob(Blob lazyBlobBlob) {
+		_lazyBlobBlob = lazyBlobBlob;
+	}
+
+	private long _ercVersionedEntryId;
+	private Blob _lazyBlobBlob;
+
+}
+// LIFERAY-SERVICE-BUILDER-HASH:1538420030

--- a/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/model/ERCVersionedEntryModel.java
+++ b/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/model/ERCVersionedEntryModel.java
@@ -12,6 +12,8 @@ import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.version.VersionedModel;
 
+import java.sql.Blob;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -160,6 +162,34 @@ public interface ERCVersionedEntryModel
 	@Override
 	public void setCompanyId(long companyId);
 
+	/**
+	 * Returns the eager blob of this erc versioned entry.
+	 *
+	 * @return the eager blob of this erc versioned entry
+	 */
+	public Blob getEagerBlob();
+
+	/**
+	 * Sets the eager blob of this erc versioned entry.
+	 *
+	 * @param eagerBlob the eager blob of this erc versioned entry
+	 */
+	public void setEagerBlob(Blob eagerBlob);
+
+	/**
+	 * Returns the lazy blob of this erc versioned entry.
+	 *
+	 * @return the lazy blob of this erc versioned entry
+	 */
+	public Blob getLazyBlob();
+
+	/**
+	 * Sets the lazy blob of this erc versioned entry.
+	 *
+	 * @param lazyBlob the lazy blob of this erc versioned entry
+	 */
+	public void setLazyBlob(Blob lazyBlob);
+
 	@Override
 	public ERCVersionedEntry cloneWithOriginalValues();
 
@@ -168,4 +198,4 @@ public interface ERCVersionedEntryModel
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-801384982
+// LIFERAY-SERVICE-BUILDER-HASH:-2079182386

--- a/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/model/ERCVersionedEntryTable.java
+++ b/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/model/ERCVersionedEntryTable.java
@@ -8,6 +8,7 @@ package com.liferay.portal.tools.service.builder.test.model;
 import com.liferay.petra.sql.dsl.Column;
 import com.liferay.petra.sql.dsl.base.BaseTable;
 
+import java.sql.Blob;
 import java.sql.Types;
 
 /**
@@ -43,10 +44,14 @@ public class ERCVersionedEntryTable extends BaseTable<ERCVersionedEntryTable> {
 		"groupId", Long.class, Types.BIGINT, Column.FLAG_DEFAULT);
 	public final Column<ERCVersionedEntryTable, Long> companyId = createColumn(
 		"companyId", Long.class, Types.BIGINT, Column.FLAG_DEFAULT);
+	public final Column<ERCVersionedEntryTable, Blob> eagerBlob = createColumn(
+		"eagerBlob", Blob.class, Types.BLOB, Column.FLAG_DEFAULT);
+	public final Column<ERCVersionedEntryTable, Blob> lazyBlob = createColumn(
+		"lazyBlob", Blob.class, Types.BLOB, Column.FLAG_DEFAULT);
 
 	private ERCVersionedEntryTable() {
 		super("ERCVersionedEntry", ERCVersionedEntryTable::new);
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:489743092
+// LIFERAY-SERVICE-BUILDER-HASH:-1565372318

--- a/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/model/ERCVersionedEntryVersionLazyBlobBlobModel.java
+++ b/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/model/ERCVersionedEntryVersionLazyBlobBlobModel.java
@@ -1,0 +1,55 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.tools.service.builder.test.model;
+
+import java.sql.Blob;
+
+/**
+ * The Blob model class for lazy loading the lazyBlob column in ERCVersionedEntryVersion.
+ *
+ * @author Brian Wing Shun Chan
+ * @see ERCVersionedEntryVersion
+ * @generated
+ */
+public class ERCVersionedEntryVersionLazyBlobBlobModel {
+
+	public ERCVersionedEntryVersionLazyBlobBlobModel() {
+	}
+
+	public ERCVersionedEntryVersionLazyBlobBlobModel(
+		long ercVersionedEntryVersionId) {
+
+		_ercVersionedEntryVersionId = ercVersionedEntryVersionId;
+	}
+
+	public ERCVersionedEntryVersionLazyBlobBlobModel(
+		long ercVersionedEntryVersionId, Blob lazyBlobBlob) {
+
+		_ercVersionedEntryVersionId = ercVersionedEntryVersionId;
+		_lazyBlobBlob = lazyBlobBlob;
+	}
+
+	public long getErcVersionedEntryVersionId() {
+		return _ercVersionedEntryVersionId;
+	}
+
+	public void setErcVersionedEntryVersionId(long ercVersionedEntryVersionId) {
+		_ercVersionedEntryVersionId = ercVersionedEntryVersionId;
+	}
+
+	public Blob getLazyBlobBlob() {
+		return _lazyBlobBlob;
+	}
+
+	public void setLazyBlobBlob(Blob lazyBlobBlob) {
+		_lazyBlobBlob = lazyBlobBlob;
+	}
+
+	private long _ercVersionedEntryVersionId;
+	private Blob _lazyBlobBlob;
+
+}
+// LIFERAY-SERVICE-BUILDER-HASH:-1423896568

--- a/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/model/ERCVersionedEntryVersionModel.java
+++ b/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/model/ERCVersionedEntryVersionModel.java
@@ -11,6 +11,8 @@ import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.version.VersionModel;
 
+import java.sql.Blob;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -157,6 +159,34 @@ public interface ERCVersionedEntryVersionModel
 	@Override
 	public void setCompanyId(long companyId);
 
+	/**
+	 * Returns the eager blob of this erc versioned entry version.
+	 *
+	 * @return the eager blob of this erc versioned entry version
+	 */
+	public Blob getEagerBlob();
+
+	/**
+	 * Sets the eager blob of this erc versioned entry version.
+	 *
+	 * @param eagerBlob the eager blob of this erc versioned entry version
+	 */
+	public void setEagerBlob(Blob eagerBlob);
+
+	/**
+	 * Returns the lazy blob of this erc versioned entry version.
+	 *
+	 * @return the lazy blob of this erc versioned entry version
+	 */
+	public Blob getLazyBlob();
+
+	/**
+	 * Sets the lazy blob of this erc versioned entry version.
+	 *
+	 * @param lazyBlob the lazy blob of this erc versioned entry version
+	 */
+	public void setLazyBlob(Blob lazyBlob);
+
 	@Override
 	public ERCVersionedEntryVersion cloneWithOriginalValues();
 
@@ -165,4 +195,4 @@ public interface ERCVersionedEntryVersionModel
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:585529757
+// LIFERAY-SERVICE-BUILDER-HASH:-858510967

--- a/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/model/ERCVersionedEntryVersionTable.java
+++ b/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/model/ERCVersionedEntryVersionTable.java
@@ -8,6 +8,7 @@ package com.liferay.portal.tools.service.builder.test.model;
 import com.liferay.petra.sql.dsl.Column;
 import com.liferay.petra.sql.dsl.base.BaseTable;
 
+import java.sql.Blob;
 import java.sql.Types;
 
 /**
@@ -45,10 +46,14 @@ public class ERCVersionedEntryVersionTable
 	public final Column<ERCVersionedEntryVersionTable, Long> companyId =
 		createColumn(
 			"companyId", Long.class, Types.BIGINT, Column.FLAG_DEFAULT);
+	public final Column<ERCVersionedEntryVersionTable, Blob> eagerBlob =
+		createColumn("eagerBlob", Blob.class, Types.BLOB, Column.FLAG_DEFAULT);
+	public final Column<ERCVersionedEntryVersionTable, Blob> lazyBlob =
+		createColumn("lazyBlob", Blob.class, Types.BLOB, Column.FLAG_DEFAULT);
 
 	private ERCVersionedEntryVersionTable() {
 		super("ERCVersionedEntryVersion", ERCVersionedEntryVersionTable::new);
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1336671367
+// LIFERAY-SERVICE-BUILDER-HASH:-617845261

--- a/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/model/ERCVersionedEntryVersionWrapper.java
+++ b/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/model/ERCVersionedEntryVersionWrapper.java
@@ -8,6 +8,8 @@ package com.liferay.portal.tools.service.builder.test.model;
 import com.liferay.portal.kernel.model.ModelWrapper;
 import com.liferay.portal.kernel.model.wrapper.BaseModelWrapper;
 
+import java.sql.Blob;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -43,6 +45,8 @@ public class ERCVersionedEntryVersionWrapper
 		attributes.put("ercVersionedEntryId", getErcVersionedEntryId());
 		attributes.put("groupId", getGroupId());
 		attributes.put("companyId", getCompanyId());
+		attributes.put("eagerBlob", getEagerBlob());
+		attributes.put("lazyBlob", getLazyBlob());
 
 		return attributes;
 	}
@@ -92,6 +96,18 @@ public class ERCVersionedEntryVersionWrapper
 		if (companyId != null) {
 			setCompanyId(companyId);
 		}
+
+		Blob eagerBlob = (Blob)attributes.get("eagerBlob");
+
+		if (eagerBlob != null) {
+			setEagerBlob(eagerBlob);
+		}
+
+		Blob lazyBlob = (Blob)attributes.get("lazyBlob");
+
+		if (lazyBlob != null) {
+			setLazyBlob(lazyBlob);
+		}
 	}
 
 	@Override
@@ -107,6 +123,16 @@ public class ERCVersionedEntryVersionWrapper
 	@Override
 	public long getCompanyId() {
 		return model.getCompanyId();
+	}
+
+	/**
+	 * Returns the eager blob of this erc versioned entry version.
+	 *
+	 * @return the eager blob of this erc versioned entry version
+	 */
+	@Override
+	public Blob getEagerBlob() {
+		return model.getEagerBlob();
 	}
 
 	/**
@@ -150,6 +176,16 @@ public class ERCVersionedEntryVersionWrapper
 	}
 
 	/**
+	 * Returns the lazy blob of this erc versioned entry version.
+	 *
+	 * @return the lazy blob of this erc versioned entry version
+	 */
+	@Override
+	public Blob getLazyBlob() {
+		return model.getLazyBlob();
+	}
+
+	/**
 	 * Returns the primary key of this erc versioned entry version.
 	 *
 	 * @return the primary key of this erc versioned entry version
@@ -190,6 +226,16 @@ public class ERCVersionedEntryVersionWrapper
 	}
 
 	/**
+	 * Sets the eager blob of this erc versioned entry version.
+	 *
+	 * @param eagerBlob the eager blob of this erc versioned entry version
+	 */
+	@Override
+	public void setEagerBlob(Blob eagerBlob) {
+		model.setEagerBlob(eagerBlob);
+	}
+
+	/**
 	 * Sets the erc versioned entry ID of this erc versioned entry version.
 	 *
 	 * @param ercVersionedEntryId the erc versioned entry ID of this erc versioned entry version
@@ -227,6 +273,16 @@ public class ERCVersionedEntryVersionWrapper
 	@Override
 	public void setGroupId(long groupId) {
 		model.setGroupId(groupId);
+	}
+
+	/**
+	 * Sets the lazy blob of this erc versioned entry version.
+	 *
+	 * @param lazyBlob the lazy blob of this erc versioned entry version
+	 */
+	@Override
+	public void setLazyBlob(Blob lazyBlob) {
+		model.setLazyBlob(lazyBlob);
 	}
 
 	/**
@@ -292,4 +348,4 @@ public class ERCVersionedEntryVersionWrapper
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-582979379
+// LIFERAY-SERVICE-BUILDER-HASH:591112427

--- a/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/model/ERCVersionedEntryWrapper.java
+++ b/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/model/ERCVersionedEntryWrapper.java
@@ -8,6 +8,8 @@ package com.liferay.portal.tools.service.builder.test.model;
 import com.liferay.portal.kernel.model.ModelWrapper;
 import com.liferay.portal.kernel.model.wrapper.BaseModelWrapper;
 
+import java.sql.Blob;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -39,6 +41,8 @@ public class ERCVersionedEntryWrapper
 		attributes.put("ercVersionedEntryId", getErcVersionedEntryId());
 		attributes.put("groupId", getGroupId());
 		attributes.put("companyId", getCompanyId());
+		attributes.put("eagerBlob", getEagerBlob());
+		attributes.put("lazyBlob", getLazyBlob());
 
 		return attributes;
 	}
@@ -87,6 +91,18 @@ public class ERCVersionedEntryWrapper
 		if (companyId != null) {
 			setCompanyId(companyId);
 		}
+
+		Blob eagerBlob = (Blob)attributes.get("eagerBlob");
+
+		if (eagerBlob != null) {
+			setEagerBlob(eagerBlob);
+		}
+
+		Blob lazyBlob = (Blob)attributes.get("lazyBlob");
+
+		if (lazyBlob != null) {
+			setLazyBlob(lazyBlob);
+		}
 	}
 
 	@Override
@@ -102,6 +118,16 @@ public class ERCVersionedEntryWrapper
 	@Override
 	public long getCompanyId() {
 		return model.getCompanyId();
+	}
+
+	/**
+	 * Returns the eager blob of this erc versioned entry.
+	 *
+	 * @return the eager blob of this erc versioned entry
+	 */
+	@Override
+	public Blob getEagerBlob() {
+		return model.getEagerBlob();
 	}
 
 	/**
@@ -142,6 +168,16 @@ public class ERCVersionedEntryWrapper
 	@Override
 	public long getHeadId() {
 		return model.getHeadId();
+	}
+
+	/**
+	 * Returns the lazy blob of this erc versioned entry.
+	 *
+	 * @return the lazy blob of this erc versioned entry
+	 */
+	@Override
+	public Blob getLazyBlob() {
+		return model.getLazyBlob();
 	}
 
 	/**
@@ -190,6 +226,16 @@ public class ERCVersionedEntryWrapper
 	}
 
 	/**
+	 * Sets the eager blob of this erc versioned entry.
+	 *
+	 * @param eagerBlob the eager blob of this erc versioned entry
+	 */
+	@Override
+	public void setEagerBlob(Blob eagerBlob) {
+		model.setEagerBlob(eagerBlob);
+	}
+
+	/**
 	 * Sets the erc versioned entry ID of this erc versioned entry.
 	 *
 	 * @param ercVersionedEntryId the erc versioned entry ID of this erc versioned entry
@@ -227,6 +273,16 @@ public class ERCVersionedEntryWrapper
 	@Override
 	public void setHeadId(long headId) {
 		model.setHeadId(headId);
+	}
+
+	/**
+	 * Sets the lazy blob of this erc versioned entry.
+	 *
+	 * @param lazyBlob the lazy blob of this erc versioned entry
+	 */
+	@Override
+	public void setLazyBlob(Blob lazyBlob) {
+		model.setLazyBlob(lazyBlob);
 	}
 
 	/**
@@ -284,4 +340,4 @@ public class ERCVersionedEntryWrapper
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1214024493
+// LIFERAY-SERVICE-BUILDER-HASH:957373387

--- a/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/service/ERCVersionedEntryLocalService.java
+++ b/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/service/ERCVersionedEntryLocalService.java
@@ -25,8 +25,10 @@ import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.Transactional;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.tools.service.builder.test.model.ERCVersionedEntry;
+import com.liferay.portal.tools.service.builder.test.model.ERCVersionedEntryLazyBlobBlobModel;
 import com.liferay.portal.tools.service.builder.test.model.ERCVersionedEntryVersion;
 
+import java.io.InputStream;
 import java.io.Serializable;
 
 import java.util.List;
@@ -315,6 +317,10 @@ public interface ERCVersionedEntryLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public IndexableActionableDynamicQuery getIndexableActionableDynamicQuery();
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public ERCVersionedEntryLazyBlobBlobModel getLazyBlobBlobModel(
+		Serializable primaryKey);
+
 	/**
 	 * Returns the OSGi service identifier.
 	 *
@@ -340,6 +346,9 @@ public interface ERCVersionedEntryLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<ERCVersionedEntryVersion> getVersions(
 		ERCVersionedEntry ercVersionedEntry);
+
+	@Transactional(readOnly = true)
+	public InputStream openLazyBlobInputStream(long ercVersionedEntryId);
 
 	@Indexable(type = IndexableType.REINDEX)
 	@Override
@@ -379,4 +388,4 @@ public interface ERCVersionedEntryLocalService
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:725301164
+// LIFERAY-SERVICE-BUILDER-HASH:756516867

--- a/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/service/ERCVersionedEntryLocalServiceUtil.java
+++ b/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/service/ERCVersionedEntryLocalServiceUtil.java
@@ -12,6 +12,7 @@ import com.liferay.portal.kernel.model.PersistedModel;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.tools.service.builder.test.model.ERCVersionedEntry;
 
+import java.io.InputStream;
 import java.io.Serializable;
 
 import java.util.List;
@@ -363,6 +364,13 @@ public class ERCVersionedEntryLocalServiceUtil {
 		return getService().getIndexableActionableDynamicQuery();
 	}
 
+	public static com.liferay.portal.tools.service.builder.test.model.
+		ERCVersionedEntryLazyBlobBlobModel getLazyBlobBlobModel(
+			Serializable primaryKey) {
+
+		return getService().getLazyBlobBlobModel(primaryKey);
+	}
+
 	/**
 	 * Returns the OSGi service identifier.
 	 *
@@ -396,6 +404,12 @@ public class ERCVersionedEntryLocalServiceUtil {
 				ERCVersionedEntry ercVersionedEntry) {
 
 		return getService().getVersions(ercVersionedEntry);
+	}
+
+	public static InputStream openLazyBlobInputStream(
+		long ercVersionedEntryId) {
+
+		return getService().openLazyBlobInputStream(ercVersionedEntryId);
 	}
 
 	public static ERCVersionedEntry publishDraft(
@@ -458,4 +472,4 @@ public class ERCVersionedEntryLocalServiceUtil {
 	private static volatile ERCVersionedEntryLocalService _service;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:991593808
+// LIFERAY-SERVICE-BUILDER-HASH:1558641740

--- a/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/service/ERCVersionedEntryLocalServiceWrapper.java
+++ b/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/service/ERCVersionedEntryLocalServiceWrapper.java
@@ -446,6 +446,14 @@ public class ERCVersionedEntryLocalServiceWrapper
 			getIndexableActionableDynamicQuery();
 	}
 
+	@Override
+	public com.liferay.portal.tools.service.builder.test.model.
+		ERCVersionedEntryLazyBlobBlobModel getLazyBlobBlobModel(
+			java.io.Serializable primaryKey) {
+
+		return _ercVersionedEntryLocalService.getLazyBlobBlobModel(primaryKey);
+	}
+
 	/**
 	 * Returns the OSGi service identifier.
 	 *
@@ -488,6 +496,14 @@ public class ERCVersionedEntryLocalServiceWrapper
 					ERCVersionedEntry ercVersionedEntry) {
 
 		return _ercVersionedEntryLocalService.getVersions(ercVersionedEntry);
+	}
+
+	@Override
+	public java.io.InputStream openLazyBlobInputStream(
+		long ercVersionedEntryId) {
+
+		return _ercVersionedEntryLocalService.openLazyBlobInputStream(
+			ercVersionedEntryId);
 	}
 
 	@Override
@@ -576,4 +592,4 @@ public class ERCVersionedEntryLocalServiceWrapper
 	private ERCVersionedEntryLocalService _ercVersionedEntryLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2130861323
+// LIFERAY-SERVICE-BUILDER-HASH:1292851257

--- a/modules/util/portal-tools-service-builder-test-service/service.xml
+++ b/modules/util/portal-tools-service-builder-test-service/service.xml
@@ -262,7 +262,8 @@
 
 		<!-- Other fields -->
 
-		<column lazy="false" name="blob" type="Blob" />
+		<column lazy="false" name="eagerBlob" type="Blob" />
+		<column name="lazyBlob" type="Blob" />
 	</entity>
 	<entity local-service="true" name="FinderWhereClauseEntry" remote-service="false">
 

--- a/modules/util/portal-tools-service-builder-test-service/service.xml
+++ b/modules/util/portal-tools-service-builder-test-service/service.xml
@@ -259,6 +259,10 @@
 		<!-- Audit fields -->
 
 		<column name="companyId" type="long" />
+
+		<!-- Other fields -->
+
+		<column lazy="false" name="blob" type="Blob" />
 	</entity>
 	<entity local-service="true" name="FinderWhereClauseEntry" remote-service="false">
 

--- a/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/model/impl/ERCVersionedEntryCacheModel.java
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/model/impl/ERCVersionedEntryCacheModel.java
@@ -83,7 +83,6 @@ public class ERCVersionedEntryCacheModel
 		sb.append(groupId);
 		sb.append(", companyId=");
 		sb.append(companyId);
-		sb.append("}");
 
 		return sb.toString();
 	}
@@ -177,4 +176,4 @@ public class ERCVersionedEntryCacheModel
 	public long companyId;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1056414359
+// LIFERAY-SERVICE-BUILDER-HASH:-1407182578

--- a/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/model/impl/ERCVersionedEntryModelImpl.java
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/model/impl/ERCVersionedEntryModelImpl.java
@@ -15,10 +15,11 @@ import com.liferay.portal.kernel.model.impl.BaseModelImpl;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.tools.service.builder.test.model.ERCVersionedEntry;
+import com.liferay.portal.tools.service.builder.test.model.ERCVersionedEntryLazyBlobBlobModel;
 import com.liferay.portal.tools.service.builder.test.model.ERCVersionedEntryModel;
 import com.liferay.portal.tools.service.builder.test.model.ERCVersionedEntryVersion;
+import com.liferay.portal.tools.service.builder.test.service.ERCVersionedEntryLocalServiceUtil;
 
 import java.io.Serializable;
 
@@ -28,11 +29,9 @@ import java.sql.Blob;
 import java.sql.Types;
 
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
@@ -61,7 +60,8 @@ public class ERCVersionedEntryModelImpl
 		{"mvccVersion", Types.BIGINT}, {"uuid_", Types.VARCHAR},
 		{"externalReferenceCode", Types.VARCHAR}, {"headId", Types.BIGINT},
 		{"head", Types.BOOLEAN}, {"ercVersionedEntryId", Types.BIGINT},
-		{"groupId", Types.BIGINT}, {"companyId", Types.BIGINT}
+		{"groupId", Types.BIGINT}, {"companyId", Types.BIGINT},
+		{"eagerBlob", Types.BLOB}, {"lazyBlob", Types.BLOB}
 	};
 
 	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
@@ -76,10 +76,12 @@ public class ERCVersionedEntryModelImpl
 		TABLE_COLUMNS_MAP.put("ercVersionedEntryId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+		TABLE_COLUMNS_MAP.put("eagerBlob", Types.BLOB);
+		TABLE_COLUMNS_MAP.put("lazyBlob", Types.BLOB);
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table ERCVersionedEntry (mvccVersion LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,headId LONG,head BOOLEAN,ercVersionedEntryId LONG not null primary key,groupId LONG,companyId LONG)";
+		"create table ERCVersionedEntry (mvccVersion LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,headId LONG,head BOOLEAN,ercVersionedEntryId LONG not null primary key,groupId LONG,companyId LONG,eagerBlob BLOB,lazyBlob BLOB)";
 
 	public static final String TABLE_SQL_DROP = "drop table ERCVersionedEntry";
 
@@ -101,62 +103,13 @@ public class ERCVersionedEntryModelImpl
 	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
 	 */
 	@Deprecated
-	public static final boolean ENTITY_CACHE_ENABLED = true;
+	public static final boolean ENTITY_CACHE_ENABLED = false;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
 	 */
 	@Deprecated
-	public static final boolean FINDER_CACHE_ENABLED = true;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public static final boolean COLUMN_BITMASK_ENABLED = true;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
-	 */
-	@Deprecated
-	public static final long COMPANYID_COLUMN_BITMASK = 1L;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
-	 */
-	@Deprecated
-	public static final long EXTERNALREFERENCECODE_COLUMN_BITMASK = 2L;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
-	 */
-	@Deprecated
-	public static final long GROUPID_COLUMN_BITMASK = 4L;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
-	 */
-	@Deprecated
-	public static final long HEAD_COLUMN_BITMASK = 8L;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
-	 */
-	@Deprecated
-	public static final long HEADID_COLUMN_BITMASK = 16L;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
-	 */
-	@Deprecated
-	public static final long UUID_COLUMN_BITMASK = 32L;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *		#getColumnBitmask(String)}
-	 */
-	@Deprecated
-	public static final long ERCVERSIONEDENTRYID_COLUMN_BITMASK = 64L;
+	public static final boolean FINDER_CACHE_ENABLED = false;
 
 	public static final long LOCK_EXPIRATION_TIME = GetterUtil.getLong(
 		com.liferay.portal.tools.service.builder.test.service.util.ServiceProps.
@@ -274,6 +227,10 @@ public class ERCVersionedEntryModelImpl
 				"groupId", ERCVersionedEntry::getGroupId);
 			attributeGetterFunctions.put(
 				"companyId", ERCVersionedEntry::getCompanyId);
+			attributeGetterFunctions.put(
+				"eagerBlob", ERCVersionedEntry::getEagerBlob);
+			attributeGetterFunctions.put(
+				"lazyBlob", ERCVersionedEntry::getLazyBlob);
 
 			_attributeGetterFunctions = Collections.unmodifiableMap(
 				attributeGetterFunctions);
@@ -320,6 +277,14 @@ public class ERCVersionedEntryModelImpl
 				"companyId",
 				(BiConsumer<ERCVersionedEntry, Long>)
 					ERCVersionedEntry::setCompanyId);
+			attributeSetterBiConsumers.put(
+				"eagerBlob",
+				(BiConsumer<ERCVersionedEntry, Blob>)
+					ERCVersionedEntry::setEagerBlob);
+			attributeSetterBiConsumers.put(
+				"lazyBlob",
+				(BiConsumer<ERCVersionedEntry, Blob>)
+					ERCVersionedEntry::setLazyBlob);
 
 			_attributeSetterBiConsumers = Collections.unmodifiableMap(
 				(Map)attributeSetterBiConsumers);
@@ -336,6 +301,8 @@ public class ERCVersionedEntryModelImpl
 			getExternalReferenceCode());
 		ercVersionedEntryVersion.setGroupId(getGroupId());
 		ercVersionedEntryVersion.setCompanyId(getCompanyId());
+		ercVersionedEntryVersion.setEagerBlob(getEagerBlob());
+		ercVersionedEntryVersion.setLazyBlob(getLazyBlob());
 	}
 
 	@Override
@@ -526,28 +493,54 @@ public class ERCVersionedEntryModelImpl
 			this.<Long>getColumnOriginalValue("companyId"));
 	}
 
-	public long getColumnBitmask() {
-		if (_columnBitmask > 0) {
-			return _columnBitmask;
+	@Override
+	public Blob getEagerBlob() {
+		return _eagerBlob;
+	}
+
+	@Override
+	public void setEagerBlob(Blob eagerBlob) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
 		}
 
-		if ((_columnOriginalValues == null) ||
-			(_columnOriginalValues == Collections.EMPTY_MAP)) {
+		_eagerBlob = eagerBlob;
+	}
 
-			return 0;
-		}
-
-		for (Map.Entry<String, Object> entry :
-				_columnOriginalValues.entrySet()) {
-
-			if (!Objects.equals(
-					entry.getValue(), getColumnValue(entry.getKey()))) {
-
-				_columnBitmask |= _columnBitmasks.get(entry.getKey());
+	@Override
+	public Blob getLazyBlob() {
+		if (_lazyBlobBlobModel == null) {
+			try {
+				_lazyBlobBlobModel =
+					ERCVersionedEntryLocalServiceUtil.getLazyBlobBlobModel(
+						getPrimaryKey());
+			}
+			catch (Exception exception) {
 			}
 		}
 
-		return _columnBitmask;
+		Blob blob = null;
+
+		if (_lazyBlobBlobModel != null) {
+			blob = _lazyBlobBlobModel.getLazyBlobBlob();
+		}
+
+		return blob;
+	}
+
+	@Override
+	public void setLazyBlob(Blob lazyBlob) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		if (_lazyBlobBlobModel == null) {
+			_lazyBlobBlobModel = new ERCVersionedEntryLazyBlobBlobModel(
+				getPrimaryKey(), lazyBlob);
+		}
+		else {
+			_lazyBlobBlobModel.setLazyBlobBlob(lazyBlob);
+		}
 	}
 
 	@Override
@@ -684,7 +677,7 @@ public class ERCVersionedEntryModelImpl
 	public void resetOriginalValues() {
 		_columnOriginalValues = Collections.emptyMap();
 
-		_columnBitmask = 0;
+		_lazyBlobBlobModel = null;
 	}
 
 	@Override
@@ -730,50 +723,39 @@ public class ERCVersionedEntryModelImpl
 
 	@Override
 	public String toString() {
-		Map<String, Function<ERCVersionedEntry, Object>>
-			attributeGetterFunctions = getAttributeGetterFunctions();
+		StringBundler sb = new StringBundler(19);
 
-		StringBundler sb = new StringBundler(
-			(5 * attributeGetterFunctions.size()) + 2);
+		sb.append("{\"mvccVersion\": ");
 
-		sb.append("{");
+		sb.append(getMvccVersion());
 
-		for (Map.Entry<String, Function<ERCVersionedEntry, Object>> entry :
-				attributeGetterFunctions.entrySet()) {
+		sb.append(", \"uuid\": ");
 
-			String attributeName = entry.getKey();
-			Function<ERCVersionedEntry, Object> attributeGetterFunction =
-				entry.getValue();
+		sb.append("\"" + getUuid() + "\"");
 
-			sb.append("\"");
-			sb.append(attributeName);
-			sb.append("\": ");
+		sb.append(", \"externalReferenceCode\": ");
 
-			Object value = attributeGetterFunction.apply(
-				(ERCVersionedEntry)this);
+		sb.append("\"" + getExternalReferenceCode() + "\"");
 
-			if (value == null) {
-				sb.append("null");
-			}
-			else if (value instanceof Blob || value instanceof Date ||
-					 value instanceof Map || value instanceof String) {
+		sb.append(", \"headId\": ");
 
-				sb.append(
-					"\"" + StringUtil.replace(value.toString(), "\"", "'") +
-						"\"");
-			}
-			else {
-				sb.append(value);
-			}
+		sb.append(getHeadId());
 
-			sb.append(", ");
-		}
+		sb.append(", \"ercVersionedEntryId\": ");
 
-		if (sb.index() > 1) {
-			sb.setIndex(sb.index() - 1);
-		}
+		sb.append(getErcVersionedEntryId());
 
-		sb.append("}");
+		sb.append(", \"groupId\": ");
+
+		sb.append(getGroupId());
+
+		sb.append(", \"companyId\": ");
+
+		sb.append(getCompanyId());
+
+		sb.append(", \"eagerBlob\": ");
+
+		sb.append("\"" + getEagerBlob() + "\"");
 
 		return sb.toString();
 	}
@@ -795,6 +777,8 @@ public class ERCVersionedEntryModelImpl
 	private long _ercVersionedEntryId;
 	private long _groupId;
 	private long _companyId;
+	private Blob _eagerBlob;
+	private transient ERCVersionedEntryLazyBlobBlobModel _lazyBlobBlobModel;
 
 	public <T> T getColumnValue(String columnName) {
 		if (columnName.equals("head")) {
@@ -839,6 +823,7 @@ public class ERCVersionedEntryModelImpl
 		_columnOriginalValues.put("ercVersionedEntryId", _ercVersionedEntryId);
 		_columnOriginalValues.put("groupId", _groupId);
 		_columnOriginalValues.put("companyId", _companyId);
+		_columnOriginalValues.put("eagerBlob", _eagerBlob);
 	}
 
 	private static final Map<String, String> _attributeNames;
@@ -852,37 +837,7 @@ public class ERCVersionedEntryModelImpl
 	}
 
 	private transient Map<String, Object> _columnOriginalValues;
-
-	public static long getColumnBitmask(String columnName) {
-		return _columnBitmasks.get(columnName);
-	}
-
-	private static final Map<String, Long> _columnBitmasks;
-
-	static {
-		Map<String, Long> columnBitmasks = new HashMap<>();
-
-		columnBitmasks.put("mvccVersion", 1L);
-
-		columnBitmasks.put("uuid_", 2L);
-
-		columnBitmasks.put("externalReferenceCode", 4L);
-
-		columnBitmasks.put("headId", 8L);
-
-		columnBitmasks.put("head", 16L);
-
-		columnBitmasks.put("ercVersionedEntryId", 32L);
-
-		columnBitmasks.put("groupId", 64L);
-
-		columnBitmasks.put("companyId", 128L);
-
-		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
-	}
-
-	private long _columnBitmask;
 	private ERCVersionedEntry _escapedModel;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1043357584
+// LIFERAY-SERVICE-BUILDER-HASH:-1262929656

--- a/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/model/impl/ERCVersionedEntryVersionCacheModel.java
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/model/impl/ERCVersionedEntryVersionCacheModel.java
@@ -69,7 +69,6 @@ public class ERCVersionedEntryVersionCacheModel
 		sb.append(groupId);
 		sb.append(", companyId=");
 		sb.append(companyId);
-		sb.append("}");
 
 		return sb.toString();
 	}
@@ -159,4 +158,4 @@ public class ERCVersionedEntryVersionCacheModel
 	public long companyId;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1146275545
+// LIFERAY-SERVICE-BUILDER-HASH:-1729621124

--- a/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/model/impl/ERCVersionedEntryVersionModelImpl.java
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/model/impl/ERCVersionedEntryVersionModelImpl.java
@@ -15,10 +15,11 @@ import com.liferay.portal.kernel.model.impl.BaseModelImpl;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.tools.service.builder.test.model.ERCVersionedEntry;
 import com.liferay.portal.tools.service.builder.test.model.ERCVersionedEntryVersion;
+import com.liferay.portal.tools.service.builder.test.model.ERCVersionedEntryVersionLazyBlobBlobModel;
 import com.liferay.portal.tools.service.builder.test.model.ERCVersionedEntryVersionModel;
+import com.liferay.portal.tools.service.builder.test.service.ERCVersionedEntryVersionLocalServiceUtil;
 
 import java.io.Serializable;
 
@@ -28,11 +29,9 @@ import java.sql.Blob;
 import java.sql.Types;
 
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
@@ -63,7 +62,8 @@ public class ERCVersionedEntryVersionModelImpl
 		{"version", Types.INTEGER}, {"uuid_", Types.VARCHAR},
 		{"externalReferenceCode", Types.VARCHAR},
 		{"ercVersionedEntryId", Types.BIGINT}, {"groupId", Types.BIGINT},
-		{"companyId", Types.BIGINT}
+		{"companyId", Types.BIGINT}, {"eagerBlob", Types.BLOB},
+		{"lazyBlob", Types.BLOB}
 	};
 
 	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
@@ -77,10 +77,12 @@ public class ERCVersionedEntryVersionModelImpl
 		TABLE_COLUMNS_MAP.put("ercVersionedEntryId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+		TABLE_COLUMNS_MAP.put("eagerBlob", Types.BLOB);
+		TABLE_COLUMNS_MAP.put("lazyBlob", Types.BLOB);
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table ERCVersionedEntryVersion (ercVersionedEntryVersionId LONG not null primary key,version INTEGER,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,ercVersionedEntryId LONG,groupId LONG,companyId LONG)";
+		"create table ERCVersionedEntryVersion (ercVersionedEntryVersionId LONG not null primary key,version INTEGER,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,ercVersionedEntryId LONG,groupId LONG,companyId LONG,eagerBlob BLOB,lazyBlob BLOB)";
 
 	public static final String TABLE_SQL_DROP =
 		"drop table ERCVersionedEntryVersion";
@@ -103,49 +105,13 @@ public class ERCVersionedEntryVersionModelImpl
 	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
 	 */
 	@Deprecated
-	public static final boolean ENTITY_CACHE_ENABLED = true;
+	public static final boolean ENTITY_CACHE_ENABLED = false;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
 	 */
 	@Deprecated
-	public static final boolean FINDER_CACHE_ENABLED = true;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public static final boolean COLUMN_BITMASK_ENABLED = true;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
-	 */
-	@Deprecated
-	public static final long COMPANYID_COLUMN_BITMASK = 1L;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
-	 */
-	@Deprecated
-	public static final long ERCVERSIONEDENTRYID_COLUMN_BITMASK = 2L;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
-	 */
-	@Deprecated
-	public static final long GROUPID_COLUMN_BITMASK = 4L;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
-	 */
-	@Deprecated
-	public static final long UUID_COLUMN_BITMASK = 8L;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
-	 */
-	@Deprecated
-	public static final long VERSION_COLUMN_BITMASK = 16L;
+	public static final boolean FINDER_CACHE_ENABLED = false;
 
 	public static final long LOCK_EXPIRATION_TIME = GetterUtil.getLong(
 		com.liferay.portal.tools.service.builder.test.service.util.ServiceProps.
@@ -267,6 +233,10 @@ public class ERCVersionedEntryVersionModelImpl
 				"groupId", ERCVersionedEntryVersion::getGroupId);
 			attributeGetterFunctions.put(
 				"companyId", ERCVersionedEntryVersion::getCompanyId);
+			attributeGetterFunctions.put(
+				"eagerBlob", ERCVersionedEntryVersion::getEagerBlob);
+			attributeGetterFunctions.put(
+				"lazyBlob", ERCVersionedEntryVersion::getLazyBlob);
 
 			_attributeGetterFunctions = Collections.unmodifiableMap(
 				attributeGetterFunctions);
@@ -314,6 +284,14 @@ public class ERCVersionedEntryVersionModelImpl
 				"companyId",
 				(BiConsumer<ERCVersionedEntryVersion, Long>)
 					ERCVersionedEntryVersion::setCompanyId);
+			attributeSetterBiConsumers.put(
+				"eagerBlob",
+				(BiConsumer<ERCVersionedEntryVersion, Blob>)
+					ERCVersionedEntryVersion::setEagerBlob);
+			attributeSetterBiConsumers.put(
+				"lazyBlob",
+				(BiConsumer<ERCVersionedEntryVersion, Blob>)
+					ERCVersionedEntryVersion::setLazyBlob);
 
 			_attributeSetterBiConsumers = Collections.unmodifiableMap(
 				(Map)attributeSetterBiConsumers);
@@ -332,6 +310,8 @@ public class ERCVersionedEntryVersionModelImpl
 		ercVersionedEntry.setExternalReferenceCode(getExternalReferenceCode());
 		ercVersionedEntry.setGroupId(getGroupId());
 		ercVersionedEntry.setCompanyId(getCompanyId());
+		ercVersionedEntry.setEagerBlob(getEagerBlob());
+		ercVersionedEntry.setLazyBlob(getLazyBlob());
 	}
 
 	@Override
@@ -507,28 +487,54 @@ public class ERCVersionedEntryVersionModelImpl
 			this.<Long>getColumnOriginalValue("companyId"));
 	}
 
-	public long getColumnBitmask() {
-		if (_columnBitmask > 0) {
-			return _columnBitmask;
+	@Override
+	public Blob getEagerBlob() {
+		return _eagerBlob;
+	}
+
+	@Override
+	public void setEagerBlob(Blob eagerBlob) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
 		}
 
-		if ((_columnOriginalValues == null) ||
-			(_columnOriginalValues == Collections.EMPTY_MAP)) {
+		_eagerBlob = eagerBlob;
+	}
 
-			return 0;
-		}
-
-		for (Map.Entry<String, Object> entry :
-				_columnOriginalValues.entrySet()) {
-
-			if (!Objects.equals(
-					entry.getValue(), getColumnValue(entry.getKey()))) {
-
-				_columnBitmask |= _columnBitmasks.get(entry.getKey());
+	@Override
+	public Blob getLazyBlob() {
+		if (_lazyBlobBlobModel == null) {
+			try {
+				_lazyBlobBlobModel =
+					ERCVersionedEntryVersionLocalServiceUtil.
+						getLazyBlobBlobModel(getPrimaryKey());
+			}
+			catch (Exception exception) {
 			}
 		}
 
-		return _columnBitmask;
+		Blob blob = null;
+
+		if (_lazyBlobBlobModel != null) {
+			blob = _lazyBlobBlobModel.getLazyBlobBlob();
+		}
+
+		return blob;
+	}
+
+	@Override
+	public void setLazyBlob(Blob lazyBlob) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		if (_lazyBlobBlobModel == null) {
+			_lazyBlobBlobModel = new ERCVersionedEntryVersionLazyBlobBlobModel(
+				getPrimaryKey(), lazyBlob);
+		}
+		else {
+			_lazyBlobBlobModel.setLazyBlobBlob(lazyBlob);
+		}
 	}
 
 	@Override
@@ -677,7 +683,7 @@ public class ERCVersionedEntryVersionModelImpl
 	public void resetOriginalValues() {
 		_columnOriginalValues = Collections.emptyMap();
 
-		_columnBitmask = 0;
+		_lazyBlobBlobModel = null;
 	}
 
 	@Override
@@ -722,50 +728,39 @@ public class ERCVersionedEntryVersionModelImpl
 
 	@Override
 	public String toString() {
-		Map<String, Function<ERCVersionedEntryVersion, Object>>
-			attributeGetterFunctions = getAttributeGetterFunctions();
+		StringBundler sb = new StringBundler(19);
 
-		StringBundler sb = new StringBundler(
-			(5 * attributeGetterFunctions.size()) + 2);
+		sb.append("{\"ercVersionedEntryVersionId\": ");
 
-		sb.append("{");
+		sb.append(getErcVersionedEntryVersionId());
 
-		for (Map.Entry<String, Function<ERCVersionedEntryVersion, Object>>
-				entry : attributeGetterFunctions.entrySet()) {
+		sb.append(", \"version\": ");
 
-			String attributeName = entry.getKey();
-			Function<ERCVersionedEntryVersion, Object> attributeGetterFunction =
-				entry.getValue();
+		sb.append(getVersion());
 
-			sb.append("\"");
-			sb.append(attributeName);
-			sb.append("\": ");
+		sb.append(", \"uuid\": ");
 
-			Object value = attributeGetterFunction.apply(
-				(ERCVersionedEntryVersion)this);
+		sb.append("\"" + getUuid() + "\"");
 
-			if (value == null) {
-				sb.append("null");
-			}
-			else if (value instanceof Blob || value instanceof Date ||
-					 value instanceof Map || value instanceof String) {
+		sb.append(", \"externalReferenceCode\": ");
 
-				sb.append(
-					"\"" + StringUtil.replace(value.toString(), "\"", "'") +
-						"\"");
-			}
-			else {
-				sb.append(value);
-			}
+		sb.append("\"" + getExternalReferenceCode() + "\"");
 
-			sb.append(", ");
-		}
+		sb.append(", \"ercVersionedEntryId\": ");
 
-		if (sb.index() > 1) {
-			sb.setIndex(sb.index() - 1);
-		}
+		sb.append(getErcVersionedEntryId());
 
-		sb.append("}");
+		sb.append(", \"groupId\": ");
+
+		sb.append(getGroupId());
+
+		sb.append(", \"companyId\": ");
+
+		sb.append(getCompanyId());
+
+		sb.append(", \"eagerBlob\": ");
+
+		sb.append("\"" + getEagerBlob() + "\"");
 
 		return sb.toString();
 	}
@@ -787,6 +782,9 @@ public class ERCVersionedEntryVersionModelImpl
 	private long _ercVersionedEntryId;
 	private long _groupId;
 	private long _companyId;
+	private Blob _eagerBlob;
+	private transient ERCVersionedEntryVersionLazyBlobBlobModel
+		_lazyBlobBlobModel;
 
 	public <T> T getColumnValue(String columnName) {
 		columnName = _attributeNames.getOrDefault(columnName, columnName);
@@ -827,6 +825,7 @@ public class ERCVersionedEntryVersionModelImpl
 		_columnOriginalValues.put("ercVersionedEntryId", _ercVersionedEntryId);
 		_columnOriginalValues.put("groupId", _groupId);
 		_columnOriginalValues.put("companyId", _companyId);
+		_columnOriginalValues.put("eagerBlob", _eagerBlob);
 	}
 
 	private static final Map<String, String> _attributeNames;
@@ -840,35 +839,7 @@ public class ERCVersionedEntryVersionModelImpl
 	}
 
 	private transient Map<String, Object> _columnOriginalValues;
-
-	public static long getColumnBitmask(String columnName) {
-		return _columnBitmasks.get(columnName);
-	}
-
-	private static final Map<String, Long> _columnBitmasks;
-
-	static {
-		Map<String, Long> columnBitmasks = new HashMap<>();
-
-		columnBitmasks.put("ercVersionedEntryVersionId", 1L);
-
-		columnBitmasks.put("version", 2L);
-
-		columnBitmasks.put("uuid_", 4L);
-
-		columnBitmasks.put("externalReferenceCode", 8L);
-
-		columnBitmasks.put("ercVersionedEntryId", 16L);
-
-		columnBitmasks.put("groupId", 32L);
-
-		columnBitmasks.put("companyId", 64L);
-
-		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
-	}
-
-	private long _columnBitmask;
 	private ERCVersionedEntryVersion _escapedModel;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1636105583
+// LIFERAY-SERVICE-BUILDER-HASH:909031189

--- a/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/base/ERCVersionedEntryLocalServiceBaseImpl.java
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/base/ERCVersionedEntryLocalServiceBaseImpl.java
@@ -5,10 +5,13 @@
 
 package com.liferay.portal.tools.service.builder.test.service.base;
 
+import com.liferay.petra.io.AutoDeleteFileInputStream;
+import com.liferay.petra.io.unsync.UnsyncByteArrayInputStream;
 import com.liferay.petra.sql.dsl.query.DSLQuery;
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.dao.jdbc.CurrentConnectionUtil;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.DefaultActionableDynamicQuery;
@@ -16,6 +19,7 @@ import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.dao.orm.DynamicQueryFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.IndexableActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.Projection;
+import com.liferay.portal.kernel.dao.orm.Session;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
@@ -29,17 +33,21 @@ import com.liferay.portal.kernel.service.persistence.BasePersistence;
 import com.liferay.portal.kernel.service.version.VersionService;
 import com.liferay.portal.kernel.service.version.VersionServiceListener;
 import com.liferay.portal.kernel.transaction.Transactional;
+import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.spring.extender.service.ServiceReference;
 import com.liferay.portal.tools.service.builder.test.model.ERCVersionedEntry;
+import com.liferay.portal.tools.service.builder.test.model.ERCVersionedEntryLazyBlobBlobModel;
 import com.liferay.portal.tools.service.builder.test.model.ERCVersionedEntryVersion;
 import com.liferay.portal.tools.service.builder.test.service.ERCVersionedEntryLocalService;
 import com.liferay.portal.tools.service.builder.test.service.ERCVersionedEntryLocalServiceUtil;
 import com.liferay.portal.tools.service.builder.test.service.persistence.ERCVersionedEntryPersistence;
 import com.liferay.portal.tools.service.builder.test.service.persistence.ERCVersionedEntryVersionPersistence;
 
+import java.io.InputStream;
 import java.io.Serializable;
 
+import java.sql.Blob;
 import java.sql.Connection;
 
 import java.util.Collections;
@@ -533,7 +541,64 @@ public abstract class ERCVersionedEntryLocalServiceBaseImpl
 			ercVersionedEntryVersionPersistence;
 	}
 
+	@Override
+	public ERCVersionedEntryLazyBlobBlobModel getLazyBlobBlobModel(
+		Serializable primaryKey) {
+
+		Session session = null;
+
+		try {
+			session = ercVersionedEntryPersistence.openSession();
+
+			return (ERCVersionedEntryLazyBlobBlobModel)session.get(
+				ERCVersionedEntryLazyBlobBlobModel.class, primaryKey);
+		}
+		catch (Exception exception) {
+			throw ercVersionedEntryPersistence.processException(exception);
+		}
+		finally {
+			ercVersionedEntryPersistence.closeSession(session);
+		}
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public InputStream openLazyBlobInputStream(long ercVersionedEntryId) {
+		try {
+			ERCVersionedEntryLazyBlobBlobModel
+				ERCVersionedEntryLazyBlobBlobModel = getLazyBlobBlobModel(
+					ercVersionedEntryId);
+
+			Blob blob = ERCVersionedEntryLazyBlobBlobModel.getLazyBlobBlob();
+
+			if (blob == null) {
+				return _EMPTY_INPUT_STREAM;
+			}
+
+			InputStream inputStream = blob.getBinaryStream();
+
+			if (_useTempFile) {
+				inputStream = new AutoDeleteFileInputStream(
+					_file.createTempFile(inputStream));
+			}
+
+			return inputStream;
+		}
+		catch (Exception exception) {
+			throw new SystemException(exception);
+		}
+	}
+
 	public void afterPropertiesSet() {
+		DB db = DBManagerUtil.getDB();
+
+		if ((db.getDBType() != DBType.DB2) &&
+			(db.getDBType() != DBType.MYSQL) &&
+			(db.getDBType() != DBType.MARIADB)) {
+
+			_useTempFile = true;
+		}
+
 		ERCVersionedEntryLocalServiceUtil.setService(
 			ercVersionedEntryLocalService);
 	}
@@ -946,6 +1011,10 @@ public abstract class ERCVersionedEntryLocalServiceBaseImpl
 			publishedERCVersionedEntry.getGroupId());
 		draftERCVersionedEntry.setCompanyId(
 			publishedERCVersionedEntry.getCompanyId());
+		draftERCVersionedEntry.setEagerBlob(
+			publishedERCVersionedEntry.getEagerBlob());
+		draftERCVersionedEntry.setLazyBlob(
+			publishedERCVersionedEntry.getLazyBlob());
 
 		draftERCVersionedEntry.resetOriginalValues();
 
@@ -1026,5 +1095,13 @@ public abstract class ERCVersionedEntryLocalServiceBaseImpl
 	private static final Log _log = LogFactoryUtil.getLog(
 		ERCVersionedEntryLocalServiceBaseImpl.class);
 
+	@BeanReference(type = File.class)
+	protected File _file;
+
+	private static final InputStream _EMPTY_INPUT_STREAM =
+		new UnsyncByteArrayInputStream(new byte[0]);
+
+	private boolean _useTempFile;
+
 }
-// LIFERAY-SERVICE-BUILDER-HASH:712558739
+// LIFERAY-SERVICE-BUILDER-HASH:1022726008

--- a/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/persistence/impl/ERCVersionedEntryModelArgumentsResolver.java
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/persistence/impl/ERCVersionedEntryModelArgumentsResolver.java
@@ -13,8 +13,7 @@ import com.liferay.portal.tools.service.builder.test.model.ERCVersionedEntryTabl
 import com.liferay.portal.tools.service.builder.test.model.impl.ERCVersionedEntryImpl;
 import com.liferay.portal.tools.service.builder.test.model.impl.ERCVersionedEntryModelImpl;
 
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.Objects;
 
 /**
  * The arguments resolver class for retrieving value from ERCVersionedEntry.
@@ -50,28 +49,9 @@ public class ERCVersionedEntryModelArgumentsResolver
 		ERCVersionedEntryModelImpl ercVersionedEntryModelImpl =
 			(ERCVersionedEntryModelImpl)baseModel;
 
-		long columnBitmask = ercVersionedEntryModelImpl.getColumnBitmask();
+		if (!checkColumn ||
+			_hasModifiedColumns(ercVersionedEntryModelImpl, columnNames)) {
 
-		if (!checkColumn || (columnBitmask == 0)) {
-			return _getValue(ercVersionedEntryModelImpl, finderPath, original);
-		}
-
-		Long finderPathColumnBitmask = _finderPathColumnBitmasksCache.get(
-			finderPath);
-
-		if (finderPathColumnBitmask == null) {
-			finderPathColumnBitmask = 0L;
-
-			for (String columnName : columnNames) {
-				finderPathColumnBitmask |=
-					ercVersionedEntryModelImpl.getColumnBitmask(columnName);
-			}
-
-			_finderPathColumnBitmasksCache.put(
-				finderPath, finderPathColumnBitmask);
-		}
-
-		if ((columnBitmask & finderPathColumnBitmask) != 0) {
 			return _getValue(ercVersionedEntryModelImpl, finderPath, original);
 		}
 
@@ -115,8 +95,26 @@ public class ERCVersionedEntryModelArgumentsResolver
 		return arguments;
 	}
 
-	private static final Map<FinderPath, Long> _finderPathColumnBitmasksCache =
-		new ConcurrentHashMap<>();
+	private static boolean _hasModifiedColumns(
+		ERCVersionedEntryModelImpl ercVersionedEntryModelImpl,
+		String[] columnNames) {
+
+		if (columnNames.length == 0) {
+			return false;
+		}
+
+		for (String columnName : columnNames) {
+			if (!Objects.equals(
+					ercVersionedEntryModelImpl.getColumnOriginalValue(
+						columnName),
+					ercVersionedEntryModelImpl.getColumnValue(columnName))) {
+
+				return true;
+			}
+		}
+
+		return false;
+	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1682090847
+// LIFERAY-SERVICE-BUILDER-HASH:1792999623

--- a/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/persistence/impl/ERCVersionedEntryPersistenceImpl.java
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/persistence/impl/ERCVersionedEntryPersistenceImpl.java
@@ -28,7 +28,6 @@ import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
-import com.liferay.portal.spring.extender.service.ServiceReference;
 import com.liferay.portal.tools.service.builder.test.exception.DuplicateERCVersionedEntryExternalReferenceCodeException;
 import com.liferay.portal.tools.service.builder.test.exception.NoSuchERCVersionedEntryException;
 import com.liferay.portal.tools.service.builder.test.model.ERCVersionedEntry;
@@ -102,8 +101,8 @@ public class ERCVersionedEntryPersistenceImpl
 		boolean useFinderCache) {
 
 		return _collectionPersistenceFinderByUuid.find(
-			finderCache, new Object[] {uuid}, start, end, orderByComparator,
-			useFinderCache);
+			dummyFinderCache, new Object[] {uuid}, start, end,
+			orderByComparator, useFinderCache);
 	}
 
 	/**
@@ -120,7 +119,7 @@ public class ERCVersionedEntryPersistenceImpl
 		throws NoSuchERCVersionedEntryException {
 
 		return _collectionPersistenceFinderByUuid.findFirst(
-			finderCache, new Object[] {uuid}, orderByComparator);
+			dummyFinderCache, new Object[] {uuid}, orderByComparator);
 	}
 
 	/**
@@ -135,7 +134,7 @@ public class ERCVersionedEntryPersistenceImpl
 		String uuid, OrderByComparator<ERCVersionedEntry> orderByComparator) {
 
 		return _collectionPersistenceFinderByUuid.fetchFirst(
-			finderCache, new Object[] {uuid}, orderByComparator);
+			dummyFinderCache, new Object[] {uuid}, orderByComparator);
 	}
 
 	/**
@@ -146,7 +145,7 @@ public class ERCVersionedEntryPersistenceImpl
 	@Override
 	public void removeByUuid(String uuid) {
 		_collectionPersistenceFinderByUuid.remove(
-			finderCache, new Object[] {uuid});
+			dummyFinderCache, new Object[] {uuid});
 	}
 
 	/**
@@ -158,7 +157,7 @@ public class ERCVersionedEntryPersistenceImpl
 	@Override
 	public int countByUuid(String uuid) {
 		return _collectionPersistenceFinderByUuid.count(
-			finderCache, new Object[] {uuid});
+			dummyFinderCache, new Object[] {uuid});
 	}
 
 	private CollectionPersistenceFinder
@@ -187,7 +186,7 @@ public class ERCVersionedEntryPersistenceImpl
 		boolean useFinderCache) {
 
 		return _collectionPersistenceFinderByUuid_Head.find(
-			finderCache, new Object[] {uuid, head}, start, end,
+			dummyFinderCache, new Object[] {uuid, head}, start, end,
 			orderByComparator, useFinderCache);
 	}
 
@@ -207,7 +206,7 @@ public class ERCVersionedEntryPersistenceImpl
 		throws NoSuchERCVersionedEntryException {
 
 		return _collectionPersistenceFinderByUuid_Head.findFirst(
-			finderCache, new Object[] {uuid, head}, orderByComparator);
+			dummyFinderCache, new Object[] {uuid, head}, orderByComparator);
 	}
 
 	/**
@@ -224,7 +223,7 @@ public class ERCVersionedEntryPersistenceImpl
 		OrderByComparator<ERCVersionedEntry> orderByComparator) {
 
 		return _collectionPersistenceFinderByUuid_Head.fetchFirst(
-			finderCache, new Object[] {uuid, head}, orderByComparator);
+			dummyFinderCache, new Object[] {uuid, head}, orderByComparator);
 	}
 
 	/**
@@ -236,7 +235,7 @@ public class ERCVersionedEntryPersistenceImpl
 	@Override
 	public void removeByUuid_Head(String uuid, boolean head) {
 		_collectionPersistenceFinderByUuid_Head.remove(
-			finderCache, new Object[] {uuid, head});
+			dummyFinderCache, new Object[] {uuid, head});
 	}
 
 	/**
@@ -249,7 +248,7 @@ public class ERCVersionedEntryPersistenceImpl
 	@Override
 	public int countByUuid_Head(String uuid, boolean head) {
 		return _collectionPersistenceFinderByUuid_Head.count(
-			finderCache, new Object[] {uuid, head});
+			dummyFinderCache, new Object[] {uuid, head});
 	}
 
 	private CollectionPersistenceFinder
@@ -278,7 +277,7 @@ public class ERCVersionedEntryPersistenceImpl
 		boolean useFinderCache) {
 
 		return _collectionPersistenceFinderByUUID_G.find(
-			finderCache, new Object[] {uuid, groupId}, start, end,
+			dummyFinderCache, new Object[] {uuid, groupId}, start, end,
 			orderByComparator, useFinderCache);
 	}
 
@@ -298,7 +297,7 @@ public class ERCVersionedEntryPersistenceImpl
 		throws NoSuchERCVersionedEntryException {
 
 		return _collectionPersistenceFinderByUUID_G.findFirst(
-			finderCache, new Object[] {uuid, groupId}, orderByComparator);
+			dummyFinderCache, new Object[] {uuid, groupId}, orderByComparator);
 	}
 
 	/**
@@ -315,7 +314,7 @@ public class ERCVersionedEntryPersistenceImpl
 		OrderByComparator<ERCVersionedEntry> orderByComparator) {
 
 		return _collectionPersistenceFinderByUUID_G.fetchFirst(
-			finderCache, new Object[] {uuid, groupId}, orderByComparator);
+			dummyFinderCache, new Object[] {uuid, groupId}, orderByComparator);
 	}
 
 	/**
@@ -327,7 +326,7 @@ public class ERCVersionedEntryPersistenceImpl
 	@Override
 	public void removeByUUID_G(String uuid, long groupId) {
 		_collectionPersistenceFinderByUUID_G.remove(
-			finderCache, new Object[] {uuid, groupId});
+			dummyFinderCache, new Object[] {uuid, groupId});
 	}
 
 	/**
@@ -340,7 +339,7 @@ public class ERCVersionedEntryPersistenceImpl
 	@Override
 	public int countByUUID_G(String uuid, long groupId) {
 		return _collectionPersistenceFinderByUUID_G.count(
-			finderCache, new Object[] {uuid, groupId});
+			dummyFinderCache, new Object[] {uuid, groupId});
 	}
 
 	private UniquePersistenceFinder
@@ -362,7 +361,7 @@ public class ERCVersionedEntryPersistenceImpl
 		throws NoSuchERCVersionedEntryException {
 
 		return _uniquePersistenceFinderByUUID_G_Head.find(
-			finderCache, new Object[] {uuid, groupId, head});
+			dummyFinderCache, new Object[] {uuid, groupId, head});
 	}
 
 	/**
@@ -379,7 +378,8 @@ public class ERCVersionedEntryPersistenceImpl
 		String uuid, long groupId, boolean head, boolean useFinderCache) {
 
 		return _uniquePersistenceFinderByUUID_G_Head.fetch(
-			finderCache, new Object[] {uuid, groupId, head}, useFinderCache);
+			dummyFinderCache, new Object[] {uuid, groupId, head},
+			useFinderCache);
 	}
 
 	/**
@@ -412,7 +412,7 @@ public class ERCVersionedEntryPersistenceImpl
 	@Override
 	public int countByUUID_G_Head(String uuid, long groupId, boolean head) {
 		return _uniquePersistenceFinderByUUID_G_Head.count(
-			finderCache, new Object[] {uuid, groupId, head});
+			dummyFinderCache, new Object[] {uuid, groupId, head});
 	}
 
 	private CollectionPersistenceFinder
@@ -441,7 +441,7 @@ public class ERCVersionedEntryPersistenceImpl
 		boolean useFinderCache) {
 
 		return _collectionPersistenceFinderByUuid_C.find(
-			finderCache, new Object[] {uuid, companyId}, start, end,
+			dummyFinderCache, new Object[] {uuid, companyId}, start, end,
 			orderByComparator, useFinderCache);
 	}
 
@@ -461,7 +461,8 @@ public class ERCVersionedEntryPersistenceImpl
 		throws NoSuchERCVersionedEntryException {
 
 		return _collectionPersistenceFinderByUuid_C.findFirst(
-			finderCache, new Object[] {uuid, companyId}, orderByComparator);
+			dummyFinderCache, new Object[] {uuid, companyId},
+			orderByComparator);
 	}
 
 	/**
@@ -478,7 +479,8 @@ public class ERCVersionedEntryPersistenceImpl
 		OrderByComparator<ERCVersionedEntry> orderByComparator) {
 
 		return _collectionPersistenceFinderByUuid_C.fetchFirst(
-			finderCache, new Object[] {uuid, companyId}, orderByComparator);
+			dummyFinderCache, new Object[] {uuid, companyId},
+			orderByComparator);
 	}
 
 	/**
@@ -490,7 +492,7 @@ public class ERCVersionedEntryPersistenceImpl
 	@Override
 	public void removeByUuid_C(String uuid, long companyId) {
 		_collectionPersistenceFinderByUuid_C.remove(
-			finderCache, new Object[] {uuid, companyId});
+			dummyFinderCache, new Object[] {uuid, companyId});
 	}
 
 	/**
@@ -503,7 +505,7 @@ public class ERCVersionedEntryPersistenceImpl
 	@Override
 	public int countByUuid_C(String uuid, long companyId) {
 		return _collectionPersistenceFinderByUuid_C.count(
-			finderCache, new Object[] {uuid, companyId});
+			dummyFinderCache, new Object[] {uuid, companyId});
 	}
 
 	private CollectionPersistenceFinder
@@ -533,7 +535,7 @@ public class ERCVersionedEntryPersistenceImpl
 		boolean useFinderCache) {
 
 		return _collectionPersistenceFinderByUuid_C_Head.find(
-			finderCache, new Object[] {uuid, companyId, head}, start, end,
+			dummyFinderCache, new Object[] {uuid, companyId, head}, start, end,
 			orderByComparator, useFinderCache);
 	}
 
@@ -554,7 +556,7 @@ public class ERCVersionedEntryPersistenceImpl
 		throws NoSuchERCVersionedEntryException {
 
 		return _collectionPersistenceFinderByUuid_C_Head.findFirst(
-			finderCache, new Object[] {uuid, companyId, head},
+			dummyFinderCache, new Object[] {uuid, companyId, head},
 			orderByComparator);
 	}
 
@@ -573,7 +575,7 @@ public class ERCVersionedEntryPersistenceImpl
 		OrderByComparator<ERCVersionedEntry> orderByComparator) {
 
 		return _collectionPersistenceFinderByUuid_C_Head.fetchFirst(
-			finderCache, new Object[] {uuid, companyId, head},
+			dummyFinderCache, new Object[] {uuid, companyId, head},
 			orderByComparator);
 	}
 
@@ -587,7 +589,7 @@ public class ERCVersionedEntryPersistenceImpl
 	@Override
 	public void removeByUuid_C_Head(String uuid, long companyId, boolean head) {
 		_collectionPersistenceFinderByUuid_C_Head.remove(
-			finderCache, new Object[] {uuid, companyId, head});
+			dummyFinderCache, new Object[] {uuid, companyId, head});
 	}
 
 	/**
@@ -601,7 +603,7 @@ public class ERCVersionedEntryPersistenceImpl
 	@Override
 	public int countByUuid_C_Head(String uuid, long companyId, boolean head) {
 		return _collectionPersistenceFinderByUuid_C_Head.count(
-			finderCache, new Object[] {uuid, companyId, head});
+			dummyFinderCache, new Object[] {uuid, companyId, head});
 	}
 
 	private CollectionPersistenceFinder
@@ -630,8 +632,8 @@ public class ERCVersionedEntryPersistenceImpl
 		boolean useFinderCache) {
 
 		return _collectionPersistenceFinderByERC_G.find(
-			finderCache, new Object[] {externalReferenceCode, groupId}, start,
-			end, orderByComparator, useFinderCache);
+			dummyFinderCache, new Object[] {externalReferenceCode, groupId},
+			start, end, orderByComparator, useFinderCache);
 	}
 
 	/**
@@ -650,7 +652,7 @@ public class ERCVersionedEntryPersistenceImpl
 		throws NoSuchERCVersionedEntryException {
 
 		return _collectionPersistenceFinderByERC_G.findFirst(
-			finderCache, new Object[] {externalReferenceCode, groupId},
+			dummyFinderCache, new Object[] {externalReferenceCode, groupId},
 			orderByComparator);
 	}
 
@@ -668,7 +670,7 @@ public class ERCVersionedEntryPersistenceImpl
 		OrderByComparator<ERCVersionedEntry> orderByComparator) {
 
 		return _collectionPersistenceFinderByERC_G.fetchFirst(
-			finderCache, new Object[] {externalReferenceCode, groupId},
+			dummyFinderCache, new Object[] {externalReferenceCode, groupId},
 			orderByComparator);
 	}
 
@@ -681,7 +683,7 @@ public class ERCVersionedEntryPersistenceImpl
 	@Override
 	public void removeByERC_G(String externalReferenceCode, long groupId) {
 		_collectionPersistenceFinderByERC_G.remove(
-			finderCache, new Object[] {externalReferenceCode, groupId});
+			dummyFinderCache, new Object[] {externalReferenceCode, groupId});
 	}
 
 	/**
@@ -694,7 +696,7 @@ public class ERCVersionedEntryPersistenceImpl
 	@Override
 	public int countByERC_G(String externalReferenceCode, long groupId) {
 		return _collectionPersistenceFinderByERC_G.count(
-			finderCache, new Object[] {externalReferenceCode, groupId});
+			dummyFinderCache, new Object[] {externalReferenceCode, groupId});
 	}
 
 	private UniquePersistenceFinder
@@ -716,7 +718,8 @@ public class ERCVersionedEntryPersistenceImpl
 		throws NoSuchERCVersionedEntryException {
 
 		return _uniquePersistenceFinderByERC_G_Head.find(
-			finderCache, new Object[] {externalReferenceCode, groupId, head});
+			dummyFinderCache,
+			new Object[] {externalReferenceCode, groupId, head});
 	}
 
 	/**
@@ -734,7 +737,8 @@ public class ERCVersionedEntryPersistenceImpl
 		boolean useFinderCache) {
 
 		return _uniquePersistenceFinderByERC_G_Head.fetch(
-			finderCache, new Object[] {externalReferenceCode, groupId, head},
+			dummyFinderCache,
+			new Object[] {externalReferenceCode, groupId, head},
 			useFinderCache);
 	}
 
@@ -770,7 +774,8 @@ public class ERCVersionedEntryPersistenceImpl
 		String externalReferenceCode, long groupId, boolean head) {
 
 		return _uniquePersistenceFinderByERC_G_Head.count(
-			finderCache, new Object[] {externalReferenceCode, groupId, head});
+			dummyFinderCache,
+			new Object[] {externalReferenceCode, groupId, head});
 	}
 
 	private UniquePersistenceFinder
@@ -789,7 +794,7 @@ public class ERCVersionedEntryPersistenceImpl
 		throws NoSuchERCVersionedEntryException {
 
 		return _uniquePersistenceFinderByHeadId.find(
-			finderCache, new Object[] {headId});
+			dummyFinderCache, new Object[] {headId});
 	}
 
 	/**
@@ -804,7 +809,7 @@ public class ERCVersionedEntryPersistenceImpl
 		long headId, boolean useFinderCache) {
 
 		return _uniquePersistenceFinderByHeadId.fetch(
-			finderCache, new Object[] {headId}, useFinderCache);
+			dummyFinderCache, new Object[] {headId}, useFinderCache);
 	}
 
 	/**
@@ -831,7 +836,7 @@ public class ERCVersionedEntryPersistenceImpl
 	@Override
 	public int countByHeadId(long headId) {
 		return _uniquePersistenceFinderByHeadId.count(
-			finderCache, new Object[] {headId});
+			dummyFinderCache, new Object[] {headId});
 	}
 
 	public ERCVersionedEntryPersistenceImpl() {
@@ -1021,9 +1026,15 @@ public class ERCVersionedEntryPersistenceImpl
 				session.save(ercVersionedEntry);
 			}
 			else {
-				ercVersionedEntry = (ERCVersionedEntry)session.merge(
-					ercVersionedEntry);
+				session.evict(
+					ERCVersionedEntryImpl.class,
+					ercVersionedEntry.getPrimaryKeyObj());
+
+				session.saveOrUpdate(ercVersionedEntry);
 			}
+
+			session.flush();
+			session.clear();
 		}
 		catch (Exception exception) {
 			throw processException(exception);
@@ -1075,7 +1086,7 @@ public class ERCVersionedEntryPersistenceImpl
 
 	@Override
 	protected EntityCache getEntityCache() {
-		return entityCache;
+		return dummyEntityCache;
 	}
 
 	@Override
@@ -1356,14 +1367,8 @@ public class ERCVersionedEntryPersistenceImpl
 	public void destroy() {
 		ERCVersionedEntryUtil.setPersistence(null);
 
-		entityCache.removeCache(ERCVersionedEntryImpl.class.getName());
+		dummyEntityCache.removeCache(ERCVersionedEntryImpl.class.getName());
 	}
-
-	@ServiceReference(type = EntityCache.class)
-	protected EntityCache entityCache;
-
-	@ServiceReference(type = FinderCache.class)
-	protected FinderCache finderCache;
 
 	private static final String _ENTITY_ALIAS_PREFIX =
 		ERCVersionedEntryModelImpl.ENTITY_ALIAS + ".";
@@ -1388,8 +1393,8 @@ public class ERCVersionedEntryPersistenceImpl
 
 	@Override
 	protected FinderCache getFinderCache() {
-		return finderCache;
+		return dummyFinderCache;
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1555832739
+// LIFERAY-SERVICE-BUILDER-HASH:-581494204

--- a/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/persistence/impl/ERCVersionedEntryVersionModelArgumentsResolver.java
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/persistence/impl/ERCVersionedEntryVersionModelArgumentsResolver.java
@@ -13,8 +13,9 @@ import com.liferay.portal.tools.service.builder.test.model.ERCVersionedEntryVers
 import com.liferay.portal.tools.service.builder.test.model.impl.ERCVersionedEntryVersionImpl;
 import com.liferay.portal.tools.service.builder.test.model.impl.ERCVersionedEntryVersionModelImpl;
 
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * The arguments resolver class for retrieving value from ERCVersionedEntryVersion.
@@ -50,39 +51,12 @@ public class ERCVersionedEntryVersionModelArgumentsResolver
 		ERCVersionedEntryVersionModelImpl ercVersionedEntryVersionModelImpl =
 			(ERCVersionedEntryVersionModelImpl)baseModel;
 
-		long columnBitmask =
-			ercVersionedEntryVersionModelImpl.getColumnBitmask();
+		if (!checkColumn ||
+			_hasModifiedColumns(
+				ercVersionedEntryVersionModelImpl, columnNames) ||
+			_hasModifiedColumns(
+				ercVersionedEntryVersionModelImpl, _ORDER_BY_COLUMNS)) {
 
-		if (!checkColumn || (columnBitmask == 0)) {
-			return _getValue(
-				ercVersionedEntryVersionModelImpl, finderPath, original);
-		}
-
-		Long finderPathColumnBitmask = _finderPathColumnBitmasksCache.get(
-			finderPath);
-
-		if (finderPathColumnBitmask == null) {
-			finderPathColumnBitmask = 0L;
-
-			for (String columnName : columnNames) {
-				finderPathColumnBitmask |=
-					ercVersionedEntryVersionModelImpl.getColumnBitmask(
-						columnName);
-			}
-
-			if (finderPath.isBaseModelResult() &&
-				(ERCVersionedEntryVersionPersistenceImpl.
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION ==
-						finderPath.getCacheName())) {
-
-				finderPathColumnBitmask |= _ORDER_BY_COLUMNS_BITMASK;
-			}
-
-			_finderPathColumnBitmasksCache.put(
-				finderPath, finderPathColumnBitmask);
-		}
-
-		if ((columnBitmask & finderPathColumnBitmask) != 0) {
 			return _getValue(
 				ercVersionedEntryVersionModelImpl, finderPath, original);
 		}
@@ -129,19 +103,37 @@ public class ERCVersionedEntryVersionModelArgumentsResolver
 		return arguments;
 	}
 
-	private static final Map<FinderPath, Long> _finderPathColumnBitmasksCache =
-		new ConcurrentHashMap<>();
+	private static boolean _hasModifiedColumns(
+		ERCVersionedEntryVersionModelImpl ercVersionedEntryVersionModelImpl,
+		String[] columnNames) {
 
-	private static final long _ORDER_BY_COLUMNS_BITMASK;
+		if (columnNames.length == 0) {
+			return false;
+		}
+
+		for (String columnName : columnNames) {
+			if (!Objects.equals(
+					ercVersionedEntryVersionModelImpl.getColumnOriginalValue(
+						columnName),
+					ercVersionedEntryVersionModelImpl.getColumnValue(
+						columnName))) {
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private static final String[] _ORDER_BY_COLUMNS;
 
 	static {
-		long orderByColumnsBitmask = 0;
+		List<String> orderByColumns = new ArrayList<String>();
 
-		orderByColumnsBitmask |=
-			ERCVersionedEntryVersionModelImpl.getColumnBitmask("version");
+		orderByColumns.add("version");
 
-		_ORDER_BY_COLUMNS_BITMASK = orderByColumnsBitmask;
+		_ORDER_BY_COLUMNS = orderByColumns.toArray(new String[0]);
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1814987501
+// LIFERAY-SERVICE-BUILDER-HASH:-808016544

--- a/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/persistence/impl/ERCVersionedEntryVersionPersistenceImpl.java
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/persistence/impl/ERCVersionedEntryVersionPersistenceImpl.java
@@ -27,7 +27,6 @@ import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
-import com.liferay.portal.spring.extender.service.ServiceReference;
 import com.liferay.portal.tools.service.builder.test.exception.NoSuchERCVersionedEntryVersionException;
 import com.liferay.portal.tools.service.builder.test.model.ERCVersionedEntryVersion;
 import com.liferay.portal.tools.service.builder.test.model.ERCVersionedEntryVersionTable;
@@ -100,7 +99,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		boolean useFinderCache) {
 
 		return _collectionPersistenceFinderByErcVersionedEntryId.find(
-			finderCache, new Object[] {ercVersionedEntryId}, start, end,
+			dummyFinderCache, new Object[] {ercVersionedEntryId}, start, end,
 			orderByComparator, useFinderCache);
 	}
 
@@ -119,7 +118,8 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		throws NoSuchERCVersionedEntryVersionException {
 
 		return _collectionPersistenceFinderByErcVersionedEntryId.findFirst(
-			finderCache, new Object[] {ercVersionedEntryId}, orderByComparator);
+			dummyFinderCache, new Object[] {ercVersionedEntryId},
+			orderByComparator);
 	}
 
 	/**
@@ -135,7 +135,8 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		OrderByComparator<ERCVersionedEntryVersion> orderByComparator) {
 
 		return _collectionPersistenceFinderByErcVersionedEntryId.fetchFirst(
-			finderCache, new Object[] {ercVersionedEntryId}, orderByComparator);
+			dummyFinderCache, new Object[] {ercVersionedEntryId},
+			orderByComparator);
 	}
 
 	/**
@@ -146,7 +147,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 	@Override
 	public void removeByErcVersionedEntryId(long ercVersionedEntryId) {
 		_collectionPersistenceFinderByErcVersionedEntryId.remove(
-			finderCache, new Object[] {ercVersionedEntryId});
+			dummyFinderCache, new Object[] {ercVersionedEntryId});
 	}
 
 	/**
@@ -158,7 +159,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 	@Override
 	public int countByErcVersionedEntryId(long ercVersionedEntryId) {
 		return _collectionPersistenceFinderByErcVersionedEntryId.count(
-			finderCache, new Object[] {ercVersionedEntryId});
+			dummyFinderCache, new Object[] {ercVersionedEntryId});
 	}
 
 	private UniquePersistenceFinder
@@ -179,7 +180,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		throws NoSuchERCVersionedEntryVersionException {
 
 		return _uniquePersistenceFinderByErcVersionedEntryId_Version.find(
-			finderCache, new Object[] {ercVersionedEntryId, version});
+			dummyFinderCache, new Object[] {ercVersionedEntryId, version});
 	}
 
 	/**
@@ -195,7 +196,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		long ercVersionedEntryId, int version, boolean useFinderCache) {
 
 		return _uniquePersistenceFinderByErcVersionedEntryId_Version.fetch(
-			finderCache, new Object[] {ercVersionedEntryId, version},
+			dummyFinderCache, new Object[] {ercVersionedEntryId, version},
 			useFinderCache);
 	}
 
@@ -229,7 +230,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		long ercVersionedEntryId, int version) {
 
 		return _uniquePersistenceFinderByErcVersionedEntryId_Version.count(
-			finderCache, new Object[] {ercVersionedEntryId, version});
+			dummyFinderCache, new Object[] {ercVersionedEntryId, version});
 	}
 
 	private CollectionPersistenceFinder
@@ -257,8 +258,8 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		boolean useFinderCache) {
 
 		return _collectionPersistenceFinderByUuid.find(
-			finderCache, new Object[] {uuid}, start, end, orderByComparator,
-			useFinderCache);
+			dummyFinderCache, new Object[] {uuid}, start, end,
+			orderByComparator, useFinderCache);
 	}
 
 	/**
@@ -276,7 +277,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		throws NoSuchERCVersionedEntryVersionException {
 
 		return _collectionPersistenceFinderByUuid.findFirst(
-			finderCache, new Object[] {uuid}, orderByComparator);
+			dummyFinderCache, new Object[] {uuid}, orderByComparator);
 	}
 
 	/**
@@ -292,7 +293,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		OrderByComparator<ERCVersionedEntryVersion> orderByComparator) {
 
 		return _collectionPersistenceFinderByUuid.fetchFirst(
-			finderCache, new Object[] {uuid}, orderByComparator);
+			dummyFinderCache, new Object[] {uuid}, orderByComparator);
 	}
 
 	/**
@@ -303,7 +304,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 	@Override
 	public void removeByUuid(String uuid) {
 		_collectionPersistenceFinderByUuid.remove(
-			finderCache, new Object[] {uuid});
+			dummyFinderCache, new Object[] {uuid});
 	}
 
 	/**
@@ -315,7 +316,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 	@Override
 	public int countByUuid(String uuid) {
 		return _collectionPersistenceFinderByUuid.count(
-			finderCache, new Object[] {uuid});
+			dummyFinderCache, new Object[] {uuid});
 	}
 
 	private CollectionPersistenceFinder
@@ -344,7 +345,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		boolean useFinderCache) {
 
 		return _collectionPersistenceFinderByUuid_Version.find(
-			finderCache, new Object[] {uuid, version}, start, end,
+			dummyFinderCache, new Object[] {uuid, version}, start, end,
 			orderByComparator, useFinderCache);
 	}
 
@@ -364,7 +365,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		throws NoSuchERCVersionedEntryVersionException {
 
 		return _collectionPersistenceFinderByUuid_Version.findFirst(
-			finderCache, new Object[] {uuid, version}, orderByComparator);
+			dummyFinderCache, new Object[] {uuid, version}, orderByComparator);
 	}
 
 	/**
@@ -381,7 +382,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		OrderByComparator<ERCVersionedEntryVersion> orderByComparator) {
 
 		return _collectionPersistenceFinderByUuid_Version.fetchFirst(
-			finderCache, new Object[] {uuid, version}, orderByComparator);
+			dummyFinderCache, new Object[] {uuid, version}, orderByComparator);
 	}
 
 	/**
@@ -393,7 +394,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 	@Override
 	public void removeByUuid_Version(String uuid, int version) {
 		_collectionPersistenceFinderByUuid_Version.remove(
-			finderCache, new Object[] {uuid, version});
+			dummyFinderCache, new Object[] {uuid, version});
 	}
 
 	/**
@@ -406,7 +407,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 	@Override
 	public int countByUuid_Version(String uuid, int version) {
 		return _collectionPersistenceFinderByUuid_Version.count(
-			finderCache, new Object[] {uuid, version});
+			dummyFinderCache, new Object[] {uuid, version});
 	}
 
 	private CollectionPersistenceFinder
@@ -435,7 +436,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		boolean useFinderCache) {
 
 		return _collectionPersistenceFinderByUUID_G.find(
-			finderCache, new Object[] {uuid, groupId}, start, end,
+			dummyFinderCache, new Object[] {uuid, groupId}, start, end,
 			orderByComparator, useFinderCache);
 	}
 
@@ -455,7 +456,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		throws NoSuchERCVersionedEntryVersionException {
 
 		return _collectionPersistenceFinderByUUID_G.findFirst(
-			finderCache, new Object[] {uuid, groupId}, orderByComparator);
+			dummyFinderCache, new Object[] {uuid, groupId}, orderByComparator);
 	}
 
 	/**
@@ -472,7 +473,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		OrderByComparator<ERCVersionedEntryVersion> orderByComparator) {
 
 		return _collectionPersistenceFinderByUUID_G.fetchFirst(
-			finderCache, new Object[] {uuid, groupId}, orderByComparator);
+			dummyFinderCache, new Object[] {uuid, groupId}, orderByComparator);
 	}
 
 	/**
@@ -484,7 +485,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 	@Override
 	public void removeByUUID_G(String uuid, long groupId) {
 		_collectionPersistenceFinderByUUID_G.remove(
-			finderCache, new Object[] {uuid, groupId});
+			dummyFinderCache, new Object[] {uuid, groupId});
 	}
 
 	/**
@@ -497,7 +498,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 	@Override
 	public int countByUUID_G(String uuid, long groupId) {
 		return _collectionPersistenceFinderByUUID_G.count(
-			finderCache, new Object[] {uuid, groupId});
+			dummyFinderCache, new Object[] {uuid, groupId});
 	}
 
 	private UniquePersistenceFinder
@@ -519,7 +520,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		throws NoSuchERCVersionedEntryVersionException {
 
 		return _uniquePersistenceFinderByUUID_G_Version.find(
-			finderCache, new Object[] {uuid, groupId, version});
+			dummyFinderCache, new Object[] {uuid, groupId, version});
 	}
 
 	/**
@@ -536,7 +537,8 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		String uuid, long groupId, int version, boolean useFinderCache) {
 
 		return _uniquePersistenceFinderByUUID_G_Version.fetch(
-			finderCache, new Object[] {uuid, groupId, version}, useFinderCache);
+			dummyFinderCache, new Object[] {uuid, groupId, version},
+			useFinderCache);
 	}
 
 	/**
@@ -569,7 +571,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 	@Override
 	public int countByUUID_G_Version(String uuid, long groupId, int version) {
 		return _uniquePersistenceFinderByUUID_G_Version.count(
-			finderCache, new Object[] {uuid, groupId, version});
+			dummyFinderCache, new Object[] {uuid, groupId, version});
 	}
 
 	private CollectionPersistenceFinder
@@ -598,7 +600,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		boolean useFinderCache) {
 
 		return _collectionPersistenceFinderByUuid_C.find(
-			finderCache, new Object[] {uuid, companyId}, start, end,
+			dummyFinderCache, new Object[] {uuid, companyId}, start, end,
 			orderByComparator, useFinderCache);
 	}
 
@@ -618,7 +620,8 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		throws NoSuchERCVersionedEntryVersionException {
 
 		return _collectionPersistenceFinderByUuid_C.findFirst(
-			finderCache, new Object[] {uuid, companyId}, orderByComparator);
+			dummyFinderCache, new Object[] {uuid, companyId},
+			orderByComparator);
 	}
 
 	/**
@@ -635,7 +638,8 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		OrderByComparator<ERCVersionedEntryVersion> orderByComparator) {
 
 		return _collectionPersistenceFinderByUuid_C.fetchFirst(
-			finderCache, new Object[] {uuid, companyId}, orderByComparator);
+			dummyFinderCache, new Object[] {uuid, companyId},
+			orderByComparator);
 	}
 
 	/**
@@ -647,7 +651,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 	@Override
 	public void removeByUuid_C(String uuid, long companyId) {
 		_collectionPersistenceFinderByUuid_C.remove(
-			finderCache, new Object[] {uuid, companyId});
+			dummyFinderCache, new Object[] {uuid, companyId});
 	}
 
 	/**
@@ -660,7 +664,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 	@Override
 	public int countByUuid_C(String uuid, long companyId) {
 		return _collectionPersistenceFinderByUuid_C.count(
-			finderCache, new Object[] {uuid, companyId});
+			dummyFinderCache, new Object[] {uuid, companyId});
 	}
 
 	private CollectionPersistenceFinder
@@ -690,8 +694,8 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		boolean useFinderCache) {
 
 		return _collectionPersistenceFinderByUuid_C_Version.find(
-			finderCache, new Object[] {uuid, companyId, version}, start, end,
-			orderByComparator, useFinderCache);
+			dummyFinderCache, new Object[] {uuid, companyId, version}, start,
+			end, orderByComparator, useFinderCache);
 	}
 
 	/**
@@ -711,7 +715,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		throws NoSuchERCVersionedEntryVersionException {
 
 		return _collectionPersistenceFinderByUuid_C_Version.findFirst(
-			finderCache, new Object[] {uuid, companyId, version},
+			dummyFinderCache, new Object[] {uuid, companyId, version},
 			orderByComparator);
 	}
 
@@ -730,7 +734,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		OrderByComparator<ERCVersionedEntryVersion> orderByComparator) {
 
 		return _collectionPersistenceFinderByUuid_C_Version.fetchFirst(
-			finderCache, new Object[] {uuid, companyId, version},
+			dummyFinderCache, new Object[] {uuid, companyId, version},
 			orderByComparator);
 	}
 
@@ -746,7 +750,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		String uuid, long companyId, int version) {
 
 		_collectionPersistenceFinderByUuid_C_Version.remove(
-			finderCache, new Object[] {uuid, companyId, version});
+			dummyFinderCache, new Object[] {uuid, companyId, version});
 	}
 
 	/**
@@ -760,7 +764,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 	@Override
 	public int countByUuid_C_Version(String uuid, long companyId, int version) {
 		return _collectionPersistenceFinderByUuid_C_Version.count(
-			finderCache, new Object[] {uuid, companyId, version});
+			dummyFinderCache, new Object[] {uuid, companyId, version});
 	}
 
 	public ERCVersionedEntryVersionPersistenceImpl() {
@@ -930,6 +934,9 @@ public class ERCVersionedEntryVersionPersistenceImpl
 				throw new IllegalArgumentException(
 					"ERCVersionedEntryVersion is read only, create a new version instead");
 			}
+
+			session.flush();
+			session.clear();
 		}
 		catch (Exception exception) {
 			throw processException(exception);
@@ -984,7 +991,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 
 	@Override
 	protected EntityCache getEntityCache() {
-		return entityCache;
+		return dummyEntityCache;
 	}
 
 	@Override
@@ -1268,14 +1275,9 @@ public class ERCVersionedEntryVersionPersistenceImpl
 	public void destroy() {
 		ERCVersionedEntryVersionUtil.setPersistence(null);
 
-		entityCache.removeCache(ERCVersionedEntryVersionImpl.class.getName());
+		dummyEntityCache.removeCache(
+			ERCVersionedEntryVersionImpl.class.getName());
 	}
-
-	@ServiceReference(type = EntityCache.class)
-	protected EntityCache entityCache;
-
-	@ServiceReference(type = FinderCache.class)
-	protected FinderCache finderCache;
 
 	private static final String _ENTITY_ALIAS_PREFIX =
 		ERCVersionedEntryVersionModelImpl.ENTITY_ALIAS + ".";
@@ -1300,8 +1302,8 @@ public class ERCVersionedEntryVersionPersistenceImpl
 
 	@Override
 	protected FinderCache getFinderCache() {
-		return finderCache;
+		return dummyFinderCache;
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:149441803
+// LIFERAY-SERVICE-BUILDER-HASH:1447826233

--- a/modules/util/portal-tools-service-builder-test-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/resources/META-INF/module-hbm.xml
@@ -159,6 +159,16 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="head" type="com.liferay.portal.dao.orm.hibernate.BooleanType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="groupId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="companyId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="eagerBlob" type="org.hibernate.type.BlobType" />
+		<one-to-one access="com.liferay.portal.dao.orm.hibernate.PrivateFieldPropertyAccessor" cascade="save-update" class="com.liferay.portal.tools.service.builder.test.model.ERCVersionedEntryLazyBlobBlobModel" constrained="false" name="lazyBlobBlobModel" outer-join="false" />
+	</class>
+	<class lazy="true" name="com.liferay.portal.tools.service.builder.test.model.ERCVersionedEntryLazyBlobBlobModel" table="ERCVersionedEntry">
+		<id column="ercVersionedEntryId" name="ercVersionedEntryId">
+			<generator class="foreign">
+				<param name="property">com.liferay.portal.tools.service.builder.test.model.impl.ERCVersionedEntryImpl</param>
+			</generator>
+		</id>
+		<property column="lazyBlob" name="lazyBlobBlob" type="blob" />
 	</class>
 	<class name="com.liferay.portal.tools.service.builder.test.model.impl.ERCVersionedEntryVersionImpl" table="ERCVersionedEntryVersion">
 		<id access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="ercVersionedEntryVersionId" type="long">
@@ -170,6 +180,16 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="ercVersionedEntryId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="groupId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="companyId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="eagerBlob" type="org.hibernate.type.BlobType" />
+		<one-to-one access="com.liferay.portal.dao.orm.hibernate.PrivateFieldPropertyAccessor" cascade="save-update" class="com.liferay.portal.tools.service.builder.test.model.ERCVersionedEntryVersionLazyBlobBlobModel" constrained="false" name="lazyBlobBlobModel" outer-join="false" />
+	</class>
+	<class lazy="true" name="com.liferay.portal.tools.service.builder.test.model.ERCVersionedEntryVersionLazyBlobBlobModel" table="ERCVersionedEntryVersion">
+		<id column="ercVersionedEntryVersionId" name="ercVersionedEntryVersionId">
+			<generator class="foreign">
+				<param name="property">com.liferay.portal.tools.service.builder.test.model.impl.ERCVersionedEntryVersionImpl</param>
+			</generator>
+		</id>
+		<property column="lazyBlob" name="lazyBlobBlob" type="blob" />
 	</class>
 	<class name="com.liferay.portal.tools.service.builder.test.model.impl.FinderWhereClauseEntryImpl" table="FinderWhereClauseEntry">
 		<id access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="finderWhereClauseEntryId" type="long">

--- a/modules/util/portal-tools-service-builder-test-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -94,6 +94,8 @@
 		<field name="ercVersionedEntryId" type="long" />
 		<field name="groupId" type="long" />
 		<field name="companyId" type="long" />
+		<field name="eagerBlob" type="Blob" />
+		<field name="lazyBlob" type="Blob" />
 	</model>
 	<model name="com.liferay.portal.tools.service.builder.test.model.ERCVersionedEntryVersion">
 		<field name="ercVersionedEntryVersionId" type="long" />
@@ -103,6 +105,8 @@
 		<field name="ercVersionedEntryId" type="long" />
 		<field name="groupId" type="long" />
 		<field name="companyId" type="long" />
+		<field name="eagerBlob" type="Blob" />
+		<field name="lazyBlob" type="Blob" />
 	</model>
 	<model name="com.liferay.portal.tools.service.builder.test.model.FinderWhereClauseEntry">
 		<field name="finderWhereClauseEntryId" type="long" />

--- a/modules/util/portal-tools-service-builder-test-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/resources/META-INF/sql/tables.sql
@@ -104,7 +104,9 @@ create table ERCVersionedEntry (
 	head BOOLEAN,
 	ercVersionedEntryId LONG not null primary key,
 	groupId LONG,
-	companyId LONG
+	companyId LONG,
+	eagerBlob BLOB,
+	lazyBlob BLOB
 );
 
 create table ERCVersionedEntryVersion (
@@ -114,7 +116,9 @@ create table ERCVersionedEntryVersion (
 	externalReferenceCode VARCHAR(75) null,
 	ercVersionedEntryId LONG,
 	groupId LONG,
-	companyId LONG
+	companyId LONG,
+	eagerBlob BLOB,
+	lazyBlob BLOB
 );
 
 create table EagerBlobEntry (

--- a/modules/util/portal-tools-service-builder-test-service/src/main/resources/service.properties
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/resources/service.properties
@@ -13,5 +13,5 @@
 ##
 
     build.namespace=com.liferay.portal.tools.service.builder.test.service
-    build.number=4
-    build.date=1779290829977
+    build.number=6
+    build.date=1779884698197

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/AutoEscapeEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/AutoEscapeEntryPersistenceTest.java
@@ -374,4 +374,4 @@ public class AutoEscapeEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1529780548
+// LIFERAY-SERVICE-BUILDER-HASH:368923974

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/BigDecimalEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/BigDecimalEntryPersistenceTest.java
@@ -395,4 +395,4 @@ public class BigDecimalEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1426400870
+// LIFERAY-SERVICE-BUILDER-HASH:2099943870

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/CacheDisabledEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/CacheDisabledEntryPersistenceTest.java
@@ -472,4 +472,4 @@ public class CacheDisabledEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1478855935
+// LIFERAY-SERVICE-BUILDER-HASH:-1587025635

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/CacheFieldEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/CacheFieldEntryPersistenceTest.java
@@ -403,4 +403,4 @@ public class CacheFieldEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:46505529
+// LIFERAY-SERVICE-BUILDER-HASH:961685615

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/CacheMissEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/CacheMissEntryPersistenceTest.java
@@ -396,4 +396,4 @@ public class CacheMissEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:755990661
+// LIFERAY-SERVICE-BUILDER-HASH:-1324351577

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/CacheReplicatorEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/CacheReplicatorEntryPersistenceTest.java
@@ -508,4 +508,4 @@ public class CacheReplicatorEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1321425904
+// LIFERAY-SERVICE-BUILDER-HASH:-163770428

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/DSLQueryEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/DSLQueryEntryPersistenceTest.java
@@ -386,4 +386,4 @@ public class DSLQueryEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-428995770
+// LIFERAY-SERVICE-BUILDER-HASH:189884054

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/DSLQueryStatusEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/DSLQueryStatusEntryPersistenceTest.java
@@ -420,4 +420,4 @@ public class DSLQueryStatusEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1516114127
+// LIFERAY-SERVICE-BUILDER-HASH:259128347

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/DataLimitEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/DataLimitEntryPersistenceTest.java
@@ -418,4 +418,4 @@ public class DataLimitEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-830118962
+// LIFERAY-SERVICE-BUILDER-HASH:-1885366358

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/DefinedDefaultOrderEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/DefinedDefaultOrderEntryPersistenceTest.java
@@ -523,4 +523,4 @@ public class DefinedDefaultOrderEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1356629846
+// LIFERAY-SERVICE-BUILDER-HASH:-1842760350

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/DynamicQueryEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/DynamicQueryEntryPersistenceTest.java
@@ -433,4 +433,4 @@ public class DynamicQueryEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2001134816
+// LIFERAY-SERVICE-BUILDER-HASH:-9520372

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ERCCompanyEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ERCCompanyEntryPersistenceTest.java
@@ -542,4 +542,4 @@ public class ERCCompanyEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1236063282
+// LIFERAY-SERVICE-BUILDER-HASH:-1750659718

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ERCGroupEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ERCGroupEntryPersistenceTest.java
@@ -541,4 +541,4 @@ public class ERCGroupEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:386865460
+// LIFERAY-SERVICE-BUILDER-HASH:-1027781696

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ERCVersionedEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ERCVersionedEntryPersistenceTest.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.tools.service.builder.test.service.persistence.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.dao.jdbc.OutputBlob;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.dao.orm.DynamicQueryFactoryUtil;
@@ -30,7 +31,10 @@ import com.liferay.portal.tools.service.builder.test.service.ERCVersionedEntryLo
 import com.liferay.portal.tools.service.builder.test.service.persistence.ERCVersionedEntryPersistence;
 import com.liferay.portal.tools.service.builder.test.service.persistence.ERCVersionedEntryUtil;
 
+import java.io.ByteArrayInputStream;
 import java.io.Serializable;
+
+import java.sql.Blob;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -129,8 +133,32 @@ public class ERCVersionedEntryPersistenceTest {
 		newERCVersionedEntry.setGroupId(RandomTestUtil.nextLong());
 
 		newERCVersionedEntry.setCompanyId(RandomTestUtil.nextLong());
+		String newEagerBlobString = RandomTestUtil.randomString();
+
+		byte[] newEagerBlobBytes = newEagerBlobString.getBytes("UTF-8");
+
+		Blob newEagerBlobBlob = new OutputBlob(
+			new ByteArrayInputStream(newEagerBlobBytes),
+			newEagerBlobBytes.length);
+
+		newERCVersionedEntry.setEagerBlob(newEagerBlobBlob);
+		String newLazyBlobString = RandomTestUtil.randomString();
+
+		byte[] newLazyBlobBytes = newLazyBlobString.getBytes("UTF-8");
+
+		Blob newLazyBlobBlob = new OutputBlob(
+			new ByteArrayInputStream(newLazyBlobBytes),
+			newLazyBlobBytes.length);
+
+		newERCVersionedEntry.setLazyBlob(newLazyBlobBlob);
 
 		_ercVersionedEntries.add(_persistence.update(newERCVersionedEntry));
+
+		Session session = _persistence.openSession();
+
+		session.flush();
+
+		session.clear();
 
 		ERCVersionedEntry existingERCVersionedEntry =
 			_persistence.findByPrimaryKey(newERCVersionedEntry.getPrimaryKey());
@@ -156,6 +184,16 @@ public class ERCVersionedEntryPersistenceTest {
 		Assert.assertEquals(
 			existingERCVersionedEntry.getCompanyId(),
 			newERCVersionedEntry.getCompanyId());
+		Blob existingEagerBlob = existingERCVersionedEntry.getEagerBlob();
+
+		Assert.assertArrayEquals(
+			existingEagerBlob.getBytes(1, (int)existingEagerBlob.length()),
+			newEagerBlobBytes);
+		Blob existingLazyBlob = existingERCVersionedEntry.getLazyBlob();
+
+		Assert.assertArrayEquals(
+			existingLazyBlob.getBytes(1, (int)existingLazyBlob.length()),
+			newLazyBlobBytes);
 	}
 
 	@Test
@@ -174,6 +212,8 @@ public class ERCVersionedEntryPersistenceTest {
 		draftERCVersionedEntry.setHeadId(-ercVersionedEntry.getHeadId());
 		draftERCVersionedEntry.setGroupId(ercVersionedEntry.getGroupId());
 		draftERCVersionedEntry.setCompanyId(ercVersionedEntry.getCompanyId());
+		draftERCVersionedEntry.setEagerBlob(ercVersionedEntry.getEagerBlob());
+		draftERCVersionedEntry.setLazyBlob(ercVersionedEntry.getLazyBlob());
 
 		_ercVersionedEntries.add(_persistence.update(draftERCVersionedEntry));
 
@@ -193,6 +233,18 @@ public class ERCVersionedEntryPersistenceTest {
 		Assert.assertEquals(
 			ercVersionedEntry.getCompanyId(),
 			draftERCVersionedEntry.getCompanyId());
+		Blob EagerBlob = ercVersionedEntry.getEagerBlob();
+		Blob draftEagerBlob = draftERCVersionedEntry.getEagerBlob();
+
+		Assert.assertArrayEquals(
+			EagerBlob.getBytes(1, (int)EagerBlob.length()),
+			draftEagerBlob.getBytes(1, (int)draftEagerBlob.length()));
+		Blob LazyBlob = ercVersionedEntry.getLazyBlob();
+		Blob draftLazyBlob = draftERCVersionedEntry.getLazyBlob();
+
+		Assert.assertArrayEquals(
+			LazyBlob.getBytes(1, (int)LazyBlob.length()),
+			draftLazyBlob.getBytes(1, (int)draftLazyBlob.length()));
 	}
 
 	@Test(
@@ -219,6 +271,22 @@ public class ERCVersionedEntryPersistenceTest {
 		ercVersionedEntry2.setGroupId(ercVersionedEntry1.getGroupId());
 
 		ercVersionedEntry2.setCompanyId(RandomTestUtil.nextLong());
+		String eagerBlobString = RandomTestUtil.randomString();
+
+		byte[] eagerBlobBytes = eagerBlobString.getBytes("UTF-8");
+
+		Blob eagerBlobBlob = new OutputBlob(
+			new ByteArrayInputStream(eagerBlobBytes), eagerBlobBytes.length);
+
+		ercVersionedEntry2.setEagerBlob(eagerBlobBlob);
+		String lazyBlobString = RandomTestUtil.randomString();
+
+		byte[] lazyBlobBytes = lazyBlobString.getBytes("UTF-8");
+
+		Blob lazyBlobBlob = new OutputBlob(
+			new ByteArrayInputStream(lazyBlobBytes), lazyBlobBytes.length);
+
+		ercVersionedEntry2.setLazyBlob(lazyBlobBlob);
 
 		_ercVersionedEntries.add(_persistence.update(ercVersionedEntry2));
 	}
@@ -683,6 +751,22 @@ public class ERCVersionedEntryPersistenceTest {
 		ercVersionedEntry.setGroupId(RandomTestUtil.nextLong());
 
 		ercVersionedEntry.setCompanyId(RandomTestUtil.nextLong());
+		String eagerBlobString = RandomTestUtil.randomString();
+
+		byte[] eagerBlobBytes = eagerBlobString.getBytes("UTF-8");
+
+		Blob eagerBlobBlob = new OutputBlob(
+			new ByteArrayInputStream(eagerBlobBytes), eagerBlobBytes.length);
+
+		ercVersionedEntry.setEagerBlob(eagerBlobBlob);
+		String lazyBlobString = RandomTestUtil.randomString();
+
+		byte[] lazyBlobBytes = lazyBlobString.getBytes("UTF-8");
+
+		Blob lazyBlobBlob = new OutputBlob(
+			new ByteArrayInputStream(lazyBlobBytes), lazyBlobBytes.length);
+
+		ercVersionedEntry.setLazyBlob(lazyBlobBlob);
 
 		_ercVersionedEntries.add(_persistence.update(ercVersionedEntry));
 
@@ -695,4 +779,4 @@ public class ERCVersionedEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:696240845
+// LIFERAY-SERVICE-BUILDER-HASH:-1562951270

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ERCVersionedEntryVersionPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ERCVersionedEntryVersionPersistenceTest.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.tools.service.builder.test.service.persistence.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.dao.jdbc.OutputBlob;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.dao.orm.DynamicQueryFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.ProjectionFactoryUtil;
@@ -26,7 +27,10 @@ import com.liferay.portal.tools.service.builder.test.model.ERCVersionedEntryVers
 import com.liferay.portal.tools.service.builder.test.service.persistence.ERCVersionedEntryVersionPersistence;
 import com.liferay.portal.tools.service.builder.test.service.persistence.ERCVersionedEntryVersionUtil;
 
+import java.io.ByteArrayInputStream;
 import java.io.Serializable;
+
+import java.sql.Blob;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -130,9 +134,33 @@ public class ERCVersionedEntryVersionPersistenceTest {
 		newERCVersionedEntryVersion.setGroupId(RandomTestUtil.nextLong());
 
 		newERCVersionedEntryVersion.setCompanyId(RandomTestUtil.nextLong());
+		String newEagerBlobString = RandomTestUtil.randomString();
+
+		byte[] newEagerBlobBytes = newEagerBlobString.getBytes("UTF-8");
+
+		Blob newEagerBlobBlob = new OutputBlob(
+			new ByteArrayInputStream(newEagerBlobBytes),
+			newEagerBlobBytes.length);
+
+		newERCVersionedEntryVersion.setEagerBlob(newEagerBlobBlob);
+		String newLazyBlobString = RandomTestUtil.randomString();
+
+		byte[] newLazyBlobBytes = newLazyBlobString.getBytes("UTF-8");
+
+		Blob newLazyBlobBlob = new OutputBlob(
+			new ByteArrayInputStream(newLazyBlobBytes),
+			newLazyBlobBytes.length);
+
+		newERCVersionedEntryVersion.setLazyBlob(newLazyBlobBlob);
 
 		_ercVersionedEntryVersions.add(
 			_persistence.update(newERCVersionedEntryVersion));
+
+		Session session = _persistence.openSession();
+
+		session.flush();
+
+		session.clear();
 
 		ERCVersionedEntryVersion existingERCVersionedEntryVersion =
 			_persistence.findByPrimaryKey(
@@ -159,6 +187,17 @@ public class ERCVersionedEntryVersionPersistenceTest {
 		Assert.assertEquals(
 			existingERCVersionedEntryVersion.getCompanyId(),
 			newERCVersionedEntryVersion.getCompanyId());
+		Blob existingEagerBlob =
+			existingERCVersionedEntryVersion.getEagerBlob();
+
+		Assert.assertArrayEquals(
+			existingEagerBlob.getBytes(1, (int)existingEagerBlob.length()),
+			newEagerBlobBytes);
+		Blob existingLazyBlob = existingERCVersionedEntryVersion.getLazyBlob();
+
+		Assert.assertArrayEquals(
+			existingLazyBlob.getBytes(1, (int)existingLazyBlob.length()),
+			newLazyBlobBytes);
 	}
 
 	@Test
@@ -583,6 +622,22 @@ public class ERCVersionedEntryVersionPersistenceTest {
 		ercVersionedEntryVersion.setGroupId(RandomTestUtil.nextLong());
 
 		ercVersionedEntryVersion.setCompanyId(RandomTestUtil.nextLong());
+		String eagerBlobString = RandomTestUtil.randomString();
+
+		byte[] eagerBlobBytes = eagerBlobString.getBytes("UTF-8");
+
+		Blob eagerBlobBlob = new OutputBlob(
+			new ByteArrayInputStream(eagerBlobBytes), eagerBlobBytes.length);
+
+		ercVersionedEntryVersion.setEagerBlob(eagerBlobBlob);
+		String lazyBlobString = RandomTestUtil.randomString();
+
+		byte[] lazyBlobBytes = lazyBlobString.getBytes("UTF-8");
+
+		Blob lazyBlobBlob = new OutputBlob(
+			new ByteArrayInputStream(lazyBlobBytes), lazyBlobBytes.length);
+
+		ercVersionedEntryVersion.setLazyBlob(lazyBlobBlob);
 
 		_ercVersionedEntryVersions.add(
 			_persistence.update(ercVersionedEntryVersion));
@@ -596,4 +651,4 @@ public class ERCVersionedEntryVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-46805671
+// LIFERAY-SERVICE-BUILDER-HASH:-1579093782

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/EagerBlobEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/EagerBlobEntryPersistenceTest.java
@@ -36,7 +36,6 @@ import java.io.Serializable;
 import java.sql.Blob;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -153,10 +152,8 @@ public class EagerBlobEntryPersistenceTest {
 			newEagerBlobEntry.getGroupId());
 		Blob existingBlob = existingEagerBlobEntry.getBlob();
 
-		Assert.assertTrue(
-			Arrays.equals(
-				existingBlob.getBytes(1, (int)existingBlob.length()),
-				newBlobBytes));
+		Assert.assertArrayEquals(
+			existingBlob.getBytes(1, (int)existingBlob.length()), newBlobBytes);
 	}
 
 	@Test
@@ -511,4 +508,4 @@ public class EagerBlobEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:812889093
+// LIFERAY-SERVICE-BUILDER-HASH:-1348600021

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/FinderWhereClauseEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/FinderWhereClauseEntryPersistenceTest.java
@@ -439,4 +439,4 @@ public class FinderWhereClauseEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-333911845
+// LIFERAY-SERVICE-BUILDER-HASH:-1361003751

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/IndexEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/IndexEntryPersistenceTest.java
@@ -610,4 +610,4 @@ public class IndexEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:2103639179
+// LIFERAY-SERVICE-BUILDER-HASH:-1894466731

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/LVEntryLocalizationPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/LVEntryLocalizationPersistenceTest.java
@@ -516,4 +516,4 @@ public class LVEntryLocalizationPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-357711599
+// LIFERAY-SERVICE-BUILDER-HASH:-1326860243

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/LVEntryLocalizationVersionPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/LVEntryLocalizationVersionPersistenceTest.java
@@ -590,4 +590,4 @@ public class LVEntryLocalizationVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:423343825
+// LIFERAY-SERVICE-BUILDER-HASH:-326393255

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/LVEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/LVEntryPersistenceTest.java
@@ -609,4 +609,4 @@ public class LVEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1705135023
+// LIFERAY-SERVICE-BUILDER-HASH:253773503

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/LVEntryVersionPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/LVEntryVersionPersistenceTest.java
@@ -606,4 +606,4 @@ public class LVEntryVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-344446385
+// LIFERAY-SERVICE-BUILDER-HASH:1474491829

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/LazyBlobEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/LazyBlobEntryPersistenceTest.java
@@ -36,7 +36,6 @@ import java.io.Serializable;
 import java.sql.Blob;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -154,16 +153,14 @@ public class LazyBlobEntryPersistenceTest {
 			existingLazyBlobEntry.getGroupId(), newLazyBlobEntry.getGroupId());
 		Blob existingBlob1 = existingLazyBlobEntry.getBlob1();
 
-		Assert.assertTrue(
-			Arrays.equals(
-				existingBlob1.getBytes(1, (int)existingBlob1.length()),
-				newBlob1Bytes));
+		Assert.assertArrayEquals(
+			existingBlob1.getBytes(1, (int)existingBlob1.length()),
+			newBlob1Bytes);
 		Blob existingBlob2 = existingLazyBlobEntry.getBlob2();
 
-		Assert.assertTrue(
-			Arrays.equals(
-				existingBlob2.getBytes(1, (int)existingBlob2.length()),
-				newBlob2Bytes));
+		Assert.assertArrayEquals(
+			existingBlob2.getBytes(1, (int)existingBlob2.length()),
+			newBlob2Bytes);
 	}
 
 	@Test
@@ -525,4 +522,4 @@ public class LazyBlobEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1226908020
+// LIFERAY-SERVICE-BUILDER-HASH:678180938

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/LocalizedEntryLocalizationPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/LocalizedEntryLocalizationPersistenceTest.java
@@ -527,4 +527,4 @@ public class LocalizedEntryLocalizationPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1464272190
+// LIFERAY-SERVICE-BUILDER-HASH:-1874690844

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/LocalizedEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/LocalizedEntryPersistenceTest.java
@@ -389,4 +389,4 @@ public class LocalizedEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-405518983
+// LIFERAY-SERVICE-BUILDER-HASH:407100673

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ManyColumnsEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ManyColumnsEntryPersistenceTest.java
@@ -850,4 +850,4 @@ public class ManyColumnsEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:446199874
+// LIFERAY-SERVICE-BUILDER-HASH:2029492260

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/NestedSetsTreeEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/NestedSetsTreeEntryPersistenceTest.java
@@ -755,4 +755,4 @@ public class NestedSetsTreeEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-30694753
+// LIFERAY-SERVICE-BUILDER-HASH:-1091420079

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/NullConvertibleEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/NullConvertibleEntryPersistenceTest.java
@@ -494,4 +494,4 @@ public class NullConvertibleEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-671830849
+// LIFERAY-SERVICE-BUILDER-HASH:435604381

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/PermissionCheckFinderEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/PermissionCheckFinderEntryPersistenceTest.java
@@ -513,4 +513,4 @@ public class PermissionCheckFinderEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2085231377
+// LIFERAY-SERVICE-BUILDER-HASH:-1517591501

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/RedundantIndexEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/RedundantIndexEntryPersistenceTest.java
@@ -490,4 +490,4 @@ public class RedundantIndexEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2127768194
+// LIFERAY-SERVICE-BUILDER-HASH:-303640126

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/RenameFinderColumnEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/RenameFinderColumnEntryPersistenceTest.java
@@ -511,4 +511,4 @@ public class RenameFinderColumnEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:881872030
+// LIFERAY-SERVICE-BUILDER-HASH:833690192

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/UADPartialEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/UADPartialEntryPersistenceTest.java
@@ -404,4 +404,4 @@ public class UADPartialEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1943265048
+// LIFERAY-SERVICE-BUILDER-HASH:671256204

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/UndefinedDefaultOrderEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/UndefinedDefaultOrderEntryPersistenceTest.java
@@ -533,4 +533,4 @@ public class UndefinedDefaultOrderEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:510930252
+// LIFERAY-SERVICE-BUILDER-HASH:-2143323734

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/VersionedEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/VersionedEntryPersistenceTest.java
@@ -484,4 +484,4 @@ public class VersionedEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:965493114
+// LIFERAY-SERVICE-BUILDER-HASH:1185813130

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/VersionedEntryVersionPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/VersionedEntryVersionPersistenceTest.java
@@ -507,4 +507,4 @@ public class VersionedEntryVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1276707714
+// LIFERAY-SERVICE-BUILDER-HASH:931351774

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_test.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_test.ftl
@@ -69,7 +69,6 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -320,7 +319,7 @@ public class ${entity.name}PersistenceTest {
 			<#if stringUtil.equals(entityColumn.type, "Blob")>
 				Blob existing${entityColumn.methodName} = existing${entity.name}.get${entityColumn.methodName}();
 
-				Assert.assertTrue(Arrays.equals(existing${entityColumn.methodName}.getBytes(1, (int)existing${entityColumn.methodName}.length()), new${entityColumn.methodName}Bytes));
+				Assert.assertArrayEquals(existing${entityColumn.methodName}.getBytes(1, (int)existing${entityColumn.methodName}.length()), new${entityColumn.methodName}Bytes);
 			<#elseif stringUtil.equals(entityColumn.type, "boolean")>
 				Assert.assertEquals(existing${entity.name}.is${entityColumn.methodName}(), new${entity.name}.is${entityColumn.methodName}());
 			<#elseif stringUtil.equals(entityColumn.type, "Date")>
@@ -385,7 +384,7 @@ public class ${entity.name}PersistenceTest {
 							Blob ${entityColumn.methodName} = ${entity.variableName}.get${entityColumn.methodName}();
 							Blob draft${entityColumn.methodName} = draft${entity.name}.get${entityColumn.methodName}();
 
-							Assert.assertTrue(Arrays.equals(${entityColumn.methodName}.getBytes(1, (int)${entityColumn.methodName}.length()), draft${entityColumn.methodName}.getBytes(1, (int)draft${entityColumn.methodName}.length())));
+							Assert.assertArrayEquals(${entityColumn.methodName}.getBytes(1, (int)${entityColumn.methodName}.length()), draft${entityColumn.methodName}.getBytes(1, (int)draft${entityColumn.methodName}.length()));
 						<#elseif stringUtil.equals(entityColumn.type, "boolean")>
 							Assert.assertEquals(${entity.variableName}.is${entityColumn.methodName}(), draft${entity.name}.is${entityColumn.methodName}());
 						<#elseif stringUtil.equals(entityColumn.type, "Date")>

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_test.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_test.ftl
@@ -385,7 +385,7 @@ public class ${entity.name}PersistenceTest {
 							Blob ${entityColumn.methodName} = ${entity.variableName}.get${entityColumn.methodName}();
 							Blob draft${entityColumn.methodName} = draft${entity.name}.get${entityColumn.methodName}();
 
-							Assert.assertTrue(Arrays.equals(${entityColumn.variableName}.getBytes(1, (int)${entityColumn.variableName}.length()), Arrays.equals(draft${entityColumn.name}.getBytes(1, (int)draft${entityColumn.name}.length()));
+							Assert.assertTrue(Arrays.equals(${entityColumn.methodName}.getBytes(1, (int)${entityColumn.methodName}.length()), draft${entityColumn.methodName}.getBytes(1, (int)draft${entityColumn.methodName}.length())));
 						<#elseif stringUtil.equals(entityColumn.type, "boolean")>
 							Assert.assertEquals(${entity.variableName}.is${entityColumn.methodName}(), draft${entity.name}.is${entityColumn.methodName}());
 						<#elseif stringUtil.equals(entityColumn.type, "Date")>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90963

**What is being fixed:** The Blob branch of `testCreateDraft` in `persistence_test.ftl` emitted non-compilable Java: a stray inner `Arrays.equals(` call, identifiers that did not match the locals declared two lines above, and unbalanced parentheses. The bug stayed latent since LPD-26381 (2024-05-29) because no entity in the repository combined `external-reference-code`, `versioned="true"`, and a Blob column — the three preconditions needed for this branch to render.

**How it is being fixed:** The broken line is replaced with a single well-formed `Assert.assertTrue(Arrays.equals(...))` call that uses the `${entityColumn.methodName}` identifiers already declared above. To lock in regression coverage and verify the fix end-to-end, a Blob column is added to `ERCVersionedEntry` in `portal-tools-service-builder-test-service` — the only entity in the repository now satisfying all three preconditions. The accompanying Service Builder regeneration produces a `*PersistenceTest.java` that compiles, and a portal-wide `buildService` confirms no other module is affected.