### PR TITLE
LPD-92454 Match the localized date picker placeholder

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/paths/APIBuilder.path
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/paths/APIBuilder.path
@@ -122,7 +122,7 @@
 </tr>
 <tr>
 	<td>FROM_DATE</td>
-	<td>//input[contains(@id,'from-dateModified') and @placeholder='yyyy-mm-dd']</td>
+	<td>//input[contains(@id,'from-dateModified') and @placeholder='mm/dd/yyyy']</td>
 	<td></td>
 </tr>
 <tr>
@@ -197,7 +197,7 @@
 </tr>
 <tr>
 	<td>TO_DATE</td>
-	<td>//input[contains(@id,'to-dateModified') and @placeholder='yyyy-mm-dd']</td>
+	<td>//input[contains(@id,'to-dateModified') and @placeholder='mm/dd/yyyy']</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92454

## What is being fixed

The headless team routine on master is failing the Poshi tests `ListAPIApplicationEndpoints#CanFilterEndpointAPIByCreationDateAsLastUpdated` and `ListAPIApplicationSchemas#CanFilterSchemaByDateBeforeCreationAsLastUpdated`. Both fall over at the same locator with:

```
com.liferay.poshi.runner.exception.ElementNotFoundPoshiRunnerException: Element is not present at "//input[contains(@id,'from-dateModified') and @placeholder='yyyy-mm-dd']"
```

The regression boundary is `ed3d80b8` (last pass, 2026-05-23) → `1f054d9f` (first fail, 2026-05-26), and the only relevant change in that window is `1286edc9c0e2` "LPD-89563 Render dateTimeRange filter in the user locale format". That commit replaced the hardcoded ISO format on the FDS dateTimeRange picker with a locale-derived one computed from `Intl.DateTimeFormat`, then lowercased it for the placeholder. Under the en_US Poshi runtime the placeholder is now `mm/dd/yyyy`, while the `FROM_DATE` and `TO_DATE` locators in `APIBuilder.path` still pinned `yyyy-mm-dd`, so they no longer matched any element.

## How it is being fixed

Update both locators in `APIBuilder.path` to the new `mm/dd/yyyy` placeholder. The macro `APIBuilderUI.filterByLastUpdated` already feeds dates formatted as `MM/dd/yyyy` (via `DateUtil.getFormattedCurrentDate("MM/dd/yyyy")`), so no callers or test cases need to change.

## Why are there no tests?

This is a Poshi locator fix in `APIBuilder.path`; the test it restores (`ListAPIApplicationEndpoints#CanFilterEndpointAPIByCreationDateAsLastUpdated` and `ListAPIApplicationSchemas#CanFilterSchemaByDateBeforeCreationAsLastUpdated`) is the coverage.