### PR TITLE
LPD-92449 Wait for the success alert before asserting endpoint schemas

### DIFF
--- a/modules/test/playwright/tests/headless-builder-web/main/schemas.spec.ts
+++ b/modules/test/playwright/tests/headless-builder-web/main/schemas.spec.ts
@@ -808,6 +808,8 @@ testFeatureFlagsEnabled(
 		);
 		await uiElementsPage.saveButton.click();
 
+		await uiElementsPage.anySuccessAlert.waitFor();
+
 		const response =
 			await apiHelpers.objectEntry.getObjectDefinitionObjectEntries(
 				'headless-builder/endpoints'


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92449

## What is being fixed

The Playwright test "Can relate the same schema with multiple endpoints" was failing on the headless CI routine with `Received: "api-application-schema,api-application-second-schema"` instead of `Expected: "api-application-second-schema,api-application-second-schema"`. The test issued the GET on `/o/headless-builder/endpoints/` immediately after clicking Save, racing the PATCH request that updated the endpoint schema. When the GET completed first, it returned the stale schema ERC for the just-edited endpoint. The race has existed since the test was added but only flipped to a consistent fail recently.

## How it is being fixed

Wait for `uiElementsPage.anySuccessAlert` to become visible before issuing the GET. The success toast is fired from the PATCH `onSuccess` handler, so by the time it appears the relationship is persisted. The same pattern is already used by the sibling test "Can edit a schema" earlier in the file.

## Why are there no tests?

The change is itself a fix to a Playwright test file. The fixed test serves as the validation: it now passes consistently locally.