### PR TITLE
LPD-92470 Fill the Title field before submitting the Custom Export form

### DIFF
--- a/modules/test/playwright/tests/export-import-web/main/pages/ExportPage.ts
+++ b/modules/test/playwright/tests/export-import-web/main/pages/ExportPage.ts
@@ -5,6 +5,7 @@
 
 import {Locator, Page} from '@playwright/test';
 
+import getRandomString from '../../../../utils/getRandomString';
 import {PORTLET_URLS} from '../../../../utils/portletUrls';
 
 export class ExportPage {
@@ -19,6 +20,9 @@ export class ExportPage {
 
 	async exportPages() {
 		await this.page.getByRole('link', {name: 'Custom Export'}).click();
+
+		await this.page.getByLabel('Title').fill(getRandomString());
+
 		await this.page.getByRole('button', {name: 'Export'}).click();
 
 		await this.page


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92470

## Failing Test

`export-import-web/main/stagingUseCase.spec.ts > Exporting a page with a manual collection that contains a link to the page`

`modules/test/playwright/tests/export-import-web/main/stagingUseCase.spec.ts:413`

```
Test timeout of 90000ms exceeded.
Error: locator.waitFor: Test timeout of 90000ms exceeded.
Call log:
  - waiting for getByTestId('processResult').first().getByText('Successful') to be visible
    at export-import-web/main/pages/ExportPage.ts:28
```

## Root Cause

The legacy Custom Export form requires a non-empty name. `ExportImportLocalServiceImpl.exportLayoutsAsFileInBackground` rejects any value that fails `DLValidatorUtil.isValidName(...)` and throws `LARFileNameException`, which the form surfaces as the inline `please-enter-a-file-with-a-valid-file-name` error. `ExportPage.exportPages()` never fills the Title field, so the action redirects back to the form with the validation error, no background task is queued, and the subsequent `getByText('Successful')` on the processes list never resolves.

## Fix

Fill the Title field with a generated name in `ExportPage.exportPages()` before clicking Export so the action passes the validator, the background task is queued, and the processes list eventually shows `Successful`. Verified locally against the legacy Custom Export form on `1f054d9` (the build SHA of the failing run): the test passes in ~54s.

- `modules/test/playwright/tests/export-import-web/main/pages/ExportPage.ts`