### PR TITLE
LPD-92480 Route endpoint creation through the API Builder UI

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/APIBuilderUI.macro
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/APIBuilderUI.macro
@@ -502,23 +502,6 @@ definition {
 	}
 
 	@summary = "Default summary"
-	macro setPanelCategoryKeyToObject(objectDefinition = null) {
-		Variables.assertDefined(parameterList = ${objectDefinition});
-
-		ObjectAdmin.openObjectAdmin();
-
-		WaitForPageLoad();
-
-		ObjectPortlet.selectCustomObject(label = ${objectDefinition});
-
-		ObjectAdmin.selectDropdownItem(
-			labelName = "Panel Link",
-			optionName = "Object");
-
-		CreateObject.saveObject();
-	}
-
-	@summary = "Default summary"
 	macro switchToRelatedEntryInEditApplication(title = null, entity = null) {
 		Variables.assertDefined(parameterList = "${entity},${title}");
 

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[APIRest]APIGenerator/GeneratePathStructureForEndpoints.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[APIRest]APIGenerator/GeneratePathStructureForEndpoints.testcase
@@ -84,29 +84,21 @@ definition {
 		property test.run.type = "single";
 
 		task ("Given creating an API application") {
-			var response = ApplicationAPI.createAPIApplication(
+			ApplicationAPI.createAPIApplication(
 				baseURL = "app-test",
 				title = "App-test");
 		}
 
-		task ("And Given setting Panel Category Key to Control Panel > Object for API Endpoint") {
-			SearchAdministration.executeReindex();
-
-			APIBuilderUI.setPanelCategoryKeyToObject(objectDefinition = "API Endpoint");
+		task ("And Given I go to Endpoints tab in Edit API application") {
+			APIBuilderUI.switchToRelatedEntryInEditApplication(
+				entity = "Endpoints",
+				title = "App-test");
 		}
 
-		task ("When I create an endpoint with id of API application and valid path") {
-			ApplicationsMenu.gotoPortlet(
-				category = "Object",
-				panel = "Control Panel",
-				portlet = "API Endpoints");
-
-			var applicationId = JSONPathUtil.getIdValue(response = ${response});
-
+		task ("When I create an endpoint with a valid path") {
 			APIBuilderUI.createAPIEndpoint(
-				applicationId = ${applicationId},
 				name = "testendpoint",
-				pathCP = "/testendpoint");
+				path = "/testendpoint");
 		}
 
 		task ("Then I can see endpoint is created with correct path") {
@@ -152,29 +144,21 @@ definition {
 		property test.run.type = "single";
 
 		task ("Given creating an API application") {
-			var response = ApplicationAPI.createAPIApplication(
+			ApplicationAPI.createAPIApplication(
 				baseURL = "app-test",
 				title = "App-test");
 		}
 
-		task ("And Given setting Panel Category Key to Control Panel > Object for API Endpoint") {
-			SearchAdministration.executeReindex();
-
-			APIBuilderUI.setPanelCategoryKeyToObject(objectDefinition = "API Endpoint");
+		task ("And Given I go to Endpoints tab in Edit API application") {
+			APIBuilderUI.switchToRelatedEntryInEditApplication(
+				entity = "Endpoints",
+				title = "App-test");
 		}
 
-		task ("When I create an endpoint with id of API application and path not start with '/'") {
-			var applicationId = JSONPathUtil.getIdValue(response = ${response});
-
-			ApplicationsMenu.gotoPortlet(
-				category = "Object",
-				panel = "Control Panel",
-				portlet = "API Endpoints");
-
+		task ("When I create an endpoint with a path not starting with '/'") {
 			APIBuilderUI.createAPIEndpoint(
-				applicationId = ${applicationId},
 				name = "testendpoint",
-				pathCP = "testendpoint");
+				path = "testendpoint");
 		}
 
 		task ("Then I can see error message") {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92480

## Failing Test

`LocalFile.GeneratePathStructureForEndpoints#CanCreateEndpointWithValidPath`

`modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[APIRest]APIGenerator/GeneratePathStructureForEndpoints.testcase`

```
com.liferay.poshi.runner.exception.ElementNotFoundPoshiRunnerException: Element is not present at "//div[(@class='table-list-title')]//a[text()='API Endpoint']"
```

## Root Cause

LPD-69946 changed the default for modifiable system object definitions so that they are hidden from the Object Admin list unless they carry an explicit `visible: true` setting. The API Builder objects (APIApplication, APIEndpoint, APIFilter, APIProperty, APISchema, APISort) are intentionally hidden under that policy — they are managed through the dedicated API Builder UI, not Object Admin. The two affected tests were using Object Admin > API Endpoint > Panel Link as a setup step to surface the standalone "API Endpoints" portlet under Control Panel > Object, and that setup step is no longer valid.

## Fix

Rewrite `CanCreateEndpointWithValidPath` and `CanValidatePathInAPIEndpoint` to drive endpoint creation through the API Builder UI instead — navigate to Control Panel > Object > **API Builder** (which is a static panel registration in `HeadlessBuilderPanelApp.java`, always present), open the application's **Endpoints** tab via the existing `APIBuilderUI.switchToRelatedEntryInEditApplication` macro, and create the endpoint from that page using `path` (the wizard input) instead of `pathCP` (the standalone-portlet form input). This matches the pattern already used by `CreateAnAPIApplicationEndpoint.testcase`. The now-orphaned `APIBuilderUI.setPanelCategoryKeyToObject` macro is removed.

No product code changes — fix is entirely in test sources.

- `modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[APIRest]APIGenerator/GeneratePathStructureForEndpoints.testcase`
- `modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/APIBuilderUI.macro`