### PR TITLE
LPD-91106 Improve the export wizard page picker integration

### DIFF
--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/LayoutSetControl.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/LayoutSetControl.tsx
@@ -43,7 +43,6 @@ function SelectPagesButton({
 								: Liferay.Language.get('public-pages')
 						)
 			}
-			className="border-0 ml-2 p-0"
 			displayType="link"
 			onClick={onClick}
 			size="sm"
@@ -65,11 +64,11 @@ function LayoutVisibilitySelector({
 	privateLayout: boolean;
 }) {
 	return (
-		<div aria-label={label} className="mt-2 pl-4" role="radiogroup">
-			<div className="align-items-center d-flex mb-1">
+		<div aria-label={label} className="pl-4" role="radiogroup">
+			<div className="align-items-center d-flex">
 				<ClayRadio
 					checked={!privateLayout}
-					containerProps={{className: 'mb-0'}}
+					containerProps={{className: 'my-1'}}
 					label={Liferay.Language.get('public-pages')}
 					name="layoutSetPrivateLayout"
 					onChange={() => onSetMode(false)}
@@ -87,7 +86,7 @@ function LayoutVisibilitySelector({
 			<div className="align-items-center d-flex mb-1">
 				<ClayRadio
 					checked={privateLayout}
-					containerProps={{className: 'mb-0'}}
+					containerProps={{className: 'my-1'}}
 					label={Liferay.Language.get('private-pages')}
 					name="layoutSetPrivateLayout"
 					onChange={() => onSetMode(true)}
@@ -123,7 +122,7 @@ export default function LayoutSetControl({
 
 	return (
 		<div className="p-3">
-			<ClayLayout.ContentRow className="mb-2">
+			<ClayLayout.ContentRow className="align-items-center mb-2">
 				<ClayLayout.ContentCol className="pr-2" expand={false}>
 					<ClayCheckbox
 						aria-label={label}

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/LayoutSetControl.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/LayoutSetControl.tsx
@@ -131,7 +131,8 @@ export default function LayoutSetControl({
 			{showModal && (
 				<PageTreeModal
 					{...modalConfiguration}
-					initialSelectedIds={layoutIds}
+					initialAll={isAll}
+					initialSelectedIds={layoutIds.map(String)}
 					onClose={() => setShowModal(false)}
 					onSubmit={(result) => {
 						setShowModal(false);

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/LayoutSetControl.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/LayoutSetControl.tsx
@@ -4,7 +4,7 @@
  */
 
 import ClayButton from '@clayui/button';
-import {ClayCheckbox} from '@clayui/form';
+import {ClayCheckbox, ClayRadio} from '@clayui/form';
 import ClayLayout from '@clayui/layout';
 import React, {useState} from 'react';
 
@@ -20,19 +20,79 @@ interface Props {
 	value: HandlerSelection | undefined;
 }
 
+function SelectPagesButton({onClick}: {onClick: () => void}) {
+	return (
+		<ClayButton
+			className="border-0 ml-2 p-0"
+			displayType="link"
+			onClick={onClick}
+			size="sm"
+		>
+			{Liferay.Language.get('select-layouts')}
+		</ClayButton>
+	);
+}
+
+function LayoutVisibilitySelector({
+	onSelectPages,
+	onSetMode,
+	privateLayout,
+}: {
+	onSelectPages: () => void;
+	onSetMode: (mode: boolean) => void;
+	privateLayout: boolean;
+}) {
+	return (
+		<div className="mt-2 pl-4">
+			<div className="align-items-center d-flex mb-1">
+				<ClayRadio
+					checked={!privateLayout}
+					containerProps={{className: 'mb-0'}}
+					label={Liferay.Language.get('public-pages')}
+					name="layoutSetPrivateLayout"
+					onChange={() => onSetMode(false)}
+					value="false"
+				/>
+
+				{!privateLayout && (
+					<SelectPagesButton onClick={onSelectPages} />
+				)}
+			</div>
+
+			<div className="align-items-center d-flex mb-1">
+				<ClayRadio
+					checked={privateLayout}
+					containerProps={{className: 'mb-0'}}
+					label={Liferay.Language.get('private-pages')}
+					name="layoutSetPrivateLayout"
+					onChange={() => onSetMode(true)}
+					value="true"
+				/>
+
+				{privateLayout && <SelectPagesButton onClick={onSelectPages} />}
+			</div>
+		</div>
+	);
+}
+
 export default function LayoutSetControl({
 	label,
 	onChange,
 	pageTreeModalConfiguration,
 	value,
 }: Props) {
+	const {privateLayoutsEnabled, ...modalConfiguration} =
+		pageTreeModalConfiguration;
+
 	const [showModal, setShowModal] = useState(false);
 
-	const selection = (value && typeof value === 'object' ? value : {}) as {
-		layoutIds?: number[];
-	};
-	const layoutIds = selection.layoutIds ?? [];
-	const isAll = !!value && typeof value === 'object' && !selection.layoutIds;
+	const {layoutIds = [], privateLayout = false} = (
+		typeof value === 'object' ? value : {}
+	) as {layoutIds?: number[]; privateLayout?: boolean};
+
+	const isAll = !!value && !layoutIds.length;
+
+	const openModal = () => setShowModal(true);
 
 	return (
 		<div className="p-3">
@@ -42,7 +102,7 @@ export default function LayoutSetControl({
 						checked={isAll}
 						indeterminate={!isAll && !!layoutIds.length}
 						onChange={() =>
-							onChange(value ? undefined : {privateLayout: false})
+							onChange(isAll ? undefined : {privateLayout})
 						}
 					/>
 				</ClayLayout.ContentCol>
@@ -53,21 +113,24 @@ export default function LayoutSetControl({
 							{label}
 						</span>
 
-						<ClayButton
-							className="border-0 p-0"
-							displayType="link"
-							onClick={() => setShowModal(true)}
-							small
-						>
-							{Liferay.Language.get('select-layouts')}
-						</ClayButton>
+						{!privateLayoutsEnabled && (
+							<SelectPagesButton onClick={openModal} />
+						)}
 					</div>
 				</ClayLayout.ContentCol>
 			</ClayLayout.ContentRow>
 
+			{privateLayoutsEnabled && (
+				<LayoutVisibilitySelector
+					onSelectPages={openModal}
+					onSetMode={(next) => onChange({privateLayout: next})}
+					privateLayout={privateLayout}
+				/>
+			)}
+
 			{showModal && (
 				<PageTreeModal
-					{...pageTreeModalConfiguration}
+					{...modalConfiguration}
 					initialSelectedIds={layoutIds}
 					onClose={() => setShowModal(false)}
 					onSubmit={(result) => {
@@ -75,6 +138,7 @@ export default function LayoutSetControl({
 
 						onChange(result ?? undefined);
 					}}
+					privateLayout={privateLayout}
 				/>
 			)}
 		</div>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/LayoutSetControl.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/LayoutSetControl.tsx
@@ -6,6 +6,7 @@
 import ClayButton from '@clayui/button';
 import {ClayCheckbox, ClayRadio} from '@clayui/form';
 import ClayLayout from '@clayui/layout';
+import {sub} from 'frontend-js-web';
 import React, {useState} from 'react';
 
 import PageTreeModal, {
@@ -20,9 +21,25 @@ interface Props {
 	value: HandlerSelection | undefined;
 }
 
-function SelectPagesButton({onClick}: {onClick: () => void}) {
+function SelectPagesButton({
+	onClick,
+	privateLayout,
+}: {
+	onClick: () => void;
+	privateLayout?: boolean;
+}) {
 	return (
 		<ClayButton
+			aria-label={
+				privateLayout === undefined
+					? undefined
+					: sub(
+							Liferay.Language.get('select-x'),
+							privateLayout
+								? Liferay.Language.get('private-pages')
+								: Liferay.Language.get('public-pages')
+						)
+			}
 			className="border-0 ml-2 p-0"
 			displayType="link"
 			onClick={onClick}
@@ -34,16 +51,18 @@ function SelectPagesButton({onClick}: {onClick: () => void}) {
 }
 
 function LayoutVisibilitySelector({
+	label,
 	onSelectPages,
 	onSetMode,
 	privateLayout,
 }: {
+	label: string;
 	onSelectPages: () => void;
 	onSetMode: (mode: boolean) => void;
 	privateLayout: boolean;
 }) {
 	return (
-		<div className="mt-2 pl-4">
+		<div aria-label={label} className="mt-2 pl-4" role="radiogroup">
 			<div className="align-items-center d-flex mb-1">
 				<ClayRadio
 					checked={!privateLayout}
@@ -55,7 +74,10 @@ function LayoutVisibilitySelector({
 				/>
 
 				{!privateLayout && (
-					<SelectPagesButton onClick={onSelectPages} />
+					<SelectPagesButton
+						onClick={onSelectPages}
+						privateLayout={false}
+					/>
 				)}
 			</div>
 
@@ -69,7 +91,9 @@ function LayoutVisibilitySelector({
 					value="true"
 				/>
 
-				{privateLayout && <SelectPagesButton onClick={onSelectPages} />}
+				{privateLayout && (
+					<SelectPagesButton onClick={onSelectPages} privateLayout />
+				)}
 			</div>
 		</div>
 	);
@@ -99,6 +123,7 @@ export default function LayoutSetControl({
 			<ClayLayout.ContentRow className="mb-2">
 				<ClayLayout.ContentCol className="pr-2" expand={false}>
 					<ClayCheckbox
+						aria-label={label}
 						checked={isAll}
 						indeterminate={!isAll && !!layoutIds.length}
 						onChange={() =>
@@ -122,6 +147,7 @@ export default function LayoutSetControl({
 
 			{privateLayoutsEnabled && (
 				<LayoutVisibilitySelector
+					label={label}
 					onSelectPages={openModal}
 					onSetMode={(next) => onChange({privateLayout: next})}
 					privateLayout={privateLayout}

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/LayoutSetControl.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/LayoutSetControl.tsx
@@ -12,7 +12,10 @@ import React, {useState} from 'react';
 import PageTreeModal, {
 	PageTreeModalConfiguration,
 } from '../../../pages/export/components/PageTreeModal';
-import {HandlerSelection} from '../../../utils/contentSelection';
+import {
+	HandlerSelection,
+	isAllLayoutsSelected,
+} from '../../../utils/contentSelection';
 
 interface Props {
 	label: string;
@@ -114,7 +117,7 @@ export default function LayoutSetControl({
 		typeof value === 'object' ? value : {}
 	) as {layoutIds?: number[]; privateLayout?: boolean};
 
-	const isAll = !!value && !layoutIds.length;
+	const isAll = isAllLayoutsSelected(value);
 
 	const openModal = () => setShowModal(true);
 

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/NewExport.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/NewExport.tsx
@@ -131,7 +131,7 @@ export function NewExport({
 					return;
 				}
 
-				window.location.href = backURL;
+				Liferay.Util.navigate(backURL);
 			}}
 			validate={(values: FormikValues) => {
 				const errors: {[key: string]: string} = {};

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/components/PageTreeModal.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/components/PageTreeModal.tsx
@@ -25,7 +25,8 @@ export interface PageTreeModalConfiguration {
 
 interface Props
 	extends Omit<PageTreeModalConfiguration, 'privateLayoutsEnabled'> {
-	initialSelectedIds: number[];
+	initialAll?: boolean;
+	initialSelectedIds: string[];
 	onClose: () => void;
 	onSubmit: (
 		result: {layoutIds?: number[]; privateLayout: boolean} | null
@@ -34,6 +35,7 @@ interface Props
 }
 
 export default function PageTreeModal({
+	initialAll = false,
 	initialSelectedIds,
 	liveGroupId,
 	onClose,
@@ -45,7 +47,10 @@ export default function PageTreeModal({
 
 	const [items, setItems] = useState<unknown[] | null>(null);
 	const [error, setError] = useState(false);
+	const [selectedLayoutIds, setSelectedLayoutIds] =
+		useState<string[]>(initialSelectedIds);
 	const treeRef = useRef<HTMLDivElement>(null);
+	const initialAllRef = useRef(initialAll);
 	const initialSelectedIdsRef = useRef(initialSelectedIds);
 	const treeId = `exportPageTreeModal_${privateLayout ? 'private' : 'public'}`;
 
@@ -67,7 +72,29 @@ export default function PageTreeModal({
 				method: 'post',
 			});
 
-			if (initialIds.length) {
+			let nextSelectedLayoutIds: string[] | undefined;
+
+			if (initialAllRef.current) {
+				const selectAllResponse = await fetch(
+					SESSION_TREE_JS_CLICK_URL,
+					{
+						body: new URLSearchParams({
+							cmd: 'layoutCheck',
+							groupId: String(liveGroupId),
+							plid: '0',
+							privateLayout: String(privateLayout),
+							recursive: 'true',
+							treeId: sessionTreeId,
+						}),
+						method: 'post',
+					}
+				);
+
+				const payload = await selectAllResponse.json();
+
+				nextSelectedLayoutIds = (payload ?? []).map(String);
+			}
+			else if (initialIds.length) {
 				await fetch(SESSION_TREE_JS_CLICK_URL, {
 					body: new URLSearchParams({
 						cmd: 'expand',
@@ -93,6 +120,10 @@ export default function PageTreeModal({
 
 			if (cancelled) {
 				return;
+			}
+
+			if (nextSelectedLayoutIds) {
+				setSelectedLayoutIds(nextSelectedLayoutIds);
 			}
 
 			setItems([
@@ -174,7 +205,7 @@ export default function PageTreeModal({
 							key={treeId}
 							portletNamespace={PAGES_TREE_NAMESPACE}
 							privateLayout={privateLayout}
-							selectedLayoutIds={initialSelectedIds.map(String)}
+							selectedLayoutIds={selectedLayoutIds}
 							treeId={treeId}
 						/>
 					</div>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/components/PageTreeModal.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/components/PageTreeModal.tsx
@@ -11,9 +11,6 @@ import ClayLoadingIndicator from '@clayui/loading-indicator';
 import ClayModal, {useModal} from '@clayui/modal';
 import {fetch} from 'frontend-js-web';
 import React, {useEffect, useRef, useState} from 'react';
-
-// @ts-ignore
-
 import {PagesTree} from 'staging-taglib';
 
 const NAMESPACE = '_exportPageTreeModal_';

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/components/PageTreeModal.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/components/PageTreeModal.tsx
@@ -5,8 +5,6 @@
 
 import ClayAlert from '@clayui/alert';
 import ClayButton from '@clayui/button';
-import ClayDropDown from '@clayui/drop-down';
-import ClayIcon from '@clayui/icon';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import ClayModal, {useModal} from '@clayui/modal';
 import {fetch} from 'frontend-js-web';
@@ -25,12 +23,14 @@ export interface PageTreeModalConfiguration {
 	privateLayoutsEnabled: boolean;
 }
 
-interface Props extends PageTreeModalConfiguration {
+interface Props
+	extends Omit<PageTreeModalConfiguration, 'privateLayoutsEnabled'> {
 	initialSelectedIds: number[];
 	onClose: () => void;
 	onSubmit: (
 		result: {layoutIds: number[]; privateLayout: boolean} | null
 	) => void;
+	privateLayout: boolean;
 }
 
 export default function PageTreeModal({
@@ -39,12 +39,10 @@ export default function PageTreeModal({
 	onClose,
 	onSubmit,
 	pageSize,
-	privateLayoutsEnabled,
+	privateLayout,
 }: Props) {
 	const {observer} = useModal({onClose});
 
-	const [privateLayout, setPrivateLayout] = useState(false);
-	const [dropdownActive, setDropdownActive] = useState(false);
 	const [items, setItems] = useState<unknown[] | null>(null);
 	const [error, setError] = useState(false);
 	const treeRef = useRef<HTMLDivElement>(null);
@@ -142,62 +140,16 @@ export default function PageTreeModal({
 			</ClayModal.Header>
 
 			<ClayModal.Body>
-				{privateLayoutsEnabled ? (
-					<ClayDropDown
-						active={dropdownActive}
-						onActiveChange={setDropdownActive}
-						trigger={
-							<ClayButton
-								className="border-bottom border-bottom-primary px-2 py-1 rounded-0"
-								displayType="unstyled"
-							>
-								{privateLayout
-									? Liferay.Language.get('private-pages')
-									: Liferay.Language.get('public-pages')}
-
-								<ClayIcon
-									className="ml-2"
-									symbol="caret-bottom"
-								/>
-							</ClayButton>
-						}
-					>
-						<ClayDropDown.ItemList>
-							<ClayDropDown.Item
-								onClick={() => {
-									setPrivateLayout(false);
-									setDropdownActive(false);
-								}}
-							>
-								{Liferay.Language.get('public-pages')}
-							</ClayDropDown.Item>
-
-							<ClayDropDown.Item
-								onClick={() => {
-									setPrivateLayout(true);
-									setDropdownActive(false);
-								}}
-							>
-								{Liferay.Language.get('private-pages')}
-							</ClayDropDown.Item>
-						</ClayDropDown.ItemList>
-					</ClayDropDown>
-				) : (
-					<div className="border-bottom border-bottom-primary px-2 py-1">
-						{Liferay.Language.get('public-pages')}
-					</div>
-				)}
-
 				{error && (
-					<ClayAlert className="mt-3" displayType="danger">
+					<ClayAlert displayType="danger">
 						{Liferay.Language.get('an-unexpected-error-occurred')}
 					</ClayAlert>
 				)}
 
-				{!items && !error && <ClayLoadingIndicator className="mt-3" />}
+				{!items && !error && <ClayLoadingIndicator />}
 
 				{items && (
-					<div className="mt-3" ref={treeRef}>
+					<div ref={treeRef}>
 						<PagesTree
 							config={{
 								changeItemSelectionURL:

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/components/PageTreeModal.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/components/PageTreeModal.tsx
@@ -28,7 +28,7 @@ interface Props
 	initialSelectedIds: number[];
 	onClose: () => void;
 	onSubmit: (
-		result: {layoutIds: number[]; privateLayout: boolean} | null
+		result: {layoutIds?: number[]; privateLayout: boolean} | null
 	) => void;
 	privateLayout: boolean;
 }
@@ -128,7 +128,18 @@ export default function PageTreeModal({
 					.filter((id) => !Number.isNaN(id) && id !== 0)
 			: [];
 
-		onSubmit(layoutIds.length ? {layoutIds, privateLayout} : null);
+		if (!layoutIds.length) {
+			onSubmit(null);
+
+			return;
+		}
+
+		const allChecked =
+			treeRef.current?.querySelectorAll(
+				'input[type="checkbox"]:not(:checked)'
+			).length === 0;
+
+		onSubmit(allChecked ? {privateLayout} : {layoutIds, privateLayout});
 	};
 
 	return (

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/components/PageTreeModal.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/components/PageTreeModal.tsx
@@ -11,7 +11,7 @@ import {fetch} from 'frontend-js-web';
 import React, {useEffect, useRef, useState} from 'react';
 import {PagesTree} from 'staging-taglib';
 
-const NAMESPACE = '_exportPageTreeModal_';
+const PAGES_TREE_NAMESPACE = '_exportPageTreeModal_';
 
 const PATH_MAIN = Liferay.ThemeDisplay.getPathMain();
 const GET_LAYOUTS_TREE_URL = `${PATH_MAIN}/portal/get_layouts_tree`;
@@ -117,9 +117,9 @@ export default function PageTreeModal({
 		};
 	}, [liveGroupId, pageSize, privateLayout, treeId]);
 
-	const select = () => {
+	const handleSelect = () => {
 		const input = treeRef.current?.querySelector<HTMLInputElement>(
-			`input[name="${NAMESPACE}layoutIds"]`
+			`input[name="${PAGES_TREE_NAMESPACE}layoutIds"]`
 		);
 
 		const layoutIds = input
@@ -156,12 +156,12 @@ export default function PageTreeModal({
 									SESSION_TREE_JS_CLICK_URL,
 								loadMoreItemsURL: GET_LAYOUTS_TREE_URL,
 								maxPageSize: pageSize,
-								namespace: NAMESPACE,
+								namespace: PAGES_TREE_NAMESPACE,
 							}}
 							groupId={String(liveGroupId)}
 							items={items}
 							key={treeId}
-							portletNamespace={NAMESPACE}
+							portletNamespace={PAGES_TREE_NAMESPACE}
 							privateLayout={privateLayout}
 							selectedLayoutIds={initialSelectedIds.map(String)}
 							treeId={treeId}
@@ -177,7 +177,7 @@ export default function PageTreeModal({
 							{Liferay.Language.get('cancel')}
 						</ClayButton>
 
-						<ClayButton onClick={select}>
+						<ClayButton onClick={handleSelect}>
 							{Liferay.Language.get('select')}
 						</ClayButton>
 					</ClayButton.Group>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/types/stagingTaglib.d.ts
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/types/stagingTaglib.d.ts
@@ -1,0 +1,25 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+declare module 'staging-taglib' {
+	import {ComponentType} from 'react';
+
+	export interface PagesTreeProps {
+		config: {
+			changeItemSelectionURL: string;
+			loadMoreItemsURL: string;
+			maxPageSize: number;
+			namespace: string;
+		};
+		groupId: string;
+		items: unknown[];
+		portletNamespace: string;
+		privateLayout: boolean;
+		selectedLayoutIds: string[];
+		treeId: string;
+	}
+
+	export const PagesTree: ComponentType<PagesTreeProps>;
+}

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/contentSelection.ts
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/contentSelection.ts
@@ -15,6 +15,12 @@ export type HandlerSelection =
 export const LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY =
 	'PORTLET_DATA_com_liferay_layout_admin_web_portlet_LayoutSetLayoutsPortlet';
 
+export function isAllLayoutsSelected(
+	value: HandlerSelection | undefined
+): boolean {
+	return typeof value === 'object' && !value.layoutIds;
+}
+
 export function isSelected(
 	value: HandlerSelection | undefined,
 	entry: PreviewPortletDataHandlerControl
@@ -24,7 +30,7 @@ export function isSelected(
 	}
 
 	if (entry.name === LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY) {
-		return typeof value === 'object' && !('layoutIds' in value);
+		return isAllLayoutsSelected(value);
 	}
 
 	if (entry.type === 'Choice') {

--- a/modules/apps/export-import/export-import-web/test/revamp/js/mocks/MockPagesTree.tsx
+++ b/modules/apps/export-import/export-import-web/test/revamp/js/mocks/MockPagesTree.tsx
@@ -1,0 +1,63 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import React, {useState} from 'react';
+
+/**
+ * Stand-in for the staging-taglib PagesTree. It honors the same contract the
+ * real component exposes to PageTreeModal: a hidden input named
+ * `${portletNamespace}layoutIds` holding the selected ids, plus one checkbox
+ * per page whose checked state the modal scrapes to detect the "all" case.
+ */
+export function MockPagesTree({
+	items,
+	portletNamespace,
+	selectedLayoutIds,
+}: {
+	items: Array<{children: Array<{layoutId: number; name: string}>}>;
+	portletNamespace: string;
+	selectedLayoutIds: string[];
+}) {
+	const leaves = items?.[0]?.children ?? [];
+	const [checkedLayoutIds, setCheckedLayoutIds] = useState(
+		() => new Set(selectedLayoutIds.map(Number))
+	);
+
+	return (
+		<div>
+			<input
+				name={`${portletNamespace}layoutIds`}
+				readOnly
+				type="hidden"
+				value={JSON.stringify([...checkedLayoutIds])}
+			/>
+
+			{leaves.map((leaf) => (
+				<input
+					aria-label={`page-${leaf.layoutId}`}
+					checked={checkedLayoutIds.has(leaf.layoutId)}
+					key={leaf.layoutId}
+					onChange={() =>
+						setCheckedLayoutIds((previousCheckedLayoutIds) => {
+							const nextCheckedLayoutIds = new Set(
+								previousCheckedLayoutIds
+							);
+
+							if (nextCheckedLayoutIds.has(leaf.layoutId)) {
+								nextCheckedLayoutIds.delete(leaf.layoutId);
+							}
+							else {
+								nextCheckedLayoutIds.add(leaf.layoutId);
+							}
+
+							return nextCheckedLayoutIds;
+						})
+					}
+					type="checkbox"
+				/>
+			))}
+		</div>
+	);
+}

--- a/modules/apps/export-import/export-import-web/test/revamp/js/mocks/mockPageTreeItems.ts
+++ b/modules/apps/export-import/export-import-web/test/revamp/js/mocks/mockPageTreeItems.ts
@@ -1,0 +1,9 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const mockPageTreeItems = [
+	{layoutId: 1, name: 'Home'},
+	{layoutId: 2, name: 'About'},
+];

--- a/modules/apps/export-import/export-import-web/test/revamp/js/pages/export/NewExport.test.tsx
+++ b/modules/apps/export-import/export-import-web/test/revamp/js/pages/export/NewExport.test.tsx
@@ -11,22 +11,29 @@ import fetch from 'jest-fetch-mock';
 import React from 'react';
 
 import {NewExport} from '../../../../../src/main/resources/META-INF/resources/revamp/js/pages/export/NewExport';
+import {ExportPreview} from '../../../../../src/main/resources/META-INF/resources/revamp/js/types/exportImportPreview';
+import {LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY} from '../../../../../src/main/resources/META-INF/resources/revamp/js/utils/contentSelection';
 import {mockExportPreview} from '../../mocks/mockExportPreview';
+import {mockPageTreeItems} from '../../mocks/mockPageTreeItems';
 
-const renderComponent = () => {
-	return render(
-		<NewExport
-			backURL="/some/back/url"
-			exportPreviewAPIURL="/o/export-import/v1.0/export-preview"
-			exportProcessAPIURL="/o/export-import/v1.0/export-processes"
-			pageTreeModalConfiguration={{
-				liveGroupId: 20121,
-				pageSize: 20,
-				privateLayoutsEnabled: false,
-			}}
-		/>
-	);
+jest.mock('staging-taglib', () => ({
+	PagesTree: require('../../mocks/MockPagesTree').MockPagesTree,
+}));
+
+const DEFAULT_PROPS = {
+	backURL: '/some/back/url',
+	exportPreviewAPIURL: '/o/export-import/v1.0/export-preview',
+	exportProcessAPIURL: '/o/export-import/v1.0/export-processes',
+	pageTreeModalConfiguration: {
+		liveGroupId: 20121,
+		pageSize: 20,
+		privateLayoutsEnabled: false,
+	},
 };
+
+const renderComponent = (
+	props: Partial<React.ComponentProps<typeof NewExport>> = {}
+) => render(<NewExport {...DEFAULT_PROPS} {...props} />);
 
 describe('NewExport', () => {
 	beforeEach(() => {
@@ -208,5 +215,246 @@ describe('NewExport', () => {
 		await userEvent.click(deletionsCheckbox);
 
 		expect(deletionsCheckbox).not.toBeChecked();
+	});
+
+	describe('page selection', () => {
+		const previewWithPagePicker: ExportPreview = {
+			additionCount: 1,
+			deletionCount: 0,
+			previewPortletDataHandlerSections: [
+				{
+					label: 'Site Builder',
+					name: 'category.site_administration.build',
+					previewPortletDataHandlers: [
+						{
+							label: 'Pages',
+							name: LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY,
+						},
+					],
+				},
+			],
+		};
+
+		const privatePageTreeModalConfiguration = {
+			...DEFAULT_PROPS.pageTreeModalConfiguration,
+			privateLayoutsEnabled: true,
+		};
+
+		const getExportRequest = () => {
+			const exportProcessCall = fetch.mock.calls.find(
+				([url, init]) =>
+					String(url).includes('export-processes') &&
+					init?.method === 'POST'
+			);
+
+			return JSON.parse(String(exportProcessCall?.[1]?.body));
+		};
+
+		const typeFileName = () =>
+			userEvent.type(
+				screen.getByRole('textbox', {name: /^name/i}),
+				'test-file'
+			);
+
+		const expandSection = () =>
+			userEvent.click(screen.getByRole('button', {name: 'expand-x'}));
+
+		const submitExport = async () => {
+			const exportButton = screen.getByRole('button', {
+				name: /^export$/i,
+			});
+
+			await waitFor(() => expect(exportButton).toBeEnabled());
+
+			await userEvent.click(exportButton);
+		};
+
+		beforeEach(() => {
+			jest.clearAllMocks();
+
+			fetch.resetMocks();
+			fetch.mockResponse(async (request) => {
+				if (request.url.includes('get_layouts_tree')) {
+					return JSON.stringify({
+						hasMoreElements: false,
+						items: mockPageTreeItems,
+					});
+				}
+
+				if (request.url.includes('session_tree_js_click')) {
+					return (await request.text()).includes('cmd=layoutCheck')
+						? JSON.stringify([1, 2])
+						: '[]';
+				}
+
+				return JSON.stringify({exportImportConfigurationId: 1});
+			});
+		});
+
+		it('exports all public pages selected from the section checkbox', async () => {
+			renderComponent({exportPreview: previewWithPagePicker});
+
+			await typeFileName();
+
+			await userEvent.click(
+				screen.getByRole('checkbox', {name: 'Site Builder'})
+			);
+
+			await submitExport();
+
+			await waitFor(() =>
+				expect(getExportRequest().requestPortletDataHandlers).toEqual([
+					{
+						name: LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY,
+						requestPortletDataHandlerControls: [
+							{name: 'privateLayout', values: ['false']},
+						],
+					},
+				])
+			);
+
+			await waitFor(() =>
+				expect(Liferay.Util.navigate).toHaveBeenCalledWith(
+					'/some/back/url'
+				)
+			);
+		});
+
+		it('hides the visibility radios and exports a public page subset through the modal', async () => {
+			renderComponent({exportPreview: previewWithPagePicker});
+
+			await typeFileName();
+			await expandSection();
+
+			expect(screen.queryAllByRole('radio')).toHaveLength(0);
+
+			await userEvent.click(
+				screen.getByRole('button', {name: 'select-layouts'})
+			);
+
+			await userEvent.click(await screen.findByLabelText('page-1'));
+			await userEvent.click(screen.getByRole('button', {name: 'select'}));
+
+			await submitExport();
+
+			await waitFor(() =>
+				expect(getExportRequest().requestPortletDataHandlers).toEqual([
+					{
+						name: LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY,
+						requestPortletDataHandlerControls: [
+							{name: 'privateLayout', values: ['false']},
+							{name: 'layoutIds', values: ['1']},
+						],
+					},
+				])
+			);
+		});
+
+		it('shows the visibility radios and exports all private pages', async () => {
+			renderComponent({
+				exportPreview: previewWithPagePicker,
+				pageTreeModalConfiguration: privatePageTreeModalConfiguration,
+			});
+
+			await typeFileName();
+			await expandSection();
+
+			const radios = screen.getAllByRole('radio');
+
+			expect(radios).toHaveLength(2);
+			expect(radios[0]).toBeChecked();
+
+			await userEvent.click(radios[1]);
+
+			expect(screen.getAllByRole('radio')[1]).toBeChecked();
+			expect(screen.getByRole('checkbox', {name: 'Pages'})).toBeChecked();
+
+			await submitExport();
+
+			await waitFor(() =>
+				expect(getExportRequest().requestPortletDataHandlers).toEqual([
+					{
+						name: LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY,
+						requestPortletDataHandlerControls: [
+							{name: 'privateLayout', values: ['true']},
+						],
+					},
+				])
+			);
+		});
+
+		it('resets the selection to public when the public radio is selected', async () => {
+			renderComponent({
+				exportPreview: previewWithPagePicker,
+				pageTreeModalConfiguration: privatePageTreeModalConfiguration,
+			});
+
+			await expandSection();
+
+			await userEvent.click(screen.getAllByRole('radio')[1]);
+
+			expect(screen.getAllByRole('radio')[1]).toBeChecked();
+
+			await userEvent.click(screen.getAllByRole('radio')[0]);
+
+			expect(screen.getAllByRole('radio')[0]).toBeChecked();
+			expect(screen.getAllByRole('radio')[1]).not.toBeChecked();
+		});
+
+		it('clears the page selection when the main checkbox is toggled off', async () => {
+			renderComponent({
+				exportPreview: previewWithPagePicker,
+				pageTreeModalConfiguration: privatePageTreeModalConfiguration,
+			});
+
+			await expandSection();
+
+			await userEvent.click(screen.getAllByRole('radio')[1]);
+
+			expect(screen.getByRole('checkbox', {name: 'Pages'})).toBeChecked();
+
+			await userEvent.click(
+				screen.getByRole('checkbox', {name: 'Pages'})
+			);
+
+			expect(
+				screen.getByRole('checkbox', {name: 'Pages'})
+			).not.toBeChecked();
+		});
+
+		it('exports a private page subset selected through the modal', async () => {
+			renderComponent({
+				exportPreview: previewWithPagePicker,
+				pageTreeModalConfiguration: privatePageTreeModalConfiguration,
+			});
+
+			await typeFileName();
+			await expandSection();
+
+			await userEvent.click(screen.getAllByRole('radio')[1]);
+			await userEvent.click(
+				screen.getByRole('button', {name: 'select-layouts'})
+			);
+
+			expect(await screen.findByLabelText('page-1')).toBeChecked();
+			expect(screen.getByLabelText('page-2')).toBeChecked();
+
+			await userEvent.click(screen.getByLabelText('page-2'));
+			await userEvent.click(screen.getByRole('button', {name: 'select'}));
+
+			await submitExport();
+
+			await waitFor(() =>
+				expect(getExportRequest().requestPortletDataHandlers).toEqual([
+					{
+						name: LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY,
+						requestPortletDataHandlerControls: [
+							{name: 'privateLayout', values: ['true']},
+							{name: 'layoutIds', values: ['1']},
+						],
+					},
+				])
+			);
+		});
 	});
 });

--- a/modules/apps/export-import/export-import-web/test/revamp/js/pages/export/NewExport.test.tsx
+++ b/modules/apps/export-import/export-import-web/test/revamp/js/pages/export/NewExport.test.tsx
@@ -433,7 +433,7 @@ describe('NewExport', () => {
 
 			await userEvent.click(screen.getAllByRole('radio')[1]);
 			await userEvent.click(
-				screen.getByRole('button', {name: 'select-layouts'})
+				screen.getByRole('button', {name: 'select-x'})
 			);
 
 			expect(await screen.findByLabelText('page-1')).toBeChecked();

--- a/modules/apps/export-import/export-import-web/test/revamp/js/pages/export/components/PageTreeModal.test.tsx
+++ b/modules/apps/export-import/export-import-web/test/revamp/js/pages/export/components/PageTreeModal.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import fetch from 'jest-fetch-mock';
+import React from 'react';
+
+import PageTreeModal from '../../../../../../src/main/resources/META-INF/resources/revamp/js/pages/export/components/PageTreeModal';
+import {mockPageTreeItems} from '../../../mocks/mockPageTreeItems';
+
+jest.mock('staging-taglib', () => ({
+	PagesTree: require('../../../mocks/MockPagesTree').MockPagesTree,
+}));
+
+const renderModal = (
+	props: Partial<React.ComponentProps<typeof PageTreeModal>>
+) =>
+	render(
+		<PageTreeModal
+			initialSelectedIds={[]}
+			liveGroupId={20121}
+			onClose={jest.fn()}
+			onSubmit={jest.fn()}
+			pageSize={20}
+			privateLayout={false}
+			{...props}
+		/>
+	);
+
+describe('PageTreeModal', () => {
+	beforeEach(() => {
+		fetch.resetMocks();
+	});
+
+	it('emits the selected subset when not every page is checked', async () => {
+		fetch
+			.mockResponseOnce('[]')
+			.mockResponseOnce('[]')
+			.mockResponseOnce(
+				JSON.stringify({
+					hasMoreElements: false,
+					items: mockPageTreeItems,
+				})
+			);
+
+		const onSubmit = jest.fn();
+
+		renderModal({initialSelectedIds: ['1'], onSubmit, privateLayout: true});
+
+		await screen.findByLabelText('page-1');
+
+		await userEvent.click(screen.getByRole('button', {name: 'select'}));
+
+		expect(onSubmit).toHaveBeenCalledWith({
+			layoutIds: [1],
+			privateLayout: true,
+		});
+	});
+
+	it('emits no layoutIds when every page is checked', async () => {
+		fetch
+			.mockResponseOnce('[]')
+			.mockResponseOnce('[]')
+			.mockResponseOnce(
+				JSON.stringify({
+					hasMoreElements: false,
+					items: mockPageTreeItems,
+				})
+			);
+
+		const onSubmit = jest.fn();
+
+		renderModal({initialSelectedIds: ['1', '2'], onSubmit});
+
+		await screen.findByLabelText('page-1');
+
+		await userEvent.click(screen.getByRole('button', {name: 'select'}));
+
+		expect(onSubmit).toHaveBeenCalledWith({privateLayout: false});
+	});
+
+	it('seeds the tree from the server when opened in the all state', async () => {
+		fetch
+			.mockResponseOnce('[]')
+			.mockResponseOnce(JSON.stringify([1, 2]))
+			.mockResponseOnce(
+				JSON.stringify({
+					hasMoreElements: false,
+					items: mockPageTreeItems,
+				})
+			);
+
+		const onSubmit = jest.fn();
+
+		renderModal({initialAll: true, onSubmit});
+
+		await screen.findByLabelText('page-1');
+
+		const layoutCheckCall = fetch.mock.calls.find(([, init]) =>
+			init?.body?.toString().includes('cmd=layoutCheck')
+		);
+
+		expect(layoutCheckCall?.[1]?.body?.toString()).toContain(
+			'groupId=20121'
+		);
+
+		expect(screen.getByLabelText('page-1')).toBeChecked();
+		expect(screen.getByLabelText('page-2')).toBeChecked();
+
+		await userEvent.click(screen.getByRole('button', {name: 'select'}));
+
+		expect(onSubmit).toHaveBeenCalledWith({privateLayout: false});
+	});
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91106

## What Is Being Fixed

The export wizard's page picker had a rough first iteration that this PR refines:

- The public/private mode toggle lived as a `<ClayDropDown>` *inside* the page tree modal, duplicating the tree's own root label and forcing the user to open the modal just to change the mode.
- Reopening the modal in the "all" state showed an empty tree, because "no `layoutIds`" was not being detected as "all".
- Submitting the wizard navigated to the back URL via `window.location.href`, bypassing the SPA engine and breaking jsdom tests.
- The `staging-taglib` import lived behind a `@ts-ignore`.
- The page picker controls (checkbox, radios, "Select Pages" link) lacked accessible names.

## How It Is Being Fixed

The mode toggle moves out of the modal and into `LayoutSetControl` as two `ClayRadio` controls inside a `role="radiogroup"` wrapper. A `Select Pages` link renders next to the active radio, opening a mode-locked modal (required `privateLayout` prop). When the site has `privateLayoutsEnabled === false`, the radios collapse to a single `Select Pages` action next to the label.

`PageTreeModal` detects the "all" case on submit by scraping `querySelectorAll('input[type="checkbox"]:not(:checked)').length === 0`, emits `{privateLayout}` with no `layoutIds`, and on reopen seeds the tree by issuing a `cmd=layoutCheck` request to populate `selectedLayoutIds` from the server.

A new shared predicate `isAllLayoutsSelected` (in `contentSelection.ts`) replaces two divergent ad-hoc checks. Navigation now uses `Liferay.Util.navigate(backURL)`: SPA-aware and assertable as a `jest.fn` in tests.

A small `staging-taglib.d.ts` declares the `PagesTree` shape we consume, dropping the `@ts-ignore`. The "Select Pages" button receives a mode-aware `aria-label` via `sub('Select {0}', <pages>)`, and the layout-set checkbox gets its own `aria-label`.

## Tests

| Test | What it asserts | Layer |
| --- | --- | --- |
| `PageTreeModal › emits the selected subset when not every page is checked` | Modal submit with a partial selection emits `{layoutIds, privateLayout}`. | Component (PageTreeModal in isolation) |
| `PageTreeModal › emits no layoutIds when every page is checked` | Modal submit with all checkboxes checked emits `{privateLayout}` (the "all" encoding). | Component |
| `PageTreeModal › seeds the tree from the server when opened in the all state` | `initialAll=true` triggers a `cmd=layoutCheck` POST; the response seeds `selectedLayoutIds` so the tree opens fully checked, and submit emits `{privateLayout}`. | Component (incl. server protocol) |
| `NewExport › page selection › exports all public pages selected from the section checkbox` | Toggling the section checkbox into "all" exports with `privateLayout=false` and no `layoutIds`; `Liferay.Util.navigate` is called with the back URL on success. | Integration (full wizard → submit) |
| `NewExport › page selection › hides the visibility radios and exports a public page subset through the modal` | With `privateLayoutsEnabled=false`, no radios render; opening the modal, selecting one page, and submitting yields `{privateLayout:false, layoutIds:['1']}`. | Integration |
| `NewExport › page selection › shows the visibility radios and exports all private pages` | With `privateLayoutsEnabled=true`, both radios render; switching to private and submitting yields `{privateLayout:true}` with no `layoutIds`. | Integration |
| `NewExport › page selection › resets the selection to public when the public radio is selected` | Switching from private back to public clears the private mode state. | Integration |
| `NewExport › page selection › clears the page selection when the main checkbox is toggled off` | Toggling off the main checkbox after a private subset clears the selection. | Integration |
| `NewExport › page selection › exports a private page subset selected through the modal` | Opening the modal in the private "all" state, unchecking one page, and submitting yields `{privateLayout:true, layoutIds:['1']}`. | Integration (incl. modal seeding) |
