### PR TITLE
LPD-92522 Click the endpoint Configuration tab by role to avoid the Control Panel menu collision

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/APIBuilderUI.macro
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/APIBuilderUI.macro
@@ -464,8 +464,8 @@ definition {
 		Click(locator1 = "APIBuilder#EDIT_BUTTON");
 
 		Click(
-			locator1 = "Button#BUTTON_WITH_VALUE",
-			value = ${tabEntity});
+			locator1 = "APIBuilder#TAB",
+			tabEntity = ${tabEntity});
 	}
 
 	@summary = "Default summary"

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/paths/APIBuilder.path
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/paths/APIBuilder.path
@@ -191,6 +191,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>TAB</td>
+	<td>//button[@role='tab' and contains(.,'${tabEntity}')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>TABLE_LIST</td>
 	<td>xpath=(//div[contains(@class,'table-list-title')])[${index}]</td>
 	<td></td>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92522

## Failing Test

`LocalFile.AllowUsersToDefinePrefilters#PrefilteringWorksWithSchemaPropertiesMadeOfMainObjectFields`

`modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefinePrefiltersAndSorts/AllowUsersToDefinePrefilters.testcase`

```
com.liferay.poshi.runner.exception.ElementNotFoundPoshiRunnerException: Element is not present at "//textarea[@placeholder='Add a filter using OData.']"
	at APIBuilderUI.addAndPublishEndpointConfiguration(APIBuilderUI.macro:28)
```

## Root Cause

The `addAndPublishEndpointConfiguration` macro navigated to the endpoint Configuration tab through `Button#BUTTON_WITH_VALUE`, whose XPath `//button[contains(.,'Configuration')]` also matches the Control Panel left product menu's "Configuration" category button. That category button appears earlier in document order than the endpoint editor tab, so when the product menu is expanded Poshi clicked the menu category instead of the tab. The endpoint stayed on the Info tab, where the OData filter textarea is not rendered (the textarea only renders on the Configuration tab for a GET collection endpoint), so the subsequent Type step failed with ElementNotFound. Because the outcome depends on the product menu's expand/collapse state, the test alternated between passing and failing across builds. The product UI itself is correct: the textarea renders as expected when the actual Configuration tab is activated.

## Fix

Added an `APIBuilder#TAB` path locator that targets the tab by its ARIA role (`//button[@role='tab' and contains(.,'${tabEntity}')]`) and switched `goToEditRelatedEntryInEditApplication` to use it instead of the ambiguous generic-button locator. This makes the Configuration tab click unambiguous regardless of the Control Panel menu state. Verified locally: the four AllowUsersToDefinePrefilters tests that exercise this macro pass, and FiltersIsPresentInEndpointConfiguration continues to pass.

- `modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/APIBuilderUI.macro`
- `modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/paths/APIBuilder.path`
