### PR TITLE
LPD-92521 Fix API Builder endpoint tab navigation colliding with product menu

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/APIBuilderUI.macro
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/APIBuilderUI.macro
@@ -464,8 +464,8 @@ definition {
 		Click(locator1 = "APIBuilder#EDIT_BUTTON");
 
 		Click(
-			locator1 = "Button#BUTTON_WITH_VALUE",
-			value = ${tabEntity});
+			key_tab = ${tabEntity},
+			locator1 = "NavTab#TAB_LINK");
 	}
 
 	@summary = "Default summary"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92521

## What is being fixed

The Poshi test `LocalFile.AllowUsersToDefinePrefilters#PrefilterIsLimitedByODataCharacterLimit` fails with `ElementNotFoundPoshiRunnerException: Element is not present at "//textarea[@placeholder='Add a filter using OData.']"`. Several other tests under the same suite that configure an endpoint share the same failure mode.

The `goToEditRelatedEntryInEditApplication` macro in `APIBuilderUI.macro` switches to the endpoint Configuration tab with the generic `Button#BUTTON_WITH_VALUE` locator, which resolves to `//button[contains(.,'Configuration') or contains(@title,'Configuration')]` and matches any button containing the tab name. When the Control Panel product menu sidebar overlaps the full-page endpoint editor, that locator matches the sidebar's "CONFIGURATION" category button instead of the endpoint's Configuration tab. The click expands the sidebar category rather than switching tabs, so the editor stays on the Info tab. The OData filter textarea is rendered only on the Configuration tab (in `EditEndpointConfiguration.tsx`, when `httpMethod` is `get` and `retrieveType` is `collection`), so it never appears and the test fails waiting for it. The endpoint data itself is correct: the API returns `httpMethod=get` and `retrieveType=collection`.

## How it is being fixed

Switch the tab click to the `NavTab#TAB_LINK` locator, whose xpath explicitly excludes the product menu and side navigation (`[not(contains(@id,'ProductMenu') or contains(@href,'site_administration') or ancestor::*[@data-qa-id='sideNavigation'])]`). This makes the endpoint's Configuration tab the only match, so the editor switches tabs correctly and the OData filter textarea renders.

Verified locally against a deployed bundle: `PrefilterIsLimitedByODataCharacterLimit` and the sibling `PrefilteringWorksWithMainObjectFieldsThatAreNotPartOfSchemaProperties` both pass.

## Why are there no tests?

This change fixes an existing functional (Poshi) test by correcting a fragile locator in a shared macro. No new test is added because the change is itself the test fix; the corrected macro restores coverage for the OData filter character-limit behavior.
