### PR TITLE
LPD-92570 Match dateModified filter locators to the locale placeholder

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/paths/APIBuilder.path
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/paths/APIBuilder.path
@@ -122,7 +122,7 @@
 </tr>
 <tr>
 	<td>FROM_DATE</td>
-	<td>//input[contains(@id,'from-dateModified') and @placeholder='yyyy-mm-dd']</td>
+	<td>//input[contains(@id,'from-dateModified') and @placeholder='mm/dd/yyyy']</td>
 	<td></td>
 </tr>
 <tr>
@@ -197,7 +197,7 @@
 </tr>
 <tr>
 	<td>TO_DATE</td>
-	<td>//input[contains(@id,'to-dateModified') and @placeholder='yyyy-mm-dd']</td>
+	<td>//input[contains(@id,'to-dateModified') and @placeholder='mm/dd/yyyy']</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92570

## Failing Test

`LocalFile.ListAPIApplicationEndpoints#CanFilterEndpointAPIByCreationDateAsLastUpdated`

`modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationEndpoints/ListAPIApplicationEndpoints.testcase`

```
com.liferay.poshi.runner.exception.ElementNotFoundPoshiRunnerException: Element is not present at "//input[contains(@id,'from-dateModified') and @placeholder='yyyy-mm-dd']"
```

## Root Cause

Commit `1286edc` ("LPD-89563 Render dateTimeRange filter in the user locale format") deliberately replaced the hardcoded `yyyy-MM-dd` date format on the frontend data set dateTimeRange filter with a locale-derived format computed by `getDateConfig` through `Intl.DateTimeFormat.formatToParts`. For the en-US test environment the input placeholder is now `mm/dd/yyyy`, so the `FROM_DATE` and `TO_DATE` locators in `APIBuilder.path`, which still matched `@placeholder='yyyy-mm-dd'`, could no longer find the inputs.

## Fix

Update the `FROM_DATE` and `TO_DATE` locators to match the new locale-derived placeholder `mm/dd/yyyy`. The test already feeds the filter `MM/dd/yyyy`-formatted dates, so only the placeholder predicate in the locators was stale. The Poshi test passes locally with the feature flag `feature.flag.LPS-178642=true` enabled.

- `modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/paths/APIBuilder.path`