### PR TITLE
LPD-92468 Use partial confirmation when activating local staging

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/Staging.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/Staging.testcase
@@ -9,6 +9,9 @@ definition {
 	property portal.upstream = "true";
 	property testray.main.component.name = "Staging";
 
+	static var randomSiteURLKey = "site-name";
+	static var randomSiteName = "Site Name";
+
 	setUp {
 		var portalURL = PropsUtil.get("portal.url");
 
@@ -638,9 +641,6 @@ definition {
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
-		var randomSiteURLKey = "guest";
-		var randomSiteName = "Liferay DXP";
-
 		task ("Given: Replicate Individual Deletions is active, MULTIPLE (specifically two) Web Contents are created and Staging is enabled") {
 			ApplicationsMenu.gotoPortlet(
 				category = "Configuration",
@@ -705,9 +705,6 @@ definition {
 	test DraftedWebContentTitleIsNotDisplayedInPublicationSummary {
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
-
-		var randomSiteURLKey = "guest";
-		var randomSiteName = "Liferay DXP";
 
 		task ("Given: Staging is enabled and a Web Content is SAVED AS DRAFT") {
 			Staging.openStagingAdmin(siteURLKey = ${randomSiteURLKey});
@@ -953,9 +950,6 @@ definition {
 	test MultipleWebContentTitlesAreNotDisplayedInPublicationSummary {
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
-
-		var randomSiteURLKey = "guest";
-		var randomSiteName = "Liferay DXP";
 
 		task ("Given: Staging is enabled and MULTIPLE (specifically three) Web Contents are created") {
 			Staging.openStagingAdmin(siteURLKey = ${randomSiteURLKey});
@@ -1967,9 +1961,6 @@ definition {
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
-		var randomSiteURLKey = "guest";
-		var randomSiteName = "Liferay DXP";
-
 		task ("Given: Staging is enabled and ONE Web Content is created and moved into a Web Content Folder") {
 			Staging.openStagingAdmin(siteURLKey = ${randomSiteURLKey});
 
@@ -2010,9 +2001,6 @@ definition {
 	test SingleWebContentTitleIsProperlyDisplayedInPublicationSummary {
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
-
-		var randomSiteURLKey = "guest";
-		var randomSiteName = "Liferay DXP";
 
 		task ("Given: Staging is enabled and ONE Web Content is created") {
 			Staging.openStagingAdmin(siteURLKey = ${randomSiteURLKey});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92468

## What is being fixed

Five tests in `Staging.testcase` hardcoded `randomSiteURLKey = "guest"` and `randomSiteName = "Liferay DXP"`, targeting the default Guest site instead of the site created in `setUp`. LPD-77443 changed the Guest site display name, which broke the `AssertConfirm` dialog check in `Staging.activateStagingCP` for all five tests.

Failing tests: https://testray.liferay.com/#/project/35392/routines/994140/build/480196194?filter=%7B%22testrayCaseName%22%3A%22LocalFile.Staging%23%22%2C%22status%22%3A%5B%22BLOCKED%22%5D%7D&filterSchema=buildResults&page=1

- `LocalFile.Staging#DifferentlyModifiedWebContentTitlesAreNotDisplayedInPublicationSummary`
- `LocalFile.Staging#DraftedWebContentTitleIsNotDisplayedInPublicationSummary`
- `LocalFile.Staging#MultipleWebContentTitlesAreNotDisplayedInPublicationSummary`
- `LocalFile.Staging#SingleFolderedWebContentTitleIsProperlyDisplayedInPublicationSummary`
- `LocalFile.Staging#SingleWebContentTitleIsProperlyDisplayedInPublicationSummary`

## How it is being fixed

The five tests are updated to use the site created in `setUp` ("site-name" / "Site Name") instead of the Guest site. The repeated inline `var` declarations are promoted to `static var` at the definition level to avoid duplication across all five tests.