### PR TITLE
LPD-89777 Add Look and Feel and Comments and Ratings to Data Selection

### DIFF
--- a/modules/apps/export-import/export-import-rest-api/src/main/java/com/liferay/exportimport/rest/dto/v1_0/ExportProcessRequest.java
+++ b/modules/apps/export-import/export-import-rest-api/src/main/java/com/liferay/exportimport/rest/dto/v1_0/ExportProcessRequest.java
@@ -59,6 +59,47 @@ public class ExportProcessRequest implements Serializable {
 	}
 
 	@io.swagger.v3.oas.annotations.media.Schema
+	public Boolean getComments() {
+		if (_commentsSupplier != null) {
+			comments = _commentsSupplier.get();
+
+			_commentsSupplier = null;
+		}
+
+		return comments;
+	}
+
+	public void setComments(Boolean comments) {
+		this.comments = comments;
+
+		_commentsSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setComments(
+		UnsafeSupplier<Boolean, Exception> commentsUnsafeSupplier) {
+
+		_commentsSupplier = () -> {
+			try {
+				return commentsUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Boolean comments;
+
+	@JsonIgnore
+	private Supplier<Boolean> _commentsSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
 	public Boolean getDeletions() {
 		if (_deletionsSupplier != null) {
 			deletions = _deletionsSupplier.get();
@@ -178,6 +219,45 @@ public class ExportProcessRequest implements Serializable {
 
 	@JsonIgnore
 	private Supplier<Integer> _lastSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Boolean getLogo() {
+		if (_logoSupplier != null) {
+			logo = _logoSupplier.get();
+
+			_logoSupplier = null;
+		}
+
+		return logo;
+	}
+
+	public void setLogo(Boolean logo) {
+		this.logo = logo;
+
+		_logoSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setLogo(UnsafeSupplier<Boolean, Exception> logoUnsafeSupplier) {
+		_logoSupplier = () -> {
+			try {
+				return logoUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Boolean logo;
+
+	@JsonIgnore
+	private Supplier<Boolean> _logoSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema
 	public String getName() {
@@ -313,6 +393,47 @@ public class ExportProcessRequest implements Serializable {
 	private Supplier<Range> _rangeSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema
+	public Boolean getRatings() {
+		if (_ratingsSupplier != null) {
+			ratings = _ratingsSupplier.get();
+
+			_ratingsSupplier = null;
+		}
+
+		return ratings;
+	}
+
+	public void setRatings(Boolean ratings) {
+		this.ratings = ratings;
+
+		_ratingsSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setRatings(
+		UnsafeSupplier<Boolean, Exception> ratingsUnsafeSupplier) {
+
+		_ratingsSupplier = () -> {
+			try {
+				return ratingsUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Boolean ratings;
+
+	@JsonIgnore
+	private Supplier<Boolean> _ratingsSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
 	@Valid
 	public RequestPortletDataHandler[] getRequestPortletDataHandlers() {
 		if (_requestPortletDataHandlersSupplier != null) {
@@ -360,6 +481,88 @@ public class ExportProcessRequest implements Serializable {
 		_requestPortletDataHandlersSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema
+	public Boolean getSitePagesSettings() {
+		if (_sitePagesSettingsSupplier != null) {
+			sitePagesSettings = _sitePagesSettingsSupplier.get();
+
+			_sitePagesSettingsSupplier = null;
+		}
+
+		return sitePagesSettings;
+	}
+
+	public void setSitePagesSettings(Boolean sitePagesSettings) {
+		this.sitePagesSettings = sitePagesSettings;
+
+		_sitePagesSettingsSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setSitePagesSettings(
+		UnsafeSupplier<Boolean, Exception> sitePagesSettingsUnsafeSupplier) {
+
+		_sitePagesSettingsSupplier = () -> {
+			try {
+				return sitePagesSettingsUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Boolean sitePagesSettings;
+
+	@JsonIgnore
+	private Supplier<Boolean> _sitePagesSettingsSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Boolean getSiteTemplateSettings() {
+		if (_siteTemplateSettingsSupplier != null) {
+			siteTemplateSettings = _siteTemplateSettingsSupplier.get();
+
+			_siteTemplateSettingsSupplier = null;
+		}
+
+		return siteTemplateSettings;
+	}
+
+	public void setSiteTemplateSettings(Boolean siteTemplateSettings) {
+		this.siteTemplateSettings = siteTemplateSettings;
+
+		_siteTemplateSettingsSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setSiteTemplateSettings(
+		UnsafeSupplier<Boolean, Exception> siteTemplateSettingsUnsafeSupplier) {
+
+		_siteTemplateSettingsSupplier = () -> {
+			try {
+				return siteTemplateSettingsUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Boolean siteTemplateSettings;
+
+	@JsonIgnore
+	private Supplier<Boolean> _siteTemplateSettingsSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
 	public Date getStartDate() {
 		if (_startDateSupplier != null) {
 			startDate = _startDateSupplier.get();
@@ -400,6 +603,47 @@ public class ExportProcessRequest implements Serializable {
 	@JsonIgnore
 	private Supplier<Date> _startDateSupplier;
 
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Boolean getThemeSettings() {
+		if (_themeSettingsSupplier != null) {
+			themeSettings = _themeSettingsSupplier.get();
+
+			_themeSettingsSupplier = null;
+		}
+
+		return themeSettings;
+	}
+
+	public void setThemeSettings(Boolean themeSettings) {
+		this.themeSettings = themeSettings;
+
+		_themeSettingsSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setThemeSettings(
+		UnsafeSupplier<Boolean, Exception> themeSettingsUnsafeSupplier) {
+
+		_themeSettingsSupplier = () -> {
+			try {
+				return themeSettingsUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Boolean themeSettings;
+
+	@JsonIgnore
+	private Supplier<Boolean> _themeSettingsSupplier;
+
 	@Override
 	public boolean equals(Object object) {
 		if (this == object) {
@@ -430,6 +674,18 @@ public class ExportProcessRequest implements Serializable {
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
 			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		Boolean comments = getComments();
+
+		if (comments != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"comments\": ");
+
+			sb.append(comments);
+		}
 
 		Boolean deletions = getDeletions();
 
@@ -469,6 +725,18 @@ public class ExportProcessRequest implements Serializable {
 			sb.append("\"last\": ");
 
 			sb.append(last);
+		}
+
+		Boolean logo = getLogo();
+
+		if (logo != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"logo\": ");
+
+			sb.append(logo);
 		}
 
 		String name = getName();
@@ -513,6 +781,18 @@ public class ExportProcessRequest implements Serializable {
 			sb.append("\"");
 		}
 
+		Boolean ratings = getRatings();
+
+		if (ratings != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"ratings\": ");
+
+			sb.append(ratings);
+		}
+
 		RequestPortletDataHandler[] requestPortletDataHandlers =
 			getRequestPortletDataHandlers();
 
@@ -536,6 +816,30 @@ public class ExportProcessRequest implements Serializable {
 			sb.append("]");
 		}
 
+		Boolean sitePagesSettings = getSitePagesSettings();
+
+		if (sitePagesSettings != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"sitePagesSettings\": ");
+
+			sb.append(sitePagesSettings);
+		}
+
+		Boolean siteTemplateSettings = getSiteTemplateSettings();
+
+		if (siteTemplateSettings != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"siteTemplateSettings\": ");
+
+			sb.append(siteTemplateSettings);
+		}
+
 		Date startDate = getStartDate();
 
 		if (startDate != null) {
@@ -550,6 +854,18 @@ public class ExportProcessRequest implements Serializable {
 			sb.append(liferayToJSONDateFormat.format(startDate));
 
 			sb.append("\"");
+		}
+
+		Boolean themeSettings = getThemeSettings();
+
+		if (themeSettings != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"themeSettings\": ");
+
+			sb.append(themeSettings);
 		}
 
 		sb.append("}");
@@ -691,4 +1007,4 @@ public class ExportProcessRequest implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:533579518
+// LIFERAY-REST-BUILDER-HASH:-1681577752

--- a/modules/apps/export-import/export-import-rest-api/src/main/java/com/liferay/exportimport/rest/dto/v1_0/ImportProcessRequest.java
+++ b/modules/apps/export-import/export-import-rest-api/src/main/java/com/liferay/exportimport/rest/dto/v1_0/ImportProcessRequest.java
@@ -53,6 +53,47 @@ public class ImportProcessRequest implements Serializable {
 	}
 
 	@io.swagger.v3.oas.annotations.media.Schema
+	public Boolean getComments() {
+		if (_commentsSupplier != null) {
+			comments = _commentsSupplier.get();
+
+			_commentsSupplier = null;
+		}
+
+		return comments;
+	}
+
+	public void setComments(Boolean comments) {
+		this.comments = comments;
+
+		_commentsSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setComments(
+		UnsafeSupplier<Boolean, Exception> commentsUnsafeSupplier) {
+
+		_commentsSupplier = () -> {
+			try {
+				return commentsUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Boolean comments;
+
+	@JsonIgnore
+	private Supplier<Boolean> _commentsSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
 	@JsonGetter("dataStrategy")
 	@Valid
 	public DataStrategy getDataStrategy() {
@@ -148,6 +189,45 @@ public class ImportProcessRequest implements Serializable {
 	private Supplier<Boolean> _deletionsSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema
+	public Boolean getLogo() {
+		if (_logoSupplier != null) {
+			logo = _logoSupplier.get();
+
+			_logoSupplier = null;
+		}
+
+		return logo;
+	}
+
+	public void setLogo(Boolean logo) {
+		this.logo = logo;
+
+		_logoSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setLogo(UnsafeSupplier<Boolean, Exception> logoUnsafeSupplier) {
+		_logoSupplier = () -> {
+			try {
+				return logoUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Boolean logo;
+
+	@JsonIgnore
+	private Supplier<Boolean> _logoSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
 	public String getName() {
 		if (_nameSupplier != null) {
 			name = _nameSupplier.get();
@@ -228,6 +308,47 @@ public class ImportProcessRequest implements Serializable {
 	private Supplier<Boolean> _permissionsSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema
+	public Boolean getRatings() {
+		if (_ratingsSupplier != null) {
+			ratings = _ratingsSupplier.get();
+
+			_ratingsSupplier = null;
+		}
+
+		return ratings;
+	}
+
+	public void setRatings(Boolean ratings) {
+		this.ratings = ratings;
+
+		_ratingsSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setRatings(
+		UnsafeSupplier<Boolean, Exception> ratingsUnsafeSupplier) {
+
+		_ratingsSupplier = () -> {
+			try {
+				return ratingsUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Boolean ratings;
+
+	@JsonIgnore
+	private Supplier<Boolean> _ratingsSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
 	@Valid
 	public RequestPortletDataHandler[] getRequestPortletDataHandlers() {
 		if (_requestPortletDataHandlersSupplier != null) {
@@ -273,6 +394,129 @@ public class ImportProcessRequest implements Serializable {
 	@JsonIgnore
 	private Supplier<RequestPortletDataHandler[]>
 		_requestPortletDataHandlersSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Boolean getSitePagesSettings() {
+		if (_sitePagesSettingsSupplier != null) {
+			sitePagesSettings = _sitePagesSettingsSupplier.get();
+
+			_sitePagesSettingsSupplier = null;
+		}
+
+		return sitePagesSettings;
+	}
+
+	public void setSitePagesSettings(Boolean sitePagesSettings) {
+		this.sitePagesSettings = sitePagesSettings;
+
+		_sitePagesSettingsSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setSitePagesSettings(
+		UnsafeSupplier<Boolean, Exception> sitePagesSettingsUnsafeSupplier) {
+
+		_sitePagesSettingsSupplier = () -> {
+			try {
+				return sitePagesSettingsUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Boolean sitePagesSettings;
+
+	@JsonIgnore
+	private Supplier<Boolean> _sitePagesSettingsSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Boolean getSiteTemplateSettings() {
+		if (_siteTemplateSettingsSupplier != null) {
+			siteTemplateSettings = _siteTemplateSettingsSupplier.get();
+
+			_siteTemplateSettingsSupplier = null;
+		}
+
+		return siteTemplateSettings;
+	}
+
+	public void setSiteTemplateSettings(Boolean siteTemplateSettings) {
+		this.siteTemplateSettings = siteTemplateSettings;
+
+		_siteTemplateSettingsSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setSiteTemplateSettings(
+		UnsafeSupplier<Boolean, Exception> siteTemplateSettingsUnsafeSupplier) {
+
+		_siteTemplateSettingsSupplier = () -> {
+			try {
+				return siteTemplateSettingsUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Boolean siteTemplateSettings;
+
+	@JsonIgnore
+	private Supplier<Boolean> _siteTemplateSettingsSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Boolean getThemeSettings() {
+		if (_themeSettingsSupplier != null) {
+			themeSettings = _themeSettingsSupplier.get();
+
+			_themeSettingsSupplier = null;
+		}
+
+		return themeSettings;
+	}
+
+	public void setThemeSettings(Boolean themeSettings) {
+		this.themeSettings = themeSettings;
+
+		_themeSettingsSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setThemeSettings(
+		UnsafeSupplier<Boolean, Exception> themeSettingsUnsafeSupplier) {
+
+		_themeSettingsSupplier = () -> {
+			try {
+				return themeSettingsUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Boolean themeSettings;
+
+	@JsonIgnore
+	private Supplier<Boolean> _themeSettingsSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema
 	@JsonGetter("userIdStrategy")
@@ -357,6 +601,18 @@ public class ImportProcessRequest implements Serializable {
 
 		sb.append("{");
 
+		Boolean comments = getComments();
+
+		if (comments != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"comments\": ");
+
+			sb.append(comments);
+		}
+
 		DataStrategy dataStrategy = getDataStrategy();
 
 		if (dataStrategy != null) {
@@ -381,6 +637,18 @@ public class ImportProcessRequest implements Serializable {
 			sb.append("\"deletions\": ");
 
 			sb.append(deletions);
+		}
+
+		Boolean logo = getLogo();
+
+		if (logo != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"logo\": ");
+
+			sb.append(logo);
 		}
 
 		String name = getName();
@@ -411,6 +679,18 @@ public class ImportProcessRequest implements Serializable {
 			sb.append(permissions);
 		}
 
+		Boolean ratings = getRatings();
+
+		if (ratings != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"ratings\": ");
+
+			sb.append(ratings);
+		}
+
 		RequestPortletDataHandler[] requestPortletDataHandlers =
 			getRequestPortletDataHandlers();
 
@@ -432,6 +712,42 @@ public class ImportProcessRequest implements Serializable {
 			}
 
 			sb.append("]");
+		}
+
+		Boolean sitePagesSettings = getSitePagesSettings();
+
+		if (sitePagesSettings != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"sitePagesSettings\": ");
+
+			sb.append(sitePagesSettings);
+		}
+
+		Boolean siteTemplateSettings = getSiteTemplateSettings();
+
+		if (siteTemplateSettings != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"siteTemplateSettings\": ");
+
+			sb.append(siteTemplateSettings);
+		}
+
+		Boolean themeSettings = getThemeSettings();
+
+		if (themeSettings != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"themeSettings\": ");
+
+			sb.append(themeSettings);
 		}
 
 		UserIdStrategy userIdStrategy = getUserIdStrategy();
@@ -627,4 +943,4 @@ public class ImportProcessRequest implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:322807122
+// LIFERAY-REST-BUILDER-HASH:-1453883374

--- a/modules/apps/export-import/export-import-rest-client/src/main/java/com/liferay/exportimport/rest/client/dto/v1_0/ExportProcessRequest.java
+++ b/modules/apps/export-import/export-import-rest-client/src/main/java/com/liferay/exportimport/rest/client/dto/v1_0/ExportProcessRequest.java
@@ -26,6 +26,27 @@ public class ExportProcessRequest implements Cloneable, Serializable {
 		return ExportProcessRequestSerDes.toDTO(json);
 	}
 
+	public Boolean getComments() {
+		return comments;
+	}
+
+	public void setComments(Boolean comments) {
+		this.comments = comments;
+	}
+
+	public void setComments(
+		UnsafeSupplier<Boolean, Exception> commentsUnsafeSupplier) {
+
+		try {
+			comments = commentsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Boolean comments;
+
 	public Boolean getDeletions() {
 		return deletions;
 	}
@@ -86,6 +107,25 @@ public class ExportProcessRequest implements Cloneable, Serializable {
 	}
 
 	protected Integer last;
+
+	public Boolean getLogo() {
+		return logo;
+	}
+
+	public void setLogo(Boolean logo) {
+		this.logo = logo;
+	}
+
+	public void setLogo(UnsafeSupplier<Boolean, Exception> logoUnsafeSupplier) {
+		try {
+			logo = logoUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Boolean logo;
 
 	public String getName() {
 		return name;
@@ -154,6 +194,27 @@ public class ExportProcessRequest implements Cloneable, Serializable {
 
 	protected Range range;
 
+	public Boolean getRatings() {
+		return ratings;
+	}
+
+	public void setRatings(Boolean ratings) {
+		this.ratings = ratings;
+	}
+
+	public void setRatings(
+		UnsafeSupplier<Boolean, Exception> ratingsUnsafeSupplier) {
+
+		try {
+			ratings = ratingsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Boolean ratings;
+
 	public RequestPortletDataHandler[] getRequestPortletDataHandlers() {
 		return requestPortletDataHandlers;
 	}
@@ -179,6 +240,48 @@ public class ExportProcessRequest implements Cloneable, Serializable {
 
 	protected RequestPortletDataHandler[] requestPortletDataHandlers;
 
+	public Boolean getSitePagesSettings() {
+		return sitePagesSettings;
+	}
+
+	public void setSitePagesSettings(Boolean sitePagesSettings) {
+		this.sitePagesSettings = sitePagesSettings;
+	}
+
+	public void setSitePagesSettings(
+		UnsafeSupplier<Boolean, Exception> sitePagesSettingsUnsafeSupplier) {
+
+		try {
+			sitePagesSettings = sitePagesSettingsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Boolean sitePagesSettings;
+
+	public Boolean getSiteTemplateSettings() {
+		return siteTemplateSettings;
+	}
+
+	public void setSiteTemplateSettings(Boolean siteTemplateSettings) {
+		this.siteTemplateSettings = siteTemplateSettings;
+	}
+
+	public void setSiteTemplateSettings(
+		UnsafeSupplier<Boolean, Exception> siteTemplateSettingsUnsafeSupplier) {
+
+		try {
+			siteTemplateSettings = siteTemplateSettingsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Boolean siteTemplateSettings;
+
 	public Date getStartDate() {
 		return startDate;
 	}
@@ -199,6 +302,27 @@ public class ExportProcessRequest implements Cloneable, Serializable {
 	}
 
 	protected Date startDate;
+
+	public Boolean getThemeSettings() {
+		return themeSettings;
+	}
+
+	public void setThemeSettings(Boolean themeSettings) {
+		this.themeSettings = themeSettings;
+	}
+
+	public void setThemeSettings(
+		UnsafeSupplier<Boolean, Exception> themeSettingsUnsafeSupplier) {
+
+		try {
+			themeSettings = themeSettingsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Boolean themeSettings;
 
 	@Override
 	public ExportProcessRequest clone() throws CloneNotSupportedException {
@@ -266,4 +390,4 @@ public class ExportProcessRequest implements Cloneable, Serializable {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:922683815
+// LIFERAY-REST-BUILDER-HASH:61670162

--- a/modules/apps/export-import/export-import-rest-client/src/main/java/com/liferay/exportimport/rest/client/dto/v1_0/ImportProcessRequest.java
+++ b/modules/apps/export-import/export-import-rest-client/src/main/java/com/liferay/exportimport/rest/client/dto/v1_0/ImportProcessRequest.java
@@ -25,6 +25,27 @@ public class ImportProcessRequest implements Cloneable, Serializable {
 		return ImportProcessRequestSerDes.toDTO(json);
 	}
 
+	public Boolean getComments() {
+		return comments;
+	}
+
+	public void setComments(Boolean comments) {
+		this.comments = comments;
+	}
+
+	public void setComments(
+		UnsafeSupplier<Boolean, Exception> commentsUnsafeSupplier) {
+
+		try {
+			comments = commentsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Boolean comments;
+
 	public DataStrategy getDataStrategy() {
 		return dataStrategy;
 	}
@@ -75,6 +96,25 @@ public class ImportProcessRequest implements Cloneable, Serializable {
 
 	protected Boolean deletions;
 
+	public Boolean getLogo() {
+		return logo;
+	}
+
+	public void setLogo(Boolean logo) {
+		this.logo = logo;
+	}
+
+	public void setLogo(UnsafeSupplier<Boolean, Exception> logoUnsafeSupplier) {
+		try {
+			logo = logoUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Boolean logo;
+
 	public String getName() {
 		return name;
 	}
@@ -115,6 +155,27 @@ public class ImportProcessRequest implements Cloneable, Serializable {
 
 	protected Boolean permissions;
 
+	public Boolean getRatings() {
+		return ratings;
+	}
+
+	public void setRatings(Boolean ratings) {
+		this.ratings = ratings;
+	}
+
+	public void setRatings(
+		UnsafeSupplier<Boolean, Exception> ratingsUnsafeSupplier) {
+
+		try {
+			ratings = ratingsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Boolean ratings;
+
 	public RequestPortletDataHandler[] getRequestPortletDataHandlers() {
 		return requestPortletDataHandlers;
 	}
@@ -139,6 +200,69 @@ public class ImportProcessRequest implements Cloneable, Serializable {
 	}
 
 	protected RequestPortletDataHandler[] requestPortletDataHandlers;
+
+	public Boolean getSitePagesSettings() {
+		return sitePagesSettings;
+	}
+
+	public void setSitePagesSettings(Boolean sitePagesSettings) {
+		this.sitePagesSettings = sitePagesSettings;
+	}
+
+	public void setSitePagesSettings(
+		UnsafeSupplier<Boolean, Exception> sitePagesSettingsUnsafeSupplier) {
+
+		try {
+			sitePagesSettings = sitePagesSettingsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Boolean sitePagesSettings;
+
+	public Boolean getSiteTemplateSettings() {
+		return siteTemplateSettings;
+	}
+
+	public void setSiteTemplateSettings(Boolean siteTemplateSettings) {
+		this.siteTemplateSettings = siteTemplateSettings;
+	}
+
+	public void setSiteTemplateSettings(
+		UnsafeSupplier<Boolean, Exception> siteTemplateSettingsUnsafeSupplier) {
+
+		try {
+			siteTemplateSettings = siteTemplateSettingsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Boolean siteTemplateSettings;
+
+	public Boolean getThemeSettings() {
+		return themeSettings;
+	}
+
+	public void setThemeSettings(Boolean themeSettings) {
+		this.themeSettings = themeSettings;
+	}
+
+	public void setThemeSettings(
+		UnsafeSupplier<Boolean, Exception> themeSettingsUnsafeSupplier) {
+
+		try {
+			themeSettings = themeSettingsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Boolean themeSettings;
 
 	public UserIdStrategy getUserIdStrategy() {
 		return userIdStrategy;
@@ -271,4 +395,4 @@ public class ImportProcessRequest implements Cloneable, Serializable {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1910214743
+// LIFERAY-REST-BUILDER-HASH:-1688479022

--- a/modules/apps/export-import/export-import-rest-client/src/main/java/com/liferay/exportimport/rest/client/serdes/v1_0/ExportProcessRequestSerDes.java
+++ b/modules/apps/export-import/export-import-rest-client/src/main/java/com/liferay/exportimport/rest/client/serdes/v1_0/ExportProcessRequestSerDes.java
@@ -53,6 +53,16 @@ public class ExportProcessRequestSerDes {
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
 			"yyyy-MM-dd'T'HH:mm:ssXX");
 
+		if (exportProcessRequest.getComments() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"comments\": ");
+
+			sb.append(exportProcessRequest.getComments());
+		}
+
 		if (exportProcessRequest.getDeletions() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -87,6 +97,16 @@ public class ExportProcessRequestSerDes {
 			sb.append("\"last\": ");
 
 			sb.append(exportProcessRequest.getLast());
+		}
+
+		if (exportProcessRequest.getLogo() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"logo\": ");
+
+			sb.append(exportProcessRequest.getLogo());
 		}
 
 		if (exportProcessRequest.getName() != null) {
@@ -125,6 +145,16 @@ public class ExportProcessRequestSerDes {
 			sb.append("\"");
 		}
 
+		if (exportProcessRequest.getRatings() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"ratings\": ");
+
+			sb.append(exportProcessRequest.getRatings());
+		}
+
 		if (exportProcessRequest.getRequestPortletDataHandlers() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -155,6 +185,26 @@ public class ExportProcessRequestSerDes {
 			sb.append("]");
 		}
 
+		if (exportProcessRequest.getSitePagesSettings() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"sitePagesSettings\": ");
+
+			sb.append(exportProcessRequest.getSitePagesSettings());
+		}
+
+		if (exportProcessRequest.getSiteTemplateSettings() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"siteTemplateSettings\": ");
+
+			sb.append(exportProcessRequest.getSiteTemplateSettings());
+		}
+
 		if (exportProcessRequest.getStartDate() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -169,6 +219,16 @@ public class ExportProcessRequestSerDes {
 					exportProcessRequest.getStartDate()));
 
 			sb.append("\"");
+		}
+
+		if (exportProcessRequest.getThemeSettings() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"themeSettings\": ");
+
+			sb.append(exportProcessRequest.getThemeSettings());
 		}
 
 		sb.append("}");
@@ -194,6 +254,14 @@ public class ExportProcessRequestSerDes {
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
 			"yyyy-MM-dd'T'HH:mm:ssXX");
+
+		if (exportProcessRequest.getComments() == null) {
+			map.put("comments", null);
+		}
+		else {
+			map.put(
+				"comments", String.valueOf(exportProcessRequest.getComments()));
+		}
 
 		if (exportProcessRequest.getDeletions() == null) {
 			map.put("deletions", null);
@@ -221,6 +289,13 @@ public class ExportProcessRequestSerDes {
 			map.put("last", String.valueOf(exportProcessRequest.getLast()));
 		}
 
+		if (exportProcessRequest.getLogo() == null) {
+			map.put("logo", null);
+		}
+		else {
+			map.put("logo", String.valueOf(exportProcessRequest.getLogo()));
+		}
+
 		if (exportProcessRequest.getName() == null) {
 			map.put("name", null);
 		}
@@ -244,6 +319,14 @@ public class ExportProcessRequestSerDes {
 			map.put("range", String.valueOf(exportProcessRequest.getRange()));
 		}
 
+		if (exportProcessRequest.getRatings() == null) {
+			map.put("ratings", null);
+		}
+		else {
+			map.put(
+				"ratings", String.valueOf(exportProcessRequest.getRatings()));
+		}
+
 		if (exportProcessRequest.getRequestPortletDataHandlers() == null) {
 			map.put("requestPortletDataHandlers", null);
 		}
@@ -254,6 +337,24 @@ public class ExportProcessRequestSerDes {
 					exportProcessRequest.getRequestPortletDataHandlers()));
 		}
 
+		if (exportProcessRequest.getSitePagesSettings() == null) {
+			map.put("sitePagesSettings", null);
+		}
+		else {
+			map.put(
+				"sitePagesSettings",
+				String.valueOf(exportProcessRequest.getSitePagesSettings()));
+		}
+
+		if (exportProcessRequest.getSiteTemplateSettings() == null) {
+			map.put("siteTemplateSettings", null);
+		}
+		else {
+			map.put(
+				"siteTemplateSettings",
+				String.valueOf(exportProcessRequest.getSiteTemplateSettings()));
+		}
+
 		if (exportProcessRequest.getStartDate() == null) {
 			map.put("startDate", null);
 		}
@@ -262,6 +363,15 @@ public class ExportProcessRequestSerDes {
 				"startDate",
 				liferayToJSONDateFormat.format(
 					exportProcessRequest.getStartDate()));
+		}
+
+		if (exportProcessRequest.getThemeSettings() == null) {
+			map.put("themeSettings", null);
+		}
+		else {
+			map.put(
+				"themeSettings",
+				String.valueOf(exportProcessRequest.getThemeSettings()));
 		}
 
 		return map;
@@ -282,13 +392,19 @@ public class ExportProcessRequestSerDes {
 
 		@Override
 		protected boolean parseMaps(String jsonParserFieldName) {
-			if (Objects.equals(jsonParserFieldName, "deletions")) {
+			if (Objects.equals(jsonParserFieldName, "comments")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "deletions")) {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "endDate")) {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "last")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "logo")) {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "name")) {
@@ -300,12 +416,26 @@ public class ExportProcessRequestSerDes {
 			else if (Objects.equals(jsonParserFieldName, "range")) {
 				return false;
 			}
+			else if (Objects.equals(jsonParserFieldName, "ratings")) {
+				return false;
+			}
 			else if (Objects.equals(
 						jsonParserFieldName, "requestPortletDataHandlers")) {
 
 				return false;
 			}
+			else if (Objects.equals(jsonParserFieldName, "sitePagesSettings")) {
+				return false;
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "siteTemplateSettings")) {
+
+				return false;
+			}
 			else if (Objects.equals(jsonParserFieldName, "startDate")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "themeSettings")) {
 				return false;
 			}
 
@@ -317,7 +447,13 @@ public class ExportProcessRequestSerDes {
 			ExportProcessRequest exportProcessRequest,
 			String jsonParserFieldName, Object jsonParserFieldValue) {
 
-			if (Objects.equals(jsonParserFieldName, "deletions")) {
+			if (Objects.equals(jsonParserFieldName, "comments")) {
+				if (jsonParserFieldValue != null) {
+					exportProcessRequest.setComments(
+						(Boolean)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "deletions")) {
 				if (jsonParserFieldValue != null) {
 					exportProcessRequest.setDeletions(
 						(Boolean)jsonParserFieldValue);
@@ -333,6 +469,11 @@ public class ExportProcessRequestSerDes {
 				if (jsonParserFieldValue != null) {
 					exportProcessRequest.setLast(
 						Integer.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "logo")) {
+				if (jsonParserFieldValue != null) {
+					exportProcessRequest.setLogo((Boolean)jsonParserFieldValue);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "name")) {
@@ -351,6 +492,12 @@ public class ExportProcessRequestSerDes {
 					exportProcessRequest.setRange(
 						ExportProcessRequest.Range.create(
 							(String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "ratings")) {
+				if (jsonParserFieldValue != null) {
+					exportProcessRequest.setRatings(
+						(Boolean)jsonParserFieldValue);
 				}
 			}
 			else if (Objects.equals(
@@ -377,10 +524,30 @@ public class ExportProcessRequestSerDes {
 						requestPortletDataHandlersArray);
 				}
 			}
+			else if (Objects.equals(jsonParserFieldName, "sitePagesSettings")) {
+				if (jsonParserFieldValue != null) {
+					exportProcessRequest.setSitePagesSettings(
+						(Boolean)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "siteTemplateSettings")) {
+
+				if (jsonParserFieldValue != null) {
+					exportProcessRequest.setSiteTemplateSettings(
+						(Boolean)jsonParserFieldValue);
+				}
+			}
 			else if (Objects.equals(jsonParserFieldName, "startDate")) {
 				if (jsonParserFieldValue != null) {
 					exportProcessRequest.setStartDate(
 						toDate((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "themeSettings")) {
+				if (jsonParserFieldValue != null) {
+					exportProcessRequest.setThemeSettings(
+						(Boolean)jsonParserFieldValue);
 				}
 			}
 		}
@@ -464,4 +631,4 @@ public class ExportProcessRequestSerDes {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1211673737
+// LIFERAY-REST-BUILDER-HASH:1447166281

--- a/modules/apps/export-import/export-import-rest-client/src/main/java/com/liferay/exportimport/rest/client/serdes/v1_0/ImportProcessRequestSerDes.java
+++ b/modules/apps/export-import/export-import-rest-client/src/main/java/com/liferay/exportimport/rest/client/serdes/v1_0/ImportProcessRequestSerDes.java
@@ -47,6 +47,16 @@ public class ImportProcessRequestSerDes {
 
 		sb.append("{");
 
+		if (importProcessRequest.getComments() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"comments\": ");
+
+			sb.append(importProcessRequest.getComments());
+		}
+
 		if (importProcessRequest.getDataStrategy() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -67,6 +77,16 @@ public class ImportProcessRequestSerDes {
 			sb.append("\"deletions\": ");
 
 			sb.append(importProcessRequest.getDeletions());
+		}
+
+		if (importProcessRequest.getLogo() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"logo\": ");
+
+			sb.append(importProcessRequest.getLogo());
 		}
 
 		if (importProcessRequest.getName() != null) {
@@ -91,6 +111,16 @@ public class ImportProcessRequestSerDes {
 			sb.append("\"permissions\": ");
 
 			sb.append(importProcessRequest.getPermissions());
+		}
+
+		if (importProcessRequest.getRatings() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"ratings\": ");
+
+			sb.append(importProcessRequest.getRatings());
 		}
 
 		if (importProcessRequest.getRequestPortletDataHandlers() != null) {
@@ -121,6 +151,36 @@ public class ImportProcessRequestSerDes {
 			}
 
 			sb.append("]");
+		}
+
+		if (importProcessRequest.getSitePagesSettings() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"sitePagesSettings\": ");
+
+			sb.append(importProcessRequest.getSitePagesSettings());
+		}
+
+		if (importProcessRequest.getSiteTemplateSettings() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"siteTemplateSettings\": ");
+
+			sb.append(importProcessRequest.getSiteTemplateSettings());
+		}
+
+		if (importProcessRequest.getThemeSettings() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"themeSettings\": ");
+
+			sb.append(importProcessRequest.getThemeSettings());
 		}
 
 		if (importProcessRequest.getUserIdStrategy() != null) {
@@ -156,6 +216,14 @@ public class ImportProcessRequestSerDes {
 
 		Map<String, String> map = new TreeMap<>();
 
+		if (importProcessRequest.getComments() == null) {
+			map.put("comments", null);
+		}
+		else {
+			map.put(
+				"comments", String.valueOf(importProcessRequest.getComments()));
+		}
+
 		if (importProcessRequest.getDataStrategy() == null) {
 			map.put("dataStrategy", null);
 		}
@@ -174,6 +242,13 @@ public class ImportProcessRequestSerDes {
 				String.valueOf(importProcessRequest.getDeletions()));
 		}
 
+		if (importProcessRequest.getLogo() == null) {
+			map.put("logo", null);
+		}
+		else {
+			map.put("logo", String.valueOf(importProcessRequest.getLogo()));
+		}
+
 		if (importProcessRequest.getName() == null) {
 			map.put("name", null);
 		}
@@ -190,6 +265,14 @@ public class ImportProcessRequestSerDes {
 				String.valueOf(importProcessRequest.getPermissions()));
 		}
 
+		if (importProcessRequest.getRatings() == null) {
+			map.put("ratings", null);
+		}
+		else {
+			map.put(
+				"ratings", String.valueOf(importProcessRequest.getRatings()));
+		}
+
 		if (importProcessRequest.getRequestPortletDataHandlers() == null) {
 			map.put("requestPortletDataHandlers", null);
 		}
@@ -198,6 +281,33 @@ public class ImportProcessRequestSerDes {
 				"requestPortletDataHandlers",
 				String.valueOf(
 					importProcessRequest.getRequestPortletDataHandlers()));
+		}
+
+		if (importProcessRequest.getSitePagesSettings() == null) {
+			map.put("sitePagesSettings", null);
+		}
+		else {
+			map.put(
+				"sitePagesSettings",
+				String.valueOf(importProcessRequest.getSitePagesSettings()));
+		}
+
+		if (importProcessRequest.getSiteTemplateSettings() == null) {
+			map.put("siteTemplateSettings", null);
+		}
+		else {
+			map.put(
+				"siteTemplateSettings",
+				String.valueOf(importProcessRequest.getSiteTemplateSettings()));
+		}
+
+		if (importProcessRequest.getThemeSettings() == null) {
+			map.put("themeSettings", null);
+		}
+		else {
+			map.put(
+				"themeSettings",
+				String.valueOf(importProcessRequest.getThemeSettings()));
 		}
 
 		if (importProcessRequest.getUserIdStrategy() == null) {
@@ -227,10 +337,16 @@ public class ImportProcessRequestSerDes {
 
 		@Override
 		protected boolean parseMaps(String jsonParserFieldName) {
-			if (Objects.equals(jsonParserFieldName, "dataStrategy")) {
+			if (Objects.equals(jsonParserFieldName, "comments")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "dataStrategy")) {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "deletions")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "logo")) {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "name")) {
@@ -239,9 +355,23 @@ public class ImportProcessRequestSerDes {
 			else if (Objects.equals(jsonParserFieldName, "permissions")) {
 				return false;
 			}
+			else if (Objects.equals(jsonParserFieldName, "ratings")) {
+				return false;
+			}
 			else if (Objects.equals(
 						jsonParserFieldName, "requestPortletDataHandlers")) {
 
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "sitePagesSettings")) {
+				return false;
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "siteTemplateSettings")) {
+
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "themeSettings")) {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "userIdStrategy")) {
@@ -256,7 +386,13 @@ public class ImportProcessRequestSerDes {
 			ImportProcessRequest importProcessRequest,
 			String jsonParserFieldName, Object jsonParserFieldValue) {
 
-			if (Objects.equals(jsonParserFieldName, "dataStrategy")) {
+			if (Objects.equals(jsonParserFieldName, "comments")) {
+				if (jsonParserFieldValue != null) {
+					importProcessRequest.setComments(
+						(Boolean)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "dataStrategy")) {
 				if (jsonParserFieldValue != null) {
 					importProcessRequest.setDataStrategy(
 						ImportProcessRequest.DataStrategy.create(
@@ -269,6 +405,11 @@ public class ImportProcessRequestSerDes {
 						(Boolean)jsonParserFieldValue);
 				}
 			}
+			else if (Objects.equals(jsonParserFieldName, "logo")) {
+				if (jsonParserFieldValue != null) {
+					importProcessRequest.setLogo((Boolean)jsonParserFieldValue);
+				}
+			}
 			else if (Objects.equals(jsonParserFieldName, "name")) {
 				if (jsonParserFieldValue != null) {
 					importProcessRequest.setName((String)jsonParserFieldValue);
@@ -277,6 +418,12 @@ public class ImportProcessRequestSerDes {
 			else if (Objects.equals(jsonParserFieldName, "permissions")) {
 				if (jsonParserFieldValue != null) {
 					importProcessRequest.setPermissions(
+						(Boolean)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "ratings")) {
+				if (jsonParserFieldValue != null) {
+					importProcessRequest.setRatings(
 						(Boolean)jsonParserFieldValue);
 				}
 			}
@@ -302,6 +449,26 @@ public class ImportProcessRequestSerDes {
 
 					importProcessRequest.setRequestPortletDataHandlers(
 						requestPortletDataHandlersArray);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "sitePagesSettings")) {
+				if (jsonParserFieldValue != null) {
+					importProcessRequest.setSitePagesSettings(
+						(Boolean)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "siteTemplateSettings")) {
+
+				if (jsonParserFieldValue != null) {
+					importProcessRequest.setSiteTemplateSettings(
+						(Boolean)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "themeSettings")) {
+				if (jsonParserFieldValue != null) {
+					importProcessRequest.setThemeSettings(
+						(Boolean)jsonParserFieldValue);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "userIdStrategy")) {
@@ -392,4 +559,4 @@ public class ImportProcessRequestSerDes {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1661068897
+// LIFERAY-REST-BUILDER-HASH:-71757991

--- a/modules/apps/export-import/export-import-rest-impl/rest-openapi.yaml
+++ b/modules/apps/export-import/export-import-rest-impl/rest-openapi.yaml
@@ -42,6 +42,9 @@ components:
             type: object
         ExportProcessRequest:
             properties:
+                comments:
+                    default: false
+                    type: boolean
                 deletions:
                     default: false
                     type: boolean
@@ -51,6 +54,9 @@ components:
                 last:
                     format: int32
                     type: integer
+                logo:
+                    default: false
+                    type: boolean
                 name:
                     type: string
                 permissions:
@@ -60,13 +66,25 @@ components:
                     default: all
                     enum: [all, dateRange, last]
                     type: string
+                ratings:
+                    default: false
+                    type: boolean
                 requestPortletDataHandlers:
                     items:
                         $ref: "#/components/schemas/RequestPortletDataHandler"
                     type: array
+                sitePagesSettings:
+                    default: false
+                    type: boolean
+                siteTemplateSettings:
+                    default: false
+                    type: boolean
                 startDate:
                     format: date-time
                     type: string
+                themeSettings:
+                    default: false
+                    type: boolean
             required:
                 -   name
             type: object
@@ -136,6 +154,9 @@ components:
             type: object
         ImportProcessRequest:
             properties:
+                comments:
+                    default: false
+                    type: boolean
                 dataStrategy:
                     default: MIRROR
                     enum: [MIRROR, MIRROR_OVERWRITE, COPY_AS_NEW]
@@ -143,15 +164,30 @@ components:
                 deletions:
                     default: false
                     type: boolean
+                logo:
+                    default: false
+                    type: boolean
                 name:
                     type: string
                 permissions:
+                    default: false
+                    type: boolean
+                ratings:
                     default: false
                     type: boolean
                 requestPortletDataHandlers:
                     items:
                         $ref: "#/components/schemas/RequestPortletDataHandler"
                     type: array
+                sitePagesSettings:
+                    default: false
+                    type: boolean
+                siteTemplateSettings:
+                    default: false
+                    type: boolean
+                themeSettings:
+                    default: false
+                    type: boolean
                 userIdStrategy:
                     default: CURRENT_USER_ID
                     enum: [CURRENT_USER_ID, ALWAYS_CURRENT_USER_ID]

--- a/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/BaseExportProcessResourceImpl.java
+++ b/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/BaseExportProcessResourceImpl.java
@@ -73,7 +73,7 @@ public abstract class BaseExportProcessResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/export-processes' -d $'{"deletions": ___, "endDate": ___, "last": ___, "name": ___, "permissions": ___, "range": ___, "requestPortletDataHandlers": ___, "startDate": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/export-processes' -d $'{"comments": ___, "deletions": ___, "endDate": ___, "last": ___, "logo": ___, "name": ___, "permissions": ___, "range": ___, "ratings": ___, "requestPortletDataHandlers": ___, "sitePagesSettings": ___, "siteTemplateSettings": ___, "startDate": ___, "themeSettings": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -109,7 +109,7 @@ public abstract class BaseExportProcessResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/export-processes/batch' -d $'{"deletions": ___, "endDate": ___, "last": ___, "name": ___, "permissions": ___, "range": ___, "requestPortletDataHandlers": ___, "startDate": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/export-processes/batch' -d $'{"comments": ___, "deletions": ___, "endDate": ___, "last": ___, "logo": ___, "name": ___, "permissions": ___, "range": ___, "ratings": ___, "requestPortletDataHandlers": ___, "sitePagesSettings": ___, "siteTemplateSettings": ___, "startDate": ___, "themeSettings": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -166,7 +166,7 @@ public abstract class BaseExportProcessResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/export-processes' -d $'{"deletions": ___, "endDate": ___, "last": ___, "name": ___, "permissions": ___, "range": ___, "requestPortletDataHandlers": ___, "startDate": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/export-processes' -d $'{"comments": ___, "deletions": ___, "endDate": ___, "last": ___, "logo": ___, "name": ___, "permissions": ___, "range": ___, "ratings": ___, "requestPortletDataHandlers": ___, "sitePagesSettings": ___, "siteTemplateSettings": ___, "startDate": ___, "themeSettings": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.tags.Tags(
 		value = {
@@ -188,7 +188,7 @@ public abstract class BaseExportProcessResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/export-processes/batch' -d $'{"deletions": ___, "endDate": ___, "last": ___, "name": ___, "permissions": ___, "range": ___, "requestPortletDataHandlers": ___, "startDate": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/export-processes/batch' -d $'{"comments": ___, "deletions": ___, "endDate": ___, "last": ___, "logo": ___, "name": ___, "permissions": ___, "range": ___, "ratings": ___, "requestPortletDataHandlers": ___, "sitePagesSettings": ___, "siteTemplateSettings": ___, "startDate": ___, "themeSettings": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -235,7 +235,7 @@ public abstract class BaseExportProcessResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/sites/{siteExternalReferenceCode}/export-processes' -d $'{"deletions": ___, "endDate": ___, "last": ___, "name": ___, "permissions": ___, "range": ___, "requestPortletDataHandlers": ___, "startDate": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/sites/{siteExternalReferenceCode}/export-processes' -d $'{"comments": ___, "deletions": ___, "endDate": ___, "last": ___, "logo": ___, "name": ___, "permissions": ___, "range": ___, "ratings": ___, "requestPortletDataHandlers": ___, "sitePagesSettings": ___, "siteTemplateSettings": ___, "startDate": ___, "themeSettings": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -269,7 +269,7 @@ public abstract class BaseExportProcessResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/sites/{siteExternalReferenceCode}/export-processes/batch' -d $'{"deletions": ___, "endDate": ___, "last": ___, "name": ___, "permissions": ___, "range": ___, "requestPortletDataHandlers": ___, "startDate": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/sites/{siteExternalReferenceCode}/export-processes/batch' -d $'{"comments": ___, "deletions": ___, "endDate": ___, "last": ___, "logo": ___, "name": ___, "permissions": ___, "range": ___, "ratings": ___, "requestPortletDataHandlers": ___, "sitePagesSettings": ___, "siteTemplateSettings": ___, "startDate": ___, "themeSettings": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -1030,4 +1030,4 @@ public abstract class BaseExportProcessResourceImpl
 		LogFactoryUtil.getLog(BaseExportProcessResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:897111375
+// LIFERAY-REST-BUILDER-HASH:393253071

--- a/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/BaseImportProcessResourceImpl.java
+++ b/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/BaseImportProcessResourceImpl.java
@@ -354,7 +354,7 @@ public abstract class BaseImportProcessResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/import-processes' -d $'{"dataStrategy": ___, "deletions": ___, "name": ___, "permissions": ___, "requestPortletDataHandlers": ___, "userIdStrategy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/import-processes' -d $'{"comments": ___, "dataStrategy": ___, "deletions": ___, "logo": ___, "name": ___, "permissions": ___, "ratings": ___, "requestPortletDataHandlers": ___, "sitePagesSettings": ___, "siteTemplateSettings": ___, "themeSettings": ___, "userIdStrategy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -390,7 +390,7 @@ public abstract class BaseImportProcessResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/import-processes/batch' -d $'{"dataStrategy": ___, "deletions": ___, "name": ___, "permissions": ___, "requestPortletDataHandlers": ___, "userIdStrategy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/import-processes/batch' -d $'{"comments": ___, "dataStrategy": ___, "deletions": ___, "logo": ___, "name": ___, "permissions": ___, "ratings": ___, "requestPortletDataHandlers": ___, "sitePagesSettings": ___, "siteTemplateSettings": ___, "themeSettings": ___, "userIdStrategy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -547,7 +547,7 @@ public abstract class BaseImportProcessResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/import-processes' -d $'{"dataStrategy": ___, "deletions": ___, "name": ___, "permissions": ___, "requestPortletDataHandlers": ___, "userIdStrategy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/import-processes' -d $'{"comments": ___, "dataStrategy": ___, "deletions": ___, "logo": ___, "name": ___, "permissions": ___, "ratings": ___, "requestPortletDataHandlers": ___, "sitePagesSettings": ___, "siteTemplateSettings": ___, "themeSettings": ___, "userIdStrategy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.tags.Tags(
 		value = {
@@ -569,7 +569,7 @@ public abstract class BaseImportProcessResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/import-processes/batch' -d $'{"dataStrategy": ___, "deletions": ___, "name": ___, "permissions": ___, "requestPortletDataHandlers": ___, "userIdStrategy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/import-processes/batch' -d $'{"comments": ___, "dataStrategy": ___, "deletions": ___, "logo": ___, "name": ___, "permissions": ___, "ratings": ___, "requestPortletDataHandlers": ___, "sitePagesSettings": ___, "siteTemplateSettings": ___, "themeSettings": ___, "userIdStrategy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -706,7 +706,7 @@ public abstract class BaseImportProcessResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/sites/{siteExternalReferenceCode}/import-processes' -d $'{"dataStrategy": ___, "deletions": ___, "name": ___, "permissions": ___, "requestPortletDataHandlers": ___, "userIdStrategy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/sites/{siteExternalReferenceCode}/import-processes' -d $'{"comments": ___, "dataStrategy": ___, "deletions": ___, "logo": ___, "name": ___, "permissions": ___, "ratings": ___, "requestPortletDataHandlers": ___, "sitePagesSettings": ___, "siteTemplateSettings": ___, "themeSettings": ___, "userIdStrategy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -740,7 +740,7 @@ public abstract class BaseImportProcessResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/sites/{siteExternalReferenceCode}/import-processes/batch' -d $'{"dataStrategy": ___, "deletions": ___, "name": ___, "permissions": ___, "requestPortletDataHandlers": ___, "userIdStrategy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/sites/{siteExternalReferenceCode}/import-processes/batch' -d $'{"comments": ___, "dataStrategy": ___, "deletions": ___, "logo": ___, "name": ___, "permissions": ___, "ratings": ___, "requestPortletDataHandlers": ___, "sitePagesSettings": ___, "siteTemplateSettings": ___, "themeSettings": ___, "userIdStrategy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -1638,4 +1638,4 @@ public abstract class BaseImportProcessResourceImpl
 		LogFactoryUtil.getLog(BaseImportProcessResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:-2001736544
+// LIFERAY-REST-BUILDER-HASH:1220442858

--- a/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/util/ParameterMapUtil.java
+++ b/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/util/ParameterMapUtil.java
@@ -30,6 +30,14 @@ public class ParameterMapUtil {
 		_addRequestPortletDataHandlers(
 			exportProcessRequest.getRequestPortletDataHandlers(), parameterMap);
 
+		Boolean comments = exportProcessRequest.getComments();
+
+		if (comments != null) {
+			parameterMap.put(
+				PortletDataHandlerKeys.COMMENTS,
+				new String[] {comments.toString()});
+		}
+
 		Boolean deletions = exportProcessRequest.getDeletions();
 
 		if (deletions != null) {
@@ -38,12 +46,52 @@ public class ParameterMapUtil {
 				new String[] {deletions.toString()});
 		}
 
+		Boolean logo = exportProcessRequest.getLogo();
+
+		if (logo != null) {
+			parameterMap.put(
+				PortletDataHandlerKeys.LOGO, new String[] {logo.toString()});
+		}
+
 		Boolean permissions = exportProcessRequest.getPermissions();
 
 		if (permissions != null) {
 			parameterMap.put(
 				PortletDataHandlerKeys.PERMISSIONS,
 				new String[] {permissions.toString()});
+		}
+
+		Boolean ratings = exportProcessRequest.getRatings();
+
+		if (ratings != null) {
+			parameterMap.put(
+				PortletDataHandlerKeys.RATINGS,
+				new String[] {ratings.toString()});
+		}
+
+		Boolean sitePagesSettings = exportProcessRequest.getSitePagesSettings();
+
+		if (sitePagesSettings != null) {
+			parameterMap.put(
+				PortletDataHandlerKeys.LAYOUT_SET_SETTINGS,
+				new String[] {sitePagesSettings.toString()});
+		}
+
+		Boolean siteTemplateSettings =
+			exportProcessRequest.getSiteTemplateSettings();
+
+		if (siteTemplateSettings != null) {
+			parameterMap.put(
+				PortletDataHandlerKeys.LAYOUT_SET_PROTOTYPE_SETTINGS,
+				new String[] {siteTemplateSettings.toString()});
+		}
+
+		Boolean themeSettings = exportProcessRequest.getThemeSettings();
+
+		if (themeSettings != null) {
+			parameterMap.put(
+				PortletDataHandlerKeys.THEME_REFERENCE,
+				new String[] {themeSettings.toString()});
 		}
 
 		return parameterMap;
@@ -66,6 +114,14 @@ public class ParameterMapUtil {
 				new String[] {"DATA_STRATEGY_" + dataStrategy});
 		}
 
+		Boolean comments = importProcessRequest.getComments();
+
+		if (comments != null) {
+			parameterMap.put(
+				PortletDataHandlerKeys.COMMENTS,
+				new String[] {comments.toString()});
+		}
+
 		Boolean deletions = importProcessRequest.getDeletions();
 
 		if (deletions != null) {
@@ -74,12 +130,52 @@ public class ParameterMapUtil {
 				new String[] {deletions.toString()});
 		}
 
+		Boolean logo = importProcessRequest.getLogo();
+
+		if (logo != null) {
+			parameterMap.put(
+				PortletDataHandlerKeys.LOGO, new String[] {logo.toString()});
+		}
+
 		Boolean permissions = importProcessRequest.getPermissions();
 
 		if (permissions != null) {
 			parameterMap.put(
 				PortletDataHandlerKeys.PERMISSIONS,
 				new String[] {permissions.toString()});
+		}
+
+		Boolean ratings = importProcessRequest.getRatings();
+
+		if (ratings != null) {
+			parameterMap.put(
+				PortletDataHandlerKeys.RATINGS,
+				new String[] {ratings.toString()});
+		}
+
+		Boolean sitePagesSettings = importProcessRequest.getSitePagesSettings();
+
+		if (sitePagesSettings != null) {
+			parameterMap.put(
+				PortletDataHandlerKeys.LAYOUT_SET_SETTINGS,
+				new String[] {sitePagesSettings.toString()});
+		}
+
+		Boolean siteTemplateSettings =
+			importProcessRequest.getSiteTemplateSettings();
+
+		if (siteTemplateSettings != null) {
+			parameterMap.put(
+				PortletDataHandlerKeys.LAYOUT_SET_PROTOTYPE_SETTINGS,
+				new String[] {siteTemplateSettings.toString()});
+		}
+
+		Boolean themeSettings = importProcessRequest.getThemeSettings();
+
+		if (themeSettings != null) {
+			parameterMap.put(
+				PortletDataHandlerKeys.THEME_REFERENCE,
+				new String[] {themeSettings.toString()});
 		}
 
 		ImportProcessRequest.UserIdStrategy userIdStrategy =

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/display/context/ExportImportPreviewDisplayContext.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/display/context/ExportImportPreviewDisplayContext.java
@@ -6,6 +6,8 @@
 package com.liferay.exportimport.web.internal.display.context;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.group.capability.GroupCapabilityUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
@@ -108,6 +110,27 @@ public class ExportImportPreviewDisplayContext {
 		_importProcessAPIURL = _getResourceAPIURL("/import-processes");
 
 		return _importProcessAPIURL;
+	}
+
+	public boolean isCommentsAndRatingsEnabled() {
+		if (!_stagingGroupHelper.isCompanyGroup(_group) ||
+			FeatureFlagManagerUtil.isEnabled(
+				_group.getCompanyId(), "LPD-43996")) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	public boolean isLookAndFeelEnabled() {
+		if (GroupCapabilityUtil.isSupportsPages(_group) &&
+			!_group.isCompany() && !_group.isLayoutPrototype()) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private String _encode(String value) {

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/css/utilities.scss
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/css/utilities.scss
@@ -7,6 +7,18 @@
 .checkbox-row .custom-control {
 	align-items: center;
 	display: flex;
+	margin-bottom: 0;
+}
+
+.checkbox-row .custom-control-label {
+	position: relative;
+}
+
+.checkbox-row .custom-control-label::after {
+	height: 1rem;
+	left: 0;
+	top: 0;
+	width: 1rem;
 }
 
 .checkbox-row-content {

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/export/new_export.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/export/new_export.jsp
@@ -34,9 +34,13 @@ portletDisplay.setURLBack(exportImportPreviewDisplayContext.getBackURL());
 			HashMapBuilder.<String, Object>put(
 				"backURL", exportImportPreviewDisplayContext.getBackURL()
 			).put(
+				"commentsAndRatingsEnabled", exportImportPreviewDisplayContext.isCommentsAndRatingsEnabled()
+			).put(
 				"exportPreviewAPIURL", exportImportPreviewDisplayContext.getExportPreviewAPIURL()
 			).put(
 				"exportProcessAPIURL", exportImportPreviewDisplayContext.getExportProcessAPIURL()
+			).put(
+				"lookAndFeelEnabled", exportImportPreviewDisplayContext.isLookAndFeelEnabled()
 			).put(
 				"pageTreeModalConfiguration",
 				HashMapBuilder.<String, Object>put(

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/import/new_import.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/import/new_import.jsp
@@ -34,9 +34,13 @@ portletDisplay.setURLBack(exportImportPreviewDisplayContext.getBackURL());
 			HashMapBuilder.<String, Object>put(
 				"backURL", exportImportPreviewDisplayContext.getBackURL()
 			).put(
+				"commentsAndRatingsEnabled", exportImportPreviewDisplayContext.isCommentsAndRatingsEnabled()
+			).put(
 				"importPreviewAPIURL", exportImportPreviewDisplayContext.getImportPreviewAPIURL()
 			).put(
 				"importProcessAPIURL", exportImportPreviewDisplayContext.getImportProcessAPIURL()
+			).put(
+				"lookAndFeelEnabled", exportImportPreviewDisplayContext.isLookAndFeelEnabled()
 			).build()
 		%>'
 	/>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/CommentsAndRatings.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/CommentsAndRatings.tsx
@@ -1,0 +1,76 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import React from 'react';
+
+import {HandlerSelection} from '../../../utils/contentSelection';
+import {FieldCheckbox} from '../FieldCheckbox';
+
+const FIELDS = [
+	{key: 'comments', label: Liferay.Language.get('comments')},
+	{key: 'ratings', label: Liferay.Language.get('ratings')},
+] as const;
+
+export default function CommentsAndRatings({
+	onChange,
+	subtitle,
+	value,
+}: {
+	onChange: (commentsAndRatingsValue: HandlerSelection | undefined) => void;
+	subtitle?: string;
+	value: HandlerSelection | undefined;
+}) {
+	const selection = value && typeof value === 'object' ? value : undefined;
+
+	return (
+		<>
+			<hr className="my-3" />
+
+			<div className="p-3">
+				<div className="font-weight-bold text-3">
+					{Liferay.Language.get('comments-and-ratings')}
+				</div>
+
+				<small className="d-block mb-3 text-secondary">
+					{subtitle ??
+						Liferay.Language.get(
+							'for-each-of-the-selected-content-types,-export-their'
+						)}
+				</small>
+
+				<div className="c-gap-1 d-flex flex-column pl-4">
+					{FIELDS.map(({key, label}) => (
+						<FieldCheckbox
+							bordered={false}
+							checked={Boolean(selection?.[key])}
+							key={key}
+							label={label}
+							name={`commentsAndRatings.${key}`}
+							onChange={(checked) => {
+								const nextSelection: Record<string, true> = {};
+
+								FIELDS.forEach((other) => {
+									if (
+										other.key === key
+											? checked
+											: Boolean(selection?.[other.key])
+									) {
+										nextSelection[other.key] = true;
+									}
+								});
+
+								onChange(
+									Object.keys(nextSelection).length
+										? (nextSelection as HandlerSelection)
+										: undefined
+								);
+							}}
+						/>
+					))}
+				</div>
+			</div>
+		</>
+	);
+}

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSection.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSection.tsx
@@ -24,8 +24,8 @@ import {
 	updateSelection,
 } from '../../../utils/contentSelection';
 import CollapsibleGroup from './CollapsibleGroup';
-import CommentsAndRatings from './CommentsAndRatings';
 import PortletDataControl from './PortletDataControl';
+import SectionFooter from './SectionFooter';
 import SectionTags from './SectionTags';
 
 export type SectionSelection = Record<string, HandlerSelection>;
@@ -52,9 +52,6 @@ export default function ContentSection({
 	value,
 }: ContentSectionProps) {
 	const checkboxId = useId();
-
-	const commentsAndRatingsApplies =
-		commentsAndRatingsEnabled && section.name === CONTENT_SECTION_KEY;
 
 	const previewPortletDataHandlers =
 		section.previewPortletDataHandlers.map<PreviewPortletDataHandlerBoolean>(
@@ -111,6 +108,26 @@ export default function ContentSection({
 	const anySelected = allPreviewPortletDataHandlers.some((context) =>
 		isSelected(sectionSelection[context.name], context)
 	);
+
+	const sectionFooters = [
+		{
+			applies:
+				commentsAndRatingsEnabled &&
+				section.name === CONTENT_SECTION_KEY &&
+				anySelected,
+			fields: [
+				{key: 'comments', label: Liferay.Language.get('comments')},
+				{key: 'ratings', label: Liferay.Language.get('ratings')},
+			],
+			name: 'commentsAndRatings',
+			subtitle:
+				commentsAndRatingsSubtitle ??
+				Liferay.Language.get(
+					'for-each-of-the-selected-content-types,-export-their'
+				),
+			title: Liferay.Language.get('comments-and-ratings'),
+		},
+	].filter(({applies}) => applies);
 
 	return (
 		<ClayLayout.Sheet className="mt-0">
@@ -192,21 +209,25 @@ export default function ContentSection({
 					))}
 				</div>
 
-				{commentsAndRatingsApplies && anySelected && (
-					<CommentsAndRatings
-						onChange={(commentsAndRatingsValue) =>
+				{sectionFooters.map((sectionFooter) => (
+					<SectionFooter
+						fields={sectionFooter.fields}
+						key={sectionFooter.name}
+						name={sectionFooter.name}
+						onChange={(sectionFooterValue) =>
 							onChange(
 								updateSelection(
 									sectionSelection,
-									'commentsAndRatings',
-									commentsAndRatingsValue
+									sectionFooter.name,
+									sectionFooterValue
 								)
 							)
 						}
-						subtitle={commentsAndRatingsSubtitle}
-						value={sectionSelection.commentsAndRatings}
+						subtitle={sectionFooter.subtitle}
+						title={sectionFooter.title}
+						value={sectionSelection[sectionFooter.name]}
 					/>
-				)}
+				))}
 			</CollapsibleGroup>
 		</ClayLayout.Sheet>
 	);

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSection.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSection.tsx
@@ -10,6 +10,7 @@ import React, {useId} from 'react';
 
 import '../../../../css/utilities.scss';
 import {PageTreeModalConfiguration} from '../../../pages/export/components/PageTreeModal';
+import {ExportImportProcess} from '../../../types/exportImportProcess';
 import {
 	PreviewPortletDataHandlerBoolean,
 	PreviewPortletDataHandlerSection as PortletDataHandlerSectionType,
@@ -32,10 +33,10 @@ export type SectionSelection = Record<string, HandlerSelection>;
 
 interface ContentSectionProps {
 	commentsAndRatingsEnabled?: boolean;
-	commentsAndRatingsSubtitle?: string;
 	lookAndFeelEnabled?: boolean;
 	onChange: (value: SectionSelection | undefined) => void;
 	pageTreeModalConfiguration?: PageTreeModalConfiguration;
+	process?: ExportImportProcess;
 	section: PortletDataHandlerSectionType;
 	showDeletions?: boolean;
 	value: SectionSelection | undefined;
@@ -43,10 +44,10 @@ interface ContentSectionProps {
 
 export default function ContentSection({
 	commentsAndRatingsEnabled = false,
-	commentsAndRatingsSubtitle,
 	lookAndFeelEnabled = false,
 	onChange,
 	pageTreeModalConfiguration,
+	process = 'export',
 	section,
 	showDeletions,
 	value,
@@ -121,10 +122,13 @@ export default function ContentSection({
 			],
 			name: 'commentsAndRatings',
 			subtitle:
-				commentsAndRatingsSubtitle ??
-				Liferay.Language.get(
-					'for-each-of-the-selected-content-types,-export-their'
-				),
+				process === 'import'
+					? Liferay.Language.get(
+							'for-each-of-the-selected-content-types,-import-their'
+						)
+					: Liferay.Language.get(
+							'for-each-of-the-selected-content-types,-export-their'
+						),
 			title: Liferay.Language.get('comments-and-ratings'),
 		},
 	].filter(({applies}) => applies);

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSection.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSection.tsx
@@ -30,34 +30,6 @@ import SectionTags from './SectionTags';
 
 export type SectionSelection = Record<string, HandlerSelection>;
 
-const LOOK_AND_FEEL_CONTROL: PreviewPortletDataHandlerBoolean = {
-	label: Liferay.Language.get('look-and-feel'),
-	name: 'lookAndFeel',
-	previewPortletDataHandlerControls: [
-		{
-			label: Liferay.Language.get('theme-settings'),
-			name: 'themeSettings',
-			type: 'Boolean',
-		},
-		{
-			label: Liferay.Language.get('logo'),
-			name: 'logo',
-			type: 'Boolean',
-		},
-		{
-			label: Liferay.Language.get('site-pages-settings'),
-			name: 'sitePagesSettings',
-			type: 'Boolean',
-		},
-		{
-			label: Liferay.Language.get('site-template-settings'),
-			name: 'siteTemplateSettings',
-			type: 'Boolean',
-		},
-	],
-	type: 'Boolean',
-};
-
 interface ContentSectionProps {
 	commentsAndRatingsEnabled?: boolean;
 	commentsAndRatingsSubtitle?: string;
@@ -81,32 +53,63 @@ export default function ContentSection({
 }: ContentSectionProps) {
 	const checkboxId = useId();
 
-	const portletContextsValue = value || {};
-
-	const isSiteBuilderSection = section.name === SITE_BUILDER_SECTION_KEY;
-
-	const isContentSection = section.name === CONTENT_SECTION_KEY;
-
-	const lookAndFeelApplies = lookAndFeelEnabled && isSiteBuilderSection;
-
 	const commentsAndRatingsApplies =
-		commentsAndRatingsEnabled && isContentSection;
+		commentsAndRatingsEnabled && section.name === CONTENT_SECTION_KEY;
 
-	const portletControls =
+	const previewPortletDataHandlers =
 		section.previewPortletDataHandlers.map<PreviewPortletDataHandlerBoolean>(
 			(handler) => ({...handler, type: 'Boolean'})
 		);
 
-	const controls = lookAndFeelApplies
-		? [...portletControls, LOOK_AND_FEEL_CONTROL]
-		: portletControls;
+	const syntheticPreviewPortletDataHandlers = [
+		{
+			applies:
+				lookAndFeelEnabled && section.name === SITE_BUILDER_SECTION_KEY,
+			previewPortletDataHandler: {
+				label: Liferay.Language.get('look-and-feel'),
+				name: 'lookAndFeel',
+				previewPortletDataHandlerControls: [
+					{
+						label: Liferay.Language.get('theme-settings'),
+						name: 'themeSettings',
+						type: 'Boolean',
+					},
+					{
+						label: Liferay.Language.get('logo'),
+						name: 'logo',
+						type: 'Boolean',
+					},
+					{
+						label: Liferay.Language.get('site-pages-settings'),
+						name: 'sitePagesSettings',
+						type: 'Boolean',
+					},
+					{
+						label: Liferay.Language.get('site-template-settings'),
+						name: 'siteTemplateSettings',
+						type: 'Boolean',
+					},
+				],
+				type: 'Boolean',
+			} as PreviewPortletDataHandlerBoolean,
+		},
+	]
+		.filter(({applies}) => applies)
+		.map(({previewPortletDataHandler}) => previewPortletDataHandler);
 
-	const selected = controls.every((context) =>
-		isSelected(portletContextsValue[context.name], context)
+	const allPreviewPortletDataHandlers = [
+		...previewPortletDataHandlers,
+		...syntheticPreviewPortletDataHandlers,
+	];
+
+	const sectionSelection = value || {};
+
+	const allSelected = allPreviewPortletDataHandlers.every((context) =>
+		isSelected(sectionSelection[context.name], context)
 	);
 
-	const hasPortletSelection = portletControls.some((context) =>
-		isSelected(portletContextsValue[context.name], context)
+	const anySelected = allPreviewPortletDataHandlers.some((context) =>
+		isSelected(sectionSelection[context.name], context)
 	);
 
 	return (
@@ -134,21 +137,28 @@ export default function ContentSection({
 					/>
 				)}
 				indeterminate={
-					!selected &&
-					controls.some(
+					!allSelected &&
+					allPreviewPortletDataHandlers.some(
 						(context) =>
-							portletContextsValue[context.name] !== undefined
+							sectionSelection[context.name] !== undefined
 					)
 				}
 				label={section.label}
 				labelClassName="font-weight-bold h3"
 				onToggle={() =>
 					onChange(
-						selected ? undefined : getInitialSelections(controls)
+						allSelected
+							? undefined
+							: getInitialSelections(
+									allPreviewPortletDataHandlers
+								)
 					)
 				}
-				selected={selected}
-				summary={getSelectionSummary(controls, portletContextsValue)}
+				selected={allSelected}
+				summary={getSelectionSummary(
+					allPreviewPortletDataHandlers,
+					sectionSelection
+				)}
 				tags={
 					<SectionTags
 						additionCount={section.additionCount}
@@ -159,14 +169,14 @@ export default function ContentSection({
 				}
 			>
 				<div className="content-section-controls overflow-auto">
-					{controls.map((context) => (
+					{allPreviewPortletDataHandlers.map((context) => (
 						<PortletDataControl
 							control={context}
 							key={context.name}
 							onChange={(controlValue) =>
 								onChange(
 									updateSelection(
-										portletContextsValue,
+										sectionSelection,
 										context.name,
 										controlValue
 									)
@@ -177,24 +187,24 @@ export default function ContentSection({
 							}
 							showDeletions={showDeletions}
 							topLevel
-							value={portletContextsValue[context.name]}
+							value={sectionSelection[context.name]}
 						/>
 					))}
 				</div>
 
-				{commentsAndRatingsApplies && hasPortletSelection && (
+				{commentsAndRatingsApplies && anySelected && (
 					<CommentsAndRatings
 						onChange={(commentsAndRatingsValue) =>
 							onChange(
 								updateSelection(
-									portletContextsValue,
+									sectionSelection,
 									'commentsAndRatings',
 									commentsAndRatingsValue
 								)
 							)
 						}
 						subtitle={commentsAndRatingsSubtitle}
-						value={portletContextsValue.commentsAndRatings}
+						value={sectionSelection.commentsAndRatings}
 					/>
 				)}
 			</CollapsibleGroup>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSection.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSection.tsx
@@ -15,19 +15,53 @@ import {
 	PreviewPortletDataHandlerSection as PortletDataHandlerSectionType,
 } from '../../../types/portletDataHandler';
 import {
+	CONTENT_SECTION_KEY,
 	HandlerSelection,
+	SITE_BUILDER_SECTION_KEY,
 	getInitialSelections,
 	getSelectionSummary,
 	isSelected,
 	updateSelection,
 } from '../../../utils/contentSelection';
 import CollapsibleGroup from './CollapsibleGroup';
+import CommentsAndRatings from './CommentsAndRatings';
 import PortletDataControl from './PortletDataControl';
 import SectionTags from './SectionTags';
 
 export type SectionSelection = Record<string, HandlerSelection>;
 
+const LOOK_AND_FEEL_CONTROL: PreviewPortletDataHandlerBoolean = {
+	label: Liferay.Language.get('look-and-feel'),
+	name: 'lookAndFeel',
+	previewPortletDataHandlerControls: [
+		{
+			label: Liferay.Language.get('theme-settings'),
+			name: 'themeReference',
+			type: 'Boolean',
+		},
+		{
+			label: Liferay.Language.get('logo'),
+			name: 'logo',
+			type: 'Boolean',
+		},
+		{
+			label: Liferay.Language.get('site-pages-settings'),
+			name: 'layoutSetSettings',
+			type: 'Boolean',
+		},
+		{
+			label: Liferay.Language.get('site-template-settings'),
+			name: 'layoutSetPrototypeSettings',
+			type: 'Boolean',
+		},
+	],
+	type: 'Boolean',
+};
+
 interface ContentSectionProps {
+	commentsAndRatingsEnabled?: boolean;
+	commentsAndRatingsSubtitle?: string;
+	lookAndFeelEnabled?: boolean;
 	onChange: (value: SectionSelection | undefined) => void;
 	pageTreeModalConfiguration?: PageTreeModalConfiguration;
 	section: PortletDataHandlerSectionType;
@@ -36,6 +70,9 @@ interface ContentSectionProps {
 }
 
 export default function ContentSection({
+	commentsAndRatingsEnabled = false,
+	commentsAndRatingsSubtitle,
+	lookAndFeelEnabled = false,
 	onChange,
 	pageTreeModalConfiguration,
 	section,
@@ -46,19 +83,36 @@ export default function ContentSection({
 
 	const portletContextsValue = value || {};
 
-	const controls =
+	const isSiteBuilderSection = section.name === SITE_BUILDER_SECTION_KEY;
+
+	const isContentSection = section.name === CONTENT_SECTION_KEY;
+
+	const lookAndFeelApplies = lookAndFeelEnabled && isSiteBuilderSection;
+
+	const commentsAndRatingsApplies =
+		commentsAndRatingsEnabled && isContentSection;
+
+	const portletControls =
 		section.previewPortletDataHandlers.map<PreviewPortletDataHandlerBoolean>(
 			(handler) => ({...handler, type: 'Boolean'})
 		);
 
+	const controls = lookAndFeelApplies
+		? [...portletControls, LOOK_AND_FEEL_CONTROL]
+		: portletControls;
+
 	const selected = controls.every((context) =>
+		isSelected(portletContextsValue[context.name], context)
+	);
+
+	const hasPortletSelection = portletControls.some((context) =>
 		isSelected(portletContextsValue[context.name], context)
 	);
 
 	return (
 		<ClayLayout.Sheet className="mt-0">
 			<CollapsibleGroup
-				bodyClassName="content-section-controls mt-2 overflow-auto pl-2"
+				bodyClassName="mt-2 pl-2"
 				checkboxId={checkboxId}
 				disclosure={({expanded, ...disclosureProps}) => (
 					<ClayButtonWithIcon
@@ -80,7 +134,11 @@ export default function ContentSection({
 					/>
 				)}
 				indeterminate={
-					!!Object.keys(portletContextsValue).length && !selected
+					!selected &&
+					controls.some(
+						(context) =>
+							portletContextsValue[context.name] !== undefined
+					)
 				}
 				label={section.label}
 				labelClassName="font-weight-bold h3"
@@ -100,25 +158,45 @@ export default function ContentSection({
 					/>
 				}
 			>
-				{controls.map((context) => (
-					<PortletDataControl
-						control={context}
-						key={context.name}
-						onChange={(controlValue) =>
+				<div className="content-section-controls overflow-auto">
+					{controls.map((context) => (
+						<PortletDataControl
+							control={context}
+							key={context.name}
+							onChange={(controlValue) =>
+								onChange(
+									updateSelection(
+										portletContextsValue,
+										context.name,
+										controlValue
+									)
+								)
+							}
+							pageTreeModalConfiguration={
+								pageTreeModalConfiguration
+							}
+							showDeletions={showDeletions}
+							topLevel
+							value={portletContextsValue[context.name]}
+						/>
+					))}
+				</div>
+
+				{commentsAndRatingsApplies && hasPortletSelection && (
+					<CommentsAndRatings
+						onChange={(commentsAndRatingsValue) =>
 							onChange(
 								updateSelection(
 									portletContextsValue,
-									context.name,
-									controlValue
+									'commentsAndRatings',
+									commentsAndRatingsValue
 								)
 							)
 						}
-						pageTreeModalConfiguration={pageTreeModalConfiguration}
-						showDeletions={showDeletions}
-						topLevel
-						value={portletContextsValue[context.name]}
+						subtitle={commentsAndRatingsSubtitle}
+						value={portletContextsValue.commentsAndRatings}
 					/>
-				))}
+				)}
 			</CollapsibleGroup>
 		</ClayLayout.Sheet>
 	);

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSection.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSection.tsx
@@ -36,7 +36,7 @@ const LOOK_AND_FEEL_CONTROL: PreviewPortletDataHandlerBoolean = {
 	previewPortletDataHandlerControls: [
 		{
 			label: Liferay.Language.get('theme-settings'),
-			name: 'themeReference',
+			name: 'themeSettings',
 			type: 'Boolean',
 		},
 		{
@@ -46,12 +46,12 @@ const LOOK_AND_FEEL_CONTROL: PreviewPortletDataHandlerBoolean = {
 		},
 		{
 			label: Liferay.Language.get('site-pages-settings'),
-			name: 'layoutSetSettings',
+			name: 'sitePagesSettings',
 			type: 'Boolean',
 		},
 		{
 			label: Liferay.Language.get('site-template-settings'),
-			name: 'layoutSetPrototypeSettings',
+			name: 'siteTemplateSettings',
 			type: 'Boolean',
 		},
 	],

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSelector.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSelector.tsx
@@ -8,14 +8,20 @@ import React from 'react';
 
 import {PageTreeModalConfiguration} from '../../../pages/export/components/PageTreeModal';
 import {PreviewPortletDataHandlerSection} from '../../../types/portletDataHandler';
-import {updateSelection} from '../../../utils/contentSelection';
+import {
+	updateSelection,
+	withSiteBuilderSection,
+} from '../../../utils/contentSelection';
 import ContentSection, {SectionSelection} from './ContentSection';
 
 export type ContentSelection = Record<string, SectionSelection>;
 
 interface ContentSelectorProps {
 	'aria-labelledby'?: string;
+	'commentsAndRatingsEnabled'?: boolean;
+	'commentsAndRatingsSubtitle'?: string;
 	'errorMessage'?: string;
+	'lookAndFeelEnabled'?: boolean;
 	'name': string;
 	'onChange': (value: ContentSelection | undefined) => void;
 	'pageTreeModalConfiguration'?: PageTreeModalConfiguration;
@@ -26,7 +32,10 @@ interface ContentSelectorProps {
 
 export default function ContentSelector({
 	'aria-labelledby': ariaLabelledby,
+	commentsAndRatingsEnabled = false,
+	commentsAndRatingsSubtitle,
 	errorMessage,
+	lookAndFeelEnabled = false,
 	name,
 	onChange,
 	pageTreeModalConfiguration,
@@ -42,6 +51,13 @@ export default function ContentSelector({
 			showDeletions || !!section.additionCount || !section.deletionCount
 	);
 
+	const renderedSections = lookAndFeelEnabled
+		? withSiteBuilderSection(
+				visibleSections,
+				Liferay.Language.get('category.site_administration.build')
+			)
+		: visibleSections;
+
 	return (
 		<div
 			aria-describedby={errorId}
@@ -50,10 +66,13 @@ export default function ContentSelector({
 			className="c-gap-4 d-flex flex-column mt-4"
 			role="group"
 		>
-			{visibleSections.map(
+			{renderedSections.map(
 				(section: PreviewPortletDataHandlerSection) => (
 					<ContentSection
+						commentsAndRatingsEnabled={commentsAndRatingsEnabled}
+						commentsAndRatingsSubtitle={commentsAndRatingsSubtitle}
 						key={section.name}
+						lookAndFeelEnabled={lookAndFeelEnabled}
 						onChange={(sectionValue) =>
 							onChange(
 								updateSelection(

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSelector.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSelector.tsx
@@ -7,6 +7,7 @@ import ClayAlert from '@clayui/alert';
 import React from 'react';
 
 import {PageTreeModalConfiguration} from '../../../pages/export/components/PageTreeModal';
+import {ExportImportProcess} from '../../../types/exportImportProcess';
 import {PreviewPortletDataHandlerSection} from '../../../types/portletDataHandler';
 import {
 	updateSelection,
@@ -19,12 +20,12 @@ export type ContentSelection = Record<string, SectionSelection>;
 interface ContentSelectorProps {
 	'aria-labelledby'?: string;
 	'commentsAndRatingsEnabled'?: boolean;
-	'commentsAndRatingsSubtitle'?: string;
 	'errorMessage'?: string;
 	'lookAndFeelEnabled'?: boolean;
 	'name': string;
 	'onChange': (value: ContentSelection | undefined) => void;
 	'pageTreeModalConfiguration'?: PageTreeModalConfiguration;
+	'process'?: ExportImportProcess;
 	'sections': PreviewPortletDataHandlerSection[];
 	'showDeletions'?: boolean;
 	'value': ContentSelection | undefined;
@@ -33,12 +34,12 @@ interface ContentSelectorProps {
 export default function ContentSelector({
 	'aria-labelledby': ariaLabelledby,
 	commentsAndRatingsEnabled = false,
-	commentsAndRatingsSubtitle,
 	errorMessage,
 	lookAndFeelEnabled = false,
 	name,
 	onChange,
 	pageTreeModalConfiguration,
+	process = 'export',
 	sections,
 	showDeletions,
 	value,
@@ -70,7 +71,6 @@ export default function ContentSelector({
 				(section: PreviewPortletDataHandlerSection) => (
 					<ContentSection
 						commentsAndRatingsEnabled={commentsAndRatingsEnabled}
-						commentsAndRatingsSubtitle={commentsAndRatingsSubtitle}
 						key={section.name}
 						lookAndFeelEnabled={lookAndFeelEnabled}
 						onChange={(sectionValue) =>
@@ -83,6 +83,7 @@ export default function ContentSelector({
 							)
 						}
 						pageTreeModalConfiguration={pageTreeModalConfiguration}
+						process={process}
 						section={section}
 						showDeletions={showDeletions}
 						value={currentValue[section.name]}

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/SectionFooter.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/SectionFooter.tsx
@@ -8,20 +8,28 @@ import React from 'react';
 import {HandlerSelection} from '../../../utils/contentSelection';
 import {FieldCheckbox} from '../FieldCheckbox';
 
-const FIELDS = [
-	{key: 'comments', label: Liferay.Language.get('comments')},
-	{key: 'ratings', label: Liferay.Language.get('ratings')},
-] as const;
+export interface SectionFooterField {
+	key: string;
+	label: string;
+}
 
-export default function CommentsAndRatings({
+interface SectionFooterProps {
+	fields: readonly SectionFooterField[];
+	name: string;
+	onChange: (value: HandlerSelection | undefined) => void;
+	subtitle?: string;
+	title: string;
+	value: HandlerSelection | undefined;
+}
+
+export default function SectionFooter({
+	fields,
+	name,
 	onChange,
 	subtitle,
+	title,
 	value,
-}: {
-	onChange: (commentsAndRatingsValue: HandlerSelection | undefined) => void;
-	subtitle?: string;
-	value: HandlerSelection | undefined;
-}) {
+}: SectionFooterProps) {
 	const selection = value && typeof value === 'object' ? value : undefined;
 
 	return (
@@ -29,35 +37,34 @@ export default function CommentsAndRatings({
 			<hr className="my-3" />
 
 			<div className="p-3">
-				<div className="font-weight-bold text-3">
-					{Liferay.Language.get('comments-and-ratings')}
-				</div>
+				<div className="font-weight-bold text-3">{title}</div>
 
-				<small className="d-block mb-3 text-secondary">
-					{subtitle ??
-						Liferay.Language.get(
-							'for-each-of-the-selected-content-types,-export-their'
-						)}
-				</small>
+				{subtitle ? (
+					<small className="d-block mb-3 text-secondary">
+						{subtitle}
+					</small>
+				) : null}
 
 				<div className="c-gap-1 d-flex flex-column pl-4">
-					{FIELDS.map(({key, label}) => (
+					{fields.map((field) => (
 						<FieldCheckbox
 							bordered={false}
-							checked={Boolean(selection?.[key])}
-							key={key}
-							label={label}
-							name={`commentsAndRatings.${key}`}
+							checked={Boolean(selection?.[field.key])}
+							key={field.key}
+							label={field.label}
+							name={`${name}.${field.key}`}
 							onChange={(checked) => {
 								const nextSelection: Record<string, true> = {};
 
-								FIELDS.forEach((other) => {
+								fields.forEach((otherField) => {
 									if (
-										other.key === key
+										otherField.key === field.key
 											? checked
-											: Boolean(selection?.[other.key])
+											: Boolean(
+													selection?.[otherField.key]
+												)
 									) {
-										nextSelection[other.key] = true;
+										nextSelection[otherField.key] = true;
 									}
 								});
 

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/formik/FormikFieldContentSelector.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/formik/FormikFieldContentSelector.tsx
@@ -7,6 +7,7 @@ import {useField, useFormikContext} from 'formik';
 import React from 'react';
 
 import {PageTreeModalConfiguration} from '../../../pages/export/components/PageTreeModal';
+import {ExportImportProcess} from '../../../types/exportImportProcess';
 import {PreviewPortletDataHandlerSection} from '../../../types/portletDataHandler';
 import ContentSelector, {
 	ContentSelection,
@@ -15,20 +16,20 @@ import ContentSelector, {
 interface FormikFieldContentSelectorProps {
 	'aria-labelledby'?: string;
 	'commentsAndRatingsEnabled'?: boolean;
-	'commentsAndRatingsSubtitle'?: string;
 	'lookAndFeelEnabled'?: boolean;
 	'name': string;
 	'pageTreeModalConfiguration'?: PageTreeModalConfiguration;
+	'process'?: ExportImportProcess;
 	'sections': PreviewPortletDataHandlerSection[];
 }
 
 export function FormikFieldContentSelector({
 	'aria-labelledby': ariaLabelledby,
 	commentsAndRatingsEnabled = false,
-	commentsAndRatingsSubtitle,
 	lookAndFeelEnabled = false,
 	name,
 	pageTreeModalConfiguration,
+	process = 'export',
 	sections,
 }: FormikFieldContentSelectorProps) {
 	const [field, meta, helpers] = useField<ContentSelection | undefined>(name);
@@ -39,7 +40,6 @@ export function FormikFieldContentSelector({
 		<ContentSelector
 			aria-labelledby={ariaLabelledby}
 			commentsAndRatingsEnabled={commentsAndRatingsEnabled}
-			commentsAndRatingsSubtitle={commentsAndRatingsSubtitle}
 			errorMessage={meta.touched && meta.error ? meta.error : undefined}
 			lookAndFeelEnabled={lookAndFeelEnabled}
 			name={name}
@@ -48,6 +48,7 @@ export function FormikFieldContentSelector({
 				setFieldTouched(name, true, false);
 			}}
 			pageTreeModalConfiguration={pageTreeModalConfiguration}
+			process={process}
 			sections={sections}
 			showDeletions={!!deletions}
 			value={field.value}

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/formik/FormikFieldContentSelector.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/formik/FormikFieldContentSelector.tsx
@@ -14,6 +14,9 @@ import ContentSelector, {
 
 interface FormikFieldContentSelectorProps {
 	'aria-labelledby'?: string;
+	'commentsAndRatingsEnabled'?: boolean;
+	'commentsAndRatingsSubtitle'?: string;
+	'lookAndFeelEnabled'?: boolean;
 	'name': string;
 	'pageTreeModalConfiguration'?: PageTreeModalConfiguration;
 	'sections': PreviewPortletDataHandlerSection[];
@@ -21,6 +24,9 @@ interface FormikFieldContentSelectorProps {
 
 export function FormikFieldContentSelector({
 	'aria-labelledby': ariaLabelledby,
+	commentsAndRatingsEnabled = false,
+	commentsAndRatingsSubtitle,
+	lookAndFeelEnabled = false,
 	name,
 	pageTreeModalConfiguration,
 	sections,
@@ -32,7 +38,10 @@ export function FormikFieldContentSelector({
 	return (
 		<ContentSelector
 			aria-labelledby={ariaLabelledby}
+			commentsAndRatingsEnabled={commentsAndRatingsEnabled}
+			commentsAndRatingsSubtitle={commentsAndRatingsSubtitle}
 			errorMessage={meta.touched && meta.error ? meta.error : undefined}
+			lookAndFeelEnabled={lookAndFeelEnabled}
 			name={name}
 			onChange={(newValue) => {
 				helpers.setValue(newValue);

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/NewExport.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/NewExport.tsx
@@ -29,15 +29,19 @@ import Setup from './components/Setup';
 
 export function NewExport({
 	backURL,
+	commentsAndRatingsEnabled = false,
 	exportPreview,
 	exportPreviewAPIURL,
 	exportProcessAPIURL,
+	lookAndFeelEnabled = false,
 	pageTreeModalConfiguration,
 }: {
 	backURL: string;
+	commentsAndRatingsEnabled?: boolean;
 	exportPreview?: ExportPreview;
 	exportPreviewAPIURL: string;
 	exportProcessAPIURL: string;
+	lookAndFeelEnabled?: boolean;
 	pageTreeModalConfiguration: PageTreeModalConfiguration;
 }) {
 	const [preview, setPreview] = useState<ExportPreview | undefined>(
@@ -157,9 +161,11 @@ export function NewExport({
 					<Setup />
 
 					<DataSelection
+						commentsAndRatingsEnabled={commentsAndRatingsEnabled}
 						deletionCount={preview?.deletionCount}
 						itemsCount={preview?.additionCount}
 						loading={loading}
+						lookAndFeelEnabled={lookAndFeelEnabled}
 						onApplyFilter={handleApplyFilter}
 						pageTreeModalConfiguration={pageTreeModalConfiguration}
 						sections={sections}

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/NewExport.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/NewExport.tsx
@@ -15,6 +15,7 @@ import {
 	Range,
 	normalizeDateFilter,
 } from '../../components/date_filter';
+import {ContentSelection} from '../../components/forms/content_selector/ContentSelector';
 import {FormikDebug} from '../../components/forms/formik';
 import {
 	ExportPreviewParams,
@@ -22,6 +23,10 @@ import {
 } from '../../services/getExportPreview';
 import {postExportProcess} from '../../services/postExportProcess';
 import {ExportPreview} from '../../types/exportImportPreview';
+import {
+	CONTENT_SECTION_KEY,
+	SITE_BUILDER_SECTION_KEY,
+} from '../../utils/contentSelection';
 import {toRequestPortletDataHandlers} from '../../utils/toRequestPortletDataHandlers';
 import DataSelection from './components/DataSelection';
 import {PageTreeModalConfiguration} from './components/PageTreeModal';
@@ -111,17 +116,34 @@ export function NewExport({
 				permissions: false,
 			}}
 			onSubmit={async (values) => {
+				const contentSelection = values.contentSelection as
+					| ContentSelection
+					| undefined;
+
+				const commentsAndRatings = contentSelection?.[
+					CONTENT_SECTION_KEY
+				]?.commentsAndRatings as Record<string, boolean> | undefined;
+				const lookAndFeel = contentSelection?.[SITE_BUILDER_SECTION_KEY]
+					?.lookAndFeel as Record<string, boolean> | undefined;
+
 				const result = await postExportProcess({
 					exportProcessRequest: {
 						...normalizeDateFilter(values.dateFilter),
+						comments: !!commentsAndRatings?.comments,
 						deletions: !!values.deletions,
+						logo: !!lookAndFeel?.logo,
 						name: values.name,
 						permissions: !!values.permissions,
+						ratings: !!commentsAndRatings?.ratings,
 						requestPortletDataHandlers:
 							toRequestPortletDataHandlers(
 								sections,
 								values.contentSelection
 							),
+						sitePagesSettings: !!lookAndFeel?.sitePagesSettings,
+						siteTemplateSettings:
+							!!lookAndFeel?.siteTemplateSettings,
+						themeSettings: !!lookAndFeel?.themeSettings,
 					},
 					url: exportProcessAPIURL,
 				});

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/NewExport.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/NewExport.tsx
@@ -23,10 +23,7 @@ import {
 } from '../../services/getExportPreview';
 import {postExportProcess} from '../../services/postExportProcess';
 import {ExportPreview} from '../../types/exportImportPreview';
-import {
-	CONTENT_SECTION_KEY,
-	SITE_BUILDER_SECTION_KEY,
-} from '../../utils/contentSelection';
+import {toProcessRequestFlags} from '../../utils/contentSelection';
 import {toRequestPortletDataHandlers} from '../../utils/toRequestPortletDataHandlers';
 import DataSelection from './components/DataSelection';
 import {PageTreeModalConfiguration} from './components/PageTreeModal';
@@ -120,30 +117,18 @@ export function NewExport({
 					| ContentSelection
 					| undefined;
 
-				const commentsAndRatings = contentSelection?.[
-					CONTENT_SECTION_KEY
-				]?.commentsAndRatings as Record<string, boolean> | undefined;
-				const lookAndFeel = contentSelection?.[SITE_BUILDER_SECTION_KEY]
-					?.lookAndFeel as Record<string, boolean> | undefined;
-
 				const result = await postExportProcess({
 					exportProcessRequest: {
 						...normalizeDateFilter(values.dateFilter),
-						comments: !!commentsAndRatings?.comments,
+						...toProcessRequestFlags(contentSelection),
 						deletions: !!values.deletions,
-						logo: !!lookAndFeel?.logo,
 						name: values.name,
 						permissions: !!values.permissions,
-						ratings: !!commentsAndRatings?.ratings,
 						requestPortletDataHandlers:
 							toRequestPortletDataHandlers(
 								sections,
 								values.contentSelection
 							),
-						sitePagesSettings: !!lookAndFeel?.sitePagesSettings,
-						siteTemplateSettings:
-							!!lookAndFeel?.siteTemplateSettings,
-						themeSettings: !!lookAndFeel?.themeSettings,
 					},
 					url: exportProcessAPIURL,
 				});

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/components/DataSelection.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/components/DataSelection.tsx
@@ -20,16 +20,20 @@ import {PageTreeModalConfiguration} from './PageTreeModal';
 const LABEL_ID = 'dataSelection-label';
 
 export default function DataSelection({
+	commentsAndRatingsEnabled = false,
 	deletionCount = 0,
 	itemsCount,
 	loading = false,
+	lookAndFeelEnabled = false,
 	onApplyFilter,
 	pageTreeModalConfiguration,
 	sections,
 }: {
+	commentsAndRatingsEnabled?: boolean;
 	deletionCount?: number;
 	itemsCount?: number;
 	loading?: boolean;
+	lookAndFeelEnabled?: boolean;
 	onApplyFilter: (filterValues: DateFilterValues) => void;
 	pageTreeModalConfiguration: PageTreeModalConfiguration;
 	sections: PreviewPortletDataHandlerSection[];
@@ -83,6 +87,8 @@ export default function DataSelection({
 				) : (
 					<FormikFieldContentSelector
 						aria-labelledby={LABEL_ID}
+						commentsAndRatingsEnabled={commentsAndRatingsEnabled}
+						lookAndFeelEnabled={lookAndFeelEnabled}
 						name="contentSelection"
 						pageTreeModalConfiguration={pageTreeModalConfiguration}
 						sections={sections}

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/components/DataSelection.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/components/DataSelection.tsx
@@ -91,6 +91,7 @@ export default function DataSelection({
 						lookAndFeelEnabled={lookAndFeelEnabled}
 						name="contentSelection"
 						pageTreeModalConfiguration={pageTreeModalConfiguration}
+						process="export"
 						sections={sections}
 					/>
 				)}

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/NewImport.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/NewImport.tsx
@@ -8,9 +8,14 @@ import ClayIcon from '@clayui/icon';
 import React, {useState} from 'react';
 
 import {Wizard, WizardStep} from '../../components/Wizard';
+import {ContentSelection} from '../../components/forms/content_selector/ContentSelector';
 import {postImportProcess} from '../../services/postImportProcess';
 import {ImportPreview} from '../../types/exportImportPreview';
 import {DataStrategy, UserIdStrategy} from '../../types/exportImportProcess';
+import {
+	CONTENT_SECTION_KEY,
+	SITE_BUILDER_SECTION_KEY,
+} from '../../utils/contentSelection';
 import {toRequestPortletDataHandlers} from '../../utils/toRequestPortletDataHandlers';
 import DataSelectionStep from './steps/DataSelectionStep';
 import FileSelectionStep from './steps/FileSelectionStep';
@@ -101,18 +106,38 @@ export function NewImport({
 						return;
 					}
 
+					const contentSelection = values.contentSelection as
+						| ContentSelection
+						| undefined;
+
+					const commentsAndRatings = contentSelection?.[
+						CONTENT_SECTION_KEY
+					]?.commentsAndRatings as
+						| Record<string, boolean>
+						| undefined;
+					const lookAndFeel = contentSelection?.[
+						SITE_BUILDER_SECTION_KEY
+					]?.lookAndFeel as Record<string, boolean> | undefined;
+
 					const result = await postImportProcess({
 						importProcessRequest: {
+							comments: !!commentsAndRatings?.comments,
 							dataStrategy: values.dataStrategy as DataStrategy,
 							deletions: !!values.deletions,
+							logo: !!lookAndFeel?.logo,
 							name: values.name,
 							permissions: !!values.permissions,
+							ratings: !!commentsAndRatings?.ratings,
 							requestPortletDataHandlers:
 								toRequestPortletDataHandlers(
 									importPreview.previewPortletDataHandlerSections ??
 										[],
 									values.contentSelection
 								),
+							sitePagesSettings: !!lookAndFeel?.sitePagesSettings,
+							siteTemplateSettings:
+								!!lookAndFeel?.siteTemplateSettings,
+							themeSettings: !!lookAndFeel?.themeSettings,
 							userIdStrategy:
 								values.userIdStrategy as UserIdStrategy,
 						},

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/NewImport.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/NewImport.tsx
@@ -12,10 +12,7 @@ import {ContentSelection} from '../../components/forms/content_selector/ContentS
 import {postImportProcess} from '../../services/postImportProcess';
 import {ImportPreview} from '../../types/exportImportPreview';
 import {DataStrategy, UserIdStrategy} from '../../types/exportImportProcess';
-import {
-	CONTENT_SECTION_KEY,
-	SITE_BUILDER_SECTION_KEY,
-} from '../../utils/contentSelection';
+import {toProcessRequestFlags} from '../../utils/contentSelection';
 import {toRequestPortletDataHandlers} from '../../utils/toRequestPortletDataHandlers';
 import DataSelectionStep from './steps/DataSelectionStep';
 import FileSelectionStep from './steps/FileSelectionStep';
@@ -110,34 +107,19 @@ export function NewImport({
 						| ContentSelection
 						| undefined;
 
-					const commentsAndRatings = contentSelection?.[
-						CONTENT_SECTION_KEY
-					]?.commentsAndRatings as
-						| Record<string, boolean>
-						| undefined;
-					const lookAndFeel = contentSelection?.[
-						SITE_BUILDER_SECTION_KEY
-					]?.lookAndFeel as Record<string, boolean> | undefined;
-
 					const result = await postImportProcess({
 						importProcessRequest: {
-							comments: !!commentsAndRatings?.comments,
+							...toProcessRequestFlags(contentSelection),
 							dataStrategy: values.dataStrategy as DataStrategy,
 							deletions: !!values.deletions,
-							logo: !!lookAndFeel?.logo,
 							name: values.name,
 							permissions: !!values.permissions,
-							ratings: !!commentsAndRatings?.ratings,
 							requestPortletDataHandlers:
 								toRequestPortletDataHandlers(
 									importPreview.previewPortletDataHandlerSections ??
 										[],
 									values.contentSelection
 								),
-							sitePagesSettings: !!lookAndFeel?.sitePagesSettings,
-							siteTemplateSettings:
-								!!lookAndFeel?.siteTemplateSettings,
-							themeSettings: !!lookAndFeel?.themeSettings,
 							userIdStrategy:
 								values.userIdStrategy as UserIdStrategy,
 						},

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/NewImport.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/NewImport.tsx
@@ -18,12 +18,16 @@ import SettingsStep, {SETTINGS_STEP_INITIAL_VALUES} from './steps/SettingsStep';
 
 export function NewImport({
 	backURL,
+	commentsAndRatingsEnabled = false,
 	importPreviewAPIURL,
 	importProcessAPIURL,
+	lookAndFeelEnabled = false,
 }: {
 	backURL: string;
+	commentsAndRatingsEnabled?: boolean;
 	importPreviewAPIURL: string;
 	importProcessAPIURL: string;
+	lookAndFeelEnabled?: boolean;
 }) {
 	const [importPreview, setImportPreview] = useState<
 		ImportPreview | undefined
@@ -64,7 +68,11 @@ export function NewImport({
 				isStepValid={(values) => !!values.contentSelection}
 				title={Liferay.Language.get('data-selection')}
 			>
-				<DataSelectionStep importPreview={importPreview} />
+				<DataSelectionStep
+					commentsAndRatingsEnabled={commentsAndRatingsEnabled}
+					importPreview={importPreview}
+					lookAndFeelEnabled={lookAndFeelEnabled}
+				/>
 			</WizardStep>
 
 			<WizardStep

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/steps/DataSelectionStep.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/steps/DataSelectionStep.tsx
@@ -47,11 +47,9 @@ export default function DataSelectionStep({
 
 			<FormikFieldContentSelector
 				commentsAndRatingsEnabled={commentsAndRatingsEnabled}
-				commentsAndRatingsSubtitle={Liferay.Language.get(
-					'for-each-of-the-selected-content-types,-import-their'
-				)}
 				lookAndFeelEnabled={lookAndFeelEnabled}
 				name="contentSelection"
+				process="import"
 				sections={importPreview.previewPortletDataHandlerSections}
 			/>
 		</>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/steps/DataSelectionStep.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/steps/DataSelectionStep.tsx
@@ -11,9 +11,13 @@ import {ImportPreview} from '../../../types/exportImportPreview';
 import FileSummary from './FileSummary';
 
 export default function DataSelectionStep({
+	commentsAndRatingsEnabled = false,
 	importPreview,
+	lookAndFeelEnabled = false,
 }: {
+	commentsAndRatingsEnabled?: boolean;
 	importPreview?: ImportPreview;
+	lookAndFeelEnabled?: boolean;
 }) {
 	if (!importPreview) {
 		return null;
@@ -42,6 +46,11 @@ export default function DataSelectionStep({
 			/>
 
 			<FormikFieldContentSelector
+				commentsAndRatingsEnabled={commentsAndRatingsEnabled}
+				commentsAndRatingsSubtitle={Liferay.Language.get(
+					'for-each-of-the-selected-content-types,-import-their'
+				)}
+				lookAndFeelEnabled={lookAndFeelEnabled}
 				name="contentSelection"
 				sections={importPreview.previewPortletDataHandlerSections}
 			/>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/types/exportImportProcess.ts
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/types/exportImportProcess.ts
@@ -15,14 +15,20 @@ export interface ExportProcess {
 }
 
 export interface ExportProcessRequest {
+	comments?: boolean;
 	deletions?: boolean;
 	endDate?: string;
 	last?: number;
+	logo?: boolean;
 	name: string;
 	permissions?: boolean;
 	range?: Range;
+	ratings?: boolean;
 	requestPortletDataHandlers?: RequestPortletDataHandler[];
+	sitePagesSettings?: boolean;
+	siteTemplateSettings?: boolean;
 	startDate?: string;
+	themeSettings?: boolean;
 }
 
 export type DataStrategy = 'MIRROR' | 'MIRROR_OVERWRITE' | 'COPY_AS_NEW';
@@ -38,10 +44,16 @@ export interface ImportProcess {
 }
 
 export interface ImportProcessRequest {
+	comments?: boolean;
 	dataStrategy?: DataStrategy;
 	deletions?: boolean;
+	logo?: boolean;
 	name?: string;
 	permissions?: boolean;
+	ratings?: boolean;
 	requestPortletDataHandlers?: RequestPortletDataHandler[];
+	sitePagesSettings?: boolean;
+	siteTemplateSettings?: boolean;
+	themeSettings?: boolean;
 	userIdStrategy?: UserIdStrategy;
 }

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/types/exportImportProcess.ts
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/types/exportImportProcess.ts
@@ -6,6 +6,8 @@
 import {Range} from '../components/date_filter';
 import {RequestPortletDataHandler} from './portletDataHandler';
 
+export type ExportImportProcess = 'export' | 'import';
+
 export interface ExportProcess {
 	dateCreated?: string;
 	dateModified?: string;

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/contentSelection.ts
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/contentSelection.ts
@@ -3,7 +3,10 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {PreviewPortletDataHandlerControl} from '../types/portletDataHandler';
+import {
+	PreviewPortletDataHandlerControl,
+	PreviewPortletDataHandlerSection,
+} from '../types/portletDataHandler';
 
 export type HandlerSelection =
 	| {
@@ -14,6 +17,10 @@ export type HandlerSelection =
 
 export const LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY =
 	'PORTLET_DATA_com_liferay_layout_admin_web_portlet_LayoutSetLayoutsPortlet';
+
+export const CONTENT_SECTION_KEY = 'category.site_administration.content';
+
+export const SITE_BUILDER_SECTION_KEY = 'category.site_administration.build';
 
 export function isAllLayoutsSelected(
 	value: HandlerSelection | undefined
@@ -94,4 +101,22 @@ export function getSelectionSummary(
 		.filter((control) => selection[control.name] !== undefined)
 		.map((control) => control.label)
 		.join(', ');
+}
+
+export function withSiteBuilderSection(
+	sections: PreviewPortletDataHandlerSection[],
+	label = ''
+): PreviewPortletDataHandlerSection[] {
+	if (sections.some((section) => section.name === SITE_BUILDER_SECTION_KEY)) {
+		return sections;
+	}
+
+	return [
+		...sections,
+		{
+			label,
+			name: SITE_BUILDER_SECTION_KEY,
+			previewPortletDataHandlers: [],
+		},
+	];
 }

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/contentSelection.ts
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/contentSelection.ts
@@ -8,6 +8,8 @@ import {
 	PreviewPortletDataHandlerSection,
 } from '../types/portletDataHandler';
 
+import type {ContentSelection} from '../components/forms/content_selector/ContentSelector';
+
 export type HandlerSelection =
 	| {
 			[key: string]: HandlerSelection | boolean | number[];
@@ -119,4 +121,22 @@ export function withSiteBuilderSection(
 			previewPortletDataHandlers: [],
 		},
 	];
+}
+
+export function toProcessRequestFlags(
+	contentSelection: ContentSelection | undefined
+) {
+	const commentsAndRatings = (contentSelection?.[CONTENT_SECTION_KEY]
+		?.commentsAndRatings ?? {}) as Record<string, boolean>;
+	const lookAndFeel = (contentSelection?.[SITE_BUILDER_SECTION_KEY]
+		?.lookAndFeel ?? {}) as Record<string, boolean>;
+
+	return {
+		comments: !!commentsAndRatings.comments,
+		logo: !!lookAndFeel.logo,
+		ratings: !!commentsAndRatings.ratings,
+		sitePagesSettings: !!lookAndFeel.sitePagesSettings,
+		siteTemplateSettings: !!lookAndFeel.siteTemplateSettings,
+		themeSettings: !!lookAndFeel.themeSettings,
+	};
 }

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/toRequestPortletDataHandlers.ts
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/toRequestPortletDataHandlers.ts
@@ -11,11 +11,8 @@ import {
 	RequestPortletDataHandlerControl,
 } from '../types/portletDataHandler';
 import {
-	CONTENT_SECTION_KEY,
 	HandlerSelection,
 	LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY,
-	SITE_BUILDER_SECTION_KEY,
-	withSiteBuilderSection,
 } from './contentSelection';
 
 export function toRequestPortletDataHandlers(
@@ -26,13 +23,9 @@ export function toRequestPortletDataHandlers(
 		return [];
 	}
 
-	const allSections = contentSelection[SITE_BUILDER_SECTION_KEY]
-		? withSiteBuilderSection(sections)
-		: sections;
-
 	const requestPortletDataHandlers: RequestPortletDataHandler[] = [];
 
-	for (const section of allSections) {
+	for (const section of sections) {
 		const sectionSelection = contentSelection[section.name];
 
 		if (!sectionSelection) {
@@ -66,50 +59,9 @@ export function toRequestPortletDataHandlers(
 				}),
 			});
 		}
-
-		if (section.name === SITE_BUILDER_SECTION_KEY) {
-			requestPortletDataHandlers.push(
-				...toExtraHandlers(sectionSelection.lookAndFeel, [
-					['themeReference', 'THEME_REFERENCE'],
-					['logo', 'LOGO'],
-					['layoutSetSettings', 'LAYOUT_SET_SETTINGS'],
-					[
-						'layoutSetPrototypeSettings',
-						'LAYOUT_SET_PROTOTYPE_SETTINGS',
-					],
-				])
-			);
-		}
-
-		if (
-			section.name === CONTENT_SECTION_KEY &&
-			section.previewPortletDataHandlers?.some(
-				(handler) => sectionSelection[handler.name]
-			)
-		) {
-			requestPortletDataHandlers.push(
-				...toExtraHandlers(sectionSelection.commentsAndRatings, [
-					['comments', 'COMMENTS'],
-					['ratings', 'RATINGS'],
-				])
-			);
-		}
 	}
 
 	return requestPortletDataHandlers;
-}
-
-function toExtraHandlers(
-	selection: HandlerSelection | undefined,
-	entries: [string, string][]
-): RequestPortletDataHandler[] {
-	if (!selection || typeof selection !== 'object') {
-		return [];
-	}
-
-	return entries
-		.filter(([field]) => selection[field])
-		.map(([, name]) => ({name}));
 }
 
 function toRequestControls(

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/toRequestPortletDataHandlers.ts
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/toRequestPortletDataHandlers.ts
@@ -11,8 +11,11 @@ import {
 	RequestPortletDataHandlerControl,
 } from '../types/portletDataHandler';
 import {
+	CONTENT_SECTION_KEY,
 	HandlerSelection,
 	LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY,
+	SITE_BUILDER_SECTION_KEY,
+	withSiteBuilderSection,
 } from './contentSelection';
 
 export function toRequestPortletDataHandlers(
@@ -23,9 +26,13 @@ export function toRequestPortletDataHandlers(
 		return [];
 	}
 
+	const allSections = contentSelection[SITE_BUILDER_SECTION_KEY]
+		? withSiteBuilderSection(sections)
+		: sections;
+
 	const requestPortletDataHandlers: RequestPortletDataHandler[] = [];
 
-	for (const section of sections) {
+	for (const section of allSections) {
 		const sectionSelection = contentSelection[section.name];
 
 		if (!sectionSelection) {
@@ -59,9 +66,50 @@ export function toRequestPortletDataHandlers(
 				}),
 			});
 		}
+
+		if (section.name === SITE_BUILDER_SECTION_KEY) {
+			requestPortletDataHandlers.push(
+				...toExtraHandlers(sectionSelection.lookAndFeel, [
+					['themeReference', 'THEME_REFERENCE'],
+					['logo', 'LOGO'],
+					['layoutSetSettings', 'LAYOUT_SET_SETTINGS'],
+					[
+						'layoutSetPrototypeSettings',
+						'LAYOUT_SET_PROTOTYPE_SETTINGS',
+					],
+				])
+			);
+		}
+
+		if (
+			section.name === CONTENT_SECTION_KEY &&
+			section.previewPortletDataHandlers?.some(
+				(handler) => sectionSelection[handler.name]
+			)
+		) {
+			requestPortletDataHandlers.push(
+				...toExtraHandlers(sectionSelection.commentsAndRatings, [
+					['comments', 'COMMENTS'],
+					['ratings', 'RATINGS'],
+				])
+			);
+		}
 	}
 
 	return requestPortletDataHandlers;
+}
+
+function toExtraHandlers(
+	selection: HandlerSelection | undefined,
+	entries: [string, string][]
+): RequestPortletDataHandler[] {
+	if (!selection || typeof selection !== 'object') {
+		return [];
+	}
+
+	return entries
+		.filter(([field]) => selection[field])
+		.map(([, name]) => ({name}));
 }
 
 function toRequestControls(

--- a/modules/apps/export-import/export-import-web/test/revamp/js/pages/export/NewExport.test.tsx
+++ b/modules/apps/export-import/export-import-web/test/revamp/js/pages/export/NewExport.test.tsx
@@ -463,7 +463,7 @@ describe('NewExport', () => {
 		});
 	});
 
-	it('submits the checked Look and Feel entries as top-level requestPortletDataHandlers', async () => {
+	it('submits the checked Look and Feel entries as request flags', async () => {
 		renderComponent({lookAndFeelEnabled: true});
 
 		await screen.findByText('loaded');
@@ -495,18 +495,62 @@ describe('NewExport', () => {
 			expect(exportCall).toBeDefined();
 
 			const body = JSON.parse(exportCall![1]!.body as string);
-			const names = body.requestPortletDataHandlers.map(
-				(entry: {name: string}) => entry.name
+
+			expect(body.themeSettings).toBe(true);
+			expect(body.sitePagesSettings).toBe(true);
+			expect(body.logo).toBe(false);
+			expect(body.siteTemplateSettings).toBe(false);
+
+			const handlerNames = body.requestPortletDataHandlers.map(
+				(handler: {name: string}) => handler.name
 			);
 
-			expect(names).toContain('THEME_REFERENCE');
-			expect(names).toContain('LAYOUT_SET_SETTINGS');
-			expect(names).not.toContain('LOGO');
-			expect(names).not.toContain('LAYOUT_SET_PROTOTYPE_SETTINGS');
+			expect(handlerNames).not.toContain('lookAndFeel');
+			expect(handlerNames).not.toContain('logo');
+			expect(handlerNames).not.toContain('THEME_REFERENCE');
 		});
 	});
 
-	it('submits the checked Comments and Ratings entries as top-level requestPortletDataHandlers', async () => {
+	it('checks every look and feel option when the Site Builder section is selected', async () => {
+		renderComponent({lookAndFeelEnabled: true});
+
+		await screen.findByText('loaded');
+
+		const nameInput = await screen.findByRole('textbox', {
+			name: /^name/i,
+		});
+		await userEvent.type(nameInput, 'test-file');
+
+		await userEvent.click(
+			screen.getByRole('checkbox', {name: 'Site Builder'})
+		);
+
+		fetch.mockResponseOnce(JSON.stringify({}));
+
+		await userEvent.click(screen.getByRole('button', {name: /^export$/i}));
+
+		await waitFor(() => {
+			const exportCall = fetch.mock.calls.find(([, init]) => {
+				const body = init?.body;
+
+				return (
+					typeof body === 'string' &&
+					body.includes('"requestPortletDataHandlers"')
+				);
+			});
+
+			expect(exportCall).toBeDefined();
+
+			const body = JSON.parse(exportCall![1]!.body as string);
+
+			expect(body.themeSettings).toBe(true);
+			expect(body.logo).toBe(true);
+			expect(body.sitePagesSettings).toBe(true);
+			expect(body.siteTemplateSettings).toBe(true);
+		});
+	});
+
+	it('submits the checked Comments and Ratings entries as request flags', async () => {
 		renderComponent({commentsAndRatingsEnabled: true});
 
 		await screen.findByText('loaded');
@@ -541,12 +585,17 @@ describe('NewExport', () => {
 			expect(exportCall).toBeDefined();
 
 			const body = JSON.parse(exportCall![1]!.body as string);
-			const names = body.requestPortletDataHandlers.map(
-				(entry: {name: string}) => entry.name
+
+			expect(body.comments).toBe(true);
+			expect(body.ratings).toBe(false);
+
+			const handlerNames = body.requestPortletDataHandlers.map(
+				(handler: {name: string}) => handler.name
 			);
 
-			expect(names).toContain('COMMENTS');
-			expect(names).not.toContain('RATINGS');
+			expect(handlerNames).not.toContain('commentsAndRatings');
+			expect(handlerNames).not.toContain('comments');
+			expect(handlerNames).not.toContain('COMMENTS');
 		});
 	});
 });

--- a/modules/apps/export-import/export-import-web/test/revamp/js/pages/export/NewExport.test.tsx
+++ b/modules/apps/export-import/export-import-web/test/revamp/js/pages/export/NewExport.test.tsx
@@ -20,6 +20,17 @@ jest.mock('staging-taglib', () => ({
 	PagesTree: require('../../mocks/MockPagesTree').MockPagesTree,
 }));
 
+const expandSection = async (label: string) => {
+	const sectionLabel = screen.getByText(label, {selector: 'label'});
+	const sheet = sectionLabel.closest('.sheet');
+
+	const button = within(sheet as HTMLElement).getByRole('button', {
+		name: /expand-x/,
+	});
+
+	await userEvent.click(button);
+};
+
 const DEFAULT_PROPS = {
 	backURL: '/some/back/url',
 	exportPreviewAPIURL: '/o/export-import/v1.0/export-preview',
@@ -109,7 +120,7 @@ describe('NewExport', () => {
 		const dataSelectionGroup = screen.getByRole('group', {
 			name: 'data-selection',
 		});
-		const checkbox = within(dataSelectionGroup).getAllByRole('checkbox')[0];
+		const checkbox = screen.getByRole('checkbox', {name: 'Design'});
 
 		await userEvent.click(checkbox);
 		await userEvent.click(checkbox);
@@ -166,13 +177,7 @@ describe('NewExport', () => {
 
 		await userEvent.type(nameInput, 'test-file');
 
-		const dataSelectionGroup = screen.getByRole('group', {
-			name: 'data-selection',
-		});
-
-		await userEvent.click(
-			within(dataSelectionGroup).getAllByRole('checkbox')[0]
-		);
+		await userEvent.click(screen.getByRole('checkbox', {name: 'Design'}));
 
 		const exportButton = screen.getByRole('button', {name: /^export$/i});
 
@@ -455,6 +460,93 @@ describe('NewExport', () => {
 					},
 				])
 			);
+		});
+	});
+
+	it('submits the checked Look and Feel entries as top-level requestPortletDataHandlers', async () => {
+		renderComponent({lookAndFeelEnabled: true});
+
+		await screen.findByText('loaded');
+
+		const nameInput = await screen.findByRole('textbox', {
+			name: /^name/i,
+		});
+		await userEvent.type(nameInput, 'test-file');
+
+		await expandSection('Site Builder');
+
+		await userEvent.click(screen.getByLabelText('theme-settings'));
+		await userEvent.click(screen.getByLabelText('site-pages-settings'));
+
+		fetch.mockResponseOnce(JSON.stringify({}));
+
+		await userEvent.click(screen.getByRole('button', {name: /^export$/i}));
+
+		await waitFor(() => {
+			const exportCall = fetch.mock.calls.find(([, init]) => {
+				const body = init?.body;
+
+				return (
+					typeof body === 'string' &&
+					body.includes('"requestPortletDataHandlers"')
+				);
+			});
+
+			expect(exportCall).toBeDefined();
+
+			const body = JSON.parse(exportCall![1]!.body as string);
+			const names = body.requestPortletDataHandlers.map(
+				(entry: {name: string}) => entry.name
+			);
+
+			expect(names).toContain('THEME_REFERENCE');
+			expect(names).toContain('LAYOUT_SET_SETTINGS');
+			expect(names).not.toContain('LOGO');
+			expect(names).not.toContain('LAYOUT_SET_PROTOTYPE_SETTINGS');
+		});
+	});
+
+	it('submits the checked Comments and Ratings entries as top-level requestPortletDataHandlers', async () => {
+		renderComponent({commentsAndRatingsEnabled: true});
+
+		await screen.findByText('loaded');
+
+		const nameInput = await screen.findByRole('textbox', {
+			name: /^name/i,
+		});
+		await userEvent.type(nameInput, 'test-file');
+
+		await userEvent.click(
+			screen.getByRole('checkbox', {name: 'Content & Data'})
+		);
+
+		await expandSection('Content & Data');
+
+		await userEvent.click(screen.getByLabelText('comments'));
+
+		fetch.mockResponseOnce(JSON.stringify({}));
+
+		await userEvent.click(screen.getByRole('button', {name: /^export$/i}));
+
+		await waitFor(() => {
+			const exportCall = fetch.mock.calls.find(([, init]) => {
+				const body = init?.body;
+
+				return (
+					typeof body === 'string' &&
+					body.includes('"requestPortletDataHandlers"')
+				);
+			});
+
+			expect(exportCall).toBeDefined();
+
+			const body = JSON.parse(exportCall![1]!.body as string);
+			const names = body.requestPortletDataHandlers.map(
+				(entry: {name: string}) => entry.name
+			);
+
+			expect(names).toContain('COMMENTS');
+			expect(names).not.toContain('RATINGS');
 		});
 	});
 });

--- a/modules/apps/export-import/export-import-web/test/revamp/js/pages/import/NewImport.test.tsx
+++ b/modules/apps/export-import/export-import-web/test/revamp/js/pages/import/NewImport.test.tsx
@@ -35,12 +35,20 @@ jest.mock(
 	})
 );
 
-const renderComponent = () =>
+const renderComponent = ({
+	commentsAndRatingsEnabled,
+	lookAndFeelEnabled,
+}: {
+	commentsAndRatingsEnabled?: boolean;
+	lookAndFeelEnabled?: boolean;
+} = {}) =>
 	render(
 		<NewImport
 			backURL="/some/back/url"
+			commentsAndRatingsEnabled={commentsAndRatingsEnabled}
 			importPreviewAPIURL="/o/export-import/v1.0/import-preview"
 			importProcessAPIURL="/o/export-import/v1.0/import-processes"
+			lookAndFeelEnabled={lookAndFeelEnabled}
 		/>
 	);
 
@@ -67,8 +75,13 @@ const uploadFile = async (fileName = 'site.lar') => {
 	jest.useRealTimers();
 };
 
-const goToDataSelectionStep = async () => {
-	const result = renderComponent();
+const goToDataSelectionStep = async (
+	options: {
+		commentsAndRatingsEnabled?: boolean;
+		lookAndFeelEnabled?: boolean;
+	} = {}
+) => {
+	const result = renderComponent(options);
 
 	await user.type(screen.getByLabelText(/^name/i), 'My import');
 
@@ -334,5 +347,31 @@ describe('NewImport', () => {
 		);
 
 		expect(screen.getByText('Deletions Only')).toBeInTheDocument();
+	});
+
+	it('renders the Look and Feel block inside the Site Builder section when lookAndFeelEnabled is true', async () => {
+		await goToDataSelectionStep({lookAndFeelEnabled: true});
+
+		expect(screen.getByText('look-and-feel')).toBeInTheDocument();
+		expect(screen.getByLabelText('theme-settings')).toBeInTheDocument();
+		expect(screen.getByLabelText('logo')).toBeInTheDocument();
+		expect(
+			screen.getByLabelText('site-pages-settings')
+		).toBeInTheDocument();
+		expect(
+			screen.getByLabelText('site-template-settings')
+		).toBeInTheDocument();
+	});
+
+	it('renders the Comments and Ratings block inside the Site Content section when commentsAndRatingsEnabled is true', async () => {
+		await goToDataSelectionStep({commentsAndRatingsEnabled: true});
+
+		await user.click(
+			screen.getByRole('checkbox', {name: 'Content & Data'})
+		);
+
+		expect(screen.getByText('comments-and-ratings')).toBeInTheDocument();
+		expect(screen.getByLabelText('comments')).toBeInTheDocument();
+		expect(screen.getByLabelText('ratings')).toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89777

## What is being added

Two new selectable groups in the Data Selection step of the export-import revamp: Look and Feel and Comments and Ratings. The revamped UI was missing them while the legacy flow already exposed both, so users could not configure theme, logo, layout-set settings or per-content-type comments and ratings export from the new wizard.

## How it is being added

Look and Feel sits under Site Builder and exposes Theme Settings, Logo, Site Pages Settings, and Site Template Settings. The group is modeled as a synthetic Boolean handler with nested children, so the standard PortletDataControl renders it like any real preview handler — master checkbox, Show all / Hide all disclosure, indeterminate state, comma-separated summary — without a one-off component. When the preview lacks a Site Builder section, the helper withSiteBuilderSection injects a synthetic placeholder so the group still appears, and the serializer uses the same helper to keep render and wire in lockstep.

Comments and Ratings sits under Site Content and exposes Comments and Ratings as a two-item group rendered through a small dedicated component. The block only appears when at least one content portlet is selected, and submission drops any stale tick when no content type is selected so the wire payload stays consistent with the visible state.

Both groups live inside the section's contentSelection state. The section's indeterminate indicator counts only real controls, so a stored but invisible selection does not falsely mark the section partial.

The JSP-side flag computations (commentsAndRatingsEnabled, lookAndFeelEnabled) moved from inline scriptlets duplicated in new_export.jsp and new_import.jsp into ExportImportPreviewDisplayContext methods, eliminating the copy-paste.