### PR TITLE
LPD-92853 Invoke REST endpoints in process from ToolSetUtil

### DIFF
--- a/modules/apps/cookies/cookies-rest-api/src/main/java/com/liferay/cookies/rest/resource/v1_0/CookiesConsentPreferenceResource.java
+++ b/modules/apps/cookies/cookies-rest-api/src/main/java/com/liferay/cookies/rest/resource/v1_0/CookiesConsentPreferenceResource.java
@@ -14,15 +14,12 @@ import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
-import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
-import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 
 import jakarta.annotation.Generated;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 
 import java.util.Collections;
@@ -44,10 +41,10 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface CookiesConsentPreferenceResource {
 
+	public void deleteCookiesConsentPreference() throws Exception;
+
 	public void deleteCookiesConsentPreferenceByName(String name)
 		throws Exception;
-
-	public void deleteCookiesConsentPreferences() throws Exception;
 
 	public CookiesConsentPreference getCookiesConsentPreferenceByName(
 			String name)
@@ -55,10 +52,6 @@ public interface CookiesConsentPreferenceResource {
 
 	public CookiesConsentPreference putCookiesConsentPreference(
 			CookiesConsentPreference cookiesConsentPreference)
-		throws Exception;
-
-	public Response putCookiesConsentPreferenceBatch(
-			String callbackURL, Object object)
 		throws Exception;
 
 	public default void setContextAcceptLanguage(
@@ -100,14 +93,6 @@ public interface CookiesConsentPreferenceResource {
 	public void setRoleLocalService(RoleLocalService roleLocalService);
 
 	public void setSortParserProvider(SortParserProvider sortParserProvider);
-
-	public void setVulcanBatchEngineExportTaskResource(
-		VulcanBatchEngineExportTaskResource
-			vulcanBatchEngineExportTaskResource);
-
-	public void setVulcanBatchEngineImportTaskResource(
-		VulcanBatchEngineImportTaskResource
-			vulcanBatchEngineImportTaskResource);
 
 	public default com.liferay.portal.kernel.search.filter.Filter toFilter(
 		String filterString) {
@@ -157,4 +142,4 @@ public interface CookiesConsentPreferenceResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-390898972
+// LIFERAY-REST-BUILDER-HASH:-636529269

--- a/modules/apps/cookies/cookies-rest-client/src/main/java/com/liferay/cookies/rest/client/resource/v1_0/CookiesConsentPreferenceResource.java
+++ b/modules/apps/cookies/cookies-rest-client/src/main/java/com/liferay/cookies/rest/client/resource/v1_0/CookiesConsentPreferenceResource.java
@@ -32,17 +32,16 @@ public interface CookiesConsentPreferenceResource {
 		return new Builder();
 	}
 
+	public void deleteCookiesConsentPreference() throws Exception;
+
+	public HttpInvoker.HttpResponse deleteCookiesConsentPreferenceHttpResponse()
+		throws Exception;
+
 	public void deleteCookiesConsentPreferenceByName(String name)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
 			deleteCookiesConsentPreferenceByNameHttpResponse(String name)
-		throws Exception;
-
-	public void deleteCookiesConsentPreferences() throws Exception;
-
-	public HttpInvoker.HttpResponse
-			deleteCookiesConsentPreferencesHttpResponse()
 		throws Exception;
 
 	public CookiesConsentPreference getCookiesConsentPreferenceByName(
@@ -59,15 +58,6 @@ public interface CookiesConsentPreferenceResource {
 
 	public HttpInvoker.HttpResponse putCookiesConsentPreferenceHttpResponse(
 			CookiesConsentPreference cookiesConsentPreference)
-		throws Exception;
-
-	public void putCookiesConsentPreferenceBatch(
-			String callbackURL, Object object)
-		throws Exception;
-
-	public HttpInvoker.HttpResponse
-			putCookiesConsentPreferenceBatchHttpResponse(
-				String callbackURL, Object object)
 		throws Exception;
 
 	public static class Builder {
@@ -179,6 +169,107 @@ public interface CookiesConsentPreferenceResource {
 	public static class CookiesConsentPreferenceResourceImpl
 		implements CookiesConsentPreferenceResource {
 
+		public void deleteCookiesConsentPreference() throws Exception {
+			HttpInvoker.HttpResponse httpResponse =
+				deleteCookiesConsentPreferenceHttpResponse();
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return;
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				deleteCookiesConsentPreferenceHttpResponse()
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.DELETE);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/cookies/v1.0/cookies-consent-preferences");
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
 		public void deleteCookiesConsentPreferenceByName(String name)
 			throws Exception {
 
@@ -275,107 +366,6 @@ public interface CookiesConsentPreferenceResource {
 						"/o/cookies/v1.0/cookies-consent-preferences/by-name/{name}");
 
 			httpInvoker.path("name", name);
-
-			if ((_builder._login != null) && (_builder._password != null)) {
-				httpInvoker.userNameAndPassword(
-					_builder._login + ":" + _builder._password);
-			}
-
-			return httpInvoker.invoke();
-		}
-
-		public void deleteCookiesConsentPreferences() throws Exception {
-			HttpInvoker.HttpResponse httpResponse =
-				deleteCookiesConsentPreferencesHttpResponse();
-
-			String content = httpResponse.getContent();
-
-			if ((httpResponse.getStatusCode() / 100) != 2) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response content: " + content);
-				_logger.log(
-					Level.WARNING,
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.log(
-					Level.WARNING,
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-
-				Problem.ProblemException problemException = null;
-
-				if (Objects.equals(
-						httpResponse.getContentType(), "application/json")) {
-
-					problemException = new Problem.ProblemException(
-						Problem.toDTO(content));
-				}
-				else {
-					_logger.log(
-						Level.WARNING,
-						"Unable to process content type: " +
-							httpResponse.getContentType());
-
-					Problem problem = new Problem();
-
-					problem.setStatus(
-						String.valueOf(httpResponse.getStatusCode()));
-
-					problemException = new Problem.ProblemException(problem);
-				}
-
-				throw problemException;
-			}
-			else {
-				_logger.fine("HTTP response content: " + content);
-				_logger.fine(
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.fine(
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-			}
-
-			try {
-				return;
-			}
-			catch (Exception e) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response: " + content, e);
-
-				throw new Problem.ProblemException(Problem.toDTO(content));
-			}
-		}
-
-		public HttpInvoker.HttpResponse
-				deleteCookiesConsentPreferencesHttpResponse()
-			throws Exception {
-
-			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
-
-			if (_builder._locale != null) {
-				httpInvoker.header(
-					"Accept-Language", _builder._locale.toLanguageTag());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._headers.entrySet()) {
-
-				httpInvoker.header(entry.getKey(), entry.getValue());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._parameters.entrySet()) {
-
-				httpInvoker.parameter(entry.getKey(), entry.getValue());
-			}
-
-			httpInvoker.httpMethod(HttpInvoker.HttpMethod.DELETE);
-
-			httpInvoker.path(
-				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + _builder._contextPath +
-						"/o/cookies/v1.0/cookies-consent-preferences");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -599,108 +589,6 @@ public interface CookiesConsentPreferenceResource {
 			return httpInvoker.invoke();
 		}
 
-		public void putCookiesConsentPreferenceBatch(
-				String callbackURL, Object object)
-			throws Exception {
-
-			HttpInvoker.HttpResponse httpResponse =
-				putCookiesConsentPreferenceBatchHttpResponse(
-					callbackURL, object);
-
-			String content = httpResponse.getContent();
-
-			if ((httpResponse.getStatusCode() / 100) != 2) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response content: " + content);
-				_logger.log(
-					Level.WARNING,
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.log(
-					Level.WARNING,
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-
-				Problem.ProblemException problemException = null;
-
-				if (Objects.equals(
-						httpResponse.getContentType(), "application/json")) {
-
-					problemException = new Problem.ProblemException(
-						Problem.toDTO(content));
-				}
-				else {
-					_logger.log(
-						Level.WARNING,
-						"Unable to process content type: " +
-							httpResponse.getContentType());
-
-					Problem problem = new Problem();
-
-					problem.setStatus(
-						String.valueOf(httpResponse.getStatusCode()));
-
-					problemException = new Problem.ProblemException(problem);
-				}
-
-				throw problemException;
-			}
-			else {
-				_logger.fine("HTTP response content: " + content);
-				_logger.fine(
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.fine(
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-			}
-		}
-
-		public HttpInvoker.HttpResponse
-				putCookiesConsentPreferenceBatchHttpResponse(
-					String callbackURL, Object object)
-			throws Exception {
-
-			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
-
-			httpInvoker.body(object.toString(), "application/json");
-
-			if (_builder._locale != null) {
-				httpInvoker.header(
-					"Accept-Language", _builder._locale.toLanguageTag());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._headers.entrySet()) {
-
-				httpInvoker.header(entry.getKey(), entry.getValue());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._parameters.entrySet()) {
-
-				httpInvoker.parameter(entry.getKey(), entry.getValue());
-			}
-
-			httpInvoker.httpMethod(HttpInvoker.HttpMethod.PUT);
-
-			if (callbackURL != null) {
-				httpInvoker.parameter(
-					"callbackURL", String.valueOf(callbackURL));
-			}
-
-			httpInvoker.path(
-				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + _builder._contextPath +
-						"/o/cookies/v1.0/cookies-consent-preferences/batch");
-
-			if ((_builder._login != null) && (_builder._password != null)) {
-				httpInvoker.userNameAndPassword(
-					_builder._login + ":" + _builder._password);
-			}
-
-			return httpInvoker.invoke();
-		}
-
 		private CookiesConsentPreferenceResourceImpl(Builder builder) {
 			_builder = builder;
 		}
@@ -713,4 +601,4 @@ public interface CookiesConsentPreferenceResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1577574750
+// LIFERAY-REST-BUILDER-HASH:1994306772

--- a/modules/apps/cookies/cookies-rest-impl/rest-config.yaml
+++ b/modules/apps/cookies/cookies-rest-impl/rest-config.yaml
@@ -7,5 +7,7 @@ application:
 author: Christopher Kian
 clientDir: ../cookies-rest-client/src/main/java
 compatibilityVersion: 14
+forcePredictableOperationId: true
+forcePredictableSchemaPropertyName: true
 javaEEPackage: jakarta
 testDir: ../cookies-rest-test/src/testIntegration/java

--- a/modules/apps/cookies/cookies-rest-impl/rest-config.yaml
+++ b/modules/apps/cookies/cookies-rest-impl/rest-config.yaml
@@ -9,5 +9,6 @@ clientDir: ../cookies-rest-client/src/main/java
 compatibilityVersion: 14
 forcePredictableOperationId: true
 forcePredictableSchemaPropertyName: true
+generateBatch: false
 javaEEPackage: jakarta
 testDir: ../cookies-rest-test/src/testIntegration/java

--- a/modules/apps/cookies/cookies-rest-impl/rest-openapi.yaml
+++ b/modules/apps/cookies/cookies-rest-impl/rest-openapi.yaml
@@ -51,7 +51,7 @@ paths:
         delete:
             description:
                 Deletes all cookies consent preference entries of the user who made the request.
-            operationId: deleteCookiesConsentPreferences
+            operationId: deleteCookiesConsentPreference
             responses:
                 204:
                     content:

--- a/modules/apps/cookies/cookies-rest-impl/src/main/java/com/liferay/cookies/rest/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/cookies/cookies-rest-impl/src/main/java/com/liferay/cookies/rest/internal/graphql/mutation/v1_0/Mutation.java
@@ -12,8 +12,6 @@ import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
-import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
-import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 
@@ -22,7 +20,6 @@ import jakarta.annotation.Generated;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 
 import java.util.function.BiFunction;
@@ -46,6 +43,20 @@ public class Mutation {
 	}
 
 	@GraphQLField(
+		description = "Deletes all cookies consent preference entries of the user who made the request."
+	)
+	public boolean deleteCookiesConsentPreference() throws Exception {
+		_applyVoidComponentServiceObjects(
+			_cookiesConsentPreferenceResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			cookiesConsentPreferenceResource ->
+				cookiesConsentPreferenceResource.
+					deleteCookiesConsentPreference());
+
+		return true;
+	}
+
+	@GraphQLField(
 		description = "Deletes the specified cookies consent preference of the user who made the request."
 	)
 	public boolean deleteCookiesConsentPreferenceByName(
@@ -58,20 +69,6 @@ public class Mutation {
 			cookiesConsentPreferenceResource ->
 				cookiesConsentPreferenceResource.
 					deleteCookiesConsentPreferenceByName(name));
-
-		return true;
-	}
-
-	@GraphQLField(
-		description = "Deletes all cookies consent preference entries of the user who made the request."
-	)
-	public boolean deleteCookiesConsentPreferences() throws Exception {
-		_applyVoidComponentServiceObjects(
-			_cookiesConsentPreferenceResourceComponentServiceObjects,
-			this::_populateResourceContext,
-			cookiesConsentPreferenceResource ->
-				cookiesConsentPreferenceResource.
-					deleteCookiesConsentPreferences());
 
 		return true;
 	}
@@ -90,20 +87,6 @@ public class Mutation {
 			cookiesConsentPreferenceResource ->
 				cookiesConsentPreferenceResource.putCookiesConsentPreference(
 					cookiesConsentPreference));
-	}
-
-	@GraphQLField
-	public Response updateCookiesConsentPreferenceBatch(
-			@GraphQLName("callbackURL") String callbackURL,
-			@GraphQLName("object") Object object)
-		throws Exception {
-
-		return _applyComponentServiceObjects(
-			_cookiesConsentPreferenceResourceComponentServiceObjects,
-			this::_populateResourceContext,
-			cookiesConsentPreferenceResource ->
-				cookiesConsentPreferenceResource.
-					putCookiesConsentPreferenceBatch(callbackURL, object));
 	}
 
 	private <T, R, E1 extends Throwable, E2 extends Throwable> R
@@ -160,12 +143,6 @@ public class Mutation {
 		cookiesConsentPreferenceResource.setGroupLocalService(
 			_groupLocalService);
 		cookiesConsentPreferenceResource.setRoleLocalService(_roleLocalService);
-
-		cookiesConsentPreferenceResource.setVulcanBatchEngineExportTaskResource(
-			_vulcanBatchEngineExportTaskResource);
-
-		cookiesConsentPreferenceResource.setVulcanBatchEngineImportTaskResource(
-			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private static ComponentServiceObjects<CookiesConsentPreferenceResource>
@@ -181,10 +158,6 @@ public class Mutation {
 		_sortsBiFunction;
 	private UriInfo _uriInfo;
 	private com.liferay.portal.kernel.model.User _user;
-	private VulcanBatchEngineExportTaskResource
-		_vulcanBatchEngineExportTaskResource;
-	private VulcanBatchEngineImportTaskResource
-		_vulcanBatchEngineImportTaskResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-936149283
+// LIFERAY-REST-BUILDER-HASH:1721433606

--- a/modules/apps/cookies/cookies-rest-impl/src/main/java/com/liferay/cookies/rest/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/cookies/cookies-rest-impl/src/main/java/com/liferay/cookies/rest/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -76,25 +76,20 @@ public class ServletDataImpl implements ServletData {
 			new HashMap<String, ObjectValuePair<Class<?>, String>>() {
 				{
 					put(
+						"mutation#deleteCookiesConsentPreference",
+						new ObjectValuePair<>(
+							CookiesConsentPreferenceResourceImpl.class,
+							"deleteCookiesConsentPreference"));
+					put(
 						"mutation#deleteCookiesConsentPreferenceByName",
 						new ObjectValuePair<>(
 							CookiesConsentPreferenceResourceImpl.class,
 							"deleteCookiesConsentPreferenceByName"));
 					put(
-						"mutation#deleteCookiesConsentPreferences",
-						new ObjectValuePair<>(
-							CookiesConsentPreferenceResourceImpl.class,
-							"deleteCookiesConsentPreferences"));
-					put(
 						"mutation#updateCookiesConsentPreference",
 						new ObjectValuePair<>(
 							CookiesConsentPreferenceResourceImpl.class,
 							"putCookiesConsentPreference"));
-					put(
-						"mutation#updateCookiesConsentPreferenceBatch",
-						new ObjectValuePair<>(
-							CookiesConsentPreferenceResourceImpl.class,
-							"putCookiesConsentPreferenceBatch"));
 
 					put(
 						"query#cookiesConsentPreferenceByName",
@@ -109,4 +104,4 @@ public class ServletDataImpl implements ServletData {
 		_cookiesConsentPreferenceResourceComponentServiceObjects;
 
 }
-// LIFERAY-REST-BUILDER-HASH:256119608
+// LIFERAY-REST-BUILDER-HASH:-2090217516

--- a/modules/apps/cookies/cookies-rest-impl/src/main/java/com/liferay/cookies/rest/internal/resource/v1_0/BaseCookiesConsentPreferenceResourceImpl.java
+++ b/modules/apps/cookies/cookies-rest-impl/src/main/java/com/liferay/cookies/rest/internal/resource/v1_0/BaseCookiesConsentPreferenceResourceImpl.java
@@ -7,8 +7,6 @@ package com.liferay.cookies.rest.internal.resource.v1_0;
 
 import com.liferay.cookies.rest.dto.v1_0.CookiesConsentPreference;
 import com.liferay.cookies.rest.resource.v1_0.CookiesConsentPreferenceResource;
-import com.liferay.petra.function.UnsafeBiConsumer;
-import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -17,24 +15,10 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
-import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.util.SetUtil;
-import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.kernel.util.Validator;
-import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
-import com.liferay.portal.odata.filter.FilterParser;
 import com.liferay.portal.odata.filter.FilterParserProvider;
-import com.liferay.portal.odata.sort.SortField;
-import com.liferay.portal.odata.sort.SortParser;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
-import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
-import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
-import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
-import com.liferay.portal.vulcan.pagination.Page;
-import com.liferay.portal.vulcan.pagination.Pagination;
-import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.UriInfoUtil;
 
@@ -43,20 +27,11 @@ import jakarta.annotation.Generated;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import jakarta.ws.rs.NotSupportedException;
-import jakarta.ws.rs.core.MultivaluedHashMap;
-import jakarta.ws.rs.core.MultivaluedMap;
-import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 
-import java.io.Serializable;
-
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * @author Christopher Kian
@@ -65,8 +40,29 @@ import java.util.Set;
 @Generated("")
 @jakarta.ws.rs.Path("/v1.0")
 public abstract class BaseCookiesConsentPreferenceResourceImpl
-	implements CookiesConsentPreferenceResource, EntityModelResource,
-			   VulcanBatchEngineTaskItemDelegate<CookiesConsentPreference> {
+	implements CookiesConsentPreferenceResource {
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'DELETE' 'http://localhost:8080/o/cookies/v1.0/cookies-consent-preferences'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Deletes all cookies consent preference entries of the user who made the request."
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(
+				name = "CookiesConsentPreference"
+			)
+		}
+	)
+	@jakarta.ws.rs.DELETE
+	@jakarta.ws.rs.Path("/cookies-consent-preferences")
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public void deleteCookiesConsentPreference() throws Exception {
+	}
 
 	/**
 	 * Invoke this method with the command line:
@@ -101,28 +97,6 @@ public abstract class BaseCookiesConsentPreferenceResourceImpl
 			@jakarta.ws.rs.PathParam("name")
 			String name)
 		throws Exception {
-	}
-
-	/**
-	 * Invoke this method with the command line:
-	 *
-	 * curl -X 'DELETE' 'http://localhost:8080/o/cookies/v1.0/cookies-consent-preferences'  -u 'test@liferay.com:test'
-	 */
-	@io.swagger.v3.oas.annotations.Operation(
-		description = "Deletes all cookies consent preference entries of the user who made the request."
-	)
-	@io.swagger.v3.oas.annotations.tags.Tags(
-		value = {
-			@io.swagger.v3.oas.annotations.tags.Tag(
-				name = "CookiesConsentPreference"
-			)
-		}
-	)
-	@jakarta.ws.rs.DELETE
-	@jakarta.ws.rs.Path("/cookies-consent-preferences")
-	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
-	@Override
-	public void deleteCookiesConsentPreferences() throws Exception {
 	}
 
 	/**
@@ -189,207 +163,8 @@ public abstract class BaseCookiesConsentPreferenceResourceImpl
 		return new CookiesConsentPreference();
 	}
 
-	/**
-	 * Invoke this method with the command line:
-	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/cookies/v1.0/cookies-consent-preferences/batch'  -u 'test@liferay.com:test'
-	 */
-	@io.swagger.v3.oas.annotations.Parameters(
-		value = {
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "callbackURL"
-			)
-		}
-	)
-	@io.swagger.v3.oas.annotations.tags.Tags(
-		value = {
-			@io.swagger.v3.oas.annotations.tags.Tag(
-				name = "CookiesConsentPreference"
-			)
-		}
-	)
-	@jakarta.ws.rs.Consumes("application/json")
-	@jakarta.ws.rs.Path("/cookies-consent-preferences/batch")
-	@jakarta.ws.rs.Produces("application/json")
-	@jakarta.ws.rs.PUT
-	@Override
-	public Response putCookiesConsentPreferenceBatch(
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.ws.rs.QueryParam("callbackURL")
-			String callbackURL,
-			Object object)
-		throws Exception {
-
-		vulcanBatchEngineImportTaskResource.setContextAcceptLanguage(
-			contextAcceptLanguage);
-		vulcanBatchEngineImportTaskResource.setContextCompany(contextCompany);
-		vulcanBatchEngineImportTaskResource.setContextHttpServletRequest(
-			contextHttpServletRequest);
-		vulcanBatchEngineImportTaskResource.setContextUriInfo(contextUriInfo);
-		vulcanBatchEngineImportTaskResource.setContextUser(contextUser);
-
-		Response.ResponseBuilder responseBuilder = Response.accepted();
-
-		return responseBuilder.entity(
-			vulcanBatchEngineImportTaskResource.putImportTask(
-				CookiesConsentPreference.class.getName(), callbackURL, object)
-		).build();
-	}
-
-	@Override
-	@SuppressWarnings("PMD.UnusedLocalVariable")
-	public void create(
-			Collection<CookiesConsentPreference> cookiesConsentPreferences,
-			Map<String, Serializable> parameters)
-		throws Exception {
-
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
-	}
-
-	@Override
-	public void delete(
-			Collection<CookiesConsentPreference> cookiesConsentPreferences,
-			Map<String, Serializable> parameters)
-		throws Exception {
-
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
-	}
-
-	public Set<String> getAvailableCreateStrategies() {
-		return SetUtil.fromArray();
-	}
-
-	public Set<String> getAvailableUpdateStrategies() {
-		return SetUtil.fromArray("UPDATE");
-	}
-
-	@Override
-	public EntityModel getEntityModel(Map<String, List<String>> multivaluedMap)
-		throws Exception {
-
-		return getEntityModel(
-			new MultivaluedHashMap<String, Object>(multivaluedMap));
-	}
-
-	public String getResourceName() {
-		return "CookiesConsentPreference";
-	}
-
-	public String getVersion() {
-		return "v1.0";
-	}
-
-	@Override
-	public Page<CookiesConsentPreference> read(
-			com.liferay.portal.kernel.search.filter.Filter filter,
-			Pagination pagination,
-			com.liferay.portal.kernel.search.Sort[] sorts,
-			Map<String, Serializable> parameters, String search)
-		throws Exception {
-
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
-	}
-
-	@Override
-	public void setLanguageId(String languageId) {
-		this.contextAcceptLanguage = new AcceptLanguage() {
-
-			@Override
-			public List<Locale> getLocales() {
-				return null;
-			}
-
-			@Override
-			public String getPreferredLanguageId() {
-				return languageId;
-			}
-
-			@Override
-			public Locale getPreferredLocale() {
-				return LocaleUtil.fromLanguageId(languageId);
-			}
-
-		};
-	}
-
-	@Override
-	public void update(
-			Collection<CookiesConsentPreference> cookiesConsentPreferences,
-			Map<String, Serializable> parameters)
-		throws Exception {
-
-		UnsafeFunction
-			<CookiesConsentPreference, CookiesConsentPreference, Exception>
-				cookiesConsentPreferenceUnsafeFunction = null;
-
-		String updateStrategy = (String)parameters.getOrDefault(
-			"updateStrategy", "UPDATE");
-
-		if (StringUtil.equalsIgnoreCase(updateStrategy, "UPDATE")) {
-			cookiesConsentPreferenceUnsafeFunction =
-				cookiesConsentPreference -> putCookiesConsentPreference(
-					cookiesConsentPreference);
-		}
-
-		if (cookiesConsentPreferenceUnsafeFunction == null) {
-			throw new NotSupportedException(
-				"Update strategy \"" + updateStrategy +
-					"\" is not supported for CookiesConsentPreference");
-		}
-
-		if (contextBatchUnsafeBiConsumer != null) {
-			contextBatchUnsafeBiConsumer.accept(
-				cookiesConsentPreferences,
-				cookiesConsentPreferenceUnsafeFunction);
-		}
-		else if (contextBatchUnsafeConsumer != null) {
-			contextBatchUnsafeConsumer.accept(
-				cookiesConsentPreferences,
-				cookiesConsentPreferenceUnsafeFunction::apply);
-		}
-		else {
-			for (CookiesConsentPreference cookiesConsentPreference :
-					cookiesConsentPreferences) {
-
-				cookiesConsentPreferenceUnsafeFunction.apply(
-					cookiesConsentPreference);
-			}
-		}
-	}
-
-	@Override
-	public EntityModel getEntityModel(MultivaluedMap multivaluedMap)
-		throws Exception {
-
-		return null;
-	}
-
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
 		this.contextAcceptLanguage = contextAcceptLanguage;
-	}
-
-	public void setContextBatchUnsafeBiConsumer(
-		UnsafeBiConsumer
-			<Collection<CookiesConsentPreference>,
-			 UnsafeFunction
-				 <CookiesConsentPreference, CookiesConsentPreference,
-				  Exception>,
-			 Exception> contextBatchUnsafeBiConsumer) {
-
-		this.contextBatchUnsafeBiConsumer = contextBatchUnsafeBiConsumer;
-	}
-
-	public void setContextBatchUnsafeConsumer(
-		UnsafeBiConsumer
-			<Collection<CookiesConsentPreference>,
-			 UnsafeConsumer<CookiesConsentPreference, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
-
-		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
 
 	public void setContextCompany(
@@ -460,87 +235,6 @@ public abstract class BaseCookiesConsentPreferenceResourceImpl
 
 	protected String getApplicationPath() {
 		return "cookies";
-	}
-
-	public void setVulcanBatchEngineExportTaskResource(
-		VulcanBatchEngineExportTaskResource
-			vulcanBatchEngineExportTaskResource) {
-
-		this.vulcanBatchEngineExportTaskResource =
-			vulcanBatchEngineExportTaskResource;
-	}
-
-	public void setVulcanBatchEngineImportTaskResource(
-		VulcanBatchEngineImportTaskResource
-			vulcanBatchEngineImportTaskResource) {
-
-		this.vulcanBatchEngineImportTaskResource =
-			vulcanBatchEngineImportTaskResource;
-	}
-
-	@Override
-	public com.liferay.portal.kernel.search.filter.Filter toFilter(
-		String filterString, Map<String, List<String>> multivaluedMap) {
-
-		try {
-			EntityModel entityModel = getEntityModel(multivaluedMap);
-
-			FilterParser filterParser = filterParserProvider.provide(
-				entityModel);
-
-			com.liferay.portal.odata.filter.Filter oDataFilter =
-				new com.liferay.portal.odata.filter.Filter(
-					filterParser.parse(filterString));
-
-			return expressionConvert.convert(
-				oDataFilter.getExpression(),
-				contextAcceptLanguage.getPreferredLocale(), entityModel);
-		}
-		catch (Exception exception) {
-			_log.error("Invalid filter " + filterString, exception);
-
-			return null;
-		}
-	}
-
-	@Override
-	public com.liferay.portal.kernel.search.Sort[] toSorts(String sortString) {
-		if (Validator.isNull(sortString)) {
-			return null;
-		}
-
-		try {
-			SortParser sortParser = sortParserProvider.provide(
-				getEntityModel(Collections.emptyMap()));
-
-			if (sortParser == null) {
-				return null;
-			}
-
-			com.liferay.portal.odata.sort.Sort oDataSort =
-				new com.liferay.portal.odata.sort.Sort(
-					sortParser.parse(sortString));
-
-			List<SortField> sortFields = oDataSort.getSortFields();
-			com.liferay.portal.kernel.search.Sort[] sorts =
-				new com.liferay.portal.kernel.search.Sort[sortFields.size()];
-
-			for (int i = 0; i < sortFields.size(); i++) {
-				SortField sortField = sortFields.get(i);
-
-				sorts[i] = new com.liferay.portal.kernel.search.Sort(
-					sortField.getSortableFieldName(
-						contextAcceptLanguage.getPreferredLocale()),
-					!sortField.isAscending());
-			}
-
-			return sorts;
-		}
-		catch (Exception exception) {
-			_log.error("Invalid sort " + sortString, exception);
-
-			return new com.liferay.portal.kernel.search.Sort[0];
-		}
 	}
 
 	protected Map<String, String> addAction(
@@ -895,15 +589,6 @@ public abstract class BaseCookiesConsentPreferenceResourceImpl
 	}
 
 	protected AcceptLanguage contextAcceptLanguage;
-	protected UnsafeBiConsumer
-		<Collection<CookiesConsentPreference>,
-		 UnsafeFunction
-			 <CookiesConsentPreference, CookiesConsentPreference, Exception>,
-		 Exception> contextBatchUnsafeBiConsumer;
-	protected UnsafeBiConsumer
-		<Collection<CookiesConsentPreference>,
-		 UnsafeConsumer<CookiesConsentPreference, Exception>, Exception>
-			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -918,13 +603,9 @@ public abstract class BaseCookiesConsentPreferenceResourceImpl
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
-	protected VulcanBatchEngineExportTaskResource
-		vulcanBatchEngineExportTaskResource;
-	protected VulcanBatchEngineImportTaskResource
-		vulcanBatchEngineImportTaskResource;
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseCookiesConsentPreferenceResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:112616867
+// LIFERAY-REST-BUILDER-HASH:-1824720156

--- a/modules/apps/cookies/cookies-rest-impl/src/main/java/com/liferay/cookies/rest/internal/resource/v1_0/CookiesConsentPreferenceResourceImpl.java
+++ b/modules/apps/cookies/cookies-rest-impl/src/main/java/com/liferay/cookies/rest/internal/resource/v1_0/CookiesConsentPreferenceResourceImpl.java
@@ -30,17 +30,17 @@ public class CookiesConsentPreferenceResourceImpl
 	extends BaseCookiesConsentPreferenceResourceImpl {
 
 	@Override
+	public void deleteCookiesConsentPreference() throws Exception {
+		_cookiesConsentPreferenceLocalService.deleteCookiesConsentPreferences(
+			contextUser.getUserId(), _getDomain());
+	}
+
+	@Override
 	public void deleteCookiesConsentPreferenceByName(String name)
 		throws Exception {
 
 		_cookiesConsentPreferenceLocalService.deleteCookiesConsentPreference(
 			contextUser.getUserId(), _getDomain(), name);
-	}
-
-	@Override
-	public void deleteCookiesConsentPreference() throws Exception {
-		_cookiesConsentPreferenceLocalService.deleteCookiesConsentPreferences(
-			contextUser.getUserId(), _getDomain());
 	}
 
 	@Override

--- a/modules/apps/cookies/cookies-rest-impl/src/main/java/com/liferay/cookies/rest/internal/resource/v1_0/CookiesConsentPreferenceResourceImpl.java
+++ b/modules/apps/cookies/cookies-rest-impl/src/main/java/com/liferay/cookies/rest/internal/resource/v1_0/CookiesConsentPreferenceResourceImpl.java
@@ -38,7 +38,7 @@ public class CookiesConsentPreferenceResourceImpl
 	}
 
 	@Override
-	public void deleteCookiesConsentPreferences() throws Exception {
+	public void deleteCookiesConsentPreference() throws Exception {
 		_cookiesConsentPreferenceLocalService.deleteCookiesConsentPreferences(
 			contextUser.getUserId(), _getDomain());
 	}

--- a/modules/apps/cookies/cookies-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/cookies-consent-preference.properties
+++ b/modules/apps/cookies/cookies-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/cookies-consent-preference.properties
@@ -3,10 +3,6 @@
 #
 
 api.version=v1.0
-batch.engine.entity.class.name=com.liferay.cookies.rest.dto.v1_0.CookiesConsentPreference
-batch.engine.task.item.delegate=true
-batch.planner.export.enabled=false
-batch.planner.import.enabled=false
 entity.class.name=com.liferay.cookies.rest.dto.v1_0.CookiesConsentPreference
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Cookies.REST)
 osgi.jaxrs.resource=true

--- a/modules/apps/cookies/cookies-rest-test/src/testIntegration/java/com/liferay/cookies/rest/resource/v1_0/test/BaseCookiesConsentPreferenceResourceTestCase.java
+++ b/modules/apps/cookies/cookies-rest-test/src/testIntegration/java/com/liferay/cookies/rest/resource/v1_0/test/BaseCookiesConsentPreferenceResourceTestCase.java
@@ -195,6 +195,31 @@ public abstract class BaseCookiesConsentPreferenceResourceTestCase {
 	}
 
 	@Test
+	public void testDeleteCookiesConsentPreference() throws Exception {
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		CookiesConsentPreference cookiesConsentPreference =
+			testDeleteCookiesConsentPreference_addCookiesConsentPreference();
+
+		assertHttpResponseStatusCode(
+			204,
+			cookiesConsentPreferenceResource.
+				deleteCookiesConsentPreferenceHttpResponse());
+	}
+
+	protected CookiesConsentPreference
+			testDeleteCookiesConsentPreference_addCookiesConsentPreference()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testGraphQLDeleteCookiesConsentPreference() throws Exception {
+		Assert.assertTrue(false);
+	}
+
+	@Test
 	public void testDeleteCookiesConsentPreferenceByName() throws Exception {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		CookiesConsentPreference cookiesConsentPreference =
@@ -319,31 +344,6 @@ public abstract class BaseCookiesConsentPreferenceResourceTestCase {
 		throws Exception {
 
 		return testGraphQLCookiesConsentPreference_addCookiesConsentPreference();
-	}
-
-	@Test
-	public void testDeleteCookiesConsentPreferences() throws Exception {
-		@SuppressWarnings("PMD.UnusedLocalVariable")
-		CookiesConsentPreference cookiesConsentPreference =
-			testDeleteCookiesConsentPreferences_addCookiesConsentPreference();
-
-		assertHttpResponseStatusCode(
-			204,
-			cookiesConsentPreferenceResource.
-				deleteCookiesConsentPreferencesHttpResponse());
-	}
-
-	protected CookiesConsentPreference
-			testDeleteCookiesConsentPreferences_addCookiesConsentPreference()
-		throws Exception {
-
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
-	}
-
-	@Test
-	public void testGraphQLDeleteCookiesConsentPreferences() throws Exception {
-		Assert.assertTrue(false);
 	}
 
 	@Test
@@ -510,11 +510,6 @@ public abstract class BaseCookiesConsentPreferenceResourceTestCase {
 
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
-	}
-
-	@Test
-	public void testBatchEngineDeleteImportTask() throws Exception {
-		Assert.assertTrue(true);
 	}
 
 	protected CookiesConsentPreference
@@ -1431,4 +1426,4 @@ public abstract class BaseCookiesConsentPreferenceResourceTestCase {
 			_cookiesConsentPreferenceResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:811696207
+// LIFERAY-REST-BUILDER-HASH:138682693

--- a/modules/apps/mcp/mcp-server-rest-impl/build.gradle
+++ b/modules/apps/mcp/mcp-server-rest-impl/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":core:petra:petra-function")
+	compileOnly project(":core:petra:petra-io")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-string")
 	testImplementation group: "org.skyscreamer", name: "jsonassert", version: "1.5.0"

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPServerHttpServletRequestWrapper.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPServerHttpServletRequestWrapper.java
@@ -1,0 +1,269 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.mcp.server.rest.internal.servlet;
+
+import com.liferay.portal.kernel.servlet.HttpHeaders;
+import com.liferay.portal.kernel.servlet.PersistentHttpServletRequestWrapper;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.HttpComponentsUtil;
+
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+import java.nio.charset.StandardCharsets;
+
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author Alejandro Tardín
+ */
+public class MCPServerHttpServletRequestWrapper
+	extends PersistentHttpServletRequestWrapper {
+
+	public MCPServerHttpServletRequestWrapper(
+		HttpServletRequest httpServletRequest, String method, String pathInfo,
+		String contentType, byte[] body) {
+
+		super(httpServletRequest);
+
+		_method = method;
+		_pathInfo = pathInfo;
+		_contentType = contentType;
+		_body = (body != null) ? body : _EMPTY_BODY;
+
+		int index = pathInfo.indexOf('?');
+
+		_queryString = (index > -1) ? pathInfo.substring(index + 1) : null;
+
+		_parameterMap = HttpComponentsUtil.getParameterMap(_queryString);
+
+		HashMapBuilder.HashMapWrapper<String, String> overrideHeadersBuilder =
+			HashMapBuilder.put(
+				HttpHeaders.ACCEPT, ContentTypes.APPLICATION_JSON);
+
+		if (contentType != null) {
+			overrideHeadersBuilder.put(HttpHeaders.CONTENT_TYPE, contentType);
+			overrideHeadersBuilder.put(
+				HttpHeaders.CONTENT_LENGTH, String.valueOf(_body.length));
+		}
+
+		_overrideHeaders = overrideHeadersBuilder.build();
+	}
+
+	@Override
+	public Object getAttribute(String name) {
+		if (_attributes.containsKey(name)) {
+			return _attributes.get(name);
+		}
+
+		if (name.startsWith("jakarta.servlet.include.") ||
+			_TRANSACTION_CLEAN_UP_MESSAGE_OBSERVER.equals(name)) {
+
+			return null;
+		}
+
+		return super.getAttribute(name);
+	}
+
+	@Override
+	public int getContentLength() {
+		if (_contentType == null) {
+			return 0;
+		}
+
+		return _body.length;
+	}
+
+	@Override
+	public long getContentLengthLong() {
+		return getContentLength();
+	}
+
+	@Override
+	public String getContentType() {
+		return _contentType;
+	}
+
+	@Override
+	public DispatcherType getDispatcherType() {
+		return DispatcherType.FORWARD;
+	}
+
+	@Override
+	public String getHeader(String name) {
+		String override = _findOverride(name);
+
+		if (override != null) {
+			return override;
+		}
+
+		return super.getHeader(name);
+	}
+
+	@Override
+	public Enumeration<String> getHeaderNames() {
+		Set<String> names = new LinkedHashSet<>(
+			Collections.list(super.getHeaderNames()));
+
+		names.addAll(_overrideHeaders.keySet());
+
+		return Collections.enumeration(names);
+	}
+
+	@Override
+	public Enumeration<String> getHeaders(String name) {
+		String override = _findOverride(name);
+
+		if (override != null) {
+			return Collections.enumeration(Collections.singletonList(override));
+		}
+
+		return super.getHeaders(name);
+	}
+
+	@Override
+	public ServletInputStream getInputStream() throws IOException {
+		return new MCPServletInputStream(new ByteArrayInputStream(_body));
+	}
+
+	@Override
+	public String getMethod() {
+		return _method;
+	}
+
+	@Override
+	public String getParameter(String name) {
+		String[] values = _parameterMap.get(name);
+
+		return ((values != null) && (values.length > 0)) ? values[0] : null;
+	}
+
+	@Override
+	public Map<String, String[]> getParameterMap() {
+		return _parameterMap;
+	}
+
+	@Override
+	public Enumeration<String> getParameterNames() {
+		return Collections.enumeration(_parameterMap.keySet());
+	}
+
+	@Override
+	public String[] getParameterValues(String name) {
+		return _parameterMap.get(name);
+	}
+
+	@Override
+	public String getPathInfo() {
+		return _pathInfo;
+	}
+
+	@Override
+	public String getQueryString() {
+		return _queryString;
+	}
+
+	@Override
+	public BufferedReader getReader() throws IOException {
+		return new BufferedReader(
+			new InputStreamReader(
+				new ByteArrayInputStream(_body), StandardCharsets.UTF_8));
+	}
+
+	@Override
+	public void removeAttribute(String name) {
+		_attributes.remove(name);
+	}
+
+	@Override
+	public void setAttribute(String name, Object object) {
+		_attributes.put(name, object);
+	}
+
+	private String _findOverride(String name) {
+		for (Map.Entry<String, String> entry : _overrideHeaders.entrySet()) {
+			if (entry.getKey(
+				).equalsIgnoreCase(
+					name
+				)) {
+
+				return entry.getValue();
+			}
+		}
+
+		return null;
+	}
+
+	private static final byte[] _EMPTY_BODY = new byte[0];
+
+	private static final String _TRANSACTION_CLEAN_UP_MESSAGE_OBSERVER =
+		"com.liferay.portal.vulcan.internal.constants.VulcanConstants" +
+			"#TRANSACTION_CLEAN_UP_MESSAGE_OBSERVER";
+
+	private final Map<String, Object> _attributes = new HashMap<>();
+	private final byte[] _body;
+	private final String _contentType;
+	private final String _method;
+	private final Map<String, String> _overrideHeaders;
+	private final Map<String, String[]> _parameterMap;
+	private final String _pathInfo;
+	private final String _queryString;
+
+	private static class MCPServletInputStream extends ServletInputStream {
+
+		public MCPServletInputStream(
+			ByteArrayInputStream byteArrayInputStream) {
+
+			_byteArrayInputStream = byteArrayInputStream;
+		}
+
+		@Override
+		public boolean isFinished() {
+			if (_byteArrayInputStream.available() == 0) {
+				return true;
+			}
+
+			return false;
+		}
+
+		@Override
+		public boolean isReady() {
+			return true;
+		}
+
+		@Override
+		public int read() {
+			return _byteArrayInputStream.read();
+		}
+
+		@Override
+		public int read(byte[] bytes, int offset, int length) {
+			return _byteArrayInputStream.read(bytes, offset, length);
+		}
+
+		@Override
+		public void setReadListener(ReadListener readListener) {
+			throw new UnsupportedOperationException();
+		}
+
+		private final ByteArrayInputStream _byteArrayInputStream;
+
+	}
+
+}

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPServerHttpServletResponse.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPServerHttpServletResponse.java
@@ -1,0 +1,62 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.mcp.server.rest.internal.servlet;
+
+import com.liferay.portal.kernel.servlet.DummyHttpServletResponse;
+import com.liferay.portal.kernel.servlet.HttpHeaders;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.util.Objects;
+
+/**
+ * @author Alejandro Tardín
+ */
+public class MCPServerHttpServletResponse extends DummyHttpServletResponse {
+
+	@Override
+	public String getContentType() {
+		return _contentType;
+	}
+
+	@Override
+	public int getStatus() {
+		return _status;
+	}
+
+	@Override
+	public void sendError(int status) {
+		_status = status;
+	}
+
+	@Override
+	public void sendError(int status, String message) {
+		_status = status;
+	}
+
+	@Override
+	public void setContentType(String contentType) {
+		_contentType = contentType;
+	}
+
+	@Override
+	public void setHeader(String name, String value) {
+		if (Objects.equals(name, HttpHeaders.CONTENT_TYPE)) {
+			_contentType = value;
+		}
+
+		super.setHeader(name, value);
+	}
+
+	@Override
+	public void setStatus(int status) {
+		_status = status;
+	}
+
+	private String _contentType;
+	private int _status = HttpServletResponse.SC_OK;
+
+}

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
@@ -374,12 +374,15 @@ public class OpenAPIUtil {
 
 		try {
 			for (Map.Entry<String, String> entry : parts.entrySet()) {
-				_writeASCII(byteArrayOutputStream, "--", boundary, _CRLF);
+				_writeASCII(
+					byteArrayOutputStream, "--", boundary,
+					StringPool.RETURN_NEW_LINE);
 				_writeASCII(
 					byteArrayOutputStream,
 					"Content-Disposition: form-data; name=\"", entry.getKey(),
-					"\"", _CRLF, "Content-Type: ", ContentTypes.TEXT_PLAIN_UTF8,
-					_CRLF, _CRLF);
+					"\"", StringPool.RETURN_NEW_LINE, "Content-Type: ",
+					ContentTypes.TEXT_PLAIN_UTF8, StringPool.RETURN_NEW_LINE,
+					StringPool.RETURN_NEW_LINE);
 
 				byteArrayOutputStream.write(
 					entry.getValue(
@@ -387,23 +390,29 @@ public class OpenAPIUtil {
 						StandardCharsets.UTF_8
 					));
 
-				_writeASCII(byteArrayOutputStream, _CRLF);
+				_writeASCII(byteArrayOutputStream, StringPool.RETURN_NEW_LINE);
 			}
 
 			for (FilePart filePart : fileParts) {
-				_writeASCII(byteArrayOutputStream, "--", boundary, _CRLF);
+				_writeASCII(
+					byteArrayOutputStream, "--", boundary,
+					StringPool.RETURN_NEW_LINE);
 				_writeASCII(
 					byteArrayOutputStream,
 					"Content-Disposition: form-data; name=\"", filePart._name,
-					"\"; filename=\"", filePart._fileName, "\"", _CRLF,
-					"Content-Type: ", filePart._contentType, _CRLF, _CRLF);
+					"\"; filename=\"", filePart._fileName, "\"",
+					StringPool.RETURN_NEW_LINE, "Content-Type: ",
+					filePart._contentType, StringPool.RETURN_NEW_LINE,
+					StringPool.RETURN_NEW_LINE);
 
 				byteArrayOutputStream.write(filePart._bytes);
 
-				_writeASCII(byteArrayOutputStream, _CRLF);
+				_writeASCII(byteArrayOutputStream, StringPool.RETURN_NEW_LINE);
 			}
 
-			_writeASCII(byteArrayOutputStream, "--", boundary, "--", _CRLF);
+			_writeASCII(
+				byteArrayOutputStream, "--", boundary, "--",
+				StringPool.RETURN_NEW_LINE);
 		}
 		catch (IOException ioException) {
 			throw new RuntimeException(ioException);
@@ -1000,8 +1009,6 @@ public class OpenAPIUtil {
 				string.getBytes(StandardCharsets.UTF_8));
 		}
 	}
-
-	private static final String _CRLF = "\r\n";
 
 	private static final String[] _METHODS = {
 		"delete", "get", "head", "options", "patch", "post", "put"

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
@@ -47,12 +47,12 @@ public class OpenAPIUtil {
 
 		Operation operation = _getOperation(openAPIJSONObject, toolName);
 
-		String pathWithQuery = _getPath(inputJSONObject, operation);
+		String path = _getPath(inputJSONObject, operation);
 
 		String queryString = _getQueryString(inputJSONObject, operation);
 
-		if (!queryString.isEmpty()) {
-			pathWithQuery = pathWithQuery + StringPool.QUESTION + queryString;
+		if (!Validator.isBlank(queryString)) {
+			path = path + StringPool.QUESTION + queryString;
 		}
 
 		String method = StringUtil.toUpperCase(operation._method);
@@ -64,23 +64,24 @@ public class OpenAPIUtil {
 				boundary, inputJSONObject, openAPIJSONObject, operation);
 
 			if (body == null) {
-				return new Request(method, pathWithQuery, null, null);
+				return new Request(method, path, null, null);
 			}
 
 			return new Request(
-				method, pathWithQuery,
-				"multipart/form-data; boundary=" + boundary, body);
+				method, path,
+				ContentTypes.MULTIPART_FORM_DATA + "; boundary=" + boundary,
+				body);
 		}
 
 		String body = _getBody(inputJSONObject);
 
 		if (Validator.isNotNull(body)) {
 			return new Request(
-				method, pathWithQuery, ContentTypes.APPLICATION_JSON,
+				method, path, ContentTypes.APPLICATION_JSON,
 				body.getBytes(StandardCharsets.UTF_8));
 		}
 
-		return new Request(method, pathWithQuery, null, null);
+		return new Request(method, path, null, null);
 	}
 
 	public static Tool getTool(JSONObject openAPIJSONObject, String toolName) {

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
@@ -47,6 +47,8 @@ public class OpenAPIUtil {
 
 		Operation operation = _getOperation(openAPIJSONObject, toolName);
 
+		String method = StringUtil.toUpperCase(operation._method);
+
 		String path = _getPath(inputJSONObject, operation);
 
 		String queryString = _getQueryString(inputJSONObject, operation);
@@ -55,33 +57,12 @@ public class OpenAPIUtil {
 			path = path + StringPool.QUESTION + queryString;
 		}
 
-		String method = StringUtil.toUpperCase(operation._method);
-
 		if (_isMultipartRequest(operation._operationJSONObject)) {
-			String boundary = String.valueOf(UUID.randomUUID());
-
-			byte[] body = _buildMultipartBody(
-				boundary, inputJSONObject, openAPIJSONObject, operation);
-
-			if (body == null) {
-				return new Request(method, path, null, null);
-			}
-
-			return new Request(
-				method, path,
-				ContentTypes.MULTIPART_FORM_DATA + "; boundary=" + boundary,
-				body);
+			return _getMultipartRequest(
+				inputJSONObject, method, openAPIJSONObject, operation, path);
 		}
 
-		String body = _getBody(inputJSONObject);
-
-		if (Validator.isNotNull(body)) {
-			return new Request(
-				method, path, ContentTypes.APPLICATION_JSON,
-				body.getBytes(StandardCharsets.UTF_8));
-		}
-
-		return new Request(method, path, null, null);
+		return _getJSONRequest(inputJSONObject, method, path);
 	}
 
 	public static Tool getTool(JSONObject openAPIJSONObject, String toolName) {
@@ -712,6 +693,39 @@ public class OpenAPIUtil {
 		).put(
 			"type", "object"
 		).build();
+	}
+
+	private static Request _getJSONRequest(
+		JSONObject inputJSONObject, String method, String path) {
+
+		String body = _getBody(inputJSONObject);
+
+		if (Validator.isNotNull(body)) {
+			return new Request(
+				method, path, ContentTypes.APPLICATION_JSON,
+				body.getBytes(StandardCharsets.UTF_8));
+		}
+
+		return new Request(method, path, null, null);
+	}
+
+	private static Request _getMultipartRequest(
+		JSONObject inputJSONObject, String method, JSONObject openAPIJSONObject,
+		Operation operation, String path) {
+
+		String boundary = String.valueOf(UUID.randomUUID());
+
+		byte[] multipartBody = _buildMultipartBody(
+			boundary, inputJSONObject, openAPIJSONObject, operation);
+
+		if (multipartBody != null) {
+			return new Request(
+				method, path,
+				ContentTypes.MULTIPART_FORM_DATA + "; boundary=" + boundary,
+				multipartBody);
+		}
+
+		return new Request(method, path, null, null);
 	}
 
 	private static Operation _getOperation(

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
@@ -348,10 +348,6 @@ public class OpenAPIUtil {
 		for (Map.Entry<String, Object> entry : partProperties.entrySet()) {
 			String partName = entry.getKey();
 
-			if (!inputJSONObject.has(partName)) {
-				continue;
-			}
-
 			Object value = inputJSONObject.get(partName);
 
 			if (value == null) {

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
@@ -375,10 +375,10 @@ public class OpenAPIUtil {
 
 		try {
 			for (Map.Entry<String, String> entry : parts.entrySet()) {
-				_writeASCII(
+				_write(
 					byteArrayOutputStream, "--", boundary,
 					StringPool.RETURN_NEW_LINE);
-				_writeASCII(
+				_write(
 					byteArrayOutputStream,
 					"Content-Disposition: form-data; name=\"", entry.getKey(),
 					"\"", StringPool.RETURN_NEW_LINE, "Content-Type: ",
@@ -391,14 +391,14 @@ public class OpenAPIUtil {
 						StandardCharsets.UTF_8
 					));
 
-				_writeASCII(byteArrayOutputStream, StringPool.RETURN_NEW_LINE);
+				_write(byteArrayOutputStream, StringPool.RETURN_NEW_LINE);
 			}
 
 			for (FilePart filePart : fileParts) {
-				_writeASCII(
+				_write(
 					byteArrayOutputStream, "--", boundary,
 					StringPool.RETURN_NEW_LINE);
-				_writeASCII(
+				_write(
 					byteArrayOutputStream,
 					"Content-Disposition: form-data; name=\"", filePart._name,
 					"\"; filename=\"", filePart._fileName, "\"",
@@ -408,10 +408,10 @@ public class OpenAPIUtil {
 
 				byteArrayOutputStream.write(filePart._bytes);
 
-				_writeASCII(byteArrayOutputStream, StringPool.RETURN_NEW_LINE);
+				_write(byteArrayOutputStream, StringPool.RETURN_NEW_LINE);
 			}
 
-			_writeASCII(
+			_write(
 				byteArrayOutputStream, "--", boundary, "--",
 				StringPool.RETURN_NEW_LINE);
 		}
@@ -1001,7 +1001,7 @@ public class OpenAPIUtil {
 		return value;
 	}
 
-	private static void _writeASCII(
+	private static void _write(
 			ByteArrayOutputStream byteArrayOutputStream, String... strings)
 		throws IOException {
 

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
@@ -358,7 +358,7 @@ public class OpenAPIUtil {
 			Map<String, Object> partSchema =
 				(Map<String, Object>)entry.getValue();
 
-			if (Objects.equals(partSchema.get("format"), "binary")) {
+			if (_isBinaryPartSchema(partSchema)) {
 				fileParts.add(_getFilePart(partName, value));
 			}
 			else {

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
@@ -15,11 +15,15 @@ import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.URLCodec;
 import com.liferay.portal.kernel.util.Validator;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import java.nio.charset.StandardCharsets;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -37,31 +41,39 @@ import java.util.UUID;
  */
 public class OpenAPIUtil {
 
-	public static Http.Options getOptions(
-		String baseURL, JSONObject inputJSONObject,
-		JSONObject openAPIJSONObject, String toolName) {
-
-		Http.Options options = new Http.Options();
+	public static Request getRequest(
+		JSONObject inputJSONObject, JSONObject openAPIJSONObject,
+		String toolName) {
 
 		Operation operation = _getOperation(openAPIJSONObject, toolName);
 
-		String url = baseURL + _getPath(inputJSONObject, operation);
+		String pathWithQuery = _getPath(inputJSONObject, operation);
 
 		String queryString = _getQueryString(inputJSONObject, operation);
 
 		if (!queryString.isEmpty()) {
-			url = url + StringPool.QUESTION + queryString;
+			pathWithQuery = pathWithQuery + StringPool.QUESTION + queryString;
 		}
 
-		options.setLocation(url);
-		options.setMethod(
-			Http.Method.valueOf(StringUtil.toUpperCase(operation._method)));
+		String method = StringUtil.toUpperCase(operation._method);
 
 		if (_isMultipartRequest(operation._operationJSONObject)) {
-			_setMultipartBody(
-				inputJSONObject, openAPIJSONObject, operation, options);
+			String boundary = UUID.randomUUID(
+			).toString();
+
+			byte[] body = _buildMultipartBody(
+				boundary, inputJSONObject, openAPIJSONObject, operation);
+
+			if (body == null) {
+				return new Request(method, pathWithQuery, null, null);
+			}
+
+			return new Request(
+				method, pathWithQuery,
+				"multipart/form-data; boundary=" + boundary, body);
 		}
-		else if (inputJSONObject.has("body")) {
+
+		if (inputJSONObject.has("body")) {
 			Object bodyValue = inputJSONObject.get("body");
 
 			String body = null;
@@ -74,14 +86,13 @@ public class OpenAPIUtil {
 			}
 
 			if (Validator.isNotNull(body)) {
-				options.setBody(
-					body, ContentTypes.APPLICATION_JSON, StringPool.UTF8);
-				options.addHeader(
-					"Content-Type", ContentTypes.APPLICATION_JSON);
+				return new Request(
+					method, pathWithQuery, ContentTypes.APPLICATION_JSON,
+					body.getBytes(StandardCharsets.UTF_8));
 			}
 		}
 
-		return options;
+		return new Request(method, pathWithQuery, null, null);
 	}
 
 	public static Tool getTool(JSONObject openAPIJSONObject, String toolName) {
@@ -138,6 +149,41 @@ public class OpenAPIUtil {
 		}
 
 		return toolSummaries;
+	}
+
+	public static class Request {
+
+		public Request(
+			String method, String pathWithQuery, String contentType,
+			byte[] body) {
+
+			_method = method;
+			_pathWithQuery = pathWithQuery;
+			_contentType = contentType;
+			_body = body;
+		}
+
+		public byte[] getBody() {
+			return _body;
+		}
+
+		public String getContentType() {
+			return _contentType;
+		}
+
+		public String getMethod() {
+			return _method;
+		}
+
+		public String getPathWithQuery() {
+			return _pathWithQuery;
+		}
+
+		private final byte[] _body;
+		private final String _contentType;
+		private final String _method;
+		private final String _pathWithQuery;
+
 	}
 
 	private static void _addMultipartParts(
@@ -290,6 +336,96 @@ public class OpenAPIUtil {
 		).put(
 			"type", "object"
 		).build();
+	}
+
+	private static byte[] _buildMultipartBody(
+		String boundary, JSONObject inputJSONObject,
+		JSONObject openAPIJSONObject, Operation operation) {
+
+		Map<String, Object> bodySchema = (Map<String, Object>)_resolveRefs(
+			openAPIJSONObject,
+			_getBodySchemaJSONObject(operation._operationJSONObject),
+			new HashSet<>());
+
+		Map<String, Object> partProperties =
+			(Map<String, Object>)bodySchema.get("properties");
+
+		if (partProperties == null) {
+			return null;
+		}
+
+		List<FilePart> fileParts = new ArrayList<>();
+		Map<String, String> parts = new LinkedHashMap<>();
+
+		for (Map.Entry<String, Object> entry : partProperties.entrySet()) {
+			String partName = entry.getKey();
+
+			if (!inputJSONObject.has(partName)) {
+				continue;
+			}
+
+			Object value = inputJSONObject.get(partName);
+
+			if (value == null) {
+				continue;
+			}
+
+			Map<String, Object> partSchema =
+				(Map<String, Object>)entry.getValue();
+
+			if (Objects.equals(partSchema.get("format"), "binary")) {
+				fileParts.add(_getFilePart(partName, value));
+			}
+			else {
+				parts.put(partName, _getPart(value));
+			}
+		}
+
+		if (fileParts.isEmpty() && parts.isEmpty()) {
+			return null;
+		}
+
+		ByteArrayOutputStream byteArrayOutputStream =
+			new ByteArrayOutputStream();
+
+		try {
+			for (Map.Entry<String, String> entry : parts.entrySet()) {
+				_writeASCII(byteArrayOutputStream, "--", boundary, _CRLF);
+				_writeASCII(
+					byteArrayOutputStream,
+					"Content-Disposition: form-data; name=\"", entry.getKey(),
+					"\"", _CRLF, "Content-Type: ", ContentTypes.TEXT_PLAIN_UTF8,
+					_CRLF, _CRLF);
+
+				byteArrayOutputStream.write(
+					entry.getValue(
+					).getBytes(
+						StandardCharsets.UTF_8
+					));
+
+				_writeASCII(byteArrayOutputStream, _CRLF);
+			}
+
+			for (FilePart filePart : fileParts) {
+				_writeASCII(byteArrayOutputStream, "--", boundary, _CRLF);
+				_writeASCII(
+					byteArrayOutputStream,
+					"Content-Disposition: form-data; name=\"", filePart._name,
+					"\"; filename=\"", filePart._fileName, "\"", _CRLF,
+					"Content-Type: ", filePart._contentType, _CRLF, _CRLF);
+
+				byteArrayOutputStream.write(filePart._bytes);
+
+				_writeASCII(byteArrayOutputStream, _CRLF);
+			}
+
+			_writeASCII(byteArrayOutputStream, "--", boundary, "--", _CRLF);
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(ioException);
+		}
+
+		return byteArrayOutputStream.toByteArray();
 	}
 
 	private static Map<String, Object> _collectMatchingParameters(
@@ -487,7 +623,7 @@ public class OpenAPIUtil {
 		return StringUtil.toUpperCase(method) + StringPool.SPACE + path;
 	}
 
-	private static Http.FilePart _getFilePart(String name, Object value) {
+	private static FilePart _getFilePart(String name, Object value) {
 		String fileName = name;
 		String contentType = ContentTypes.APPLICATION_OCTET_STREAM;
 		String base64Data;
@@ -524,10 +660,8 @@ public class OpenAPIUtil {
 
 		Base64.Decoder decoder = Base64.getDecoder();
 
-		byte[] bytes = decoder.decode(base64Data);
-
-		return new Http.FilePart(
-			name, fileName, bytes, contentType, StringPool.UTF8);
+		return new FilePart(
+			name, fileName, contentType, decoder.decode(base64Data));
 	}
 
 	private static Map<String, Object> _getInputSchema(
@@ -860,63 +994,17 @@ public class OpenAPIUtil {
 		return value;
 	}
 
-	private static void _setMultipartBody(
-		JSONObject inputJSONObject, JSONObject openAPIJSONObject,
-		Operation operation, Http.Options options) {
+	private static void _writeASCII(
+			ByteArrayOutputStream byteArrayOutputStream, String... strings)
+		throws IOException {
 
-		Map<String, Object> bodySchema = (Map<String, Object>)_resolveRefs(
-			openAPIJSONObject,
-			_getBodySchemaJSONObject(operation._operationJSONObject),
-			new HashSet<>());
-
-		Map<String, Object> partProperties =
-			(Map<String, Object>)bodySchema.get("properties");
-
-		if (partProperties == null) {
-			return;
-		}
-
-		List<Http.FilePart> fileParts = new ArrayList<>();
-		Map<String, String> parts = new LinkedHashMap<>();
-
-		for (Map.Entry<String, Object> entry : partProperties.entrySet()) {
-			String partName = entry.getKey();
-
-			if (!inputJSONObject.has(partName)) {
-				continue;
-			}
-
-			Object value = inputJSONObject.get(partName);
-
-			if (value == null) {
-				continue;
-			}
-
-			Map<String, Object> partSchema =
-				(Map<String, Object>)entry.getValue();
-
-			if (Objects.equals(partSchema.get("format"), "binary")) {
-				fileParts.add(_getFilePart(partName, value));
-			}
-			else {
-				parts.put(partName, _getPart(value));
-			}
-		}
-
-		if (!fileParts.isEmpty()) {
-			options.setFileParts(fileParts);
-		}
-
-		if (!parts.isEmpty()) {
-			options.setParts(parts);
-		}
-
-		if (!fileParts.isEmpty() || !parts.isEmpty()) {
-			options.addHeader(
-				"Content-Type",
-				"multipart/form-data; boundary=" + UUID.randomUUID());
+		for (String string : strings) {
+			byteArrayOutputStream.write(
+				string.getBytes(StandardCharsets.UTF_8));
 		}
 	}
+
+	private static final String _CRLF = "\r\n";
 
 	private static final String[] _METHODS = {
 		"delete", "get", "head", "options", "patch", "post", "put"
@@ -926,6 +1014,24 @@ public class OpenAPIUtil {
 		"actions", "example", "exclusiveMaximum", "exclusiveMinimum", "xml");
 	private static final Set<String> _vulcanFieldSelectionParameterNames =
 		Set.of("fields", "restrictFields");
+
+	private static class FilePart {
+
+		private FilePart(
+			String name, String fileName, String contentType, byte[] bytes) {
+
+			_name = name;
+			_fileName = fileName;
+			_contentType = contentType;
+			_bytes = bytes;
+		}
+
+		private final byte[] _bytes;
+		private final String _contentType;
+		private final String _fileName;
+		private final String _name;
+
+	}
 
 	private static class Operation {
 

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
@@ -58,8 +58,7 @@ public class OpenAPIUtil {
 		String method = StringUtil.toUpperCase(operation._method);
 
 		if (_isMultipartRequest(operation._operationJSONObject)) {
-			String boundary = UUID.randomUUID(
-			).toString();
+			String boundary = String.valueOf(UUID.randomUUID());
 
 			byte[] body = _buildMultipartBody(
 				boundary, inputJSONObject, openAPIJSONObject, operation);

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
@@ -72,23 +72,12 @@ public class OpenAPIUtil {
 				"multipart/form-data; boundary=" + boundary, body);
 		}
 
-		if (inputJSONObject.has("body")) {
-			Object bodyValue = inputJSONObject.get("body");
+		String body = _getBody(inputJSONObject);
 
-			String body = null;
-
-			if (bodyValue instanceof JSONObject) {
-				body = bodyValue.toString();
-			}
-			else if (bodyValue != null) {
-				body = String.valueOf(bodyValue);
-			}
-
-			if (Validator.isNotNull(body)) {
-				return new Request(
-					method, pathWithQuery, ContentTypes.APPLICATION_JSON,
-					body.getBytes(StandardCharsets.UTF_8));
-			}
+		if (Validator.isNotNull(body)) {
+			return new Request(
+				method, pathWithQuery, ContentTypes.APPLICATION_JSON,
+				body.getBytes(StandardCharsets.UTF_8));
 		}
 
 		return new Request(method, pathWithQuery, null, null);
@@ -555,6 +544,19 @@ public class OpenAPIUtil {
 		return LinkedHashMapBuilder.<String, Object>put(
 			"oneOf", oneOfList
 		).build();
+	}
+
+	private static String _getBody(JSONObject jsonObject) {
+		Object body = jsonObject.get("body");
+
+		if (body instanceof JSONObject) {
+			return body.toString();
+		}
+		else if (body != null) {
+			return String.valueOf(body);
+		}
+
+		return null;
 	}
 
 	private static JSONObject _getBodySchemaJSONObject(

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/ToolSetUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/ToolSetUtil.java
@@ -10,7 +10,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.liferay.mcp.server.rest.dto.v1_0.Tool;
 import com.liferay.mcp.server.rest.dto.v1_0.ToolSet;
 import com.liferay.mcp.server.rest.dto.v1_0.ToolSummary;
+import com.liferay.mcp.server.rest.internal.servlet.MCPServerHttpServletRequestWrapper;
+import com.liferay.mcp.server.rest.internal.servlet.MCPServerHttpServletResponse;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.io.unsync.UnsyncStringWriter;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -19,13 +22,15 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.module.service.Snapshot;
+import com.liferay.portal.kernel.security.access.control.AccessControlUtil;
+import com.liferay.portal.kernel.security.auth.AccessControlContext;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.servlet.PipingServletResponse;
+import com.liferay.portal.kernel.servlet.ServletContextPool;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.Http;
-import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.vulcan.jackson.databind.ObjectMapperProviderUtil;
@@ -34,6 +39,8 @@ import com.liferay.portal.vulcan.pagination.Page;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServletRequest;
 
 import jakarta.ws.rs.core.Response;
@@ -147,55 +154,67 @@ public class ToolSetUtil {
 			}
 		}
 
-		Http.Options options = _getOptions(
-			httpServletRequest, inputJSONObject, toolName, toolSetName);
+		OpenAPIBrief openAPIBrief = _getOpenAPIBrief(toolSetName);
 
-		String content = _getContent(HttpUtil.URLtoString(options));
+		OpenAPIUtil.Request request = OpenAPIUtil.getRequest(
+			inputJSONObject,
+			_getOpenAPIJSONObject(openAPIBrief, httpServletRequest), toolName);
 
-		Http.Response response = options.getResponse();
+		DispatchResult dispatchResult = _dispatch(
+			httpServletRequest, request.getMethod(),
+			openAPIBrief._basePath + request.getPathWithQuery(),
+			request.getContentType(), request.getBody());
 
 		return Response.status(
-			response.getResponseCode()
+			dispatchResult._status
 		).entity(
-			content
+			_getContent(dispatchResult._body)
 		).type(
 			ContentTypes.TEXT_PLAIN_UTF8
 		).build();
 	}
 
-	private static String _get(
-			HttpServletRequest httpServletRequest, String url)
+	private static DispatchResult _dispatch(
+			HttpServletRequest httpServletRequest, String method, String path,
+			String contentType, byte[] body)
 		throws Exception {
 
-		Http.Options options = new Http.Options();
+		ServletContext servletContext = _getServletContext();
 
-		Map<String, String> headers = _getHeaders(httpServletRequest);
+		RequestDispatcher requestDispatcher =
+			servletContext.getRequestDispatcher(Portal.PATH_MODULE + path);
 
-		if (!headers.isEmpty()) {
-			options.setHeaders(headers);
+		UnsyncStringWriter unsyncStringWriter = new UnsyncStringWriter();
+
+		MCPServerHttpServletResponse mcpServerHttpServletResponse =
+			new MCPServerHttpServletResponse();
+
+		PipingServletResponse pipingServletResponse = new PipingServletResponse(
+			mcpServerHttpServletResponse, unsyncStringWriter);
+
+		AccessControlContext accessControlContext =
+			AccessControlUtil.getAccessControlContext();
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		try {
+			AccessControlUtil.setAccessControlContext(null);
+
+			requestDispatcher.forward(
+				new MCPServerHttpServletRequestWrapper(
+					httpServletRequest, method, path, contentType, body),
+				pipingServletResponse);
+		}
+		finally {
+			AccessControlUtil.setAccessControlContext(accessControlContext);
+			PermissionThreadLocal.setPermissionChecker(permissionChecker);
 		}
 
-		options.setLocation(url);
-		options.setTimeout(60000);
+		String responseBody = unsyncStringWriter.toString();
 
-		String content = HttpUtil.URLtoString(options);
-
-		Http.Response response = options.getResponse();
-
-		int responseCode = response.getResponseCode();
-
-		if (responseCode >= 300) {
-			throw new Exception(
-				StringBundler.concat(
-					"HTTP ", responseCode, " for ", url, ": ", content));
-		}
-
-		return content;
-	}
-
-	private static String _getBaseURL(HttpServletRequest httpServletRequest) {
-		return PortalUtil.getPortalURL(httpServletRequest) +
-			PortalUtil.getPathContext() + Portal.PATH_MODULE;
+		return new DispatchResult(
+			mcpServerHttpServletResponse.getStatus(),
+			Validator.isNull(responseBody) ? null : responseBody);
 	}
 
 	private static String _getContent(String content) {
@@ -248,34 +267,6 @@ public class ToolSetUtil {
 		}
 
 		return description;
-	}
-
-	private static Map<String, String> _getHeaders(
-		HttpServletRequest httpServletRequest) {
-
-		String authorization = httpServletRequest.getHeader("Authorization");
-
-		if (authorization != null) {
-			return HashMapBuilder.put(
-				"Authorization", authorization
-			).build();
-		}
-
-		Map<String, String> headers = new HashMap<>();
-
-		String cookie = httpServletRequest.getHeader("Cookie");
-
-		if (cookie != null) {
-			headers.put("Cookie", cookie);
-		}
-
-		String csrfToken = httpServletRequest.getHeader("X-CSRF-Token");
-
-		if (csrfToken != null) {
-			headers.put("X-CSRF-Token", csrfToken);
-		}
-
-		return headers;
 	}
 
 	private static OpenAPIBrief _getOpenAPIBrief(String toolSetName) {
@@ -334,12 +325,21 @@ public class ToolSetUtil {
 		OpenAPIBrief openAPIBrief, HttpServletRequest httpServletRequest) {
 
 		return _openAPIJSONObjectCache.computeIfAbsent(
-			_getBaseURL(httpServletRequest) + openAPIBrief._basePath +
-				openAPIBrief._openAPIPath,
-			url -> {
+			openAPIBrief._basePath + openAPIBrief._openAPIPath,
+			path -> {
 				try {
+					DispatchResult dispatchResult = _dispatch(
+						httpServletRequest, "GET", path, null, null);
+
+					if (dispatchResult._status >= 300) {
+						throw new RuntimeException(
+							StringBundler.concat(
+								"HTTP ", dispatchResult._status, " for ", path,
+								": ", dispatchResult._body));
+					}
+
 					return JSONFactoryUtil.createJSONObject(
-						_get(httpServletRequest, url));
+						dispatchResult._body);
 				}
 				catch (Exception exception) {
 					throw new RuntimeException(exception);
@@ -379,35 +379,26 @@ public class ToolSetUtil {
 		return null;
 	}
 
-	private static Http.Options _getOptions(
-		HttpServletRequest httpServletRequest, JSONObject inputJSONObject,
-		String toolName, String toolSetName) {
-
-		OpenAPIBrief openAPIBrief = _getOpenAPIBrief(toolSetName);
-
-		Http.Options options = OpenAPIUtil.getOptions(
-			_getBaseURL(httpServletRequest) + openAPIBrief._basePath,
-			inputJSONObject,
-			_getOpenAPIJSONObject(openAPIBrief, httpServletRequest), toolName);
-
-		Map<String, String> headers = _getHeaders(httpServletRequest);
-
-		if (options.getHeaders() != null) {
-			headers.putAll(options.getHeaders());
-		}
-
-		options.setHeaders(headers);
-		options.setTimeout(60000);
-
-		return options;
-	}
-
 	private static Response _getResponse(Object value) throws Exception {
 		ObjectMapper objectMapper = ObjectMapperProviderUtil.getObjectMapper();
 
 		return Response.ok(
 			objectMapper.writeValueAsString(value), ContentTypes.TEXT_PLAIN_UTF8
 		).build();
+	}
+
+	private static ServletContext _getServletContext() {
+		ServletContext servletContext = _servletContext;
+
+		if (servletContext != null) {
+			return servletContext;
+		}
+
+		servletContext = ServletContextPool.get(StringPool.BLANK);
+
+		_servletContext = servletContext;
+
+		return servletContext;
 	}
 
 	private static Map<String, String> _getToolSetDescriptions() {
@@ -480,6 +471,19 @@ public class ToolSetUtil {
 			ToolSetUtil.class, JaxrsServiceRuntime.class);
 	private static final Map<String, JSONObject> _openAPIJSONObjectCache =
 		new ConcurrentHashMap<>();
+	private static volatile ServletContext _servletContext;
+
+	private static class DispatchResult {
+
+		private DispatchResult(int status, String body) {
+			_status = status;
+			_body = body;
+		}
+
+		private final String _body;
+		private final int _status;
+
+	}
 
 	private static class OpenAPIBrief {
 

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/ToolSetUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/ToolSetUtil.java
@@ -184,13 +184,10 @@ public class ToolSetUtil {
 		RequestDispatcher requestDispatcher =
 			servletContext.getRequestDispatcher(Portal.PATH_MODULE + path);
 
-		UnsyncStringWriter unsyncStringWriter = new UnsyncStringWriter();
-
 		MCPServerHttpServletResponse mcpServerHttpServletResponse =
 			new MCPServerHttpServletResponse();
 
-		PipingServletResponse pipingServletResponse = new PipingServletResponse(
-			mcpServerHttpServletResponse, unsyncStringWriter);
+		UnsyncStringWriter unsyncStringWriter = new UnsyncStringWriter();
 
 		AccessControlContext accessControlContext =
 			AccessControlUtil.getAccessControlContext();
@@ -203,18 +200,17 @@ public class ToolSetUtil {
 			requestDispatcher.forward(
 				new MCPServerHttpServletRequestWrapper(
 					httpServletRequest, method, path, contentType, body),
-				pipingServletResponse);
+				new PipingServletResponse(
+					mcpServerHttpServletResponse, unsyncStringWriter));
 		}
 		finally {
 			AccessControlUtil.setAccessControlContext(accessControlContext);
 			PermissionThreadLocal.setPermissionChecker(permissionChecker);
 		}
 
-		String responseBody = unsyncStringWriter.toString();
-
 		return new DispatchResult(
 			mcpServerHttpServletResponse.getStatus(),
-			Validator.isNull(responseBody) ? null : responseBody);
+			unsyncStringWriter.toString());
 	}
 
 	private static String _getContent(String content) {

--- a/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
@@ -9,14 +9,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.liferay.mcp.server.rest.dto.v1_0.Tool;
 import com.liferay.mcp.server.rest.dto.v1_0.ToolSummary;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.nio.charset.StandardCharsets;
 
 import java.util.Base64;
 import java.util.List;
@@ -49,44 +51,37 @@ public class OpenAPIUtilTest {
 	}
 
 	@Test
-	public void testGetOptions() {
-		_testGetOptions(
-			null, null, Http.Method.GET,
-			"http://localhost/test/v1.0/items?restrictFields=actions",
+	public void testGetRequest() {
+		_testGetRequest(
+			null, null, "GET", "/v1.0/items?restrictFields=actions",
 			JSONFactoryUtil.createJSONObject(), "getItems");
-		_testGetOptions(
-			null, null, Http.Method.GET,
-			"http://localhost/test/v1.0/items?page=1&pageSize=20" +
-				"&restrictFields=actions",
+		_testGetRequest(
+			null, null, "GET",
+			"/v1.0/items?page=1&pageSize=20&restrictFields=actions",
 			JSONUtil.put(
 				"page", "1"
 			).put(
 				"pageSize", "20"
 			),
 			"getItems");
-		_testGetOptions(
-			null, null, Http.Method.GET,
-			"http://localhost/test/v1.0/items?filter=name+eq+%27John+Doe%27" +
-				"&restrictFields=actions",
+		_testGetRequest(
+			null, null, "GET",
+			"/v1.0/items?filter=name+eq+%27John+Doe%27&restrictFields=actions",
 			JSONUtil.put("filter", "name eq 'John Doe'"), "getItems");
-		_testGetOptions(
-			null, null, Http.Method.GET,
-			"http://localhost/test/v1.0/items?restrictFields=actions",
+		_testGetRequest(
+			null, null, "GET", "/v1.0/items?restrictFields=actions",
 			JSONUtil.put("fields", "name"), "getItems");
-		_testGetOptions(
-			null, null, Http.Method.GET,
-			"http://localhost/test/v1.0/items?restrictFields=actions",
+		_testGetRequest(
+			null, null, "GET", "/v1.0/items?restrictFields=actions",
 			JSONUtil.put("restrictFields", "name"), "getItems");
-		_testGetOptions(
-			null, null, Http.Method.GET,
-			"http://localhost/test/v1.0/items/123?restrictFields=actions",
+		_testGetRequest(
+			null, null, "GET", "/v1.0/items/123?restrictFields=actions",
 			JSONUtil.put("itemId", "123"), "getItem");
-		_testGetOptions(
+		_testGetRequest(
 			JSONUtil.put(
 				"name", "Test"
 			).toString(),
-			"application/json", Http.Method.PATCH,
-			"http://localhost/test/v1.0/items/123",
+			"application/json", "PATCH", "/v1.0/items/123",
 			JSONUtil.put(
 				"body", JSONUtil.put("name", "Test")
 			).put(
@@ -98,8 +93,7 @@ public class OpenAPIUtilTest {
 		String fileName = RandomTestUtil.randomString();
 		String name = RandomTestUtil.randomString();
 
-		Http.Options options = OpenAPIUtil.getOptions(
-			"http://localhost/test",
+		OpenAPIUtil.Request request = OpenAPIUtil.getRequest(
 			JSONUtil.put(
 				"data",
 				JSONUtil.put(
@@ -119,30 +113,32 @@ public class OpenAPIUtilTest {
 			),
 			_openAPIJSONObject, "postBinary");
 
-		Assert.assertNull(options.getBody());
-		_assertMultipartContentType(options);
-		Assert.assertEquals(Http.Method.POST, options.getMethod());
-		Assert.assertEquals(
-			"http://localhost/test/v1.0/binaries", options.getLocation());
+		Assert.assertEquals("POST", request.getMethod());
+		Assert.assertEquals("/v1.0/binaries", request.getPathWithQuery());
 
-		List<Http.FilePart> fileParts = options.getFileParts();
+		String boundary = _assertMultipartContentType(request);
+		String body = new String(request.getBody(), StandardCharsets.UTF_8);
 
-		Assert.assertEquals(fileParts.toString(), 1, fileParts.size());
+		Assert.assertTrue(
+			body,
+			body.contains(
+				StringBundler.concat(
+					"--", boundary,
+					"\r\nContent-Disposition: form-data; name=\"name\"\r\n",
+					"Content-Type: text/plain; charset=UTF-8\r\n\r\n", name,
+					"\r\n")));
+		Assert.assertTrue(
+			body,
+			body.contains(
+				StringBundler.concat(
+					"--", boundary,
+					"\r\nContent-Disposition: form-data; name=\"data\"; ",
+					"filename=\"", fileName,
+					"\"\r\nContent-Type: text/plain\r\n\r\n", fileContent,
+					"\r\n")));
+		Assert.assertTrue(body, body.endsWith("--" + boundary + "--\r\n"));
 
-		Http.FilePart filePart = fileParts.get(0);
-
-		Assert.assertEquals("text/plain", filePart.getContentType());
-		Assert.assertEquals(fileName, filePart.getFileName());
-		Assert.assertEquals("data", filePart.getName());
-		Assert.assertArrayEquals(fileContent.getBytes(), filePart.getValue());
-
-		Map<String, String> parts = options.getParts();
-
-		Assert.assertEquals(parts.toString(), 1, parts.size());
-		Assert.assertEquals(name, parts.get("name"));
-
-		options = OpenAPIUtil.getOptions(
-			"http://localhost/test",
+		request = OpenAPIUtil.getRequest(
 			JSONUtil.put(
 				"boolean", true
 			).put(
@@ -152,19 +148,37 @@ public class OpenAPIUtilTest {
 			),
 			_openAPIJSONObject, "postUpload");
 
-		Assert.assertNull(options.getBody());
-		_assertMultipartContentType(options);
-		Assert.assertNull(options.getFileParts());
-		Assert.assertEquals(Http.Method.POST, options.getMethod());
-		Assert.assertEquals(
-			"http://localhost/test/v1.0/uploads", options.getLocation());
+		Assert.assertEquals("POST", request.getMethod());
+		Assert.assertEquals("/v1.0/uploads", request.getPathWithQuery());
 
-		parts = options.getParts();
+		boundary = _assertMultipartContentType(request);
+		body = new String(request.getBody(), StandardCharsets.UTF_8);
 
-		Assert.assertEquals(parts.toString(), 3, parts.size());
-		Assert.assertEquals("true", parts.get("boolean"));
-		Assert.assertEquals("1", parts.get("integer"));
-		Assert.assertEquals(fileContent, parts.get("string"));
+		Assert.assertTrue(
+			body,
+			body.contains(
+				StringBundler.concat(
+					"--", boundary,
+					"\r\nContent-Disposition: form-data; name=\"boolean\"",
+					"\r\nContent-Type: text/plain; charset=UTF-8\r\n\r\n",
+					"true\r\n")));
+		Assert.assertTrue(
+			body,
+			body.contains(
+				StringBundler.concat(
+					"--", boundary,
+					"\r\nContent-Disposition: form-data; name=\"integer\"",
+					"\r\nContent-Type: text/plain; charset=UTF-8\r\n\r\n",
+					"1\r\n")));
+		Assert.assertTrue(
+			body,
+			body.contains(
+				StringBundler.concat(
+					"--", boundary,
+					"\r\nContent-Disposition: form-data; name=\"string\"",
+					"\r\nContent-Type: text/plain; charset=UTF-8\r\n\r\n",
+					fileContent, "\r\n")));
+		Assert.assertTrue(body, body.endsWith("--" + boundary + "--\r\n"));
 	}
 
 	@Test
@@ -254,13 +268,16 @@ public class OpenAPIUtilTest {
 				JSONFactoryUtil.createJSONObject()));
 	}
 
-	private void _assertMultipartContentType(Http.Options options) {
-		String contentTypeHeader = options.getHeader("Content-Type");
+	private String _assertMultipartContentType(OpenAPIUtil.Request request) {
+		String contentType = request.getContentType();
 
-		Assert.assertNotNull(contentTypeHeader);
-		Assert.assertTrue(
-			contentTypeHeader,
-			contentTypeHeader.startsWith("multipart/form-data; boundary="));
+		Assert.assertNotNull(contentType);
+
+		String prefix = "multipart/form-data; boundary=";
+
+		Assert.assertTrue(contentType, contentType.startsWith(prefix));
+
+		return contentType.substring(prefix.length());
 	}
 
 	private void _assertToolSummary(
@@ -284,29 +301,27 @@ public class OpenAPIUtilTest {
 			getClass().getResourceAsStream("dependencies/" + fileName));
 	}
 
-	private void _testGetOptions(
-		String expectedBody, String expectedContentType,
-		Http.Method expectedMethod, String expectedURL,
-		JSONObject inputJSONObject, String toolName) {
+	private void _testGetRequest(
+		String expectedBody, String expectedContentType, String expectedMethod,
+		String expectedPathWithQuery, JSONObject inputJSONObject,
+		String toolName) {
 
-		Http.Options options = OpenAPIUtil.getOptions(
-			"http://localhost/test", inputJSONObject, _openAPIJSONObject,
-			toolName);
-
-		Http.Body body = options.getBody();
+		OpenAPIUtil.Request request = OpenAPIUtil.getRequest(
+			inputJSONObject, _openAPIJSONObject, toolName);
 
 		if (expectedBody == null) {
-			Assert.assertNull(body);
+			Assert.assertNull(request.getBody());
+			Assert.assertNull(request.getContentType());
 		}
 		else {
-			Assert.assertEquals(expectedBody, body.getContent());
-			Assert.assertEquals(expectedContentType, body.getContentType());
+			Assert.assertEquals(
+				expectedBody,
+				new String(request.getBody(), StandardCharsets.UTF_8));
+			Assert.assertEquals(expectedContentType, request.getContentType());
 		}
 
-		Assert.assertNull(options.getFileParts());
-		Assert.assertEquals(expectedURL, options.getLocation());
-		Assert.assertEquals(expectedMethod, options.getMethod());
-		Assert.assertNull(options.getParts());
+		Assert.assertEquals(expectedMethod, request.getMethod());
+		Assert.assertEquals(expectedPathWithQuery, request.getPathWithQuery());
 	}
 
 	private void _testGetTool(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -505,7 +505,8 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 				TrashHandler.class,
 				new ObjectEntryTrashHandler(
 					objectDefinition, _objectDefinitionLocalService,
-					_objectEntryService, _systemEventLocalService),
+					_objectEntryLocalService, _objectEntryService,
+					_systemEventLocalService),
 				HashMapDictionaryBuilder.<String, Object>put(
 					"model.class.name", objectDefinition.getClassName()
 				).build()));

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/trash/ObjectEntryFolderTrashHandler.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/trash/ObjectEntryFolderTrashHandler.java
@@ -31,7 +31,7 @@ public class ObjectEntryFolderTrashHandler extends BaseTrashHandler {
 
 	@Override
 	public void deleteTrashEntry(long classPK) throws PortalException {
-		_objectEntryFolderService.deleteObjectEntryFolder(classPK);
+		_objectEntryFolderLocalService.deleteObjectEntryFolder(classPK);
 	}
 
 	@Override

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/trash/ObjectEntryTrashHandler.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/trash/ObjectEntryTrashHandler.java
@@ -8,6 +8,7 @@ package com.liferay.object.internal.trash;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectEntryService;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringPool;
@@ -30,11 +31,13 @@ public class ObjectEntryTrashHandler extends BaseTrashHandler {
 	public ObjectEntryTrashHandler(
 		ObjectDefinition objectDefinition,
 		ObjectDefinitionLocalService objectDefinitionLocalService,
+		ObjectEntryLocalService objectEntryLocalService,
 		ObjectEntryService objectEntryService,
 		SystemEventLocalService systemEventLocalService) {
 
 		_objectDefinition = objectDefinition;
 		_objectDefinitionLocalService = objectDefinitionLocalService;
+		_objectEntryLocalService = objectEntryLocalService;
 		_objectEntryService = objectEntryService;
 		_systemEventLocalService = systemEventLocalService;
 	}
@@ -55,7 +58,7 @@ public class ObjectEntryTrashHandler extends BaseTrashHandler {
 
 	@Override
 	public void deleteTrashEntry(long classPK) throws PortalException {
-		_objectEntryService.deleteObjectEntry(classPK);
+		_objectEntryLocalService.deleteObjectEntry(classPK);
 	}
 
 	@Override
@@ -100,6 +103,7 @@ public class ObjectEntryTrashHandler extends BaseTrashHandler {
 
 	private final ObjectDefinition _objectDefinition;
 	private final ObjectDefinitionLocalService _objectDefinitionLocalService;
+	private final ObjectEntryLocalService _objectEntryLocalService;
 	private final ObjectEntryService _objectEntryService;
 	private final SystemEventLocalService _systemEventLocalService;
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/trash/test/ObjectEntryFolderTrashHandlerTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/trash/test/ObjectEntryFolderTrashHandlerTest.java
@@ -1,0 +1,119 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.internal.trash.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.object.test.util.ObjectEntryFolderTestUtil;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.UserLocalServiceUtil;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.trash.model.TrashEntry;
+import com.liferay.trash.service.TrashEntryLocalServiceUtil;
+
+import java.util.Date;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alicia García
+ */
+@RunWith(Arquillian.class)
+public class ObjectEntryFolderTrashHandlerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	@TestInfo("LPD-91679")
+	public void testCheckEntries() throws Exception {
+		_testCheckEntriesWithPermissions();
+		_testCheckEntriesWithoutPermissions();
+	}
+
+	private ObjectEntryFolder _addExpiredTrashedObjectEntryFolder()
+		throws Exception {
+
+		ObjectEntryFolder objectEntryFolder =
+			ObjectEntryFolderTestUtil.addObjectEntryFolder();
+
+		_objectEntryFolderLocalService.moveObjectEntryFolderToTrash(
+			TestPropsValues.getUserId(), objectEntryFolder,
+			ServiceContextTestUtil.getServiceContext());
+
+		TrashEntry trashEntry = TrashEntryLocalServiceUtil.getEntry(
+			ObjectEntryFolder.class.getName(),
+			objectEntryFolder.getObjectEntryFolderId());
+
+		Date createDate = trashEntry.getCreateDate();
+
+		trashEntry.setCreateDate(new Date(createDate.getTime() - Time.YEAR));
+
+		TrashEntryLocalServiceUtil.updateTrashEntry(trashEntry);
+
+		return objectEntryFolder;
+	}
+
+	private void _testCheckEntriesWithoutPermissions() throws Exception {
+		ObjectEntryFolder objectEntryFolder =
+			_addExpiredTrashedObjectEntryFolder();
+
+		PermissionChecker originalPermissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		try {
+			PermissionThreadLocal.setPermissionChecker(
+				PermissionCheckerFactoryUtil.create(
+					UserLocalServiceUtil.getGuestUser(
+						TestPropsValues.getCompanyId())));
+
+			TrashEntryLocalServiceUtil.checkEntries();
+		}
+		finally {
+			PermissionThreadLocal.setPermissionChecker(
+				originalPermissionChecker);
+		}
+
+		Assert.assertNull(
+			TrashEntryLocalServiceUtil.fetchEntry(
+				ObjectEntryFolder.class.getName(),
+				objectEntryFolder.getObjectEntryFolderId()));
+	}
+
+	private void _testCheckEntriesWithPermissions() throws Exception {
+		ObjectEntryFolder objectEntryFolder =
+			_addExpiredTrashedObjectEntryFolder();
+
+		TrashEntryLocalServiceUtil.checkEntries();
+
+		Assert.assertNull(
+			TrashEntryLocalServiceUtil.fetchEntry(
+				ObjectEntryFolder.class.getName(),
+				objectEntryFolder.getObjectEntryFolderId()));
+	}
+
+	@Inject
+	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
+
+}

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/trash/test/ObjectEntryFolderTrashHandlerTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/trash/test/ObjectEntryFolderTrashHandlerTest.java
@@ -48,8 +48,8 @@ public class ObjectEntryFolderTrashHandlerTest {
 	@Test
 	@TestInfo("LPD-91679")
 	public void testCheckEntries() throws Exception {
-		_testCheckEntriesWithPermissions();
 		_testCheckEntriesWithoutPermissions();
+		_testCheckEntriesWithPermissions();
 	}
 
 	private ObjectEntryFolder _addExpiredTrashedObjectEntryFolder()

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/trash/test/ObjectEntryTrashHandlerTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/trash/test/ObjectEntryTrashHandlerTest.java
@@ -117,8 +117,8 @@ public class ObjectEntryTrashHandlerTest extends BaseTrashHandlerTestCase {
 	@Test
 	@TestInfo("LPD-91679")
 	public void testCheckEntries() throws Exception {
-		_testCheckEntriesWithPermissions();
 		_testCheckEntriesWithoutPermissions();
+		_testCheckEntriesWithPermissions();
 	}
 
 	@Override

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/trash/test/ObjectEntryTrashHandlerTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/trash/test/ObjectEntryTrashHandlerTest.java
@@ -20,8 +20,13 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.SystemEvent;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.TrashedModel;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.SystemEventLocalService;
+import com.liferay.portal.kernel.service.UserLocalServiceUtil;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -29,14 +34,18 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.trash.TrashHandler;
 import com.liferay.portal.kernel.trash.TrashHandlerRegistryUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.trash.TrashHelper;
+import com.liferay.trash.model.TrashEntry;
+import com.liferay.trash.service.TrashEntryLocalServiceUtil;
 import com.liferay.trash.test.util.BaseTrashHandlerTestCase;
 
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 
 import org.junit.Assert;
@@ -103,6 +112,13 @@ public class ObjectEntryTrashHandlerTest extends BaseTrashHandlerTestCase {
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 
 		_testAddDeletionSystemEvent(group.getGroupId(), (ObjectEntry)baseModel);
+	}
+
+	@Test
+	@TestInfo("LPD-91679")
+	public void testCheckEntries() throws Exception {
+		_testCheckEntriesWithPermissions();
+		_testCheckEntriesWithoutPermissions();
 	}
 
 	@Override
@@ -203,6 +219,27 @@ public class ObjectEntryTrashHandlerTest extends BaseTrashHandlerTestCase {
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 	}
 
+	private ObjectEntry _addExpiredTrashedObjectEntry() throws Exception {
+		baseModel = addBaseModel(
+			group,
+			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
+
+		long primaryKey = (Long)baseModel.getPrimaryKeyObj();
+
+		moveBaseModelToTrash(primaryKey);
+
+		TrashEntry trashEntry = TrashEntryLocalServiceUtil.getEntry(
+			_objectDefinition.getClassName(), primaryKey);
+
+		Date createDate = trashEntry.getCreateDate();
+
+		trashEntry.setCreateDate(new Date(createDate.getTime() - Time.YEAR));
+
+		TrashEntryLocalServiceUtil.updateTrashEntry(trashEntry);
+
+		return (ObjectEntry)baseModel;
+	}
+
 	private void _testAddDeletionSystemEvent(
 			long groupId, ObjectEntry objectEntry)
 		throws Exception {
@@ -226,6 +263,42 @@ public class ObjectEntryTrashHandlerTest extends BaseTrashHandlerTestCase {
 			systemEvent.getClassExternalReferenceCode());
 		Assert.assertEquals(
 			SystemEventConstants.TYPE_DELETE, systemEvent.getType());
+	}
+
+	private void _testCheckEntriesWithoutPermissions() throws Exception {
+		ObjectEntry objectEntry = _addExpiredTrashedObjectEntry();
+
+		PermissionChecker originalPermissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		try {
+			PermissionThreadLocal.setPermissionChecker(
+				PermissionCheckerFactoryUtil.create(
+					UserLocalServiceUtil.getGuestUser(
+						TestPropsValues.getCompanyId())));
+
+			TrashEntryLocalServiceUtil.checkEntries();
+		}
+		finally {
+			PermissionThreadLocal.setPermissionChecker(
+				originalPermissionChecker);
+		}
+
+		Assert.assertNull(
+			TrashEntryLocalServiceUtil.fetchEntry(
+				_objectDefinition.getClassName(),
+				objectEntry.getObjectEntryId()));
+	}
+
+	private void _testCheckEntriesWithPermissions() throws Exception {
+		ObjectEntry objectEntry = _addExpiredTrashedObjectEntry();
+
+		TrashEntryLocalServiceUtil.checkEntries();
+
+		Assert.assertNull(
+			TrashEntryLocalServiceUtil.fetchEntry(
+				_objectDefinition.getClassName(),
+				objectEntry.getObjectEntryId()));
 	}
 
 	private ObjectDefinition _objectDefinition;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92853

## What Is Being Fixed

ToolSetUtil invoked the underlying REST endpoint by calling HttpUtil.URLtoString against the same portal, so every MCP tool call issued outbound HTTP traffic that held an HTTP-client pool slot and a second Tomcat thread for its full duration. Under load this exhausts the connection pool and doubles the thread footprint of every call.

## How It Is Being Fixed

Dispatch now happens entirely in process through RequestDispatcher.forward, following the pattern already used by RESTClientTemplateContextContributor. A custom HttpServletRequestWrapper carries the per-tool method, path, content type, and body bytes, while a PipingServletResponse wrapped around a DummyHttpServletResponse subclass captures status, content type, and body, and multipart bodies are encoded inline in OpenAPIUtil instead of relying on Apache HttpClient. The wrapper extends PersistentHttpServletRequestWrapper and isolates request attributes so the in-process forward survives PortalImpl.getUploadServletRequest unwrapping the request on multipart calls and the Vulcan transaction filter inheriting the outer request's cleanup observer. An empty captured response body is normalized back to null so that a no-content response such as a 204 from a delete renders as "Status code: 204" rather than empty text, matching the previous HTTP-client contract.
