### PR TITLE
LPD-75473 Fix batch engine HSQLDB deadlock on concurrent task updates

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -9850,6 +9850,10 @@ ${output.content}</echo>
 		<run-playwright-js-test app.server.type="wildfly" database.type="mariadb" />
 	</target>
 
+	<target name="playwright-js-tomcat101-hypersonic20">
+		<run-playwright-js-test database.type="hypersonic" />
+	</target>
+
 	<target name="playwright-js-tomcat101-mysql84">
 		<run-playwright-js-test database.type="mysql" />
 	</target>

--- a/modules/.releng/test/jenkins-results-parser/artifact.properties
+++ b/modules/.releng/test/jenkins-results-parser/artifact.properties
@@ -1,3 +1,3 @@
-artifact.git.id=15d19aa0249a7207c38152f27b9c547119aff08b
-artifact.sources.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.jenkins.results.parser/1.0.1827/com.liferay.jenkins.results.parser-1.0.1827-sources.jar
-artifact.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.jenkins.results.parser/1.0.1827/com.liferay.jenkins.results.parser-1.0.1827.jar
+artifact.git.id=b8de1678f63c3ee5a8a2f1064de50675fac5e2b0
+artifact.sources.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.jenkins.results.parser/1.0.1828/com.liferay.jenkins.results.parser-1.0.1828-sources.jar
+artifact.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.jenkins.results.parser/1.0.1828/com.liferay.jenkins.results.parser-1.0.1828.jar

--- a/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/service/BatchEngineExportTaskLocalService.java
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/service/BatchEngineExportTaskLocalService.java
@@ -343,8 +343,9 @@ public interface BatchEngineExportTaskLocalService
 	 * @return the batch engine export task that was updated
 	 */
 	@Indexable(type = IndexableType.REINDEX)
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	public BatchEngineExportTask updateBatchEngineExportTask(
 		BatchEngineExportTask batchEngineExportTask);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:753350967
+// LIFERAY-SERVICE-BUILDER-HASH:-587742894

--- a/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/service/BatchEngineImportTaskLocalService.java
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/java/com/liferay/batch/engine/service/BatchEngineImportTaskLocalService.java
@@ -352,8 +352,9 @@ public interface BatchEngineImportTaskLocalService
 	 * @return the batch engine import task that was updated
 	 */
 	@Indexable(type = IndexableType.REINDEX)
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	public BatchEngineImportTask updateBatchEngineImportTask(
 		BatchEngineImportTask batchEngineImportTask);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-964169574
+// LIFERAY-SERVICE-BUILDER-HASH:1324455093

--- a/modules/apps/batch-engine/batch-engine-api/src/main/resources/com/liferay/batch/engine/service/packageinfo
+++ b/modules/apps/batch-engine/batch-engine-api/src/main/resources/com/liferay/batch/engine/service/packageinfo
@@ -1,1 +1,1 @@
-version 6.1.0
+version 6.1.1

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/service/impl/BatchEngineExportTaskLocalServiceImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/service/impl/BatchEngineExportTaskLocalServiceImpl.java
@@ -108,4 +108,12 @@ public class BatchEngineExportTaskLocalServiceImpl
 		return batchEngineExportTaskPersistence.countByCompanyId(companyId);
 	}
 
+	@Override
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public BatchEngineExportTask updateBatchEngineExportTask(
+		BatchEngineExportTask batchEngineExportTask) {
+
+		return super.updateBatchEngineExportTask(batchEngineExportTask);
+	}
+
 }

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/service/impl/BatchEngineImportTaskLocalServiceImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/service/impl/BatchEngineImportTaskLocalServiceImpl.java
@@ -156,6 +156,14 @@ public class BatchEngineImportTaskLocalServiceImpl
 		return batchEngineImportTaskPersistence.countByCompanyId(companyId);
 	}
 
+	@Override
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public BatchEngineImportTask updateBatchEngineImportTask(
+		BatchEngineImportTask batchEngineImportTask) {
+
+		return super.updateBatchEngineImportTask(batchEngineImportTask);
+	}
+
 	private void _validateDelimiter(String delimiter)
 		throws BatchEngineImportTaskParametersException {
 

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BaseBatchEngineTaskServiceTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BaseBatchEngineTaskServiceTest.java
@@ -61,30 +61,30 @@ public class BaseBatchEngineTaskServiceTest {
 	}
 
 	protected void assertConcurrentRunnables(
-			CheckedRunnable runnable1, CheckedRunnable runnable2)
+			CheckedRunnable checkedRunnable1, CheckedRunnable checkedRunnable2)
 		throws Exception {
 
-		AtomicReference<Throwable> throwableReference = new AtomicReference<>();
+		AtomicReference<Throwable> atomicReference = new AtomicReference<>();
 
 		ExecutorService executorService = Executors.newFixedThreadPool(2);
 
 		Future<?> future1 = executorService.submit(
 			() -> {
 				try {
-					runnable1.run();
+					checkedRunnable1.run();
 				}
 				catch (Throwable throwable) {
-					throwableReference.compareAndSet(null, throwable);
+					atomicReference.compareAndSet(null, throwable);
 				}
 			});
 
 		Future<?> future2 = executorService.submit(
 			() -> {
 				try {
-					runnable2.run();
+					checkedRunnable2.run();
 				}
 				catch (Throwable throwable) {
-					throwableReference.compareAndSet(null, throwable);
+					atomicReference.compareAndSet(null, throwable);
 				}
 			});
 
@@ -102,7 +102,7 @@ public class BaseBatchEngineTaskServiceTest {
 			executorService.shutdownNow();
 		}
 
-		Assert.assertNull(throwableReference.get());
+		Assert.assertNull(atomicReference.get());
 	}
 
 	protected static final TransactionConfig REQUIRED_TRANSACTION_CONFIG =

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BaseBatchEngineTaskServiceTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BaseBatchEngineTaskServiceTest.java
@@ -12,10 +12,20 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.transaction.Propagation;
+import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -50,10 +60,66 @@ public class BaseBatchEngineTaskServiceTest {
 		CompanyLocalServiceUtil.deleteCompany(company);
 	}
 
+	protected void assertConcurrentRunnables(
+			CheckedRunnable runnable1, CheckedRunnable runnable2)
+		throws Exception {
+
+		AtomicReference<Throwable> throwableReference = new AtomicReference<>();
+
+		ExecutorService executorService = Executors.newFixedThreadPool(2);
+
+		Future<?> future1 = executorService.submit(
+			() -> {
+				try {
+					runnable1.run();
+				}
+				catch (Throwable throwable) {
+					throwableReference.compareAndSet(null, throwable);
+				}
+			});
+
+		Future<?> future2 = executorService.submit(
+			() -> {
+				try {
+					runnable2.run();
+				}
+				catch (Throwable throwable) {
+					throwableReference.compareAndSet(null, throwable);
+				}
+			});
+
+		try {
+			future1.get(10, TimeUnit.SECONDS);
+			future2.get(10, TimeUnit.SECONDS);
+		}
+		catch (TimeoutException timeoutException) {
+			throw new AssertionError(timeoutException);
+		}
+		finally {
+			future1.cancel(true);
+			future2.cancel(true);
+
+			executorService.shutdownNow();
+		}
+
+		Assert.assertNull(throwableReference.get());
+	}
+
+	protected static final TransactionConfig REQUIRED_TRANSACTION_CONFIG =
+		TransactionConfig.Factory.create(
+			Propagation.REQUIRED, new Class<?>[] {Exception.class});
+
 	protected static Company company;
 	protected static User companyAdminUser;
 	protected static Company defaultCompany;
 	protected static User omniadminUser;
 	protected static User user;
+
+	@FunctionalInterface
+	protected interface CheckedRunnable {
+
+		public void run() throws Throwable;
+
+	}
 
 }

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BaseBatchEngineTaskServiceTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BaseBatchEngineTaskServiceTest.java
@@ -15,6 +15,7 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -42,6 +43,11 @@ public class BaseBatchEngineTaskServiceTest {
 		companyAdminUser = UserTestUtil.addCompanyAdminUser(company);
 
 		user = UserTestUtil.addUser(company);
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		CompanyLocalServiceUtil.deleteCompany(company);
 	}
 
 	protected static Company company;

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BatchEngineExportTaskServiceTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BatchEngineExportTaskServiceTest.java
@@ -274,13 +274,13 @@ public class BatchEngineExportTaskServiceTest
 			_batchEngineExportTaskLocalService.addBatchEngineExportTask(
 				null, omniadminUser.getCompanyId(), omniadminUser.getUserId(),
 				null, BlogPosting.class.getName(), "JSON",
-				BatchEngineTaskExecuteStatus.COMPLETED.name(),
+				BatchEngineTaskExecuteStatus.INITIAL.name(),
 				Collections.emptyList(), null, null);
 		BatchEngineExportTask batchEngineExportTask2 =
 			_batchEngineExportTaskLocalService.addBatchEngineExportTask(
 				null, omniadminUser.getCompanyId(), omniadminUser.getUserId(),
 				null, BlogPosting.class.getName(), "JSON",
-				BatchEngineTaskExecuteStatus.COMPLETED.name(),
+				BatchEngineTaskExecuteStatus.INITIAL.name(),
 				Collections.emptyList(), null, null);
 
 		CountDownLatch countDownLatch1 = new CountDownLatch(1);

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BatchEngineExportTaskServiceTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BatchEngineExportTaskServiceTest.java
@@ -17,6 +17,7 @@ import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.test.rule.Inject;
 
@@ -24,6 +25,7 @@ import java.io.Serializable;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 
 import org.hamcrest.CoreMatchers;
 
@@ -266,13 +268,70 @@ public class BatchEngineExportTaskServiceTest
 				QueryUtil.ALL_POS));
 	}
 
+	@Test
+	public void testUpdateBatchEngineExportTask() throws Exception {
+		BatchEngineExportTask batchEngineExportTask1 =
+			_batchEngineExportTaskLocalService.addBatchEngineExportTask(
+				null, omniadminUser.getCompanyId(), omniadminUser.getUserId(),
+				null, BlogPosting.class.getName(), "JSON",
+				BatchEngineTaskExecuteStatus.COMPLETED.name(),
+				Collections.emptyList(), null, null);
+		BatchEngineExportTask batchEngineExportTask2 =
+			_batchEngineExportTaskLocalService.addBatchEngineExportTask(
+				null, omniadminUser.getCompanyId(), omniadminUser.getUserId(),
+				null, BlogPosting.class.getName(), "JSON",
+				BatchEngineTaskExecuteStatus.COMPLETED.name(),
+				Collections.emptyList(), null, null);
+
+		CountDownLatch countDownLatch1 = new CountDownLatch(1);
+		CountDownLatch countDownLatch2 = new CountDownLatch(1);
+
+		assertConcurrentRunnables(
+			() -> TransactionInvokerUtil.invoke(
+				REQUIRED_TRANSACTION_CONFIG,
+				() -> {
+					batchEngineExportTask1.setExecuteStatus(
+						BatchEngineTaskExecuteStatus.COMPLETED.name());
+
+					_batchEngineExportTaskLocalService.
+						updateBatchEngineExportTask(batchEngineExportTask1);
+
+					countDownLatch1.countDown();
+
+					countDownLatch2.await();
+
+					return null;
+				}),
+			() -> {
+				countDownLatch1.await();
+
+				try {
+					TransactionInvokerUtil.invoke(
+						REQUIRED_TRANSACTION_CONFIG,
+						() -> {
+							batchEngineExportTask2.setExecuteStatus(
+								BatchEngineTaskExecuteStatus.COMPLETED.name());
+
+							_batchEngineExportTaskLocalService.
+								updateBatchEngineExportTask(
+									batchEngineExportTask2);
+
+							return null;
+						});
+				}
+				finally {
+					countDownLatch2.countDown();
+				}
+			});
+	}
+
 	private BatchEngineExportTask _addBatchEngineExportTask(User user)
 		throws Exception {
 
 		return _batchEngineExportTaskLocalService.addBatchEngineExportTask(
 			null, user.getCompanyId(), user.getUserId(), null,
 			BlogPosting.class.getName(), "JSON",
-			BatchEngineTaskExecuteStatus.INITIAL.name(),
+			BatchEngineTaskExecuteStatus.COMPLETED.name(),
 			Collections.emptyList(),
 			HashMapBuilder.<String, Serializable>put(
 				"siteId", TestPropsValues.getGroupId()

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BatchEngineImportTaskServiceTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BatchEngineImportTaskServiceTest.java
@@ -266,14 +266,14 @@ public class BatchEngineImportTaskServiceTest
 			_batchEngineImportTaskLocalService.addBatchEngineImportTask(
 				null, omniadminUser.getCompanyId(), omniadminUser.getUserId(),
 				10, null, BlogPosting.class.getName(), new byte[0], "JSON",
-				BatchEngineTaskExecuteStatus.COMPLETED.name(), null,
+				BatchEngineTaskExecuteStatus.INITIAL.name(), null,
 				BatchEngineImportTaskConstants.IMPORT_STRATEGY_ON_ERROR_FAIL,
 				BatchEngineTaskOperation.CREATE.name(), new HashMap<>(), null);
 		BatchEngineImportTask batchEngineImportTask2 =
 			_batchEngineImportTaskLocalService.addBatchEngineImportTask(
 				null, omniadminUser.getCompanyId(), omniadminUser.getUserId(),
 				10, null, BlogPosting.class.getName(), new byte[0], "JSON",
-				BatchEngineTaskExecuteStatus.COMPLETED.name(), null,
+				BatchEngineTaskExecuteStatus.INITIAL.name(), null,
 				BatchEngineImportTaskConstants.IMPORT_STRATEGY_ON_ERROR_FAIL,
 				BatchEngineTaskOperation.CREATE.name(), new HashMap<>(), null);
 

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BatchEngineImportTaskServiceTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BatchEngineImportTaskServiceTest.java
@@ -18,10 +18,12 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
 import com.liferay.portal.test.rule.Inject;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 
 import org.hamcrest.CoreMatchers;
 
@@ -258,13 +260,72 @@ public class BatchEngineImportTaskServiceTest
 				QueryUtil.ALL_POS));
 	}
 
+	@Test
+	public void testUpdateBatchEngineImportTask() throws Exception {
+		BatchEngineImportTask batchEngineImportTask1 =
+			_batchEngineImportTaskLocalService.addBatchEngineImportTask(
+				null, omniadminUser.getCompanyId(), omniadminUser.getUserId(),
+				10, null, BlogPosting.class.getName(), new byte[0], "JSON",
+				BatchEngineTaskExecuteStatus.COMPLETED.name(), null,
+				BatchEngineImportTaskConstants.IMPORT_STRATEGY_ON_ERROR_FAIL,
+				BatchEngineTaskOperation.CREATE.name(), new HashMap<>(), null);
+		BatchEngineImportTask batchEngineImportTask2 =
+			_batchEngineImportTaskLocalService.addBatchEngineImportTask(
+				null, omniadminUser.getCompanyId(), omniadminUser.getUserId(),
+				10, null, BlogPosting.class.getName(), new byte[0], "JSON",
+				BatchEngineTaskExecuteStatus.COMPLETED.name(), null,
+				BatchEngineImportTaskConstants.IMPORT_STRATEGY_ON_ERROR_FAIL,
+				BatchEngineTaskOperation.CREATE.name(), new HashMap<>(), null);
+
+		CountDownLatch countDownLatch1 = new CountDownLatch(1);
+		CountDownLatch countDownLatch2 = new CountDownLatch(1);
+
+		assertConcurrentRunnables(
+			() -> TransactionInvokerUtil.invoke(
+				REQUIRED_TRANSACTION_CONFIG,
+				() -> {
+					batchEngineImportTask1.setExecuteStatus(
+						BatchEngineTaskExecuteStatus.COMPLETED.name());
+
+					_batchEngineImportTaskLocalService.
+						updateBatchEngineImportTask(batchEngineImportTask1);
+
+					countDownLatch1.countDown();
+
+					countDownLatch2.await();
+
+					return null;
+				}),
+			() -> {
+				countDownLatch1.await();
+
+				try {
+					TransactionInvokerUtil.invoke(
+						REQUIRED_TRANSACTION_CONFIG,
+						() -> {
+							batchEngineImportTask2.setExecuteStatus(
+								BatchEngineTaskExecuteStatus.COMPLETED.name());
+
+							_batchEngineImportTaskLocalService.
+								updateBatchEngineImportTask(
+									batchEngineImportTask2);
+
+							return null;
+						});
+				}
+				finally {
+					countDownLatch2.countDown();
+				}
+			});
+	}
+
 	private BatchEngineImportTask _addBatchEngineImportTask(User user)
 		throws Exception {
 
 		return _batchEngineImportTaskLocalService.addBatchEngineImportTask(
 			null, user.getCompanyId(), user.getUserId(), 10, null,
 			BlogPosting.class.getName(), new byte[0], "JSON",
-			BatchEngineTaskExecuteStatus.INITIAL.name(), null,
+			BatchEngineTaskExecuteStatus.COMPLETED.name(), null,
 			BatchEngineImportTaskConstants.IMPORT_STRATEGY_ON_ERROR_FAIL,
 			BatchEngineTaskOperation.CREATE.name(), new HashMap<>(), null);
 	}

--- a/modules/apps/batch-engine/test.properties
+++ b/modules/apps/batch-engine/test.properties
@@ -6,6 +6,10 @@ modified.files.includes[relevant][batch-engine-java-rule]=\
 modules.includes.required.test.batch.class.names.includes[batch-engine-java-rule][relevant][modules-integration-db-partition-postgresql163]=\
     apps/batch-engine/**/BatchEngineUnitProcessorImplDBPartitionTest.java
 
+modules.includes.required.test.batch.class.names.includes[modules-integration-hypersonic20][relevant][batch-engine-java-rule]=\
+    apps/batch-engine/**/BatchEngineExportTaskServiceTest.java,\
+    apps/batch-engine/**/BatchEngineImportTaskServiceTest.java
+
 modules.includes.required.test.batch.class.names.includes[modules-integration-postgresql163][relevant][batch-engine-java-rule]=\
     apps/batch-engine/**/*Test.java,\
     util/portal-tools-rest-builder-test-test/**/exportimport/test/*Test.java
@@ -17,6 +21,7 @@ relevant.rule.names=batch-engine-java-rule
 
 test.batch.names[relevant][batch-engine-java-rule]=\
     modules-integration-db-partition-postgresql163,\
+    modules-integration-hypersonic20,\
     modules-integration-postgresql163,\
     modules-unit
 

--- a/modules/apps/site/site-api/src/main/java/com/liferay/site/manager/SitemapManager.java
+++ b/modules/apps/site/site-api/src/main/java/com/liferay/site/manager/SitemapManager.java
@@ -11,6 +11,8 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.xml.Element;
 
+import java.io.InputStream;
+
 import java.util.Date;
 import java.util.Locale;
 import java.util.Map;
@@ -62,6 +64,11 @@ public interface SitemapManager {
 	public String getSitemap(
 			String assetType, String layoutUuid, long groupId,
 			boolean privateLayout, ThemeDisplay themeDisplay)
+		throws PortalException;
+
+	public InputStream getSitemapInputStream(
+			String assetTypeKey, String layoutUuid, long groupId,
+			boolean privateLayout, ThemeDisplay themeDisplay, int page)
 		throws PortalException;
 
 }

--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/manager/SitemapManagerImpl.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/manager/SitemapManagerImpl.java
@@ -51,6 +51,12 @@ import com.liferay.site.configuration.manager.SitemapConfigurationManager;
 import com.liferay.site.constants.SitemapConstants;
 import com.liferay.site.manager.SitemapManager;
 import com.liferay.site.provider.SitemapURLProvider;
+import com.liferay.site.storage.helper.SitemapStorageHelper;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import java.nio.charset.StandardCharsets;
 
 import java.text.DateFormat;
 
@@ -283,6 +289,47 @@ public class SitemapManagerImpl implements SitemapManager {
 		return _getSitemap(layoutUuid, groupId, privateLayout, themeDisplay);
 	}
 
+	@Override
+	public InputStream getSitemapInputStream(
+			String assetTypeKey, String layoutUuid, long groupId,
+			boolean privateLayout, ThemeDisplay themeDisplay, int page)
+		throws PortalException {
+
+		long companyId = themeDisplay.getCompanyId();
+
+		if (_sitemapConfigurationManager.xmlSitemapIndexCompanyEnabled(
+				companyId) &&
+			StringUtil.equals(
+				_sitemapConfigurationManager.xmlSitemapIndexMode(companyId),
+				SitemapConstants.INDEX_MODE_ASSET_TYPE)) {
+
+			try {
+				if (assetTypeKey == null) {
+					return _sitemapStorageHelper.getSitemapInputStream(
+						companyId, groupId);
+				}
+
+				return _sitemapStorageHelper.getSitemapInputStream(
+					companyId, groupId, assetTypeKey, page);
+			}
+			catch (PortalException portalException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(portalException);
+				}
+			}
+		}
+
+		String xml = getSitemap(
+			getAssetTypeClassName(assetTypeKey), layoutUuid, groupId,
+			privateLayout, themeDisplay);
+
+		if (xml == null) {
+			return null;
+		}
+
+		return new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
+	}
+
 	@Activate
 	protected void activate(BundleContext bundleContext) {
 		_serviceTrackerMap = ServiceTrackerMapFactory.openSingleValueMap(
@@ -359,7 +406,20 @@ public class SitemapManagerImpl implements SitemapManager {
 
 		_removeEntriesAndSize(rootElement);
 
-		return document.asXML();
+		String xml = document.asXML();
+
+		try {
+			_sitemapStorageHelper.storeSitemapFile(
+				themeDisplay.getCompanyId(), groupId,
+				_assetTypeKeys.get(assetType), 1, xml);
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(exception);
+			}
+		}
+
+		return xml;
 	}
 
 	private String _getFriendlyURL(String path, long groupId) {
@@ -429,10 +489,12 @@ public class SitemapManagerImpl implements SitemapManager {
 
 		_initEntriesAndSize(rootElement);
 
+		String xmlSitemapIndexMode =
+			_sitemapConfigurationManager.xmlSitemapIndexMode(
+				themeDisplay.getCompanyId());
+
 		if (StringUtil.equals(
-				_sitemapConfigurationManager.xmlSitemapIndexMode(
-					themeDisplay.getCompanyId()),
-				SitemapConstants.INDEX_MODE_ASSET_TYPE)) {
+				xmlSitemapIndexMode, SitemapConstants.INDEX_MODE_ASSET_TYPE)) {
 
 			String portalURL = themeDisplay.getPortalURL();
 
@@ -484,7 +546,23 @@ public class SitemapManagerImpl implements SitemapManager {
 
 		_removeEntriesAndSize(rootElement);
 
-		return document.asXML();
+		String xml = document.asXML();
+
+		if (StringUtil.equals(
+				xmlSitemapIndexMode, SitemapConstants.INDEX_MODE_ASSET_TYPE)) {
+
+			try {
+				_sitemapStorageHelper.storeSitemapFile(
+					themeDisplay.getCompanyId(), groupId, xml);
+			}
+			catch (Exception exception) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(exception);
+				}
+			}
+		}
+
+		return xml;
 	}
 
 	private List<LayoutSet> _getLayoutSets(
@@ -828,5 +906,8 @@ public class SitemapManagerImpl implements SitemapManager {
 
 	@Reference
 	private SitemapConfigurationManager _sitemapConfigurationManager;
+
+	@Reference
+	private SitemapStorageHelper _sitemapStorageHelper;
 
 }

--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/struts/SitemapStrutsAction.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/struts/SitemapStrutsAction.java
@@ -5,7 +5,6 @@
 
 package com.liferay.site.internal.struts;
 
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.NoSuchLayoutSetException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -32,6 +31,8 @@ import com.liferay.site.manager.SitemapManager;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.InputStream;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -112,35 +113,26 @@ public class SitemapStrutsAction implements StrutsAction {
 			Group currentGroup = _groupLocalService.getGroup(
 				layoutSet.getGroupId());
 
-			if (currentGroup.isActive()) {
-				String assetTypeKey = ParamUtil.getString(
-					httpServletRequest, "assetTypeKey");
-
-				String assetTypeClassName =
-					_sitemapManager.getAssetTypeClassName(assetTypeKey);
-
-				String layoutUuid = ParamUtil.getString(
-					httpServletRequest, "layoutUuid");
-
-				String sitemap = _sitemapManager.getSitemap(
-					assetTypeClassName, layoutUuid, layoutSet.getGroupId(),
-					layoutSet.isPrivateLayout(), themeDisplay);
-
-				if (sitemap == null) {
-					httpServletResponse.sendError(
-						HttpServletResponse.SC_NOT_FOUND);
-
-					return null;
-				}
-
-				ServletResponseUtil.sendFile(
-					httpServletRequest, httpServletResponse, null,
-					sitemap.getBytes(StringPool.UTF8),
-					ContentTypes.TEXT_XML_UTF8);
-			}
-			else {
+			if (!currentGroup.isActive()) {
 				throw new NoSuchLayoutSetException();
 			}
+
+			InputStream inputStream = _sitemapManager.getSitemapInputStream(
+				ParamUtil.getString(httpServletRequest, "assetTypeKey"),
+				ParamUtil.getString(httpServletRequest, "layoutUuid"),
+				layoutSet.getGroupId(), layoutSet.isPrivateLayout(),
+				themeDisplay,
+				ParamUtil.getInteger(httpServletRequest, "page", 1));
+
+			if (inputStream == null) {
+				httpServletResponse.sendError(HttpServletResponse.SC_NOT_FOUND);
+
+				return null;
+			}
+
+			ServletResponseUtil.sendFile(
+				httpServletRequest, httpServletResponse, null, inputStream,
+				ContentTypes.TEXT_XML_UTF8);
 		}
 		catch (NoSuchLayoutSetException noSuchLayoutSetException) {
 			_portal.sendError(

--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/internal/struts/test/SitemapStrutsActionTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/internal/struts/test/SitemapStrutsActionTest.java
@@ -6,25 +6,60 @@
 package com.liferay.site.internal.struts.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.display.page.constants.AssetDisplayPageConstants;
+import com.liferay.asset.display.page.service.AssetDisplayPageEntryLocalService;
+import com.liferay.journal.constants.JournalArticleConstants;
+import com.liferay.journal.constants.JournalFolderConstants;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.test.util.JournalTestUtil;
+import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
+import com.liferay.layout.page.template.test.util.DisplayPageTemplateTestUtil;
+import com.liferay.layout.test.util.ContentLayoutTestUtil;
+import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.VirtualHostLocalService;
 import com.liferay.portal.kernel.struts.StrutsAction;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.TreeMapBuilder;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.kernel.xml.Document;
+import com.liferay.portal.kernel.xml.Element;
+import com.liferay.portal.kernel.xml.SAXReader;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.site.constants.SitemapConstants;
+import com.liferay.site.manager.SitemapManager;
+import com.liferay.site.storage.helper.SitemapStorageHelper;
 
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -42,7 +77,48 @@ public class SitemapStrutsActionTest {
 	@ClassRule
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
-		new LiferayIntegrationTestRule();
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_companyConfigurationTemporarySwapper =
+			new CompanyConfigurationTemporarySwapper(
+				TestPropsValues.getCompanyId(),
+				_PID_SITEMAP_COMPANY_CONFIGURATION,
+				HashMapDictionaryBuilder.<String, Object>put(
+					"xmlSitemapIndexEnabled", true
+				).build());
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		_companyConfigurationTemporarySwapper.close();
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		_company = _companyLocalService.getCompany(
+			TestPropsValues.getCompanyId());
+
+		_group = GroupTestUtil.addGroup();
+
+		_layout = LayoutTestUtil.addTypePortletLayout(_group);
+
+		_serviceContext = ServiceContextTestUtil.getServiceContext(
+			_group.getGroupId());
+
+		_setUpThemeDisplay();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		if (_group != null) {
+			_sitemapStorageHelper.deleteSitemaps(
+				TestPropsValues.getCompanyId(), _group.getGroupId());
+		}
+	}
 
 	@Test
 	public void testExecute() throws Exception {
@@ -69,12 +145,9 @@ public class SitemapStrutsActionTest {
 
 		ThemeDisplay themeDisplay = new ThemeDisplay();
 
-		Company company = _companyLocalService.getCompany(
-			TestPropsValues.getCompanyId());
-
-		themeDisplay.setCompany(company);
+		themeDisplay.setCompany(_company);
 		themeDisplay.setPermissionChecker(
-			PermissionCheckerFactoryUtil.create(company.getGuestUser()));
+			PermissionCheckerFactoryUtil.create(_company.getGuestUser()));
 
 		mockHttpServletRequest.setAttribute(
 			WebKeys.THEME_DISPLAY, themeDisplay);
@@ -101,13 +174,249 @@ public class SitemapStrutsActionTest {
 		Assert.assertEquals(200, mockHttpServletResponse.getStatus());
 	}
 
+	@Test
+	public void testExecuteReturnsSitemapIndexXMLFromDLStore()
+		throws Exception {
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						_PID_SITEMAP_COMPANY_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"xmlSitemapIndexEnabled", true
+						).put(
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
+						).build())) {
+
+			MockHttpServletResponse mockHttpServletResponse = _executeRequest(
+				null, null);
+
+			Assert.assertEquals(200, mockHttpServletResponse.getStatus());
+
+			Document document = _saxReader.read(
+				mockHttpServletResponse.getContentAsString());
+
+			Element rootElement = document.getRootElement();
+
+			Assert.assertEquals("sitemapindex", rootElement.getName());
+
+			List<Element> elements = rootElement.elements();
+
+			Assert.assertFalse(elements.isEmpty());
+
+			Assert.assertTrue(
+				_sitemapStorageHelper.hasSitemapFile(
+					TestPropsValues.getCompanyId(), _group.getGroupId()));
+		}
+	}
+
+	@Test
+	public void testExecuteReturnsWebContentSitemapXMLFromDLStore()
+		throws Exception {
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						_PID_SITEMAP_COMPANY_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"xmlSitemapIndexEnabled", true
+						).put(
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
+						).build())) {
+
+			_addJournalArticleAssetDisplayPageEntry(_addJournalArticle());
+
+			Map<String, String> assetTypeKeys =
+				_sitemapManager.getAssetTypeKeys();
+
+			MockHttpServletResponse mockHttpServletResponse = _executeRequest(
+				assetTypeKeys.get(JournalArticle.class.getName()), null);
+
+			Assert.assertEquals(200, mockHttpServletResponse.getStatus());
+
+			Document document = _saxReader.read(
+				mockHttpServletResponse.getContentAsString());
+
+			Element rootElement = document.getRootElement();
+
+			Assert.assertEquals("urlset", rootElement.getName());
+
+			List<Element> elements = rootElement.elements();
+
+			Assert.assertFalse(elements.isEmpty());
+
+			Assert.assertTrue(
+				_sitemapStorageHelper.hasSitemapFile(
+					TestPropsValues.getCompanyId(), _group.getGroupId(),
+					"web-content", 1));
+		}
+	}
+
+	@Test
+	public void testExecuteWithIndexDisabledDoesNotStore() throws Exception {
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						_PID_SITEMAP_COMPANY_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"xmlSitemapIndexEnabled", false
+						).build())) {
+
+			MockHttpServletResponse mockHttpServletResponse = _executeRequest(
+				null, null);
+
+			Assert.assertEquals(200, mockHttpServletResponse.getStatus());
+
+			Assert.assertFalse(
+				_sitemapStorageHelper.hasSitemapFile(
+					TestPropsValues.getCompanyId(), _group.getGroupId()));
+		}
+	}
+
+	@Test
+	public void testExecuteWithPageLayoutModeDoesNotStore() throws Exception {
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						_PID_SITEMAP_COMPANY_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"xmlSitemapIndexEnabled", true
+						).put(
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_PAGE_LAYOUT
+						).build())) {
+
+			MockHttpServletResponse mockHttpServletResponse = _executeRequest(
+				null, _layout.getUuid());
+
+			Assert.assertEquals(200, mockHttpServletResponse.getStatus());
+
+			Assert.assertFalse(
+				_sitemapStorageHelper.hasSitemapFile(
+					TestPropsValues.getCompanyId(), _group.getGroupId()));
+		}
+	}
+
+	private JournalArticle _addJournalArticle() throws Exception {
+		Locale locale = LocaleUtil.getSiteDefault();
+
+		return JournalTestUtil.addArticle(
+			_group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			JournalArticleConstants.CLASS_NAME_ID_DEFAULT, StringPool.BLANK,
+			true, RandomTestUtil.randomLocaleStringMap(locale),
+			RandomTestUtil.randomLocaleStringMap(locale),
+			RandomTestUtil.randomLocaleStringMap(locale), null, locale, null,
+			false, false, _serviceContext);
+	}
+
+	private void _addJournalArticleAssetDisplayPageEntry(
+			JournalArticle journalArticle)
+		throws Exception {
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			DisplayPageTemplateTestUtil.addDisplayPageTemplate(
+				_group.getGroupId(),
+				_portal.getClassNameId(JournalArticle.class.getName()),
+				journalArticle.getDDMStructureKey(), true,
+				WorkflowConstants.STATUS_APPROVED);
+
+		_assetDisplayPageEntryLocalService.addAssetDisplayPageEntry(
+			TestPropsValues.getUserId(), _group.getGroupId(),
+			_portal.getClassNameId(JournalArticle.class.getName()),
+			journalArticle.getResourcePrimKey(),
+			layoutPageTemplateEntry.getLayoutPageTemplateEntryId(),
+			AssetDisplayPageConstants.TYPE_SPECIFIC, _serviceContext);
+	}
+
+	private MockHttpServletResponse _executeRequest(
+			String assetTypeKey, String layoutUuid)
+		throws Exception {
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(WebKeys.LAYOUT, _layout);
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _themeDisplay);
+		mockHttpServletRequest.setParameter(
+			"groupId", String.valueOf(_group.getGroupId()));
+
+		_themeDisplay.setRequest(mockHttpServletRequest);
+
+		if (assetTypeKey != null) {
+			mockHttpServletRequest.setParameter("assetTypeKey", assetTypeKey);
+		}
+
+		if (layoutUuid != null) {
+			mockHttpServletRequest.setParameter("layoutUuid", layoutUuid);
+		}
+
+		MockHttpServletResponse mockHttpServletResponse =
+			new MockHttpServletResponse();
+
+		_sitemapStrutsAction.execute(
+			mockHttpServletRequest, mockHttpServletResponse);
+
+		return mockHttpServletResponse;
+	}
+
+	private void _setUpThemeDisplay() throws Exception {
+		_themeDisplay = ContentLayoutTestUtil.getThemeDisplay(
+			_company, _group, _layout);
+
+		_themeDisplay.setPortalDomain(_company.getVirtualHostname());
+		_themeDisplay.setPortalURL(_company.getPortalURL(_group.getGroupId()));
+		_themeDisplay.setServerName(_company.getVirtualHostname());
+		_themeDisplay.setServerPort(8080);
+	}
+
+	private static final String _PID_SITEMAP_COMPANY_CONFIGURATION =
+		"com.liferay.site.internal.configuration.SitemapCompanyConfiguration";
+
+	private static CompanyConfigurationTemporarySwapper
+		_companyConfigurationTemporarySwapper;
+
+	@Inject
+	private AssetDisplayPageEntryLocalService
+		_assetDisplayPageEntryLocalService;
+
+	private Company _company;
+
 	@Inject
 	private CompanyLocalService _companyLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	private Layout _layout;
+
+	@Inject
+	private Portal _portal;
+
+	@Inject
+	private SAXReader _saxReader;
+
+	private ServiceContext _serviceContext;
+
+	@Inject
+	private SitemapManager _sitemapManager;
+
+	@Inject
+	private SitemapStorageHelper _sitemapStorageHelper;
 
 	@Inject(
 		filter = "component.name=com.liferay.site.internal.struts.SitemapStrutsAction"
 	)
 	private StrutsAction _sitemapStrutsAction;
+
+	private ThemeDisplay _themeDisplay;
 
 	@Inject
 	private VirtualHostLocalService _virtualHostLocalService;

--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/manager/test/SitemapManagerTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/manager/test/SitemapManagerTest.java
@@ -88,7 +88,9 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 import com.liferay.redirect.model.RedirectEntry;
 import com.liferay.redirect.service.RedirectEntryLocalService;
+import com.liferay.site.constants.SitemapConstants;
 import com.liferay.site.manager.SitemapManager;
+import com.liferay.site.storage.helper.SitemapStorageHelper;
 import com.liferay.translation.info.item.provider.InfoItemLanguagesProvider;
 
 import java.io.Serializable;
@@ -106,6 +108,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
@@ -159,6 +162,14 @@ public class SitemapManagerTest {
 			_group.getGroupId());
 
 		_setUpThemeDisplay();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		if (_group != null) {
+			_sitemapStorageHelper.deleteSitemaps(
+				TestPropsValues.getCompanyId(), _group.getGroupId());
+		}
 	}
 
 	@Test
@@ -336,7 +347,8 @@ public class SitemapManagerTest {
 						).put(
 							"xmlSitemapIndexEnabled", true
 						).put(
-							"xmlSitemapIndexMode", _INDEX_MODE_ASSET_TYPE
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
 						).build())) {
 
 			ObjectEntry includedObjectEntry = _addObjectEntry(
@@ -387,7 +399,8 @@ public class SitemapManagerTest {
 						).put(
 							"xmlSitemapIndexEnabled", true
 						).put(
-							"xmlSitemapIndexMode", _INDEX_MODE_ASSET_TYPE
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
 						).build())) {
 
 			JournalArticle journalArticle = _addJournalArticle();
@@ -412,7 +425,8 @@ public class SitemapManagerTest {
 						HashMapDictionaryBuilder.<String, Object>put(
 							"xmlSitemapIndexEnabled", true
 						).put(
-							"xmlSitemapIndexMode", _INDEX_MODE_ASSET_TYPE
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
 						).build())) {
 
 			JournalArticle journalArticle = _addJournalArticle();
@@ -1164,7 +1178,8 @@ public class SitemapManagerTest {
 						HashMapDictionaryBuilder.<String, Object>put(
 							"xmlSitemapIndexEnabled", true
 						).put(
-							"xmlSitemapIndexMode", _INDEX_MODE_ASSET_TYPE
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
 						).build())) {
 
 			List<String> urls = new ArrayList<>();
@@ -1202,7 +1217,8 @@ public class SitemapManagerTest {
 						HashMapDictionaryBuilder.<String, Object>put(
 							"xmlSitemapIndexEnabled", true
 						).put(
-							"xmlSitemapIndexMode", _INDEX_MODE_ASSET_TYPE
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
 						).build())) {
 
 			JournalArticle journalArticle = _addJournalArticle();
@@ -1251,7 +1267,8 @@ public class SitemapManagerTest {
 						).put(
 							"xmlSitemapIndexEnabled", true
 						).put(
-							"xmlSitemapIndexMode", _INDEX_MODE_ASSET_TYPE
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
 						).build())) {
 
 			_assertSitemap(
@@ -1272,7 +1289,8 @@ public class SitemapManagerTest {
 						).put(
 							"xmlSitemapIndexEnabled", true
 						).put(
-							"xmlSitemapIndexMode", _INDEX_MODE_ASSET_TYPE
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
 						).build())) {
 
 			_assertSitemap(
@@ -1290,7 +1308,8 @@ public class SitemapManagerTest {
 						).put(
 							"xmlSitemapIndexEnabled", true
 						).put(
-							"xmlSitemapIndexMode", _INDEX_MODE_ASSET_TYPE
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
 						).build())) {
 
 			_assertSitemap(
@@ -1312,7 +1331,8 @@ public class SitemapManagerTest {
 						).put(
 							"xmlSitemapIndexEnabled", true
 						).put(
-							"xmlSitemapIndexMode", _INDEX_MODE_ASSET_TYPE
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
 						).build())) {
 
 			_assertSitemap(false, _group.getGroupId(), StringPool.BLANK);
@@ -1849,8 +1869,6 @@ public class SitemapManagerTest {
 	private static final String _CLASS_NAME_OBJECT_ENTRY =
 		ObjectEntry.class.getName();
 
-	private static final String _INDEX_MODE_ASSET_TYPE = "asset-type";
-
 	private static final String _PID_SITEMAP_COMPANY_CONFIGURATION =
 		"com.liferay.site.internal.configuration.SitemapCompanyConfiguration";
 
@@ -1926,6 +1944,9 @@ public class SitemapManagerTest {
 
 	@Inject
 	private SitemapManager _sitemapManager;
+
+	@Inject
+	private SitemapStorageHelper _sitemapStorageHelper;
 
 	private ThemeDisplay _themeDisplay;
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/ActivityStreamTimeline.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/ActivityStreamTimeline.tsx
@@ -411,9 +411,9 @@ const EventRow: React.FC<IEventRowProps> = ({event, timeZoneId}) => {
 								{event.pageTitle || event.assetTitle}
 							</div>
 
-							{event.url && (
+							{event.canonicalUrl && (
 								<div className='text-secondary text-truncate'>
-									{event.url}
+									{event.canonicalUrl}
 								</div>
 							)}
 						</div>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/ActivityStreamTimeline.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/ActivityStreamTimeline.tsx
@@ -257,6 +257,69 @@ describe('ActivityStreamTimeline rendering', () => {
 		).toBeInTheDocument();
 	});
 
+	it('renders an event canonicalUrl and not its raw url', () => {
+		const {getByText, queryByText} = render(
+			<ActivityStreamTimeline
+				{...baseProps}
+				sessions={[
+					buildSession({
+						events: [
+							{
+								applicationId: 'app',
+								assetTitle: 'Asset',
+								canonicalUrl: 'https://example.com/canonical',
+								createDate: '2024-04-03T08:05:00.000Z',
+								name: 'View Page',
+								pageDescription: '',
+								pageKeywords: '',
+								pageTitle: 'Home',
+								referrer: '',
+								url: 'https://example.com/raw?utm=1'
+							}
+						]
+					})
+				]}
+				totalItems={1}
+			/>
+		);
+
+		expect(getByText('https://example.com/canonical')).toBeInTheDocument();
+		expect(
+			queryByText('https://example.com/raw?utm=1')
+		).not.toBeInTheDocument();
+	});
+
+	it('omits the event url line when canonicalUrl is empty', () => {
+		const {queryByText} = render(
+			<ActivityStreamTimeline
+				{...baseProps}
+				sessions={[
+					buildSession({
+						events: [
+							{
+								applicationId: 'app',
+								assetTitle: 'Asset',
+								canonicalUrl: '',
+								createDate: '2024-04-03T08:05:00.000Z',
+								name: 'View Page',
+								pageDescription: '',
+								pageKeywords: '',
+								pageTitle: 'Home',
+								referrer: '',
+								url: 'https://example.com/raw?utm=1'
+							}
+						]
+					})
+				]}
+				totalItems={1}
+			/>
+		);
+
+		expect(
+			queryByText('https://example.com/raw?utm=1')
+		).not.toBeInTheDocument();
+	});
+
 	it('renders an anonymous session with the anonymize icon', () => {
 		const {container, getByText} = render(
 			<ActivityStreamTimeline

--- a/modules/sdk/ant-build-logger/build.gradle
+++ b/modules/sdk/ant-build-logger/build.gradle
@@ -8,7 +8,7 @@ clean {
 }
 
 dependencies {
-	compileOnly group: "com.liferay", name: "com.liferay.jenkins.results.parser", version: "1.0.1827"
+	compileOnly group: "com.liferay", name: "com.liferay.jenkins.results.parser", version: "1.0.1828"
 	compileOnly group: "org.apache.ant", name: "ant", version: "1.10.14"
 }
 

--- a/modules/sdk/ant-secure-property/build.gradle
+++ b/modules/sdk/ant-secure-property/build.gradle
@@ -8,7 +8,7 @@ clean {
 }
 
 dependencies {
-	compileOnly group: "com.liferay", name: "com.liferay.jenkins.results.parser", version: "1.0.1827"
+	compileOnly group: "com.liferay", name: "com.liferay.jenkins.results.parser", version: "1.0.1828"
 	compileOnly group: "org.apache.ant", name: "ant", transitive: false, version: "1.10.14"
 }
 

--- a/modules/test/jenkins-results-parser/bnd.bnd
+++ b/modules/test/jenkins-results-parser/bnd.bnd
@@ -1,3 +1,3 @@
 Bundle-Name: Liferay Jenkins Results Parser
 Bundle-SymbolicName: com.liferay.jenkins.results.parser
-Bundle-Version: 1.0.1828
+Bundle-Version: 1.0.1829

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
@@ -10,12 +10,8 @@ import com.google.common.collect.Lists;
 import java.io.File;
 import java.io.IOException;
 
-import java.time.Duration;
-import java.time.Instant;
-
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -900,51 +896,6 @@ public abstract class BaseWorkspaceGitRepository
 		String senderBranchSHA = getSenderBranchSHA();
 
 		if (!gitWorkingDirectory.localSHAExists(senderBranchSHA)) {
-			if (JenkinsResultsParserUtil.isCloudCINode()) {
-				try {
-					GitHubRemoteGitCommit gitHubRemoteGitCommit =
-						GitCommitFactory.newGitHubRemoteGitCommit(
-							getSenderBranchUsername(),
-							gitWorkingDirectory.getGitRepositoryName(),
-							senderBranchSHA);
-
-					Date commitDate = gitHubRemoteGitCommit.getCommitDate();
-
-					Instant commitInstant = commitDate.toInstant();
-
-					Instant oneMonthAgo = Instant.now(
-					).minus(
-						Duration.ofDays(30)
-					);
-
-					if (commitInstant.isBefore(oneMonthAgo) &&
-						_isPullRequest()) {
-
-						PullRequest pullRequest =
-							PullRequestFactory.newPullRequest(getGitHubURL());
-
-						if (pullRequest != null) {
-							String message =
-								"User's commit " + senderBranchSHA +
-									" is more than 1 month old. Rebase and " +
-										"retest your changes.";
-
-							pullRequest.addComment(message);
-
-							throw new RuntimeException(
-								"Sender's commit is more than 1 month old");
-						}
-					}
-				}
-				catch (Exception exception) {
-					exception.printStackTrace();
-
-					throw new RuntimeException(
-						"Sender's commit is more than 1 month old or there " +
-							"was an error retrieving commit information");
-				}
-			}
-
 			gitWorkingDirectory.fetch(_getSenderRemoteGitRef());
 		}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
@@ -1438,10 +1438,10 @@ public abstract class BaseWorkspaceGitRepository
 
 		GitWorkingDirectory gitWorkingDirectory = getGitWorkingDirectory();
 
-		gitWorkingDirectory.fetch(remoteGitRef);
+		LocalGitBranch localGitBranch = gitWorkingDirectory.fetch(remoteGitRef);
 
-		if (!gitWorkingDirectory.localSHAExists(sha) ||
-			!gitWorkingDirectory.refContainsSHA(remoteGitRef.getSHA(), sha)) {
+		if ((localGitBranch == null) ||
+			!gitWorkingDirectory.refContainsSHA(localGitBranch, sha)) {
 
 			throw new RuntimeException(
 				JenkinsResultsParserUtil.combine(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
@@ -800,9 +800,7 @@ public class CIForwardProcessor {
 
 			String message = gitWorkingDirectoryRuntimeException.getMessage();
 
-			if ((message != null) && message.contains("Unable to rebase ") &&
-				message.contains("CONFLICT (")) {
-
+			if ((message != null) && message.contains("Unable to rebase ")) {
 				System.out.println(
 					JenkinsResultsParserUtil.combine(
 						"Detected merge conflict between ",
@@ -815,8 +813,8 @@ public class CIForwardProcessor {
 			}
 
 			System.out.println(
-				"WARNING: Unable to detect merge conflict marker but rebase " +
-					"failed\n" + String.valueOf(message));
+				"WARNING: Unable to determine merge conflict status\n" +
+					String.valueOf(message));
 
 			return false;
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
@@ -776,47 +776,41 @@ public class CIForwardProcessor {
 		}
 
 		String expectedMergeBaseSHA = mergeBaseCommit.getSHA();
-		String receiverSHA = receiverRemoteGitBranch.getSHA();
-		String senderSHA = _pullRequest.getSenderSHA();
 
-		Date mergeBaseCommitDate = mergeBaseCommit.getCommitDate();
-
-		gitWorkingDirectory.fetch(receiverRemoteGitBranch, mergeBaseCommitDate);
-		gitWorkingDirectory.fetch(senderRemoteGitBranch, mergeBaseCommitDate);
-
-		if (!_localMergeBaseMatches(
-				gitWorkingDirectory, senderSHA, receiverSHA,
-				expectedMergeBaseSHA)) {
-
-			Date deepenedSinceDate = new Date(
-				mergeBaseCommitDate.getTime() -
-					_BRANCH_DEEPENING_STEP_SIZE_MILLIS);
-
-			gitWorkingDirectory.fetch(
-				receiverRemoteGitBranch, deepenedSinceDate);
-			gitWorkingDirectory.fetch(senderRemoteGitBranch, deepenedSinceDate);
-
-			if (!_localMergeBaseMatches(
-					gitWorkingDirectory, senderSHA, receiverSHA,
-					expectedMergeBaseSHA)) {
-
-				System.out.println(
-					"WARNING: Unable to identify merge base SHA");
-
-				return false;
-			}
-		}
+		gitWorkingDirectory.fetch(receiverRemoteGitBranch);
+		gitWorkingDirectory.fetch(senderRemoteGitBranch);
 
 		LocalGitBranch receiverLocalGitBranch =
 			gitWorkingDirectory.createLocalGitBranch(
 				JenkinsResultsParserUtil.combine(
 					_recipientUsername, "-", upstreamBranchName, "-precheck"),
-				true, receiverSHA);
+				true, receiverRemoteGitBranch.getSHA(),
+				receiverRemoteGitBranch);
 
 		LocalGitBranch senderLocalGitBranch =
 			gitWorkingDirectory.createLocalGitBranch(
 				_pullRequest.getLocalSenderBranchName() + "-precheck", true,
-				senderSHA);
+				_pullRequest.getSenderSHA(), senderRemoteGitBranch);
+
+		String localMergeBaseSHA = null;
+
+		try {
+			localMergeBaseSHA = gitWorkingDirectory.getMergeBaseCommitSHA(
+				receiverLocalGitBranch, senderLocalGitBranch);
+		}
+		catch (GitWorkingDirectory.GitWorkingDirectoryRuntimeException
+					gitWorkingDirectoryRuntimeException) {
+
+			gitWorkingDirectoryRuntimeException.printStackTrace();
+		}
+
+		if ((localMergeBaseSHA == null) ||
+			!expectedMergeBaseSHA.equals(localMergeBaseSHA.trim())) {
+
+			System.out.println("WARNING: Unable to identify merge base SHA");
+
+			return false;
+		}
 
 		try {
 			gitWorkingDirectory.rebase(
@@ -864,31 +858,6 @@ public class CIForwardProcessor {
 
 		return failedRequiredPassingTestSuiteNames.isEmpty();
 	}
-
-	private boolean _localMergeBaseMatches(
-		GitWorkingDirectory gitWorkingDirectory, String senderSHA,
-		String receiverSHA, String expectedMergeBaseSHA) {
-
-		try {
-			String localMergeBaseSHA =
-				gitWorkingDirectory.getMergeBaseCommitSHA(
-					senderSHA, receiverSHA);
-
-			if (localMergeBaseSHA != null) {
-				localMergeBaseSHA = localMergeBaseSHA.trim();
-			}
-
-			return expectedMergeBaseSHA.equals(localMergeBaseSHA);
-		}
-		catch (GitWorkingDirectory.GitWorkingDirectoryRuntimeException
-					gitWorkingDirectoryRuntimeException) {
-
-			return false;
-		}
-	}
-
-	private static final long _BRANCH_DEEPENING_STEP_SIZE_MILLIS =
-		1000L * 60L * 60L * 24L;
 
 	private static final long _RETRY_PERIOD = 1000L * 60L;
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
@@ -768,14 +768,11 @@ public class CIForwardProcessor {
 			gitWorkingDirectory.getRemoteGitBranch(
 				upstreamBranchName, receiverRemoteURL, true);
 
-		GitCommit mergeBaseCommit = receiverRemoteGitBranch.getMergeBaseCommit(
-			senderRemoteGitBranch);
+		if (receiverRemoteGitBranch.getMergeBaseCommit(senderRemoteGitBranch) ==
+				null) {
 
-		if (mergeBaseCommit == null) {
 			return false;
 		}
-
-		String expectedMergeBaseSHA = mergeBaseCommit.getSHA();
 
 		gitWorkingDirectory.fetch(receiverRemoteGitBranch);
 		gitWorkingDirectory.fetch(senderRemoteGitBranch);
@@ -791,26 +788,6 @@ public class CIForwardProcessor {
 			gitWorkingDirectory.createLocalGitBranch(
 				_pullRequest.getLocalSenderBranchName() + "-precheck", true,
 				_pullRequest.getSenderSHA(), senderRemoteGitBranch);
-
-		String localMergeBaseSHA = null;
-
-		try {
-			localMergeBaseSHA = gitWorkingDirectory.getMergeBaseCommitSHA(
-				receiverLocalGitBranch, senderLocalGitBranch);
-		}
-		catch (GitWorkingDirectory.GitWorkingDirectoryRuntimeException
-					gitWorkingDirectoryRuntimeException) {
-
-			gitWorkingDirectoryRuntimeException.printStackTrace();
-		}
-
-		if ((localMergeBaseSHA == null) ||
-			!expectedMergeBaseSHA.equals(localMergeBaseSHA.trim())) {
-
-			System.out.println("WARNING: Unable to identify merge base SHA");
-
-			return false;
-		}
 
 		try {
 			gitWorkingDirectory.rebase(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitBranchFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitBranchFactory.java
@@ -16,6 +16,14 @@ public class GitBranchFactory {
 		return new LocalGitBranch(localGitRepository, name, sha);
 	}
 
+	public static LocalGitBranch newLocalGitBranch(
+		LocalGitRepository localGitRepository, String name, String sha,
+		RemoteGitBranch sourceRemoteGitBranch) {
+
+		return new LocalGitBranch(
+			localGitRepository, name, sha, sourceRemoteGitBranch);
+	}
+
 	public static RemoteGitRef newRemoteGitRef(
 		RemoteGitRepository remoteGitRepository, String name, String sha,
 		String type) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -2733,6 +2733,29 @@ public class GitWorkingDirectory {
 		}
 	}
 
+	public boolean refContainsSHA(LocalGitBranch localGitBranch, String sha) {
+		for (int deepenAttempt = 0;; deepenAttempt++) {
+			if (refContainsSHA(localGitBranch.getName(), sha)) {
+				return true;
+			}
+
+			boolean deepened = false;
+
+			if (deepenAttempt < _DEEPEN_MAX_ATTEMPTS) {
+				Date shallowSinceDate = new Date(
+					JenkinsResultsParserUtil.getCurrentTimeMillis() -
+						(_DEEPEN_STEP_SIZE_MILLIS << deepenAttempt));
+
+				deepened = deepenLocalGitBranch(
+					localGitBranch, shallowSinceDate);
+			}
+
+			if (!deepened) {
+				return false;
+			}
+		}
+	}
+
 	public boolean refContainsSHA(String ref, String sha) {
 		GitUtil.ExecutionResult executionResult = executeBashCommands(
 			GitUtil.RETRIES_SIZE_MAX, GitUtil.MILLIS_RETRY_DELAY, 1000 * 60 * 2,

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -499,6 +499,27 @@ public class GitWorkingDirectory {
 		return retryable.executeWithRetries();
 	}
 
+	public boolean deepenLocalGitBranch(
+		LocalGitBranch localGitBranch, Date shallowSinceDate) {
+
+		RemoteGitBranch sourceRemoteGitBranch =
+			localGitBranch.getSourceRemoteGitBranch();
+
+		if (sourceRemoteGitBranch == null) {
+			return false;
+		}
+
+		System.out.println(
+			JenkinsResultsParserUtil.combine(
+				"Deepening ", localGitBranch.getName(), " to ",
+				JenkinsResultsParserUtil.toDateString(
+					shallowSinceDate, "yyyy-MM-dd'T'HH:mm:ss'Z'", "UTC")));
+
+		fetch(sourceRemoteGitBranch, shallowSinceDate);
+
+		return true;
+	}
+
 	public void deleteLocalGitBranch(LocalGitBranch localGitBranch) {
 		if (localGitBranch == null) {
 			return;
@@ -1635,45 +1656,28 @@ public class GitWorkingDirectory {
 				return executionResult.getStandardOut();
 			}
 
-			boolean canDeepen = false;
+			boolean deepened = false;
 
-			for (LocalGitBranch localGitBranch : localGitBranches) {
-				if (localGitBranch.getSourceRemoteGitBranch() != null) {
-					canDeepen = true;
+			if (deepenAttempt < _DEEPEN_MAX_ATTEMPTS) {
+				Date shallowSinceDate = new Date(
+					JenkinsResultsParserUtil.getCurrentTimeMillis() -
+						(_DEEPEN_STEP_SIZE_MILLIS << deepenAttempt));
 
-					break;
+				for (LocalGitBranch localGitBranch : localGitBranches) {
+					if (deepenLocalGitBranch(
+							localGitBranch, shallowSinceDate)) {
+
+						deepened = true;
+					}
 				}
 			}
 
-			if (!canDeepen ||
-				(deepenAttempt >= _MERGE_BASE_DEEPEN_MAX_ATTEMPTS)) {
-
+			if (!deepened) {
 				throw new GitWorkingDirectoryRuntimeException(
 					this,
 					JenkinsResultsParserUtil.combine(
 						"Unable to get merge base commit SHA\n",
 						executionResult.getStandardError()));
-			}
-
-			Date shallowSinceDate = new Date(
-				JenkinsResultsParserUtil.getCurrentTimeMillis() -
-					(_MERGE_BASE_DEEPEN_STEP_SIZE_MILLIS << deepenAttempt));
-
-			System.out.println(
-				JenkinsResultsParserUtil.combine(
-					"WARNING: No merge base found within the local shallow ",
-					"horizon. Deepening to ",
-					JenkinsResultsParserUtil.toDateString(
-						shallowSinceDate, "yyyy-MM-dd'T'HH:mm:ss'Z'", "UTC"),
-					" and retrying."));
-
-			for (LocalGitBranch localGitBranch : localGitBranches) {
-				RemoteGitBranch sourceRemoteGitBranch =
-					localGitBranch.getSourceRemoteGitBranch();
-
-				if (sourceRemoteGitBranch != null) {
-					fetch(sourceRemoteGitBranch, shallowSinceDate);
-				}
 			}
 		}
 	}
@@ -1948,9 +1952,6 @@ public class GitWorkingDirectory {
 			LocalGitBranch rebasedLocalGitBranch = createLocalGitBranch(
 				rebasedLocalGitBranchName, true, senderSHA,
 				senderRemoteGitBranch);
-
-			getMergeBaseCommitSHA(
-				upstreamLocalGitBranch, rebasedLocalGitBranch);
 
 			rebasedLocalGitBranch = rebase(
 				true, upstreamLocalGitBranch, rebasedLocalGitBranch);
@@ -2660,32 +2661,45 @@ public class GitWorkingDirectory {
 			return localGitBranch;
 		}
 
-		checkoutLocalGitBranch(baseLocalGitBranch);
-
-		reset("--hard " + baseLocalGitBranch.getSHA());
-
 		String rebaseCommand = JenkinsResultsParserUtil.combine(
 			"git rebase ", baseLocalGitBranch.getName(), " ",
 			localGitBranch.getName());
 
-		GitUtil.ExecutionResult executionResult = executeBashCommands(
-			GitUtil.RETRIES_SIZE_MAX, GitUtil.MILLIS_RETRY_DELAY,
-			1000 * 60 * 10, rebaseCommand);
+		for (int deepenAttempt = 0;; deepenAttempt++) {
+			checkoutLocalGitBranch(baseLocalGitBranch);
 
-		if (executionResult.getExitValue() != 0) {
+			reset("--hard " + baseLocalGitBranch.getSHA());
+
+			GitUtil.ExecutionResult executionResult = executeBashCommands(
+				GitUtil.RETRIES_SIZE_MAX, GitUtil.MILLIS_RETRY_DELAY,
+				1000 * 60 * 10, rebaseCommand);
+
+			if (executionResult.getExitValue() == 0) {
+				return getCurrentLocalGitBranch();
+			}
+
 			if (abortOnFail) {
 				rebaseAbort();
 			}
 
-			throw new GitWorkingDirectoryRuntimeException(
-				this,
-				JenkinsResultsParserUtil.combine(
-					"Unable to rebase ", localGitBranch.getName(), " to ",
-					baseLocalGitBranch.getName(), "\n",
-					executionResult.getStandardError()));
-		}
+			long deepenStepSizeMillis =
+				_DEEPEN_STEP_SIZE_MILLIS << deepenAttempt;
 
-		return getCurrentLocalGitBranch();
+			Date shallowSinceDate = new Date(
+				JenkinsResultsParserUtil.getCurrentTimeMillis() -
+					deepenStepSizeMillis);
+
+			if (!abortOnFail || (deepenAttempt >= _DEEPEN_MAX_ATTEMPTS) ||
+				!deepenLocalGitBranch(baseLocalGitBranch, shallowSinceDate)) {
+
+				throw new GitWorkingDirectoryRuntimeException(
+					this,
+					JenkinsResultsParserUtil.combine(
+						"Unable to rebase ", localGitBranch.getName(), " to ",
+						baseLocalGitBranch.getName(), "\n",
+						executionResult.getStandardError()));
+			}
+		}
 	}
 
 	public void rebaseAbort() {
@@ -3614,14 +3628,14 @@ public class GitWorkingDirectory {
 
 	private static final int _BRANCHES_DELETE_BATCH_SIZE = 5;
 
+	private static final int _DEEPEN_MAX_ATTEMPTS = 5;
+
+	private static final long _DEEPEN_STEP_SIZE_MILLIS =
+		1000L * 60L * 60L * 24L * 30L;
+
 	private static final String _GIT_COMMIT_LOG_SEPARATOR = "\u0000";
 
 	private static final String _GIT_COMMIT_LOG_SEPARATOR_FORMAT = "%x00";
-
-	private static final int _MERGE_BASE_DEEPEN_MAX_ATTEMPTS = 5;
-
-	private static final long _MERGE_BASE_DEEPEN_STEP_SIZE_MILLIS =
-		1000L * 60L * 60L * 24L * 30L;
 
 	private static final Pattern _badRefPattern = Pattern.compile(
 		"fatal: bad object (?<badRef>.+/HEAD)");

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -1555,10 +1555,6 @@ public class GitWorkingDirectory {
 			return getUpstreamLocalGitBranch();
 		}
 
-		if (!localGitBranchExists(branchName)) {
-			return null;
-		}
-
 		return _getLocalGitBranch(branchName, required);
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -795,13 +795,15 @@ public class GitWorkingDirectory {
 				fetch(null, noTags, gitHubDevRemoteGitBranch);
 
 				if (localSHAExists(remoteGitRefSHA)) {
-					if (localGitBranch != null) {
+					if (localGitBranch == null) {
 						return createLocalGitBranch(
-							localGitBranch.getName(), true, remoteGitRefSHA,
+							remoteGitRef.getName(), true, remoteGitRefSHA,
 							sourceRemoteGitBranch);
 					}
 
-					return null;
+					return createLocalGitBranch(
+						localGitBranch.getName(), true, remoteGitRefSHA,
+						sourceRemoteGitBranch);
 				}
 			}
 		}
@@ -929,7 +931,13 @@ public class GitWorkingDirectory {
 			}
 		}
 
-		if (localSHAExists(remoteGitRefSHA) && (localGitBranch != null)) {
+		if (localSHAExists(remoteGitRefSHA)) {
+			if (localGitBranch == null) {
+				return createLocalGitBranch(
+					remoteGitRef.getName(), true, remoteGitRefSHA,
+					sourceRemoteGitBranch);
+			}
+
 			return createLocalGitBranch(
 				localGitBranch.getName(), true, remoteGitRefSHA,
 				sourceRemoteGitBranch);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -1747,16 +1747,11 @@ public class GitWorkingDirectory {
 			return "";
 		}
 
-		executeBashCommands(
-			GitUtil.RETRIES_SIZE_MAX, GitUtil.MILLIS_RETRY_DELAY,
-			GitUtil.MILLIS_TIMEOUT,
-			JenkinsResultsParserUtil.combine(
-				"git fetch ", upstreamGitRemote.getName(), " master"));
+		RemoteGitBranch upstreamMasterRemoteGitBranch = getRemoteGitBranch(
+			"master", upstreamGitRemote, true);
 
 		return getMergeBaseCommitSHA(
-			getCurrentBranchName(),
-			JenkinsResultsParserUtil.combine(
-				upstreamGitRemote.getName(), "/master"));
+			getCurrentLocalGitBranch(), fetch(upstreamMasterRemoteGitBranch));
 	}
 
 	public List<File> getModifiedDirsList(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -1572,10 +1572,17 @@ public class GitWorkingDirectory {
 
 		if (branchName != null) {
 			try {
+				RemoteGitBranch upstreamRemoteGitBranch = null;
+
+				if (branchName.equals(upstreamBranchName)) {
+					upstreamRemoteGitBranch = getUpstreamRemoteGitBranch();
+				}
+
 				return Arrays.asList(
 					GitBranchFactory.newLocalGitBranch(
 						localGitRepository, branchName,
-						getLocalGitBranchSHA(branchName)));
+						getLocalGitBranchSHA(branchName),
+						upstreamRemoteGitBranch));
 			}
 			catch (Exception exception) {
 				if (!branchName.equals(upstreamBranchName)) {
@@ -1601,10 +1608,17 @@ public class GitWorkingDirectory {
 				continue;
 			}
 
+			RemoteGitBranch remoteGitBranch = null;
+
+			if (localGitBranchName.equals(upstreamBranchName)) {
+				remoteGitBranch = getUpstreamRemoteGitBranch();
+			}
+
 			localGitBranches.add(
 				GitBranchFactory.newLocalGitBranch(
 					localGitRepository, localGitBranchName,
-					localGitBranchesShaMap.get(localGitBranchName)));
+					localGitBranchesShaMap.get(localGitBranchName),
+					remoteGitBranch));
 		}
 
 		return localGitBranches;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -442,6 +442,18 @@ public class GitWorkingDirectory {
 		return createLocalGitBranchRetryable.executeWithRetries();
 	}
 
+	public LocalGitBranch createLocalGitBranch(
+		String localGitBranchName, boolean force, String startPoint,
+		RemoteGitBranch sourceRemoteGitBranch) {
+
+		LocalGitBranch localGitBranch = createLocalGitBranch(
+			localGitBranchName, force, startPoint);
+
+		return GitBranchFactory.newLocalGitBranch(
+			localGitBranch.getLocalGitRepository(), localGitBranch.getName(),
+			localGitBranch.getSHA(), sourceRemoteGitBranch);
+	}
+
 	public String createPullRequest(
 		final String body, final String pullRequestBranchName,
 		final String receiverUserName, final String senderUserName,
@@ -711,6 +723,12 @@ public class GitWorkingDirectory {
 
 		String remoteGitRefSHA = remoteGitRef.getSHA();
 
+		RemoteGitBranch sourceRemoteGitBranch = null;
+
+		if (remoteGitRef instanceof RemoteGitBranch) {
+			sourceRemoteGitBranch = (RemoteGitBranch)remoteGitRef;
+		}
+
 		if ((shallowSinceDate == null) && localSHAExists(remoteGitRefSHA)) {
 			System.out.println(
 				remoteGitRefSHA + " already exists in Git repository");
@@ -723,11 +741,13 @@ public class GitWorkingDirectory {
 
 			if (localGitBranch == null) {
 				return createLocalGitBranch(
-					remoteGitRef.getName(), true, remoteGitRefSHA);
+					remoteGitRef.getName(), true, remoteGitRefSHA,
+					sourceRemoteGitBranch);
 			}
 
 			return createLocalGitBranch(
-				localGitBranch.getName(), true, remoteGitRefSHA);
+				localGitBranch.getName(), true, remoteGitRefSHA,
+				sourceRemoteGitBranch);
 		}
 
 		StringBuilder gitBranchesSHAReportStringBuilder = new StringBuilder();
@@ -760,7 +780,8 @@ public class GitWorkingDirectory {
 				if (localSHAExists(remoteGitRefSHA)) {
 					if (localGitBranch != null) {
 						return createLocalGitBranch(
-							localGitBranch.getName(), true, remoteGitRefSHA);
+							localGitBranch.getName(), true, remoteGitRefSHA,
+							sourceRemoteGitBranch);
 					}
 
 					return null;
@@ -893,7 +914,8 @@ public class GitWorkingDirectory {
 
 		if (localSHAExists(remoteGitRefSHA) && (localGitBranch != null)) {
 			return createLocalGitBranch(
-				localGitBranch.getName(), true, remoteGitRefSHA);
+				localGitBranch.getName(), true, remoteGitRefSHA,
+				sourceRemoteGitBranch);
 		}
 
 		return null;
@@ -1606,19 +1628,58 @@ public class GitWorkingDirectory {
 			sb.append(localGitBranch.getName());
 		}
 
-		GitUtil.ExecutionResult executionResult = executeBashCommands(
-			GitUtil.RETRIES_SIZE_MAX, GitUtil.MILLIS_RETRY_DELAY,
-			GitUtil.MILLIS_TIMEOUT, sb.toString());
+		String command = sb.toString();
 
-		if (executionResult.getExitValue() != 0) {
-			throw new GitWorkingDirectoryRuntimeException(
-				this,
+		for (int deepenAttempt = 0;; deepenAttempt++) {
+			GitUtil.ExecutionResult executionResult = executeBashCommands(
+				GitUtil.RETRIES_SIZE_MAX, GitUtil.MILLIS_RETRY_DELAY,
+				GitUtil.MILLIS_TIMEOUT, command);
+
+			if (executionResult.getExitValue() == 0) {
+				return executionResult.getStandardOut();
+			}
+
+			boolean canDeepen = false;
+
+			for (LocalGitBranch localGitBranch : localGitBranches) {
+				if (localGitBranch.getSourceRemoteGitBranch() != null) {
+					canDeepen = true;
+
+					break;
+				}
+			}
+
+			if (!canDeepen ||
+				(deepenAttempt >= _MERGE_BASE_DEEPEN_MAX_ATTEMPTS)) {
+
+				throw new GitWorkingDirectoryRuntimeException(
+					this,
+					JenkinsResultsParserUtil.combine(
+						"Unable to get merge base commit SHA\n",
+						executionResult.getStandardError()));
+			}
+
+			Date shallowSinceDate = new Date(
+				JenkinsResultsParserUtil.getCurrentTimeMillis() -
+					(_MERGE_BASE_DEEPEN_STEP_SIZE_MILLIS << deepenAttempt));
+
+			System.out.println(
 				JenkinsResultsParserUtil.combine(
-					"Unable to get merge base commit SHA\n",
-					executionResult.getStandardError()));
-		}
+					"WARNING: No merge base found within the local shallow ",
+					"horizon. Deepening to ",
+					JenkinsResultsParserUtil.toDateString(
+						shallowSinceDate, "yyyy-MM-dd'T'HH:mm:ss'Z'", "UTC"),
+					" and retrying."));
 
-		return executionResult.getStandardOut();
+			for (LocalGitBranch localGitBranch : localGitBranches) {
+				RemoteGitBranch sourceRemoteGitBranch =
+					localGitBranch.getSourceRemoteGitBranch();
+
+				if (sourceRemoteGitBranch != null) {
+					fetch(sourceRemoteGitBranch, shallowSinceDate);
+				}
+			}
+		}
 	}
 
 	public String getMergeBaseCommitSHA(String... refNames) {
@@ -1863,14 +1924,14 @@ public class GitWorkingDirectory {
 				checkoutLocalGitBranch(tempLocalGitBranch);
 			}
 
+			RemoteGitBranch senderRemoteGitBranch = getRemoteGitBranch(
+				senderBranchName, senderRemoteURL, true);
+
 			if (localSHAExists(senderSHA)) {
 				createLocalGitBranch(senderBranchName, true, senderSHA);
 			}
 			else {
-				RemoteGitRef senderRemoteGitRef = getRemoteGitRef(
-					senderBranchName, senderRemoteURL, true);
-
-				fetch(senderRemoteGitRef);
+				fetch(senderRemoteGitBranch);
 			}
 
 			RemoteGitBranch upstreamRemoteGitBranch = getRemoteGitBranch(
@@ -1880,21 +1941,20 @@ public class GitWorkingDirectory {
 				upstreamBranchSHA = upstreamRemoteGitBranch.getSHA();
 			}
 
-			LocalGitBranch upstreamLocalGitBranch;
-
-			if (localSHAExists(upstreamBranchSHA)) {
-				upstreamLocalGitBranch = createLocalGitBranch(
-					upstreamBranchName, true, upstreamBranchSHA);
-			}
-			else {
+			if (!localSHAExists(upstreamBranchSHA)) {
 				fetch(upstreamRemoteGitBranch);
-
-				upstreamLocalGitBranch = createLocalGitBranch(
-					upstreamRemoteGitBranch.getName(), true, upstreamBranchSHA);
 			}
+
+			LocalGitBranch upstreamLocalGitBranch = createLocalGitBranch(
+				upstreamBranchName, true, upstreamBranchSHA,
+				upstreamRemoteGitBranch);
 
 			LocalGitBranch rebasedLocalGitBranch = createLocalGitBranch(
-				rebasedLocalGitBranchName, true, senderSHA);
+				rebasedLocalGitBranchName, true, senderSHA,
+				senderRemoteGitBranch);
+
+			getMergeBaseCommitSHA(
+				upstreamLocalGitBranch, rebasedLocalGitBranch);
 
 			rebasedLocalGitBranch = rebase(
 				true, upstreamLocalGitBranch, rebasedLocalGitBranch);
@@ -3551,6 +3611,11 @@ public class GitWorkingDirectory {
 	private static final String _GIT_COMMIT_LOG_SEPARATOR = "\u0000";
 
 	private static final String _GIT_COMMIT_LOG_SEPARATOR_FORMAT = "%x00";
+
+	private static final int _MERGE_BASE_DEEPEN_MAX_ATTEMPTS = 5;
+
+	private static final long _MERGE_BASE_DEEPEN_STEP_SIZE_MILLIS =
+		1000L * 60L * 60L * 24L * 30L;
 
 	private static final Pattern _badRefPattern = Pattern.compile(
 		"fatal: bad object (?<badRef>.+/HEAD)");

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -2674,45 +2674,33 @@ public class GitWorkingDirectory {
 			return localGitBranch;
 		}
 
-		String rebaseCommand = JenkinsResultsParserUtil.combine(
-			"git rebase ", baseLocalGitBranch.getName(), " ",
-			localGitBranch.getName());
+		getMergeBaseCommitSHA(baseLocalGitBranch, localGitBranch);
 
-		for (int deepenAttempt = 0;; deepenAttempt++) {
-			checkoutLocalGitBranch(baseLocalGitBranch);
+		checkoutLocalGitBranch(baseLocalGitBranch);
 
-			reset("--hard " + baseLocalGitBranch.getSHA());
+		reset("--hard " + baseLocalGitBranch.getSHA());
 
-			GitUtil.ExecutionResult executionResult = executeBashCommands(
-				GitUtil.RETRIES_SIZE_MAX, GitUtil.MILLIS_RETRY_DELAY,
-				1000 * 60 * 10, rebaseCommand);
+		GitUtil.ExecutionResult executionResult = executeBashCommands(
+			GitUtil.RETRIES_SIZE_MAX, GitUtil.MILLIS_RETRY_DELAY,
+			1000 * 60 * 10,
+			JenkinsResultsParserUtil.combine(
+				"git rebase ", baseLocalGitBranch.getName(), " ",
+				localGitBranch.getName()));
 
-			if (executionResult.getExitValue() == 0) {
-				return getCurrentLocalGitBranch();
-			}
-
-			if (abortOnFail) {
-				rebaseAbort();
-			}
-
-			long deepenStepSizeMillis =
-				_DEEPEN_STEP_SIZE_MILLIS << deepenAttempt;
-
-			Date shallowSinceDate = new Date(
-				JenkinsResultsParserUtil.getCurrentTimeMillis() -
-					deepenStepSizeMillis);
-
-			if (!abortOnFail || (deepenAttempt >= _DEEPEN_MAX_ATTEMPTS) ||
-				!deepenLocalGitBranch(baseLocalGitBranch, shallowSinceDate)) {
-
-				throw new GitWorkingDirectoryRuntimeException(
-					this,
-					JenkinsResultsParserUtil.combine(
-						"Unable to rebase ", localGitBranch.getName(), " to ",
-						baseLocalGitBranch.getName(), "\n",
-						executionResult.getStandardError()));
-			}
+		if (executionResult.getExitValue() == 0) {
+			return getCurrentLocalGitBranch();
 		}
+
+		if (abortOnFail) {
+			rebaseAbort();
+		}
+
+		throw new GitWorkingDirectoryRuntimeException(
+			this,
+			JenkinsResultsParserUtil.combine(
+				"Unable to rebase ", localGitBranch.getName(), " to ",
+				baseLocalGitBranch.getName(), "\n",
+				executionResult.getStandardError()));
 	}
 
 	public void rebaseAbort() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -425,8 +425,15 @@ public class GitWorkingDirectory {
 	}
 
 	public LocalGitBranch createLocalGitBranch(
+		String localGitBranchName, boolean force, String startPoint) {
+
+		return createLocalGitBranch(
+			localGitBranchName, force, startPoint, null);
+	}
+
+	public LocalGitBranch createLocalGitBranch(
 		final String localGitBranchName, final boolean force,
-		final String startPoint) {
+		final String startPoint, final RemoteGitBranch sourceRemoteGitBranch) {
 
 		Retryable<LocalGitBranch> createLocalGitBranchRetryable =
 			new Retryable<LocalGitBranch>(true, 3, 0, true) {
@@ -434,24 +441,13 @@ public class GitWorkingDirectory {
 				@Override
 				public LocalGitBranch execute() {
 					return _createLocalGitBranch(
-						localGitBranchName, force, startPoint);
+						localGitBranchName, force, startPoint,
+						sourceRemoteGitBranch);
 				}
 
 			};
 
 		return createLocalGitBranchRetryable.executeWithRetries();
-	}
-
-	public LocalGitBranch createLocalGitBranch(
-		String localGitBranchName, boolean force, String startPoint,
-		RemoteGitBranch sourceRemoteGitBranch) {
-
-		LocalGitBranch localGitBranch = createLocalGitBranch(
-			localGitBranchName, force, startPoint);
-
-		return GitBranchFactory.newLocalGitBranch(
-			localGitBranch.getLocalGitRepository(), localGitBranch.getName(),
-			localGitBranch.getSHA(), sourceRemoteGitBranch);
 	}
 
 	public String createPullRequest(
@@ -3192,7 +3188,8 @@ public class GitWorkingDirectory {
 	}
 
 	private LocalGitBranch _createLocalGitBranch(
-		String localGitBranchName, boolean force, String startPoint) {
+		String localGitBranchName, boolean force, String startPoint,
+		RemoteGitBranch sourceRemoteGitBranch) {
 
 		if (JenkinsResultsParserUtil.isNullOrEmpty(localGitBranchName)) {
 			throw new GitWorkingDirectoryRuntimeException(
@@ -3260,7 +3257,16 @@ public class GitWorkingDirectory {
 				"Created local branch ", localGitBranchName, " at ",
 				startPoint));
 
-		return getLocalGitBranch(localGitBranchName, true);
+		LocalGitBranch localGitBranch = getLocalGitBranch(
+			localGitBranchName, true);
+
+		if (sourceRemoteGitBranch == null) {
+			return localGitBranch;
+		}
+
+		return GitBranchFactory.newLocalGitBranch(
+			localGitBranch.getLocalGitRepository(), localGitBranch.getName(),
+			localGitBranch.getSHA(), sourceRemoteGitBranch);
 	}
 
 	private boolean _deleteLocalGitBranches(String... branchNames) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitBranch.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitBranch.java
@@ -7,6 +7,8 @@ package com.liferay.jenkins.results.parser;
 
 import java.io.File;
 
+import java.util.List;
+
 /**
  * @author Michael Hashimoto
  */
@@ -26,6 +28,24 @@ public class LocalGitBranch extends BaseGitRef {
 
 	public LocalGitRepository getLocalGitRepository() {
 		return _localGitRepository;
+	}
+
+	public RemoteGitBranch getSourceRemoteGitBranch() {
+		if (_sourceRemoteGitBranch == null) {
+			return null;
+		}
+
+		GitWorkingDirectory gitWorkingDirectory = getGitWorkingDirectory();
+
+		List<String> branchNamesContainingSHA =
+			gitWorkingDirectory.getBranchNamesContainingSHA(
+				_sourceRemoteGitBranch.getSHA());
+
+		if (!branchNamesContainingSHA.contains(getName())) {
+			return null;
+		}
+
+		return _sourceRemoteGitBranch;
 	}
 
 	public String getUpstreamBranchName() {
@@ -53,6 +73,13 @@ public class LocalGitBranch extends BaseGitRef {
 	protected LocalGitBranch(
 		LocalGitRepository localGitRepository, String name, String sha) {
 
+		this(localGitRepository, name, sha, null);
+	}
+
+	protected LocalGitBranch(
+		LocalGitRepository localGitRepository, String name, String sha,
+		RemoteGitBranch sourceRemoteGitBranch) {
+
 		super(name, sha);
 
 		if (localGitRepository == null) {
@@ -60,8 +87,11 @@ public class LocalGitBranch extends BaseGitRef {
 		}
 
 		_localGitRepository = localGitRepository;
+
+		_sourceRemoteGitBranch = sourceRemoteGitBranch;
 	}
 
 	private final LocalGitRepository _localGitRepository;
+	private final RemoteGitBranch _sourceRemoteGitBranch;
 
 }

--- a/modules/test/playwright/tests/export-import-web/main/site.import.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/site.import.spec.ts
@@ -95,24 +95,6 @@ const testWithDeprecationFF = mergeTests(
 	uiElementsPageTest
 );
 
-export const testWithExportImportAtInstanceLevelFF = mergeTests(
-	companyExportImportPageTest,
-	dataApiHelpersTest,
-	depotAdminPageTest,
-	exportImportPagesTest,
-	featureFlagsTest({
-		'LPD-17564': {enabled: true},
-		'LPD-35443': {enabled: true},
-		'LPD-44307': {enabled: true},
-		'LPD-44771': {enabled: true},
-		'LPD-45276': {enabled: true},
-	}),
-	isolatedSiteTest,
-	loginTest(),
-	styleBookPageTest,
-	uiElementsPageTest
-);
-
 const testWithObjectExportImportFF = mergeTests(
 	assetCategoriesPagesTest,
 	dataApiHelpersTest,

--- a/modules/test/playwright/tests/export-import-web/main/site.import.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/site.import.spec.ts
@@ -25,6 +25,7 @@ import {uiElementsPageTest} from '../../../fixtures/uiElementsTest';
 import {usersAndOrganizationsPagesTest} from '../../../fixtures/usersAndOrganizationsPagesTest';
 import {wikiPagesTest} from '../../../fixtures/wikiPagesTest';
 import {DataApiHelpers} from '../../../helpers/ApiHelpers';
+import {createCategories} from '../../../helpers/CreateCategories';
 import {liferayConfig} from '../../../liferay.config';
 import {HomePage} from '../../../pages/portal-web/HomePage';
 import {getRandomInt} from '../../../utils/getRandomInt';
@@ -34,6 +35,7 @@ import {openFieldset} from '../../../utils/openFieldset';
 import {performLoginViaApi} from '../../../utils/performLogin';
 import {PORTLET_URLS} from '../../../utils/portletUrls';
 import {readFileFromZip} from '../../../utils/zip';
+import {assetCategoriesPagesTest} from '../../asset-categories-admin-web/main/fixtures/assetCategoriesAdminPagesTest';
 import {companyExportImportPageTest} from './fixtures/companyExportImportPagesTest';
 import {exportImportPagesTest} from './fixtures/exportImportPagesTest';
 import {stagingPageTest} from './fixtures/stagingPageTest';
@@ -91,6 +93,109 @@ const testWithDeprecationFF = mergeTests(
 	}),
 	loginTest(),
 	uiElementsPageTest
+);
+
+export const testWithExportImportAtInstanceLevelFF = mergeTests(
+	companyExportImportPageTest,
+	dataApiHelpersTest,
+	depotAdminPageTest,
+	exportImportPagesTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+		'LPD-35443': {enabled: true},
+		'LPD-44307': {enabled: true},
+		'LPD-44771': {enabled: true},
+		'LPD-45276': {enabled: true},
+	}),
+	isolatedSiteTest,
+	loginTest(),
+	styleBookPageTest,
+	uiElementsPageTest
+);
+
+const testWithObjectExportImportFF = mergeTests(
+	assetCategoriesPagesTest,
+	dataApiHelpersTest,
+	exportImportPagesTest,
+	featureFlagsTest({'LPD-35443': {enabled: true}}),
+	isolatedSiteTest,
+	loginTest()
+);
+
+testWithObjectExportImportFF(
+	'Can export and import vocabularies and categories',
+	{tag: '@LPD-75473'},
+	async ({apiHelpers, assetCategoriesAdminPage, exportImportPage, site}) => {
+		const categoryNames = [
+			{name: getRandomString()},
+			{name: getRandomString()},
+		];
+		const vocabularyName = getRandomString();
+
+		const categories: Array<any> = await createCategories({
+			apiHelpers,
+			categoryNames,
+			siteId: site.id,
+			vocabularyName,
+		});
+
+		apiHelpers.data.push({
+			id: categories[0].vocabularyId,
+			type: 'taxonomyVocabulary',
+		});
+
+		await exportImportPage.goToExport(site.friendlyUrlPath);
+
+		const exportFilePath = await exportImportPage.export({
+			portletLabels: [`Categories 3 Items`],
+		});
+
+		const content1 = await readFileFromZip(
+			'TaxonomyVocabularyResourceImpl.json',
+			exportFilePath
+		);
+
+		expect(JSON.parse(content1).length).toBe(1);
+
+		const content2 = await readFileFromZip(
+			'TaxonomyCategoryResourceImpl.json',
+			exportFilePath
+		);
+
+		expect(JSON.parse(content2).length).toBe(2);
+
+		expect(
+			await apiHelpers.headlessAdminTaxonomy.deleteTaxonomyVocabulary(
+				categories[0].vocabularyId
+			)
+		).toBeOK();
+
+		await assetCategoriesAdminPage.goto(site.friendlyUrlPath);
+
+		await expect(
+			assetCategoriesAdminPage.page.getByRole('menuitem', {
+				exact: true,
+				name: vocabularyName,
+			})
+		).not.toBeVisible();
+
+		await exportImportPage.goToImport(site.friendlyUrlPath);
+
+		await exportImportPage.import({
+			filePath: exportFilePath,
+			taskStatus: 'success',
+		});
+
+		await assetCategoriesAdminPage.goto(site.friendlyUrlPath);
+
+		await assetCategoriesAdminPage.gotoVocabulary(vocabularyName);
+
+		for (const {name} of categoryNames) {
+			await expect(
+				assetCategoriesAdminPage.page.getByRole('row', {name})
+			).toBeVisible();
+		}
+	}
 );
 
 test('Can export and import custom object entries at site level', async ({

--- a/modules/util.gradle
+++ b/modules/util.gradle
@@ -15,7 +15,7 @@ buildscript {
 	apply from: file("build-buildscript.gradle"), to: buildscript
 
 	dependencies {
-		classpath group: "com.liferay", name: "com.liferay.jenkins.results.parser", version: "1.0.1827"
+		classpath group: "com.liferay", name: "com.liferay.jenkins.results.parser", version: "1.0.1828"
 	}
 }
 

--- a/test.properties
+++ b/test.properties
@@ -4200,7 +4200,8 @@
         **/portal-security/portal-security-ldap-impl/**/*Test.java
 
     test.batch.class.names.includes[modules-integration-hypersonic20][headless]=\
-        **/batch-engine/**/src/testIntegration/**/BatchEngineTaskDeadlockTest.java
+        **/batch-engine/**/src/testIntegration/**/BatchEngineExportTaskServiceTest.java,\
+        **/batch-engine/**/src/testIntegration/**/BatchEngineImportTaskServiceTest.java
 
     test.batch.class.names.includes[modules-integration-*][headless]=\
         **/batch-engine/**/src/testIntegration/**/*Test.java,\

--- a/test.properties
+++ b/test.properties
@@ -912,6 +912,7 @@
         modules-integration-solr-mysql84,\
         modules-semantic-versioning,\
         modules-unit,\
+        playwright-js-tomcat101-hypersonic20,\
         playwright-js-tomcat101-postgresql163,\
         semantic-versioning,\
         unit
@@ -4161,6 +4162,9 @@
     # Headless
     #
 
+    headless.hypersonic.playwright.projects=\
+        export-import-web.main
+
     headless.playwright.projects=\
         batch-planner.main,\
         dispatch-web.main,\
@@ -4448,6 +4452,9 @@
     # Headless Playwright
     #
 
+    playwright.projects.includes[playwright-js-tomcat101-hypersonic20][headless-playwright]=\
+        ${headless.hypersonic.playwright.projects}
+
     playwright.projects.includes[playwright-js-tomcat101-postgresql163][headless-playwright]=\
         ${headless.playwright.projects},\
         ${headless.staging.playwright.projects}
@@ -4455,6 +4462,7 @@
     test.batch.dist.app.servers[headless-playwright]=tomcat
 
     test.batch.names[headless-playwright]=\
+        playwright-js-tomcat101-hypersonic20,\
         playwright-js-tomcat101-postgresql163
 
     #

--- a/test.properties
+++ b/test.properties
@@ -4199,6 +4199,9 @@
         **/layout/layout-page-template-test/**/*Test.java,\
         **/portal-security/portal-security-ldap-impl/**/*Test.java
 
+    test.batch.class.names.includes[modules-integration-hypersonic20][headless]=\
+        **/batch-engine/**/src/testIntegration/**/BatchEngineTaskDeadlockTest.java
+
     test.batch.class.names.includes[modules-integration-*][headless]=\
         **/batch-engine/**/src/testIntegration/**/*Test.java,\
         **/batch-planner/**/src/testIntegration/**/*Test.java,\
@@ -4235,6 +4238,7 @@
     test.batch.names[headless]=\
         functional-tomcat101-postgresql163,\
         js-unit,\
+        modules-integration-hypersonic20,\
         modules-integration-postgresql163,\
         modules-unit,\
         playwright-js-tomcat101-postgresql163


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-75473

## What Is Being Fixed

Importing a vocabulary and its categories at the same time could leave the import process stuck. On HSQLDB (Hypersonic), concurrent updates to the batch engine task rows deadlocked because each task-status update ran inside the caller's wider transaction, holding row locks until that transaction completed.

## How It Is Being Fixed

The `updateBatchEngineExportTask` and `updateBatchEngineImportTask` local service methods are overridden to run with `Propagation.REQUIRES_NEW`, so each task-status update commits in its own short transaction and releases its locks immediately instead of waiting on the surrounding transaction. The Service Builder API was regenerated to reflect the new overrides.

Coverage was added on Hypersonic, where the deadlock reproduced: integration tests that drive concurrent task updates through the export and import task services, a Playwright test that exercises vocabulary and category export/import, and the CI batches (integration and Playwright) that run them against HSQLDB.