### PR TITLE
LPD-92456 Sanitize redirect parameter on the export Cancel link

### DIFF
--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/export_portlet.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/export_portlet.jsp
@@ -513,7 +513,7 @@ PortletURL portletURL = PortletURLBuilder.createRenderURL(
 
 								<clay:link
 									cssClass="btn btn-secondary"
-									href="<%= PortalUtil.escapeRedirect(redirect) %>"
+									href="<%= GetterUtil.getString(PortalUtil.escapeRedirect(redirect), themeDisplay.getURLCurrent()) %>"
 									label='<%= LanguageUtil.get(request, "cancel") %>'
 									role="button"
 								/>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/export_portlet.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/export_portlet.jsp
@@ -513,7 +513,7 @@ PortletURL portletURL = PortletURLBuilder.createRenderURL(
 
 								<clay:link
 									cssClass="btn btn-secondary"
-									href="<%= redirect %>"
+									href="<%= PortalUtil.escapeRedirect(redirect) %>"
 									label='<%= LanguageUtil.get(request, "cancel") %>'
 									role="button"
 								/>

--- a/modules/test/playwright/tests/export-import-web/main/portlet.exportRedirect.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/portlet.exportRedirect.spec.ts
@@ -1,0 +1,46 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../fixtures/loginTest';
+
+export const test = mergeTests(
+	featureFlagsTest({'LPD-57655': {enabled: true}}),
+	loginTest()
+);
+
+const NAMESPACE = '_com_liferay_exportimport_web_portlet_ExportImportPortlet_';
+
+test(
+	'sanitizes a javascript: redirect parameter on the portlet export Cancel link',
+	{tag: '@LPD-92456'},
+	async ({page}) => {
+		const searchParams = new URLSearchParams({
+			p_p_id: 'com_liferay_exportimport_web_portlet_ExportImportPortlet',
+			p_p_lifecycle: '0',
+			[NAMESPACE + 'mvcPath']: '/export_portlet.jsp',
+			[NAMESPACE + 'portletConfiguration']: 'true',
+			[NAMESPACE + 'portletResource']:
+				'com_liferay_journal_web_portlet_JournalPortlet',
+			[NAMESPACE + 'redirect']: 'javascript:alert(document.domain)',
+			[NAMESPACE + 'resourcePrimKey']:
+				'1_LAYOUT_com_liferay_journal_web_portlet_JournalPortlet',
+		});
+
+		await page.goto(
+			`/group/guest/~/control_panel/manage?${searchParams.toString()}`
+		);
+
+		const cancelLink = page.getByRole('button', {name: 'Cancel'});
+
+		await expect(cancelLink).toBeVisible();
+
+		const href = await cancelLink.getAttribute('href');
+
+		expect(href ?? '').not.toMatch(/^\s*javascript:/i);
+	}
+);

--- a/modules/test/playwright/tests/export-import-web/main/portlet.exportRedirect.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/portlet.exportRedirect.spec.ts
@@ -39,8 +39,9 @@ test(
 
 		await expect(cancelLink).toBeVisible();
 
-		const href = await cancelLink.getAttribute('href');
-
-		expect(href ?? '').not.toMatch(/^\s*javascript:/i);
+		await expect(cancelLink).toHaveAttribute(
+			'href',
+			/^(?!\s*javascript:)/i
+		);
 	}
 );


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92456

## What Is Being Fixed

The portlet export screen (`export_portlet.jsp`) read the `redirect` URL parameter via `ParamUtil.getString` and injected it unescaped into the Cancel `<clay:link>`, which renders as an `<a href>`. A crafted link with `redirect=javascript:alert(document.domain)` produced `<a href="javascript:...">Cancel</a>`, so an authenticated admin who opened the link and clicked Cancel executed arbitrary JavaScript in the portal's origin.

## How It Is Being Fixed

The `redirect` value is now wrapped in `PortalUtil.escapeRedirect(...)` at the `<clay:link href>` sink. `escapeRedirect` returns null for a `javascript:` scheme (no host / disallowed protocol), neutralizing the attack while leaving legitimate same-host redirects intact. It is applied only at the href sink — `redirect` is also passed to `setURLBack` (which escapes internally) and to non-href form inputs, where escaping is unnecessary. `HtmlUtil.escape` was not used because `javascript:alert(1)` has no HTML metacharacters and would pass through unchanged. A Playwright test loads the export screen with a `javascript:` redirect and asserts the Cancel link's href is not a `javascript:` URI.