### PR TITLE
LPD-93481 Default the LAR file name when exporting

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/LAR.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/LAR.macro
@@ -2,12 +2,14 @@ definition {
 
 	@summary = "Default summary"
 	macro _configureExportSiteOptions(contentDateRange = null, checkContentNameList = null, uncheckContentNameList = null, checkPageName = null, uncheckLogo = null, larFileName = null, uncheckSiteTemplateSettings = null, contentName = null, uncheckSubSubContent = null, uncheckSubContent = null, exportPermissions = null, uncheckSitePagesSettings = null, contentDeletion = null, mainContent = null, subContent = null) {
-		if (isSet(larFileName)) {
-			Type(
-				inputFieldId = "ExportPortlet_name",
-				locator1 = "TextInput#INPUT_ID",
-				value1 = ${larFileName});
+		if (!(isSet(larFileName))) {
+			var larFileName = "Export";
 		}
+
+		Type(
+			inputFieldId = "ExportPortlet_name",
+			locator1 = "TextInput#INPUT_ID",
+			value1 = ${larFileName});
 
 		if (isSet(contentDateRange)) {
 			ContentConfiguration.contentDateRange(contentDateRange = ${contentDateRange});

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/exportimport/ExportImport.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/exportimport/ExportImport.testcase
@@ -1093,6 +1093,8 @@ definition {
 
 			LexiconEntry.gotoAdd();
 
+			LAR.configureExportOptions();
+
 			LAR.exportWithAssertionOnSuccess();
 
 			LAR.downloadLar();
@@ -1610,6 +1612,8 @@ definition {
 				portlet = "Export");
 
 			LexiconEntry.gotoAdd();
+
+			LAR.configureExportOptions();
 
 			LAR.exportWithAssertionOnSuccess();
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/exportimport/ExportImport.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/exportimport/ExportImport.testcase
@@ -156,6 +156,8 @@ definition {
 
 			LexiconEntry.gotoAdd();
 
+			LAR.configureExportOptions();
+
 			LAR.exportWithAssertionOnSuccess();
 		}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/site/SitesExportImport.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/site/SitesExportImport.testcase
@@ -619,6 +619,8 @@ definition {
 
 			LexiconEntry.gotoAdd();
 
+			LAR.configureExportOptions();
+
 			LAR.exportWithAssertionOnSuccess();
 
 			LAR.downloadLar();

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/site/SitesExportImportWithStaging.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/site/SitesExportImportWithStaging.testcase
@@ -209,6 +209,8 @@ definition {
 
 			LexiconEntry.gotoAdd();
 
+			LAR.configureExportOptions();
+
 			LAR.exportWithAssertionOnSuccess();
 
 			LAR.downloadLar();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93481

## Failing Test

`LocalFile.ExportImport#ExportImportGlobalDDMStructureViaInstances`

`portal-web/test/functional/com/liferay/portalweb/tests/enduser/exportimport/ExportImport.testcase`

```
com.liferay.poshi.runner.exception.ElementNotFoundPoshiRunnerException: Element is not present at "//tr[1]/td[2]//div[contains(@class,'h5')] | //span[contains(@data-qa-id,'processResult')]"
```

## Root Cause

The new export wizard (LPD-89688, LPD-90092) makes the process name a required field with no default value. Exports submitted without typing one are rejected with a `LARFileNameException`, the process never starts, and the "Successful" status row the tests assert on never renders. Several tests in the same build fail with this exact trace (`ExportImportGlobalPagesViaInstances`, `AssetLinksCanBeConfiguredWhenExport`, `ExportImportPortletWithADT`, `ExportImportThemeSettings`, `ExportImportValidation`, `DisplayStyleCanRemainAfterNavigation`).

## Fix

Default `larFileName` to "Export" in `LAR._configureExportSiteOptions`, so every test that exports without an explicit name gets a valid one. Five tests (`DisplayStyleCanRemainAfterNavigation`, `ExportImportSiteWithCopyAsNew`, `ImportDMUrlWithoutUUID`, `ExportImportSiteWithStyleBook`, `ImportLiveSiteToStagingSite`) submit the wizard directly without going through the configuration macros, so they now call `LAR.configureExportOptions()` before exporting to pick up the default.

Verified locally on `ExportImportGlobalDDMStructureViaInstances` and `ExportImportSiteWithStyleBook`: without the fix both fail with the exact CI trace, and with it the export completes with a "Successful" status row.

- `portal-web/test/functional/com/liferay/portalweb/macros/LAR.macro`
- `portal-web/test/functional/com/liferay/portalweb/tests/enduser/exportimport/ExportImport.testcase`
- `portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/site/SitesExportImport.testcase`
- `portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/site/SitesExportImportWithStaging.testcase`
