### PR TITLE
LPD-92575 LPD-92576 Restrict import data strategies by scope

### DIFF
--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/display/context/ExportImportPreviewDisplayContext.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/display/context/ExportImportPreviewDisplayContext.java
@@ -110,8 +110,16 @@ public class ExportImportPreviewDisplayContext {
 		return _importProcessAPIURL;
 	}
 
-	public boolean isCompanyGroup() {
-		return _stagingGroupHelper.isCompanyGroup(_group);
+	public String getScope() {
+		if (_stagingGroupHelper.isCompanyGroup(_group)) {
+			return "company";
+		}
+
+		if (_group.isDepot()) {
+			return "assetLibrary";
+		}
+
+		return "site";
 	}
 
 	private String _encode(String value) {

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/display/context/ExportImportPreviewDisplayContext.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/display/context/ExportImportPreviewDisplayContext.java
@@ -110,6 +110,10 @@ public class ExportImportPreviewDisplayContext {
 		return _importProcessAPIURL;
 	}
 
+	public boolean isCompanyGroup() {
+		return _stagingGroupHelper.isCompanyGroup(_group);
+	}
+
 	private String _encode(String value) {
 		if (Validator.isBlank(value)) {
 			return "";

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/import/new_import.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/import/new_import.jsp
@@ -38,7 +38,7 @@ portletDisplay.setURLBack(exportImportPreviewDisplayContext.getBackURL());
 			).put(
 				"importProcessAPIURL", exportImportPreviewDisplayContext.getImportProcessAPIURL()
 			).put(
-				"instance", exportImportPreviewDisplayContext.isCompanyGroup()
+				"scope", exportImportPreviewDisplayContext.getScope()
 			).build()
 		%>'
 	/>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/import/new_import.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/import/new_import.jsp
@@ -37,6 +37,8 @@ portletDisplay.setURLBack(exportImportPreviewDisplayContext.getBackURL());
 				"importPreviewAPIURL", exportImportPreviewDisplayContext.getImportPreviewAPIURL()
 			).put(
 				"importProcessAPIURL", exportImportPreviewDisplayContext.getImportProcessAPIURL()
+			).put(
+				"instance", exportImportPreviewDisplayContext.isCompanyGroup()
 			).build()
 		%>'
 	/>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/NewImport.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/NewImport.tsx
@@ -11,6 +11,7 @@ import {Wizard, WizardStep} from '../../components/Wizard';
 import {postImportProcess} from '../../services/postImportProcess';
 import {ImportPreview} from '../../types/exportImportPreview';
 import {DataStrategy, UserIdStrategy} from '../../types/exportImportProcess';
+import {Scope} from '../../types/scope';
 import {toRequestPortletDataHandlers} from '../../utils/toRequestPortletDataHandlers';
 import DataSelectionStep from './steps/DataSelectionStep';
 import FileSelectionStep from './steps/FileSelectionStep';
@@ -20,12 +21,12 @@ export function NewImport({
 	backURL,
 	importPreviewAPIURL,
 	importProcessAPIURL,
-	instance,
+	scope,
 }: {
 	backURL: string;
 	importPreviewAPIURL: string;
 	importProcessAPIURL: string;
-	instance: boolean;
+	scope: Scope;
 }) {
 	const [importPreview, setImportPreview] = useState<
 		ImportPreview | undefined
@@ -126,7 +127,7 @@ export function NewImport({
 				}}
 				title={Liferay.Language.get('settings')}
 			>
-				<SettingsStep instance={instance} />
+				<SettingsStep scope={scope} />
 			</WizardStep>
 		</Wizard>
 	);

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/NewImport.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/NewImport.tsx
@@ -20,10 +20,12 @@ export function NewImport({
 	backURL,
 	importPreviewAPIURL,
 	importProcessAPIURL,
+	instance,
 }: {
 	backURL: string;
 	importPreviewAPIURL: string;
 	importProcessAPIURL: string;
+	instance: boolean;
 }) {
 	const [importPreview, setImportPreview] = useState<
 		ImportPreview | undefined
@@ -124,7 +126,7 @@ export function NewImport({
 				}}
 				title={Liferay.Language.get('settings')}
 			>
-				<SettingsStep />
+				<SettingsStep instance={instance} />
 			</WizardStep>
 		</Wizard>
 	);

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/steps/SettingsStep.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/steps/SettingsStep.tsx
@@ -14,7 +14,7 @@ export const SETTINGS_STEP_INITIAL_VALUES = {
 	userIdStrategy: 'CURRENT_USER_ID',
 };
 
-export default function SettingsStep() {
+export default function SettingsStep({instance}: {instance: boolean}) {
 	return (
 		<>
 			<ClayLayout.Sheet>
@@ -57,35 +57,58 @@ export default function SettingsStep() {
 					title={Liferay.Language.get('update-data')}
 				/>
 
-				<FormikFieldRadioGroup
-					aria-labelledby="dataStrategy-label"
-					name="dataStrategy"
-					options={[
-						{
-							description: Liferay.Language.get(
-								'import-data-strategy-mirror-help'
-							),
-							label: Liferay.Language.get('mirror'),
-							value: 'MIRROR',
-						},
-						{
-							description: Liferay.Language.get(
-								'import-data-strategy-mirror-with-overwriting-help'
-							),
-							label: Liferay.Language.get(
-								'mirror-with-overwriting'
-							),
-							value: 'MIRROR_OVERWRITE',
-						},
-						{
-							description: Liferay.Language.get(
-								'import-data-strategy-copy-as-new-help'
-							),
-							label: Liferay.Language.get('copy-as-new'),
-							value: 'COPY_AS_NEW',
-						},
-					]}
-				/>
+				{instance ? (
+					<div className="d-flex mb-2">
+						<span
+							aria-hidden="true"
+							className="inline-item inline-item-before invisible small text-secondary"
+						>
+							<ClayIcon className="mr-1" symbol="restore" />
+						</span>
+
+						<div>
+							<span className="d-block font-weight-semi-bold text-dark">
+								{Liferay.Language.get('mirror')}
+							</span>
+
+							<span className="d-block small text-secondary">
+								{Liferay.Language.get(
+									'import-data-strategy-mirror-help'
+								)}
+							</span>
+						</div>
+					</div>
+				) : (
+					<FormikFieldRadioGroup
+						aria-labelledby="dataStrategy-label"
+						name="dataStrategy"
+						options={[
+							{
+								description: Liferay.Language.get(
+									'import-data-strategy-mirror-help'
+								),
+								label: Liferay.Language.get('mirror'),
+								value: 'MIRROR',
+							},
+							{
+								description: Liferay.Language.get(
+									'import-data-strategy-mirror-with-overwriting-help'
+								),
+								label: Liferay.Language.get(
+									'mirror-with-overwriting'
+								),
+								value: 'MIRROR_OVERWRITE',
+							},
+							{
+								description: Liferay.Language.get(
+									'import-data-strategy-copy-as-new-help'
+								),
+								label: Liferay.Language.get('copy-as-new'),
+								value: 'COPY_AS_NEW',
+							},
+						]}
+					/>
+				)}
 			</ClayLayout.Sheet>
 		</>
 	);

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/steps/SettingsStep.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/steps/SettingsStep.tsx
@@ -8,23 +8,27 @@ import ClayLayout from '@clayui/layout';
 import React from 'react';
 
 import {FormikFieldRadioGroup} from '../../../components/forms/formik';
-import {DataStrategy} from '../../../types/exportImportProcess';
+import {
+	DATA_STRATEGIES,
+	DataStrategy,
+	USER_ID_STRATEGIES,
+} from '../../../types/exportImportProcess';
 import {SCOPES, Scope} from '../../../types/scope';
 
 export const SETTINGS_STEP_INITIAL_VALUES = {
-	dataStrategy: 'MIRROR',
-	userIdStrategy: 'CURRENT_USER_ID',
+	dataStrategy: DATA_STRATEGIES.MIRROR,
+	userIdStrategy: USER_ID_STRATEGIES.CURRENT_USER_ID,
 };
 
-const DATA_STRATEGIES: Record<
+const DATA_STRATEGY_LABELS: Record<
 	DataStrategy,
 	{description: string; label: string}
 > = {
-	MIRROR: {
+	[DATA_STRATEGIES.MIRROR]: {
 		description: Liferay.Language.get('import-data-strategy-mirror-help'),
 		label: Liferay.Language.get('mirror'),
 	},
-	MIRROR_OVERWRITE: {
+	[DATA_STRATEGIES.MIRROR_OVERWRITE]: {
 		description: Liferay.Language.get(
 			'import-data-strategy-mirror-with-overwriting-help'
 		),
@@ -33,16 +37,19 @@ const DATA_STRATEGIES: Record<
 };
 
 const DATA_STRATEGY_OPTIONS: Record<Scope, DataStrategy[]> = {
-	[SCOPES.ASSET_LIBRARY]: ['MIRROR', 'MIRROR_OVERWRITE'],
-	[SCOPES.COMPANY]: ['MIRROR'],
-	[SCOPES.SITE]: ['MIRROR', 'MIRROR_OVERWRITE'],
+	[SCOPES.ASSET_LIBRARY]: [
+		DATA_STRATEGIES.MIRROR,
+		DATA_STRATEGIES.MIRROR_OVERWRITE,
+	],
+	[SCOPES.COMPANY]: [DATA_STRATEGIES.MIRROR],
+	[SCOPES.SITE]: [DATA_STRATEGIES.MIRROR, DATA_STRATEGIES.MIRROR_OVERWRITE],
 };
 
 export default function SettingsStep({scope}: {scope: Scope}) {
 	const dataStrategyOptions = (
 		DATA_STRATEGY_OPTIONS[scope] ?? DATA_STRATEGY_OPTIONS[SCOPES.SITE]
 	).map((value) => ({
-		...DATA_STRATEGIES[value],
+		...DATA_STRATEGY_LABELS[value],
 		value,
 	}));
 
@@ -66,7 +73,7 @@ export default function SettingsStep({scope}: {scope: Scope}) {
 							label: Liferay.Language.get(
 								'use-the-original-author'
 							),
-							value: 'CURRENT_USER_ID',
+							value: USER_ID_STRATEGIES.CURRENT_USER_ID,
 						},
 						{
 							description: Liferay.Language.get(
@@ -75,7 +82,7 @@ export default function SettingsStep({scope}: {scope: Scope}) {
 							label: Liferay.Language.get(
 								'use-the-current-user-as-author'
 							),
-							value: 'ALWAYS_CURRENT_USER_ID',
+							value: USER_ID_STRATEGIES.ALWAYS_CURRENT_USER_ID,
 						},
 					]}
 				/>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/steps/SettingsStep.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/steps/SettingsStep.tsx
@@ -39,7 +39,9 @@ const DATA_STRATEGY_OPTIONS: Record<Scope, DataStrategy[]> = {
 };
 
 export default function SettingsStep({scope}: {scope: Scope}) {
-	const dataStrategyOptions = DATA_STRATEGY_OPTIONS[scope].map((value) => ({
+	const dataStrategyOptions = (
+		DATA_STRATEGY_OPTIONS[scope] ?? DATA_STRATEGY_OPTIONS[SCOPES.SITE]
+	).map((value) => ({
 		...DATA_STRATEGIES[value],
 		value,
 	}));

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/steps/SettingsStep.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/steps/SettingsStep.tsx
@@ -8,6 +8,7 @@ import ClayLayout from '@clayui/layout';
 import React from 'react';
 
 import {FormikFieldRadioGroup} from '../../../components/forms/formik';
+import {DataStrategy} from '../../../types/exportImportProcess';
 import {SCOPES, Scope} from '../../../types/scope';
 
 export const SETTINGS_STEP_INITIAL_VALUES = {
@@ -15,7 +16,34 @@ export const SETTINGS_STEP_INITIAL_VALUES = {
 	userIdStrategy: 'CURRENT_USER_ID',
 };
 
+const DATA_STRATEGIES: Record<
+	DataStrategy,
+	{description: string; label: string}
+> = {
+	MIRROR: {
+		description: Liferay.Language.get('import-data-strategy-mirror-help'),
+		label: Liferay.Language.get('mirror'),
+	},
+	MIRROR_OVERWRITE: {
+		description: Liferay.Language.get(
+			'import-data-strategy-mirror-with-overwriting-help'
+		),
+		label: Liferay.Language.get('mirror-with-overwriting'),
+	},
+};
+
+const DATA_STRATEGY_OPTIONS: Record<Scope, DataStrategy[]> = {
+	[SCOPES.ASSET_LIBRARY]: ['MIRROR', 'MIRROR_OVERWRITE'],
+	[SCOPES.COMPANY]: ['MIRROR'],
+	[SCOPES.SITE]: ['MIRROR', 'MIRROR_OVERWRITE'],
+};
+
 export default function SettingsStep({scope}: {scope: Scope}) {
+	const dataStrategyOptions = DATA_STRATEGY_OPTIONS[scope].map((value) => ({
+		...DATA_STRATEGIES[value],
+		value,
+	}));
+
 	return (
 		<>
 			<ClayLayout.Sheet>
@@ -58,60 +86,51 @@ export default function SettingsStep({scope}: {scope: Scope}) {
 					title={Liferay.Language.get('update-data')}
 				/>
 
-				{scope === SCOPES.COMPANY ? (
-					<div className="d-flex mb-2">
-						<span
-							aria-hidden="true"
-							className="inline-item inline-item-before invisible small text-secondary"
-						>
-							<ClayIcon className="mr-1" symbol="restore" />
-						</span>
-
-						<div>
-							<span className="d-block font-weight-semi-bold text-dark">
-								{Liferay.Language.get('mirror')}
-							</span>
-
-							<span className="d-block small text-secondary">
-								{Liferay.Language.get(
-									'import-data-strategy-mirror-help'
-								)}
-							</span>
-						</div>
-					</div>
+				{dataStrategyOptions.length === 1 ? (
+					<ReadOnlyOption
+						option={dataStrategyOptions[0]}
+						symbol="restore"
+					/>
 				) : (
 					<FormikFieldRadioGroup
 						aria-labelledby="dataStrategy-label"
 						name="dataStrategy"
-						options={[
-							{
-								description: Liferay.Language.get(
-									'import-data-strategy-mirror-help'
-								),
-								label: Liferay.Language.get('mirror'),
-								value: 'MIRROR',
-							},
-							{
-								description: Liferay.Language.get(
-									'import-data-strategy-mirror-with-overwriting-help'
-								),
-								label: Liferay.Language.get(
-									'mirror-with-overwriting'
-								),
-								value: 'MIRROR_OVERWRITE',
-							},
-							{
-								description: Liferay.Language.get(
-									'import-data-strategy-copy-as-new-help'
-								),
-								label: Liferay.Language.get('copy-as-new'),
-								value: 'COPY_AS_NEW',
-							},
-						]}
+						options={dataStrategyOptions}
 					/>
 				)}
 			</ClayLayout.Sheet>
 		</>
+	);
+}
+
+function ReadOnlyOption({
+	option,
+	symbol,
+}: {
+	option: {description: string; label: string};
+	symbol: string;
+}) {
+	return (
+		<ClayLayout.ContentRow className="mb-2">
+			<ClayLayout.ContentCol expand={false}>
+				<span
+					aria-hidden="true"
+					className="inline-item inline-item-before invisible small text-secondary"
+				>
+					<ClayIcon className="mr-1" symbol={symbol} />
+				</span>
+			</ClayLayout.ContentCol>
+
+			<ClayLayout.ContentCol expand>
+				<span className="d-block font-weight-semi-bold text-dark">
+					{option.label}
+				</span>
+
+				<span className="d-block small text-secondary">
+					{option.description}
+				</span>
+			</ClayLayout.ContentCol>
+		</ClayLayout.ContentRow>
 	);
 }
 

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/steps/SettingsStep.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/steps/SettingsStep.tsx
@@ -8,13 +8,14 @@ import ClayLayout from '@clayui/layout';
 import React from 'react';
 
 import {FormikFieldRadioGroup} from '../../../components/forms/formik';
+import {SCOPES, Scope} from '../../../types/scope';
 
 export const SETTINGS_STEP_INITIAL_VALUES = {
 	dataStrategy: 'MIRROR',
 	userIdStrategy: 'CURRENT_USER_ID',
 };
 
-export default function SettingsStep({instance}: {instance: boolean}) {
+export default function SettingsStep({scope}: {scope: Scope}) {
 	return (
 		<>
 			<ClayLayout.Sheet>
@@ -57,7 +58,7 @@ export default function SettingsStep({instance}: {instance: boolean}) {
 					title={Liferay.Language.get('update-data')}
 				/>
 
-				{instance ? (
+				{scope === SCOPES.COMPANY ? (
 					<div className="d-flex mb-2">
 						<span
 							aria-hidden="true"

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/types/exportImportProcess.ts
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/types/exportImportProcess.ts
@@ -25,7 +25,7 @@ export interface ExportProcessRequest {
 	startDate?: string;
 }
 
-export type DataStrategy = 'MIRROR' | 'MIRROR_OVERWRITE' | 'COPY_AS_NEW';
+export type DataStrategy = 'MIRROR' | 'MIRROR_OVERWRITE';
 
 export type UserIdStrategy = 'CURRENT_USER_ID' | 'ALWAYS_CURRENT_USER_ID';
 

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/types/exportImportProcess.ts
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/types/exportImportProcess.ts
@@ -25,9 +25,21 @@ export interface ExportProcessRequest {
 	startDate?: string;
 }
 
-export type DataStrategy = 'MIRROR' | 'MIRROR_OVERWRITE';
+export const DATA_STRATEGIES = {
+	MIRROR: 'MIRROR',
+	MIRROR_OVERWRITE: 'MIRROR_OVERWRITE',
+} as const;
 
-export type UserIdStrategy = 'CURRENT_USER_ID' | 'ALWAYS_CURRENT_USER_ID';
+export type DataStrategy =
+	(typeof DATA_STRATEGIES)[keyof typeof DATA_STRATEGIES];
+
+export const USER_ID_STRATEGIES = {
+	ALWAYS_CURRENT_USER_ID: 'ALWAYS_CURRENT_USER_ID',
+	CURRENT_USER_ID: 'CURRENT_USER_ID',
+} as const;
+
+export type UserIdStrategy =
+	(typeof USER_ID_STRATEGIES)[keyof typeof USER_ID_STRATEGIES];
 
 export interface ImportProcess {
 	dateCreated?: string;

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/types/scope.ts
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/types/scope.ts
@@ -1,0 +1,12 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const SCOPES = {
+	ASSET_LIBRARY: 'assetLibrary',
+	COMPANY: 'company',
+	SITE: 'site',
+} as const;
+
+export type Scope = (typeof SCOPES)[keyof typeof SCOPES];

--- a/modules/apps/export-import/export-import-web/test/revamp/js/pages/import/NewImport.test.tsx
+++ b/modules/apps/export-import/export-import-web/test/revamp/js/pages/import/NewImport.test.tsx
@@ -11,6 +11,7 @@ import React from 'react';
 
 import {NewImport} from '../../../../../src/main/resources/META-INF/resources/revamp/js/pages/import/NewImport';
 import {postImportPreview} from '../../../../../src/main/resources/META-INF/resources/revamp/js/services/postImportPreview';
+import {SCOPES} from '../../../../../src/main/resources/META-INF/resources/revamp/js/types/scope';
 import {mockImportPreview} from '../../mocks/mockImportPreview';
 import {mockSectionsForFilterTest} from '../../mocks/mockSectionsForFilterTest';
 
@@ -41,7 +42,7 @@ const renderComponent = () =>
 			backURL="/some/back/url"
 			importPreviewAPIURL="/o/export-import/v1.0/import-preview"
 			importProcessAPIURL="/o/export-import/v1.0/import-processes"
-			instance={false}
+			scope={SCOPES.SITE}
 		/>
 	);
 

--- a/modules/apps/export-import/export-import-web/test/revamp/js/pages/import/NewImport.test.tsx
+++ b/modules/apps/export-import/export-import-web/test/revamp/js/pages/import/NewImport.test.tsx
@@ -41,6 +41,7 @@ const renderComponent = () =>
 			backURL="/some/back/url"
 			importPreviewAPIURL="/o/export-import/v1.0/import-preview"
 			importProcessAPIURL="/o/export-import/v1.0/import-processes"
+			instance={false}
 		/>
 	);
 

--- a/modules/apps/export-import/export-import-web/test/revamp/js/pages/import/steps/SettingsStep.test.tsx
+++ b/modules/apps/export-import/export-import-web/test/revamp/js/pages/import/steps/SettingsStep.test.tsx
@@ -10,13 +10,17 @@ import React from 'react';
 
 import SettingsStep from '../../../../../../src/main/resources/META-INF/resources/revamp/js/pages/import/steps/SettingsStep';
 import {
+	DATA_STRATEGIES,
+	USER_ID_STRATEGIES,
+} from '../../../../../../src/main/resources/META-INF/resources/revamp/js/types/exportImportProcess';
+import {
 	SCOPES,
 	Scope,
 } from '../../../../../../src/main/resources/META-INF/resources/revamp/js/types/scope';
 
 const defaultInitialValues = {
-	dataStrategy: 'MIRROR',
-	userIdStrategy: 'CURRENT_USER_ID',
+	dataStrategy: DATA_STRATEGIES.MIRROR,
+	userIdStrategy: USER_ID_STRATEGIES.CURRENT_USER_ID,
 };
 
 const renderSettingsStep = (

--- a/modules/apps/export-import/export-import-web/test/revamp/js/pages/import/steps/SettingsStep.test.tsx
+++ b/modules/apps/export-import/export-import-web/test/revamp/js/pages/import/steps/SettingsStep.test.tsx
@@ -16,14 +16,15 @@ const defaultInitialValues = {
 };
 
 const renderSettingsStep = (
-	overrides: Partial<typeof defaultInitialValues> = {}
+	overrides: Partial<typeof defaultInitialValues> = {},
+	instance = false
 ) =>
 	render(
 		<Formik
 			initialValues={{...defaultInitialValues, ...overrides}}
 			onSubmit={jest.fn()}
 		>
-			<SettingsStep />
+			<SettingsStep instance={instance} />
 		</Formik>
 	);
 
@@ -82,5 +83,24 @@ describe('SettingsStep', () => {
 
 		expect(radio).toBeChecked();
 		expect(screen.getByLabelText('mirror')).not.toBeChecked();
+	});
+
+	it('shows mirror as a read-only label at the instance level', () => {
+		renderSettingsStep({}, true);
+
+		expect(screen.getByText('mirror')).toBeInTheDocument();
+		expect(
+			screen.getByText('import-data-strategy-mirror-help')
+		).toBeInTheDocument();
+	});
+
+	it('hides the update-data strategy options at the instance level', () => {
+		renderSettingsStep({}, true);
+
+		expect(screen.queryByLabelText('mirror')).not.toBeInTheDocument();
+		expect(
+			screen.queryByLabelText('mirror-with-overwriting')
+		).not.toBeInTheDocument();
+		expect(screen.queryByLabelText('copy-as-new')).not.toBeInTheDocument();
 	});
 });

--- a/modules/apps/export-import/export-import-web/test/revamp/js/pages/import/steps/SettingsStep.test.tsx
+++ b/modules/apps/export-import/export-import-web/test/revamp/js/pages/import/steps/SettingsStep.test.tsx
@@ -9,6 +9,10 @@ import {Formik} from 'formik';
 import React from 'react';
 
 import SettingsStep from '../../../../../../src/main/resources/META-INF/resources/revamp/js/pages/import/steps/SettingsStep';
+import {
+	SCOPES,
+	Scope,
+} from '../../../../../../src/main/resources/META-INF/resources/revamp/js/types/scope';
 
 const defaultInitialValues = {
 	dataStrategy: 'MIRROR',
@@ -17,14 +21,14 @@ const defaultInitialValues = {
 
 const renderSettingsStep = (
 	overrides: Partial<typeof defaultInitialValues> = {},
-	instance = false
+	scope: Scope = SCOPES.SITE
 ) =>
 	render(
 		<Formik
 			initialValues={{...defaultInitialValues, ...overrides}}
 			onSubmit={jest.fn()}
 		>
-			<SettingsStep instance={instance} />
+			<SettingsStep scope={scope} />
 		</Formik>
 	);
 
@@ -85,8 +89,8 @@ describe('SettingsStep', () => {
 		expect(screen.getByLabelText('mirror')).not.toBeChecked();
 	});
 
-	it('shows mirror as a read-only label at the instance level', () => {
-		renderSettingsStep({}, true);
+	it('shows mirror as a read-only label at the company scope', () => {
+		renderSettingsStep({}, SCOPES.COMPANY);
 
 		expect(screen.getByText('mirror')).toBeInTheDocument();
 		expect(
@@ -94,8 +98,8 @@ describe('SettingsStep', () => {
 		).toBeInTheDocument();
 	});
 
-	it('hides the update-data strategy options at the instance level', () => {
-		renderSettingsStep({}, true);
+	it('hides the update-data strategy options at the company scope', () => {
+		renderSettingsStep({}, SCOPES.COMPANY);
 
 		expect(screen.queryByLabelText('mirror')).not.toBeInTheDocument();
 		expect(

--- a/modules/apps/export-import/export-import-web/test/revamp/js/pages/import/steps/SettingsStep.test.tsx
+++ b/modules/apps/export-import/export-import-web/test/revamp/js/pages/import/steps/SettingsStep.test.tsx
@@ -73,7 +73,6 @@ describe('SettingsStep', () => {
 		expect(
 			screen.getByLabelText('mirror-with-overwriting')
 		).not.toBeChecked();
-		expect(screen.getByLabelText('copy-as-new')).not.toBeChecked();
 	});
 
 	it('switches the update-data strategy when a different option is selected', async () => {
@@ -81,12 +80,18 @@ describe('SettingsStep', () => {
 
 		renderSettingsStep();
 
-		const radio = screen.getByLabelText('copy-as-new');
+		const radio = screen.getByLabelText('mirror-with-overwriting');
 
 		await user.click(radio);
 
 		expect(radio).toBeChecked();
 		expect(screen.getByLabelText('mirror')).not.toBeChecked();
+	});
+
+	it('does not show the copy-as-new strategy', () => {
+		renderSettingsStep();
+
+		expect(screen.queryByLabelText('copy-as-new')).not.toBeInTheDocument();
 	});
 
 	it('shows mirror as a read-only label at the company scope', () => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92575
https://liferay.atlassian.net/browse/LPD-92576

## What Is Being Fixed

At the instance level the import wizard offered the three Update Data strategies, although only Mirror applies there. In addition, the Copy as New option was removed from the product for all use cases, but the revamped wizard still offered it at the site level.

## How It Is Being Fixed

The display context now exposes the import scope (company, asset library, or site) instead of a boolean flag, and the React wizard receives it as a `scope` prop. The Settings step derives the available data strategies from a per-scope map: company allows only Mirror and renders it as a read-only label, while site and asset library allow Mirror and Mirror with Overwriting. Copy as New is removed from the options and from the `DataStrategy` type, so it cannot be reintroduced silently.

## Screenshots
Instance: 
<img width="1428" height="333" alt="image" src="https://github.com/user-attachments/assets/3a734fb0-8ee2-46e2-aa19-79632bbfdb4f" />

Site:
<img width="1428" height="333" alt="image" src="https://github.com/user-attachments/assets/0b522f58-72a2-451a-9180-0bc327b3ce03" />

