### PR TITLE
LPD-93634 Fix PGStaging#PublishLayoutIconDeletion Poshi test

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/staging/JSONStaging.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/staging/JSONStaging.macro
@@ -48,7 +48,7 @@ definition {
 			parentGroupName = ${parentGroupName},
 			site = "false");
 
-		while (("" == "")) {
+		while ((${groupId} == "")) {
 			var groupId = JSONGroupAPI._getGroupIdByNameNoError(
 				grandParentGroupName = ${grandParentGroupName},
 				groupName = "${groupName} (Staging)",

--- a/portal-web/test/functional/com/liferay/portalweb/paths/util/Home.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/util/Home.path
@@ -226,7 +226,7 @@
 </tr>
 <tr>
 	<td>PAGE_ACTIVE</td>
-	<td>//div[contains(@id,'navbar')]/ul//*[contains(@class,'active')][.//*[normalize-space(text())='${key_pageName}']]</td>
+	<td>//div[contains(@id,'navbar')]/ul//*[contains(@class,'active')][.//a[normalize-space()='${key_pageName}']]</td>
 	<td>Page</td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/pgstaging/PGStaging.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/pgstaging/PGStaging.testcase
@@ -537,7 +537,7 @@ definition {
 
 		Navigator.openSiteURL(siteName = "Site Name");
 
-		Navigator.gotoStagedView();
+		ProductMenu.gotoStagingSite(site = "Site Name");
 
 		PagesAdmin.changeLogo(
 			logoFile = "Document_3.png",


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93634

## Failing Test

`LocalFile.PGStaging#PublishLayoutIconDeletion`

`portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/pgstaging/PGStaging.testcase`

```
java.lang.Exception: Element is not present at "//div[contains(@id,'navbar')]/ul//*[contains(@class,'active')][.//*[normalize-space(text())='Staging Test Page']]"
```

## Root Cause

The `Home#PAGE_ACTIVE` locator predicate `.//*[normalize-space(text())='...']` only evaluates the first text node of the matched element. When a page has a custom logo, `LayoutIconTag` renders an `<img class="layout-logo">` before the page name inside the navbar link, so the first text node becomes whitespace and the locator never matches — exactly on the tests that upload a page logo right before navigating (`PGStaging#PublishLayoutIconDeletion` and its twin `StagingUsecaseWithVersioning#StagingPageLogo`, which has the identical chronic failure on the same routine; siblings that never upload a logo pass). Two further defects kept the test from reaching that point: commit `32ddae0d28bda` ("POSHI-471 Regen Poshi Script") corrupted the staging-group polling loop in `JSONStaging.enableLocalStaging` into the never-checking `while (("" == ""))`, and the changeLogo step used `Navigator.gotoStagedView()`, which does not verify the staging view switch, so Pages admin rendered the read-only Live view where the "Configure" menu entry is absent.

## Fix

Match the active page by the whole string-value of the navbar link (`.//a[normalize-space()='...']`, mirroring the sibling `PAGE` locator) so the optional logo `<img>` no longer breaks the predicate; restore the polling condition in `JSONStaging.enableLocalStaging`; and reach the Pages admin through `ProductMenu.gotoStagingSite`, which asserts the staging view is selected. Validated locally: `PGStaging#PublishLayoutIconDeletion` 114 steps passed / 0 failed, twin `StagingUsecaseWithVersioning#StagingPageLogo` 112/0, and the green sibling `PGStaging#AddDMDocumentWCArticleStagingLocalLive` is unaffected.

- `portal-web/test/functional/com/liferay/portalweb/macros/json/staging/JSONStaging.macro`
- `portal-web/test/functional/com/liferay/portalweb/paths/util/Home.path`
- `portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/pgstaging/PGStaging.testcase`