### PR TITLE
LPD-93952 Return unlinked entries when relationship ERC filter is empty

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
@@ -115,11 +115,16 @@ public class PredicateExpressionVisitorImpl
 		Predicate predicate = null;
 
 		if (_isComplexProperExpression(left)) {
-			predicate = _getObjectRelationshipPredicate(
-				left,
-				(objectFieldName, relatedObjectDefinition) -> _getPredicate(
-					objectFieldName, relatedObjectDefinition, operation,
-					right));
+			predicate = _getUnlinkedRelationshipPredicate(
+				operation, (String)left, right);
+
+			if (predicate == null) {
+				predicate = _getObjectRelationshipPredicate(
+					left,
+					(objectFieldName, relatedObjectDefinition) -> _getPredicate(
+						objectFieldName, relatedObjectDefinition, operation,
+						right));
+			}
 		}
 		else {
 			predicate = _getPredicate(
@@ -687,6 +692,46 @@ public class PredicateExpressionVisitorImpl
 		return BinaryExpressionConverterUtil.getExpressionPredicate(
 			_getColumn(left, objectDefinition), operation,
 			_getValue(left, objectDefinition, right));
+	}
+
+	private Predicate _getUnlinkedRelationshipPredicate(
+			BinaryExpression.Operation operation, String left, Object right)
+		throws ExpressionVisitException {
+
+		if ((!Objects.equals(BinaryExpression.Operation.EQ, operation) &&
+			 !Objects.equals(BinaryExpression.Operation.NE, operation)) ||
+			Validator.isNotNull(String.valueOf(right))) {
+
+			return null;
+		}
+
+		List<String> leftParts = ListUtil.fromString(left, StringPool.SLASH);
+
+		if ((leftParts.size() != 2) ||
+			!Objects.equals(leftParts.get(1), "externalReferenceCode")) {
+
+			return null;
+		}
+
+		ObjectRelationship objectRelationship = _fetchObjectRelationship(
+			_objectDefinition, leftParts.get(0));
+
+		if (objectRelationship == null) {
+			return null;
+		}
+
+		ObjectField objectField = _objectFieldLocalService.fetchObjectField(
+			objectRelationship.getObjectFieldId2());
+
+		if ((objectField == null) ||
+			(objectField.getObjectDefinitionId() !=
+				_objectDefinition.getObjectDefinitionId())) {
+
+			return null;
+		}
+
+		return _getPredicate(
+			objectField.getName(), _objectDefinition, operation, right);
 	}
 
 	private Object _getValue(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
@@ -115,7 +115,7 @@ public class PredicateExpressionVisitorImpl
 		Predicate predicate = null;
 
 		if (_isComplexProperExpression(left)) {
-			predicate = _getUnlinkedRelationshipPredicate(
+			predicate = _getEmptyRelationshipExternalReferenceCodePredicate(
 				operation, (String)left, right);
 
 			if (predicate == null) {
@@ -463,6 +463,46 @@ public class PredicateExpressionVisitorImpl
 			entityField.getFilterableName(null));
 	}
 
+	private Predicate _getEmptyRelationshipExternalReferenceCodePredicate(
+			BinaryExpression.Operation operation, String left, Object right)
+		throws ExpressionVisitException {
+
+		if ((!Objects.equals(BinaryExpression.Operation.EQ, operation) &&
+			 !Objects.equals(BinaryExpression.Operation.NE, operation)) ||
+			Validator.isNotNull(String.valueOf(right))) {
+
+			return null;
+		}
+
+		List<String> leftParts = ListUtil.fromString(left, StringPool.SLASH);
+
+		if ((leftParts.size() != 2) ||
+			!Objects.equals(leftParts.get(1), "externalReferenceCode")) {
+
+			return null;
+		}
+
+		ObjectRelationship objectRelationship = _fetchObjectRelationship(
+			_objectDefinition, leftParts.get(0));
+
+		if (objectRelationship == null) {
+			return null;
+		}
+
+		ObjectField objectField = _objectFieldLocalService.fetchObjectField(
+			objectRelationship.getObjectFieldId2());
+
+		if ((objectField == null) ||
+			(objectField.getObjectDefinitionId() !=
+				_objectDefinition.getObjectDefinitionId())) {
+
+			return null;
+		}
+
+		return _getPredicate(
+			objectField.getName(), _objectDefinition, operation, right);
+	}
+
 	private EntityField _getEntityField(
 		String fieldName, ObjectDefinition objectDefinition) {
 
@@ -692,46 +732,6 @@ public class PredicateExpressionVisitorImpl
 		return BinaryExpressionConverterUtil.getExpressionPredicate(
 			_getColumn(left, objectDefinition), operation,
 			_getValue(left, objectDefinition, right));
-	}
-
-	private Predicate _getUnlinkedRelationshipPredicate(
-			BinaryExpression.Operation operation, String left, Object right)
-		throws ExpressionVisitException {
-
-		if ((!Objects.equals(BinaryExpression.Operation.EQ, operation) &&
-			 !Objects.equals(BinaryExpression.Operation.NE, operation)) ||
-			Validator.isNotNull(String.valueOf(right))) {
-
-			return null;
-		}
-
-		List<String> leftParts = ListUtil.fromString(left, StringPool.SLASH);
-
-		if ((leftParts.size() != 2) ||
-			!Objects.equals(leftParts.get(1), "externalReferenceCode")) {
-
-			return null;
-		}
-
-		ObjectRelationship objectRelationship = _fetchObjectRelationship(
-			_objectDefinition, leftParts.get(0));
-
-		if (objectRelationship == null) {
-			return null;
-		}
-
-		ObjectField objectField = _objectFieldLocalService.fetchObjectField(
-			objectRelationship.getObjectFieldId2());
-
-		if ((objectField == null) ||
-			(objectField.getObjectDefinitionId() !=
-				_objectDefinition.getObjectDefinitionId())) {
-
-			return null;
-		}
-
-		return _getPredicate(
-			objectField.getName(), _objectDefinition, operation, right);
 	}
 
 	private Object _getValue(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -6105,6 +6105,69 @@ public class DefaultObjectEntryManagerImplTest
 	}
 
 	@Test
+	@TestInfo("LPD-93952")
+	public void testGetObjectEntriesFilterByUnlinkedRelationshipExternalReferenceCode()
+		throws Exception {
+
+		ObjectEntry parentObjectEntry =
+			_defaultObjectEntryManager.addObjectEntry(
+				_simpleDTOConverterContext, _objectDefinition1,
+				new ObjectEntry() {
+					{
+						properties = HashMapBuilder.<String, Object>put(
+							"textObjectFieldName", RandomTestUtil.randomString()
+						).build();
+					}
+				},
+				ObjectDefinitionConstants.SCOPE_COMPANY);
+
+		ObjectEntry linkedObjectEntry =
+			_defaultObjectEntryManager.addObjectEntry(
+				dtoConverterContext, _objectDefinition2,
+				new ObjectEntry() {
+					{
+						properties = HashMapBuilder.<String, Object>put(
+							_objectRelationshipFieldName,
+							parentObjectEntry.getId()
+						).put(
+							"textObjectFieldName", RandomTestUtil.randomString()
+						).build();
+					}
+				},
+				ObjectDefinitionConstants.SCOPE_COMPANY);
+
+		ObjectEntry unlinkedObjectEntry =
+			_defaultObjectEntryManager.addObjectEntry(
+				dtoConverterContext, _objectDefinition2,
+				new ObjectEntry() {
+					{
+						properties = HashMapBuilder.<String, Object>put(
+							"textObjectFieldName", RandomTestUtil.randomString()
+						).build();
+					}
+				},
+				ObjectDefinitionConstants.SCOPE_COMPANY);
+
+		// Filtering the relationship's external reference code for an empty
+		// value must return the entries that are not linked through the
+		// relationship
+
+		_assertFilteredObjectEntryIds(
+			buildEqualsExpressionFilterString(
+				_objectRelationshipERCObjectFieldName, StringPool.BLANK),
+			unlinkedObjectEntry.getId());
+
+		// Filtering by a linked external reference code must still return only
+		// the linked entry
+
+		_assertFilteredObjectEntryIds(
+			buildEqualsExpressionFilterString(
+				_objectRelationshipERCObjectFieldName,
+				parentObjectEntry.getExternalReferenceCode()),
+			linkedObjectEntry.getId());
+	}
+
+	@Test
 	public void testGetObjectEntriesWithAccountEntryRestricted1()
 		throws Exception {
 
@@ -10666,6 +10729,27 @@ public class DefaultObjectEntryManagerImplTest
 
 		Assert.assertEquals(
 			objectEntries.toString(), size, objectEntries.size());
+	}
+
+	private void _assertFilteredObjectEntryIds(
+			String filterString, Long... expectedObjectEntryIds)
+		throws Exception {
+
+		Page<ObjectEntry> page = getObjectEntries(
+			HashMapBuilder.put(
+				"filter", filterString
+			).build(),
+			null);
+
+		List<Long> actualObjectEntryIds = new ArrayList<>();
+
+		for (ObjectEntry objectEntry : page.getItems()) {
+			actualObjectEntryIds.add(objectEntry.getId());
+		}
+
+		Assert.assertEquals(
+			page.toString(), Arrays.asList(expectedObjectEntryIds),
+			actualObjectEntryIds);
 	}
 
 	private void _assertListEntries(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -6106,7 +6106,7 @@ public class DefaultObjectEntryManagerImplTest
 
 	@Test
 	@TestInfo("LPD-93952")
-	public void testGetObjectEntriesFilterByUnlinkedRelationshipExternalReferenceCode()
+	public void testGetObjectEntriesFilterByEmptyRelationshipExternalReferenceCode()
 		throws Exception {
 
 		ObjectEntry parentObjectEntry =


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93952

## What Is Being Fixed

When a custom object has a relationship to another object, the Headless Object Entries REST API exposes the relationship as two filterable accessors: the numeric foreign key (`r_<relationship>_c_<parent>Id`) and the parent's external reference code (`r_<relationship>_c_<parent>ERC`). Filtering the external reference code accessor for an empty value (for example `filter=r_shippingDocumentBooking_c_bookingERC eq ''`) returned zero entries instead of the entries that are not linked through the relationship. The numeric accessor (`... eq ''`) returned those unlinked entries correctly, so the two accessors disagreed.

## How It Is Being Fixed

The external reference code accessor is registered as a `ReferenceStringEntityField` that resolves to the reference path `<relationship>/externalReferenceCode`, so an empty-value comparison was translated into a predicate against the related object's external reference code. That predicate requires a related entry to exist and therefore can never match unlinked entries. The fix intercepts equality comparisons (`eq` and `ne`) against a relationship's external reference code accessor when the value is empty and routes them to the local foreign key column instead, matching the numeric accessor so that an empty external reference code correctly means "not linked". An integration test in `DefaultObjectEntryManagerImplTest` covers both the unlinked empty-value case and the still-linked case.

## PR Check

**pr-check: PASS** — tested on `c40e4efd0d6b1e0e63f0cf085d41480698809777`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "c40e4efd0d6b1e0e63f0cf085d41480698809777"} -->