### PR TITLE
LPD-93614 Contain the objects section in a compact bordered scroll

### DIFF
--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/css/utilities.scss
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/css/utilities.scss
@@ -1,5 +1,13 @@
-.content-section-controls {
-	max-height: 400px;
+@import 'atlas-variables';
+
+.content-section-scroll {
+	max-height: 600px;
+	overflow: auto;
+
+	@include media-breakpoint-down(sm) {
+		max-height: none;
+		overflow: visible;
+	}
 }
 
 .cursor-pointer {

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/CollapsibleGroup.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/CollapsibleGroup.tsx
@@ -4,12 +4,13 @@
  */
 
 import classnames from 'classnames';
-import React, {ReactNode, useId, useState} from 'react';
+import React, {ReactNode, Ref, useId, useState} from 'react';
 
 import ControlRow from './ControlRow';
 
 export default function CollapsibleGroup({
 	bodyClassName,
+	bodyRef,
 	bodyVisibleClassName,
 	checkboxId,
 	children,
@@ -24,6 +25,7 @@ export default function CollapsibleGroup({
 	tags,
 }: {
 	bodyClassName?: string;
+	bodyRef?: Ref<HTMLDivElement>;
 	bodyVisibleClassName?: string;
 	checkboxId: string;
 	children: ReactNode;
@@ -75,6 +77,7 @@ export default function CollapsibleGroup({
 				)}
 				hidden={!expanded}
 				id={bodyId}
+				ref={bodyRef}
 			>
 				{children}
 			</div>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSection.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSection.tsx
@@ -17,8 +17,10 @@ import {
 	PreviewPortletDataHandlerSection as PortletDataHandlerSectionType,
 } from '../../../types/portletDataHandler';
 import {
+	COMPACT_SECTION_NAMES,
 	CONTENT_SECTION_KEY,
 	HandlerSelection,
+	SCROLLABLE_SECTION_NAMES,
 	SITE_BUILDER_SECTION_KEY,
 	getInitialSelections,
 	getSelectionSummary,
@@ -57,8 +59,8 @@ export default function ContentSection({
 	const checkboxId = useId();
 	const [overflowing, setOverflowing] = useState(false);
 
-	const compact = section.name === 'objects';
-	const scrollable = section.name === 'objects';
+	const compact = COMPACT_SECTION_NAMES.includes(section.name);
+	const scrollable = SCROLLABLE_SECTION_NAMES.includes(section.name);
 
 	useEffect(() => {
 		const element = bodyRef.current;

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSection.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSection.tsx
@@ -5,8 +5,9 @@
 
 import {ClayButtonWithIcon} from '@clayui/button';
 import ClayLayout from '@clayui/layout';
+import classnames from 'classnames';
 import {sub} from 'frontend-js-web';
-import React, {useId} from 'react';
+import React, {useEffect, useId, useRef, useState} from 'react';
 
 import '../../../../css/utilities.scss';
 import {PageTreeModalConfiguration} from '../../../pages/export/components/PageTreeModal';
@@ -52,7 +53,31 @@ export default function ContentSection({
 	showDeletions,
 	value,
 }: ContentSectionProps) {
+	const bodyRef = useRef<HTMLDivElement>(null);
 	const checkboxId = useId();
+	const [overflowing, setOverflowing] = useState(false);
+
+	const scrollable = section.name === 'objects';
+
+	useEffect(() => {
+		const element = bodyRef.current;
+
+		if (!scrollable || !element || typeof ResizeObserver === 'undefined') {
+			return;
+		}
+
+		const resizeObserver = new ResizeObserver(() =>
+			setOverflowing(element.scrollHeight > element.clientHeight)
+		);
+
+		resizeObserver.observe(element);
+
+		for (const child of Array.from(element.children)) {
+			resizeObserver.observe(child);
+		}
+
+		return () => resizeObserver.disconnect();
+	}, [scrollable, section]);
 
 	const previewPortletDataHandlers =
 		section.previewPortletDataHandlers.map<PreviewPortletDataHandlerBoolean>(
@@ -136,7 +161,11 @@ export default function ContentSection({
 	return (
 		<ClayLayout.Sheet className="mt-0">
 			<CollapsibleGroup
-				bodyClassName="mt-2 pl-2"
+				bodyClassName={classnames('mt-2 pl-2', {
+					'border rounded': overflowing,
+					'content-section-scroll': scrollable,
+				})}
+				bodyRef={bodyRef}
 				checkboxId={checkboxId}
 				disclosure={({expanded, ...disclosureProps}) => (
 					<ClayButtonWithIcon
@@ -189,29 +218,25 @@ export default function ContentSection({
 					/>
 				}
 			>
-				<div className="content-section-controls overflow-auto">
-					{allPreviewPortletDataHandlers.map((context) => (
-						<PortletDataControl
-							control={context}
-							key={context.name}
-							onChange={(controlValue) =>
-								onChange(
-									updateSelection(
-										sectionSelection,
-										context.name,
-										controlValue
-									)
+				{allPreviewPortletDataHandlers.map((context) => (
+					<PortletDataControl
+						control={context}
+						key={context.name}
+						onChange={(controlValue) =>
+							onChange(
+								updateSelection(
+									sectionSelection,
+									context.name,
+									controlValue
 								)
-							}
-							pageTreeModalConfiguration={
-								pageTreeModalConfiguration
-							}
-							showDeletions={showDeletions}
-							topLevel
-							value={sectionSelection[context.name]}
-						/>
-					))}
-				</div>
+							)
+						}
+						pageTreeModalConfiguration={pageTreeModalConfiguration}
+						showDeletions={showDeletions}
+						topLevel
+						value={sectionSelection[context.name]}
+					/>
+				))}
 
 				{sectionFooters.map((sectionFooter) => (
 					<SectionFooter

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSection.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSection.tsx
@@ -57,6 +57,7 @@ export default function ContentSection({
 	const checkboxId = useId();
 	const [overflowing, setOverflowing] = useState(false);
 
+	const compact = section.name === 'objects';
 	const scrollable = section.name === 'objects';
 
 	useEffect(() => {
@@ -220,6 +221,7 @@ export default function ContentSection({
 			>
 				{allPreviewPortletDataHandlers.map((context) => (
 					<PortletDataControl
+						compact={compact}
 						control={context}
 						key={context.name}
 						onChange={(controlValue) =>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/PortletDataControl.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/PortletDataControl.tsx
@@ -5,6 +5,7 @@
 
 import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
+import classnames from 'classnames';
 import {sub} from 'frontend-js-web';
 import React, {ReactNode, useId} from 'react';
 
@@ -25,6 +26,7 @@ import PortletDataControlChoice from './PortletDataControlChoice';
 import SectionTags from './SectionTags';
 
 export default function PortletDataControl({
+	compact = false,
 	control,
 	onChange,
 	pageTreeModalConfiguration,
@@ -32,6 +34,7 @@ export default function PortletDataControl({
 	topLevel = false,
 	value,
 }: {
+	compact?: boolean;
 	control: PreviewPortletDataHandlerControl;
 	onChange: (value: HandlerSelection | undefined) => void;
 	pageTreeModalConfiguration?: PageTreeModalConfiguration;
@@ -126,6 +129,7 @@ export default function PortletDataControl({
 		return (
 			<PortletDataHandlerPanel
 				bodyChildren={body}
+				compact={compact}
 				currentSelection={currentSelection}
 				expandable={expandable}
 				nestedControls={nestedControls}
@@ -147,19 +151,21 @@ export default function PortletDataControl({
 
 function PortletDataHandlerPanel({
 	bodyChildren,
+	compact = false,
 	currentSelection,
 	expandable,
 	nestedControls,
 	rowProps,
 }: {
 	bodyChildren: ReactNode;
+	compact?: boolean;
 	currentSelection: Record<string, HandlerSelection>;
 	expandable: boolean;
 	nestedControls: PreviewPortletDataHandlerControl[];
 	rowProps: React.ComponentProps<typeof ControlRow>;
 }) {
 	return (
-		<div className="p-3">
+		<div className={classnames('px-3', compact ? 'py-2' : 'py-3')}>
 			{expandable ? (
 				<CollapsibleGroup
 					{...rowProps}

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/contentSelection.ts
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/contentSelection.ts
@@ -19,7 +19,10 @@ export type HandlerSelection =
 	| string
 	| true;
 
-export const COMPACT_SECTION_NAMES = ['objects'];
+export const COMPACT_SECTION_NAMES = [
+	'category.control_panel.users',
+	'objects',
+];
 
 export const CONTENT_SECTION_KEY = 'category.site_administration.content';
 

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/contentSelection.ts
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/contentSelection.ts
@@ -19,10 +19,14 @@ export type HandlerSelection =
 	| string
 	| true;
 
+export const COMPACT_SECTION_NAMES = ['objects'];
+
+export const CONTENT_SECTION_KEY = 'category.site_administration.content';
+
 export const LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY =
 	'PORTLET_DATA_com_liferay_layout_admin_web_portlet_LayoutSetLayoutsPortlet';
 
-export const CONTENT_SECTION_KEY = 'category.site_administration.content';
+export const SCROLLABLE_SECTION_NAMES = ['objects'];
 
 export const SITE_BUILDER_SECTION_KEY = 'category.site_administration.build';
 

--- a/modules/apps/export-import/export-import-web/test/revamp/js/components/forms/content_selector/ContentSection.test.tsx
+++ b/modules/apps/export-import/export-import-web/test/revamp/js/components/forms/content_selector/ContentSection.test.tsx
@@ -1,0 +1,46 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {render} from '@testing-library/react';
+import React from 'react';
+
+import ContentSection from '../../../../../../src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSection';
+import {PreviewPortletDataHandlerSection} from '../../../../../../src/main/resources/META-INF/resources/revamp/js/types/portletDataHandler';
+
+function makeSection(name: string): PreviewPortletDataHandlerSection {
+	return {
+		label: name,
+		name,
+		previewPortletDataHandlers: [{label: 'Handler', name: 'handler'}],
+	};
+}
+
+describe('ContentSection', () => {
+	it('renders a compact scrollable body for sections in COMPACT_SECTION_NAMES', () => {
+		const {container} = render(
+			<ContentSection
+				onChange={jest.fn()}
+				section={makeSection('objects')}
+				value={undefined}
+			/>
+		);
+
+		expect(
+			container.querySelector('.content-section-scroll')
+		).not.toBeNull();
+	});
+
+	it('renders a regular body for sections not in COMPACT_SECTION_NAMES', () => {
+		const {container} = render(
+			<ContentSection
+				onChange={jest.fn()}
+				section={makeSection('web-content')}
+				value={undefined}
+			/>
+		);
+
+		expect(container.querySelector('.content-section-scroll')).toBeNull();
+	});
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93614

## What Is Being Fixed

The Sections content selector renders every portlet data handler inline. The "objects" section can list a large number of object definitions, so it stretched the page and was hard to scan, and its handlers used the same loose vertical spacing as much smaller sections.

## How It Is Being Fixed

The objects section now renders its handlers inside a fixed-height scroll region with tighter vertical spacing, and a border is drawn only while the content actually overflows — detected with a ResizeObserver on the body and its direct children so the border tracks handlers expanding and collapsing. Which sections receive this compact, scrollable treatment is no longer hardcoded against the "objects" name: it is driven by a single COMPACT_SECTION_NAMES list in contentSelection.ts, so the rule lives in one place and is trivial to extend. A new ContentSection unit test asserts that a section named in the list gets the scrollable body class while one outside it does not.

## PR Check

**pr-check: PASS** — tested on `5986681cdf55534111a9c6ad7291bf6b36403238`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "5986681cdf55534111a9c6ad7291bf6b36403238"} -->
