### PR TITLE
LPD-93810 Prevent batch engine task user impersonation

### DIFF
--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/service/impl/BatchEngineExportTaskServiceImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/service/impl/BatchEngineExportTaskServiceImpl.java
@@ -44,7 +44,7 @@ public class BatchEngineExportTaskServiceImpl
 			Map<String, Serializable> parameters, String taskItemDelegateName)
 		throws PortalException {
 
-		_checkPermission(companyId);
+		_checkPermission(companyId, userId);
 
 		return batchEngineExportTaskLocalService.addBatchEngineExportTask(
 			externalReferenceCode, companyId, userId, callbackURL, className,
@@ -149,6 +149,18 @@ public class BatchEngineExportTaskServiceImpl
 		if ((companyId != permissionChecker.getCompanyId()) &&
 			!permissionChecker.isOmniadmin()) {
 
+			throw new PrincipalException();
+		}
+	}
+
+	private void _checkPermission(long companyId, long userId)
+		throws PrincipalException {
+
+		_checkPermission(companyId);
+
+		PermissionChecker permissionChecker = getPermissionChecker();
+
+		if (userId != permissionChecker.getUserId()) {
 			throw new PrincipalException();
 		}
 	}

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/service/impl/BatchEngineImportTaskServiceImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/service/impl/BatchEngineImportTaskServiceImpl.java
@@ -51,7 +51,7 @@ public class BatchEngineImportTaskServiceImpl
 			String taskItemDelegateName)
 		throws PortalException {
 
-		_checkPermission(companyId);
+		_checkPermission(companyId, userId);
 
 		return batchEngineImportTaskLocalService.addBatchEngineImportTask(
 			externalReferenceCode, companyId, userId, batchSize, callbackURL,
@@ -70,7 +70,7 @@ public class BatchEngineImportTaskServiceImpl
 			BatchEngineTaskItemDelegate<?> batchEngineTaskItemDelegate)
 		throws PortalException {
 
-		_checkPermission(companyId);
+		_checkPermission(companyId, userId);
 
 		return batchEngineImportTaskLocalService.addBatchEngineImportTask(
 			externalReferenceCode, companyId, userId, batchSize, callbackURL,
@@ -176,6 +176,18 @@ public class BatchEngineImportTaskServiceImpl
 		if ((companyId != permissionChecker.getCompanyId()) &&
 			!permissionChecker.isOmniadmin()) {
 
+			throw new PrincipalException();
+		}
+	}
+
+	private void _checkPermission(long companyId, long userId)
+		throws PrincipalException {
+
+		_checkPermission(companyId);
+
+		PermissionChecker permissionChecker = getPermissionChecker();
+
+		if (userId != permissionChecker.getUserId()) {
 			throw new PrincipalException();
 		}
 	}

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BatchEngineExportTaskServiceTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BatchEngineExportTaskServiceTest.java
@@ -66,6 +66,18 @@ public class BatchEngineExportTaskServiceTest
 				).build(),
 				null));
 
+		AssertUtils.assertFailure(
+			PrincipalException.class, null,
+			() -> _batchEngineExportTaskService.addBatchEngineExportTask(
+				null, company.getCompanyId(), omniadminUser.getUserId(), null,
+				BlogPosting.class.getName(), "JSON",
+				BatchEngineTaskExecuteStatus.INITIAL.name(),
+				Collections.emptyList(),
+				HashMapBuilder.<String, Serializable>put(
+					"siteId", TestPropsValues.getGroupId()
+				).build(),
+				null));
+
 		_batchEngineExportTaskService.addBatchEngineExportTask(
 			null, company.getCompanyId(), user.getUserId(), null,
 			BlogPosting.class.getName(), "JSON",

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BatchEngineImportTaskServiceTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BatchEngineImportTaskServiceTest.java
@@ -61,6 +61,15 @@ public class BatchEngineImportTaskServiceTest
 				BatchEngineImportTaskConstants.IMPORT_STRATEGY_ON_ERROR_FAIL,
 				BatchEngineTaskOperation.CREATE.name(), new HashMap<>(), null));
 
+		AssertUtils.assertFailure(
+			PrincipalException.class, null,
+			() -> _batchEngineImportTaskService.addBatchEngineImportTask(
+				null, company.getCompanyId(), omniadminUser.getUserId(), 10,
+				null, BlogPosting.class.getName(), new byte[0], "JSON",
+				BatchEngineTaskExecuteStatus.INITIAL.name(), null,
+				BatchEngineImportTaskConstants.IMPORT_STRATEGY_ON_ERROR_FAIL,
+				BatchEngineTaskOperation.CREATE.name(), new HashMap<>(), null));
+
 		_batchEngineImportTaskService.addBatchEngineImportTask(
 			null, company.getCompanyId(), user.getUserId(), 10, null,
 			BlogPosting.class.getName(), new byte[0], "JSON",


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93810

## What Is Being Fixed

`BatchEngineImportTaskService` and `BatchEngineExportTaskService` expose `addBatchEngineImportTask` / `addBatchEngineExportTask` with a caller-supplied `userId`, and these services are reachable as JSON web services. The add methods only enforced a company-isolation check and never verified that the supplied `userId` belonged to the caller. A low-privileged user could therefore submit a batch task carrying another user's id (for example an omniadmin's). When the task is later executed by the orphan scanner or an immediate trigger, it runs under a real permission checker created for that `userId`, so the caller effectively acts with that user's privileges — for instance deploying a company-wide workflow definition.

The ticket's suggested remediation (changing `&&` to `||` in the company-isolation check) is inaccurate: that helper is shared with the read operations, which legitimately allow same-company access, so flipping it would break those reads and omniadmin cross-company usage while still not addressing the impersonation.

## How It Is Being Fixed

The add methods now verify that the supplied `userId` matches the caller's own `userId`, rejecting anything else with a `PrincipalException`, in addition to the existing company-isolation check. This is implemented in both `BatchEngineImportTaskServiceImpl` and `BatchEngineExportTaskServiceImpl` as a new `_checkPermission(companyId, userId)` overload called from the add methods; the read/list permission helper is left unchanged. Integration tests assert that a user cannot create a task for another company, cannot create a task on behalf of another user, but can create a task on its own behalf.

## PR Check

**pr-check: PASS** — tested on `f041c5e48ba86f81d4ef59b76d44cd8f278b6ee8`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "f041c5e48ba86f81d4ef59b76d44cd8f278b6ee8"} -->
