### PR TITLE
LPD-94208 Reliably enable the scope feature flag in Poshi setup

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/Portlet.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Portlet.macro
@@ -525,12 +525,7 @@ definition {
 			configurationName = "Deprecation",
 			configurationScope = "Virtual Instance Scope");
 
-		if (IsElementPresent(locator1 = "FeatureFlag#TOGGLE_ROW", title_row = "Widget Setting Scope", toggle_state = "Disabled")) {
-			Check.checkToggleSwitch(
-				locator1 = "FeatureFlag#TOGGLE_ROW",
-				title_row = "Widget Setting Scope",
-				toggle_state = "Disabled");
-		}
+		FeatureFlag.enableFeatureFlag(featureFlag = "LPD-11131");
 
 		Navigator.openURL();
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94208

## Failing Test

`LocalFile.PGStaging#LayoutScope`

`portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/pgstaging/PGStaging.testcase`

```
com.liferay.poshi.runner.exception.ElementNotFoundPoshiRunnerException: Element is not present at "//*[contains(@class,'nav-link') and contains(.,'Scope')]"
```

## Root Cause

Outdated test, not a product regression. The `Portlet.enableScopeConfiguration` macro toggled the "Widget Setting Scope" (`LPD-11131`) deprecation feature flag with a hand-rolled conditional that acted only when the flag row was already present in the default Deprecation page view and never waited for the toggle to flip. The Deprecation list is sorted by name and paginated, so as more deprecation flags were added the "Widget Setting Scope" row fell out of the initial view; the conditional was skipped and the flag stayed off. The Scope configuration tab is gated on that flag, so `selectScope` could not find the Scope nav link.

## Fix

Delegate to the maintained `FeatureFlag.enableFeatureFlag` macro, which searches for the flag and waits for the toggle to read "Enabled" before continuing, so the flag is reliably enabled regardless of its position in the list. Verified locally: `cliferay poshi 'PGStaging#LayoutScope'` now passes (BUILD SUCCESSFUL).

- `portal-web/test/functional/com/liferay/portalweb/macros/Portlet.macro`