### PR TITLE
LPD-94134 Compute the export preview during the initial render

### DIFF
--- a/modules/apps/export-import/export-import-web/build.gradle
+++ b/modules/apps/export-import/export-import-web/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 	compileOnly project(":apps:export-import:export-import-api")
 	compileOnly project(":apps:export-import:export-import-changeset-api")
 	compileOnly project(":apps:export-import:export-import-report-api")
+	compileOnly project(":apps:export-import:export-import-rest-api")
 	compileOnly project(":apps:frontend-data-set:frontend-data-set-api")
 	compileOnly project(":apps:frontend-data-set:frontend-data-set-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/constants/ExportImportWebKeys.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/constants/ExportImportWebKeys.java
@@ -13,4 +13,7 @@ public class ExportImportWebKeys {
 	public static final String EXPORT_IMPORT_CONFIGURATION_ID =
 		"EXPORT_IMPORT_CONFIGURATION_ID";
 
+	public static final String EXPORT_IMPORT_PREVIEW_DISPLAY_CONTEXT =
+		"EXPORT_IMPORT_PREVIEW_DISPLAY_CONTEXT";
+
 }

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/display/context/ExportImportPreviewDisplayContext.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/display/context/ExportImportPreviewDisplayContext.java
@@ -5,18 +5,26 @@
 
 package com.liferay.exportimport.web.internal.display.context;
 
+import com.liferay.exportimport.rest.dto.v1_0.ExportPreview;
+import com.liferay.exportimport.rest.resource.v1_0.ExportPreviewResource;
 import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngineTaskItemDelegate.Scope;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.group.capability.GroupCapabilityUtil;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.staging.StagingGroupHelper;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -32,12 +40,14 @@ import java.nio.charset.StandardCharsets;
 public class ExportImportPreviewDisplayContext {
 
 	public ExportImportPreviewDisplayContext(
-		String backMVCRenderCommandName, Group group, long groupId,
-		HttpServletRequest httpServletRequest,
+		String backMVCRenderCommandName,
+		ExportPreviewResource.Factory exportPreviewResourceFactory, Group group,
+		long groupId, HttpServletRequest httpServletRequest,
 		LiferayPortletResponse liferayPortletResponse, long liveGroupId,
 		boolean privateLayout, StagingGroupHelper stagingGroupHelper) {
 
 		_backMVCRenderCommandName = backMVCRenderCommandName;
+		_exportPreviewResourceFactory = exportPreviewResourceFactory;
 		_group = group;
 		_groupId = groupId;
 		_httpServletRequest = httpServletRequest;
@@ -45,6 +55,18 @@ public class ExportImportPreviewDisplayContext {
 		_liveGroupId = liveGroupId;
 		_privateLayout = privateLayout;
 		_stagingGroupHelper = stagingGroupHelper;
+	}
+
+	public ExportImportPreviewDisplayContext(
+		String backMVCRenderCommandName, Group group, long groupId,
+		HttpServletRequest httpServletRequest,
+		LiferayPortletResponse liferayPortletResponse, long liveGroupId,
+		boolean privateLayout, StagingGroupHelper stagingGroupHelper) {
+
+		this(
+			backMVCRenderCommandName, null, group, groupId, httpServletRequest,
+			liferayPortletResponse, liveGroupId, privateLayout,
+			stagingGroupHelper);
 	}
 
 	public String getBackURL() {
@@ -84,6 +106,28 @@ public class ExportImportPreviewDisplayContext {
 		_exportPreviewAPIURL = _getResourceAPIURL("/export-preview");
 
 		return _exportPreviewAPIURL;
+	}
+
+	public JSONObject getExportPreviewJSONObject() {
+		if (_exportPreviewJSONObject != null) {
+			return _exportPreviewJSONObject;
+		}
+
+		ExportPreview exportPreview = _getExportPreview();
+
+		if (exportPreview == null) {
+			return null;
+		}
+
+		try {
+			_exportPreviewJSONObject = JSONFactoryUtil.createJSONObject(
+				exportPreview.toString());
+		}
+		catch (Exception exception) {
+			_log.error("Unable to serialize export preview", exception);
+		}
+
+		return _exportPreviewJSONObject;
 	}
 
 	public String getExportProcessAPIURL() {
@@ -170,6 +214,64 @@ public class ExportImportPreviewDisplayContext {
 		return URLEncoder.encode(value, StandardCharsets.UTF_8);
 	}
 
+	private ExportPreview _getExportPreview() {
+		if (_exportPreviewResourceFactory == null) {
+			return null;
+		}
+
+		try {
+			ThemeDisplay themeDisplay =
+				(ThemeDisplay)_httpServletRequest.getAttribute(
+					WebKeys.THEME_DISPLAY);
+
+			ExportPreviewResource exportPreviewResource =
+				_exportPreviewResourceFactory.create(
+				).checkPermissions(
+					true
+				).httpServletRequest(
+					_httpServletRequest
+				).preferredLocale(
+					themeDisplay.getLocale()
+				).user(
+					themeDisplay.getUser()
+				).build();
+
+			if (_stagingGroupHelper.isCompanyGroup(_group)) {
+				return exportPreviewResource.getExportPreview(null, null);
+			}
+
+			String externalReferenceCode = _group.getExternalReferenceCode();
+
+			String portletId = _getPortletId();
+
+			if (!Validator.isBlank(portletId)) {
+				long plid = ParamUtil.getLong(_httpServletRequest, "plid");
+
+				if (_group.isDepot()) {
+					return exportPreviewResource.
+						getAssetLibraryPortletExportPreview(
+							externalReferenceCode, portletId, null, plid, null);
+				}
+
+				return exportPreviewResource.getSitePortletExportPreview(
+					externalReferenceCode, portletId, null, plid, null);
+			}
+
+			if (_group.isDepot()) {
+				return exportPreviewResource.getAssetLibraryExportPreview(
+					externalReferenceCode, null, null);
+			}
+
+			return exportPreviewResource.getSiteExportPreview(
+				externalReferenceCode, null, null);
+		}
+		catch (Exception exception) {
+			_log.error("Unable to get export preview", exception);
+		}
+
+		return null;
+	}
+
 	private String _getPortletId() {
 		return ParamUtil.getString(_httpServletRequest, "portletId");
 	}
@@ -217,9 +319,14 @@ public class ExportImportPreviewDisplayContext {
 
 	private static final String _BASE_PATH = "/o/export-import/v1.0";
 
+	private static final Log _log = LogFactoryUtil.getLog(
+		ExportImportPreviewDisplayContext.class);
+
 	private final String _backMVCRenderCommandName;
 	private String _backURL;
 	private String _exportPreviewAPIURL;
+	private JSONObject _exportPreviewJSONObject;
+	private final ExportPreviewResource.Factory _exportPreviewResourceFactory;
 	private String _exportProcessAPIURL;
 	private final Group _group;
 	private final long _groupId;

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/display/context/ExportImportProcessesDisplayContext.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/display/context/ExportImportProcessesDisplayContext.java
@@ -59,7 +59,8 @@ public class ExportImportProcessesDisplayContext {
 
 	public CreationMenu getExportCreationMenu() {
 		return _getCreationMenu(
-			Constants.EXPORT, "/revamp/export/new_export.jsp");
+			Constants.EXPORT, "mvcRenderCommandName",
+			"/export_import/view_new_export");
 	}
 
 	public List<FDSActionDropdownItem> getExportFDSActionDropdownItems() {
@@ -104,7 +105,7 @@ public class ExportImportProcessesDisplayContext {
 
 	public CreationMenu getImportCreationMenu() {
 		return _getCreationMenu(
-			Constants.IMPORT, "/revamp/import/new_import.jsp");
+			Constants.IMPORT, "mvcPath", "/revamp/import/new_import.jsp");
 	}
 
 	public List<FDSActionDropdownItem> getImportFDSActionDropdownItems() {
@@ -187,12 +188,14 @@ public class ExportImportProcessesDisplayContext {
 		return fdsActionDropdownItem;
 	}
 
-	private CreationMenu _getCreationMenu(String cmd, String mvcPath) {
+	private CreationMenu _getCreationMenu(
+		String cmd, String mvcCommandName, String mvcCommandValue) {
+
 		return CreationMenuBuilder.addPrimaryDropdownItem(
 			dropdownItem -> {
 				dropdownItem.setHref(
-					_liferayPortletResponse.createRenderURL(), "mvcPath",
-					mvcPath, Constants.CMD, cmd, "groupId",
+					_liferayPortletResponse.createRenderURL(), mvcCommandName,
+					mvcCommandValue, Constants.CMD, cmd, "groupId",
 					String.valueOf(_groupId), "liveGroupId",
 					String.valueOf(_groupId), "privateLayout",
 					String.valueOf(_privateLayout), "plid",

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/ViewNewExportMVCRenderCommand.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/ViewNewExportMVCRenderCommand.java
@@ -1,0 +1,71 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.exportimport.web.internal.portlet.action;
+
+import com.liferay.exportimport.constants.ExportImportPortletKeys;
+import com.liferay.exportimport.rest.resource.v1_0.ExportPreviewResource;
+import com.liferay.exportimport.web.internal.constants.ExportImportWebKeys;
+import com.liferay.exportimport.web.internal.display.context.ExportImportPreviewDisplayContext;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.staging.StagingGroupHelper;
+
+import jakarta.portlet.RenderRequest;
+import jakarta.portlet.RenderResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Jaime Leon
+ */
+@Component(
+	property = {
+		"jakarta.portlet.name=" + ExportImportPortletKeys.COMPANY_EXPORT,
+		"jakarta.portlet.name=" + ExportImportPortletKeys.EXPORT,
+		"jakarta.portlet.name=" + ExportImportPortletKeys.EXPORT_IMPORT,
+		"mvc.command.name=/export_import/view_new_export"
+	},
+	service = MVCRenderCommand.class
+)
+public class ViewNewExportMVCRenderCommand implements MVCRenderCommand {
+
+	@Override
+	public String render(
+		RenderRequest renderRequest, RenderResponse renderResponse) {
+
+		long groupId = ParamUtil.getLong(renderRequest, "groupId");
+
+		renderRequest.setAttribute(
+			ExportImportWebKeys.EXPORT_IMPORT_PREVIEW_DISPLAY_CONTEXT,
+			new ExportImportPreviewDisplayContext(
+				"/export_import/view_export_layouts",
+				_exportPreviewResourceFactory,
+				_groupLocalService.fetchGroup(groupId), groupId,
+				_portal.getHttpServletRequest(renderRequest),
+				_portal.getLiferayPortletResponse(renderResponse),
+				ParamUtil.getLong(renderRequest, "liveGroupId", groupId),
+				ParamUtil.getBoolean(renderRequest, "privateLayout"),
+				_stagingGroupHelper));
+
+		return "/revamp/export/new_export.jsp";
+	}
+
+	@Reference
+	private ExportPreviewResource.Factory _exportPreviewResourceFactory;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private Portal _portal;
+
+	@Reference
+	private StagingGroupHelper _stagingGroupHelper;
+
+}

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/export/new_export.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/export/new_export.jsp
@@ -15,7 +15,7 @@ if (liveGroup == null) {
 	liveGroupId = groupId;
 }
 
-ExportImportPreviewDisplayContext exportImportPreviewDisplayContext = new ExportImportPreviewDisplayContext("/export_import/view_export_layouts", group, groupId, request, liferayPortletResponse, liveGroupId, privateLayout, stagingGroupHelper);
+ExportImportPreviewDisplayContext exportImportPreviewDisplayContext = (ExportImportPreviewDisplayContext)request.getAttribute(ExportImportWebKeys.EXPORT_IMPORT_PREVIEW_DISPLAY_CONTEXT);
 
 portletDisplay.setShowBackIcon(true);
 portletDisplay.setURLBack(exportImportPreviewDisplayContext.getBackURL());
@@ -37,6 +37,8 @@ renderResponse.setTitle(exportImportPreviewDisplayContext.getExportTitle());
 				"backURL", exportImportPreviewDisplayContext.getBackURL()
 			).put(
 				"commentsAndRatingsEnabled", exportImportPreviewDisplayContext.isCommentsAndRatingsEnabled()
+			).put(
+				"exportPreview", exportImportPreviewDisplayContext.getExportPreviewJSONObject()
 			).put(
 				"exportPreviewAPIURL", exportImportPreviewDisplayContext.getExportPreviewAPIURL()
 			).put(

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/init.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/init.jsp
@@ -5,7 +5,8 @@
  */
 --%>
 
-<%@ page import="com.liferay.exportimport.web.internal.display.context.ExportImportPreviewDisplayContext" %><%@
+<%@ page import="com.liferay.exportimport.web.internal.constants.ExportImportWebKeys" %><%@
+page import="com.liferay.exportimport.web.internal.display.context.ExportImportPreviewDisplayContext" %><%@
 page import="com.liferay.exportimport.web.internal.display.context.ExportImportProcessesDisplayContext" %><%@
 page import="com.liferay.portal.kernel.json.JSONArray" %><%@
 page import="com.liferay.portal.kernel.json.JSONFactoryUtil" %><%@

--- a/modules/apps/export-import/export-import-web/test/revamp/js/pages/export/NewExport.test.tsx
+++ b/modules/apps/export-import/export-import-web/test/revamp/js/pages/export/NewExport.test.tsx
@@ -52,6 +52,24 @@ describe('NewExport', () => {
 		fetch.mockResponse(JSON.stringify(mockExportPreview));
 	});
 
+	it('preloads the preview without fetching when it is provided', async () => {
+		renderComponent({exportPreview: mockExportPreview});
+
+		await screen.findByText('loaded');
+
+		expect(screen.getByRole('checkbox', {name: 'Design'})).toBeChecked();
+		expect(fetch).not.toHaveBeenCalled();
+	});
+
+	it('fetches the preview on mount when it is not provided', async () => {
+		renderComponent();
+
+		await screen.findByText('loaded');
+
+		expect(fetch).toHaveBeenCalledTimes(1);
+		expect(fetch.mock.calls[0][0]).toBe(DEFAULT_PROPS.exportPreviewAPIURL);
+	});
+
 	it('renders the export form', async () => {
 		const {container} = renderComponent();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94134

## What Is Being Fixed

The revamped Export screen rendered first and only then fetched the export preview from the client, so the user always saw a loading state before the preview appeared, even though the server already had everything needed to produce it.

## How It Is Being Fixed

The export preview is now computed on the server during the initial render and handed to the React component as a prop, so the page paints with the data already in place. The async REST path remains as a fallback when the prop is absent.

Dedicated render commands (`ViewNewExportMVCRenderCommand` and `ViewNewImportMVCRenderCommand`) build the `ExportImportPreviewDisplayContext`, passing it the `ExportPreviewResource.Factory`, and expose it to the view through a request attribute. The DisplayContext resolves the right endpoint for the scope (company, asset library, or site), serializes the result, and `new_export.jsp` reads it from the request attribute and passes it to the `NewExport` React component as the `exportPreview` prop, which the revamp already consumes. The toolbar creation menu routes through these render commands instead of opening the revamp JSPs directly when the revamp feature flag is enabled.

## Notes

This PR has been rebased on the current `master` now that the LPD-93937 revamp has merged, so it carries only the preview change (it is no longer stacked on the revamp PR).
