### PR TITLE
LPD-94116 Refine export/import data selection weights, sizes, and spacing

### DIFF
--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/SectionHeader.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/SectionHeader.tsx
@@ -21,7 +21,7 @@ export default function SectionHeader({
 }: SectionHeaderProps) {
 	return (
 		<div className={classNames('mb-1 sheet-header', className)}>
-			<div className="h2 mb-1" id={id}>
+			<div className="font-weight-bold mb-1 text-7" id={id}>
 				{title}
 			</div>
 

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSection.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSection.tsx
@@ -165,7 +165,7 @@ export default function ContentSection({
 					)
 				}
 				label={section.label}
-				labelClassName="font-weight-bold h3"
+				labelClassName="font-weight-bold text-6"
 				onToggle={() =>
 					onChange(
 						allSelected

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/LayoutSetControl.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/LayoutSetControl.tsx
@@ -7,7 +7,7 @@ import ClayButton from '@clayui/button';
 import {ClayCheckbox, ClayRadio} from '@clayui/form';
 import ClayLayout from '@clayui/layout';
 import {sub} from 'frontend-js-web';
-import React, {useState} from 'react';
+import React, {useId, useState} from 'react';
 
 import PageTreeModal, {
 	PageTreeModalConfiguration,
@@ -110,6 +110,8 @@ export default function LayoutSetControl({
 	const {privateLayoutsEnabled, ...modalConfiguration} =
 		pageTreeModalConfiguration;
 
+	const checkboxId = useId();
+
 	const [showModal, setShowModal] = useState(false);
 
 	const {layoutIds = [], privateLayout = false} = (
@@ -125,8 +127,8 @@ export default function LayoutSetControl({
 			<ClayLayout.ContentRow className="align-items-center mb-2">
 				<ClayLayout.ContentCol className="pr-2" expand={false}>
 					<ClayCheckbox
-						aria-label={label}
 						checked={isAll}
+						id={checkboxId}
 						indeterminate={!isAll && !!layoutIds.length}
 						onChange={() =>
 							onChange(isAll ? undefined : {privateLayout})
@@ -136,9 +138,12 @@ export default function LayoutSetControl({
 
 				<ClayLayout.ContentCol expand>
 					<div className="align-items-center d-flex justify-content-between">
-						<span className="font-weight-semi-bold small">
+						<label
+							className="cursor-pointer font-weight-semi-bold mb-0 small"
+							htmlFor={checkboxId}
+						>
 							{label}
-						</span>
+						</label>
 
 						{!privateLayoutsEnabled && (
 							<SelectPagesButton onClick={openModal} />

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/LayoutSetControl.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/LayoutSetControl.tsx
@@ -43,6 +43,7 @@ function SelectPagesButton({
 								: Liferay.Language.get('public-pages')
 						)
 			}
+			className="font-weight-semi-bold"
 			displayType="link"
 			onClick={onClick}
 			size="sm"

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/PortletDataControl.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/PortletDataControl.tsx
@@ -181,6 +181,7 @@ function PortletDataHandlerPanel({
 											rowProps.label
 										)
 							}
+							className="font-weight-semi-bold"
 							displayType="link"
 							size="sm"
 						>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/PortletDataControl.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/PortletDataControl.tsx
@@ -91,7 +91,9 @@ export default function PortletDataControl({
 		description,
 		indeterminate: !!value && !selected,
 		label: control.label,
-		labelClassName: topLevel ? 'font-weight-semi-bold' : '',
+		labelClassName: topLevel
+			? 'font-weight-semi-bold'
+			: 'font-weight-normal',
 		onToggle: () =>
 			onChange(selected ? undefined : getInitialSelection(control)),
 		selected,

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/steps/FileSelectionStep.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/steps/FileSelectionStep.tsx
@@ -88,7 +88,7 @@ export default function FileSelectionStep({
 				/>
 			</ClayLayout.Sheet>
 
-			<ClayLayout.Sheet>
+			<ClayLayout.Sheet className="mt-4">
 				<ClayLayout.SheetHeader className="mb-1">
 					<div className="mb-2 sheet-title" id="fileSelector-label">
 						{Liferay.Language.get('file-upload')}

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/steps/SettingsStep.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/steps/SettingsStep.tsx
@@ -89,7 +89,7 @@ export default function SettingsStep({scope}: {scope: Scope}) {
 				/>
 			</ClayLayout.Sheet>
 
-			<ClayLayout.Sheet>
+			<ClayLayout.Sheet className="mt-4">
 				<SectionHeader
 					name="dataStrategy"
 					symbol="restore"


### PR DESCRIPTION
# https://liferay.atlassian.net/browse/LPD-94116

## What this does

Polish on the revamped Export/Import data-selection UI:

- **LPD-94116**
  - nested controls use a regular font weight (`font-weight-normal`)
  - section titles resized with the Clay text scale (section labels `text-6`, section headers `text-7` bold)
  - the Show All and Select Pages action buttons are semi-bold
  - stacked sheets use a consistent 24px gap
- **LPD-94136** — the "Site Pages" name is now a clickable label that toggles its checkbox.

## Decision

For now we are leaving the checkbox alignment workaround out of this PR. The misalignment is a Clay regression tracked in LPD-94305 (caused by LPD-91533); we wait for the proper Clay fix rather than ship a local override.
