### PR TITLE
LPD-87027 Move the Site Template sync flow to LayoutSetPrototypeHelperImpl

### DIFF
--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
@@ -140,51 +140,6 @@ public class LayoutSetPrototypePropagationTest
 	}
 
 	@Test
-	@TestInfo("LPD-81592")
-	public void testIsLayoutSetMergeable() throws Exception {
-		setLinkEnabled(true);
-
-		LayoutSet layoutSet = LayoutSetLocalServiceUtil.getLayoutSet(
-			group.getGroupId(), false);
-
-		UnicodeProperties settingsUnicodeProperties =
-			layoutSet.getSettingsProperties();
-
-		settingsUnicodeProperties.remove(Sites.LAST_MERGE_TIME);
-		settingsUnicodeProperties.remove(Sites.LAST_MERGE_VERSION);
-
-		layoutSet = LayoutSetLocalServiceUtil.updateLayoutSet(layoutSet);
-
-		_layoutSetPrototype =
-			LayoutSetPrototypeLocalServiceUtil.getLayoutSetPrototype(
-				_layoutSetPrototype.getLayoutSetPrototypeId());
-
-		_layoutSetPrototype.setModifiedDate(new Date());
-
-		_layoutSetPrototype =
-			LayoutSetPrototypeLocalServiceUtil.updateLayoutSetPrototype(
-				_layoutSetPrototype);
-
-		Assert.assertTrue(_sites.isLayoutSetMergeable(group, layoutSet));
-
-		settingsUnicodeProperties = layoutSet.getSettingsProperties();
-
-		settingsUnicodeProperties.setProperty(
-			Sites.LAST_MERGE_TIME,
-			String.valueOf(System.currentTimeMillis() - Time.MINUTE));
-
-		_layoutSetPrototype.setModifiedDate(new Date());
-
-		_layoutSetPrototype =
-			LayoutSetPrototypeLocalServiceUtil.updateLayoutSetPrototype(
-				_layoutSetPrototype);
-
-		Assert.assertFalse(
-			_sites.isLayoutSetMergeable(
-				group, LayoutSetLocalServiceUtil.updateLayoutSet(layoutSet)));
-	}
-
-	@Test
 	public void testIsLayoutSortable() throws Exception {
 		Assert.assertFalse(layout.isLayoutSortable());
 

--- a/modules/apps/layout/layout-set-prototype-api/src/main/java/com/liferay/layout/set/prototype/helper/LayoutSetPrototypeHelper.java
+++ b/modules/apps/layout/layout-set-prototype-api/src/main/java/com/liferay/layout/set/prototype/helper/LayoutSetPrototypeHelper.java
@@ -21,6 +21,12 @@ import java.util.List;
 @ProviderType
 public interface LayoutSetPrototypeHelper {
 
+	public void executeLayoutSetPrototypeSync(
+			long layoutSetPrototypeId, long userId)
+		throws PortalException;
+
+	public void executeLayoutSetSync(LayoutSet layoutSet) throws Exception;
+
 	public List<Layout> getDuplicatedFriendlyURLLayouts(Layout layout)
 		throws PortalException;
 

--- a/modules/apps/layout/layout-set-prototype-api/src/main/java/com/liferay/layout/set/prototype/helper/LayoutSetPrototypeHelper.java
+++ b/modules/apps/layout/layout-set-prototype-api/src/main/java/com/liferay/layout/set/prototype/helper/LayoutSetPrototypeHelper.java
@@ -14,6 +14,7 @@ import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.LayoutSetPrototype;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * @author Eudaldo Alonso
@@ -35,6 +36,9 @@ public interface LayoutSetPrototypeHelper {
 	public List<Long> getDuplicatedFriendlyURLPlids(
 			LayoutSetPrototype layoutSetPrototype)
 		throws PortalException;
+
+	public Map<String, String[]> getLayoutSetPrototypeParameters(
+		boolean importData);
 
 	public boolean hasDuplicatedFriendlyURLs(
 			String layoutUuid, long groupId, boolean privateLayout,

--- a/modules/apps/layout/layout-set-prototype-impl/build.gradle
+++ b/modules/apps/layout/layout-set-prototype-impl/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 	compileOnly project(":apps:export-import:export-import-api")
 	compileOnly project(":apps:layout:layout-page-template-api")
 	compileOnly project(":apps:layout:layout-set-prototype-api")
+	compileOnly project(":apps:portal-background-task:portal-background-task-api")
 	compileOnly project(":apps:xstream:xstream-configurator-api")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-sql-dsl-api")

--- a/modules/apps/layout/layout-set-prototype-impl/src/main/java/com/liferay/layout/set/prototype/internal/helper/LayoutSetPrototypeHelperImpl.java
+++ b/modules/apps/layout/layout-set-prototype-impl/src/main/java/com/liferay/layout/set/prototype/internal/helper/LayoutSetPrototypeHelperImpl.java
@@ -5,10 +5,25 @@
 
 package com.liferay.layout.set.prototype.internal.helper;
 
+import com.liferay.exportimport.kernel.background.task.BackgroundTaskExecutorNames;
+import com.liferay.exportimport.kernel.configuration.ExportImportConfigurationSettingsMapFactoryUtil;
+import com.liferay.exportimport.kernel.configuration.constants.ExportImportConfigurationConstants;
+import com.liferay.exportimport.kernel.lar.ExportImportHelper;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
+import com.liferay.exportimport.kernel.lar.PortletDataHandlerKeys;
+import com.liferay.exportimport.kernel.lar.UserIdStrategy;
+import com.liferay.exportimport.kernel.model.ExportImportConfiguration;
+import com.liferay.exportimport.kernel.service.ExportImportConfigurationLocalService;
+import com.liferay.exportimport.kernel.service.ExportImportLocalService;
 import com.liferay.exportimport.kernel.staging.MergeLayoutPrototypesThreadLocal;
 import com.liferay.layout.set.prototype.helper.LayoutSetPrototypeHelper;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.sql.dsl.expression.Predicate;
+import com.liferay.portal.background.task.util.comparator.BackgroundTaskCreateDateComparator;
+import com.liferay.portal.kernel.backgroundtask.BackgroundTask;
+import com.liferay.portal.kernel.backgroundtask.BackgroundTaskManager;
+import com.liferay.portal.kernel.backgroundtask.constants.BackgroundTaskConstants;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -22,6 +37,7 @@ import com.liferay.portal.kernel.model.LayoutSetPrototype;
 import com.liferay.portal.kernel.model.LayoutSetPrototypeTable;
 import com.liferay.portal.kernel.model.LayoutSetTable;
 import com.liferay.portal.kernel.model.LayoutTable;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
@@ -32,14 +48,22 @@ import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutService;
 import com.liferay.portal.kernel.service.LayoutSetLocalService;
 import com.liferay.portal.kernel.service.LayoutSetPrototypeLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
 import com.liferay.portal.kernel.service.permission.LayoutPermission;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.sites.kernel.util.Sites;
 
+import java.io.Serializable;
+
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -83,7 +107,29 @@ public class LayoutSetPrototypeHelperImpl implements LayoutSetPrototypeHelper {
 	public void executeLayoutSetSync(LayoutSet layoutSet) throws Exception {
 		MergeLayoutPrototypesThreadLocal.setSkipMerge(false);
 
-		_sites.mergeLayoutSetPrototypeLayouts(layoutSet.getGroup(), layoutSet);
+		if (MergeLayoutPrototypesThreadLocal.isSkipMerge()) {
+			return;
+		}
+
+		MergeLayoutPrototypesThreadLocal.setSkipMerge(true);
+
+		Group group = layoutSet.getGroup();
+
+		layoutSet = _layoutSetLocalService.fetchLayoutSet(
+			layoutSet.getLayoutSetId());
+
+		if (!_isLayoutSetMergeable(group, layoutSet)) {
+			return;
+		}
+
+		LayoutSetPrototype layoutSetPrototype =
+			_layoutSetPrototypeLocalService.
+				getLayoutSetPrototypeByUuidAndCompanyId(
+					layoutSet.getLayoutSetPrototypeUuid(),
+					layoutSet.getCompanyId());
+
+		_mergeLayoutSetPrototypeLayoutsInBackground(
+			layoutSetPrototype, layoutSet);
 	}
 
 	@Override
@@ -228,6 +274,106 @@ public class LayoutSetPrototypeHelperImpl implements LayoutSetPrototypeHelper {
 					LayoutTable.INSTANCE.system.eq(false)
 				)
 			));
+	}
+
+	public Map<String, String[]> getLayoutSetPrototypeParameters(
+		boolean importData) {
+
+		Map<String, String[]> parameterMap = LinkedHashMapBuilder.put(
+			PortletDataHandlerKeys.DELETE_MISSING_LAYOUTS,
+			new String[] {Boolean.FALSE.toString()}
+		).put(
+			PortletDataHandlerKeys.DELETE_PORTLET_DATA,
+			new String[] {Boolean.FALSE.toString()}
+		).put(
+			PortletDataHandlerKeys.IGNORE_LAST_PUBLISH_DATE,
+			new String[] {Boolean.TRUE.toString()}
+		).put(
+			PortletDataHandlerKeys.LAYOUT_SET_SETTINGS,
+			new String[] {Boolean.TRUE.toString()}
+		).put(
+			PortletDataHandlerKeys.LAYOUT_SET_PROTOTYPE_LINK_ENABLED,
+			new String[] {Boolean.TRUE.toString()}
+		).put(
+			PortletDataHandlerKeys.LAYOUT_SET_PROTOTYPE_SETTINGS,
+			new String[] {Boolean.TRUE.toString()}
+		).put(
+			PortletDataHandlerKeys.LAYOUTS_IMPORT_MODE,
+			new String[] {
+				PortletDataHandlerKeys.
+					LAYOUTS_IMPORT_MODE_CREATED_FROM_PROTOTYPE
+			}
+		).put(
+			PortletDataHandlerKeys.PERMISSIONS,
+			new String[] {Boolean.TRUE.toString()}
+		).put(
+			PortletDataHandlerKeys.PORTLET_CONFIGURATION,
+			new String[] {Boolean.TRUE.toString()}
+		).put(
+			PortletDataHandlerKeys.PORTLET_CONFIGURATION_ALL,
+			new String[] {Boolean.TRUE.toString()}
+		).put(
+			PortletDataHandlerKeys.PORTLET_SETUP_ALL,
+			new String[] {Boolean.TRUE.toString()}
+		).put(
+			PortletDataHandlerKeys.THEME_REFERENCE,
+			new String[] {Boolean.TRUE.toString()}
+		).put(
+			PortletDataHandlerKeys.UPDATE_LAST_PUBLISH_DATE,
+			new String[] {Boolean.FALSE.toString()}
+		).put(
+			PortletDataHandlerKeys.USER_ID_STRATEGY,
+			new String[] {UserIdStrategy.CURRENT_USER_ID}
+		).build();
+
+		if (importData) {
+			parameterMap.put(
+				PortletDataHandlerKeys.DATA_STRATEGY,
+				new String[] {PortletDataHandlerKeys.DATA_STRATEGY_MIRROR});
+			parameterMap.put(
+				PortletDataHandlerKeys.FAVICON,
+				new String[] {Boolean.TRUE.toString()});
+			parameterMap.put(
+				PortletDataHandlerKeys.LOGO,
+				new String[] {Boolean.TRUE.toString()});
+			parameterMap.put(
+				PortletDataHandlerKeys.PORTLET_DATA,
+				new String[] {Boolean.TRUE.toString()});
+			parameterMap.put(
+				PortletDataHandlerKeys.PORTLET_DATA_ALL,
+				new String[] {Boolean.TRUE.toString()});
+		}
+		else {
+			parameterMap.put(
+				PortletDataHandlerKeys.DELETE_LAYOUTS,
+				new String[] {Boolean.TRUE.toString()});
+			parameterMap.put(
+				PortletDataHandlerKeys.DELETIONS,
+				new String[] {Boolean.TRUE.toString()});
+			parameterMap.put(
+				PortletDataHandlerKeys.FAVICON,
+				new String[] {Boolean.FALSE.toString()});
+
+			if (PropsValues.LAYOUT_SET_PROTOTYPE_PROPAGATE_LOGO) {
+				parameterMap.put(
+					PortletDataHandlerKeys.LOGO,
+					new String[] {Boolean.TRUE.toString()});
+			}
+			else {
+				parameterMap.put(
+					PortletDataHandlerKeys.LOGO,
+					new String[] {Boolean.FALSE.toString()});
+			}
+
+			parameterMap.put(
+				PortletDataHandlerKeys.PORTLET_DATA,
+				new String[] {Boolean.FALSE.toString()});
+			parameterMap.put(
+				PortletDataHandlerKeys.PORTLET_DATA_ALL,
+				new String[] {Boolean.FALSE.toString()});
+		}
+
+		return parameterMap;
 	}
 
 	@Override
@@ -541,6 +687,162 @@ public class LayoutSetPrototypeHelperImpl implements LayoutSetPrototypeHelper {
 		return true;
 	}
 
+	private boolean _isLayoutSetMergeable(Group group, LayoutSet layoutSet) {
+		if (!layoutSet.isLayoutSetPrototypeLinkActive() ||
+			group.isLayoutPrototype() || group.isLayoutSetPrototype()) {
+
+			return false;
+		}
+
+		return true;
+	}
+
+	private boolean _isLayoutSetPrototypeMergeBackgroundTaskExists(
+			LayoutSetPrototype layoutSetPrototype, LayoutSet layoutSet)
+		throws Exception {
+
+		List<BackgroundTask> incompleteBackgroundTasks =
+			_backgroundTaskManager.getBackgroundTasks(
+				layoutSet.getGroupId(),
+				BackgroundTaskExecutorNames.
+					LAYOUT_SET_PROTOTYPE_MERGE_BACKGROUND_TASK_EXECUTOR,
+				false, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+				BackgroundTaskCreateDateComparator.getInstance(false));
+
+		for (BackgroundTask incompleteBackgroundTask :
+				incompleteBackgroundTasks) {
+
+			long exportImportConfigurationId = MapUtil.getLong(
+				incompleteBackgroundTask.getTaskContextMap(),
+				"exportImportConfigurationId");
+
+			ExportImportConfiguration exportImportConfiguration =
+				_exportImportConfigurationLocalService.
+					fetchExportImportConfiguration(exportImportConfigurationId);
+
+			if (exportImportConfiguration != null) {
+				Map<String, Serializable> settingsMap =
+					exportImportConfiguration.getSettingsMap();
+
+				Map<String, String[]> parameterMap =
+					(Map<String, String[]>)settingsMap.get("parameterMap");
+
+				long layoutSetId = MapUtil.getLong(parameterMap, "layoutSetId");
+
+				if (layoutSetId == layoutSet.getLayoutSetId()) {
+					if (incompleteBackgroundTask.getStatus() !=
+							BackgroundTaskConstants.STATUS_IN_PROGRESS) {
+
+						return true;
+					}
+
+					long lastMergeVersion = MapUtil.getLong(
+						parameterMap, "lastMergeVersion");
+
+					if (lastMergeVersion ==
+							layoutSetPrototype.getMvccVersion()) {
+
+						return true;
+					}
+				}
+			}
+		}
+
+		return false;
+	}
+
+	private void _mergeLayoutSetPrototypeLayoutsInBackground(
+			LayoutSetPrototype layoutSetPrototype, LayoutSet layoutSet)
+		throws Exception {
+
+		if (ExportImportThreadLocal.isExportInProcess() ||
+			ExportImportThreadLocal.isImportInProcess() ||
+			ExportImportThreadLocal.isStagingInProcess()) {
+
+			return;
+		}
+
+		if (_isLayoutSetPrototypeMergeBackgroundTaskExists(
+				layoutSetPrototype, layoutSet)) {
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Layout set prototype merge is in progress for layout " +
+						"set " + layoutSet.getLayoutSetId());
+			}
+
+			return;
+		}
+
+		UnicodeProperties settingsUnicodeProperties =
+			layoutSet.getSettingsProperties();
+
+		boolean importData = true;
+
+		long lastMergeTime = GetterUtil.getLong(
+			settingsUnicodeProperties.getProperty(Sites.LAST_MERGE_TIME));
+		long lastResetTime = GetterUtil.getLong(
+			settingsUnicodeProperties.getProperty(Sites.LAST_RESET_TIME));
+
+		if ((lastMergeTime > 0) || (lastResetTime > 0)) {
+			importData = false;
+		}
+
+		Map<String, String[]> parameterMap = getLayoutSetPrototypeParameters(
+			importData);
+
+		parameterMap.put(
+			PortletDataHandlerKeys.LAYOUT_SET_PRIVATE_LAYOUT,
+			new String[] {String.valueOf(layoutSet.isPrivateLayout())});
+		parameterMap.put(
+			"importData", new String[] {String.valueOf(importData)});
+		parameterMap.put(
+			"lastMergeVersion",
+			new String[] {String.valueOf(layoutSetPrototype.getMvccVersion())});
+		parameterMap.put(
+			"layoutSetId",
+			new String[] {String.valueOf(layoutSet.getLayoutSetId())});
+		parameterMap.put(
+			"layoutSetPrototypeId",
+			new String[] {
+				String.valueOf(layoutSetPrototype.getLayoutSetPrototypeId())
+			});
+
+		User user = _userLocalService.getDefaultUser(layoutSet.getCompanyId());
+
+		List<Layout> layoutSetPrototypeLayouts = _layoutLocalService.getLayouts(
+			layoutSetPrototype.getGroupId(), true);
+
+		Map<String, Serializable> exportLayoutSettingsMap =
+			ExportImportConfigurationSettingsMapFactoryUtil.
+				buildExportLayoutSettingsMap(
+					user, layoutSetPrototype.getGroupId(), true,
+					_exportImportHelper.getLayoutIds(layoutSetPrototypeLayouts),
+					parameterMap);
+
+		ExportImportConfiguration exportImportConfiguration = null;
+
+		try {
+			exportImportConfiguration =
+				_exportImportConfigurationLocalService.
+					addDraftExportImportConfiguration(
+						user.getUserId(),
+						ExportImportConfigurationConstants.TYPE_EXPORT_LAYOUT,
+						exportLayoutSettingsMap);
+		}
+		catch (PortalException portalException) {
+			_log.error(
+				"Unable to add draft export-import configuration",
+				portalException);
+
+			return;
+		}
+
+		_exportImportLocalService.mergeLayoutSetPrototypeInBackground(
+			user.getUserId(), layoutSet.getGroupId(),
+			exportImportConfiguration);
+	}
+
 	/**
 	 * Resets the modified timestamp on the layout so the linked page template is
 	 * merged into the layout when it is first accessed.
@@ -555,6 +857,19 @@ public class LayoutSetPrototypeHelperImpl implements LayoutSetPrototypeHelper {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		LayoutSetPrototypeHelperImpl.class);
+
+	@Reference
+	private BackgroundTaskManager _backgroundTaskManager;
+
+	@Reference
+	private ExportImportConfigurationLocalService
+		_exportImportConfigurationLocalService;
+
+	@Reference
+	private ExportImportHelper _exportImportHelper;
+
+	@Reference
+	private ExportImportLocalService _exportImportLocalService;
 
 	@Reference
 	private GroupLocalService _groupLocalService;
@@ -578,6 +893,6 @@ public class LayoutSetPrototypeHelperImpl implements LayoutSetPrototypeHelper {
 	private LayoutSetPrototypeLocalService _layoutSetPrototypeLocalService;
 
 	@Reference
-	private Sites _sites;
+	private UserLocalService _userLocalService;
 
 }

--- a/modules/apps/layout/layout-set-prototype-impl/src/main/java/com/liferay/layout/set/prototype/internal/helper/LayoutSetPrototypeHelperImpl.java
+++ b/modules/apps/layout/layout-set-prototype-impl/src/main/java/com/liferay/layout/set/prototype/internal/helper/LayoutSetPrototypeHelperImpl.java
@@ -5,10 +5,13 @@
 
 package com.liferay.layout.set.prototype.internal.helper;
 
+import com.liferay.exportimport.kernel.staging.MergeLayoutPrototypesThreadLocal;
 import com.liferay.layout.set.prototype.helper.LayoutSetPrototypeHelper;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupTable;
 import com.liferay.portal.kernel.model.Layout;
@@ -46,6 +49,42 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(service = LayoutSetPrototypeHelper.class)
 public class LayoutSetPrototypeHelperImpl implements LayoutSetPrototypeHelper {
+
+	@Override
+	public void executeLayoutSetPrototypeSync(
+			long layoutSetPrototypeId, long userId)
+		throws PortalException {
+
+		LayoutSetPrototype layoutSetPrototype =
+			_layoutSetPrototypeLocalService.fetchLayoutSetPrototype(
+				layoutSetPrototypeId);
+
+		if (layoutSetPrototype == null) {
+			return;
+		}
+
+		for (LayoutSet layoutSet :
+				_layoutSetLocalService.getLayoutSetsByLayoutSetPrototypeUuid(
+					layoutSetPrototype.getUuid())) {
+
+			try {
+				executeLayoutSetSync(layoutSet);
+			}
+			catch (Exception exception) {
+				_log.error(
+					"Unable to start site template sync for layout set " +
+						layoutSet.getLayoutSetId(),
+					exception);
+			}
+		}
+	}
+
+	@Override
+	public void executeLayoutSetSync(LayoutSet layoutSet) throws Exception {
+		MergeLayoutPrototypesThreadLocal.setSkipMerge(false);
+
+		_sites.mergeLayoutSetPrototypeLayouts(layoutSet.getGroup(), layoutSet);
+	}
 
 	@Override
 	public List<Layout> getDuplicatedFriendlyURLLayouts(Layout layout)
@@ -514,6 +553,9 @@ public class LayoutSetPrototypeHelperImpl implements LayoutSetPrototypeHelper {
 		_layoutLocalService.updateLayout(layout);
 	}
 
+	private static final Log _log = LogFactoryUtil.getLog(
+		LayoutSetPrototypeHelperImpl.class);
+
 	@Reference
 	private GroupLocalService _groupLocalService;
 
@@ -534,5 +576,8 @@ public class LayoutSetPrototypeHelperImpl implements LayoutSetPrototypeHelper {
 
 	@Reference
 	private LayoutSetPrototypeLocalService _layoutSetPrototypeLocalService;
+
+	@Reference
+	private Sites _sites;
 
 }

--- a/modules/apps/layout/layout-set-prototype-web/src/main/java/com/liferay/layout/set/prototype/web/internal/portlet/LayoutSetPrototypePortlet.java
+++ b/modules/apps/layout/layout-set-prototype-web/src/main/java/com/liferay/layout/set/prototype/web/internal/portlet/LayoutSetPrototypePortlet.java
@@ -9,25 +9,24 @@ import com.liferay.application.list.PanelAppRegistry;
 import com.liferay.application.list.constants.ApplicationListWebKeys;
 import com.liferay.application.list.display.context.logic.PanelCategoryHelper;
 import com.liferay.layout.set.prototype.constants.LayoutSetPrototypePortletKeys;
+import com.liferay.layout.set.prototype.helper.LayoutSetPrototypeHelper;
 import com.liferay.portal.kernel.exception.NoSuchLayoutSetPrototypeException;
 import com.liferay.portal.kernel.exception.RequiredLayoutSetPrototypeException;
-import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.LayoutSetPrototype;
-import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.portlet.PortalPreferences;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
-import com.liferay.portal.kernel.service.LayoutSetLocalService;
 import com.liferay.portal.kernel.service.LayoutSetPrototypeService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.servlet.SessionErrors;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Localization;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
-import com.liferay.sites.kernel.util.Sites;
+import com.liferay.portal.kernel.util.WebKeys;
 
 import jakarta.portlet.ActionRequest;
 import jakarta.portlet.ActionResponse;
@@ -120,23 +119,11 @@ public class LayoutSetPrototypePortlet extends MVCPortlet {
 		long layoutSetPrototypeId = ParamUtil.getLong(
 			actionRequest, "layoutSetPrototypeId");
 
-		LayoutSetPrototype layoutSetPrototype =
-			layoutSetPrototypeService.fetchLayoutSetPrototype(
-				layoutSetPrototypeId);
+		ThemeDisplay themeDisplay = (ThemeDisplay)actionRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
 
-		if (layoutSetPrototype == null) {
-			return;
-		}
-
-		Sites sites = _sitesSnapshot.get();
-
-		for (LayoutSet layoutSet :
-				layoutSetLocalService.getLayoutSetsByLayoutSetPrototypeUuid(
-					layoutSetPrototype.getUuid())) {
-
-			sites.mergeLayoutSetPrototypeLayouts(
-				layoutSet.getGroup(), layoutSet);
-		}
+		layoutSetPrototypeHelper.executeLayoutSetPrototypeSync(
+			layoutSetPrototypeId, themeDisplay.getUserId());
 	}
 
 	public void updateLayoutSetPrototype(
@@ -261,7 +248,7 @@ public class LayoutSetPrototypePortlet extends MVCPortlet {
 	}
 
 	@Reference
-	protected LayoutSetLocalService layoutSetLocalService;
+	protected LayoutSetPrototypeHelper layoutSetPrototypeHelper;
 
 	@Reference
 	protected LayoutSetPrototypeService layoutSetPrototypeService;
@@ -271,8 +258,5 @@ public class LayoutSetPrototypePortlet extends MVCPortlet {
 
 	@Reference
 	protected PanelAppRegistry panelAppRegistry;
-
-	private static final Snapshot<Sites> _sitesSnapshot = new Snapshot<>(
-		LayoutSetPrototypePortlet.class, Sites.class);
 
 }

--- a/modules/apps/site/site-impl/build.gradle
+++ b/modules/apps/site/site-impl/build.gradle
@@ -16,6 +16,7 @@ dependencies {
 	compileOnly project(":apps:layout:layout-api")
 	compileOnly project(":apps:layout:layout-page-template-api")
 	compileOnly project(":apps:layout:layout-seo-api")
+	compileOnly project(":apps:layout:layout-set-prototype-api")
 	compileOnly project(":apps:object:object-api")
 	compileOnly project(":apps:portal-background-task:portal-background-task-api")
 	compileOnly project(":apps:portal-configuration:portal-configuration-module-configuration-api")

--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/util/SitesImpl.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/util/SitesImpl.java
@@ -7,28 +7,20 @@ package com.liferay.site.internal.util;
 
 import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
-import com.liferay.exportimport.kernel.background.task.BackgroundTaskExecutorNames;
 import com.liferay.exportimport.kernel.configuration.ExportImportConfigurationSettingsMapFactoryUtil;
 import com.liferay.exportimport.kernel.configuration.constants.ExportImportConfigurationConstants;
 import com.liferay.exportimport.kernel.lar.ExportImportHelper;
-import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
-import com.liferay.exportimport.kernel.lar.PortletDataHandlerKeys;
-import com.liferay.exportimport.kernel.lar.UserIdStrategy;
 import com.liferay.exportimport.kernel.model.ExportImportConfiguration;
 import com.liferay.exportimport.kernel.service.ExportImportConfigurationLocalService;
 import com.liferay.exportimport.kernel.service.ExportImportLocalService;
 import com.liferay.exportimport.kernel.staging.MergeLayoutPrototypesThreadLocal;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
+import com.liferay.layout.set.prototype.helper.LayoutSetPrototypeHelper;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.background.task.util.comparator.BackgroundTaskCreateDateComparator;
-import com.liferay.portal.kernel.backgroundtask.BackgroundTask;
-import com.liferay.portal.kernel.backgroundtask.BackgroundTaskManager;
-import com.liferay.portal.kernel.backgroundtask.constants.BackgroundTaskConstants;
 import com.liferay.portal.kernel.change.tracking.CTTransactionException;
 import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.lock.Lock;
 import com.liferay.portal.kernel.lock.LockManagerUtil;
@@ -67,10 +59,8 @@ import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.permission.PortletPermissionUtil;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleThreadLocal;
-import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.PropsValues;
@@ -396,17 +386,6 @@ public class SitesImpl implements Sites {
 	 *         the layout set; <code>false</code> otherwise
 	 */
 	@Override
-	public boolean isLayoutSetMergeable(Group group, LayoutSet layoutSet) {
-		if (!layoutSet.isLayoutSetPrototypeLinkActive() ||
-			group.isLayoutPrototype() || group.isLayoutSetPrototype()) {
-
-			return false;
-		}
-
-		return true;
-	}
-
-	@Override
 	public void mergeLayoutPrototypeLayout(Group group, Layout layout)
 		throws Exception {
 
@@ -446,27 +425,7 @@ public class SitesImpl implements Sites {
 	public void mergeLayoutSetPrototypeLayouts(Group group, LayoutSet layoutSet)
 		throws Exception {
 
-		if (MergeLayoutPrototypesThreadLocal.isSkipMerge()) {
-			return;
-		}
-
-		MergeLayoutPrototypesThreadLocal.setSkipMerge(true);
-
-		layoutSet = _layoutSetLocalService.fetchLayoutSet(
-			layoutSet.getLayoutSetId());
-
-		if (!isLayoutSetMergeable(group, layoutSet)) {
-			return;
-		}
-
-		LayoutSetPrototype layoutSetPrototype =
-			_layoutSetPrototypeLocalService.
-				getLayoutSetPrototypeByUuidAndCompanyId(
-					layoutSet.getLayoutSetPrototypeUuid(),
-					layoutSet.getCompanyId());
-
-		mergeLayoutSetPrototypeLayoutsInBackground(
-			layoutSetPrototype, layoutSet);
+		_layoutSetPrototypeHelper.executeLayoutSetSync(layoutSet);
 	}
 
 	@Override
@@ -726,106 +685,6 @@ public class SitesImpl implements Sites {
 		return cacheFile;
 	}
 
-	protected Map<String, String[]> getLayoutSetPrototypesParameters(
-		boolean importData) {
-
-		Map<String, String[]> parameterMap = LinkedHashMapBuilder.put(
-			PortletDataHandlerKeys.DELETE_MISSING_LAYOUTS,
-			new String[] {Boolean.FALSE.toString()}
-		).put(
-			PortletDataHandlerKeys.DELETE_PORTLET_DATA,
-			new String[] {Boolean.FALSE.toString()}
-		).put(
-			PortletDataHandlerKeys.IGNORE_LAST_PUBLISH_DATE,
-			new String[] {Boolean.TRUE.toString()}
-		).put(
-			PortletDataHandlerKeys.LAYOUT_SET_SETTINGS,
-			new String[] {Boolean.TRUE.toString()}
-		).put(
-			PortletDataHandlerKeys.LAYOUT_SET_PROTOTYPE_LINK_ENABLED,
-			new String[] {Boolean.TRUE.toString()}
-		).put(
-			PortletDataHandlerKeys.LAYOUT_SET_PROTOTYPE_SETTINGS,
-			new String[] {Boolean.TRUE.toString()}
-		).put(
-			PortletDataHandlerKeys.LAYOUTS_IMPORT_MODE,
-			new String[] {
-				PortletDataHandlerKeys.
-					LAYOUTS_IMPORT_MODE_CREATED_FROM_PROTOTYPE
-			}
-		).put(
-			PortletDataHandlerKeys.PERMISSIONS,
-			new String[] {Boolean.TRUE.toString()}
-		).put(
-			PortletDataHandlerKeys.PORTLET_CONFIGURATION,
-			new String[] {Boolean.TRUE.toString()}
-		).put(
-			PortletDataHandlerKeys.PORTLET_CONFIGURATION_ALL,
-			new String[] {Boolean.TRUE.toString()}
-		).put(
-			PortletDataHandlerKeys.PORTLET_SETUP_ALL,
-			new String[] {Boolean.TRUE.toString()}
-		).put(
-			PortletDataHandlerKeys.THEME_REFERENCE,
-			new String[] {Boolean.TRUE.toString()}
-		).put(
-			PortletDataHandlerKeys.UPDATE_LAST_PUBLISH_DATE,
-			new String[] {Boolean.FALSE.toString()}
-		).put(
-			PortletDataHandlerKeys.USER_ID_STRATEGY,
-			new String[] {UserIdStrategy.CURRENT_USER_ID}
-		).build();
-
-		if (importData) {
-			parameterMap.put(
-				PortletDataHandlerKeys.DATA_STRATEGY,
-				new String[] {PortletDataHandlerKeys.DATA_STRATEGY_MIRROR});
-			parameterMap.put(
-				PortletDataHandlerKeys.FAVICON,
-				new String[] {Boolean.TRUE.toString()});
-			parameterMap.put(
-				PortletDataHandlerKeys.LOGO,
-				new String[] {Boolean.TRUE.toString()});
-			parameterMap.put(
-				PortletDataHandlerKeys.PORTLET_DATA,
-				new String[] {Boolean.TRUE.toString()});
-			parameterMap.put(
-				PortletDataHandlerKeys.PORTLET_DATA_ALL,
-				new String[] {Boolean.TRUE.toString()});
-		}
-		else {
-			parameterMap.put(
-				PortletDataHandlerKeys.DELETE_LAYOUTS,
-				new String[] {Boolean.TRUE.toString()});
-			parameterMap.put(
-				PortletDataHandlerKeys.DELETIONS,
-				new String[] {Boolean.TRUE.toString()});
-			parameterMap.put(
-				PortletDataHandlerKeys.FAVICON,
-				new String[] {Boolean.FALSE.toString()});
-
-			if (PropsValues.LAYOUT_SET_PROTOTYPE_PROPAGATE_LOGO) {
-				parameterMap.put(
-					PortletDataHandlerKeys.LOGO,
-					new String[] {Boolean.TRUE.toString()});
-			}
-			else {
-				parameterMap.put(
-					PortletDataHandlerKeys.LOGO,
-					new String[] {Boolean.FALSE.toString()});
-			}
-
-			parameterMap.put(
-				PortletDataHandlerKeys.PORTLET_DATA,
-				new String[] {Boolean.FALSE.toString()});
-			parameterMap.put(
-				PortletDataHandlerKeys.PORTLET_DATA_ALL,
-				new String[] {Boolean.FALSE.toString()});
-		}
-
-		return parameterMap;
-	}
-
 	protected void importLayoutSetPrototype(
 			LayoutSetPrototype layoutSetPrototype, long groupId,
 			boolean privateLayout, Map<String, String[]> parameterMap,
@@ -900,152 +759,6 @@ public class SitesImpl implements Sites {
 			user.getUserId(), exportImportConfiguration, file);
 	}
 
-	protected boolean isLayoutSetPrototypeMergeBackgroundTaskExists(
-			LayoutSetPrototype layoutSetPrototype, LayoutSet layoutSet)
-		throws PortalException {
-
-		List<BackgroundTask> incompleteBackgroundTasks =
-			_backgroundTaskManager.getBackgroundTasks(
-				layoutSet.getGroupId(),
-				BackgroundTaskExecutorNames.
-					LAYOUT_SET_PROTOTYPE_MERGE_BACKGROUND_TASK_EXECUTOR,
-				false, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
-				BackgroundTaskCreateDateComparator.getInstance(false));
-
-		for (BackgroundTask incompleteBackgroundTask :
-				incompleteBackgroundTasks) {
-
-			long exportImportConfigurationId = MapUtil.getLong(
-				incompleteBackgroundTask.getTaskContextMap(),
-				"exportImportConfigurationId");
-
-			ExportImportConfiguration exportImportConfiguration =
-				_exportImportConfigurationLocalService.
-					fetchExportImportConfiguration(exportImportConfigurationId);
-
-			if (exportImportConfiguration != null) {
-				Map<String, Serializable> settingsMap =
-					exportImportConfiguration.getSettingsMap();
-
-				Map<String, String[]> parameterMap =
-					(Map<String, String[]>)settingsMap.get("parameterMap");
-
-				long layoutSetId = MapUtil.getLong(parameterMap, "layoutSetId");
-
-				if (layoutSetId == layoutSet.getLayoutSetId()) {
-					if (incompleteBackgroundTask.getStatus() !=
-							BackgroundTaskConstants.STATUS_IN_PROGRESS) {
-
-						return true;
-					}
-
-					long lastMergeVersion = MapUtil.getLong(
-						parameterMap, "lastMergeVersion");
-
-					if (lastMergeVersion ==
-							layoutSetPrototype.getMvccVersion()) {
-
-						return true;
-					}
-				}
-			}
-		}
-
-		return false;
-	}
-
-	protected void mergeLayoutSetPrototypeLayoutsInBackground(
-			LayoutSetPrototype layoutSetPrototype, LayoutSet layoutSet)
-		throws PortalException {
-
-		if (ExportImportThreadLocal.isExportInProcess() ||
-			ExportImportThreadLocal.isImportInProcess() ||
-			ExportImportThreadLocal.isStagingInProcess()) {
-
-			return;
-		}
-
-		if (isLayoutSetPrototypeMergeBackgroundTaskExists(
-				layoutSetPrototype, layoutSet)) {
-
-			if (_log.isDebugEnabled()) {
-				_log.debug(
-					"Layout set prototype merge is in progress for layout " +
-						"set " + layoutSet.getLayoutSetId());
-			}
-
-			return;
-		}
-
-		UnicodeProperties settingsUnicodeProperties =
-			layoutSet.getSettingsProperties();
-
-		boolean importData = true;
-
-		long lastMergeTime = GetterUtil.getLong(
-			settingsUnicodeProperties.getProperty(LAST_MERGE_TIME));
-		long lastResetTime = GetterUtil.getLong(
-			settingsUnicodeProperties.getProperty(LAST_RESET_TIME));
-
-		if ((lastMergeTime > 0) || (lastResetTime > 0)) {
-			importData = false;
-		}
-
-		Map<String, String[]> parameterMap = getLayoutSetPrototypesParameters(
-			importData);
-
-		parameterMap.put(
-			PortletDataHandlerKeys.LAYOUT_SET_PRIVATE_LAYOUT,
-			new String[] {String.valueOf(layoutSet.isPrivateLayout())});
-		parameterMap.put(
-			"importData", new String[] {String.valueOf(importData)});
-		parameterMap.put(
-			"lastMergeVersion",
-			new String[] {String.valueOf(layoutSetPrototype.getMvccVersion())});
-		parameterMap.put(
-			"layoutSetId",
-			new String[] {String.valueOf(layoutSet.getLayoutSetId())});
-		parameterMap.put(
-			"layoutSetPrototypeId",
-			new String[] {
-				String.valueOf(layoutSetPrototype.getLayoutSetPrototypeId())
-			});
-
-		User user = _userLocalService.getDefaultUser(layoutSet.getCompanyId());
-
-		List<Layout> layoutSetPrototypeLayouts = _layoutLocalService.getLayouts(
-			layoutSetPrototype.getGroupId(), true);
-
-		Map<String, Serializable> exportLayoutSettingsMap =
-			ExportImportConfigurationSettingsMapFactoryUtil.
-				buildExportLayoutSettingsMap(
-					user, layoutSetPrototype.getGroupId(), true,
-					_exportImportHelper.getLayoutIds(layoutSetPrototypeLayouts),
-					parameterMap);
-
-		ExportImportConfiguration exportImportConfiguration = null;
-
-		try {
-			exportImportConfiguration =
-				_exportImportConfigurationLocalService.
-					addDraftExportImportConfiguration(
-						user.getUserId(),
-						ExportImportConfigurationConstants.TYPE_EXPORT_LAYOUT,
-						exportLayoutSettingsMap);
-		}
-		catch (PortalException portalException) {
-			_log.error(
-				"Unable to add draft export-import configuration",
-				portalException);
-
-			return;
-		}
-
-		_exportImportLocalService.mergeLayoutSetPrototypeInBackground(
-			user.getUserId(), layoutSet.getGroupId(),
-			exportImportConfiguration);
-	}
-
 	protected void updateLayoutSetPrototypeLink(
 			long groupId, boolean privateLayout, long layoutSetPrototypeId,
 			boolean layoutSetPrototypeLinkEnabled)
@@ -1074,7 +787,9 @@ public class SitesImpl implements Sites {
 
 						importLayoutSetPrototype(
 							layoutSetPrototype, groupId, privateLayout,
-							getLayoutSetPrototypesParameters(true), true);
+							_layoutSetPrototypeHelper.
+								getLayoutSetPrototypeParameters(true),
+							true);
 					}
 					finally {
 						MergeLayoutPrototypesThreadLocal.setInProgress(
@@ -1214,9 +929,6 @@ public class SitesImpl implements Sites {
 	private AssetEntryLocalService _assetEntryLocalService;
 
 	@Reference
-	private BackgroundTaskManager _backgroundTaskManager;
-
-	@Reference
 	private ExportImportConfigurationLocalService
 		_exportImportConfigurationLocalService;
 
@@ -1247,6 +959,9 @@ public class SitesImpl implements Sites {
 
 	@Reference
 	private LayoutSetLocalService _layoutSetLocalService;
+
+	@Reference
+	private LayoutSetPrototypeHelper _layoutSetPrototypeHelper;
 
 	@Reference
 	private LayoutSetPrototypeLocalService _layoutSetPrototypeLocalService;

--- a/portal-kernel/src/com/liferay/sites/kernel/util/Sites.java
+++ b/portal-kernel/src/com/liferay/sites/kernel/util/Sites.java
@@ -7,7 +7,6 @@ package com.liferay.sites.kernel.util;
 
 import com.liferay.expando.kernel.model.ExpandoBridge;
 import com.liferay.expando.kernel.util.ExpandoBridgeFactoryUtil;
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutPrototype;
@@ -85,9 +84,6 @@ public interface Sites {
 
 	public void copyPortletSetups(Layout sourceLayout, Layout targetLayout)
 		throws Exception;
-
-	public boolean isLayoutSetMergeable(Group group, LayoutSet layoutSet)
-		throws PortalException;
 
 	public void mergeLayoutPrototypeLayout(Group group, Layout layout)
 		throws Exception;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87027

## What Is Being Fixed

The Site Template sync orchestration (the mergeable check, the background merge scheduling, the export parameters, and the in-progress task lookup) lived in `SitesImpl`, mixing site-template-specific logic into the generic `Sites` utility.

## How It Is Being Fixed

A pure move with no behavior change: the sync orchestration is pulled out of `SitesImpl` into `LayoutSetPrototypeHelperImpl`, where it belongs conceptually. `SitesImpl.mergeLayoutSetPrototypeLayouts` now delegates to the helper, and the public `Sites.isLayoutSetMergeable` is removed (the mergeable check becomes a private helper). The "set template without enabling the link" one-shot import stays in `site-impl` alongside its only caller, reusing the helper's export parameters through the new `LayoutSetPrototypeHelper.getLayoutSetPrototypeParameters(boolean)`.

## Why Are There No Tests?

This is a pure refactoring move with no behavior change; the existing integration coverage (`LayoutSetPrototypePropagationTest`) continues to exercise the unchanged sync behavior.

## PR Check

**pr-check: RUNNING** — being re-validated on `6d5c51f2a6edb721e436c93d87f41f77bd846628` after rebasing onto master; result will be posted as a comment.
