### PR TITLE
LPD-94688 Resolve getModelClassName reference through ClassedModel

### DIFF
--- a/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/BulkActionResourceImpl.java
+++ b/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/BulkActionResourceImpl.java
@@ -57,6 +57,7 @@ import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.ClassedModel;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.module.service.Snapshot;
@@ -1093,9 +1094,12 @@ public class BulkActionResourceImpl extends BaseBulkActionResourceImpl {
 			).put(
 				"type", "FOLDER"
 			).build());
+
+		ClassedModel classedModel = objectEntryFolder;
+
 		bulkActionItem.setClassExternalReferenceCode(
 			objectEntryFolder::getExternalReferenceCode);
-		bulkActionItem.setClassName(objectEntryFolder::getModelClassName);
+		bulkActionItem.setClassName(classedModel::getModelClassName);
 		bulkActionItem.setClassPK(objectEntryFolder::getObjectEntryFolderId);
 		bulkActionItem.setName(objectEntryFolder::getName);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94688

**What is being fixed:** The method reference `objectEntryFolder::getModelClassName` in `BulkActionResourceImpl` produced nondeterministic compiled output. `getModelClassName` is inherited through more than one interface on the generated `ObjectEntryFolder` model, so the compiler does not always bind the method reference to the same owner type, which makes the resulting bytecode vary between builds.

**How it is being fixed:** The `objectEntryFolder` instance is first assigned to a local variable typed as `ClassedModel`, and the method reference is taken from that variable. This pins the method reference's owner to `ClassedModel`, so the compiler always emits the same bytecode and the build output becomes reproducible.