### PR TITLE
LPD-94752 Fix ExportImportSiteWithCopyAsNew for CKEditor 5 default

### DIFF
--- a/modules/apps/feature-flag/feature-flag-test/src/testFunctional/macros/FeatureFlag.macro
+++ b/modules/apps/feature-flag/feature-flag-test/src/testFunctional/macros/FeatureFlag.macro
@@ -20,7 +20,7 @@ definition {
 
 	@summary = "Default summary"
 	macro toggleFeatureFlag(toggleState = null, configurationScope = null, featureFlag = null, scope = null) {
-		if (!(isSet(toggleState))) {
+		if (!(isSet(configurationScope))) {
 			var configurationScope = "Virtual Instance Scope";
 		}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/exportimport/ExportImport.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/exportimport/ExportImport.testcase
@@ -1057,17 +1057,11 @@ definition {
 		}
 
 		task ("Add a web content with a link as content") {
-			WebContentNavigator.openWebContentAdmin(siteURLKey = "test-site-name");
-
-			WebContentNavigator.gotoAddCP();
-
-			WebContent.addCP(webContentTitle = "WC WebContent 1");
-
-			CKEditor.addSourceContent(content = '''
-<p>Test: <a href="/web/test-site-name/test-site-name">Link</a></p>
-''');
-
-			WebContent.publishWithPermissions();
+			JSONWebcontent.addWebContent(
+				content = '''<p>Test: <a href="/web/test-site-name/test-site-name">Link</a></p>''',
+				groupName = "Test Site Name",
+				source = "true",
+				title = "WC WebContent 1");
 		}
 
 		task ("Add the second web content") {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94752

## What Is Being Fixed

The Poshi test ExportImport#ExportImportSiteWithCopyAsNew fails in the headless CI routine: ElementNotFound at "//a[...cke_button...source...]". The DDM rich text field used by basic Web Content now renders CKEditor 5 by default (epic LPD-11235 — CKEditor 5 has been selected as the default editor for Liferay DXP); classic CKEditor 4 renders only when the LPD-11235 deprecation flag is enabled. The headless CI routine runs with deprecation flags disabled, so the classic "Source" toolbar button (cke_button source) that CKEditor.addSourceContent clicks no longer exists.

## How It Is Being Fixed

The link-bearing web content is now created via the JSON API (JSONWebcontent.addWebContent with source="true") instead of the classic CKEditor source-editing UI, so the test no longer depends on the editor version while storing identical content. Verifying the copy-as-new import surfaced a separate, pre-existing breakage: FeatureFlag.toggleFeatureFlag defaulted configurationScope only when toggleState was unset, leaving Staging.enableCopyAsNewImport's feature-flag navigation with an empty scope; it now defaults whenever configurationScope is unset, verified against every caller (Staging copy-as-new, Segmentation, Questions) with no change to callers that pass configurationScope explicitly.

## Why Are There No Tests?

This change only modifies functional test code — a Poshi test and a shared Poshi test macro — to adapt to the documented CKEditor 5 migration. There is no product code change, so no new test coverage is added.

## PR Check

**pr-check: PASS** — tested on `af967717e14c2107f4db23a5d36237b58a7ffb82`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "af967717e14c2107f4db23a5d36237b58a7ffb82"} -->
