### PR TITLE
LPD-94779 Enable Widget Pages flag in PGStagingWithVersioning setUp

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/pgstaging/PGStagingWithVersioning.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/pgstaging/PGStagingWithVersioning.testcase
@@ -14,6 +14,10 @@ definition {
 			User.firstLoginPG();
 		}
 
+		task ("Setup: Enable the Widget Pages deprecation feature flag") {
+			PagesAdmin.enableWidgetPages();
+		}
+
 		task ("Setup: Add a group with the name Site Name") {
 			HeadlessSite.addSite(siteName = "Site Name");
 		}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94779

## What Is Being Fixed

The Poshi test PGStagingWithVersioning#AddPageWithPageVersioningEnabled fails in the headless CI routine: "Element is not present at //*[card-body][contains(.,'Widget Page')]". It adds a page that defaults to the Widget Page type, but Widget Pages are deprecated behind the LPD-76864 ("Widget Pages") deprecation feature flag, which the headless CI routine runs with disabled. With the flag off the "Widget Page" card no longer renders, so PagesAdmin.addPage cannot select the page type.

## How It Is Being Fixed

The test now opts into the deprecated Widget Pages feature by calling PagesAdmin.enableWidgetPages() in setUp, the established pattern already used by CPCustomfields, MBThread, Search, and other testcases that add Widget Pages. Verified green twice locally with the deprecation flag disabled (mirroring CI).

## Why Are There No Tests?

This change only modifies functional test code (a Poshi testcase setUp) to opt into a deprecated feature. There is no product code change, so no new test coverage is added.

## PR Check

**pr-check: PASS** — tested on `7ed3e3b0af274dc3c612819a76407afed3728715`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "7ed3e3b0af274dc3c612819a76407afed3728715"} -->
