### PR TITLE
LPD-94782 Enable Widget Pages flag in ExportImportPrivatePage

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/exportimport/ExportImport.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/exportimport/ExportImport.testcase
@@ -879,8 +879,10 @@ definition {
 	@description = "Verify is possible export/import a Private Page."
 	@priority = 3
 	test ExportImportPrivatePage {
-		task ("Enable private pages") {
+		task ("Enable private pages and widget pages") {
 			PagesAdmin.enablePrivatePages();
+
+			PagesAdmin.enableWidgetPages();
 		}
 
 		task ("Given: User adds a new private page") {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94782

## What Is Being Fixed

The Poshi test ExportImport#ExportImportPrivatePage fails in the headless CI routine: "Element is not present at //*[card-body][contains(.,'Widget Page')]". It enables Private Pages then calls PagesAdmin.addPrivatePage, which defaults to the Widget Page type; but Widget Pages are deprecated behind the LPD-76864 ("Widget Pages") deprecation feature flag, which the headless CI routine runs with disabled. With the flag off the "Widget Page" card no longer renders, so the page type cannot be selected.

## How It Is Being Fixed

The test now also opts into the deprecated Widget Pages feature by calling PagesAdmin.enableWidgetPages() alongside the existing PagesAdmin.enablePrivatePages(). This mirrors the established pattern used by other testcases that add Widget Pages. Verified green twice locally with the deprecation flag disabled (mirroring CI).

## Why Are There No Tests?

This change only modifies functional test code (a Poshi testcase) to opt into a deprecated feature. There is no product code change, so no new test coverage is added.

## PR Check

**pr-check: PASS** — tested on `bc92518f4913e1fa7be12ce25eafd9c8000f1ecb`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "bc92518f4913e1fa7be12ce25eafd9c8000f1ecb"} -->
