### PR TITLE
LPD-94809 Fix ExportImportThemeSettings for Widget Pages and new page UI

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/exportimport/ExportImport.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/exportimport/ExportImport.testcase
@@ -1239,6 +1239,10 @@ definition {
 	@description = "Verify is possible export/import theme settings."
 	@priority = 3
 	test ExportImportThemeSettings {
+		task ("Enable widget pages") {
+			PagesAdmin.enableWidgetPages();
+		}
+
 		task ("Given: User adds a new site with a page") {
 			HeadlessSite.addSite(siteName = "Site Name");
 
@@ -1250,7 +1254,7 @@ definition {
 
 			PagesAdmin.openPagesAdmin(siteURLKey = "Site Name");
 
-			PagesAdmin.addPage(pageName = "Test Page");
+			PagesAdmin.addPublicPage(pageName = "Test Page");
 
 			PagesAdmin.openPagesAdmin(siteURLKey = "Site Name");
 		}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94809

## What Is Being Fixed

The Poshi test ExportImport#ExportImportThemeSettings fails in the headless CI routine: "Element is not present at //*[card-body][contains(.,'Widget Page')]". Two issues block it: (1) it adds a page defaulting to the Widget Page type, which is deprecated behind the LPD-76864 ("Widget Pages") deprecation flag that the headless CI routine runs disabled, so the card is gone; and (2) on the current build the empty pages list renders an action dropdown rather than the old single "Add Page" link, which the legacy PagesAdmin.addPage empty-result path does not handle.

## How It Is Being Fixed

The test now calls PagesAdmin.addPublicPage (the migrated macro whose empty-result path already handles the new dropdown empty-state via gotoAddFirstPage) instead of PagesAdmin.addPage, and adds PagesAdmin.enableWidgetPages() to opt into the deprecated Widget Pages feature. This keeps the change inside the testcase rather than modifying the shared PagesAdmin.addPage macro. Verified green twice locally with the deprecation flag disabled (mirroring CI).

## Why Are There No Tests?

This change only modifies functional test code (a Poshi testcase) to adapt to a UI change and opt into a deprecated feature. There is no product code change, so no new test coverage is added.

## PR Check

**pr-check: PASS** — tested on `7c1e71dd19840ef8570b70c51c37bc035a151140`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "7c1e71dd19840ef8570b70c51c37bc035a151140"} -->
