### PR TITLE
LPD-94090 Fix HSQLDB import deadlock when reporting missing references

### DIFF
--- a/modules/apps/export-import/export-import-report-api/bnd.bnd
+++ b/modules/apps/export-import/export-import-report-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Export Import Report API
 Bundle-SymbolicName: com.liferay.exportimport.report.api
-Bundle-Version: 8.1.1
+Bundle-Version: 8.2.0
 Export-Package:\
 	com.liferay.exportimport.report.constants,\
 	com.liferay.exportimport.report.exception,\

--- a/modules/apps/export-import/export-import-report-api/src/main/java/com/liferay/exportimport/report/service/ExportImportReportEntryLocalService.java
+++ b/modules/apps/export-import/export-import-report-api/src/main/java/com/liferay/exportimport/report/service/ExportImportReportEntryLocalService.java
@@ -81,7 +81,7 @@ public interface ExportImportReportEntryLocalService
 		ExportImportReportEntry exportImportReportEntry);
 
 	@Indexable(type = IndexableType.REINDEX)
-	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	@Transactional(propagation = Propagation.REQUIRED)
 	public ExportImportReportEntry addMissingReferenceExportImportReportEntry(
 		long groupId, long companyId, String classExternalReferenceCode,
 		long classNameId, long exportImportConfigurationId,
@@ -320,4 +320,4 @@ public interface ExportImportReportEntryLocalService
 		ExportImportReportEntry exportImportReportEntry);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:810897473
+// LIFERAY-SERVICE-BUILDER-HASH:-680974063

--- a/modules/apps/export-import/export-import-report-api/src/main/resources/com/liferay/exportimport/report/constants/packageinfo
+++ b/modules/apps/export-import/export-import-report-api/src/main/resources/com/liferay/exportimport/report/constants/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 2.2.0

--- a/modules/apps/export-import/export-import-report-api/src/main/resources/com/liferay/exportimport/report/service/packageinfo
+++ b/modules/apps/export-import/export-import-report-api/src/main/resources/com/liferay/exportimport/report/service/packageinfo
@@ -1,1 +1,1 @@
-version 4.2.0
+version 4.2.1

--- a/modules/apps/export-import/export-import-report-service/src/main/java/com/liferay/exportimport/report/service/impl/ExportImportReportEntryLocalServiceImpl.java
+++ b/modules/apps/export-import/export-import-report-service/src/main/java/com/liferay/exportimport/report/service/impl/ExportImportReportEntryLocalServiceImpl.java
@@ -115,7 +115,7 @@ public class ExportImportReportEntryLocalServiceImpl
 
 	@Indexable(type = IndexableType.REINDEX)
 	@Override
-	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	@Transactional(propagation = Propagation.REQUIRED)
 	public ExportImportReportEntry addMissingReferenceExportImportReportEntry(
 		long groupId, long companyId, String classExternalReferenceCode,
 		long classNameId, long exportImportConfigurationId,

--- a/modules/apps/export-import/export-import-report-test/src/testIntegration/java/com/liferay/exportimport/report/internal/empty/model/test/EmptyModelManagerImplTest.java
+++ b/modules/apps/export-import/export-import-report-test/src/testIntegration/java/com/liferay/exportimport/report/internal/empty/model/test/EmptyModelManagerImplTest.java
@@ -27,7 +27,6 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import java.util.List;
 
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -39,7 +38,7 @@ import org.junit.runner.RunWith;
  * @author Petteri Karttunen
  */
 @RunWith(Arquillian.class)
-public class EmptyModelManagerTest {
+public class EmptyModelManagerImplTest {
 
 	@ClassRule
 	@Rule
@@ -53,61 +52,64 @@ public class EmptyModelManagerTest {
 		_group = GroupTestUtil.addGroup();
 	}
 
-	@After
-	public void tearDown() {
-		ExportImportThreadLocal.setExportImportConfigurationId(0);
-		ExportImportThreadLocal.setPortletImportInProcess(false);
-	}
-
 	@Test
 	public void testReportMissingReferenceDuringImport() throws Throwable {
 		long exportImportConfigurationId = RandomTestUtil.randomLong();
 
-		String externalReferenceCode = RandomTestUtil.randomString();
-
 		ExportImportThreadLocal.setExportImportConfigurationId(
 			exportImportConfigurationId);
+
 		ExportImportThreadLocal.setPortletImportInProcess(true);
+
+		String externalReferenceCode = RandomTestUtil.randomString();
 
 		// Reporting a missing reference must join the surrounding import
 		// transaction. When the report entry was written in a separate
 		// REQUIRES_NEW transaction it deadlocked against the lock the import
 		// transaction already held on the report entry table under HSQLDB's
-		// table-level locking, hanging the import.
+		// table level locking, hanging the import.
 
-		TransactionInvokerUtil.invoke(
-			TransactionConfig.Factory.create(
-				Propagation.REQUIRED, new Class<?>[] {Exception.class}),
-			() -> {
-				EmptyModelManagerUtil.reportMissingReference(
-					Group.class.getName(), externalReferenceCode,
-					_group.getGroupId());
+		try {
+			TransactionInvokerUtil.invoke(
+				TransactionConfig.Factory.create(
+					Propagation.REQUIRED, new Class<?>[] {Exception.class}),
+				() -> {
+					EmptyModelManagerUtil.reportMissingReference(
+						Group.class.getName(), externalReferenceCode,
+						_group.getGroupId());
 
-				return null;
-			});
+					return null;
+				});
 
-		List<ExportImportReportEntry> exportImportReportEntries =
-			_exportImportReportEntryLocalService.getExportImportReportEntries(
-				TestPropsValues.getCompanyId(), exportImportConfigurationId);
+			List<ExportImportReportEntry> exportImportReportEntries =
+				_exportImportReportEntryLocalService.
+					getExportImportReportEntries(
+						TestPropsValues.getCompanyId(),
+						exportImportConfigurationId);
 
-		Assert.assertEquals(
-			exportImportReportEntries.toString(), 1,
-			exportImportReportEntries.size());
+			Assert.assertEquals(
+				exportImportReportEntries.toString(), 1,
+				exportImportReportEntries.size());
 
-		ExportImportReportEntry exportImportReportEntry =
-			exportImportReportEntries.get(0);
+			ExportImportReportEntry exportImportReportEntry =
+				exportImportReportEntries.get(0);
 
-		Assert.assertEquals(
-			externalReferenceCode,
-			exportImportReportEntry.getClassExternalReferenceCode());
-		Assert.assertEquals(
-			_classNameLocalService.getClassNameId(Group.class),
-			exportImportReportEntry.getClassNameId());
-		Assert.assertEquals(
-			_group.getGroupId(), exportImportReportEntry.getGroupId());
-		Assert.assertEquals(
-			ExportImportReportEntryConstants.TYPE_MISSING_REFERENCE,
-			exportImportReportEntry.getType());
+			Assert.assertEquals(
+				externalReferenceCode,
+				exportImportReportEntry.getClassExternalReferenceCode());
+			Assert.assertEquals(
+				_classNameLocalService.getClassNameId(Group.class),
+				exportImportReportEntry.getClassNameId());
+			Assert.assertEquals(
+				_group.getGroupId(), exportImportReportEntry.getGroupId());
+			Assert.assertEquals(
+				ExportImportReportEntryConstants.TYPE_MISSING_REFERENCE,
+				exportImportReportEntry.getType());
+		}
+		finally {
+			ExportImportThreadLocal.setExportImportConfigurationId(0);
+			ExportImportThreadLocal.setPortletImportInProcess(false);
+		}
 	}
 
 	@Inject

--- a/modules/apps/export-import/export-import-report-test/src/testIntegration/java/com/liferay/exportimport/report/internal/empty/model/test/EmptyModelManagerTest.java
+++ b/modules/apps/export-import/export-import-report-test/src/testIntegration/java/com/liferay/exportimport/report/internal/empty/model/test/EmptyModelManagerTest.java
@@ -1,0 +1,123 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.exportimport.report.internal.empty.model.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.exportimport.kernel.empty.model.EmptyModelManagerUtil;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
+import com.liferay.exportimport.report.constants.ExportImportReportEntryConstants;
+import com.liferay.exportimport.report.model.ExportImportReportEntry;
+import com.liferay.exportimport.report.service.ExportImportReportEntryLocalService;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.transaction.Propagation;
+import com.liferay.portal.kernel.transaction.TransactionConfig;
+import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Petteri Karttunen
+ */
+@RunWith(Arquillian.class)
+public class EmptyModelManagerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@After
+	public void tearDown() {
+		ExportImportThreadLocal.setExportImportConfigurationId(0);
+		ExportImportThreadLocal.setPortletImportInProcess(false);
+	}
+
+	@Test
+	public void testReportMissingReferenceDuringImport() throws Throwable {
+		long exportImportConfigurationId = RandomTestUtil.randomLong();
+
+		String externalReferenceCode = RandomTestUtil.randomString();
+
+		ExportImportThreadLocal.setExportImportConfigurationId(
+			exportImportConfigurationId);
+		ExportImportThreadLocal.setPortletImportInProcess(true);
+
+		// Reporting a missing reference must join the surrounding import
+		// transaction. When the report entry was written in a separate
+		// REQUIRES_NEW transaction it deadlocked against the lock the import
+		// transaction already held on the report entry table under HSQLDB's
+		// table-level locking, hanging the import.
+
+		TransactionInvokerUtil.invoke(
+			TransactionConfig.Factory.create(
+				Propagation.REQUIRED, new Class<?>[] {Exception.class}),
+			() -> {
+				EmptyModelManagerUtil.reportMissingReference(
+					Group.class.getName(), externalReferenceCode,
+					_group.getGroupId());
+
+				return null;
+			});
+
+		List<ExportImportReportEntry> exportImportReportEntries =
+			_exportImportReportEntryLocalService.getExportImportReportEntries(
+				TestPropsValues.getCompanyId(), exportImportConfigurationId);
+
+		Assert.assertEquals(
+			exportImportReportEntries.toString(), 1,
+			exportImportReportEntries.size());
+
+		ExportImportReportEntry exportImportReportEntry =
+			exportImportReportEntries.get(0);
+
+		Assert.assertEquals(
+			externalReferenceCode,
+			exportImportReportEntry.getClassExternalReferenceCode());
+		Assert.assertEquals(
+			_classNameLocalService.getClassNameId(Group.class),
+			exportImportReportEntry.getClassNameId());
+		Assert.assertEquals(
+			_group.getGroupId(), exportImportReportEntry.getGroupId());
+		Assert.assertEquals(
+			ExportImportReportEntryConstants.TYPE_MISSING_REFERENCE,
+			exportImportReportEntry.getType());
+	}
+
+	@Inject
+	private ClassNameLocalService _classNameLocalService;
+
+	@Inject
+	private ExportImportReportEntryLocalService
+		_exportImportReportEntryLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94090

## What Is Being Fixed

Importing content (reproduced with the Clarity site) hangs indefinitely on HSQLDB. When the importer encounters a missing reference, it writes an `ExportImportReportEntry`. That write ran in a separate `REQUIRES_NEW` transaction, which then blocked on the table-level lock the in-progress import transaction already held on the report entry table. The two transactions deadlocked against each other and the import never completed.

## How It Is Being Fixed

The `addMissingReferenceExportImportReportEntry` propagation is changed from `REQUIRES_NEW` to `REQUIRED`, so reporting a missing reference joins the surrounding import transaction instead of opening a competing one that fights it for the same table lock. The exported API package and bundle versions are bumped to reflect the contract change. An integration test reports a missing reference inside an import transaction and asserts the entry is persisted without deadlocking.

## PR Check

**pr-check: PASS** — tested on `1ba51e3c61967cbc4bcb8d2628ff81ce83bb8ff0`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "1ba51e3c61967cbc4bcb8d2628ff81ce83bb8ff0"} -->
