### PR TITLE
LPD-87027 Fix the initial Site Template sync on site creation

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutSetLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutSetLocalServiceImpl.java
@@ -285,7 +285,12 @@ public class LayoutSetLocalServiceImpl extends LayoutSetLocalServiceBaseImpl {
 
 		LayoutSetBranch layoutSetBranch = _getLayoutSetBranch(layoutSet);
 
+		String previousLayoutSetPrototypeUuid = null;
+
 		if (layoutSetBranch == null) {
+			previousLayoutSetPrototypeUuid =
+				layoutSet.getLayoutSetPrototypeUuid();
+
 			if (Validator.isNull(layoutSetPrototypeUuid)) {
 				layoutSetPrototypeUuid = layoutSet.getLayoutSetPrototypeUuid();
 			}
@@ -302,6 +307,9 @@ public class LayoutSetLocalServiceImpl extends LayoutSetLocalServiceBaseImpl {
 			layoutSet = layoutSetPersistence.update(layoutSet);
 		}
 		else {
+			previousLayoutSetPrototypeUuid =
+				layoutSetBranch.getLayoutSetPrototypeUuid();
+
 			if (Validator.isNull(layoutSetPrototypeUuid)) {
 				layoutSetPrototypeUuid =
 					layoutSetBranch.getLayoutSetPrototypeUuid();
@@ -321,9 +329,6 @@ public class LayoutSetLocalServiceImpl extends LayoutSetLocalServiceBaseImpl {
 
 			_layoutSetBranchPersistence.update(layoutSetBranch);
 		}
-
-		String previousLayoutSetPrototypeUuid =
-			layoutSet.getLayoutSetPrototypeUuid();
 
 		if (!layoutSetPrototypeLinkEnabled ||
 			Validator.isNotNull(previousLayoutSetPrototypeUuid) ||


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87027

## What Is Being Fixed

The initial Site Template sync did not run when creating a site from a Site
Template. The first-link guard in updateLayoutSetPrototypeLinkEnabled relied on
previousLayoutSetPrototypeUuid being null, but that value was read from the
layout set after the new prototype UUID had already been written and persisted,
so the guard saw a non-null UUID, treated the link as a re-link, and skipped the
initial propagation.

## How It Is Being Fixed

The previous prototype UUID is now captured before the layout set or layout set
branch is mutated, reading it from whichever entity is being updated. With the
true prior value in hand, the first-link guard fires the initial merge the first
time a site template is linked, while still skipping propagation on subsequent
updates.

## Why Are There No Tests?

Test coverage for the Site Template sync behavior will be added in subsequent
PRs.

## PR Check

**pr-check: PASS** — tested on `2cdbf756cd6d9914af00004cc2e429c3d333fd02`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Full Portal Build | PASS |

<!-- pr-check {"result": "success", "sha": "2cdbf756cd6d9914af00004cc2e429c3d333fd02"} -->
