### PR TITLE
LPD-94660 Expect "Completed with errors" for new instance site import

### DIFF
--- a/modules/test/playwright/tests/export-import-web/main/pages/ExportImportPage.ts
+++ b/modules/test/playwright/tests/export-import-web/main/pages/ExportImportPage.ts
@@ -538,13 +538,16 @@ export class ExportImportPage {
 		});
 	}
 
-	async importByDefault(filePath: string) {
+	async importByDefault(
+		filePath: string,
+		taskStatus: taskStatus = 'success'
+	) {
 		await this.selectImportFile({filePath});
 
 		await this.importButton.click();
 
 		await expect(
-			this.taskStatusLabel(path.basename(filePath), 'success')
+			this.taskStatusLabel(path.basename(filePath), taskStatus)
 		).toBeVisible();
 	}
 

--- a/modules/test/playwright/tests/export-import-web/main/site.import.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/site.import.spec.ts
@@ -806,6 +806,7 @@ testWithDeprecationFFDisabled(
 
 testWithDeprecationFF(
 	'Can import the default site on a new instance twice',
+	{tag: '@LPD-94660'},
 	async ({apiHelpers, exportImportPage, featureFlags, page}) => {
 		test.slow();
 
@@ -852,7 +853,14 @@ testWithDeprecationFF(
 		await page.goto(
 			`http://www.able.com:${liferayConfig.environment.port}/group${site.friendlyUrlPath}${PORTLET_URLS.import}`
 		);
-		await exportImportPage.importByDefault(exportFilePath);
-		await exportImportPage.importByDefault(exportFilePath);
+
+		await exportImportPage.importByDefault(
+			exportFilePath,
+			'completedWithErrors'
+		);
+		await exportImportPage.importByDefault(
+			exportFilePath,
+			'completedWithErrors'
+		);
 	}
 );


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94660

## What Is Being Fixed

The Playwright test "Can import the default site on a new instance twice" asserted the import process finishes as "Successful". Since LPD-86259 (commit acb90ae), the import records tolerated optional references — the deprecated global "Search" widget-page template and the per-instance sample image, neither of which resolves on a fresh instance — as missing-reference report entries. The confirmed product rule is that any entry in the import report marks the process "Completed with errors", regardless of cause. Importing the default site onto a new instance therefore now legitimately reports "Completed with errors", and the stale assertion made the test fail.

## How It Is Being Fixed

The expected status in the test is updated to match the confirmed product behavior. The `importByDefault` helper on `ExportImportPage` gains a `taskStatus` parameter (defaulting to "success"), and the two import calls in the test pass "completedWithErrors". The test is also tagged `@LPD-94660`.

## PR Check

**pr-check: PASS** — tested on `f51c9c2c38f84d8290cf760f0fc2a689f39d8e20`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "f51c9c2c38f84d8290cf760f0fc2a689f39d8e20"} -->
