### PR TITLE
LPD-95002 LPD-95003 Default entities to checked in Export/Import revamp

### DIFF
--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSection.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSection.tsx
@@ -19,7 +19,7 @@ import {
 	HandlerSelection,
 	SCROLLABLE_SECTION_NAMES,
 	getSectionPreviewPortletDataHandlers,
-	getInitialSectionSelection,
+	getSectionSelection,
 	getSelectionSummary,
 	isSelected,
 	updateSelection,
@@ -158,7 +158,7 @@ export default function ContentSection({
 					onChange(
 						allSelected
 							? undefined
-							: getInitialSectionSelection(section, {
+							: getSectionSelection(section, {
 									commentsAndRatingsEnabled,
 									lookAndFeelEnabled,
 								})

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSection.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSection.tsx
@@ -12,17 +12,14 @@ import React, {useEffect, useId, useRef, useState} from 'react';
 import '../../../../css/utilities.scss';
 import {PageTreeModalConfiguration} from '../../../pages/export/components/PageTreeModal';
 import {ExportImportProcess} from '../../../types/exportImportProcess';
-import {
-	PreviewPortletDataHandlerBoolean,
-	PreviewPortletDataHandlerSection as PortletDataHandlerSectionType,
-} from '../../../types/portletDataHandler';
+import {PreviewPortletDataHandlerSection as PortletDataHandlerSectionType} from '../../../types/portletDataHandler';
 import {
 	COMPACT_SECTION_NAMES,
 	CONTENT_SECTION_KEY,
 	HandlerSelection,
 	SCROLLABLE_SECTION_NAMES,
-	SITE_BUILDER_SECTION_KEY,
-	getInitialSelections,
+	getSectionPreviewPortletDataHandlers,
+	getInitialSectionSelection,
 	getSelectionSummary,
 	isSelected,
 	updateSelection,
@@ -82,51 +79,10 @@ export default function ContentSection({
 		return () => resizeObserver.disconnect();
 	}, [scrollable, section]);
 
-	const previewPortletDataHandlers =
-		section.previewPortletDataHandlers.map<PreviewPortletDataHandlerBoolean>(
-			(handler) => ({...handler, type: 'Boolean'})
-		);
-
-	const syntheticPreviewPortletDataHandlers = [
-		{
-			applies:
-				lookAndFeelEnabled && section.name === SITE_BUILDER_SECTION_KEY,
-			previewPortletDataHandler: {
-				label: Liferay.Language.get('look-and-feel'),
-				name: 'lookAndFeel',
-				previewPortletDataHandlerControls: [
-					{
-						label: Liferay.Language.get('theme-settings'),
-						name: 'themeSettings',
-						type: 'Boolean',
-					},
-					{
-						label: Liferay.Language.get('logo'),
-						name: 'logo',
-						type: 'Boolean',
-					},
-					{
-						label: Liferay.Language.get('site-pages-settings'),
-						name: 'sitePagesSettings',
-						type: 'Boolean',
-					},
-					{
-						label: Liferay.Language.get('site-template-settings'),
-						name: 'siteTemplateSettings',
-						type: 'Boolean',
-					},
-				],
-				type: 'Boolean',
-			} as PreviewPortletDataHandlerBoolean,
-		},
-	]
-		.filter(({applies}) => applies)
-		.map(({previewPortletDataHandler}) => previewPortletDataHandler);
-
-	const allPreviewPortletDataHandlers = [
-		...previewPortletDataHandlers,
-		...syntheticPreviewPortletDataHandlers,
-	];
+	const allPreviewPortletDataHandlers = getSectionPreviewPortletDataHandlers(
+		section,
+		{lookAndFeelEnabled}
+	);
 
 	const sectionSelection = value || {};
 
@@ -202,9 +158,10 @@ export default function ContentSection({
 					onChange(
 						allSelected
 							? undefined
-							: getInitialSelections(
-									allPreviewPortletDataHandlers
-								)
+							: getInitialSectionSelection(section, {
+									commentsAndRatingsEnabled,
+									lookAndFeelEnabled,
+								})
 					)
 				}
 				selected={allSelected}

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSelector.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSelector.tsx
@@ -10,8 +10,8 @@ import {PageTreeModalConfiguration} from '../../../pages/export/components/PageT
 import {ExportImportProcess} from '../../../types/exportImportProcess';
 import {PreviewPortletDataHandlerSection} from '../../../types/portletDataHandler';
 import {
+	getVisibleSections,
 	updateSelection,
-	withSiteBuilderSection,
 } from '../../../utils/contentSelection';
 import ContentSection, {SectionSelection} from './ContentSection';
 
@@ -47,17 +47,10 @@ export default function ContentSelector({
 	const currentValue = value || {};
 	const errorId = errorMessage ? `${name}-error-message` : undefined;
 
-	const visibleSections = sections.filter(
-		(section) =>
-			showDeletions || !!section.additionCount || !section.deletionCount
-	);
-
-	const renderedSections = lookAndFeelEnabled
-		? withSiteBuilderSection(
-				visibleSections,
-				Liferay.Language.get('category.site_administration.build')
-			)
-		: visibleSections;
+	const visibleSections = getVisibleSections(sections, {
+		lookAndFeelEnabled,
+		showDeletions,
+	});
 
 	return (
 		<div
@@ -67,7 +60,7 @@ export default function ContentSelector({
 			className="c-gap-4 d-flex flex-column mt-4"
 			role="group"
 		>
-			{renderedSections.map(
+			{visibleSections.map(
 				(section: PreviewPortletDataHandlerSection) => (
 					<ContentSection
 						commentsAndRatingsEnabled={commentsAndRatingsEnabled}

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/PortletDataControl.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/PortletDataControl.tsx
@@ -14,7 +14,7 @@ import {PreviewPortletDataHandlerControl} from '../../../types/portletDataHandle
 import {
 	HandlerSelection,
 	LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY,
-	getInitialSelection,
+	getHandlerSelection,
 	getSelectionSummary,
 	isSelected,
 	updateSelection,
@@ -98,7 +98,7 @@ export default function PortletDataControl({
 			? 'font-weight-semi-bold'
 			: 'font-weight-normal',
 		onToggle: () =>
-			onChange(selected ? undefined : getInitialSelection(control)),
+			onChange(selected ? undefined : getHandlerSelection(control)),
 		selected,
 		tags: (
 			<SectionTags

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/formik/FormikFieldContentSelector.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/formik/FormikFieldContentSelector.tsx
@@ -4,7 +4,7 @@
  */
 
 import {useField, useFormikContext} from 'formik';
-import React, {useEffect} from 'react';
+import React, {useEffect, useRef} from 'react';
 
 import {PageTreeModalConfiguration} from '../../../pages/export/components/PageTreeModal';
 import {ExportImportProcess} from '../../../types/exportImportProcess';
@@ -50,10 +50,16 @@ export function FormikFieldContentSelector({
 			})
 		: undefined;
 
+	const hasSeededRef = useRef(false);
+
 	useEffect(() => {
-		if (seededContentSelection) {
-			setFieldValue(name, seededContentSelection);
+		if (hasSeededRef.current || !seededContentSelection) {
+			return;
 		}
+
+		hasSeededRef.current = true;
+
+		setFieldValue(name, seededContentSelection);
 	}, [name, seededContentSelection, setFieldValue]);
 
 	return (

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/formik/FormikFieldContentSelector.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/formik/FormikFieldContentSelector.tsx
@@ -4,11 +4,12 @@
  */
 
 import {useField, useFormikContext} from 'formik';
-import React from 'react';
+import React, {useEffect} from 'react';
 
 import {PageTreeModalConfiguration} from '../../../pages/export/components/PageTreeModal';
 import {ExportImportProcess} from '../../../types/exportImportProcess';
 import {PreviewPortletDataHandlerSection} from '../../../types/portletDataHandler';
+import {getInitialContentSelection} from '../../../utils/contentSelection';
 import ContentSelector, {
 	ContentSelection,
 } from '../content_selector/ContentSelector';
@@ -34,7 +35,26 @@ export function FormikFieldContentSelector({
 }: FormikFieldContentSelectorProps) {
 	const [field, meta, helpers] = useField<ContentSelection | undefined>(name);
 	const [{value: deletions}] = useField<boolean | undefined>('deletions');
-	const {setFieldTouched} = useFormikContext();
+	const {setFieldTouched, setFieldValue} = useFormikContext();
+
+	const showDeletions = !!deletions;
+
+	const shouldSeed =
+		!!sections.length && field.value === undefined && !meta.touched;
+
+	const seededContentSelection = shouldSeed
+		? getInitialContentSelection(sections, {
+				commentsAndRatingsEnabled,
+				lookAndFeelEnabled,
+				showDeletions,
+			})
+		: undefined;
+
+	useEffect(() => {
+		if (seededContentSelection) {
+			setFieldValue(name, seededContentSelection);
+		}
+	}, [name, seededContentSelection, setFieldValue]);
 
 	return (
 		<ContentSelector
@@ -50,8 +70,8 @@ export function FormikFieldContentSelector({
 			pageTreeModalConfiguration={pageTreeModalConfiguration}
 			process={process}
 			sections={sections}
-			showDeletions={!!deletions}
-			value={field.value}
+			showDeletions={showDeletions}
+			value={field.value ?? seededContentSelection}
 		/>
 	);
 }

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/formik/FormikFieldContentSelector.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/formik/FormikFieldContentSelector.tsx
@@ -42,7 +42,7 @@ export function FormikFieldContentSelector({
 	const shouldSeed =
 		!!sections.length && field.value === undefined && !meta.touched;
 
-	const seededContentSelection = shouldSeed
+	const defaultContentSelection = shouldSeed
 		? getFullDataSelection(sections, {
 				commentsAndRatingsEnabled,
 				lookAndFeelEnabled,
@@ -53,14 +53,14 @@ export function FormikFieldContentSelector({
 	const hasSeededRef = useRef(false);
 
 	useEffect(() => {
-		if (hasSeededRef.current || !seededContentSelection) {
+		if (hasSeededRef.current || !defaultContentSelection) {
 			return;
 		}
 
 		hasSeededRef.current = true;
 
-		setFieldValue(name, seededContentSelection);
-	}, [name, seededContentSelection, setFieldValue]);
+		setFieldValue(name, defaultContentSelection);
+	}, [name, defaultContentSelection, setFieldValue]);
 
 	return (
 		<ContentSelector
@@ -77,7 +77,7 @@ export function FormikFieldContentSelector({
 			process={process}
 			sections={sections}
 			showDeletions={showDeletions}
-			value={field.value ?? seededContentSelection}
+			value={field.value ?? defaultContentSelection}
 		/>
 	);
 }

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/formik/FormikFieldContentSelector.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/formik/FormikFieldContentSelector.tsx
@@ -9,7 +9,7 @@ import React, {useEffect} from 'react';
 import {PageTreeModalConfiguration} from '../../../pages/export/components/PageTreeModal';
 import {ExportImportProcess} from '../../../types/exportImportProcess';
 import {PreviewPortletDataHandlerSection} from '../../../types/portletDataHandler';
-import {getInitialContentSelection} from '../../../utils/contentSelection';
+import {getFullDataSelection} from '../../../utils/contentSelection';
 import ContentSelector, {
 	ContentSelection,
 } from '../content_selector/ContentSelector';
@@ -43,7 +43,7 @@ export function FormikFieldContentSelector({
 		!!sections.length && field.value === undefined && !meta.touched;
 
 	const seededContentSelection = shouldSeed
-		? getInitialContentSelection(sections, {
+		? getFullDataSelection(sections, {
 				commentsAndRatingsEnabled,
 				lookAndFeelEnabled,
 				showDeletions,

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/steps/FileSelectionStep.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/steps/FileSelectionStep.tsx
@@ -21,7 +21,7 @@ export default function FileSelectionStep({
 }) {
 	const [progress, setProgress] = useState<number>();
 
-	const {setFieldValue, values} = useFormikContext<{
+	const {setFieldTouched, setFieldValue, values} = useFormikContext<{
 		fileSelector?: File;
 		name: string;
 	}>();
@@ -42,9 +42,16 @@ export default function FileSelectionStep({
 
 		if (!currentFile) {
 			setFieldValue('contentSelection', undefined);
+			setFieldTouched('contentSelection', false, false);
 			setImportPreview(undefined);
 		}
-	}, [values.fileSelector, values.name, setFieldValue, setImportPreview]);
+	}, [
+		values.fileSelector,
+		values.name,
+		setFieldTouched,
+		setFieldValue,
+		setImportPreview,
+	]);
 
 	const handleUpload = async (file: File, signal?: AbortSignal) => {
 		const result = await postImportPreview({

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/contentSelection.ts
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/contentSelection.ts
@@ -6,6 +6,7 @@
 import {sub} from 'frontend-js-web';
 
 import {
+	PreviewPortletDataHandlerBoolean,
 	PreviewPortletDataHandlerControl,
 	PreviewPortletDataHandlerSection,
 } from '../types/portletDataHandler';
@@ -93,6 +94,94 @@ export function getInitialSelections(
 	);
 }
 
+export function getSectionPreviewPortletDataHandlers(
+	section: PreviewPortletDataHandlerSection,
+	{lookAndFeelEnabled = false}: {lookAndFeelEnabled?: boolean} = {}
+): PreviewPortletDataHandlerBoolean[] {
+	const previewPortletDataHandlers =
+		section.previewPortletDataHandlers.map<PreviewPortletDataHandlerBoolean>(
+			(handler) => ({...handler, type: 'Boolean'})
+		);
+
+	if (!(lookAndFeelEnabled && section.name === SITE_BUILDER_SECTION_KEY)) {
+		return previewPortletDataHandlers;
+	}
+
+	return [
+		...previewPortletDataHandlers,
+		{
+			label: Liferay.Language.get('look-and-feel'),
+			name: 'lookAndFeel',
+			previewPortletDataHandlerControls: [
+				{
+					label: Liferay.Language.get('theme-settings'),
+					name: 'themeSettings',
+					type: 'Boolean',
+				},
+				{
+					label: Liferay.Language.get('logo'),
+					name: 'logo',
+					type: 'Boolean',
+				},
+				{
+					label: Liferay.Language.get('site-pages-settings'),
+					name: 'sitePagesSettings',
+					type: 'Boolean',
+				},
+				{
+					label: Liferay.Language.get('site-template-settings'),
+					name: 'siteTemplateSettings',
+					type: 'Boolean',
+				},
+			],
+			type: 'Boolean',
+		},
+	];
+}
+
+export function getInitialSectionSelection(
+	section: PreviewPortletDataHandlerSection,
+	{
+		commentsAndRatingsEnabled = false,
+		lookAndFeelEnabled = false,
+	}: {commentsAndRatingsEnabled?: boolean; lookAndFeelEnabled?: boolean} = {}
+): Record<string, HandlerSelection> {
+	const selection = getInitialSelections(
+		getSectionPreviewPortletDataHandlers(section, {lookAndFeelEnabled})
+	);
+
+	if (commentsAndRatingsEnabled && section.name === CONTENT_SECTION_KEY) {
+		selection.commentsAndRatings = {comments: true, ratings: true};
+	}
+
+	return selection;
+}
+
+export function getInitialContentSelection(
+	sections: PreviewPortletDataHandlerSection[],
+	{
+		commentsAndRatingsEnabled = false,
+		lookAndFeelEnabled = false,
+		showDeletions = false,
+	}: {
+		commentsAndRatingsEnabled?: boolean;
+		lookAndFeelEnabled?: boolean;
+		showDeletions?: boolean;
+	} = {}
+): ContentSelection {
+	return Object.fromEntries(
+		getVisibleSections(sections, {lookAndFeelEnabled, showDeletions}).map(
+			(section) => [
+				section.name,
+				getInitialSectionSelection(section, {
+					commentsAndRatingsEnabled,
+					lookAndFeelEnabled,
+				}),
+			]
+		)
+	);
+}
+
 export function updateSelection<V>(
 	current: Record<string, V>,
 	key: string,
@@ -144,6 +233,26 @@ export function withSiteBuilderSection(
 			previewPortletDataHandlers: [],
 		},
 	];
+}
+
+export function getVisibleSections(
+	sections: PreviewPortletDataHandlerSection[],
+	{
+		lookAndFeelEnabled = false,
+		showDeletions = false,
+	}: {lookAndFeelEnabled?: boolean; showDeletions?: boolean} = {}
+): PreviewPortletDataHandlerSection[] {
+	const filteredSections = sections.filter(
+		(section) =>
+			showDeletions || !!section.additionCount || !section.deletionCount
+	);
+
+	return lookAndFeelEnabled
+		? withSiteBuilderSection(
+				filteredSections,
+				Liferay.Language.get('category.site_administration.build')
+			)
+		: filteredSections;
 }
 
 export function toProcessRequestFlags(

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/contentSelection.ts
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/contentSelection.ts
@@ -68,7 +68,7 @@ export function isSelected(
 	);
 }
 
-export function getInitialSelection(
+export function getHandlerSelection(
 	entry: PreviewPortletDataHandlerControl
 ): HandlerSelection {
 	if (entry.name === LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY) {
@@ -83,14 +83,14 @@ export function getInitialSelection(
 		return true;
 	}
 
-	return getInitialSelections(entry.previewPortletDataHandlerControls);
+	return getHandlerSelections(entry.previewPortletDataHandlerControls);
 }
 
-export function getInitialSelections(
+export function getHandlerSelections(
 	controls: PreviewPortletDataHandlerControl[]
 ): Record<string, HandlerSelection> {
 	return Object.fromEntries(
-		controls.map((control) => [control.name, getInitialSelection(control)])
+		controls.map((control) => [control.name, getHandlerSelection(control)])
 	);
 }
 
@@ -139,14 +139,14 @@ export function getSectionPreviewPortletDataHandlers(
 	];
 }
 
-export function getInitialSectionSelection(
+export function getSectionSelection(
 	section: PreviewPortletDataHandlerSection,
 	{
 		commentsAndRatingsEnabled = false,
 		lookAndFeelEnabled = false,
 	}: {commentsAndRatingsEnabled?: boolean; lookAndFeelEnabled?: boolean} = {}
 ): Record<string, HandlerSelection> {
-	const selection = getInitialSelections(
+	const selection = getHandlerSelections(
 		getSectionPreviewPortletDataHandlers(section, {lookAndFeelEnabled})
 	);
 
@@ -157,7 +157,7 @@ export function getInitialSectionSelection(
 	return selection;
 }
 
-export function getInitialContentSelection(
+export function getFullDataSelection(
 	sections: PreviewPortletDataHandlerSection[],
 	{
 		commentsAndRatingsEnabled = false,
@@ -173,7 +173,7 @@ export function getInitialContentSelection(
 		getVisibleSections(sections, {lookAndFeelEnabled, showDeletions}).map(
 			(section) => [
 				section.name,
-				getInitialSectionSelection(section, {
+				getSectionSelection(section, {
 					commentsAndRatingsEnabled,
 					lookAndFeelEnabled,
 				}),

--- a/modules/apps/export-import/export-import-web/test/revamp/js/pages/export/NewExport.test.tsx
+++ b/modules/apps/export-import/export-import-web/test/revamp/js/pages/export/NewExport.test.tsx
@@ -75,6 +75,20 @@ describe('NewExport', () => {
 		});
 	});
 
+	it('checks every section by default', async () => {
+		renderComponent();
+
+		await screen.findByText('loaded');
+
+		expect(screen.getByRole('checkbox', {name: 'Design'})).toBeChecked();
+		expect(
+			screen.getByRole('checkbox', {name: 'Site Builder'})
+		).toBeChecked();
+		expect(
+			screen.getByRole('checkbox', {name: 'Content & Data'})
+		).toBeChecked();
+	});
+
 	it('renders the error alert when the API fails', async () => {
 		fetch.resetMocks();
 		fetch.mockResponseOnce(JSON.stringify({title: 'boom'}), {status: 500});
@@ -120,17 +134,21 @@ describe('NewExport', () => {
 		const dataSelectionGroup = screen.getByRole('group', {
 			name: 'data-selection',
 		});
-		const checkbox = screen.getByRole('checkbox', {name: 'Design'});
 
-		await userEvent.click(checkbox);
-		await userEvent.click(checkbox);
+		await userEvent.click(screen.getByRole('checkbox', {name: 'Design'}));
+		await userEvent.click(
+			screen.getByRole('checkbox', {name: 'Site Builder'})
+		);
+		await userEvent.click(
+			screen.getByRole('checkbox', {name: 'Content & Data'})
+		);
 
 		await screen.findByText(
 			'please-select-at-least-one-entity-type-to-continue'
 		);
 		expect(dataSelectionGroup).toHaveAttribute('aria-invalid', 'true');
 
-		await userEvent.click(checkbox);
+		await userEvent.click(screen.getByRole('checkbox', {name: 'Design'}));
 
 		await waitFor(() => {
 			expect(
@@ -168,18 +186,20 @@ describe('NewExport', () => {
 		);
 	});
 
-	it('enables the export button once name and contentSelection are set', async () => {
+	it('enables the export button once the name is set since entities are checked by default', async () => {
 		renderComponent();
 
 		const nameInput = await screen.findByRole('textbox', {
 			name: /^name/i,
 		});
 
-		await userEvent.type(nameInput, 'test-file');
-
-		await userEvent.click(screen.getByRole('checkbox', {name: 'Design'}));
-
 		const exportButton = screen.getByRole('button', {name: /^export$/i});
+
+		await waitFor(() => {
+			expect(exportButton).toBeDisabled();
+		});
+
+		await userEvent.type(nameInput, 'test-file');
 
 		await waitFor(() => {
 			expect(exportButton).toBeEnabled();
@@ -296,14 +316,10 @@ describe('NewExport', () => {
 			});
 		});
 
-		it('exports all public pages selected from the section checkbox', async () => {
+		it('exports all public pages selected by default', async () => {
 			renderComponent({exportPreview: previewWithPagePicker});
 
 			await typeFileName();
-
-			await userEvent.click(
-				screen.getByRole('checkbox', {name: 'Site Builder'})
-			);
 
 			await submitExport();
 
@@ -337,7 +353,10 @@ describe('NewExport', () => {
 				screen.getByRole('button', {name: 'select-layouts'})
 			);
 
-			await userEvent.click(await screen.findByLabelText('page-1'));
+			expect(await screen.findByLabelText('page-1')).toBeChecked();
+			expect(screen.getByLabelText('page-2')).toBeChecked();
+
+			await userEvent.click(screen.getByLabelText('page-2'));
 			await userEvent.click(screen.getByRole('button', {name: 'select'}));
 
 			await submitExport();
@@ -475,8 +494,8 @@ describe('NewExport', () => {
 
 		await expandSection('Site Builder');
 
-		await userEvent.click(screen.getByLabelText('theme-settings'));
-		await userEvent.click(screen.getByLabelText('site-pages-settings'));
+		await userEvent.click(screen.getByLabelText('logo'));
+		await userEvent.click(screen.getByLabelText('site-template-settings'));
 
 		fetch.mockResponseOnce(JSON.stringify({}));
 
@@ -507,11 +526,10 @@ describe('NewExport', () => {
 
 			expect(handlerNames).not.toContain('lookAndFeel');
 			expect(handlerNames).not.toContain('logo');
-			expect(handlerNames).not.toContain('THEME_REFERENCE');
 		});
 	});
 
-	it('checks every look and feel option when the Site Builder section is selected', async () => {
+	it('checks every look and feel option by default', async () => {
 		renderComponent({lookAndFeelEnabled: true});
 
 		await screen.findByText('loaded');
@@ -520,10 +538,6 @@ describe('NewExport', () => {
 			name: /^name/i,
 		});
 		await userEvent.type(nameInput, 'test-file');
-
-		await userEvent.click(
-			screen.getByRole('checkbox', {name: 'Site Builder'})
-		);
 
 		fetch.mockResponseOnce(JSON.stringify({}));
 
@@ -560,13 +574,9 @@ describe('NewExport', () => {
 		});
 		await userEvent.type(nameInput, 'test-file');
 
-		await userEvent.click(
-			screen.getByRole('checkbox', {name: 'Content & Data'})
-		);
-
 		await expandSection('Content & Data');
 
-		await userEvent.click(screen.getByLabelText('comments'));
+		await userEvent.click(screen.getByLabelText('ratings'));
 
 		fetch.mockResponseOnce(JSON.stringify({}));
 

--- a/modules/apps/export-import/export-import-web/test/revamp/js/pages/import/NewImport.test.tsx
+++ b/modules/apps/export-import/export-import-web/test/revamp/js/pages/import/NewImport.test.tsx
@@ -221,6 +221,18 @@ describe('NewImport', () => {
 		expect(nameInput).toHaveValue('');
 	});
 
+	it('checks every section by default', async () => {
+		await goToDataSelectionStep();
+
+		expect(screen.getByRole('checkbox', {name: 'Design'})).toBeChecked();
+		expect(
+			screen.getByRole('checkbox', {name: 'Site Builder'})
+		).toBeChecked();
+		expect(
+			screen.getByRole('checkbox', {name: 'Content & Data'})
+		).toBeChecked();
+	});
+
 	it('shows the file summary and the lar contents on the Data Selection step after uploading a file and clicking Continue', async () => {
 		(postImportPreview as jest.Mock).mockImplementationOnce(() =>
 			Promise.resolve({
@@ -240,8 +252,6 @@ describe('NewImport', () => {
 		expect(screen.getByText('4 KB')).toBeInTheDocument();
 
 		expect(screen.getByText('Design')).toBeInTheDocument();
-
-		await user.click(screen.getByRole('checkbox', {name: 'Design'}));
 
 		await user.click(screen.getByRole('button', {name: 'Expand Design'}));
 
@@ -266,10 +276,7 @@ describe('NewImport', () => {
 
 		await user.click(screen.getByRole('button', {name: 'Expand Design'}));
 
-		await user.click(
-			screen.getByRole('checkbox', {name: 'Theme Settings'})
-		);
-		await user.click(screen.getByRole('checkbox', {name: 'Logo'}));
+		await user.click(screen.getByRole('checkbox', {name: 'Fragments'}));
 
 		expect(
 			screen.getByRole('checkbox', {name: 'Design'})
@@ -282,6 +289,8 @@ describe('NewImport', () => {
 
 	it('lists the available handlers with a Select prefix when nothing is selected', async () => {
 		await goToDataSelectionStep();
+
+		await user.click(screen.getByRole('checkbox', {name: 'Design'}));
 
 		expect(
 			screen.getByText('Select Theme Settings, Logo, Fragments')
@@ -371,11 +380,9 @@ describe('NewImport', () => {
 	it('renders the Comments and Ratings block inside the Site Content section when commentsAndRatingsEnabled is true', async () => {
 		await goToDataSelectionStep({commentsAndRatingsEnabled: true});
 
-		await user.click(
-			screen.getByRole('checkbox', {name: 'Content & Data'})
-		);
-
-		expect(screen.getByText('comments-and-ratings')).toBeInTheDocument();
+		expect(
+			await screen.findByText('comments-and-ratings')
+		).toBeInTheDocument();
 		expect(screen.getByLabelText('comments')).toBeInTheDocument();
 		expect(screen.getByLabelText('ratings')).toBeInTheDocument();
 	});

--- a/modules/test/playwright/tests/export-import-web/revamp/site.import.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/revamp/site.import.spec.ts
@@ -138,3 +138,37 @@ test('Should show error on invalid lar upload (extension not .lar)', async ({
 
 	await expect(exportImportPage.continueButton).toBeDisabled();
 });
+
+test(
+	'checks every content section by default on the Data Selection step',
+	{tag: '@LPD-95002'},
+	async ({exportImportPage, page, productMenuPage}) => {
+		await productMenuPage.openProductMenuIfClosed();
+
+		await productMenuPage.goToPublishingImport();
+
+		await exportImportPage.newImport.click();
+
+		await exportImportPage.selectFile(
+			path.join(__dirname, '../main/dependencies', 'site.lar')
+		);
+
+		await exportImportPage.completedLabel.waitFor();
+
+		await exportImportPage.continueButton.click();
+
+		// Sections are checked by default; a render loop never reaches this state.
+
+		const sectionToggle = page
+			.getByRole('button', {name: /^Expand /})
+			.first();
+
+		const sectionName = (await sectionToggle.getAttribute(
+			'aria-label'
+		))!.replace(/^Expand /, '');
+
+		await expect(
+			page.getByRole('checkbox', {name: sectionName})
+		).toBeChecked();
+	}
+);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95002

## What Is Being Fixed

The first version of the Export/Import revamp started every content entity unchecked, forcing users to select everything by hand before exporting or importing. After testing with real data the team reversed that decision: all entities should be checked by default, while Deletions and Permissions stay unchecked.

## How It Is Being Fixed

The default selection is seeded as the preview sections load, through the shared FormikFieldContentSelector binding used by both the export and import flows. The selected value is derived during render (not only in an effect) so the checkboxes never flash from unchecked to checked, and it is written into Formik state for submit and validation. The empty state is preserved once the user edits the selection. Look and Feel and Comments and Ratings are part of "all entities", so they are seeded checked too, including when the Content & Data section is reselected.

## PR Check

**pr-check: PASS** — tested on `ccfee5efcb200f685634d84fb96e98f5d4663db8`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "ccfee5efcb200f685634d84fb96e98f5d4663db8"} -->
