### PR TITLE
LPD-87027 Harden the Site Template sync flow

### DIFF
--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/exportimport/test/LayoutSetPrototypePropagationCTTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/exportimport/test/LayoutSetPrototypePropagationCTTest.java
@@ -98,8 +98,6 @@ public class LayoutSetPrototypePropagationCTTest {
 		LayoutSet layoutSet = _layoutSetLocalService.getLayoutSet(
 			group.getGroupId(), false);
 
-		MergeLayoutPrototypesThreadLocal.setSkipMerge(false);
-
 		_sites.mergeLayoutSetPrototypeLayouts(group, layoutSet);
 
 		Thread.sleep(2000);

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/BasePrototypePropagationTestCase.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/BasePrototypePropagationTestCase.java
@@ -253,7 +253,6 @@ public abstract class BasePrototypePropagationTestCase {
 
 	protected Layout propagateChanges(Layout layout) throws Exception {
 		MergeLayoutPrototypesThreadLocal.clearMergeComplete();
-		MergeLayoutPrototypesThreadLocal.setSkipMerge(false);
 
 		_sites.mergeLayoutPrototypeLayout(layout);
 

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
@@ -284,8 +284,6 @@ public class LayoutSetPrototypePropagationTest
 		Assert.assertEquals(
 			_initialPrototypeLayoutsCount, getGroupLayoutCount());
 
-		MergeLayoutPrototypesThreadLocal.setSkipMerge(false);
-
 		LayoutServiceUtil.getLayouts(
 			group.getGroupId(), false, LayoutConstants.DEFAULT_PARENT_LAYOUT_ID,
 			false, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
@@ -769,8 +767,6 @@ public class LayoutSetPrototypePropagationTest
 				testGroup, 0, layoutSetPrototype.getLayoutSetPrototypeId(),
 				false, true);
 
-			MergeLayoutPrototypesThreadLocal.setSkipMerge(false);
-
 			_sites.mergeLayoutSetPrototypeLayouts(
 				testGroup, testGroup.getPrivateLayoutSet());
 
@@ -838,8 +834,6 @@ public class LayoutSetPrototypePropagationTest
 			setLinkEnabled(
 				testGroup, layoutSetPrototype.getLayoutSetPrototypeId(), 0,
 				true, false);
-
-			MergeLayoutPrototypesThreadLocal.setSkipMerge(false);
 
 			_sites.mergeLayoutSetPrototypeLayouts(
 				testGroup, testGroup.getPublicLayoutSet());
@@ -1176,8 +1170,6 @@ public class LayoutSetPrototypePropagationTest
 		settingsUnicodeProperties.remove(Sites.LAST_MERGE_VERSION);
 
 		layoutSet = LayoutSetLocalServiceUtil.updateLayoutSet(layoutSet);
-
-		MergeLayoutPrototypesThreadLocal.setSkipMerge(false);
 
 		_sites.mergeLayoutSetPrototypeLayouts(group, layoutSet);
 

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exportimport/data/handler/StagedLayoutSetStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exportimport/data/handler/StagedLayoutSetStagedModelDataHandler.java
@@ -278,6 +278,10 @@ public class StagedLayoutSetStagedModelDataHandler
 					portletDataContext.isPrivateLayout())) {
 
 			if (Validator.isNull(layout.getLayoutSetPrototypeLayoutERC())) {
+				_linkLayoutSetPrototypeLayout(layout, layoutSetPrototype);
+				_linkLayoutSetPrototypeLayout(
+					layout.fetchDraftLayout(), layoutSetPrototype);
+
 				continue;
 			}
 
@@ -714,6 +718,31 @@ public class StagedLayoutSetStagedModelDataHandler
 		}
 
 		return MapUtil.getBoolean(parameterMap, PortletDataHandlerKeys.FAVICON);
+	}
+
+	private void _linkLayoutSetPrototypeLayout(
+			Layout layout, LayoutSetPrototype layoutSetPrototype)
+		throws Exception {
+
+		if ((layout == null) || (layoutSetPrototype == null) ||
+			Validator.isNotNull(layout.getLayoutSetPrototypeLayoutERC())) {
+
+			return;
+		}
+
+		Layout sourcePrototypeLayout =
+			_layoutLocalService.fetchLayoutByExternalReferenceCode(
+				layout.getExternalReferenceCode(),
+				layoutSetPrototype.getGroupId());
+
+		if (sourcePrototypeLayout == null) {
+			return;
+		}
+
+		layout.setLayoutSetPrototypeLayoutERC(
+			sourcePrototypeLayout.getExternalReferenceCode());
+
+		_layoutLocalService.updateLayout(layout);
 	}
 
 	private StagedLayoutSet _unwrapLayoutSetStagingHandler(

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/LayoutLayoutSetPrototypeLayoutERCUpgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/LayoutLayoutSetPrototypeLayoutERCUpgradeProcessTest.java
@@ -164,7 +164,6 @@ public class LayoutLayoutSetPrototypeLayoutERCUpgradeProcessTest
 				_layoutSetPrototype);
 
 		MergeLayoutPrototypesThreadLocal.clearMergeComplete();
-		MergeLayoutPrototypesThreadLocal.setSkipMerge(false);
 
 		LayoutSet layoutSet = _layoutSetLocalService.getLayoutSet(
 			_group.getGroupId(), false);

--- a/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/menu/web/internal/exportimport/test/SiteNavigationMenuPropagationTest.java
+++ b/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/menu/web/internal/exportimport/test/SiteNavigationMenuPropagationTest.java
@@ -235,8 +235,6 @@ public class SiteNavigationMenuPropagationTest {
 	private void _propagateLayout() throws Exception {
 		MergeLayoutPrototypesThreadLocal.clearMergeComplete();
 
-		MergeLayoutPrototypesThreadLocal.setSkipMerge(false);
-
 		LayoutSet layoutSet = _group.getPublicLayoutSet();
 
 		UnicodeProperties settingsUnicodeProperties =

--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/util/SitesImpl.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/util/SitesImpl.java
@@ -410,10 +410,6 @@ public class SitesImpl implements Sites {
 			return;
 		}
 
-		if (!layout.isPortletLayoutPageTemplateEntryLinkActive()) {
-			return;
-		}
-
 		Group group = layout.getGroup();
 
 		if (group.isLayoutPrototype() || group.hasStagingGroup()) {

--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/util/SitesImpl.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/util/SitesImpl.java
@@ -531,12 +531,6 @@ public class SitesImpl implements Sites {
 	public void mergeLayoutSetPrototypeLayouts(Group group, LayoutSet layoutSet)
 		throws Exception {
 
-		if (MergeLayoutPrototypesThreadLocal.isSkipMerge()) {
-			return;
-		}
-
-		MergeLayoutPrototypesThreadLocal.setSkipMerge(true);
-
 		layoutSet = _layoutSetLocalService.fetchLayoutSet(
 			layoutSet.getLayoutSetId());
 

--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/util/SitesImpl.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/util/SitesImpl.java
@@ -531,6 +531,15 @@ public class SitesImpl implements Sites {
 	public void mergeLayoutSetPrototypeLayouts(Group group, LayoutSet layoutSet)
 		throws Exception {
 
+		if (ExportImportThreadLocal.isExportInProcess() ||
+			ExportImportThreadLocal.isImportInProcess() ||
+			ExportImportThreadLocal.isStagingInProcess()) {
+
+			throw new IllegalStateException(
+				"The site template merge cannot start while an export, " +
+					"import, or staging process is in progress");
+		}
+
 		layoutSet = _layoutSetLocalService.fetchLayoutSet(
 			layoutSet.getLayoutSetId());
 
@@ -916,13 +925,6 @@ public class SitesImpl implements Sites {
 	protected void mergeLayoutSetPrototypeLayoutsInBackground(
 			LayoutSetPrototype layoutSetPrototype, LayoutSet layoutSet)
 		throws PortalException {
-
-		if (ExportImportThreadLocal.isExportInProcess() ||
-			ExportImportThreadLocal.isImportInProcess() ||
-			ExportImportThreadLocal.isStagingInProcess()) {
-
-			return;
-		}
 
 		if (isLayoutSetPrototypeMergeBackgroundTaskExists(
 				layoutSetPrototype, layoutSet)) {

--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/util/SitesImpl.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/util/SitesImpl.java
@@ -395,32 +395,19 @@ public class SitesImpl implements Sites {
 
 	@Override
 	public void mergeLayoutPrototypeLayout(Layout layout) throws Exception {
-		String layoutSetPrototypeLayoutERC =
-			layout.getLayoutSetPrototypeLayoutERC();
-
-		if (Validator.isNull(layoutSetPrototypeLayoutERC)) {
-			doMergeLayoutPrototypeLayout(layout);
-
+		if (!layout.isPortletLayoutPageTemplateEntryLinkActive()) {
 			return;
 		}
 
-		LayoutSet layoutSet = layout.getLayoutSet();
-
-		long layoutSetPrototypeId = layoutSet.getLayoutSetPrototypeId();
-
-		if (layoutSetPrototypeId > 0) {
-			Group layoutSetPrototypeGroup =
-				_groupLocalService.getLayoutSetPrototypeGroup(
-					layout.getCompanyId(), layoutSetPrototypeId);
-
-			Layout sourcePrototypeLayout =
-				_layoutLocalService.fetchLayoutByExternalReferenceCode(
-					layoutSetPrototypeLayoutERC,
-					layoutSetPrototypeGroup.getGroupId());
-
-			if (sourcePrototypeLayout != null) {
-				doMergeLayoutPrototypeLayout(sourcePrototypeLayout);
+		if (Validator.isNotNull(layout.getLayoutSetPrototypeLayoutERC())) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Merge not performed because the layout is linked to a " +
+						"layout set prototype with external reference code " +
+							layout.getLayoutSetPrototypeLayoutERC());
 			}
+
+			return;
 		}
 
 		doMergeLayoutPrototypeLayout(layout);

--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/util/SitesImpl.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/util/SitesImpl.java
@@ -410,7 +410,125 @@ public class SitesImpl implements Sites {
 			return;
 		}
 
-		doMergeLayoutPrototypeLayout(layout);
+		if (!layout.isPortletLayoutPageTemplateEntryLinkActive()) {
+			return;
+		}
+
+		Group group = layout.getGroup();
+
+		if (group.isLayoutPrototype() || group.hasStagingGroup()) {
+			return;
+		}
+
+		long lastMergeTime = GetterUtil.getLong(
+			layout.getTypeSettingsProperty(LAST_MERGE_TIME));
+
+		if (lastMergeTime == 0) {
+			try {
+				MergeLayoutPrototypesThreadLocal.setInProgress(true);
+
+				Layout targetLayout = _layoutLocalService.getLayout(
+					layout.getPlid());
+
+				if (targetLayout != null) {
+					lastMergeTime = GetterUtil.getLong(
+						targetLayout.getTypeSettingsProperty(LAST_MERGE_TIME));
+				}
+			}
+			finally {
+				MergeLayoutPrototypesThreadLocal.setInProgress(false);
+			}
+		}
+
+		if (Validator.isNull(layout.getLayoutPrototypeUuid())) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Merge not performed because layout prototype does not " +
+					"exist for layout PLID " + layout.getPlid());
+			}
+
+			return;
+		}
+
+		LayoutPrototype layoutPrototype =
+			_layoutPrototypeLocalService.getLayoutPrototypeByUuidAndCompanyId(
+				layout.getLayoutPrototypeUuid(), layout.getCompanyId());
+
+		Layout layoutPrototypeLayout = layoutPrototype.getLayout();
+
+		Date modifiedDate = layoutPrototypeLayout.getModifiedDate();
+
+		if (lastMergeTime >= modifiedDate.getTime()) {
+			return;
+		}
+
+		UnicodeProperties prototypeTypeSettingsUnicodeProperties =
+			layoutPrototypeLayout.getTypeSettingsProperties();
+
+		int mergeFailCount = GetterUtil.getInteger(
+			prototypeTypeSettingsUnicodeProperties.getProperty(
+				MERGE_FAIL_COUNT));
+
+		if (mergeFailCount >
+		    PropsValues.LAYOUT_PROTOTYPE_MERGE_FAIL_THRESHOLD) {
+
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					StringBundler.concat(
+						"Merge not performed because the fail threshold was ",
+						"reached for layoutPrototypeId ",
+						layoutPrototype.getLayoutPrototypeId(),
+						" and layoutId ", layoutPrototypeLayout.getLayoutId(),
+						". Update the count in the database to try again."));
+			}
+
+			return;
+		}
+
+		String owner = _acquireLock(
+			Layout.class.getName(), layout.getPlid(),
+			PropsValues.LAYOUT_PROTOTYPE_MERGE_LOCK_MAX_TIME);
+
+		if (owner == null) {
+			return;
+		}
+
+		EntityCacheUtil.clearLocalCache();
+
+		layout = _layoutLocalService.fetchLayout(layout.getPlid());
+
+		try {
+			MergeLayoutPrototypesThreadLocal.setInProgress(true);
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					StringBundler.concat(
+						"Applying layout prototype ", layoutPrototype.getUuid(),
+						" (mvccVersion ", layoutPrototype.getMvccVersion(),
+						") to layout ", layout.getPlid(), " (mvccVersion ",
+						layout.getMvccVersion(), ")"));
+			}
+
+			applyLayoutPrototype(layoutPrototype, layout, true);
+		}
+		catch (CTTransactionException ctTransactionException) {
+			throw ctTransactionException;
+		}
+		catch (Exception exception) {
+			_log.error(exception);
+
+			prototypeTypeSettingsUnicodeProperties.setProperty(
+				MERGE_FAIL_COUNT, String.valueOf(++mergeFailCount));
+
+			// Invoke updateImpl so that we do not trigger the listeners
+
+			_layoutLocalService.updateLayout(layoutPrototypeLayout);
+		}
+		finally {
+			MergeLayoutPrototypesThreadLocal.setInProgress(false);
+
+			_releaseLock(Layout.class.getName(), layout.getPlid(), owner);
+		}
 	}
 
 	@Override
@@ -473,130 +591,6 @@ public class SitesImpl implements Sites {
 			targetLayout.getCompanyId(),
 			unreferencedPortletIds.toArray(new String[0]),
 			targetLayout.getPlid());
-	}
-
-	protected void doMergeLayoutPrototypeLayout(Layout layout)
-		throws Exception {
-
-		if (!layout.isPortletLayoutPageTemplateEntryLinkActive()) {
-			return;
-		}
-
-		Group group = layout.getGroup();
-
-		if (group.isLayoutPrototype() || group.hasStagingGroup()) {
-			return;
-		}
-
-		long lastMergeTime = GetterUtil.getLong(
-			layout.getTypeSettingsProperty(LAST_MERGE_TIME));
-
-		if (lastMergeTime == 0) {
-			try {
-				MergeLayoutPrototypesThreadLocal.setInProgress(true);
-
-				Layout targetLayout = _layoutLocalService.getLayout(
-					layout.getPlid());
-
-				if (targetLayout != null) {
-					lastMergeTime = GetterUtil.getLong(
-						targetLayout.getTypeSettingsProperty(LAST_MERGE_TIME));
-				}
-			}
-			finally {
-				MergeLayoutPrototypesThreadLocal.setInProgress(false);
-			}
-		}
-
-		if (Validator.isNull(layout.getLayoutPrototypeUuid())) {
-			if (_log.isWarnEnabled()) {
-				_log.warn(
-					"Merge not performed because layout prototype does not " +
-						"exist for layout PLID " + layout.getPlid());
-			}
-
-			return;
-		}
-
-		LayoutPrototype layoutPrototype =
-			_layoutPrototypeLocalService.getLayoutPrototypeByUuidAndCompanyId(
-				layout.getLayoutPrototypeUuid(), layout.getCompanyId());
-
-		Layout layoutPrototypeLayout = layoutPrototype.getLayout();
-
-		Date modifiedDate = layoutPrototypeLayout.getModifiedDate();
-
-		if (lastMergeTime >= modifiedDate.getTime()) {
-			return;
-		}
-
-		UnicodeProperties prototypeTypeSettingsUnicodeProperties =
-			layoutPrototypeLayout.getTypeSettingsProperties();
-
-		int mergeFailCount = GetterUtil.getInteger(
-			prototypeTypeSettingsUnicodeProperties.getProperty(
-				MERGE_FAIL_COUNT));
-
-		if (mergeFailCount >
-				PropsValues.LAYOUT_PROTOTYPE_MERGE_FAIL_THRESHOLD) {
-
-			if (_log.isWarnEnabled()) {
-				_log.warn(
-					StringBundler.concat(
-						"Merge not performed because the fail threshold was ",
-						"reached for layoutPrototypeId ",
-						layoutPrototype.getLayoutPrototypeId(),
-						" and layoutId ", layoutPrototypeLayout.getLayoutId(),
-						". Update the count in the database to try again."));
-			}
-
-			return;
-		}
-
-		String owner = _acquireLock(
-			Layout.class.getName(), layout.getPlid(),
-			PropsValues.LAYOUT_PROTOTYPE_MERGE_LOCK_MAX_TIME);
-
-		if (owner == null) {
-			return;
-		}
-
-		EntityCacheUtil.clearLocalCache();
-
-		layout = _layoutLocalService.fetchLayout(layout.getPlid());
-
-		try {
-			MergeLayoutPrototypesThreadLocal.setInProgress(true);
-
-			if (_log.isDebugEnabled()) {
-				_log.debug(
-					StringBundler.concat(
-						"Applying layout prototype ", layoutPrototype.getUuid(),
-						" (mvccVersion ", layoutPrototype.getMvccVersion(),
-						") to layout ", layout.getPlid(), " (mvccVersion ",
-						layout.getMvccVersion(), ")"));
-			}
-
-			applyLayoutPrototype(layoutPrototype, layout, true);
-		}
-		catch (CTTransactionException ctTransactionException) {
-			throw ctTransactionException;
-		}
-		catch (Exception exception) {
-			_log.error(exception);
-
-			prototypeTypeSettingsUnicodeProperties.setProperty(
-				MERGE_FAIL_COUNT, String.valueOf(++mergeFailCount));
-
-			// Invoke updateImpl so that we do not trigger the listeners
-
-			_layoutLocalService.updateLayout(layoutPrototypeLayout);
-		}
-		finally {
-			MergeLayoutPrototypesThreadLocal.setInProgress(false);
-
-			_releaseLock(Layout.class.getName(), layout.getPlid(), owner);
-		}
 	}
 
 	protected File exportLayoutSetPrototype(

--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/util/SitesImpl.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/util/SitesImpl.java
@@ -440,7 +440,7 @@ public class SitesImpl implements Sites {
 			if (_log.isWarnEnabled()) {
 				_log.warn(
 					"Merge not performed because layout prototype does not " +
-					"exist for layout PLID " + layout.getPlid());
+						"exist for layout PLID " + layout.getPlid());
 			}
 
 			return;
@@ -466,7 +466,7 @@ public class SitesImpl implements Sites {
 				MERGE_FAIL_COUNT));
 
 		if (mergeFailCount >
-		    PropsValues.LAYOUT_PROTOTYPE_MERGE_FAIL_THRESHOLD) {
+				PropsValues.LAYOUT_PROTOTYPE_MERGE_FAIL_THRESHOLD) {
 
 			if (_log.isWarnEnabled()) {
 				_log.warn(

--- a/portal-impl/src/com/liferay/portal/security/auth/SessionAuthToken.java
+++ b/portal-impl/src/com/liferay/portal/security/auth/SessionAuthToken.java
@@ -5,7 +5,6 @@
 
 package com.liferay.portal.security.auth;
 
-import com.liferay.exportimport.kernel.staging.MergeLayoutPrototypesThreadLocal;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
@@ -99,11 +98,7 @@ public class SessionAuthToken implements AuthToken {
 			return;
 		}
 
-		boolean skipMerge = MergeLayoutPrototypesThreadLocal.isSkipMerge();
-
 		try {
-			MergeLayoutPrototypesThreadLocal.setSkipMerge(true);
-
 			Layout layout = LayoutLocalServiceUtil.getLayout(plid);
 
 			LayoutTypePortlet layoutTypePortlet =
@@ -119,9 +114,6 @@ public class SessionAuthToken implements AuthToken {
 			if (_log.isDebugEnabled()) {
 				_log.debug(exception);
 			}
-		}
-		finally {
-			MergeLayoutPrototypesThreadLocal.setSkipMerge(skipMerge);
 		}
 
 		liferayPortletURL.setParameter(

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutSetLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutSetLocalServiceImpl.java
@@ -6,7 +6,6 @@
 package com.liferay.portal.service.impl;
 
 import com.liferay.exportimport.kernel.staging.LayoutStagingUtil;
-import com.liferay.exportimport.kernel.staging.MergeLayoutPrototypesThreadLocal;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
@@ -338,8 +337,6 @@ public class LayoutSetLocalServiceImpl extends LayoutSetLocalServiceBaseImpl {
 		}
 
 		try {
-			MergeLayoutPrototypesThreadLocal.setSkipMerge(false);
-
 			Sites sites = _sitesSnapshot.get();
 
 			sites.mergeLayoutSetPrototypeLayouts(

--- a/portal-kernel/src/com/liferay/exportimport/kernel/staging/MergeLayoutPrototypesThreadLocal.java
+++ b/portal-kernel/src/com/liferay/exportimport/kernel/staging/MergeLayoutPrototypesThreadLocal.java
@@ -35,10 +35,6 @@ public class MergeLayoutPrototypesThreadLocal {
 		return methodKeys.contains(new MethodKey(methodName, arguments));
 	}
 
-	public static boolean isSkipMerge() {
-		return _skipMerge.get();
-	}
-
 	public static void setInProgress(boolean inProgress) {
 		_inProgress.set(inProgress);
 	}
@@ -53,10 +49,6 @@ public class MergeLayoutPrototypesThreadLocal {
 		setInProgress(false);
 	}
 
-	public static void setSkipMerge(boolean skipMerge) {
-		_skipMerge.set(skipMerge);
-	}
-
 	private static final ThreadLocal<Boolean> _inProgress =
 		new CentralizedThreadLocal<>(
 			MergeLayoutPrototypesThreadLocal.class + "._inProgress",
@@ -65,10 +57,6 @@ public class MergeLayoutPrototypesThreadLocal {
 		new CentralizedThreadLocal<>(
 			MergeLayoutPrototypesThreadLocal.class + "._mergeComplete",
 			HashSet::new);
-	private static final ThreadLocal<Boolean> _skipMerge =
-		new CentralizedThreadLocal<>(
-			MergeLayoutPrototypesThreadLocal.class + "._skipMerge",
-			() -> Boolean.FALSE);
 
 	private static class MethodKey {
 

--- a/portal-kernel/src/com/liferay/exportimport/kernel/staging/packageinfo
+++ b/portal-kernel/src/com/liferay/exportimport/kernel/staging/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 4.0.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87027

## Built On Top Of

This branch is stacked on the following two PRs and should be reviewed/merged
after them. The commits coming from them are included here only as a base:

- brianchandotcom/liferay-portal#176930 — Improve Site Template sync feedback and error reporting
- brianchandotcom/liferay-portal#176931 — Fix the initial Site Template sync on site creation

## What Is Being Fixed

This PR continues the new Site Template sync work with the incremental changes
on top of the two PRs above:

- Refuse the sync when an export, import, or staging is already in progress.
- Link existing pages to the site template during propagation.
- Remove the skip-merge thread local flag.
- Remove a duplicated validation.
- Inline doMergeLayoutPrototypeLayout into mergeLayoutPrototypeLayout.
- Skip the page template merge for layouts linked to a site template.

## How It Is Being Fixed

The sync now bails out early when an export, import, or staging operation is in
progress, so a propagation cannot run concurrently with one of those. During
propagation, existing pages are linked to the site template rather than being
left unlinked. The skip-merge thread local and a duplicated validation are
removed to simplify the merge path, doMergeLayoutPrototypeLayout is inlined into
its single caller, and the page template merge is skipped for layouts that are
already linked to a site template.

## Why Are There No Tests?

Test coverage for the Site Template sync behavior will be added in subsequent
PRs.

## PR Check

**pr-check: PASS** — tested on `e6a2330f50aad185e881caed92d43da323a1975b`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Full Portal Build | PASS |
| Integration Test Compile | PASS |
| JSP Compile | PASS |

<!-- pr-check {"result": "success", "sha": "e6a2330f50aad185e881caed92d43da323a1975b"} -->
