### PR TITLE
LPD-95096 Assert mapped-image site import completes with errors

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/LAR.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/LAR.macro
@@ -149,7 +149,11 @@ definition {
 	}
 
 	@summary = "Default summary"
-	macro _importSite(checkContentNameList = null, uncheckContentNameList = null, contentDeletion = null, mirrorWithOverwriting = null, importPermissions = null, privateLayout = null, deleteApplicationData = null, copyAsNew = null) {
+	macro _importSite(checkContentNameList = null, uncheckContentNameList = null, contentDeletion = null, mirrorWithOverwriting = null, importPermissions = null, importProcessStatus = null, privateLayout = null, deleteApplicationData = null, copyAsNew = null) {
+		if (!(isSet(importProcessStatus))) {
+			var importProcessStatus = "Successful";
+		}
+
 		while (IsElementNotPresent(locator1 = "Button#CONTINUE")) {
 			WaitForElementPresent(locator1 = "Button#CONTINUE");
 		}
@@ -214,7 +218,7 @@ definition {
 
 		AssertTextEquals(
 			locator1 = "ExportImport#CURRENT_AND_PREVIOUS_STATUS_1",
-			value1 = "Successful");
+			value1 = ${importProcessStatus});
 	}
 
 	@summary = "Default summary"
@@ -781,7 +785,7 @@ definition {
 	}
 
 	@summary = "Default summary"
-	macro importSiteCP(depotName = null, importValidationMissingItem = null, checkContentNameList = null, uncheckContentNameList = null, siteName = null, larFileName = null, privateLayout = null, deleteApplicationData = null, copyAsNew = null, contentName = null, baseURL = null, contentDeletion = null, uploadFrom = null, importCampaignValidationError = null, importPermissions = null) {
+	macro importSiteCP(depotName = null, importValidationMissingItem = null, checkContentNameList = null, uncheckContentNameList = null, siteName = null, larFileName = null, privateLayout = null, deleteApplicationData = null, copyAsNew = null, contentName = null, baseURL = null, contentDeletion = null, uploadFrom = null, importCampaignValidationError = null, importPermissions = null, importProcessStatus = null) {
 		if (${copyAsNew} == "true") {
 			Staging.enableCopyAsNewImport(baseURL = ${baseURL});
 		}
@@ -811,6 +815,7 @@ definition {
 				copyAsNew = ${copyAsNew},
 				deleteApplicationData = ${deleteApplicationData},
 				importPermissions = ${importPermissions},
+				importProcessStatus = ${importProcessStatus},
 				larFileName = ${larFileName},
 				privateLayout = ${privateLayout},
 				uncheckContentNameList = ${uncheckContentNameList});

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/site/SitesExportImport.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/site/SitesExportImport.testcase
@@ -376,6 +376,7 @@ definition {
 			var larFileName = LAR.getLarFileName();
 
 			LAR.importSiteCP(
+				importProcessStatus = "Completed With Errors",
 				larFileName = ${larFileName},
 				siteName = "Site Name");
 		}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95096

## Failing Test

`LocalFile.SitesExportImport#ExportImportSiteWithMappedImage`

`portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/site/SitesExportImport.testcase`

```
java.lang.Exception: Actual text "Completed With Errors" does not match pattern "(?iu)Successful" at "//tr[1]/td[2]//div[contains(@class,'h5')] | //span[contains(@data-qa-id,'processResult')]"
```

## Root Cause

Commit `acb90ae` ("LPD-86259 Create Missing Reference errors on import process when no empty shell is created importing Pages") added `reportMissingReference(...)` to the `LogUtil.logOptionalReference(...)` paths. The test maps a `Document_1.jpg` image into a fragment, exports the site, and imports the LAR into a brand-new site; the mapped FileEntry cannot be resolved in the new site, so it is recorded as a missing-reference report entry, and the import background task marks any process with report entries as "Completed With Errors". The import is otherwise functionally successful (no exception or data loss), and the product owner confirmed on LPD-94660 that this status is intended.

## Fix

Add an optional `importProcessStatus` parameter (defaulting to "Successful") to the shared `LAR.importSiteCP` and `LAR._importSite` macros, so the import-process status assertion is configurable without affecting the dozens of tests that still import successfully. `ExportImportSiteWithMappedImage` now asserts "Completed With Errors" to match the current contract. Verified locally: the test reproduced the exact failure, then passed after the change.

- `portal-web/test/functional/com/liferay/portalweb/macros/LAR.macro`
- `portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/site/SitesExportImport.testcase`

## PR Check

**pr-check: PASS** — tested on `2256aec052cc095ae177b75db8009c67cf52c761`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "2256aec052cc095ae177b75db8009c67cf52c761"} -->
