### PR TITLE
LPD-94449 Fix web content reference lost after changeset publish

### DIFF
--- a/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/constants/ExportImportConstants.java
+++ b/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/constants/ExportImportConstants.java
@@ -12,6 +12,9 @@ public class ExportImportConstants {
 
 	public static final String EXPORT_IMPORT_SCHEMA_VERSION = "4.0.0";
 
+	public static final String POST_PROCESS_ENTRY_UUID =
+		".postProcessEntryUuid";
+
 	public static final String SECTION_KEY_CONTENT =
 		"category.site_administration.content";
 

--- a/modules/apps/export-import/export-import-api/src/main/resources/com/liferay/exportimport/constants/packageinfo
+++ b/modules/apps/export-import/export-import-api/src/main/resources/com/liferay/exportimport/constants/packageinfo
@@ -1,1 +1,1 @@
-version 1.4.0
+version 1.5.0

--- a/modules/apps/export-import/export-import-changeset-web/build.gradle
+++ b/modules/apps/export-import/export-import-changeset-web/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 	compileOnly project(":apps:changeset:changeset-api")
 	compileOnly project(":apps:export-import:export-import-api")
 	compileOnly project(":apps:export-import:export-import-changeset-api")
+	compileOnly project(":apps:journal:journal-api")
 	compileOnly project(":core:petra:petra-io")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")

--- a/modules/apps/export-import/export-import-changeset-web/build.gradle
+++ b/modules/apps/export-import/export-import-changeset-web/build.gradle
@@ -9,7 +9,6 @@ dependencies {
 	compileOnly project(":apps:changeset:changeset-api")
 	compileOnly project(":apps:export-import:export-import-api")
 	compileOnly project(":apps:export-import:export-import-changeset-api")
-	compileOnly project(":apps:journal:journal-api")
 	compileOnly project(":core:petra:petra-io")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")

--- a/modules/apps/export-import/export-import-changeset-web/src/main/java/com/liferay/exportimport/changeset/web/internal/portlet/data/handler/ChangesetPortletDataHandler.java
+++ b/modules/apps/export-import/export-import-changeset-web/src/main/java/com/liferay/exportimport/changeset/web/internal/portlet/data/handler/ChangesetPortletDataHandler.java
@@ -29,7 +29,6 @@ import com.liferay.exportimport.kernel.lar.StagedModelType;
 import com.liferay.exportimport.kernel.staging.constants.StagingConstants;
 import com.liferay.exportimport.staged.model.repository.StagedModelRepository;
 import com.liferay.exportimport.staged.model.repository.StagedModelRepositoryRegistryUtil;
-import com.liferay.journal.model.JournalArticle;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
@@ -50,6 +49,7 @@ import com.liferay.portal.model.adapter.util.ModelAdapterUtil;
 
 import jakarta.portlet.PortletPreferences;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -219,7 +219,7 @@ public class ChangesetPortletDataHandler extends BasePortletDataHandler {
 			}
 		}
 
-		_importPostProcessArticleUuids(entityTypeElements, portletDataContext);
+		_importPostProcessStagedModels(entityTypeElements, portletDataContext);
 
 		String[] portletResourceNames = _getPortletResourceNames(
 			portletDataContext);
@@ -362,21 +362,31 @@ public class ChangesetPortletDataHandler extends BasePortletDataHandler {
 		return parameterMap.getOrDefault("portletResourceNames", new String[0]);
 	}
 
-	private void _importPostProcessArticleUuids(
+	private void _importPostProcessStagedModels(
 			List<Element> entityTypeElements,
 			PortletDataContext portletDataContext)
 		throws Exception {
 
-		Map<String, String> postProcessArticleUuids =
-			(Map<String, String>)portletDataContext.getNewPrimaryKeysMap(
-				JournalArticle.class + ".postProcessArticleUuid");
+		Map<String, String> postProcessEntryUuids = new HashMap<>();
 
-		if (postProcessArticleUuids.isEmpty()) {
+		for (Map.Entry<String, Map<?, ?>> entry :
+				portletDataContext.getNewPrimaryKeysMaps(
+				).entrySet()) {
+
+			String key = entry.getKey();
+
+			if (key.endsWith(ExportImportConstants.POST_PROCESS_ENTRY_UUID)) {
+				postProcessEntryUuids.putAll(
+					(Map<String, String>)entry.getValue());
+			}
+		}
+
+		if (postProcessEntryUuids.isEmpty()) {
 			return;
 		}
 
-		for (String articleModelPath : postProcessArticleUuids.values()) {
-			portletDataContext.removePrimaryKey(articleModelPath);
+		for (String modelPath : postProcessEntryUuids.values()) {
+			portletDataContext.removePrimaryKey(modelPath);
 		}
 
 		for (Element entityTypeElement : entityTypeElements) {
@@ -385,7 +395,7 @@ public class ChangesetPortletDataHandler extends BasePortletDataHandler {
 			for (Element entityElement : entityElements) {
 				String uuid = entityElement.attributeValue("uuid");
 
-				if (postProcessArticleUuids.remove(uuid) != null) {
+				if (postProcessEntryUuids.remove(uuid) != null) {
 					StagedModelDataHandlerUtil.importStagedModel(
 						portletDataContext, entityElement);
 				}

--- a/modules/apps/export-import/export-import-changeset-web/src/main/java/com/liferay/exportimport/changeset/web/internal/portlet/data/handler/ChangesetPortletDataHandler.java
+++ b/modules/apps/export-import/export-import-changeset-web/src/main/java/com/liferay/exportimport/changeset/web/internal/portlet/data/handler/ChangesetPortletDataHandler.java
@@ -29,6 +29,7 @@ import com.liferay.exportimport.kernel.lar.StagedModelType;
 import com.liferay.exportimport.kernel.staging.constants.StagingConstants;
 import com.liferay.exportimport.staged.model.repository.StagedModelRepository;
 import com.liferay.exportimport.staged.model.repository.StagedModelRepositoryRegistryUtil;
+import com.liferay.journal.model.JournalArticle;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
@@ -218,6 +219,8 @@ public class ChangesetPortletDataHandler extends BasePortletDataHandler {
 			}
 		}
 
+		_importPostProcessArticleUuids(entityTypeElements, portletDataContext);
+
 		String[] portletResourceNames = _getPortletResourceNames(
 			portletDataContext);
 
@@ -357,6 +360,37 @@ public class ChangesetPortletDataHandler extends BasePortletDataHandler {
 			portletDataContext.getParameterMap();
 
 		return parameterMap.getOrDefault("portletResourceNames", new String[0]);
+	}
+
+	private void _importPostProcessArticleUuids(
+			List<Element> entityTypeElements,
+			PortletDataContext portletDataContext)
+		throws Exception {
+
+		Map<String, String> postProcessArticleUuids =
+			(Map<String, String>)portletDataContext.getNewPrimaryKeysMap(
+				JournalArticle.class + ".postProcessArticleUuid");
+
+		if (postProcessArticleUuids.isEmpty()) {
+			return;
+		}
+
+		for (String articleModelPath : postProcessArticleUuids.values()) {
+			portletDataContext.removePrimaryKey(articleModelPath);
+		}
+
+		for (Element entityTypeElement : entityTypeElements) {
+			List<Element> entityElements = entityTypeElement.elements();
+
+			for (Element entityElement : entityElements) {
+				String uuid = entityElement.attributeValue("uuid");
+
+				if (postProcessArticleUuids.remove(uuid) != null) {
+					StagedModelDataHandlerUtil.importStagedModel(
+						portletDataContext, entityElement);
+				}
+			}
+		}
 	}
 
 	private boolean _isExportModel(

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/dynamic/data/mapping/util/JournalArticleImportDDMFormFieldValueTransformer.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/dynamic/data/mapping/util/JournalArticleImportDDMFormFieldValueTransformer.java
@@ -8,6 +8,7 @@ package com.liferay.journal.internal.dynamic.data.mapping.util;
 import com.liferay.dynamic.data.mapping.model.Value;
 import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
 import com.liferay.dynamic.data.mapping.util.DDMFormFieldValueTransformer;
+import com.liferay.exportimport.constants.ExportImportConstants;
 import com.liferay.exportimport.kernel.lar.ExportImportPathUtil;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.journal.article.dynamic.data.mapping.form.field.type.constants.JournalArticleDDMFormFieldTypeConstants;
@@ -112,7 +113,8 @@ public class JournalArticleImportDDMFormFieldValueTransformer
 						(Map<String, String>)
 							_portletDataContext.getNewPrimaryKeysMap(
 								JournalArticle.class +
-									".postProcessArticleUuid");
+									ExportImportConstants.
+										POST_PROCESS_ENTRY_UUID);
 
 					postProcessArticleUuids.computeIfAbsent(
 						_stagedModel.getUuid(),

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalPortletDataHandler.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalPortletDataHandler.java
@@ -479,7 +479,8 @@ public class JournalPortletDataHandler extends BasePortletDataHandler {
 
 			Map<String, String> postProcessArticleUuids =
 				(Map<String, String>)portletDataContext.getNewPrimaryKeysMap(
-					JournalArticle.class + ".postProcessArticleUuid");
+					JournalArticle.class +
+						ExportImportConstants.POST_PROCESS_ENTRY_UUID);
 
 			Collection<String> articleModelPaths =
 				postProcessArticleUuids.values();

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/exportimport/data/handler/test/JournalArticleCircularReferencePublishTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/exportimport/data/handler/test/JournalArticleCircularReferencePublishTest.java
@@ -1,0 +1,253 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.journal.exportimport.data.handler.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.asset.kernel.service.AssetEntryLocalServiceUtil;
+import com.liferay.data.engine.rest.dto.v2_0.DataDefinition;
+import com.liferay.data.engine.rest.resource.v2_0.DataDefinitionResource;
+import com.liferay.exportimport.changeset.Changeset;
+import com.liferay.exportimport.changeset.ChangesetManager;
+import com.liferay.exportimport.changeset.constants.ChangesetPortletKeys;
+import com.liferay.exportimport.kernel.configuration.ExportImportConfigurationParameterMapFactoryUtil;
+import com.liferay.exportimport.kernel.service.StagingLocalServiceUtil;
+import com.liferay.exportimport.kernel.staging.StagingUtil;
+import com.liferay.journal.constants.JournalArticleConstants;
+import com.liferay.journal.constants.JournalFolderConstants;
+import com.liferay.journal.constants.JournalPortletKeys;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.service.JournalArticleLocalServiceUtil;
+import com.liferay.journal.test.util.JournalTestUtil;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.io.Serializable;
+
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Chaitanya Sammetla
+ */
+@RunWith(Arquillian.class)
+public class JournalArticleCircularReferencePublishTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			SynchronousDestinationTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		UserTestUtil.setUser(TestPropsValues.getUser());
+
+		_liveGroup = GroupTestUtil.addGroup();
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(_liveGroup.getGroupId());
+
+		Map<String, Serializable> attributes = serviceContext.getAttributes();
+
+		attributes.putAll(
+			ExportImportConfigurationParameterMapFactoryUtil.
+				buildParameterMap());
+
+		StagingLocalServiceUtil.enableLocalStaging(
+			TestPropsValues.getUserId(), _liveGroup, false, false,
+			serviceContext);
+
+		_stagingGroup = _liveGroup.getStagingGroup();
+
+		_stagingLayout = LayoutTestUtil.addTypePortletLayout(_stagingGroup);
+
+		StagingUtil.publishLayouts(
+			TestPropsValues.getUserId(), _stagingGroup.getGroupId(),
+			_liveGroup.getGroupId(), false,
+			ExportImportConfigurationParameterMapFactoryUtil.
+				buildParameterMap());
+
+		_liveLayout = LayoutLocalServiceUtil.getLayoutByUuidAndGroupId(
+			_stagingLayout.getUuid(), _liveGroup.getGroupId(),
+			_stagingLayout.isPrivateLayout());
+	}
+
+	@Test
+	public void testIndividualPublishPreservesCircularArticleReference()
+		throws Exception {
+
+		DataDefinitionResource dataDefinitionResource =
+			_dataDefinitionResourceFactory.create(
+			).user(
+				TestPropsValues.getUser()
+			).build();
+
+		String dataDefinitionString = _read(
+			"repeatable_journal_article_field_data_definition.json");
+
+		DataDefinition dataDefinition =
+			dataDefinitionResource.postSiteDataDefinitionByContentType(
+				_stagingGroup.getGroupId(), "journal",
+				DataDefinition.toDTO(dataDefinitionString));
+
+		String structureKey = dataDefinition.getDataDefinitionKey();
+
+		JournalArticle wc1 = JournalTestUtil.addArticleWithXMLContent(
+			_stagingGroup.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			JournalArticleConstants.CLASS_NAME_ID_DEFAULT,
+			_buildXmlContent("{}"), structureKey, null, LocaleUtil.US);
+
+		JournalArticle wc2 = JournalTestUtil.addArticleWithXMLContent(
+			_stagingGroup.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			JournalArticleConstants.CLASS_NAME_ID_DEFAULT,
+			_buildXmlContent(
+				_getArticleReferenceJSONObject(
+					wc1
+				).toString()),
+			structureKey, null, LocaleUtil.US);
+
+		JournalArticle stagingWc1 = JournalTestUtil.updateArticle(
+			wc1, RandomTestUtil.randomString(),
+			_buildXmlContent(
+				_getArticleReferenceJSONObject(
+					wc2
+				).toString()));
+
+		StagingUtil.publishPortlet(
+			TestPropsValues.getUserId(), _stagingGroup.getGroupId(),
+			_liveGroup.getGroupId(), _stagingLayout.getPlid(),
+			_liveLayout.getPlid(), JournalPortletKeys.JOURNAL,
+			ExportImportConfigurationParameterMapFactoryUtil.
+				buildParameterMap());
+
+		JournalArticle liveWc1 =
+			JournalArticleLocalServiceUtil.fetchJournalArticleByUuidAndGroupId(
+				stagingWc1.getUuid(), _liveGroup.getGroupId());
+		JournalArticle liveWc2 =
+			JournalArticleLocalServiceUtil.fetchJournalArticleByUuidAndGroupId(
+				wc2.getUuid(), _liveGroup.getGroupId());
+
+		Assert.assertNotNull(liveWc1);
+		Assert.assertNotNull(liveWc2);
+
+		String liveWc2ContentString = liveWc2.getContent();
+
+		Assert.assertTrue(
+			liveWc2ContentString.contains(
+				"\"classPK\":\"" + liveWc1.getResourcePrimKey() + "\""));
+
+		Changeset changeset = Changeset.create(
+		).addStagedModel(
+			() -> stagingWc1
+		).build();
+
+		_changesetManager.addChangeset(changeset);
+
+		Map<String, String[]> parameterMap =
+			ExportImportConfigurationParameterMapFactoryUtil.
+				buildParameterMap();
+
+		parameterMap.put("changesetUuid", new String[] {changeset.getUuid()});
+
+		StagingUtil.publishPortlet(
+			TestPropsValues.getUserId(), _stagingGroup.getGroupId(),
+			_liveGroup.getGroupId(), _stagingLayout.getPlid(),
+			_liveLayout.getPlid(), ChangesetPortletKeys.CHANGESET,
+			parameterMap);
+
+		liveWc2 =
+			JournalArticleLocalServiceUtil.fetchJournalArticleByUuidAndGroupId(
+				wc2.getUuid(), _liveGroup.getGroupId());
+
+		Assert.assertNotNull(liveWc2);
+
+		liveWc2ContentString = liveWc2.getContent();
+
+		Assert.assertTrue(
+			liveWc2ContentString.contains(
+				"\"classPK\":\"" + liveWc1.getResourcePrimKey() + "\""));
+	}
+
+	private String _buildXmlContent(String referenceJSON) {
+		return StringBundler.concat(
+			"<?xml version=\"1.0\"?>",
+			"<root available-locales=\"en_US\" default-locale=\"en_US\" ",
+			"version=\"1.0\">",
+			"<dynamic-element field-reference=\"JournalArticle45391501\" ",
+			"index-type=\"keyword\" instance-id=\"",
+			RandomTestUtil.randomString(),
+			"\" name=\"JournalArticle45391501\" type=\"journal_article\">",
+			"<dynamic-content language-id=\"en_US\"><![CDATA[", referenceJSON,
+			"]]></dynamic-content></dynamic-element></root>");
+	}
+
+	private JSONObject _getArticleReferenceJSONObject(JournalArticle article)
+		throws Exception {
+
+		AssetEntry assetEntry = AssetEntryLocalServiceUtil.fetchEntry(
+			JournalArticle.class.getName(), article.getResourcePrimKey());
+
+		return JSONUtil.put(
+			"assetEntryId", assetEntry.getEntryId()
+		).put(
+			"className", JournalArticle.class.getName()
+		).put(
+			"classNameId", PortalUtil.getClassNameId(JournalArticle.class)
+		).put(
+			"classPK", article.getResourcePrimKey()
+		).put(
+			"type", "Web Content Article"
+		);
+	}
+
+	private String _read(String fileName) throws Exception {
+		return new String(
+			FileUtil.getBytes(getClass(), "dependencies/" + fileName));
+	}
+
+	@Inject
+	private ChangesetManager _changesetManager;
+
+	@Inject
+	private DataDefinitionResource.Factory _dataDefinitionResourceFactory;
+
+	@DeleteAfterTestRun
+	private Group _liveGroup;
+
+	private Layout _liveLayout;
+	private Group _stagingGroup;
+	private Layout _stagingLayout;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94449

## What Is Being Fixed

When a web content references another web content and that referenced web content was published to live individually rather than as part of the same changeset, the referencing web content loses the reference after the changeset is published.

## How It Is Being Fixed

The changeset import already re-resolved references through a post-processing pass, but that logic lived in the journal article handlers and was keyed off a hardcoded ".postProcessArticleUuid" suffix, so it only covered journal articles. This generalizes the mechanism: a shared ExportImportConstants.POST_PROCESS_ENTRY_UUID constant replaces the journal-specific suffix, and ChangesetPortletDataHandler now runs a generic post-process pass over every staged model whose new-primary-key map carries that suffix, re-importing each referenced entity after the main import so its references resolve correctly. JournalPortletDataHandler and JournalArticleImportDDMFormFieldValueTransformer are updated to use the shared constant.

## PR Check

**pr-check: PASS** — tested on `a07c32153b6eb5813c04c05df1eb1bd582f35b5d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "a07c32153b6eb5813c04c05df1eb1bd582f35b5d"} -->
