### PR TITLE
LPD-94736 Show Comments and Ratings for lower-level content nodes

### DIFF
--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSection.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSection.tsx
@@ -134,8 +134,8 @@ export default function ContentSection({
 		isSelected(sectionSelection[context.name], context)
 	);
 
-	const anySelected = allPreviewPortletDataHandlers.some((context) =>
-		isSelected(sectionSelection[context.name], context)
+	const anySelected = allPreviewPortletDataHandlers.some(
+		(context) => sectionSelection[context.name] !== undefined
 	);
 
 	const sectionFooters = [

--- a/modules/apps/export-import/export-import-web/test/revamp/js/components/forms/content_selector/ContentSection.test.tsx
+++ b/modules/apps/export-import/export-import-web/test/revamp/js/components/forms/content_selector/ContentSection.test.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 
 import ContentSection from '../../../../../../src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSection';
 import {PreviewPortletDataHandlerSection} from '../../../../../../src/main/resources/META-INF/resources/revamp/js/types/portletDataHandler';
+import {CONTENT_SECTION_KEY} from '../../../../../../src/main/resources/META-INF/resources/revamp/js/utils/contentSelection';
 
 function makeSection(
 	name: string,
@@ -20,6 +21,21 @@ function makeSection(
 		previewPortletDataHandlers: [{label: 'Handler', name: 'handler'}],
 	};
 }
+
+const contentSection: PreviewPortletDataHandlerSection = {
+	label: CONTENT_SECTION_KEY,
+	name: CONTENT_SECTION_KEY,
+	previewPortletDataHandlers: [
+		{
+			label: 'Handler',
+			name: 'handler',
+			previewPortletDataHandlerControls: [
+				{label: 'Child 1', name: 'child1', type: 'Boolean'},
+				{label: 'Child 2', name: 'child2', type: 'Boolean'},
+			],
+		},
+	],
+};
 
 describe('ContentSection', () => {
 	it('renders a compact scrollable body for sections in COMPACT_SECTION_NAMES', () => {
@@ -65,5 +81,44 @@ describe('ContentSection', () => {
 		expect(queryByText('x-deletion')).not.toBeNull();
 		expect(queryByText('x-items')).toBeNull();
 		expect(queryByText('x-deletions')).toBeNull();
+	});
+
+	it('hides the comments and ratings footer when nothing is selected', () => {
+		const {queryByText} = render(
+			<ContentSection
+				commentsAndRatingsEnabled
+				onChange={jest.fn()}
+				section={contentSection}
+				value={undefined}
+			/>
+		);
+
+		expect(queryByText('comments-and-ratings')).toBeNull();
+	});
+
+	it('shows the comments and ratings footer when a handler is fully selected', () => {
+		const {queryByText} = render(
+			<ContentSection
+				commentsAndRatingsEnabled
+				onChange={jest.fn()}
+				section={contentSection}
+				value={{handler: {child1: true, child2: true}}}
+			/>
+		);
+
+		expect(queryByText('comments-and-ratings')).not.toBeNull();
+	});
+
+	it('shows the comments and ratings footer when a lower-level node is selected', () => {
+		const {queryByText} = render(
+			<ContentSection
+				commentsAndRatingsEnabled
+				onChange={jest.fn()}
+				section={contentSection}
+				value={{handler: {child1: true}}}
+			/>
+		);
+
+		expect(queryByText('comments-and-ratings')).not.toBeNull();
 	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94736

## What Is Being Fixed

In the Export/Import revamp (feature flag LPD-57655), within the Content & Data section, the Comments and Ratings subsection was not displayed when selecting or previewing a node below the portlet level (for example, a folder inside Documents and Media or a Web Content item). Selecting the parent Content & Data checkbox did show it, so a lower-level selection should behave the same.

## How It Is Being Fixed

The Comments and Ratings footer in ContentSection was gated on `anySelected`, computed with `isSelected()`. That helper only returns true when a handler is fully selected (every nested control, or all layouts), so a partial selection from a lower-level node left it false and the footer hidden. `anySelected` now means "any handler has a selection", using the same predicate the component already uses for the indeterminate state (`sectionSelection[context.name] !== undefined`), which covers full and partial selections alike. `allSelected` (the parent checkbox) is unchanged.

## PR Check

**pr-check: PASS** — tested on `8eb0299`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "8eb0299dda9982ba9b8dcfaa68a2734cfbacdcc1"} -->
