### PR TITLE
LPD-95647 Set the user before the batch engine add task assertions

### DIFF
--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BatchEngineExportTaskServiceTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BatchEngineExportTaskServiceTest.java
@@ -52,6 +52,8 @@ public class BatchEngineExportTaskServiceTest
 
 	@Test
 	public void testAddBatchEngineExportTask() throws Exception {
+		UserTestUtil.setUser(user);
+
 		AssertUtils.assertFailure(
 			PrincipalException.class, null,
 			() -> _batchEngineExportTaskService.addBatchEngineExportTask(
@@ -63,8 +65,6 @@ public class BatchEngineExportTaskServiceTest
 					"siteId", TestPropsValues.getGroupId()
 				).build(),
 				null));
-
-		UserTestUtil.setUser(user);
 
 		AssertUtils.assertFailure(
 			PrincipalException.class, null,

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BatchEngineImportTaskServiceTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BatchEngineImportTaskServiceTest.java
@@ -50,6 +50,8 @@ public class BatchEngineImportTaskServiceTest
 
 	@Test
 	public void testAddBatchEngineImportTask() throws Exception {
+		UserTestUtil.setUser(user);
+
 		AssertUtils.assertFailure(
 			PrincipalException.class, null,
 			() -> _batchEngineImportTaskService.addBatchEngineImportTask(
@@ -58,8 +60,6 @@ public class BatchEngineImportTaskServiceTest
 				BatchEngineTaskExecuteStatus.INITIAL.name(), null,
 				BatchEngineImportTaskConstants.IMPORT_STRATEGY_ON_ERROR_FAIL,
 				BatchEngineTaskOperation.CREATE.name(), new HashMap<>(), null));
-
-		UserTestUtil.setUser(user);
 
 		AssertUtils.assertFailure(
 			PrincipalException.class, null,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95647

## Failing Test

`com.liferay.batch.engine.service.test.BatchEngineImportTaskServiceTest`

`modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BatchEngineImportTaskServiceTest.java`

```
testAddBatchEngineImportTask: java.lang.AssertionError
	at org.junit.Assert.fail(Assert.java:87)
	at org.junit.Assert.fail(Assert.java:96)
	at com.liferay.portal.kernel.test.AssertUtils._assertFailure(AssertUtils.java:157)
	at com.liferay.portal.kernel.test.AssertUtils.assertFailure(AssertUtils.java:117)
	at com.liferay.portal.kernel.test.AssertUtils.assertFailure(AssertUtils.java:138)
	at com.liferay.batch.engine.service.test.BatchEngineImportTaskServiceTest.testAddBatchEngineImportTask(BatchEngineImportTaskServiceTest.java:53)
```

## Root Cause

Commit `8af8c738` ("LPD-93810 Sort") reordered the two `AssertUtils.assertFailure` blocks in `testAddBatchEngineImportTask` (and the sibling `testAddBatchEngineExportTask`) but left `UserTestUtil.setUser(user)` sitting between them instead of before them. The first assertion therefore ran as the default omniadmin user, so adding a task in another company for the omniadmin's own user id passed both the company isolation check (omniadmin bypass) and the impersonation check added in `3e94d85e` (the user id matched the caller). No `PrincipalException` was thrown and the assertion failed.

## Fix

Move `UserTestUtil.setUser(user)` back to the top of each test method, before the assertions. Both assertion scenarios — impersonating another user and creating a task in a foreign company — depend on the caller being a regular (non-omniadmin) user, so establishing that context first restores the intended coverage. The product code is unchanged and still behaves per the LPD-93810 contract.

- `modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BatchEngineImportTaskServiceTest.java`
- `modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/service/test/BatchEngineExportTaskServiceTest.java`

## PR Check

**pr-check: PASS** — tested on `b7e41103e0312b6898cecb73e551363dd3f4bbaf`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "b7e41103e0312b6898cecb73e551363dd3f4bbaf"} -->
