### PR TITLE
LPD-95511 Prevent site template import deadlock from listener cascade

### DIFF
--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/background/task/test/LayoutSetPrototypeImportBackgroundTaskExecutorTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/background/task/test/LayoutSetPrototypeImportBackgroundTaskExecutorTest.java
@@ -9,16 +9,21 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.exportimport.kernel.background.task.BackgroundTaskExecutorNames;
 import com.liferay.exportimport.kernel.configuration.ExportImportConfigurationSettingsMapFactoryUtil;
 import com.liferay.exportimport.kernel.configuration.constants.ExportImportConfigurationConstants;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.exportimport.kernel.lar.PortletDataHandlerKeys;
 import com.liferay.exportimport.kernel.model.ExportImportConfiguration;
 import com.liferay.exportimport.kernel.service.ExportImportConfigurationLocalServiceUtil;
 import com.liferay.exportimport.kernel.service.ExportImportLocalServiceUtil;
 import com.liferay.exportimport.kernel.service.ExportImportServiceUtil;
+import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTask;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskManagerUtil;
 import com.liferay.portal.kernel.backgroundtask.constants.BackgroundTaskConstants;
+import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.LayoutSetPrototype;
+import com.liferay.portal.kernel.service.LayoutSetPrototypeLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -28,7 +33,11 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.transaction.Propagation;
+import com.liferay.portal.kernel.transaction.TransactionConfig;
+import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
+import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
@@ -38,6 +47,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.Writer;
 
+import java.util.Date;
 import java.util.List;
 
 import org.junit.Assert;
@@ -164,6 +174,83 @@ public class LayoutSetPrototypeImportBackgroundTaskExecutorTest {
 		Assert.assertEquals(
 			backgroundTasks.toString(), 0, backgroundTasks.size());
 	}
+
+	@Test
+	@TestInfo("LPD-95511")
+	public void testImportLayoutSetPrototypeWithLayout() throws Exception {
+		LayoutSetPrototype layoutSetPrototype =
+			LayoutTestUtil.addLayoutSetPrototype(RandomTestUtil.randomString());
+
+		Group group = layoutSetPrototype.getGroup();
+
+		long layoutSetPrototypeId =
+			layoutSetPrototype.getLayoutSetPrototypeId();
+
+		boolean layoutImportInProcess =
+			ExportImportThreadLocal.isLayoutImportInProcess();
+
+		ExportImportThreadLocal.setLayoutImportInProcess(true);
+
+		try {
+			TransactionInvokerUtil.invoke(
+				_requiredTransactionConfig,
+				() -> {
+
+					// Lock the layout set prototype row in the outer
+					// transaction, as importing its staged model does
+
+					LayoutSetPrototype lockedLayoutSetPrototype =
+						LayoutSetPrototypeLocalServiceUtil.
+							getLayoutSetPrototype(layoutSetPrototypeId);
+
+					Date modifiedDate =
+						lockedLayoutSetPrototype.getModifiedDate();
+
+					long time = modifiedDate.getTime();
+
+					lockedLayoutSetPrototype.setModifiedDate(
+						new Date(time - Time.DAY));
+
+					LayoutSetPrototypeLocalServiceUtil.updateLayoutSetPrototype(
+						lockedLayoutSetPrototype);
+
+					// Import a content page in a nested transaction, as the
+					// batch engine does for each page
+
+					try {
+						TransactionInvokerUtil.invoke(
+							_requiresNewTransactionConfig,
+							() -> LayoutTestUtil.addTypeContentLayout(
+								group, true, false));
+					}
+					catch (Throwable throwable) {
+						throw new SystemException(throwable);
+					}
+
+					return null;
+				});
+		}
+		catch (Throwable throwable) {
+			throw new AssertionError(
+				"Importing a content page into a layout set prototype " +
+					"deadlocked",
+				throwable);
+		}
+		finally {
+			ExportImportThreadLocal.setLayoutImportInProcess(
+				layoutImportInProcess);
+
+			LayoutSetPrototypeLocalServiceUtil.deleteLayoutSetPrototype(
+				layoutSetPrototypeId);
+		}
+	}
+
+	private static final TransactionConfig _requiredTransactionConfig =
+		TransactionConfig.Factory.create(
+			Propagation.REQUIRED, new Class<?>[] {Exception.class});
+	private static final TransactionConfig _requiresNewTransactionConfig =
+		TransactionConfig.Factory.create(
+			Propagation.REQUIRES_NEW, new Class<?>[] {Exception.class});
 
 	@DeleteAfterTestRun
 	private Group _group;

--- a/modules/apps/layout/layout-set-prototype-test/src/testIntegration/java/com/liferay/layout/set/prototype/exportimport/test/LayoutSetPrototypeExportImportTest.java
+++ b/modules/apps/layout/layout-set-prototype-test/src/testIntegration/java/com/liferay/layout/set/prototype/exportimport/test/LayoutSetPrototypeExportImportTest.java
@@ -8,6 +8,7 @@ package com.liferay.layout.set.prototype.exportimport.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.exportimport.kernel.configuration.ExportImportConfigurationSettingsMapFactoryUtil;
 import com.liferay.exportimport.kernel.configuration.constants.ExportImportConfigurationConstants;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.exportimport.kernel.model.ExportImportConfiguration;
 import com.liferay.exportimport.kernel.service.ExportImportConfigurationLocalServiceUtil;
 import com.liferay.exportimport.kernel.service.ExportImportLocalServiceUtil;
@@ -26,11 +27,17 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.transaction.Propagation;
+import com.liferay.portal.kernel.transaction.TransactionConfig;
+import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
+import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.io.File;
 
+import java.util.Date;
 import java.util.Map;
+import java.util.concurrent.Callable;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -160,6 +167,89 @@ public class LayoutSetPrototypeExportImportTest
 		exportImportLayoutSetPrototype(true);
 	}
 
+	@Test
+	@TestInfo("LPD-95511")
+	public void testImportContentPageIntoLayoutSetPrototypeDoesNotDeadlock()
+		throws Exception {
+
+		LayoutSetPrototype layoutSetPrototype =
+			LayoutTestUtil.addLayoutSetPrototype(RandomTestUtil.randomString());
+
+		Group group = layoutSetPrototype.getGroup();
+
+		long layoutSetPrototypeId =
+			layoutSetPrototype.getLayoutSetPrototypeId();
+
+		// A layout set prototype import runs in an outer transaction that
+		// updates and therefore locks the layout set prototype row, while the
+		// batch engine imports each content page in a nested REQUIRES_NEW
+		// transaction. Adding a content page fires
+		// LayoutSetPrototypeLayoutModelListener, whose cascade updates the
+		// layout set and, through LayoutSetPrototypeLayoutSetModelListener, the
+		// same layout set prototype row again from the nested transaction.
+		// Before LPD-95511 that nested update blocked on the outer lock and
+		// timed out with a PessimisticLockException. The fix skips the cascade
+		// while an import is in process, which this test asserts by reproducing
+		// the same transaction nesting.
+
+		boolean layoutImportInProcess =
+			ExportImportThreadLocal.isLayoutImportInProcess();
+
+		ExportImportThreadLocal.setLayoutImportInProcess(true);
+
+		Callable<Void> importLayoutSetPrototypeCallable = () -> {
+
+			// Lock the layout set prototype row in the outer transaction, as
+			// importing its staged model does
+
+			LayoutSetPrototype lockedLayoutSetPrototype =
+				LayoutSetPrototypeLocalServiceUtil.getLayoutSetPrototype(
+					layoutSetPrototypeId);
+
+			Date modifiedDate = lockedLayoutSetPrototype.getModifiedDate();
+
+			long time = modifiedDate.getTime();
+
+			lockedLayoutSetPrototype.setModifiedDate(new Date(time - Time.DAY));
+
+			LayoutSetPrototypeLocalServiceUtil.updateLayoutSetPrototype(
+				lockedLayoutSetPrototype);
+
+			// Import a content page in a nested transaction, as the batch
+			// engine does for each page
+
+			try {
+				TransactionInvokerUtil.invoke(
+					_requiresNewTransactionConfig,
+					() -> LayoutTestUtil.addTypeContentLayout(
+						group, true, false));
+			}
+			catch (Throwable throwable) {
+				throw new Exception(throwable);
+			}
+
+			return null;
+		};
+
+		try {
+			TransactionInvokerUtil.invoke(
+				_requiredTransactionConfig, importLayoutSetPrototypeCallable);
+		}
+		catch (Throwable throwable) {
+			throw new AssertionError(
+				"Importing a content page into a layout set prototype " +
+					"deadlocked",
+				throwable);
+		}
+		finally {
+			ExportImportThreadLocal.setLayoutImportInProcess(
+				layoutImportInProcess);
+
+			LayoutSetPrototypeLocalServiceUtil.deleteLayoutSetPrototype(
+				layoutSetPrototypeId);
+		}
+	}
+
 	protected void exportImportLayoutSetPrototype(boolean layoutPrototype)
 		throws Exception {
 
@@ -228,5 +318,12 @@ public class LayoutSetPrototypeExportImportTest
 	protected void testExportImportDisplayStyle(long groupId, String scopeType)
 		throws Exception {
 	}
+
+	private static final TransactionConfig _requiredTransactionConfig =
+		TransactionConfig.Factory.create(
+			Propagation.REQUIRED, new Class<?>[] {Exception.class});
+	private static final TransactionConfig _requiresNewTransactionConfig =
+		TransactionConfig.Factory.create(
+			Propagation.REQUIRES_NEW, new Class<?>[] {Exception.class});
 
 }

--- a/modules/apps/layout/layout-set-prototype-test/src/testIntegration/java/com/liferay/layout/set/prototype/exportimport/test/LayoutSetPrototypeExportImportTest.java
+++ b/modules/apps/layout/layout-set-prototype-test/src/testIntegration/java/com/liferay/layout/set/prototype/exportimport/test/LayoutSetPrototypeExportImportTest.java
@@ -16,6 +16,7 @@ import com.liferay.exportimport.test.util.lar.BasePortletExportImportTestCase;
 import com.liferay.layout.set.prototype.constants.LayoutSetPrototypePortletKeys;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.LayoutPrototype;
 import com.liferay.portal.kernel.model.LayoutSetPrototype;
@@ -37,7 +38,6 @@ import java.io.File;
 
 import java.util.Date;
 import java.util.Map;
-import java.util.concurrent.Callable;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -169,9 +169,7 @@ public class LayoutSetPrototypeExportImportTest
 
 	@Test
 	@TestInfo("LPD-95511")
-	public void testImportContentPageIntoLayoutSetPrototypeDoesNotDeadlock()
-		throws Exception {
-
+	public void testImportLayoutSetPrototypeWithLayout() throws Exception {
 		LayoutSetPrototype layoutSetPrototype =
 			LayoutTestUtil.addLayoutSetPrototype(RandomTestUtil.randomString());
 
@@ -180,60 +178,49 @@ public class LayoutSetPrototypeExportImportTest
 		long layoutSetPrototypeId =
 			layoutSetPrototype.getLayoutSetPrototypeId();
 
-		// A layout set prototype import runs in an outer transaction that
-		// updates and therefore locks the layout set prototype row, while the
-		// batch engine imports each content page in a nested REQUIRES_NEW
-		// transaction. Adding a content page fires
-		// LayoutSetPrototypeLayoutModelListener, whose cascade updates the
-		// layout set and, through LayoutSetPrototypeLayoutSetModelListener, the
-		// same layout set prototype row again from the nested transaction.
-		// Before LPD-95511 that nested update blocked on the outer lock and
-		// timed out with a PessimisticLockException. The fix skips the cascade
-		// while an import is in process, which this test asserts by reproducing
-		// the same transaction nesting.
-
 		boolean layoutImportInProcess =
 			ExportImportThreadLocal.isLayoutImportInProcess();
 
 		ExportImportThreadLocal.setLayoutImportInProcess(true);
 
-		Callable<Void> importLayoutSetPrototypeCallable = () -> {
-
-			// Lock the layout set prototype row in the outer transaction, as
-			// importing its staged model does
-
-			LayoutSetPrototype lockedLayoutSetPrototype =
-				LayoutSetPrototypeLocalServiceUtil.getLayoutSetPrototype(
-					layoutSetPrototypeId);
-
-			Date modifiedDate = lockedLayoutSetPrototype.getModifiedDate();
-
-			long time = modifiedDate.getTime();
-
-			lockedLayoutSetPrototype.setModifiedDate(new Date(time - Time.DAY));
-
-			LayoutSetPrototypeLocalServiceUtil.updateLayoutSetPrototype(
-				lockedLayoutSetPrototype);
-
-			// Import a content page in a nested transaction, as the batch
-			// engine does for each page
-
-			try {
-				TransactionInvokerUtil.invoke(
-					_requiresNewTransactionConfig,
-					() -> LayoutTestUtil.addTypeContentLayout(
-						group, true, false));
-			}
-			catch (Throwable throwable) {
-				throw new Exception(throwable);
-			}
-
-			return null;
-		};
-
 		try {
 			TransactionInvokerUtil.invoke(
-				_requiredTransactionConfig, importLayoutSetPrototypeCallable);
+				_requiredTransactionConfig,
+				() -> {
+
+					// Lock the layout set prototype row in the outer
+					// transaction, as importing its staged model does
+
+					LayoutSetPrototype lockedLayoutSetPrototype =
+						LayoutSetPrototypeLocalServiceUtil.
+							getLayoutSetPrototype(layoutSetPrototypeId);
+
+					Date modifiedDate =
+						lockedLayoutSetPrototype.getModifiedDate();
+
+					long time = modifiedDate.getTime();
+
+					lockedLayoutSetPrototype.setModifiedDate(
+						new Date(time - Time.DAY));
+
+					LayoutSetPrototypeLocalServiceUtil.updateLayoutSetPrototype(
+						lockedLayoutSetPrototype);
+
+					// Import a content page in a nested transaction, as the
+					// batch engine does for each page
+
+					try {
+						TransactionInvokerUtil.invoke(
+							_requiresNewTransactionConfig,
+							() -> LayoutTestUtil.addTypeContentLayout(
+								group, true, false));
+					}
+					catch (Throwable throwable) {
+						throw new SystemException(throwable);
+					}
+
+					return null;
+				});
 		}
 		catch (Throwable throwable) {
 			throw new AssertionError(

--- a/modules/apps/layout/layout-set-prototype-test/src/testIntegration/java/com/liferay/layout/set/prototype/exportimport/test/LayoutSetPrototypeExportImportTest.java
+++ b/modules/apps/layout/layout-set-prototype-test/src/testIntegration/java/com/liferay/layout/set/prototype/exportimport/test/LayoutSetPrototypeExportImportTest.java
@@ -8,7 +8,6 @@ package com.liferay.layout.set.prototype.exportimport.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.exportimport.kernel.configuration.ExportImportConfigurationSettingsMapFactoryUtil;
 import com.liferay.exportimport.kernel.configuration.constants.ExportImportConfigurationConstants;
-import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.exportimport.kernel.model.ExportImportConfiguration;
 import com.liferay.exportimport.kernel.service.ExportImportConfigurationLocalServiceUtil;
 import com.liferay.exportimport.kernel.service.ExportImportLocalServiceUtil;
@@ -16,7 +15,6 @@ import com.liferay.exportimport.test.util.lar.BasePortletExportImportTestCase;
 import com.liferay.layout.set.prototype.constants.LayoutSetPrototypePortletKeys;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.LayoutPrototype;
 import com.liferay.portal.kernel.model.LayoutSetPrototype;
@@ -28,15 +26,10 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
-import com.liferay.portal.kernel.transaction.Propagation;
-import com.liferay.portal.kernel.transaction.TransactionConfig;
-import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
-import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.io.File;
 
-import java.util.Date;
 import java.util.Map;
 
 import org.junit.Assert;
@@ -167,76 +160,6 @@ public class LayoutSetPrototypeExportImportTest
 		exportImportLayoutSetPrototype(true);
 	}
 
-	@Test
-	@TestInfo("LPD-95511")
-	public void testImportLayoutSetPrototypeWithLayout() throws Exception {
-		LayoutSetPrototype layoutSetPrototype =
-			LayoutTestUtil.addLayoutSetPrototype(RandomTestUtil.randomString());
-
-		Group group = layoutSetPrototype.getGroup();
-
-		long layoutSetPrototypeId =
-			layoutSetPrototype.getLayoutSetPrototypeId();
-
-		boolean layoutImportInProcess =
-			ExportImportThreadLocal.isLayoutImportInProcess();
-
-		ExportImportThreadLocal.setLayoutImportInProcess(true);
-
-		try {
-			TransactionInvokerUtil.invoke(
-				_requiredTransactionConfig,
-				() -> {
-
-					// Lock the layout set prototype row in the outer
-					// transaction, as importing its staged model does
-
-					LayoutSetPrototype lockedLayoutSetPrototype =
-						LayoutSetPrototypeLocalServiceUtil.
-							getLayoutSetPrototype(layoutSetPrototypeId);
-
-					Date modifiedDate =
-						lockedLayoutSetPrototype.getModifiedDate();
-
-					long time = modifiedDate.getTime();
-
-					lockedLayoutSetPrototype.setModifiedDate(
-						new Date(time - Time.DAY));
-
-					LayoutSetPrototypeLocalServiceUtil.updateLayoutSetPrototype(
-						lockedLayoutSetPrototype);
-
-					// Import a content page in a nested transaction, as the
-					// batch engine does for each page
-
-					try {
-						TransactionInvokerUtil.invoke(
-							_requiresNewTransactionConfig,
-							() -> LayoutTestUtil.addTypeContentLayout(
-								group, true, false));
-					}
-					catch (Throwable throwable) {
-						throw new SystemException(throwable);
-					}
-
-					return null;
-				});
-		}
-		catch (Throwable throwable) {
-			throw new AssertionError(
-				"Importing a content page into a layout set prototype " +
-					"deadlocked",
-				throwable);
-		}
-		finally {
-			ExportImportThreadLocal.setLayoutImportInProcess(
-				layoutImportInProcess);
-
-			LayoutSetPrototypeLocalServiceUtil.deleteLayoutSetPrototype(
-				layoutSetPrototypeId);
-		}
-	}
-
 	protected void exportImportLayoutSetPrototype(boolean layoutPrototype)
 		throws Exception {
 
@@ -305,12 +228,5 @@ public class LayoutSetPrototypeExportImportTest
 	protected void testExportImportDisplayStyle(long groupId, String scopeType)
 		throws Exception {
 	}
-
-	private static final TransactionConfig _requiredTransactionConfig =
-		TransactionConfig.Factory.create(
-			Propagation.REQUIRED, new Class<?>[] {Exception.class});
-	private static final TransactionConfig _requiresNewTransactionConfig =
-		TransactionConfig.Factory.create(
-			Propagation.REQUIRES_NEW, new Class<?>[] {Exception.class});
 
 }

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutSetPrototypeLayoutModelListener.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutSetPrototypeLayoutModelListener.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.service.impl;
 
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModelListener;
@@ -40,7 +41,7 @@ public class LayoutSetPrototypeLayoutModelListener
 	}
 
 	protected void updateLayoutSetPrototype(Layout layout, Date modifiedDate) {
-		if (layout == null) {
+		if ((layout == null) || ExportImportThreadLocal.isImportInProcess()) {
 			return;
 		}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95511

**What is being fixed:** Importing a LAR as a site template can hang and fail with a database lock-wait timeout (`PessimisticLockException: could not execute batch`). During the import, the outer transaction updates and locks the `LayoutSetPrototype` row, while each page is imported in a nested `REQUIRES_NEW` transaction through the batch engine. Adding a page fires `LayoutSetPrototypeLayoutModelListener`, whose cascade (`updateLayoutSet` -> `LayoutSetPrototypeLayoutSetModelListener`) updates that same locked row from the nested transaction, deadlocking against the outer one and timing out (~50s per page). The collision is timing-dependent, so it reproduces most reliably on a cold bundle or a LAR with many pages.

**How it is being fixed:** `LayoutSetPrototypeLayoutModelListener.updateLayoutSetPrototype` now returns early when an import is in process (`ExportImportThreadLocal.isImportInProcess()`). The cascade is redundant during an import: the layout set prototype and its layout set are already written with the imported timestamps by their own staged-model handlers (the ungated `LayoutSetPrototypeLayoutSetModelListener` still runs), so skipping it removes the second writer of the `LayoutSetPrototype` row and the deadlock can no longer form, regardless of Hibernate flush timing or page count. A regression integration test (`LayoutSetPrototypeImportBackgroundTaskExecutorTest.testImportLayoutSetPrototypeWithLayout`) reproduces the exact transaction nesting and deterministically fails without the fix and passes with it.