### PR TITLE
LPD-95679 Hide only the nested Choice control when its parent is unchecked

### DIFF
--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/PortletDataControl.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/PortletDataControl.tsx
@@ -74,7 +74,6 @@ export default function PortletDataControl({
 			? (value as Record<string, HandlerSelection>)
 			: {};
 	const nestedControls = control.previewPortletDataHandlerControls ?? [];
-	const expandable = !!nestedControls.length;
 
 	const additionCount =
 		control.type === 'Boolean' ? control.additionCount : undefined;
@@ -129,6 +128,8 @@ export default function PortletDataControl({
 			/>
 		));
 
+	const expandable = !!body.length;
+
 	if (topLevel) {
 		return (
 			<PortletDataHandlerPanel
@@ -146,7 +147,7 @@ export default function PortletDataControl({
 		<>
 			<ControlRow {...rowProps} />
 
-			{!!body.length && (
+			{expandable && (
 				<div className="c-gap-1 d-flex flex-column pl-4">{body}</div>
 			)}
 		</>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/PortletDataControl.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/PortletDataControl.tsx
@@ -109,23 +109,25 @@ export default function PortletDataControl({
 		),
 	};
 
-	const body = nestedControls.map((nestedControl) => (
-		<PortletDataControl
-			control={nestedControl}
-			key={nestedControl.name}
-			onChange={(controlValue) =>
-				onChange(
-					updateSelection(
-						currentSelection,
-						nestedControl.name,
-						controlValue
+	const body = nestedControls
+		.filter((nestedControl) => nestedControl.type !== 'Choice' || !!value)
+		.map((nestedControl) => (
+			<PortletDataControl
+				control={nestedControl}
+				key={nestedControl.name}
+				onChange={(controlValue) =>
+					onChange(
+						updateSelection(
+							currentSelection,
+							nestedControl.name,
+							controlValue
+						)
 					)
-				)
-			}
-			pageTreeModalConfiguration={pageTreeModalConfiguration}
-			value={currentSelection[nestedControl.name]}
-		/>
-	));
+				}
+				pageTreeModalConfiguration={pageTreeModalConfiguration}
+				value={currentSelection[nestedControl.name]}
+			/>
+		));
 
 	if (topLevel) {
 		return (
@@ -144,7 +146,7 @@ export default function PortletDataControl({
 		<>
 			<ControlRow {...rowProps} />
 
-			{expandable && (
+			{!!body.length && (
 				<div className="c-gap-1 d-flex flex-column pl-4">{body}</div>
 			)}
 		</>

--- a/modules/apps/export-import/export-import-web/test/revamp/js/pages/export/NewExport.test.tsx
+++ b/modules/apps/export-import/export-import-web/test/revamp/js/pages/export/NewExport.test.tsx
@@ -598,4 +598,35 @@ describe('NewExport', () => {
 			expect(handlerNames).not.toContain('COMMENTS');
 		});
 	});
+
+	it('hides a nested control when its parent control is unchecked', async () => {
+		renderComponent();
+
+		await screen.findByText('loaded');
+
+		await expandSection('Content & Data');
+
+		await userEvent.click(
+			screen.getAllByRole('button', {name: 'show-all-x'})[0]
+		);
+
+		const referencedContentCheckbox = screen.getByRole('checkbox', {
+			name: 'Referenced Content',
+		}) as HTMLInputElement;
+
+		if (!referencedContentCheckbox.checked) {
+			await userEvent.click(referencedContentCheckbox);
+		}
+
+		expect(
+			screen.getByText('Referenced Content Behavior')
+		).toBeInTheDocument();
+
+		await userEvent.click(referencedContentCheckbox);
+
+		expect(referencedContentCheckbox).not.toBeChecked();
+		expect(
+			screen.queryByText('Referenced Content Behavior')
+		).not.toBeInTheDocument();
+	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95679

## What Is Being Fixed

In the Export/Import revamp content selector, a nested sub-control was rendered regardless of its parent control's checkbox state. For example, the "Referenced Content Behavior" choice (Include Always / Include If Modified) appeared even when its parent "Referenced Content" was unchecked.

This is a regression from the LPD-86882 collapsibility refactor (commit 8007b24, "Make content sections and handlers collapsible"), which rewrote nested rendering around an expanded disclosure state and dropped the original gate that hid a Choice sub-control when its parent was unselected.

## How It Is Being Fixed

Filter only `Choice` sub-controls by the parent control's value, rather than gating the entire nested body. A Choice (such as "Referenced Content Behavior") configures how the selected parent is exported and has no meaning when the parent is unselected, so it is hidden once the parent has no value. Boolean sub-controls (such as "Version History" or "Previews and Thumbnails") remain independently selectable and stay visible even when their container is unchecked. Using the presence of a value keeps the Choice visible for an indeterminate, partially-selected parent.

A `NewExport` test asserts that, with "Documents" selected, unchecking the "Documents" container keeps its Boolean sub-controls visible while hiding the "Referenced Content Behavior" choice.

## Screenshot 
<img width="529" height="351" alt="image" src="https://github.com/user-attachments/assets/95e99628-6c8f-4e11-860b-33bac14183ee" />
<img width="508" height="255" alt="image" src="https://github.com/user-attachments/assets/64241074-43c9-4665-acc8-59ef5fde6ee5" />

## PR Check

**pr-check: PASS** — tested on `74c69d09178e374a139f2214300c14138e93b088`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |
