### PR TITLE
LPD-95759 Fix REST client SerDes for enum array properties

### DIFF
--- a/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/serdes/v1_0/ChildTestEntity1SerDes.java
+++ b/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/serdes/v1_0/ChildTestEntity1SerDes.java
@@ -197,7 +197,11 @@ public class ChildTestEntity1SerDes {
 			for (int i = 0; i < childTestEntity1.getStringTestEntities().length;
 				 i++) {
 
+				sb.append("\"");
+
 				sb.append(childTestEntity1.getStringTestEntities()[i]);
+
+				sb.append("\"");
 
 				if ((i + 1) < childTestEntity1.getStringTestEntities().length) {
 					sb.append(", ");
@@ -512,8 +516,19 @@ public class ChildTestEntity1SerDes {
 						jsonParserFieldName, "stringTestEntities")) {
 
 				if (jsonParserFieldValue != null) {
+					Object[] jsonParserFieldValues =
+						(Object[])jsonParserFieldValue;
+
+					StringTestEntity[] stringTestEntitiesArray =
+						new StringTestEntity[jsonParserFieldValues.length];
+
+					for (int i = 0; i < stringTestEntitiesArray.length; i++) {
+						stringTestEntitiesArray[i] = StringTestEntity.create(
+							(String)jsonParserFieldValues[i]);
+					}
+
 					childTestEntity1.setStringTestEntities(
-						(StringTestEntity[])jsonParserFieldValue);
+						stringTestEntitiesArray);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "stringTestEntity")) {
@@ -616,4 +631,4 @@ public class ChildTestEntity1SerDes {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1447548494
+// LIFERAY-REST-BUILDER-HASH:1394767970

--- a/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/serdes/v1_0/ChildTestEntity2SerDes.java
+++ b/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/serdes/v1_0/ChildTestEntity2SerDes.java
@@ -197,7 +197,11 @@ public class ChildTestEntity2SerDes {
 			for (int i = 0; i < childTestEntity2.getStringTestEntities().length;
 				 i++) {
 
+				sb.append("\"");
+
 				sb.append(childTestEntity2.getStringTestEntities()[i]);
+
+				sb.append("\"");
 
 				if ((i + 1) < childTestEntity2.getStringTestEntities().length) {
 					sb.append(", ");
@@ -512,8 +516,19 @@ public class ChildTestEntity2SerDes {
 						jsonParserFieldName, "stringTestEntities")) {
 
 				if (jsonParserFieldValue != null) {
+					Object[] jsonParserFieldValues =
+						(Object[])jsonParserFieldValue;
+
+					StringTestEntity[] stringTestEntitiesArray =
+						new StringTestEntity[jsonParserFieldValues.length];
+
+					for (int i = 0; i < stringTestEntitiesArray.length; i++) {
+						stringTestEntitiesArray[i] = StringTestEntity.create(
+							(String)jsonParserFieldValues[i]);
+					}
+
 					childTestEntity2.setStringTestEntities(
-						(StringTestEntity[])jsonParserFieldValue);
+						stringTestEntitiesArray);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "stringTestEntity")) {
@@ -616,4 +631,4 @@ public class ChildTestEntity2SerDes {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-2079904537
+// LIFERAY-REST-BUILDER-HASH:989882527

--- a/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/serdes/v1_0/ChildTestEntity3SerDes.java
+++ b/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/serdes/v1_0/ChildTestEntity3SerDes.java
@@ -183,7 +183,11 @@ public class ChildTestEntity3SerDes {
 			for (int i = 0; i < childTestEntity3.getStringTestEntities().length;
 				 i++) {
 
+				sb.append("\"");
+
 				sb.append(childTestEntity3.getStringTestEntities()[i]);
+
+				sb.append("\"");
 
 				if ((i + 1) < childTestEntity3.getStringTestEntities().length) {
 					sb.append(", ");
@@ -482,8 +486,19 @@ public class ChildTestEntity3SerDes {
 						jsonParserFieldName, "stringTestEntities")) {
 
 				if (jsonParserFieldValue != null) {
+					Object[] jsonParserFieldValues =
+						(Object[])jsonParserFieldValue;
+
+					StringTestEntity[] stringTestEntitiesArray =
+						new StringTestEntity[jsonParserFieldValues.length];
+
+					for (int i = 0; i < stringTestEntitiesArray.length; i++) {
+						stringTestEntitiesArray[i] = StringTestEntity.create(
+							(String)jsonParserFieldValues[i]);
+					}
+
 					childTestEntity3.setStringTestEntities(
-						(StringTestEntity[])jsonParserFieldValue);
+						stringTestEntitiesArray);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "stringTestEntity")) {
@@ -586,4 +601,4 @@ public class ChildTestEntity3SerDes {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-430355436
+// LIFERAY-REST-BUILDER-HASH:565722706

--- a/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/serdes/v1_0/TestEntitySerDes.java
+++ b/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/serdes/v1_0/TestEntitySerDes.java
@@ -345,8 +345,18 @@ public class TestEntitySerDes {
 						jsonParserFieldName, "stringTestEntities")) {
 
 				if (jsonParserFieldValue != null) {
-					testEntity.setStringTestEntities(
-						(StringTestEntity[])jsonParserFieldValue);
+					Object[] jsonParserFieldValues =
+						(Object[])jsonParserFieldValue;
+
+					StringTestEntity[] stringTestEntitiesArray =
+						new StringTestEntity[jsonParserFieldValues.length];
+
+					for (int i = 0; i < stringTestEntitiesArray.length; i++) {
+						stringTestEntitiesArray[i] = StringTestEntity.create(
+							(String)jsonParserFieldValues[i]);
+					}
+
+					testEntity.setStringTestEntities(stringTestEntitiesArray);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "stringTestEntity")) {
@@ -448,4 +458,4 @@ public class TestEntitySerDes {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:2091280272
+// LIFERAY-REST-BUILDER-HASH:-1561943429

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/TestEntityResourceTest.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/TestEntityResourceTest.java
@@ -17,6 +17,7 @@ import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.tools.rest.builder.test.client.constant.v1_0.StringTestEntity;
 import com.liferay.portal.tools.rest.builder.test.client.dto.v1_0.ChildTestEntity1;
 import com.liferay.portal.tools.rest.builder.test.client.dto.v1_0.ChildTestEntity2;
 import com.liferay.portal.tools.rest.builder.test.client.dto.v1_0.ChildTestEntity3;
@@ -353,6 +354,8 @@ public class TestEntityResourceTest extends BaseTestEntityResourceTestCase {
 			StringUtil.toLowerCase(RandomTestUtil.randomString()));
 		childTestEntity1.setProperty1(
 			StringUtil.toLowerCase(RandomTestUtil.randomString()));
+		childTestEntity1.setStringTestEntities(
+			new StringTestEntity[] {StringTestEntity.VALUE});
 		childTestEntity1.setType(TestEntity.Type.create("ChildTestEntity1"));
 
 		ChildTestEntity2 childTestEntity2 = new ChildTestEntity2();

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/TestEntityResourceTest.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/TestEntityResourceTest.java
@@ -11,6 +11,7 @@ import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.Http;
@@ -213,6 +214,7 @@ public class TestEntityResourceTest extends BaseTestEntityResourceTestCase {
 
 	@Override
 	@Test
+	@TestInfo("LPD-95759")
 	public void testPostTestEntity() throws Exception {
 		super.testPostTestEntity();
 

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/client_serdes.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/client_serdes.ftl
@@ -151,7 +151,7 @@ public class ${schemaName}SerDes {
 							sb.append("[");
 
 							for (int i = 0; i < ${schemaVarName}.get${capitalizedPropertyName}().length; i++) {
-								<#if stringUtil.equals(propertyType, "Date[]") || enumSchemas?keys?seq_contains(propertyType)>
+								<#if stringUtil.equals(propertyType, "Date[]") || enumSchemas?keys?seq_contains(propertyType?remove_ending("[]")) || globalEnumSchemas?keys?seq_contains(propertyType?remove_ending("[]"))>
 									sb.append("\"");
 
 									<#if stringUtil.equals(propertyType, "Date[]")>
@@ -417,6 +417,16 @@ public class ${schemaName}SerDes {
 
 							for (int i = 0; i < ${propertyName}Array.length; i++) {
 								${propertyName}Array[i] = ${propertyType?remove_ending("[]")}SerDes.toDTO((String)jsonParserFieldValues[i]);
+							}
+
+							${schemaVarName}.set${capitalizedPropertyName}(${propertyName}Array);
+						<#elseif propertyType?ends_with("[]") && globalEnumSchemas?keys?seq_contains(propertyType?remove_ending("[]"))>
+							Object[] jsonParserFieldValues = (Object[])jsonParserFieldValue;
+
+							${propertyType?remove_ending("[]")}[] ${propertyName}Array = new ${propertyType?remove_ending("[]")}[jsonParserFieldValues.length];
+
+							for (int i = 0; i < ${propertyName}Array.length; i++) {
+								${propertyName}Array[i] = ${propertyType?remove_ending("[]")}.create((String)jsonParserFieldValues[i]);
 							}
 
 							${schemaVarName}.set${capitalizedPropertyName}(${propertyName}Array);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95759

## What Is Being Fixed

REST Builder's generated client SerDes mishandled a DTO property that is an array whose items reference a top-level (global) enum schema. The generated `toJSON` wrote the enum values without quotes — producing invalid JSON — and the generated `toDTO` cast the parsed `Object[]` straight to the enum array type, throwing `ClassCastException` at runtime. A client generated for such a property could therefore neither serialize nor deserialize it. This surfaced while adding the `fieldTypes` property (an array of the `FieldType` enum) to the Headless Admin Fragment API.

## How It Is Being Fixed

The fix is in `client_serdes.ftl`. The `toJSON` array branch now quotes elements whose item type matches a global enum schema — it strips the trailing `[]` before matching and checks `globalEnumSchemas` in addition to the inline `enumSchemas`. The `toDTO` branch builds the enum array element by element via `<Enum>.create(...)` instead of casting the raw `Object[]`. The REST Builder test bed is regenerated accordingly, and `TestEntityResourceTest` — which already defines a top-level-enum array property (`stringTestEntities`) — now populates it so the import round trip exercises the generated client `toJSON`/`toDTO` for that type.

## PR Check

**pr-check: PASS** — tested on `19e7bcef7362cd7f9fe822592d544a1ac302a4e9`

| Validation | Result |
| --- | --- |
| REST Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "19e7bcef7362cd7f9fe822592d544a1ac302a4e9"} -->
