### PR TITLE
LPD-94216 Make ImportProcess page endpoints follow the ERC pattern

### DIFF
--- a/modules/apps/export-import/export-import-rest-api/bnd.bnd
+++ b/modules/apps/export-import/export-import-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Export Import REST API
 Bundle-SymbolicName: com.liferay.exportimport.rest.api
-Bundle-Version: 4.1.1
+Bundle-Version: 5.0.0
 Export-Package:\
 	com.liferay.exportimport.rest.dto.v1_0,\
 	com.liferay.exportimport.rest.resource.v1_0

--- a/modules/apps/export-import/export-import-rest-api/src/main/java/com/liferay/exportimport/rest/resource/v1_0/ImportProcessResource.java
+++ b/modules/apps/export-import/export-import-rest-api/src/main/java/com/liferay/exportimport/rest/resource/v1_0/ImportProcessResource.java
@@ -48,8 +48,8 @@ import org.osgi.annotation.versioning.ProviderType;
 public interface ImportProcessResource {
 
 	public Page<ImportProcess> getAssetLibraryImportProcessesPage(
-			Long assetLibraryId, Long creatorId, String search, Integer status,
-			Pagination pagination,
+			String assetLibraryExternalReferenceCode, Long creatorId,
+			String search, Integer status, Pagination pagination,
 			com.liferay.portal.kernel.search.Sort[] sorts)
 		throws Exception;
 
@@ -63,8 +63,8 @@ public interface ImportProcessResource {
 		throws Exception;
 
 	public Page<ImportProcess> getSiteImportProcessesPage(
-			Long siteId, Long creatorId, String search, Integer status,
-			Pagination pagination,
+			String siteExternalReferenceCode, Long creatorId, String search,
+			Integer status, Pagination pagination,
 			com.liferay.portal.kernel.search.Sort[] sorts)
 		throws Exception;
 
@@ -80,7 +80,8 @@ public interface ImportProcessResource {
 		throws Exception;
 
 	public Response postAssetLibraryImportProcessesPageExportBatch(
-			Long assetLibraryId, Long creatorId, String search, Integer status,
+			String assetLibraryExternalReferenceCode, Long creatorId,
+			String search, Integer status,
 			com.liferay.portal.kernel.search.Sort[] sorts, String callbackURL,
 			String contentType, String fieldNames)
 		throws Exception;
@@ -112,9 +113,9 @@ public interface ImportProcessResource {
 		throws Exception;
 
 	public Response postSiteImportProcessesPageExportBatch(
-			Long siteId, Long creatorId, String search, Integer status,
-			com.liferay.portal.kernel.search.Sort[] sorts, String callbackURL,
-			String contentType, String fieldNames)
+			String siteExternalReferenceCode, Long creatorId, String search,
+			Integer status, com.liferay.portal.kernel.search.Sort[] sorts,
+			String callbackURL, String contentType, String fieldNames)
 		throws Exception;
 
 	public default void setContextAcceptLanguage(
@@ -213,4 +214,4 @@ public interface ImportProcessResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:862013812
+// LIFERAY-REST-BUILDER-HASH:165486924

--- a/modules/apps/export-import/export-import-rest-api/src/main/resources/com/liferay/exportimport/rest/resource/v1_0/packageinfo
+++ b/modules/apps/export-import/export-import-rest-api/src/main/resources/com/liferay/exportimport/rest/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 4.0.0

--- a/modules/apps/export-import/export-import-rest-client/src/main/java/com/liferay/exportimport/rest/client/resource/v1_0/ImportProcessResource.java
+++ b/modules/apps/export-import/export-import-rest-client/src/main/java/com/liferay/exportimport/rest/client/resource/v1_0/ImportProcessResource.java
@@ -36,14 +36,16 @@ public interface ImportProcessResource {
 	}
 
 	public Page<ImportProcess> getAssetLibraryImportProcessesPage(
-			Long assetLibraryId, Long creatorId, String search, Integer status,
-			Pagination pagination, String sortString)
+			String assetLibraryExternalReferenceCode, Long creatorId,
+			String search, Integer status, Pagination pagination,
+			String sortString)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
 			getAssetLibraryImportProcessesPageHttpResponse(
-				Long assetLibraryId, Long creatorId, String search,
-				Integer status, Pagination pagination, String sortString)
+				String assetLibraryExternalReferenceCode, Long creatorId,
+				String search, Integer status, Pagination pagination,
+				String sortString)
 		throws Exception;
 
 	public ImportProcess getImportProcess(Long importProcessId)
@@ -64,13 +66,13 @@ public interface ImportProcessResource {
 		throws Exception;
 
 	public Page<ImportProcess> getSiteImportProcessesPage(
-			Long siteId, Long creatorId, String search, Integer status,
-			Pagination pagination, String sortString)
+			String siteExternalReferenceCode, Long creatorId, String search,
+			Integer status, Pagination pagination, String sortString)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse getSiteImportProcessesPageHttpResponse(
-			Long siteId, Long creatorId, String search, Integer status,
-			Pagination pagination, String sortString)
+			String siteExternalReferenceCode, Long creatorId, String search,
+			Integer status, Pagination pagination, String sortString)
 		throws Exception;
 
 	public ImportProcess postAssetLibraryImportProcess(
@@ -97,16 +99,16 @@ public interface ImportProcessResource {
 		throws Exception;
 
 	public void postAssetLibraryImportProcessesPageExportBatch(
-			Long assetLibraryId, Long creatorId, String search, Integer status,
-			String sortString, String callbackURL, String contentType,
-			String fieldNames)
+			String assetLibraryExternalReferenceCode, Long creatorId,
+			String search, Integer status, String sortString,
+			String callbackURL, String contentType, String fieldNames)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
 			postAssetLibraryImportProcessesPageExportBatchHttpResponse(
-				Long assetLibraryId, Long creatorId, String search,
-				Integer status, String sortString, String callbackURL,
-				String contentType, String fieldNames)
+				String assetLibraryExternalReferenceCode, Long creatorId,
+				String search, Integer status, String sortString,
+				String callbackURL, String contentType, String fieldNames)
 		throws Exception;
 
 	public ImportProcess postImportProcess(
@@ -162,16 +164,16 @@ public interface ImportProcessResource {
 		throws Exception;
 
 	public void postSiteImportProcessesPageExportBatch(
-			Long siteId, Long creatorId, String search, Integer status,
-			String sortString, String callbackURL, String contentType,
-			String fieldNames)
+			String siteExternalReferenceCode, Long creatorId, String search,
+			Integer status, String sortString, String callbackURL,
+			String contentType, String fieldNames)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
 			postSiteImportProcessesPageExportBatchHttpResponse(
-				Long siteId, Long creatorId, String search, Integer status,
-				String sortString, String callbackURL, String contentType,
-				String fieldNames)
+				String siteExternalReferenceCode, Long creatorId, String search,
+				Integer status, String sortString, String callbackURL,
+				String contentType, String fieldNames)
 		throws Exception;
 
 	public static class Builder {
@@ -284,14 +286,15 @@ public interface ImportProcessResource {
 		implements ImportProcessResource {
 
 		public Page<ImportProcess> getAssetLibraryImportProcessesPage(
-				Long assetLibraryId, Long creatorId, String search,
-				Integer status, Pagination pagination, String sortString)
+				String assetLibraryExternalReferenceCode, Long creatorId,
+				String search, Integer status, Pagination pagination,
+				String sortString)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
 				getAssetLibraryImportProcessesPageHttpResponse(
-					assetLibraryId, creatorId, search, status, pagination,
-					sortString);
+					assetLibraryExternalReferenceCode, creatorId, search,
+					status, pagination, sortString);
 
 			String content = httpResponse.getContent();
 
@@ -354,8 +357,9 @@ public interface ImportProcessResource {
 
 		public HttpInvoker.HttpResponse
 				getAssetLibraryImportProcessesPageHttpResponse(
-					Long assetLibraryId, Long creatorId, String search,
-					Integer status, Pagination pagination, String sortString)
+					String assetLibraryExternalReferenceCode, Long creatorId,
+					String search, Integer status, Pagination pagination,
+					String sortString)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -405,9 +409,11 @@ public interface ImportProcessResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/asset-libraries/{assetLibraryId}/import-processes");
+						"/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/import-processes");
 
-			httpInvoker.path("assetLibraryId", assetLibraryId);
+			httpInvoker.path(
+				"assetLibraryExternalReferenceCode",
+				assetLibraryExternalReferenceCode);
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -653,13 +659,14 @@ public interface ImportProcessResource {
 		}
 
 		public Page<ImportProcess> getSiteImportProcessesPage(
-				Long siteId, Long creatorId, String search, Integer status,
-				Pagination pagination, String sortString)
+				String siteExternalReferenceCode, Long creatorId, String search,
+				Integer status, Pagination pagination, String sortString)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
 				getSiteImportProcessesPageHttpResponse(
-					siteId, creatorId, search, status, pagination, sortString);
+					siteExternalReferenceCode, creatorId, search, status,
+					pagination, sortString);
 
 			String content = httpResponse.getContent();
 
@@ -721,8 +728,8 @@ public interface ImportProcessResource {
 		}
 
 		public HttpInvoker.HttpResponse getSiteImportProcessesPageHttpResponse(
-				Long siteId, Long creatorId, String search, Integer status,
-				Pagination pagination, String sortString)
+				String siteExternalReferenceCode, Long creatorId, String search,
+				Integer status, Pagination pagination, String sortString)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -772,9 +779,10 @@ public interface ImportProcessResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/sites/{siteId}/import-processes");
+						"/o/export-import/v1.0/sites/{siteExternalReferenceCode}/import-processes");
 
-			httpInvoker.path("siteId", siteId);
+			httpInvoker.path(
+				"siteExternalReferenceCode", siteExternalReferenceCode);
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -1011,15 +1019,15 @@ public interface ImportProcessResource {
 		}
 
 		public void postAssetLibraryImportProcessesPageExportBatch(
-				Long assetLibraryId, Long creatorId, String search,
-				Integer status, String sortString, String callbackURL,
-				String contentType, String fieldNames)
+				String assetLibraryExternalReferenceCode, Long creatorId,
+				String search, Integer status, String sortString,
+				String callbackURL, String contentType, String fieldNames)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
 				postAssetLibraryImportProcessesPageExportBatchHttpResponse(
-					assetLibraryId, creatorId, search, status, sortString,
-					callbackURL, contentType, fieldNames);
+					assetLibraryExternalReferenceCode, creatorId, search,
+					status, sortString, callbackURL, contentType, fieldNames);
 
 			String content = httpResponse.getContent();
 
@@ -1071,9 +1079,9 @@ public interface ImportProcessResource {
 
 		public HttpInvoker.HttpResponse
 				postAssetLibraryImportProcessesPageExportBatchHttpResponse(
-					Long assetLibraryId, Long creatorId, String search,
-					Integer status, String sortString, String callbackURL,
-					String contentType, String fieldNames)
+					String assetLibraryExternalReferenceCode, Long creatorId,
+					String search, Integer status, String sortString,
+					String callbackURL, String contentType, String fieldNames)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -1132,9 +1140,11 @@ public interface ImportProcessResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/asset-libraries/{assetLibraryId}/import-processes/export-batch");
+						"/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/import-processes/export-batch");
 
-			httpInvoker.path("assetLibraryId", assetLibraryId);
+			httpInvoker.path(
+				"assetLibraryExternalReferenceCode",
+				assetLibraryExternalReferenceCode);
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -1709,15 +1719,15 @@ public interface ImportProcessResource {
 		}
 
 		public void postSiteImportProcessesPageExportBatch(
-				Long siteId, Long creatorId, String search, Integer status,
-				String sortString, String callbackURL, String contentType,
-				String fieldNames)
+				String siteExternalReferenceCode, Long creatorId, String search,
+				Integer status, String sortString, String callbackURL,
+				String contentType, String fieldNames)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
 				postSiteImportProcessesPageExportBatchHttpResponse(
-					siteId, creatorId, search, status, sortString, callbackURL,
-					contentType, fieldNames);
+					siteExternalReferenceCode, creatorId, search, status,
+					sortString, callbackURL, contentType, fieldNames);
 
 			String content = httpResponse.getContent();
 
@@ -1769,9 +1779,9 @@ public interface ImportProcessResource {
 
 		public HttpInvoker.HttpResponse
 				postSiteImportProcessesPageExportBatchHttpResponse(
-					Long siteId, Long creatorId, String search, Integer status,
-					String sortString, String callbackURL, String contentType,
-					String fieldNames)
+					String siteExternalReferenceCode, Long creatorId,
+					String search, Integer status, String sortString,
+					String callbackURL, String contentType, String fieldNames)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -1830,9 +1840,10 @@ public interface ImportProcessResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/export-import/v1.0/sites/{siteId}/import-processes/export-batch");
+						"/o/export-import/v1.0/sites/{siteExternalReferenceCode}/import-processes/export-batch");
 
-			httpInvoker.path("siteId", siteId);
+			httpInvoker.path(
+				"siteExternalReferenceCode", siteExternalReferenceCode);
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -1854,4 +1865,4 @@ public interface ImportProcessResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1743775649
+// LIFERAY-REST-BUILDER-HASH:116708527

--- a/modules/apps/export-import/export-import-rest-impl/rest-openapi.yaml
+++ b/modules/apps/export-import/export-import-rest-impl/rest-openapi.yaml
@@ -559,44 +559,16 @@ paths:
                                 $ref: "#/components/schemas/ImportPreview"
             tags: ["ImportPreview"]
     "/asset-libraries/{assetLibraryExternalReferenceCode}/import-processes":
-        post:
-            operationId: postAssetLibraryImportProcess
+        get:
+            description:
+                Retrieves the layout import process entries for the specified asset library.
+            operationId: getAssetLibraryImportProcessesPage
             parameters:
                 -   in: path
                     name: assetLibraryExternalReferenceCode
                     required: true
                     schema:
                         type: string
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: "#/components/schemas/ImportProcessRequest"
-                    application/xml:
-                        schema:
-                            $ref: "#/components/schemas/ImportProcessRequest"
-            responses:
-                200:
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/ImportProcess"
-                        application/xml:
-                            schema:
-                                $ref: "#/components/schemas/ImportProcess"
-            tags: ["ImportProcess"]
-    "/asset-libraries/{assetLibraryId}/import-processes":
-        description:
-            Retrieves the import process entries for the specified asset library.
-        get:
-            operationId: getAssetLibraryImportProcessesPage
-            parameters:
-                -   in: path
-                    name: assetLibraryId
-                    required: true
-                    schema:
-                        format: int64
-                        type: integer
                 -   in: query
                     name: creatorId
                     schema:
@@ -647,6 +619,32 @@ paths:
                                 items:
                                     $ref: "#/components/schemas/ImportProcess"
                                 type: array
+            tags: ["ImportProcess"]
+        post:
+            operationId: postAssetLibraryImportProcess
+            parameters:
+                -   in: path
+                    name: assetLibraryExternalReferenceCode
+                    required: true
+                    schema:
+                        type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/ImportProcessRequest"
+                    application/xml:
+                        schema:
+                            $ref: "#/components/schemas/ImportProcessRequest"
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ImportProcess"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/ImportProcess"
             tags: ["ImportProcess"]
     "/export-preview":
         get:
@@ -1025,44 +1023,16 @@ paths:
                                 $ref: "#/components/schemas/ImportPreview"
             tags: ["ImportPreview"]
     "/sites/{siteExternalReferenceCode}/import-processes":
-        post:
-            operationId: postSiteImportProcess
+        description:
+            Retrieves the layout import process entries for the specified site.
+        get:
+            operationId: getSiteImportProcessesPage
             parameters:
                 -   in: path
                     name: siteExternalReferenceCode
                     required: true
                     schema:
                         type: string
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: "#/components/schemas/ImportProcessRequest"
-                    application/xml:
-                        schema:
-                            $ref: "#/components/schemas/ImportProcessRequest"
-            responses:
-                200:
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/ImportProcess"
-                        application/xml:
-                            schema:
-                                $ref: "#/components/schemas/ImportProcess"
-            tags: ["ImportProcess"]
-    "/sites/{siteId}/import-processes":
-        description:
-            Retrieves the import process entries for the specified site.
-        get:
-            operationId: getSiteImportProcessesPage
-            parameters:
-                -   in: path
-                    name: siteId
-                    required: true
-                    schema:
-                        format: int64
-                        type: integer
                 -   in: query
                     name: creatorId
                     schema:
@@ -1113,4 +1083,30 @@ paths:
                                 items:
                                     $ref: "#/components/schemas/ImportProcess"
                                 type: array
+            tags: ["ImportProcess"]
+        post:
+            operationId: postSiteImportProcess
+            parameters:
+                -   in: path
+                    name: siteExternalReferenceCode
+                    required: true
+                    schema:
+                        type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/ImportProcessRequest"
+                    application/xml:
+                        schema:
+                            $ref: "#/components/schemas/ImportProcessRequest"
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ImportProcess"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/ImportProcess"
             tags: ["ImportProcess"]

--- a/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/BaseImportProcessResourceImpl.java
+++ b/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/BaseImportProcessResourceImpl.java
@@ -75,13 +75,16 @@ public abstract class BaseImportProcessResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/export-import/v1.0/asset-libraries/{assetLibraryId}/import-processes'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/import-processes'  -u 'test@liferay.com:test'
 	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Retrieves the layout import process entries for the specified asset library."
+	)
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
-				name = "assetLibraryId"
+				name = "assetLibraryExternalReferenceCode"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -127,14 +130,16 @@ public abstract class BaseImportProcessResourceImpl
 		}
 	)
 	@jakarta.ws.rs.GET
-	@jakarta.ws.rs.Path("/asset-libraries/{assetLibraryId}/import-processes")
+	@jakarta.ws.rs.Path(
+		"/asset-libraries/{assetLibraryExternalReferenceCode}/import-processes"
+	)
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
 	public Page<ImportProcess> getAssetLibraryImportProcessesPage(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.validation.constraints.NotNull
-			@jakarta.ws.rs.PathParam("assetLibraryId")
-			Long assetLibraryId,
+			@jakarta.ws.rs.PathParam("assetLibraryExternalReferenceCode")
+			String assetLibraryExternalReferenceCode,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.ws.rs.QueryParam("creatorId")
 			Long creatorId,
@@ -274,13 +279,13 @@ public abstract class BaseImportProcessResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/export-import/v1.0/sites/{siteId}/import-processes'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/export-import/v1.0/sites/{siteExternalReferenceCode}/import-processes'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
-				name = "siteId"
+				name = "siteExternalReferenceCode"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -326,14 +331,14 @@ public abstract class BaseImportProcessResourceImpl
 		}
 	)
 	@jakarta.ws.rs.GET
-	@jakarta.ws.rs.Path("/sites/{siteId}/import-processes")
+	@jakarta.ws.rs.Path("/sites/{siteExternalReferenceCode}/import-processes")
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
 	public Page<ImportProcess> getSiteImportProcessesPage(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.validation.constraints.NotNull
-			@jakarta.ws.rs.PathParam("siteId")
-			Long siteId,
+			@jakarta.ws.rs.PathParam("siteExternalReferenceCode")
+			String siteExternalReferenceCode,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.ws.rs.QueryParam("creatorId")
 			Long creatorId,
@@ -447,13 +452,13 @@ public abstract class BaseImportProcessResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/asset-libraries/{assetLibraryId}/import-processes/export-batch'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/import-processes/export-batch'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
-				name = "assetLibraryId"
+				name = "assetLibraryExternalReferenceCode"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -492,7 +497,7 @@ public abstract class BaseImportProcessResourceImpl
 	)
 	@jakarta.ws.rs.Consumes("application/json")
 	@jakarta.ws.rs.Path(
-		"/asset-libraries/{assetLibraryId}/import-processes/export-batch"
+		"/asset-libraries/{assetLibraryExternalReferenceCode}/import-processes/export-batch"
 	)
 	@jakarta.ws.rs.POST
 	@jakarta.ws.rs.Produces("application/json")
@@ -500,8 +505,8 @@ public abstract class BaseImportProcessResourceImpl
 	public Response postAssetLibraryImportProcessesPageExportBatch(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.validation.constraints.NotNull
-			@jakarta.ws.rs.PathParam("assetLibraryId")
-			Long assetLibraryId,
+			@jakarta.ws.rs.PathParam("assetLibraryExternalReferenceCode")
+			String assetLibraryExternalReferenceCode,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.ws.rs.QueryParam("creatorId")
 			Long creatorId,
@@ -797,13 +802,13 @@ public abstract class BaseImportProcessResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/sites/{siteId}/import-processes/export-batch'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/export-import/v1.0/sites/{siteExternalReferenceCode}/import-processes/export-batch'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
-				name = "siteId"
+				name = "siteExternalReferenceCode"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -841,15 +846,17 @@ public abstract class BaseImportProcessResourceImpl
 		}
 	)
 	@jakarta.ws.rs.Consumes("application/json")
-	@jakarta.ws.rs.Path("/sites/{siteId}/import-processes/export-batch")
+	@jakarta.ws.rs.Path(
+		"/sites/{siteExternalReferenceCode}/import-processes/export-batch"
+	)
 	@jakarta.ws.rs.POST
 	@jakarta.ws.rs.Produces("application/json")
 	@Override
 	public Response postSiteImportProcessesPageExportBatch(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.validation.constraints.NotNull
-			@jakarta.ws.rs.PathParam("siteId")
-			Long siteId,
+			@jakarta.ws.rs.PathParam("siteExternalReferenceCode")
+			String siteExternalReferenceCode,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.ws.rs.QueryParam("creatorId")
 			Long creatorId,
@@ -992,16 +999,16 @@ public abstract class BaseImportProcessResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		if (parameters.containsKey("assetLibraryId")) {
+		if (parameters.containsKey("assetLibraryExternalReferenceCode")) {
 			return getAssetLibraryImportProcessesPage(
-				(Long)parameters.get("assetLibraryId"),
+				(String)parameters.get("assetLibraryExternalReferenceCode"),
 				_parseLong((String)parameters.get("creatorId")), search,
 				_parseInteger((String)parameters.get("status")), pagination,
 				sorts);
 		}
-		else if (parameters.containsKey("siteId")) {
+		else if (parameters.containsKey("siteExternalReferenceCode")) {
 			return getSiteImportProcessesPage(
-				(Long)parameters.get("siteId"),
+				(String)parameters.get("siteExternalReferenceCode"),
 				_parseLong((String)parameters.get("creatorId")), search,
 				_parseInteger((String)parameters.get("status")), pagination,
 				sorts);
@@ -1638,4 +1645,4 @@ public abstract class BaseImportProcessResourceImpl
 		LogFactoryUtil.getLog(BaseImportProcessResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:1220442858
+// LIFERAY-REST-BUILDER-HASH:-1372080786

--- a/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/ImportProcessResourceImpl.java
+++ b/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/ImportProcessResourceImpl.java
@@ -66,19 +66,27 @@ public class ImportProcessResourceImpl extends BaseImportProcessResourceImpl {
 
 	@Override
 	public Page<ImportProcess> getAssetLibraryImportProcessesPage(
-			Long assetLibraryId, Long creatorId, String search, Integer status,
-			Pagination pagination, Sort[] sorts)
+			String assetLibraryExternalReferenceCode, Long creatorId,
+			String search, Integer status, Pagination pagination, Sort[] sorts)
 		throws Exception {
+
+		Group group = groupLocalService.fetchGroupByExternalReferenceCode(
+			assetLibraryExternalReferenceCode, contextCompany.getCompanyId());
+
+		if ((group == null) || !group.isDepot()) {
+			throw new NotFoundException();
+		}
 
 		return Page.of(
 			transform(
 				_getBackgroundTasks(
-					creatorId, assetLibraryId, pagination, search, sorts,
+					creatorId, group.getGroupId(), pagination, search, sorts,
 					status),
 				this::_toImportProcess),
 			pagination,
 			_backgroundTaskLocalService.dynamicQueryCount(
-				_getDynamicQuery(creatorId, assetLibraryId, search, status)));
+				_getDynamicQuery(
+					creatorId, group.getGroupId(), search, status)));
 	}
 
 	@Override
@@ -122,18 +130,27 @@ public class ImportProcessResourceImpl extends BaseImportProcessResourceImpl {
 
 	@Override
 	public Page<ImportProcess> getSiteImportProcessesPage(
-			Long siteId, Long creatorId, String search, Integer status,
-			Pagination pagination, Sort[] sorts)
+			String siteExternalReferenceCode, Long creatorId, String search,
+			Integer status, Pagination pagination, Sort[] sorts)
 		throws Exception {
+
+		Group group = groupLocalService.fetchGroupByExternalReferenceCode(
+			siteExternalReferenceCode, contextCompany.getCompanyId());
+
+		if ((group == null) || !group.isSite()) {
+			throw new NotFoundException();
+		}
 
 		return Page.of(
 			transform(
 				_getBackgroundTasks(
-					creatorId, siteId, pagination, search, sorts, status),
+					creatorId, group.getGroupId(), pagination, search, sorts,
+					status),
 				this::_toImportProcess),
 			pagination,
 			_backgroundTaskLocalService.dynamicQueryCount(
-				_getDynamicQuery(creatorId, siteId, search, status)));
+				_getDynamicQuery(
+					creatorId, group.getGroupId(), search, status)));
 	}
 
 	@Override

--- a/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/BaseImportProcessResourceTestCase.java
+++ b/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/BaseImportProcessResourceTestCase.java
@@ -241,24 +241,26 @@ public abstract class BaseImportProcessResourceTestCase {
 
 	@Test
 	public void testGetAssetLibraryImportProcessesPage() throws Exception {
-		Long assetLibraryId =
-			testGetAssetLibraryImportProcessesPage_getAssetLibraryId();
-		Long irrelevantAssetLibraryId =
-			testGetAssetLibraryImportProcessesPage_getIrrelevantAssetLibraryId();
+		String assetLibraryExternalReferenceCode =
+			testGetAssetLibraryImportProcessesPage_getAssetLibraryExternalReferenceCode();
+		String irrelevantAssetLibraryExternalReferenceCode =
+			testGetAssetLibraryImportProcessesPage_getIrrelevantAssetLibraryExternalReferenceCode();
 
 		Page<ImportProcess> page =
 			importProcessResource.getAssetLibraryImportProcessesPage(
-				assetLibraryId, null, null, null, Pagination.of(1, 10), null);
+				assetLibraryExternalReferenceCode, null, null, null,
+				Pagination.of(1, 10), null);
 
 		long totalCount = page.getTotalCount();
 
-		if (irrelevantAssetLibraryId != null) {
+		if (irrelevantAssetLibraryExternalReferenceCode != null) {
 			ImportProcess irrelevantImportProcess =
 				testGetAssetLibraryImportProcessesPage_addImportProcess(
-					irrelevantAssetLibraryId, randomIrrelevantImportProcess());
+					irrelevantAssetLibraryExternalReferenceCode,
+					randomIrrelevantImportProcess());
 
 			page = importProcessResource.getAssetLibraryImportProcessesPage(
-				irrelevantAssetLibraryId, null, null, null,
+				irrelevantAssetLibraryExternalReferenceCode, null, null, null,
 				Pagination.of(1, (int)totalCount + 1), null);
 
 			Assert.assertEquals(totalCount + 1, page.getTotalCount());
@@ -268,19 +270,20 @@ public abstract class BaseImportProcessResourceTestCase {
 			assertValid(
 				page,
 				testGetAssetLibraryImportProcessesPage_getExpectedActions(
-					irrelevantAssetLibraryId));
+					irrelevantAssetLibraryExternalReferenceCode));
 		}
 
 		ImportProcess importProcess1 =
 			testGetAssetLibraryImportProcessesPage_addImportProcess(
-				assetLibraryId, randomImportProcess());
+				assetLibraryExternalReferenceCode, randomImportProcess());
 
 		ImportProcess importProcess2 =
 			testGetAssetLibraryImportProcessesPage_addImportProcess(
-				assetLibraryId, randomImportProcess());
+				assetLibraryExternalReferenceCode, randomImportProcess());
 
 		page = importProcessResource.getAssetLibraryImportProcessesPage(
-			assetLibraryId, null, null, null, Pagination.of(1, 10), null);
+			assetLibraryExternalReferenceCode, null, null, null,
+			Pagination.of(1, 10), null);
 
 		Assert.assertEquals(totalCount + 2, page.getTotalCount());
 
@@ -289,15 +292,27 @@ public abstract class BaseImportProcessResourceTestCase {
 		assertValid(
 			page,
 			testGetAssetLibraryImportProcessesPage_getExpectedActions(
-				assetLibraryId));
+				assetLibraryExternalReferenceCode));
 	}
 
 	protected Map<String, Map<String, String>>
 			testGetAssetLibraryImportProcessesPage_getExpectedActions(
-				Long assetLibraryId)
+				String assetLibraryExternalReferenceCode)
 		throws Exception {
 
 		Map<String, Map<String, String>> expectedActions = new HashMap<>();
+
+		Map createBatchAction = new HashMap<>();
+		createBatchAction.put("method", "POST");
+		createBatchAction.put(
+			"href",
+			("http://localhost:" + PortalUtil.getPortalServerPort(false) +
+				"/o/export-import/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/import-processes/batch").
+					replace(
+						"{assetLibraryExternalReferenceCode}",
+						String.valueOf(assetLibraryExternalReferenceCode)));
+
+		expectedActions.put("createBatch", createBatchAction);
 
 		return expectedActions;
 	}
@@ -306,27 +321,28 @@ public abstract class BaseImportProcessResourceTestCase {
 	public void testGetAssetLibraryImportProcessesPageWithPagination()
 		throws Exception {
 
-		Long assetLibraryId =
-			testGetAssetLibraryImportProcessesPage_getAssetLibraryId();
+		String assetLibraryExternalReferenceCode =
+			testGetAssetLibraryImportProcessesPage_getAssetLibraryExternalReferenceCode();
 
 		Page<ImportProcess> importProcessesPage =
 			importProcessResource.getAssetLibraryImportProcessesPage(
-				assetLibraryId, null, null, null, null, null);
+				assetLibraryExternalReferenceCode, null, null, null, null,
+				null);
 
 		int totalCount = GetterUtil.getInteger(
 			importProcessesPage.getTotalCount());
 
 		ImportProcess importProcess1 =
 			testGetAssetLibraryImportProcessesPage_addImportProcess(
-				assetLibraryId, randomImportProcess());
+				assetLibraryExternalReferenceCode, randomImportProcess());
 
 		ImportProcess importProcess2 =
 			testGetAssetLibraryImportProcessesPage_addImportProcess(
-				assetLibraryId, randomImportProcess());
+				assetLibraryExternalReferenceCode, randomImportProcess());
 
 		ImportProcess importProcess3 =
 			testGetAssetLibraryImportProcessesPage_addImportProcess(
-				assetLibraryId, randomImportProcess());
+				assetLibraryExternalReferenceCode, randomImportProcess());
 
 		// See com.liferay.portal.vulcan.internal.configuration.HeadlessAPICompanyConfiguration#pageSizeLimit
 
@@ -335,7 +351,7 @@ public abstract class BaseImportProcessResourceTestCase {
 		if (totalCount >= (pageSizeLimit - 2)) {
 			Page<ImportProcess> page1 =
 				importProcessResource.getAssetLibraryImportProcessesPage(
-					assetLibraryId, null, null, null,
+					assetLibraryExternalReferenceCode, null, null, null,
 					Pagination.of(
 						(int)Math.ceil((totalCount + 1.0) / pageSizeLimit),
 						pageSizeLimit),
@@ -348,7 +364,7 @@ public abstract class BaseImportProcessResourceTestCase {
 
 			Page<ImportProcess> page2 =
 				importProcessResource.getAssetLibraryImportProcessesPage(
-					assetLibraryId, null, null, null,
+					assetLibraryExternalReferenceCode, null, null, null,
 					Pagination.of(
 						(int)Math.ceil((totalCount + 2.0) / pageSizeLimit),
 						pageSizeLimit),
@@ -359,7 +375,7 @@ public abstract class BaseImportProcessResourceTestCase {
 
 			Page<ImportProcess> page3 =
 				importProcessResource.getAssetLibraryImportProcessesPage(
-					assetLibraryId, null, null, null,
+					assetLibraryExternalReferenceCode, null, null, null,
 					Pagination.of(
 						(int)Math.ceil((totalCount + 3.0) / pageSizeLimit),
 						pageSizeLimit),
@@ -371,7 +387,7 @@ public abstract class BaseImportProcessResourceTestCase {
 		else {
 			Page<ImportProcess> page1 =
 				importProcessResource.getAssetLibraryImportProcessesPage(
-					assetLibraryId, null, null, null,
+					assetLibraryExternalReferenceCode, null, null, null,
 					Pagination.of(1, totalCount + 2), null);
 
 			List<ImportProcess> importProcesses1 =
@@ -383,7 +399,7 @@ public abstract class BaseImportProcessResourceTestCase {
 
 			Page<ImportProcess> page2 =
 				importProcessResource.getAssetLibraryImportProcessesPage(
-					assetLibraryId, null, null, null,
+					assetLibraryExternalReferenceCode, null, null, null,
 					Pagination.of(2, totalCount + 2), null);
 
 			Assert.assertEquals(totalCount + 3, page2.getTotalCount());
@@ -396,7 +412,7 @@ public abstract class BaseImportProcessResourceTestCase {
 
 			Page<ImportProcess> page3 =
 				importProcessResource.getAssetLibraryImportProcessesPage(
-					assetLibraryId, null, null, null,
+					assetLibraryExternalReferenceCode, null, null, null,
 					Pagination.of(1, (int)totalCount + 3), null);
 
 			assertContains(
@@ -515,8 +531,8 @@ public abstract class BaseImportProcessResourceTestCase {
 			return;
 		}
 
-		Long assetLibraryId =
-			testGetAssetLibraryImportProcessesPage_getAssetLibraryId();
+		String assetLibraryExternalReferenceCode =
+			testGetAssetLibraryImportProcessesPage_getAssetLibraryExternalReferenceCode();
 
 		ImportProcess importProcess1 = randomImportProcess();
 		ImportProcess importProcess2 = randomImportProcess();
@@ -528,20 +544,21 @@ public abstract class BaseImportProcessResourceTestCase {
 
 		importProcess1 =
 			testGetAssetLibraryImportProcessesPage_addImportProcess(
-				assetLibraryId, importProcess1);
+				assetLibraryExternalReferenceCode, importProcess1);
 
 		importProcess2 =
 			testGetAssetLibraryImportProcessesPage_addImportProcess(
-				assetLibraryId, importProcess2);
+				assetLibraryExternalReferenceCode, importProcess2);
 
 		Page<ImportProcess> page =
 			importProcessResource.getAssetLibraryImportProcessesPage(
-				assetLibraryId, null, null, null, null, null);
+				assetLibraryExternalReferenceCode, null, null, null, null,
+				null);
 
 		for (EntityField entityField : entityFields) {
 			Page<ImportProcess> ascPage =
 				importProcessResource.getAssetLibraryImportProcessesPage(
-					assetLibraryId, null, null, null,
+					assetLibraryExternalReferenceCode, null, null, null,
 					Pagination.of(1, (int)page.getTotalCount() + 1),
 					entityField.getName() + ":asc");
 
@@ -552,7 +569,7 @@ public abstract class BaseImportProcessResourceTestCase {
 
 			Page<ImportProcess> descPage =
 				importProcessResource.getAssetLibraryImportProcessesPage(
-					assetLibraryId, null, null, null,
+					assetLibraryExternalReferenceCode, null, null, null,
 					Pagination.of(1, (int)page.getTotalCount() + 1),
 					entityField.getName() + ":desc");
 
@@ -565,24 +582,26 @@ public abstract class BaseImportProcessResourceTestCase {
 
 	protected ImportProcess
 			testGetAssetLibraryImportProcessesPage_addImportProcess(
-				Long assetLibraryId, ImportProcess importProcess)
+				String assetLibraryExternalReferenceCode,
+				ImportProcess importProcess)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
 	}
 
-	protected Long testGetAssetLibraryImportProcessesPage_getAssetLibraryId()
+	protected String
+			testGetAssetLibraryImportProcessesPage_getAssetLibraryExternalReferenceCode()
 		throws Exception {
 
-		return testDepotEntry.getDepotEntryId();
+		return testDepotEntryGroup.getExternalReferenceCode();
 	}
 
-	protected Long
-			testGetAssetLibraryImportProcessesPage_getIrrelevantAssetLibraryId()
+	protected String
+			testGetAssetLibraryImportProcessesPage_getIrrelevantAssetLibraryExternalReferenceCode()
 		throws Exception {
 
-		return irrelevantDepotEntry.getDepotEntryId();
+		return irrelevantDepotEntryGroup.getExternalReferenceCode();
 	}
 
 	@Test
@@ -1080,23 +1099,26 @@ public abstract class BaseImportProcessResourceTestCase {
 
 	@Test
 	public void testGetSiteImportProcessesPage() throws Exception {
-		Long siteId = testGetSiteImportProcessesPage_getSiteId();
-		Long irrelevantSiteId =
-			testGetSiteImportProcessesPage_getIrrelevantSiteId();
+		String siteExternalReferenceCode =
+			testGetSiteImportProcessesPage_getSiteExternalReferenceCode();
+		String irrelevantSiteExternalReferenceCode =
+			testGetSiteImportProcessesPage_getIrrelevantSiteExternalReferenceCode();
 
 		Page<ImportProcess> page =
 			importProcessResource.getSiteImportProcessesPage(
-				siteId, null, null, null, Pagination.of(1, 10), null);
+				siteExternalReferenceCode, null, null, null,
+				Pagination.of(1, 10), null);
 
 		long totalCount = page.getTotalCount();
 
-		if (irrelevantSiteId != null) {
+		if (irrelevantSiteExternalReferenceCode != null) {
 			ImportProcess irrelevantImportProcess =
 				testGetSiteImportProcessesPage_addImportProcess(
-					irrelevantSiteId, randomIrrelevantImportProcess());
+					irrelevantSiteExternalReferenceCode,
+					randomIrrelevantImportProcess());
 
 			page = importProcessResource.getSiteImportProcessesPage(
-				irrelevantSiteId, null, null, null,
+				irrelevantSiteExternalReferenceCode, null, null, null,
 				Pagination.of(1, (int)totalCount + 1), null);
 
 			Assert.assertEquals(totalCount + 1, page.getTotalCount());
@@ -1106,33 +1128,49 @@ public abstract class BaseImportProcessResourceTestCase {
 			assertValid(
 				page,
 				testGetSiteImportProcessesPage_getExpectedActions(
-					irrelevantSiteId));
+					irrelevantSiteExternalReferenceCode));
 		}
 
 		ImportProcess importProcess1 =
 			testGetSiteImportProcessesPage_addImportProcess(
-				siteId, randomImportProcess());
+				siteExternalReferenceCode, randomImportProcess());
 
 		ImportProcess importProcess2 =
 			testGetSiteImportProcessesPage_addImportProcess(
-				siteId, randomImportProcess());
+				siteExternalReferenceCode, randomImportProcess());
 
 		page = importProcessResource.getSiteImportProcessesPage(
-			siteId, null, null, null, Pagination.of(1, 10), null);
+			siteExternalReferenceCode, null, null, null, Pagination.of(1, 10),
+			null);
 
 		Assert.assertEquals(totalCount + 2, page.getTotalCount());
 
 		assertContains(importProcess1, (List<ImportProcess>)page.getItems());
 		assertContains(importProcess2, (List<ImportProcess>)page.getItems());
 		assertValid(
-			page, testGetSiteImportProcessesPage_getExpectedActions(siteId));
+			page,
+			testGetSiteImportProcessesPage_getExpectedActions(
+				siteExternalReferenceCode));
 	}
 
 	protected Map<String, Map<String, String>>
-			testGetSiteImportProcessesPage_getExpectedActions(Long siteId)
+			testGetSiteImportProcessesPage_getExpectedActions(
+				String siteExternalReferenceCode)
 		throws Exception {
 
 		Map<String, Map<String, String>> expectedActions = new HashMap<>();
+
+		Map createBatchAction = new HashMap<>();
+		createBatchAction.put("method", "POST");
+		createBatchAction.put(
+			"href",
+			("http://localhost:" + PortalUtil.getPortalServerPort(false) +
+				"/o/export-import/v1.0/sites/{siteExternalReferenceCode}/import-processes/batch").
+					replace(
+						"{siteExternalReferenceCode}",
+						String.valueOf(siteExternalReferenceCode)));
+
+		expectedActions.put("createBatch", createBatchAction);
 
 		return expectedActions;
 	}
@@ -1141,26 +1179,27 @@ public abstract class BaseImportProcessResourceTestCase {
 	public void testGetSiteImportProcessesPageWithPagination()
 		throws Exception {
 
-		Long siteId = testGetSiteImportProcessesPage_getSiteId();
+		String siteExternalReferenceCode =
+			testGetSiteImportProcessesPage_getSiteExternalReferenceCode();
 
 		Page<ImportProcess> importProcessesPage =
 			importProcessResource.getSiteImportProcessesPage(
-				siteId, null, null, null, null, null);
+				siteExternalReferenceCode, null, null, null, null, null);
 
 		int totalCount = GetterUtil.getInteger(
 			importProcessesPage.getTotalCount());
 
 		ImportProcess importProcess1 =
 			testGetSiteImportProcessesPage_addImportProcess(
-				siteId, randomImportProcess());
+				siteExternalReferenceCode, randomImportProcess());
 
 		ImportProcess importProcess2 =
 			testGetSiteImportProcessesPage_addImportProcess(
-				siteId, randomImportProcess());
+				siteExternalReferenceCode, randomImportProcess());
 
 		ImportProcess importProcess3 =
 			testGetSiteImportProcessesPage_addImportProcess(
-				siteId, randomImportProcess());
+				siteExternalReferenceCode, randomImportProcess());
 
 		// See com.liferay.portal.vulcan.internal.configuration.HeadlessAPICompanyConfiguration#pageSizeLimit
 
@@ -1169,7 +1208,7 @@ public abstract class BaseImportProcessResourceTestCase {
 		if (totalCount >= (pageSizeLimit - 2)) {
 			Page<ImportProcess> page1 =
 				importProcessResource.getSiteImportProcessesPage(
-					siteId, null, null, null,
+					siteExternalReferenceCode, null, null, null,
 					Pagination.of(
 						(int)Math.ceil((totalCount + 1.0) / pageSizeLimit),
 						pageSizeLimit),
@@ -1182,7 +1221,7 @@ public abstract class BaseImportProcessResourceTestCase {
 
 			Page<ImportProcess> page2 =
 				importProcessResource.getSiteImportProcessesPage(
-					siteId, null, null, null,
+					siteExternalReferenceCode, null, null, null,
 					Pagination.of(
 						(int)Math.ceil((totalCount + 2.0) / pageSizeLimit),
 						pageSizeLimit),
@@ -1193,7 +1232,7 @@ public abstract class BaseImportProcessResourceTestCase {
 
 			Page<ImportProcess> page3 =
 				importProcessResource.getSiteImportProcessesPage(
-					siteId, null, null, null,
+					siteExternalReferenceCode, null, null, null,
 					Pagination.of(
 						(int)Math.ceil((totalCount + 3.0) / pageSizeLimit),
 						pageSizeLimit),
@@ -1205,8 +1244,8 @@ public abstract class BaseImportProcessResourceTestCase {
 		else {
 			Page<ImportProcess> page1 =
 				importProcessResource.getSiteImportProcessesPage(
-					siteId, null, null, null, Pagination.of(1, totalCount + 2),
-					null);
+					siteExternalReferenceCode, null, null, null,
+					Pagination.of(1, totalCount + 2), null);
 
 			List<ImportProcess> importProcesses1 =
 				(List<ImportProcess>)page1.getItems();
@@ -1217,8 +1256,8 @@ public abstract class BaseImportProcessResourceTestCase {
 
 			Page<ImportProcess> page2 =
 				importProcessResource.getSiteImportProcessesPage(
-					siteId, null, null, null, Pagination.of(2, totalCount + 2),
-					null);
+					siteExternalReferenceCode, null, null, null,
+					Pagination.of(2, totalCount + 2), null);
 
 			Assert.assertEquals(totalCount + 3, page2.getTotalCount());
 
@@ -1230,7 +1269,7 @@ public abstract class BaseImportProcessResourceTestCase {
 
 			Page<ImportProcess> page3 =
 				importProcessResource.getSiteImportProcessesPage(
-					siteId, null, null, null,
+					siteExternalReferenceCode, null, null, null,
 					Pagination.of(1, (int)totalCount + 3), null);
 
 			assertContains(
@@ -1349,7 +1388,8 @@ public abstract class BaseImportProcessResourceTestCase {
 			return;
 		}
 
-		Long siteId = testGetSiteImportProcessesPage_getSiteId();
+		String siteExternalReferenceCode =
+			testGetSiteImportProcessesPage_getSiteExternalReferenceCode();
 
 		ImportProcess importProcess1 = randomImportProcess();
 		ImportProcess importProcess2 = randomImportProcess();
@@ -1360,19 +1400,19 @@ public abstract class BaseImportProcessResourceTestCase {
 		}
 
 		importProcess1 = testGetSiteImportProcessesPage_addImportProcess(
-			siteId, importProcess1);
+			siteExternalReferenceCode, importProcess1);
 
 		importProcess2 = testGetSiteImportProcessesPage_addImportProcess(
-			siteId, importProcess2);
+			siteExternalReferenceCode, importProcess2);
 
 		Page<ImportProcess> page =
 			importProcessResource.getSiteImportProcessesPage(
-				siteId, null, null, null, null, null);
+				siteExternalReferenceCode, null, null, null, null, null);
 
 		for (EntityField entityField : entityFields) {
 			Page<ImportProcess> ascPage =
 				importProcessResource.getSiteImportProcessesPage(
-					siteId, null, null, null,
+					siteExternalReferenceCode, null, null, null,
 					Pagination.of(1, (int)page.getTotalCount() + 1),
 					entityField.getName() + ":asc");
 
@@ -1383,7 +1423,7 @@ public abstract class BaseImportProcessResourceTestCase {
 
 			Page<ImportProcess> descPage =
 				importProcessResource.getSiteImportProcessesPage(
-					siteId, null, null, null,
+					siteExternalReferenceCode, null, null, null,
 					Pagination.of(1, (int)page.getTotalCount() + 1),
 					entityField.getName() + ":desc");
 
@@ -1395,21 +1435,25 @@ public abstract class BaseImportProcessResourceTestCase {
 	}
 
 	protected ImportProcess testGetSiteImportProcessesPage_addImportProcess(
-			Long siteId, ImportProcess importProcess)
+			String siteExternalReferenceCode, ImportProcess importProcess)
 		throws Exception {
 
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
 	}
 
-	protected Long testGetSiteImportProcessesPage_getSiteId() throws Exception {
-		return testGroup.getGroupId();
-	}
-
-	protected Long testGetSiteImportProcessesPage_getIrrelevantSiteId()
+	protected String
+			testGetSiteImportProcessesPage_getSiteExternalReferenceCode()
 		throws Exception {
 
-		return irrelevantGroup.getGroupId();
+		return testGroup.getExternalReferenceCode();
+	}
+
+	protected String
+			testGetSiteImportProcessesPage_getIrrelevantSiteExternalReferenceCode()
+		throws Exception {
+
+		return irrelevantGroup.getExternalReferenceCode();
 	}
 
 	@Test
@@ -2299,4 +2343,4 @@ public abstract class BaseImportProcessResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1862664561
+// LIFERAY-REST-BUILDER-HASH:104236579

--- a/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ImportProcessResourceTest.java
+++ b/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ImportProcessResourceTest.java
@@ -6,7 +6,6 @@
 package com.liferay.exportimport.rest.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
-import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.exportimport.kernel.background.task.BackgroundTaskExecutorNames;
 import com.liferay.exportimport.kernel.configuration.ExportImportConfigurationSettingsMapFactoryUtil;
 import com.liferay.exportimport.kernel.configuration.constants.ExportImportConfigurationConstants;
@@ -59,7 +58,6 @@ import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
-import com.liferay.portal.vulcan.util.GroupUtil;
 import com.liferay.staging.StagingGroupHelper;
 
 import java.io.File;
@@ -289,13 +287,12 @@ public class ImportProcessResourceTest
 	@Override
 	protected ImportProcess
 			testGetAssetLibraryImportProcessesPage_addImportProcess(
-				Long assetLibraryId, ImportProcess importProcess)
+				String assetLibraryExternalReferenceCode,
+				ImportProcess importProcess)
 		throws Exception {
 
 		return _addImportProcess(
-			GroupUtil.getDepotGroupId(
-				String.valueOf(assetLibraryId), TestPropsValues.getCompanyId(),
-				_depotEntryLocalService, _groupLocalService),
+			_getGroupId(assetLibraryExternalReferenceCode),
 			randomImportProcess());
 	}
 
@@ -316,10 +313,11 @@ public class ImportProcessResourceTest
 
 	@Override
 	protected ImportProcess testGetSiteImportProcessesPage_addImportProcess(
-			Long siteId, ImportProcess importProcess)
+			String siteExternalReferenceCode, ImportProcess importProcess)
 		throws Exception {
 
-		return _addImportProcess(siteId, randomImportProcess());
+		return _addImportProcess(
+			_getGroupId(siteExternalReferenceCode), randomImportProcess());
 	}
 
 	private ImportProcess _addImportProcess(
@@ -392,6 +390,13 @@ public class ImportProcessResourceTest
 	private long _getCompanyGroupId() throws Exception {
 		Group group = _stagingGroupHelper.fetchCompanyGroup(
 			TestPropsValues.getCompanyId());
+
+		return group.getGroupId();
+	}
+
+	private long _getGroupId(String externalReferenceCode) throws Exception {
+		Group group = _groupLocalService.getGroupByExternalReferenceCode(
+			externalReferenceCode, TestPropsValues.getCompanyId());
 
 		return group.getGroupId();
 	}
@@ -582,9 +587,6 @@ public class ImportProcessResourceTest
 
 	@Inject
 	private BackgroundTaskLocalService _backgroundTaskLocalService;
-
-	@Inject
-	private DepotEntryLocalService _depotEntryLocalService;
 
 	@Inject
 	private GroupLocalService _groupLocalService;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94216

## What Is Being Fixed

The import-processes list endpoints identified their scope group by internal numeric ID (`siteId` / `assetLibraryId`). Internal IDs are neither stable nor portable identifiers, and this is inconsistent with the external reference code (ERC) pattern used across the headless APIs.

## How It Is Being Fixed

The `rest-openapi.yaml` site and asset library page operations now take an external reference code path parameter instead of the numeric ID, and the REST artifacts (API, client, base impl, base test case) were regenerated with REST Builder. The resource methods resolve the `Group` through `groupLocalService.fetchGroupByExternalReferenceCode`, validate that it is a site or a depot respectively, and throw a `NotFoundException` otherwise. The integration test was updated to add import processes by ERC. The API package version was bumped to `5.0.0` to reflect the breaking signature change.

## PR Check

**pr-check: PASS** — tested on `8512355b38cb1e2204a43e06701f871be1adf7d4`

| Validation | Result |
| --- | --- |
| REST Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "8512355b38cb1e2204a43e06701f871be1adf7d4"} -->
