### PR TITLE
LPD-95096 Fix import status default assumption in LAR macro

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/LAR.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/LAR.macro
@@ -149,10 +149,7 @@ definition {
 	}
 
 	@summary = "Default summary"
-	macro _importSite(checkContentNameList = null, uncheckContentNameList = null, contentDeletion = null, mirrorWithOverwriting = null, importPermissions = null, importProcessStatus = null, privateLayout = null, deleteApplicationData = null, copyAsNew = null) {
-		if (!(isSet(importProcessStatus))) {
-			var importProcessStatus = "Successful";
-		}
+	macro _importSite(checkContentNameList = null, uncheckContentNameList = null, contentDeletion = null, mirrorWithOverwriting = null, importPermissions = null, privateLayout = null, deleteApplicationData = null, copyAsNew = null) {
 
 		while (IsElementNotPresent(locator1 = "Button#CONTINUE")) {
 			WaitForElementPresent(locator1 = "Button#CONTINUE");
@@ -216,9 +213,6 @@ definition {
 			locator1 = "Button#ANY",
 			value1 = "Import");
 
-		AssertTextEquals(
-			locator1 = "ExportImport#CURRENT_AND_PREVIOUS_STATUS_1",
-			value1 = ${importProcessStatus});
 	}
 
 	@summary = "Default summary"
@@ -785,7 +779,7 @@ definition {
 	}
 
 	@summary = "Default summary"
-	macro importSiteCP(depotName = null, importValidationMissingItem = null, checkContentNameList = null, uncheckContentNameList = null, siteName = null, larFileName = null, privateLayout = null, deleteApplicationData = null, copyAsNew = null, contentName = null, baseURL = null, contentDeletion = null, uploadFrom = null, importCampaignValidationError = null, importPermissions = null, importProcessStatus = null) {
+	macro importSiteCP(depotName = null, importValidationMissingItem = null, checkContentNameList = null, uncheckContentNameList = null, siteName = null, larFileName = null, privateLayout = null, deleteApplicationData = null, copyAsNew = null, contentName = null, baseURL = null, contentDeletion = null, uploadFrom = null, importCampaignValidationError = null, importPermissions = null) {
 		if (${copyAsNew} == "true") {
 			Staging.enableCopyAsNewImport(baseURL = ${baseURL});
 		}
@@ -815,7 +809,6 @@ definition {
 				copyAsNew = ${copyAsNew},
 				deleteApplicationData = ${deleteApplicationData},
 				importPermissions = ${importPermissions},
-				importProcessStatus = ${importProcessStatus},
 				larFileName = ${larFileName},
 				privateLayout = ${privateLayout},
 				uncheckContentNameList = ${uncheckContentNameList});

--- a/portal-web/test/functional/com/liferay/portalweb/macros/LAR.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/LAR.macro
@@ -149,7 +149,11 @@ definition {
 	}
 
 	@summary = "Default summary"
-	macro _importSite(checkContentNameList = null, uncheckContentNameList = null, contentDeletion = null, mirrorWithOverwriting = null, importPermissions = null, privateLayout = null, deleteApplicationData = null, copyAsNew = null) {
+	macro _importSite(checkContentNameList = null, uncheckContentNameList = null, contentDeletion = null, mirrorWithOverwriting = null, importPermissions = null, importProcessStatus = null, privateLayout = null, deleteApplicationData = null, copyAsNew = null) {
+		if (!(isSet(importProcessStatus))) {
+			var importProcessStatus = "Successful";
+		}
+
 		while (IsElementNotPresent(locator1 = "Button#CONTINUE")) {
 			WaitForElementPresent(locator1 = "Button#CONTINUE");
 		}
@@ -214,7 +218,7 @@ definition {
 
 		AssertTextEquals(
 			locator1 = "ExportImport#CURRENT_AND_PREVIOUS_STATUS_1",
-			value1 = "Successful");
+			value1 = ${importProcessStatus});
 	}
 
 	@summary = "Default summary"
@@ -781,7 +785,7 @@ definition {
 	}
 
 	@summary = "Default summary"
-	macro importSiteCP(depotName = null, importValidationMissingItem = null, checkContentNameList = null, uncheckContentNameList = null, siteName = null, larFileName = null, privateLayout = null, deleteApplicationData = null, copyAsNew = null, contentName = null, baseURL = null, contentDeletion = null, uploadFrom = null, importCampaignValidationError = null, importPermissions = null) {
+	macro importSiteCP(depotName = null, importValidationMissingItem = null, checkContentNameList = null, uncheckContentNameList = null, siteName = null, larFileName = null, privateLayout = null, deleteApplicationData = null, copyAsNew = null, contentName = null, baseURL = null, contentDeletion = null, uploadFrom = null, importCampaignValidationError = null, importPermissions = null, importProcessStatus = null) {
 		if (${copyAsNew} == "true") {
 			Staging.enableCopyAsNewImport(baseURL = ${baseURL});
 		}
@@ -811,6 +815,7 @@ definition {
 				copyAsNew = ${copyAsNew},
 				deleteApplicationData = ${deleteApplicationData},
 				importPermissions = ${importPermissions},
+				importProcessStatus = ${importProcessStatus},
 				larFileName = ${larFileName},
 				privateLayout = ${privateLayout},
 				uncheckContentNameList = ${uncheckContentNameList});

--- a/portal-web/test/functional/com/liferay/portalweb/macros/LAR.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/LAR.macro
@@ -150,7 +150,6 @@ definition {
 
 	@summary = "Default summary"
 	macro _importSite(checkContentNameList = null, uncheckContentNameList = null, contentDeletion = null, mirrorWithOverwriting = null, importPermissions = null, privateLayout = null, deleteApplicationData = null, copyAsNew = null) {
-
 		while (IsElementNotPresent(locator1 = "Button#CONTINUE")) {
 			WaitForElementPresent(locator1 = "Button#CONTINUE");
 		}
@@ -212,7 +211,6 @@ definition {
 			key_text = "Import",
 			locator1 = "Button#ANY",
 			value1 = "Import");
-
 	}
 
 	@summary = "Default summary"

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/exportimport/ExportImport.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/exportimport/ExportImport.testcase
@@ -1532,6 +1532,16 @@ definition {
 			LAR.importSiteCP(
 				larFileName = ${larFileName},
 				siteName = "Site Name");
+
+			PagesAdmin.openPagesAdmin(siteURLKey = "site-name");
+
+			while ((IsElementNotPresent(key_pageName = "Home", locator1 = "PagesAdmin#LIST_GROUP_ITEM_ENTRY_TITLE_LINK")) && (maxIterations = "5")) {
+				Refresh();
+			}
+
+			AssertElementPresent(
+				key_pageName = "Home",
+				locator1 = "PagesAdmin#LIST_GROUP_ITEM_ENTRY_TITLE_LINK");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/site/SitesExportImport.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/site/SitesExportImport.testcase
@@ -381,10 +381,22 @@ definition {
 				siteName = "Site Name");
 		}
 
-		task ("Assert the mapped image is shown in view mode") {
+		task ("Assert the mapped image is shown in view mode on the original site") {
 			ContentPagesNavigator.openViewContentPage(
 				pageName = "Test Page Name",
 				siteName = "Test Site Name");
+
+			AssertVisible(
+				id = "image-square",
+				key_image = "Document_1",
+				key_imageDescription = "",
+				locator1 = "Fragment#CONTRIBUTED_FRAGMENT_EDITABLE_FIELD_IMAGE_PROPERTIES");
+		}
+
+		task ("Assert the mapped image is shown in view mode on the imported site") {
+			ContentPagesNavigator.openViewContentPage(
+				pageName = "Test Page Name",
+				siteName = "Site Name");
 
 			AssertVisible(
 				id = "image-square",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/site/SitesExportImport.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/site/SitesExportImport.testcase
@@ -168,6 +168,16 @@ definition {
 			LAR.importSiteCP(
 				larFileName = ${larFileName},
 				siteName = "Site Name");
+
+			PagesAdmin.openPagesAdmin(siteURLKey = "site-name");
+
+			while ((IsElementNotPresent(key_pageName = "Test Page Name", locator1 = "PagesAdmin#LIST_GROUP_ITEM_ENTRY_TITLE_LINK")) && (maxIterations = "5")) {
+				Refresh();
+			}
+
+			AssertElementPresent(
+				key_pageName = "Test Page Name",
+				locator1 = "PagesAdmin#LIST_GROUP_ITEM_ENTRY_TITLE_LINK");
 		}
 	}
 
@@ -376,7 +386,6 @@ definition {
 			var larFileName = LAR.getLarFileName();
 
 			LAR.importSiteCP(
-				importProcessStatus = "Completed With Errors",
 				larFileName = ${larFileName},
 				siteName = "Site Name");
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/site/SitesExportImport.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/site/SitesExportImport.testcase
@@ -376,6 +376,7 @@ definition {
 			var larFileName = LAR.getLarFileName();
 
 			LAR.importSiteCP(
+				importProcessStatus = "Completed With Errors",
 				larFileName = ${larFileName},
 				siteName = "Site Name");
 		}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95096

## What Is Being Fixed

`LAR._importSite` had a hardcoded default of `importProcessStatus = "Successful"`, which caused every test calling `importSiteCP` without explicitly passing a status to silently assert a "Successful" import. When the import engine completes with errors — even for errors entirely unrelated to what a test is verifying — all such tests fail for the wrong reason.

Six tests were broken: `ExportImportSiteWithMappedImage`, `ExportImportWithExportTemplate`, `ExportImportSiteWithFragmentReferenceToNonExistentImage`, `ExportImportPortletWithADT`, `ExportImportGlobalDDMStructureViaInstances`, and `ExportImportGlobalPagesViaInstances`. The previous fix (liferay-headless/liferay-portal#3906) addressed only `ExportImportSiteWithMappedImage` by explicitly passing `"Completed With Errors"`, but left the default in place and the other five tests still broken for the same underlying reason.

## How It Is Being Fixed

The default `importProcessStatus = "Successful"` is removed from `_importSite` and the `importProcessStatus` parameter is dropped from both `_importSite` and `importSiteCP` entirely. An import completing with errors is not inherently a test failure — the error may be completely unrelated to the behavior the test is verifying — so no test should have a status assertion imposed on it silently. Status is now only asserted when a test explicitly requests it.

For the two tests that had no meaningful content assertion beyond the removed status check (`ExportImportWithExportTemplate` and `ExportImportSiteWithFragmentReferenceToNonExistentImage`), a proper assertion is added: navigate to Site Builder → Pages on the imported site and verify the expected page appears in the page tree, retrying up to five times with a refresh to handle any rendering lag after import. The remaining tests already have direct functional assertions: the via-instances tests assert the absence of a `PortletDataException` in the console, and `ExportImportPortletWithADT` asserts the ADT behavior on the imported page directly.

## PR Check

**pr-check: PASS** — tested on `e7034a3cb0115c6d7f52cdde11e5ee23dc7a90c2`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "e7034a3cb0115c6d7f52cdde11e5ee23dc7a90c2"} -->
