### PR TITLE
LPD-95823 Refresh when navbar is absent in _gotoPage

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/Navigator.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Navigator.macro
@@ -6,9 +6,14 @@ definition {
 		var count = 0;
 
 		while ((${count} != 3) && (IsElementNotPresent(locator1 = "Home#PAGE_ACTIVE"))) {
-			AssertClick.assertPartialTextClickAt(
-				locator1 = "Home#PAGE",
-				value1 = ${pageName});
+			if (IsElementPresent(locator1 = "Home#PAGE")) {
+				AssertClick.assertPartialTextClickAt(
+					locator1 = "Home#PAGE",
+					value1 = ${pageName});
+			}
+			else {
+				Refresh();
+			}
 
 			var count = ${count} + 1;
 		}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95823

## What Is Being Fixed

All 20 tests in StagingUsecase that call Navigator.gotoStagedSitePage were failing with ElementNotFoundPoshiRunnerException on the staging navbar element after commit ac9159a (LPD-94744) added utility page processing to the staging init.

## How It Is Being Fixed

Enabling staging via API returns before the portal has flushed its routing cache for the new staging group URL. The first navigation to the staging site therefore hits a 404, leaving the navbar absent and causing AssertClick to throw immediately before the retry loop could help. The _gotoPage macro now refreshes instead of crashing when Home#PAGE is not present, giving the portal time to flush its routing cache, then retries up to three times before asserting visibility.

## PR Check

**pr-check: PASS** — tested on `2d69822662893c9a38b025e686cd00b52c3d30e5`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "2d69822662893c9a38b025e686cd00b52c3d30e5"} -->

cc @GaborKomaromi 
