### PR TITLE
LPD-95967 Fix staging bar tests failing after LPD-94744 widens routing-cache flush window

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/Navigator.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Navigator.macro
@@ -368,6 +368,14 @@ definition {
 		else {
 			Open(value1 = "${baseURL}/web/${siteNameURL}-staging");
 		}
+
+		var count = 0;
+
+		while ((${count} != 3) && (IsElementNotPresent(locator1 = "Staging#STAGING_PUBLISH_TO_LIVE_BUTTON"))) {
+			Refresh();
+
+			var count = ${count} + 1;
+		}
 	}
 
 	@summary = "Default summary"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95967

## What Is Being Fixed

Eight Poshi tests in PGStagingWithVersioning and StagingUsecaseWithVersioning fail with ElementNotFoundPoshiRunnerException on Icon#STAGING_BAR_VERTICAL_ELLIPSIS. Commit ac9159a (LPD-94744) added utility page processing to the staging init sequence, widening the window between JSONStaging.enableLocalStaging() returning and the portal flushing its routing cache for the new staging group URL. The browser navigates to the staging URL immediately after setUp and lands on a 404; the test body then looks for the staging bar ellipsis on that 404 page and fails.

## How It Is Being Fixed

A retry loop (up to 3 attempts) is added to Navigator.openStagingSiteURL in portal-web/test/functional/com/liferay/portalweb/macros/Navigator.macro. After the initial Open(url) call, the macro checks for Staging#STAGING_PUBLISH_TO_LIVE_BUTTON — always present on any staging-enabled site page for a logged-in admin — and refreshes until it appears or the retry limit is reached. This gives the portal's routing cache time to flush before the test body executes. The pattern mirrors the _gotoPage fix already merged for the related LPD-95823 work.

## PR Check

**pr-check: PASS** — tested on `c7624963824d083af5ce49799c2ab0d43d20f0f2`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "c7624963824d083af5ce49799c2ab0d43d20f0f2"} -->

cc @GaborKomaromi 
