### PR TITLE
LPD-95971 Refine the import file selector spacing and alignment

### DIFF
--- a/modules/apps/export-import/export-import-web/package.json
+++ b/modules/apps/export-import/export-import-web/package.json
@@ -14,6 +14,7 @@
 		"@clayui/modal": "^3.165.0",
 		"@clayui/multi-step-nav": "^3.165.0",
 		"@clayui/progress-bar": "^3.165.0",
+		"@clayui/sticker": "^3.165.0",
 		"@liferay/frontend-data-set-web": "*",
 		"@liferay/layout-js-components-web": "*",
 		"classnames": "2.3.1",

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/FileSelector.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/FileSelector.tsx
@@ -12,6 +12,7 @@ import ClayAlert from '@clayui/alert';
 import {ButtonWithIcon} from '@clayui/core';
 import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
+import ClaySticker from '@clayui/sticker';
 import {formatStorage} from 'frontend-js-web';
 
 import DragZone from './forms/DragZone';
@@ -103,67 +104,70 @@ export default function FileSelector({
 			aria-labelledby={ariaLabelledby}
 		>
 			{config.showFileInfo && file && (
-				<div className="align-items-center border border-light flex-fill p-4 rounded">
-					<ClayLayout.Row>
-						<ClayLayout.Col lg={1}>
-							<ClayIcon
-								className="text-secondary"
-								symbol="document"
-							/>
-						</ClayLayout.Col>
-
-						<ClayLayout.Col lg={9}>
-							<p className="font-weight-semi-bold mb-1">
-								{file.name}
-							</p>
-
-							<p className="mb-1">
-								{formatStorage(file.size, {
-									addSpaceBeforeSuffix: true,
-								})}
-							</p>
-						</ClayLayout.Col>
-
-						<ClayLayout.Col
-							className="d-flex justify-content-end"
-							lg={2}
-						>
-							<ButtonWithIcon
-								aria-label={Liferay.Language.get('remove-file')}
-								borderless
+				<div className="border flex-fill p-3 rounded">
+					<ClayLayout.ContentRow padded verticalAlign="center">
+						<ClayLayout.ContentCol>
+							<ClaySticker
+								className="sticker-border-secondary"
 								displayType="secondary"
-								onClick={onRemove}
-								symbol="times"
-							/>
-						</ClayLayout.Col>
-					</ClayLayout.Row>
+							>
+								<ClayIcon symbol="document" />
+							</ClaySticker>
+						</ClayLayout.ContentCol>
 
-					{config.showProgressBar && (
-						<ClayLayout.Row className="flex-fill mt-2">
-							<ClayLayout.Col lg={12}>
-								<ProgressBar
-									fillBarClassName={
-										status === 'VALIDATING'
-											? 'progress-bar-animated progress-bar-striped'
-											: ''
-									}
-									value={
-										status === 'SUCCESS' ||
-										status === 'VALIDATING'
-											? 100
-											: progress ?? 0
-									}
-								/>
+						<ClayLayout.ContentCol expand>
+							<ClayLayout.ContentRow verticalAlign="center">
+								<ClayLayout.ContentCol expand>
+									<div className="font-weight-semi-bold">
+										{file.name}
+									</div>
 
-								<div
-									aria-live="polite"
-									className="mt-1 small text-secondary"
-								>
-									{config.statusText}...
+									<div className="small text-secondary">
+										{formatStorage(file.size, {
+											addSpaceBeforeSuffix: true,
+										})}
+									</div>
+								</ClayLayout.ContentCol>
+
+								<ClayLayout.ContentCol>
+									<ButtonWithIcon
+										aria-label={Liferay.Language.get(
+											'remove-file'
+										)}
+										borderless
+										displayType="secondary"
+										onClick={onRemove}
+										symbol="times"
+									/>
+								</ClayLayout.ContentCol>
+							</ClayLayout.ContentRow>
+
+							{config.showProgressBar && (
+								<div className="mt-2">
+									<ProgressBar
+										fillBarClassName={
+											status === 'VALIDATING'
+												? 'progress-bar-animated progress-bar-striped'
+												: ''
+										}
+										value={
+											status === 'SUCCESS' ||
+											status === 'VALIDATING'
+												? 100
+												: progress ?? 0
+										}
+									/>
+
+									<div
+										aria-live="polite"
+										className="mt-1 small text-secondary"
+									>
+										{config.statusText}...
+									</div>
 								</div>
-							</ClayLayout.Col>
-						</ClayLayout.Row>
-					)}
+							)}
+						</ClayLayout.ContentCol>
+					</ClayLayout.ContentRow>
 				</div>
 			)}
 

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/steps/SettingsStep.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/steps/SettingsStep.tsx
@@ -151,9 +151,9 @@ function SectionHeader({
 	title: string;
 }) {
 	return (
-		<ClayLayout.SheetHeader className="mb-1">
+		<ClayLayout.SheetHeader className="mb-0">
 			<div
-				className="mb-2 sheet-title"
+				className="sheet-title"
 				id={name ? `${name}-label` : undefined}
 			>
 				<span className="inline-item inline-item-before small text-secondary">


### PR DESCRIPTION
# [LPD-95971](https://liferay.atlassian.net/browse/LPD-95971)

## What

Refines the spacing and alignment of the revamp import flow: the uploaded-file card in the file selector (`FileSelector.tsx`) and the section headers in the Settings step (`SettingsStep.tsx`), so both are more compact and properly aligned, matching the design.

## Why

In the revamp import flow, the uploaded-file card took up too much vertical space and its elements (icon, file name, size, and progress bar) were loosely spaced and not properly aligned, so it did not match the design.

The card previously used a 12-column `ClayLayout.Row` / `Col` grid with the progress bar living in a separate full-width row below the file metadata. This produced uneven spacing and excess height.

The Settings step section titles were also too close to their content, so the section header whitespace needed adjusting to match the design.

## Changes

**Import file selector card** (`FileSelector.tsx`):

- Rebuild the uploaded-file card on the standard file-row idiom used by `MultipleFileUploader` (`ClayLayout.ContentRow` / `ContentCol`) instead of the 12-column grid.
- Replace the bare small icon with a 32px document `ClaySticker`.
- Show the file size as smaller secondary metadata (`small text-secondary`) sitting tight under the file name.
- Vertically center the remove (X) button and the icon within the row.
- Move the upload percentage inline into the progress bar (Clay's `progress-group` addon) instead of a separate full-width row with a status text line below.
- Tighten the card padding from `p-4` to `p-3` and use the default border color.
- Add the `@clayui/sticker` dependency in `package.json` for the document sticker.

**Import settings step** (`SettingsStep.tsx`):

- Adjust the section header spacing (SheetHeader mb-0 and the sheet-title without a bottom margin) so each section title is spaced further from its content, matching the design.

## Screenshots

### Current / New file selector

<img width="3458" height="1914" alt="image" src="https://github.com/user-attachments/assets/36439535-965f-4d4b-a6ea-4b78d33cf17a" />


### Seettings title margin
<img width="3453" height="1737" alt="image" src="https://github.com/user-attachments/assets/7d18d92e-3bc1-472d-93de-bca24153b640" />
