### PR TITLE
LPD-95672 Group page template export/import under Page Templates

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/build.gradle
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 	compileOnly project(":apps:journal:journal-api")
 	compileOnly project(":apps:layout:layout-admin-api")
 	compileOnly project(":apps:layout:layout-api")
+	compileOnly project(":apps:layout:layout-page-template-admin-api")
 	compileOnly project(":apps:layout:layout-page-template-api")
 	compileOnly project(":apps:layout:layout-seo-api")
 	compileOnly project(":apps:layout:layout-utility-page-api")

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/DisplayPageTemplateFolderResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/DisplayPageTemplateFolderResourceImpl.java
@@ -119,7 +119,7 @@ public class DisplayPageTemplateFolderResourceImpl
 
 			@Override
 			public String getSectionKey() {
-				return ExportImportConstants.SECTION_KEY_SITE_BUILDER;
+				return ExportImportConstants.SECTION_KEY_DESIGN;
 			}
 
 			@Override

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/DisplayPageTemplateFolderResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/DisplayPageTemplateFolderResourceImpl.java
@@ -13,7 +13,7 @@ import com.liferay.headless.admin.site.internal.resource.v1_0.util.DisplayPageTe
 import com.liferay.headless.admin.site.internal.util.EnabledUtil;
 import com.liferay.headless.admin.site.resource.v1_0.DisplayPageTemplateFolderResource;
 import com.liferay.headless.common.spi.util.GroupUtil;
-import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
+import com.liferay.layout.page.template.admin.constants.LayoutPageTemplateAdminPortletKeys;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateCollectionTypeConstants;
 import com.liferay.layout.page.template.model.LayoutPageTemplateCollection;
 import com.liferay.layout.page.template.service.LayoutPageTemplateCollectionService;
@@ -109,7 +109,7 @@ public class DisplayPageTemplateFolderResourceImpl
 
 			@Override
 			public String getPortletId() {
-				return LayoutAdminPortletKeys.GROUP_PAGES;
+				return LayoutPageTemplateAdminPortletKeys.LAYOUT_PAGE_TEMPLATES;
 			}
 
 			@Override

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/DisplayPageTemplateResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/DisplayPageTemplateResourceImpl.java
@@ -167,7 +167,7 @@ public class DisplayPageTemplateResourceImpl
 
 			@Override
 			public String getSectionKey() {
-				return ExportImportConstants.SECTION_KEY_SITE_BUILDER;
+				return ExportImportConstants.SECTION_KEY_DESIGN;
 			}
 
 			@Override

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/DisplayPageTemplateResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/DisplayPageTemplateResourceImpl.java
@@ -34,6 +34,7 @@ import com.liferay.headless.common.spi.util.GroupUtil;
 import com.liferay.info.item.InfoItemServiceRegistry;
 import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
 import com.liferay.layout.admin.kernel.model.LayoutTypePortletConstants;
+import com.liferay.layout.page.template.admin.constants.LayoutPageTemplateAdminPortletKeys;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateCollectionTypeConstants;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateConstants;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
@@ -156,7 +157,7 @@ public class DisplayPageTemplateResourceImpl
 
 			@Override
 			public String getPortletId() {
-				return LayoutAdminPortletKeys.GROUP_PAGES;
+				return LayoutPageTemplateAdminPortletKeys.LAYOUT_PAGE_TEMPLATES;
 			}
 
 			@Override

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/MasterPageResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/MasterPageResourceImpl.java
@@ -143,7 +143,7 @@ public class MasterPageResourceImpl
 
 			@Override
 			public String getSectionKey() {
-				return ExportImportConstants.SECTION_KEY_SITE_BUILDER;
+				return ExportImportConstants.SECTION_KEY_DESIGN;
 			}
 
 			@Override

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/MasterPageResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/MasterPageResourceImpl.java
@@ -23,6 +23,7 @@ import com.liferay.headless.admin.site.resource.v1_0.MasterPageResource;
 import com.liferay.headless.common.spi.util.GroupUtil;
 import com.liferay.info.item.InfoItemServiceRegistry;
 import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
+import com.liferay.layout.page.template.admin.constants.LayoutPageTemplateAdminPortletKeys;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateConstants;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
@@ -132,7 +133,7 @@ public class MasterPageResourceImpl
 
 			@Override
 			public String getPortletId() {
-				return LayoutAdminPortletKeys.GROUP_PAGES;
+				return LayoutPageTemplateAdminPortletKeys.LAYOUT_PAGE_TEMPLATES;
 			}
 
 			@Override

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageTemplateResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageTemplateResourceImpl.java
@@ -168,7 +168,7 @@ public class PageTemplateResourceImpl
 
 			@Override
 			public String getSectionKey() {
-				return ExportImportConstants.SECTION_KEY_SITE_BUILDER;
+				return ExportImportConstants.SECTION_KEY_DESIGN;
 			}
 
 			@Override

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageTemplateResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageTemplateResourceImpl.java
@@ -31,6 +31,7 @@ import com.liferay.headless.admin.site.resource.v1_0.PageTemplateResource;
 import com.liferay.headless.common.spi.util.GroupUtil;
 import com.liferay.info.item.InfoItemServiceRegistry;
 import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
+import com.liferay.layout.page.template.admin.constants.LayoutPageTemplateAdminPortletKeys;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateCollectionTypeConstants;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateConstants;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
@@ -157,7 +158,7 @@ public class PageTemplateResourceImpl
 
 			@Override
 			public String getPortletId() {
-				return LayoutAdminPortletKeys.GROUP_PAGES;
+				return LayoutPageTemplateAdminPortletKeys.LAYOUT_PAGE_TEMPLATES;
 			}
 
 			@Override

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageTemplateSetResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageTemplateSetResourceImpl.java
@@ -14,7 +14,7 @@ import com.liferay.headless.admin.site.internal.resource.v1_0.util.PageTemplateS
 import com.liferay.headless.admin.site.internal.util.EnabledUtil;
 import com.liferay.headless.admin.site.resource.v1_0.PageTemplateSetResource;
 import com.liferay.headless.common.spi.util.GroupUtil;
-import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
+import com.liferay.layout.page.template.admin.constants.LayoutPageTemplateAdminPortletKeys;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateCollectionTypeConstants;
 import com.liferay.layout.page.template.model.LayoutPageTemplateCollection;
 import com.liferay.layout.page.template.service.LayoutPageTemplateCollectionService;
@@ -108,7 +108,7 @@ public class PageTemplateSetResourceImpl
 
 			@Override
 			public String getPortletId() {
-				return LayoutAdminPortletKeys.GROUP_PAGES;
+				return LayoutPageTemplateAdminPortletKeys.LAYOUT_PAGE_TEMPLATES;
 			}
 
 			@Override

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageTemplateSetResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageTemplateSetResourceImpl.java
@@ -118,7 +118,7 @@ public class PageTemplateSetResourceImpl
 
 			@Override
 			public String getSectionKey() {
-				return ExportImportConstants.SECTION_KEY_SITE_BUILDER;
+				return ExportImportConstants.SECTION_KEY_DESIGN;
 			}
 
 			@Override

--- a/modules/apps/layout/layout-page-template-test/build.gradle
+++ b/modules/apps/layout/layout-page-template-test/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:layout:layout-admin-api")
 	testIntegrationImplementation project(":apps:layout:layout-api")
 	testIntegrationImplementation project(":apps:layout:layout-display-page-api")
+	testIntegrationImplementation project(":apps:layout:layout-page-template-admin-api")
 	testIntegrationImplementation project(":apps:layout:layout-page-template-api")
 	testIntegrationImplementation project(":apps:layout:layout-page-template-service")
 	testIntegrationImplementation project(":apps:layout:layout-page-template-test-util")

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/exportimport/test/LayoutPageTemplatePortletDataHandlerTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/exportimport/test/LayoutPageTemplatePortletDataHandlerTest.java
@@ -13,7 +13,7 @@ import com.liferay.exportimport.kernel.model.ExportImportConfiguration;
 import com.liferay.exportimport.kernel.service.ExportImportConfigurationLocalService;
 import com.liferay.exportimport.kernel.service.ExportImportLocalService;
 import com.liferay.journal.model.JournalArticle;
-import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
+import com.liferay.layout.page.template.admin.constants.LayoutPageTemplateAdminPortletKeys;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateCollectionTypeConstants;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateConstants;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
@@ -279,7 +279,7 @@ public class LayoutPageTemplatePortletDataHandlerTest {
 			new String[] {Boolean.TRUE.toString()}
 		).put(
 			PortletDataHandlerKeys.PORTLET_DATA + "_" +
-				LayoutAdminPortletKeys.GROUP_PAGES,
+				LayoutPageTemplateAdminPortletKeys.LAYOUT_PAGE_TEMPLATES,
 			new String[] {Boolean.TRUE.toString()}
 		).build();
 	}

--- a/modules/test/playwright/tests/export-import-web/main/pages/ExportImportPage.ts
+++ b/modules/test/playwright/tests/export-import-web/main/pages/ExportImportPage.ts
@@ -256,15 +256,44 @@ export class ExportImportPage {
 		label: string | RegExp,
 		{
 			counts = {},
+			portletId,
 			registrations,
 		}: {
 			counts?: {deletions?: number; items?: number};
+			portletId?: string;
 			registrations?: Array<{
 				counts: {deletions?: number; items?: number};
 				label: string | RegExp;
 			}>;
 		} = {}
 	) {
+		if (portletId) {
+			if (registrations) {
+				await this._expandPortlet(portletId);
+			}
+
+			await this._assertLabelCounts(
+				this._portletLabel(portletId),
+				counts
+			);
+
+			const contentLocator = this.page.locator(
+				`[id$="_content_${portletId}"]`
+			);
+
+			for (const registration of registrations ?? []) {
+				await this._assertLabelCounts(
+					this._filterLabels(
+						contentLocator.locator('label'),
+						registration.label
+					),
+					registration.counts
+				);
+			}
+
+			return;
+		}
+
 		if (registrations) {
 			if (typeof label === 'string') {
 				await this.page
@@ -311,6 +340,34 @@ export class ExportImportPage {
 		await this._assertPortletEntryCounts(label, {deletions: 'hidden'});
 	}
 
+	private _filterLabels(labels: Locator, label: string | RegExp): Locator {
+		return labels.filter(
+			typeof label === 'string'
+				? {has: this.page.locator(`:text-is("${label}")`)}
+				: {hasText: label}
+		);
+	}
+
+	private _portletLabel(portletId: string): Locator {
+		return this.page.locator('label').filter({
+			has: this.page.locator(`input[name$="_PORTLET_DATA_${portletId}"]`),
+		});
+	}
+
+	private async _expandPortlet(portletId: string) {
+		const dataCheckbox = this.page.locator(
+			`input[name$="_PORTLET_DATA_${portletId}"]`
+		);
+
+		if (!(await dataCheckbox.isChecked())) {
+			await dataCheckbox.check();
+		}
+
+		await this.page
+			.locator(`button.content-link[data-portletid="${portletId}"]`)
+			.click();
+	}
+
 	private async _assertPortletEntryCounts(
 		label: string | RegExp,
 		counts: {
@@ -318,12 +375,19 @@ export class ExportImportPage {
 			items?: 'absent' | number;
 		}
 	) {
-		const filter =
-			typeof label === 'string'
-				? {has: this.page.locator(`:text-is("${label}")`)}
-				: {hasText: label};
+		await this._assertLabelCounts(
+			this._filterLabels(this.page.locator('label'), label),
+			counts
+		);
+	}
 
-		const labelLocator = this.page.locator('label').filter(filter);
+	private async _assertLabelCounts(
+		labelLocator: Locator,
+		counts: {
+			deletions?: 'absent' | 'hidden' | number;
+			items?: 'absent' | number;
+		}
+	) {
 		const {deletions, items} = counts;
 
 		if (items !== undefined) {

--- a/modules/test/playwright/tests/export-import-web/main/site.export.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/main/site.export.spec.ts
@@ -188,7 +188,7 @@ test(
 
 		await uiElementsPage.clickNewButton();
 
-		await exportImportPage.expectPortletCounts(/^\s*Pages\s*/, {
+		await exportImportPage.expectPortletCounts(/^\s*Page Templates\s*/, {
 			registrations: [{counts: {items: 2}, label: 'Master Pages'}],
 		});
 	}
@@ -372,12 +372,16 @@ test(
 
 			await uiElementsPage.clickNewButton();
 
-			await exportImportPage.expectPortletDeletionsHidden('Pages');
+			await exportImportPage.expectPortletDeletionsHidden(
+				'Page Templates'
+			);
 
 			await exportImportPage.deletionsLabel.check();
 
-			await exportImportPage.expectPortletCounts('Pages', {
+			await exportImportPage.expectPortletCounts('Page Templates', {
 				counts: {deletions: 5},
+				portletId:
+					'com_liferay_layout_page_template_admin_web_portlet_LayoutPageTemplatesPortlet',
 				registrations: [
 					{
 						counts: {deletions: 1},


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95672

## What Is Being Fixed

The headless export/import descriptors for page templates, display page templates, master pages, and page template sets pointed their staged-model data handlers at the Group Pages portlet (`LayoutAdminPortletKeys.GROUP_PAGES`) and filed them under the Site Builder export/import section. That misplaced page template content under Pages in the export/import UI instead of under the Page Templates portlet where it belongs, and it sat in the wrong section grouping.

## How It Is Being Fixed

The four `headless-admin-site` resource implementations now report `LayoutPageTemplateAdminPortletKeys.LAYOUT_PAGE_TEMPLATES` as their portlet ID and `ExportImportConstants.SECTION_KEY_DESIGN` as their section key, grouping page template export/import under the Page Templates portlet within the Design category. The `headless-admin-site-impl` build picks up the `layout-page-template-admin-api` dependency for the new portlet-key constant. The `LayoutPageTemplatePortletDataHandlerTest` integration test and the `export-import-web` Playwright specs are updated to assert against the new portlet key and the Design section placement.

## PR Check

**pr-check: PASS** — tested on `0dfceecc1a4e9f8385b8a9b7c03f676b26bf56d1`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "0dfceecc1a4e9f8385b8a9b7c03f676b26bf56d1"} -->
