### PR TITLE
LPD-95978 Fix ImportDMUrlWithoutUUID for CKEditor 5 default

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/CKEditor.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/CKEditor.macro
@@ -154,6 +154,14 @@ definition {
 	}
 
 	@summary = "Default summary"
+	macro assertBodyLinkWithoutUUID(fieldLabel = null, fileName = null) {
+		AssertElementPresent(
+			key_fieldLabel = ${fieldLabel},
+			key_fileName = ${fileName},
+			locator1 = "CKEditor#BODY_FIELD_CONTENTEDITABLE_LINK_WITHOUT_UUID");
+	}
+
+	@summary = "Default summary"
 	macro assertEditorPresent() {
 		AssertElementPresent(locator1 = "CKEditor#BODY_FIELD");
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/CKEditor.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/CKEditor.path
@@ -61,6 +61,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>BODY_FIELD_CONTENTEDITABLE_LINK_WITHOUT_UUID</td>
+	<td>//label[contains(.,'${key_fieldLabel}')]//following-sibling::div//div[contains(@class,'ck-editor__editable_inline')]//a[contains(@href,'${key_fileName}') and not(contains(@href,'${key_fileName}/'))]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>BODY</td>
 	<td>//body[contains(@class,'cke_editable')]</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/exportimport/ExportImport.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/exportimport/ExportImport.testcase
@@ -1250,21 +1250,15 @@ definition {
 
 			DMDocument.expandInfo();
 
-			var dmDocumentURL = selenium.getAttribute("//input[contains(@id,'urlInput')]@value");
-
-			var editDocumentURL = StringUtil.extractFirst(${dmDocumentURL}, "jpg");
+			var editDocumentURL = selenium.getAttribute("//input[contains(@id,'urlInput')]@value");
 		}
 
 		task ("And: Create a new WC with the saved URL as reference in the source content") {
-			WebContentNavigator.openWebContentAdmin(siteURLKey = "guest");
-
-			WebContentNavigator.gotoAddCP();
-
-			PortletEntry.inputTitle(title = "Web Content Title");
-
-			CKEditor.addSourceContent(content = '''<a href="${editDocumentURL}jpg">Link to Document</a>''');
-
-			WebContent.publishWithPermissions();
+			JSONWebcontent.addWebContent(
+				content = '''<a href="${editDocumentURL}">Link to Document</a>''',
+				groupName = "Guest",
+				source = "true",
+				title = "Web Content Title");
 		}
 
 		task ("When: User export with default settings") {
@@ -1302,7 +1296,9 @@ definition {
 
 			WebContentNavigator.gotoEditCP(webContentTitle = "Web Content Title");
 
-			CKEditor.assertSourceContent();
+			CKEditor.assertBodyLinkWithoutUUID(
+				fieldLabel = "Content",
+				fileName = "document_1");
 		}
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95978

## Failing Test

`LocalFile.ExportImport#ImportDMUrlWithoutUUID`

`portal-web/test/functional/com/liferay/portalweb/tests/enduser/exportimport/ExportImport.testcase`

```
com.liferay.poshi.runner.exception.ElementNotFoundPoshiRunnerException: Element is not present at "//a[contains(@class,'cke_button') and contains(@class,'source')]"
```

## Root Cause

The CKEditor 4 to CKEditor 5 migration. The journal article editor is gated on the `LPD-11235` deprecation feature flag, which CI runs disabled, so the editor renders as CKEditor 5 and the CKEditor 4 "Source" toolbar button (`cke_button source`) used by `CKEditor.addSourceContent` and `CKEditor.assertSourceContent` no longer exists.

## Fix

Create the web content through the JSON API with `source="true"` instead of the editor UI (mirroring LPD-94752 / liferay-headless/liferay-portal#3886), and verify the imported content through the CKEditor 5 editable body instead of the source view. This removes the test's dependency on the removed CKEditor 4 source button.

Depends on liferay-headless/liferay-portal#3950 (LPD-95096): once this fix lets the test reach the import, the import reports "Completed With Errors" (LPD-86259, by design), which #3950 handles by removing the hardcoded "Successful" status assertion in `LAR.macro`.

- `portal-web/test/functional/com/liferay/portalweb/tests/enduser/exportimport/ExportImport.testcase`

## PR Check

**pr-check: PASS** — tested on `e3d710dcd54689b386b6d89dd3fb63f3cc333190`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "e3d710dcd54689b386b6d89dd3fb63f3cc333190"} -->
