### PR TITLE
LPD-95984 Wait for staging layouts before returning from enableLocalStaging

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/staging/JSONStaging.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/staging/JSONStaging.macro
@@ -22,7 +22,7 @@ definition {
 			var site = "true";
 		}
 
-		var groupId = JSONGroupAPI._getGroupIdByName(
+		var liveGroupId = JSONGroupAPI._getGroupIdByName(
 			grandParentGroupName = ${grandParentGroupName},
 			groupName = ${groupName},
 			parentGroupName = ${parentGroupName},
@@ -39,21 +39,48 @@ definition {
 		JSONStagingAPI._enableLocalStaging(
 			branchingPrivate = ${branchingPrivate},
 			branchingPublic = ${branchingPublic},
-			groupId = ${groupId},
+			groupId = ${liveGroupId},
 			unCheckedContent = ${unCheckedContent});
 
-		var groupId = JSONGroupAPI._getGroupIdByNameNoError(
+		var stagingGroupId = JSONGroupAPI._getGroupIdByNameNoError(
 			grandParentGroupName = ${grandParentGroupName},
 			groupName = "${groupName} (Staging)",
 			parentGroupName = ${parentGroupName},
 			site = "false");
 
-		while ((${groupId} == "")) {
-			var groupId = JSONGroupAPI._getGroupIdByNameNoError(
+		while ((${stagingGroupId} == "")) {
+			var stagingGroupId = JSONGroupAPI._getGroupIdByNameNoError(
 				grandParentGroupName = ${grandParentGroupName},
 				groupName = "${groupName} (Staging)",
 				parentGroupName = ${parentGroupName},
 				site = "false");
+		}
+
+		var portalURL = JSONCompany.getPortalURL();
+		var userLoginInfo = JSONUtil2.formatJSONUser();
+
+		var liveLayoutsCurl = '''
+			${portalURL}/api/jsonws/layout/get-layouts \
+				-u ${userLoginInfo} \
+				-d groupId=${liveGroupId} \
+				-d privateLayout=false
+		''';
+
+		var liveLayoutId = JSONCurlUtil.post(${liveLayoutsCurl}, "$.[?(@['nameCurrentValue'] != '')]['layoutId']");
+
+		if (${liveLayoutId} != "") {
+			var stagingLayoutsCurl = '''
+				${portalURL}/api/jsonws/layout/get-layouts \
+					-u ${userLoginInfo} \
+					-d groupId=${stagingGroupId} \
+					-d privateLayout=false
+			''';
+
+			var stagingLayoutId = JSONCurlUtil.post(${stagingLayoutsCurl}, "$.[?(@['nameCurrentValue'] != '')]['layoutId']");
+
+			while ((${stagingLayoutId} == "")) {
+				var stagingLayoutId = JSONCurlUtil.post(${stagingLayoutsCurl}, "$.[?(@['nameCurrentValue'] != '')]['layoutId']");
+			}
 		}
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95984

## Failing Test

`LocalFile.StagingActivation#CheckPublicationSummaryLocal` (and 7 others in StagingActivation/StagingUsecase/Staging)

`portal-web/test/functional/com/liferay/portalweb/macros/json/staging/JSONStaging.macro`

```
java.lang.Exception: FAIL. Cannot find layout.
```

## Root Cause

Commit `803e383` ("LPD-93634 Restore staging group polling condition lost in Poshi regen") changed the staging group polling loop condition from `while (("" == ""))` to `while ((${groupId} == ""))`. The corrected condition exits as soon as the staging group row is created, but at that point the portal has not yet copied layouts from the live site to the staging site. Tests that add a page to the live site before enabling staging then fail with "Cannot find layout" when they try to open that page on the staging site.

## Fix

Added a second polling loop after the staging group appears: it fetches public layouts from the staging group and keeps retrying until at least one exists. The outer check first confirms the live group actually has public layouts — when the live site is empty there is nothing to copy, so no poll is needed. This restores the behaviour all 8 failing tests depend on.

- `portal-web/test/functional/com/liferay/portalweb/macros/json/staging/JSONStaging.macro`

## PR Check

**pr-check: PASS** — tested on `4664419b3d64f9064981eb3d028ed89599da6c35`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "4664419b3d64f9064981eb3d028ed89599da6c35"} -->
