### PR TITLE
LPD-96090 Resolve a subtype when a batch delete row omits the type id

### DIFF
--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/reader/BatchEngineImportTaskItemReaderUtil.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/reader/BatchEngineImportTaskItemReaderUtil.java
@@ -7,6 +7,7 @@ package com.liferay.batch.engine.internal.reader;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -16,6 +17,7 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 
 import com.liferay.batch.engine.BatchEngineTaskContentType;
+import com.liferay.batch.engine.BatchEngineTaskOperation;
 import com.liferay.batch.engine.action.ItemReaderPostAction;
 import com.liferay.batch.engine.exception.BatchEngineImportTaskExecutorException;
 import com.liferay.batch.engine.model.BatchEngineImportTask;
@@ -62,7 +64,7 @@ public class BatchEngineImportTaskItemReaderUtil {
 
 		try {
 			Class<? extends T> resolvedClass = _resolveClass(
-				fieldNameValueMap, itemClass);
+				batchEngineImportTask, fieldNameValueMap, itemClass);
 
 			Constructor<? extends T> constructor =
 				resolvedClass.getDeclaredConstructor();
@@ -347,6 +349,7 @@ public class BatchEngineImportTaskItemReaderUtil {
 	}
 
 	private static <T> Class<? extends T> _resolveClass(
+		BatchEngineImportTask batchEngineImportTask,
 		Map<String, Object> fieldNameValueMap, Class<T> itemClass) {
 
 		JsonTypeInfo jsonTypeInfo = itemClass.getAnnotation(JsonTypeInfo.class);
@@ -357,16 +360,40 @@ public class BatchEngineImportTaskItemReaderUtil {
 
 		String property = jsonTypeInfo.property();
 
+		Object typeValue = fieldNameValueMap.get(property);
+
+		if ((typeValue == null) &&
+			StringUtil.equals(
+				batchEngineImportTask.getOperation(),
+				BatchEngineTaskOperation.DELETE.name())) {
+
+			return _resolveSubtypeClass(itemClass);
+		}
+
 		ObjectMapper objectMapper =
 			ObjectMapperProviderUtil.getBatchEngineObjectMapper();
 
 		T value = objectMapper.convertValue(
 			HashMapBuilder.put(
-				property, fieldNameValueMap.get(property)
+				property, typeValue
 			).build(),
 			itemClass);
 
 		return (Class<? extends T>)value.getClass();
+	}
+
+	private static <T> Class<? extends T> _resolveSubtypeClass(
+		Class<T> itemClass) {
+
+		JsonSubTypes jsonSubTypes = itemClass.getAnnotation(JsonSubTypes.class);
+
+		if (jsonSubTypes != null) {
+			for (JsonSubTypes.Type type : jsonSubTypes.value()) {
+				return (Class<? extends T>)type.value();
+			}
+		}
+
+		return itemClass;
 	}
 
 	private static void _setField(

--- a/modules/apps/batch-engine/batch-engine-service/src/test/java/com/liferay/batch/engine/internal/reader/PolymorphicDeleteBatchEngineImportTaskItemReaderUtilTest.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/test/java/com/liferay/batch/engine/internal/reader/PolymorphicDeleteBatchEngineImportTaskItemReaderUtilTest.java
@@ -1,0 +1,114 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.batch.engine.internal.reader;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import com.liferay.batch.engine.BatchEngineTaskOperation;
+import com.liferay.batch.engine.model.BatchEngineImportTask;
+import com.liferay.batch.engine.model.impl.BatchEngineImportTaskImpl;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Georgel Pop
+ */
+public class PolymorphicDeleteBatchEngineImportTaskItemReaderUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testConvertValueCreateFailsWithoutType() throws Exception {
+		try {
+			BatchEngineImportTaskItemReaderUtil.convertValue(
+				_getBatchEngineImportTask(BatchEngineTaskOperation.CREATE),
+				PageTemplate.class,
+				Collections.singletonMap(
+					"externalReferenceCode", RandomTestUtil.randomString()),
+				Collections.emptyList());
+
+			Assert.fail();
+		}
+		catch (Exception exception) {
+		}
+	}
+
+	@Test
+	public void testConvertValueDeleteResolvesSubtypeWithoutType()
+		throws Exception {
+
+		String externalReferenceCode = RandomTestUtil.randomString();
+
+		PageTemplate pageTemplate =
+			BatchEngineImportTaskItemReaderUtil.convertValue(
+				_getBatchEngineImportTask(BatchEngineTaskOperation.DELETE),
+				PageTemplate.class,
+				Collections.singletonMap(
+					"externalReferenceCode", externalReferenceCode),
+				Collections.emptyList());
+
+		Assert.assertTrue(pageTemplate instanceof ContentPageTemplate);
+		Assert.assertEquals(
+			externalReferenceCode, pageTemplate.getExternalReferenceCode());
+	}
+
+	public static class ContentPageTemplate extends PageTemplate {
+	}
+
+	@JsonSubTypes(
+		{
+			@JsonSubTypes.Type(
+				name = "ContentPageTemplate", value = ContentPageTemplate.class
+			),
+			@JsonSubTypes.Type(
+				name = "WidgetPageTemplate", value = WidgetPageTemplate.class
+			)
+		}
+	)
+	@JsonTypeInfo(
+		include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type",
+		use = JsonTypeInfo.Id.NAME, visible = true
+	)
+	public abstract static class PageTemplate {
+
+		public String getExternalReferenceCode() {
+			return _externalReferenceCode;
+		}
+
+		public void setExternalReferenceCode(String externalReferenceCode) {
+			_externalReferenceCode = externalReferenceCode;
+		}
+
+		private String _externalReferenceCode;
+
+	}
+
+	public static class WidgetPageTemplate extends PageTemplate {
+	}
+
+	private BatchEngineImportTask _getBatchEngineImportTask(
+		BatchEngineTaskOperation batchEngineTaskOperation) {
+
+		BatchEngineImportTask batchEngineImportTask =
+			new BatchEngineImportTaskImpl();
+
+		batchEngineImportTask.setOperation(batchEngineTaskOperation.name());
+
+		return batchEngineImportTask;
+	}
+
+}


### PR DESCRIPTION
## What

Fixes an intermittent CI failure in `LayoutPageTemplatePortletDataHandlerTest.testExportImportLayoutPageTemplateEntriesDeletions` (and the `PortalLogAssertorTest.testScanXMLLog` failure it triggers in the same run).

Routing to **@liferay-headless**: the fix is in `modules/apps/batch-engine`. The failing test and the polymorphic DTO are `@liferay-page-management`.

## Root cause

Layout page template deletions import through the Batch Engine, not a staged-model handler. The deletion row is written with only `externalReferenceCode` and no `type` discriminator (`BatchEnginePortletDataHandler.java:194-198`). On import, `BatchEngineImportTaskItemReaderUtil._resolveClass` calls `convertValue({type: null}, PageTemplate.class)` against the abstract `@JsonTypeInfo` DTO (`PageTemplate.java`, subtypes `ContentPageTemplate` / `WidgetPageTemplate`) and throws:

```
java.lang.IllegalArgumentException: Could not resolve subtype of
[simple type, class com.liferay.headless.admin.site.dto.v1_0.PageTemplate]: missing type id property 'type'
```

Under `IMPORT_STRATEGY_ON_ERROR_CONTINUE` the row is logged and skipped, so the entry is never deleted (`assertNull` fails) and the logged error trips `PortalLogAssertorTest`.

## Fix

In `BatchEngineImportTaskItemReaderUtil._resolveClass`, for `DELETE` operations fall back to the first declared `@JsonSubTypes` subtype when the discriminator is absent. A delete keys only on `externalReferenceCode` (`BasePageTemplateResourceImpl.delete` -> `findByERC_G`), so the concrete subtype is irrelevant for a delete. `CREATE`/`UPDATE` stay strict.

## Reviewer notes (caveats)

- The fallback resolves the *first* declared subtype, not the row's actual one. Safe here because PageTemplate's delete is subtype-agnostic (same ERC lookup), but it is a general assumption.
- An abstract base with no `@JsonSubTypes` would fall back to the abstract class and throw an opaque `InstantiationException`; a guard/clearer message could be added.
- Export side unchanged: untyped codes are still sprayed into every registration's deletions file (`BatchEnginePortletDataHandler:184`); a mis-routed code can log `NoSuchPageTemplateEntryException` under bad timing. Possible follow-up.

## Validation

- New unit test reproduces the crash deterministically (red without the fix, green with it).
- Full integration test `LayoutPageTemplatePortletDataHandlerTest` green end-to-end against a patched bundle.

**pr-check: PASS** — tested on `fa31204155d5a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS (no integration sources) |
| Cross-Module Compile | PASS (internal util, not exported) |
| Java Unit Tests | PASS (2/2) |

## Jira

- Subtask (this work): LPD-96090
- Parent: LPD-96084
