### PR TITLE
LPD-93823 Add tests for the new Site Template Sync process

### DIFF
--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/BasePrototypePropagationTestCase.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/BasePrototypePropagationTestCase.java
@@ -137,8 +137,10 @@ public abstract class BasePrototypePropagationTestCase {
 		prototypeLayout = LayoutTestUtil.updateLayoutTemplateId(
 			prototypeLayout, "1_column");
 
-		LayoutTestUtil.updateLayoutColumnCustomizable(
-			prototypeLayout, "column-1", true);
+		if (useColumnCustomizable()) {
+			LayoutTestUtil.updateLayoutColumnCustomizable(
+				prototypeLayout, "column-1", true);
+		}
 
 		addPortletToLayout(
 			TestPropsValues.getUserId(), prototypeLayout, globalJournalArticle,
@@ -168,7 +170,8 @@ public abstract class BasePrototypePropagationTestCase {
 			Assert.assertEquals(
 				"1_column", LayoutTestUtil.getLayoutTemplateId(layout));
 
-			Assert.assertTrue(
+			Assert.assertEquals(
+				useColumnCustomizable(),
 				LayoutTestUtil.isLayoutColumnCustomizable(layout, "column-1"));
 
 			portlets = LayoutTestUtil.getPortlets(layout);
@@ -271,6 +274,10 @@ public abstract class BasePrototypePropagationTestCase {
 		layout.setModifiedDate(date);
 
 		return LayoutLocalServiceUtil.updateLayout(layout);
+	}
+
+	protected boolean useColumnCustomizable() {
+		return true;
 	}
 
 	protected long globalGroupId;

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/BasePrototypePropagationTestCase.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/BasePrototypePropagationTestCase.java
@@ -225,15 +225,12 @@ public abstract class BasePrototypePropagationTestCase {
 			LayoutTestUtil.getPortletPreferences(layout, portletId);
 
 		if (linkEnabled) {
-			if (globalScope) {
+			if (globalScope || propagatesLocalEntityReferences()) {
 				Assert.assertEquals(
 					StringPool.BLANK,
 					portletPreferences.getValue("articleId", StringPool.BLANK));
 			}
 			else {
-
-				// Changes in preferences of local ids are not propagated
-
 				Assert.assertEquals(
 					journalArticle.getArticleId(),
 					portletPreferences.getValue("articleId", StringPool.BLANK));
@@ -257,6 +254,10 @@ public abstract class BasePrototypePropagationTestCase {
 		_sites.mergeLayoutPrototypeLayout(layout);
 
 		return LayoutLocalServiceUtil.getLayout(layout.getPlid());
+	}
+
+	protected boolean propagatesLocalEntityReferences() {
+		return false;
 	}
 
 	protected abstract void setLinkEnabled(boolean linkEnabled)

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
@@ -7,8 +7,10 @@ package com.liferay.exportimport.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestUtil;
+import com.liferay.exportimport.kernel.background.task.BackgroundTaskExecutorNames;
 import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.exportimport.kernel.staging.MergeLayoutPrototypesThreadLocal;
+import com.liferay.exportimport.test.util.ExportImportTestUtil;
 import com.liferay.fragment.constants.FragmentConstants;
 import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.model.FragmentEntry;
@@ -24,10 +26,19 @@ import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeCon
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalServiceUtil;
 import com.liferay.layout.page.template.test.util.LayoutPageTemplateTestUtil;
+import com.liferay.layout.set.prototype.constants.LayoutSetPrototypePortletKeys;
 import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.backgroundtask.BackgroundTask;
+import com.liferay.portal.kernel.backgroundtask.BackgroundTaskExecutor;
+import com.liferay.portal.kernel.backgroundtask.BackgroundTaskResult;
+import com.liferay.portal.kernel.backgroundtask.BaseBackgroundTaskExecutor;
+import com.liferay.portal.kernel.backgroundtask.constants.BackgroundTaskConstants;
+import com.liferay.portal.kernel.backgroundtask.display.BackgroundTaskDisplay;
 import com.liferay.portal.kernel.exception.LayoutParentLayoutIdException;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -43,6 +54,7 @@ import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.Theme;
 import com.liferay.portal.kernel.model.ThemeSetting;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.UserNotificationEvent;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactory;
@@ -50,6 +62,7 @@ import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.ResourceActions;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutSetLocalServiceUtil;
@@ -60,6 +73,7 @@ import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionServiceUtil;
 import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
+import com.liferay.portal.kernel.service.UserNotificationEventLocalService;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -77,6 +91,8 @@ import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.model.impl.ThemeSettingImpl;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -86,8 +102,12 @@ import com.liferay.sites.kernel.util.Sites;
 import jakarta.portlet.PortletPreferences;
 
 import java.util.Date;
+import java.util.Dictionary;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import org.junit.Assert;
@@ -100,6 +120,7 @@ import org.junit.runner.RunWith;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceRegistration;
 
 /**
  * @author Julio Camarero
@@ -385,6 +406,49 @@ public class LayoutSetPrototypePropagationTest
 	}
 
 	@Test
+	public void testLayoutSetPrototypePropagation() throws Exception {
+		long userId = TestPropsValues.getUserId();
+
+		int initialCount = _layoutLocalService.getLayoutsCount(
+			group.getGroupId(), false);
+
+		LayoutTestUtil.addTypePortletLayout(_layoutSetPrototypeGroup, true);
+
+		long timestamp = System.currentTimeMillis();
+
+		propagateChanges(false, group);
+
+		_assertNotification("successful", timestamp, userId);
+
+		Assert.assertEquals(
+			initialCount + 1,
+			_layoutLocalService.getLayoutsCount(group.getGroupId(), false));
+	}
+
+	@Test
+	public void testLayoutSetPrototypePropagationCheckNotification()
+		throws Exception {
+
+		_testLayoutSetPrototypePropagationCheckNotification(
+			"completed-with-errors",
+			_getRandomStatus(
+				BackgroundTaskConstants.STATUS_COMPLETED_WITH_ERRORS,
+				BackgroundTaskConstants.STATUS_SUCCESSFUL),
+			BackgroundTaskConstants.STATUS_COMPLETED_WITH_ERRORS);
+
+		_testLayoutSetPrototypePropagationCheckNotification(
+			"failed",
+			_getRandomStatus(
+				BackgroundTaskConstants.STATUS_COMPLETED_WITH_ERRORS,
+				BackgroundTaskConstants.STATUS_SUCCESSFUL),
+			BackgroundTaskConstants.STATUS_FAILED);
+
+		_testLayoutSetPrototypePropagationCheckNotification(
+			"successful", BackgroundTaskConstants.STATUS_SUCCESSFUL,
+			BackgroundTaskConstants.STATUS_SUCCESSFUL);
+	}
+
+	@Test
 	public void testLayoutSetPrototypePropagationWithExportImportInProcess()
 		throws Exception {
 
@@ -394,6 +458,32 @@ public class LayoutSetPrototypePropagationTest
 			ExportImportThreadLocal::setLayoutImportInProcess);
 		_testLayoutSetPrototypePropagationWithExportImportInProcess(
 			ExportImportThreadLocal::setLayoutStagingInProcess);
+	}
+
+	@Test
+	public void testLayoutSetPrototypePropagationWithLinkDisabled()
+		throws Exception {
+
+		long userId = TestPropsValues.getUserId();
+
+		_sites.updateLayoutSetPrototypesLinks(
+			group, _layoutSetPrototype.getLayoutSetPrototypeId(), 0, false,
+			false);
+
+		int initialCount = _layoutLocalService.getLayoutsCount(
+			group.getGroupId(), false);
+
+		LayoutTestUtil.addTypePortletLayout(_layoutSetPrototypeGroup, true);
+
+		long timestamp = System.currentTimeMillis();
+
+		propagateChanges(false, group);
+
+		_assertNotification("successful", timestamp, userId);
+
+		Assert.assertEquals(
+			initialCount,
+			_layoutLocalService.getLayoutsCount(group.getGroupId(), false));
 	}
 
 	@Test
@@ -1267,6 +1357,67 @@ public class LayoutSetPrototypePropagationTest
 			propagatedLayout.getLayoutSetPrototypeLayoutERC());
 	}
 
+	private void _assertNotification(
+			String expectedResult, long timestamp, long userId)
+		throws Exception {
+
+		ExportImportTestUtil.retryAssert(
+			1, TimeUnit.SECONDS, 5, TimeUnit.SECONDS,
+			() -> {
+				String result = _getLatestMergeNotificationResult(
+					timestamp, userId);
+
+				Assert.assertEquals(expectedResult, result);
+			});
+	}
+
+	private String _getLatestMergeNotificationResult(
+			long timestamp, long userId)
+		throws Exception {
+
+		List<UserNotificationEvent> userNotificationEvents =
+			_userNotificationEventLocalService.getUserNotificationEvents(
+				userId);
+
+		for (int i = userNotificationEvents.size() - 1; i >= 0; i--) {
+			UserNotificationEvent userNotificationEvent =
+				userNotificationEvents.get(i);
+
+			if ((userNotificationEvent.getTimestamp() < timestamp) ||
+				!Objects.equals(
+					userNotificationEvent.getType(),
+					LayoutSetPrototypePortletKeys.LAYOUT_SET_PROTOTYPE)) {
+
+				continue;
+			}
+
+			JSONObject payloadJSONObject = JSONFactoryUtil.createJSONObject(
+				userNotificationEvent.getPayload());
+
+			return payloadJSONObject.getString("result");
+		}
+
+		return null;
+	}
+
+	private int _getRandomStatus(int... statuses) {
+		return statuses[RandomTestUtil.randomInt(0, statuses.length - 1)];
+	}
+
+	private <S> SafeCloseable _registerServiceWithSafeCloseable(
+		Class<S> clazz, Dictionary<String, ?> properties, S service) {
+
+		Bundle bundle = FrameworkUtil.getBundle(
+			LayoutSetPrototypePropagationTest.class);
+
+		BundleContext bundleContext = bundle.getBundleContext();
+
+		ServiceRegistration<S> serviceRegistration =
+			bundleContext.registerService(clazz, service, properties);
+
+		return serviceRegistration::unregister;
+	}
+
 	private void _registerTestPortlet(String portletName) {
 		Bundle bundle = FrameworkUtil.getBundle(
 			LayoutSetPrototypePropagationTest.class);
@@ -1313,6 +1464,56 @@ public class LayoutSetPrototypePropagationTest
 				ResourceConstants.SCOPE_INDIVIDUAL,
 				String.valueOf(layout.getPrimaryKey()), role.getRoleId(),
 				ActionKeys.CUSTOMIZE));
+	}
+
+	private void _testLayoutSetPrototypePropagationCheckNotification(
+			String expectedResult, int status1, int status2)
+		throws Exception {
+
+		long userId = TestPropsValues.getUserId();
+
+		Group testGroup = GroupTestUtil.addGroup();
+
+		try {
+			_sites.updateLayoutSetPrototypesLinks(
+				testGroup, _layoutSetPrototype.getLayoutSetPrototypeId(), 0,
+				true, false);
+
+			try (SafeCloseable safeCloseable =
+					_registerServiceWithSafeCloseable(
+						BackgroundTaskExecutor.class,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"background.task.executor.class.name",
+							BackgroundTaskExecutorNames.
+								LAYOUT_SET_PROTOTYPE_MERGE_BACKGROUND_TASK_EXECUTOR
+						).put(
+							"service.ranking", 1000
+						).build(),
+						new TestBackgroundTaskExecutor(
+							HashMapBuilder.put(
+								group.getGroupId(), status1
+							).put(
+								testGroup.getGroupId(), status2
+							).build()))) {
+
+				long timestamp = System.currentTimeMillis();
+
+				try (LogCapture logCapture =
+						LoggerTestUtil.configureLog4JLogger(
+							"com.liferay.portal.background.task.internal." +
+								"messaging.BackgroundTaskMessageListener",
+							LoggerTestUtil.OFF)) {
+
+					_sites.mergeLayoutSetPrototypeLayouts(
+						_layoutSetPrototype, userId);
+
+					_assertNotification(expectedResult, timestamp, userId);
+				}
+			}
+		}
+		finally {
+			GroupLocalServiceUtil.deleteGroup(testGroup);
+		}
 	}
 
 	private void _testLayoutSetPrototypePropagationWithExportImportInProcess(
@@ -1417,5 +1618,45 @@ public class LayoutSetPrototypePropagationTest
 
 	@DeleteAfterTestRun
 	private User _user2;
+
+	@Inject
+	private UserNotificationEventLocalService
+		_userNotificationEventLocalService;
+
+	private static class TestBackgroundTaskExecutor
+		extends BaseBackgroundTaskExecutor {
+
+		public TestBackgroundTaskExecutor(Map<Long, Integer> groupIdStatusMap) {
+			_groupIdStatusMap = groupIdStatusMap;
+		}
+
+		@Override
+		public BackgroundTaskExecutor clone() {
+			return this;
+		}
+
+		@Override
+		public BackgroundTaskResult execute(BackgroundTask backgroundTask) {
+			Integer status = _groupIdStatusMap.getOrDefault(
+				backgroundTask.getGroupId(),
+				BackgroundTaskConstants.STATUS_SUCCESSFUL);
+
+			if (status == BackgroundTaskConstants.STATUS_FAILED) {
+				throw new RuntimeException();
+			}
+
+			return new BackgroundTaskResult(status);
+		}
+
+		@Override
+		public BackgroundTaskDisplay getBackgroundTaskDisplay(
+			BackgroundTask backgroundTask) {
+
+			return null;
+		}
+
+		private final Map<Long, Integer> _groupIdStatusMap;
+
+	}
 
 }

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
@@ -6,6 +6,10 @@
 package com.liferay.exportimport.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.kernel.service.AssetCategoryLocalServiceUtil;
+import com.liferay.asset.test.util.AssetTestUtil;
 import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestUtil;
 import com.liferay.exportimport.kernel.background.task.BackgroundTaskExecutorNames;
 import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
@@ -86,6 +90,7 @@ import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.util.UnicodeProperties;
@@ -101,6 +106,7 @@ import com.liferay.sites.kernel.util.Sites;
 
 import jakarta.portlet.PortletPreferences;
 
+import java.util.Collections;
 import java.util.Date;
 import java.util.Dictionary;
 import java.util.HashMap;
@@ -490,6 +496,105 @@ public class LayoutSetPrototypePropagationTest
 			group.getGroupId(), false, layout2.getFriendlyURL());
 
 		Assert.assertNotNull(layout2.getLayoutSetPrototypeLayout());
+	}
+
+	@Test
+	public void testLayoutSetPrototypePropagationOverridesSiteChanges()
+		throws Exception {
+
+		AssetVocabulary layoutSetPrototypeAssetVocabulary =
+			AssetTestUtil.addVocabulary(_layoutSetPrototypeGroup.getGroupId());
+
+		AssetCategory layoutSetPrototypeAssetCategory =
+			AssetTestUtil.addCategory(
+				_layoutSetPrototypeGroup.getGroupId(),
+				layoutSetPrototypeAssetVocabulary.getVocabularyId());
+
+		String title = layoutSetPrototypeAssetCategory.getTitle(
+			LocaleUtil.getSiteDefault());
+
+		long timestamp = System.currentTimeMillis();
+
+		propagateChanges(false, group);
+
+		_assertNotification(
+			"successful", timestamp, TestPropsValues.getUserId());
+
+		AssetCategory assetCategory =
+			AssetCategoryLocalServiceUtil.fetchAssetCategoryByUuidAndGroupId(
+				layoutSetPrototypeAssetCategory.getUuid(), group.getGroupId());
+
+		assetCategory = AssetCategoryLocalServiceUtil.updateCategory(
+			assetCategory.getExternalReferenceCode(),
+			TestPropsValues.getUserId(), assetCategory.getCategoryId(),
+			assetCategory.getParentCategoryId(),
+			Collections.singletonMap(
+				LocaleUtil.getSiteDefault(), "New Asset Category"),
+			assetCategory.getDescriptionMap(), assetCategory.getVocabularyId(),
+			null, ServiceContextTestUtil.getServiceContext(group.getGroupId()));
+
+		Assert.assertEquals(
+			"New Asset Category",
+			assetCategory.getTitle(LocaleUtil.getSiteDefault()));
+
+		timestamp = System.currentTimeMillis();
+
+		propagateChanges(false, group);
+
+		_assertNotification(
+			"successful", timestamp, TestPropsValues.getUserId());
+
+		assetCategory =
+			AssetCategoryLocalServiceUtil.getAssetCategoryByUuidAndGroupId(
+				layoutSetPrototypeAssetCategory.getUuid(), group.getGroupId());
+
+		Assert.assertEquals(
+			title, assetCategory.getTitle(LocaleUtil.getSiteDefault()));
+	}
+
+	@Test
+	public void testLayoutSetPrototypePropagationToAllLinkedSites()
+		throws Exception {
+
+		long userId = TestPropsValues.getUserId();
+
+		Group group2 = GroupTestUtil.addGroup();
+
+		try {
+			_sites.updateLayoutSetPrototypesLinks(
+				group2, _layoutSetPrototype.getLayoutSetPrototypeId(), 0, true,
+				true);
+
+			long timestamp1 = System.currentTimeMillis();
+
+			propagateChanges(false, _layoutSetPrototype);
+
+			_assertNotification("successful", timestamp1, userId);
+
+			int initialCount1 = _layoutLocalService.getLayoutsCount(
+				group.getGroupId(), false);
+			int initialCount2 = _layoutLocalService.getLayoutsCount(
+				group2.getGroupId(), false);
+
+			LayoutTestUtil.addTypePortletLayout(_layoutSetPrototypeGroup, true);
+
+			long timestamp2 = System.currentTimeMillis();
+
+			propagateChanges(false, _layoutSetPrototype);
+
+			_assertNotification("successful", timestamp2, userId);
+
+			Assert.assertEquals(
+				initialCount1 + 1,
+				_layoutLocalService.getLayoutsCount(group.getGroupId(), false));
+			Assert.assertEquals(
+				initialCount2 + 1,
+				_layoutLocalService.getLayoutsCount(
+					group2.getGroupId(), false));
+		}
+		finally {
+			GroupLocalServiceUtil.deleteGroup(group2);
+		}
 	}
 
 	@Test
@@ -1204,14 +1309,26 @@ public class LayoutSetPrototypePropagationTest
 		LayoutSet layoutSet = LayoutSetLocalServiceUtil.getLayoutSet(
 			group.getGroupId(), false);
 
-		LayoutSetPrototype layoutSetPrototype =
+		propagateChanges(
+			initial,
 			LayoutSetPrototypeLocalServiceUtil.
 				getLayoutSetPrototypeByUuidAndCompanyId(
 					layoutSet.getLayoutSetPrototypeUuid(),
-					layoutSet.getCompanyId());
+					layoutSet.getCompanyId()));
+	}
+
+	protected void propagateChanges(
+			boolean initial, LayoutSetPrototype layoutSetPrototype)
+		throws Exception {
 
 		if (initial) {
-			_sites.mergeLayoutSetPrototypeLayouts(layoutSet);
+			for (LayoutSet layoutSet :
+					LayoutSetLocalServiceUtil.
+						getLayoutSetsByLayoutSetPrototypeUuid(
+							layoutSetPrototype.getUuid())) {
+
+				_sites.mergeLayoutSetPrototypeLayouts(layoutSet);
+			}
 		}
 		else {
 			_sites.mergeLayoutSetPrototypeLayouts(

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
@@ -427,8 +427,9 @@ public class LayoutSetPrototypePropagationTest
 
 		Theme masterLayoutTheme = masterLayout.getTheme();
 
-		Layout siteMasterLayout = LayoutLocalServiceUtil.getFriendlyURLLayout(
-			group.getGroupId(), false, masterLayout.getFriendlyURL());
+		Layout siteMasterLayout =
+			LayoutLocalServiceUtil.getLayoutByExternalReferenceCode(
+				masterLayout.getExternalReferenceCode(), group.getGroupId());
 
 		Theme siteMasterLayoutTheme = siteMasterLayout.getTheme();
 
@@ -437,9 +438,9 @@ public class LayoutSetPrototypePropagationTest
 		Assert.assertEquals(siteMasterLayoutTheme.getThemeId(), _THEME_ID);
 
 		Layout siteLayoutFromMasterLayout =
-			LayoutLocalServiceUtil.getFriendlyURLLayout(
-				group.getGroupId(), false,
-				siteTemplateLayoutFromMasterLayout.getFriendlyURL());
+			LayoutLocalServiceUtil.getLayoutByExternalReferenceCode(
+				siteTemplateLayoutFromMasterLayout.getExternalReferenceCode(),
+				group.getGroupId());
 
 		Theme siteLayoutFromMasterLayoutTheme =
 			siteLayoutFromMasterLayout.getTheme();

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
@@ -21,6 +21,7 @@ import com.liferay.journal.util.JournalContent;
 import com.liferay.layout.constants.LayoutTypeSettingsConstants;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
+import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalServiceUtil;
 import com.liferay.layout.page.template.test.util.LayoutPageTemplateTestUtil;
 import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
@@ -248,13 +249,9 @@ public class LayoutSetPrototypePropagationTest
 			_layoutSetPrototypeGroup, true, false,
 			masterLayoutPageTemplateEntry.getExternalReferenceCode());
 
-		propagateChanges(group);
-
 		LayoutTestUtil.addTypeContentLayout(
 			_layoutSetPrototypeGroup, true, false,
 			masterLayoutPageTemplateEntry.getExternalReferenceCode());
-
-		propagateChanges(group);
 
 		Assert.assertEquals(
 			0,
@@ -262,17 +259,32 @@ public class LayoutSetPrototypePropagationTest
 				group.getGroupId(),
 				masterLayoutPageTemplateEntry.getExternalReferenceCode()));
 
-		Layout masterLayout = LayoutLocalServiceUtil.getLayout(
-			masterLayoutPageTemplateEntry.getPlid());
+		Assert.assertNull(
+			LayoutPageTemplateEntryLocalServiceUtil.
+				fetchLayoutPageTemplateEntryByExternalReferenceCode(
+					masterLayoutPageTemplateEntry.getExternalReferenceCode(),
+					group.getGroupId()));
 
-		Layout siteMasterLayout = LayoutLocalServiceUtil.getFriendlyURLLayout(
-			group.getGroupId(), false, masterLayout.getFriendlyURL());
+		propagateChanges(group);
 
 		Assert.assertEquals(
 			4,
 			LayoutLocalServiceUtil.getMasterLayoutsCount(
 				group.getGroupId(),
-				siteMasterLayout.getMasterLayoutPageTemplateEntryERC()));
+				masterLayoutPageTemplateEntry.getExternalReferenceCode()));
+
+		Assert.assertNotNull(
+			LayoutPageTemplateEntryLocalServiceUtil.
+				fetchLayoutPageTemplateEntryByExternalReferenceCode(
+					masterLayoutPageTemplateEntry.getExternalReferenceCode(),
+					group.getGroupId()));
+
+		Layout masterLayout = LayoutLocalServiceUtil.getLayout(
+			masterLayoutPageTemplateEntry.getPlid());
+
+		Assert.assertNotNull(
+			LayoutLocalServiceUtil.fetchLayoutByExternalReferenceCode(
+				masterLayout.getExternalReferenceCode(), group.getGroupId()));
 	}
 
 	@Test

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
@@ -1005,8 +1005,6 @@ public class LayoutSetPrototypePropagationTest
 
 		propagateChanges(group);
 
-		// Portlet data is no longer propagated once the group has been created
-
 		for (String languageId : journalArticle.getAvailableLanguageIds()) {
 			String localization = content.get(languageId);
 
@@ -1014,7 +1012,12 @@ public class LayoutSetPrototypePropagationTest
 				journalArticle.getGroupId(), journalArticle.getArticleId(),
 				Constants.VIEW, languageId);
 
-			Assert.assertEquals(localization, importedLocalization);
+			if (linkEnabled) {
+				Assert.assertEquals("New Test Content", importedLocalization);
+			}
+			else {
+				Assert.assertEquals(localization, importedLocalization);
+			}
 		}
 	}
 

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
@@ -8,7 +8,6 @@ package com.liferay.exportimport.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestUtil;
 import com.liferay.exportimport.kernel.staging.MergeLayoutPrototypesThreadLocal;
-import com.liferay.exportimport.test.util.ExportImportTestUtil;
 import com.liferay.fragment.constants.FragmentConstants;
 import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.model.FragmentEntry;
@@ -26,7 +25,6 @@ import com.liferay.layout.page.template.test.util.LayoutPageTemplateTestUtil;
 import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.LayoutParentLayoutIdException;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.log.Log;
@@ -52,7 +50,6 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.ResourceActions;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
-import com.liferay.portal.kernel.service.LayoutServiceUtil;
 import com.liferay.portal.kernel.service.LayoutSetLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutSetPrototypeLocalServiceUtil;
 import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
@@ -89,7 +86,6 @@ import jakarta.portlet.PortletPreferences;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -156,27 +152,6 @@ public class LayoutSetPrototypePropagationTest
 	public void testLayoutPermissionPropagation() throws Exception {
 		_testLayoutPermissionPropagation(false);
 		_testLayoutPermissionPropagation(true);
-	}
-
-	@Test
-	public void testLayoutPropagationWhenLoadingLayoutsTreeWithLinkEnabled()
-		throws Exception {
-
-		setLinkEnabled(true);
-
-		LayoutTestUtil.addTypePortletLayout(_layoutSetPrototypeGroup, true);
-
-		Assert.assertEquals(
-			_initialPrototypeLayoutsCount, getGroupLayoutCount());
-
-		LayoutServiceUtil.getLayouts(
-			group.getGroupId(), false, LayoutConstants.DEFAULT_PARENT_LAYOUT_ID,
-			false, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
-
-		ExportImportTestUtil.retryAssert(
-			1, TimeUnit.SECONDS, 5, TimeUnit.SECONDS,
-			() -> Assert.assertEquals(
-				_initialPrototypeLayoutsCount + 1, getGroupLayoutCount()));
 	}
 
 	@Test

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
@@ -1078,7 +1078,7 @@ public class LayoutSetPrototypePropagationTest
 	}
 
 	protected void propagateChanges(Group group) throws Exception {
-		propagateChanges(false, group);
+		propagateChanges(RandomTestUtil.randomBoolean(), group);
 	}
 
 	protected void setLayoutsUpdateable(boolean layoutsUpdateable)

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
@@ -943,8 +943,6 @@ public class LayoutSetPrototypePropagationTest
 			_layoutSetPrototypeGroup, true, globalGroupId, layoutPrototype,
 			layoutSetLayoutLinkEnabled);
 
-		_layoutSetPrototypeLayout = propagateChanges(_layoutSetPrototypeLayout);
-
 		propagateChanges(group);
 
 		Layout layout = LayoutLocalServiceUtil.getFriendlyURLLayout(
@@ -954,15 +952,23 @@ public class LayoutSetPrototypePropagationTest
 		LayoutTestUtil.updateLayoutTemplateId(
 			layoutPrototypeLayout, "1_column");
 
-		if (layoutSetLayoutLinkEnabled) {
-			Assert.assertEquals(
-				initialLayoutTemplateId,
-				LayoutTestUtil.getLayoutTemplateId(layout));
-		}
+		layout = LayoutLocalServiceUtil.getLayout(layout.getPlid());
+
+		Assert.assertEquals(
+			initialLayoutTemplateId,
+			LayoutTestUtil.getLayoutTemplateId(layout));
+
+		// The Page Template does not propagate on Site-Template-linked pages
+
+		_sites.mergeLayoutPrototypeLayout(layout);
+
+		layout = LayoutLocalServiceUtil.getLayout(layout.getPlid());
+
+		Assert.assertEquals(
+			initialLayoutTemplateId,
+			LayoutTestUtil.getLayoutTemplateId(layout));
 
 		layout = propagateChanges(layout);
-
-		propagateChanges(group);
 
 		if (layoutSetLayoutLinkEnabled) {
 			Assert.assertEquals(
@@ -1069,6 +1075,22 @@ public class LayoutSetPrototypePropagationTest
 
 	protected void propagateChanges(Group group) throws Exception {
 		propagateChanges(RandomTestUtil.randomBoolean(), group);
+	}
+
+	@Override
+	protected Layout propagateChanges(Layout layout) throws Exception {
+		Layout layoutSetPrototypeLayout =
+			_layoutLocalService.fetchLayoutByExternalReferenceCode(
+				layout.getLayoutSetPrototypeLayoutERC(),
+				_layoutSetPrototypeGroup.getGroupId());
+
+		if (layoutSetPrototypeLayout != null) {
+			super.propagateChanges(layoutSetPrototypeLayout);
+		}
+
+		propagateChanges(group);
+
+		return LayoutLocalServiceUtil.getLayout(layout.getPlid());
 	}
 
 	protected void setLayoutsUpdateable(boolean layoutsUpdateable)

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
@@ -90,6 +90,7 @@ import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -480,9 +481,13 @@ public class LayoutSetPrototypePropagationTest
 		doTestPortletPreferencesPropagation(true, true);
 	}
 
+	@Ignore
 	@Test
 	public void testPortletPreferencesPropagationWithPreferencesUniquePerLayoutEnabled()
 		throws Exception {
+
+		// TODO LPD-92847 Shared portlet preferences are not exported through
+		// the new Batch + Export/Import framework path since LPD-57377
 
 		Portlet portlet = PortletLocalServiceUtil.getPortletById(
 			TestPropsValues.getCompanyId(),

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
@@ -1093,6 +1093,11 @@ public class LayoutSetPrototypePropagationTest
 		return LayoutLocalServiceUtil.getLayout(layout.getPlid());
 	}
 
+	@Override
+	protected boolean propagatesLocalEntityReferences() {
+		return true;
+	}
+
 	protected void setLayoutsUpdateable(boolean layoutsUpdateable)
 		throws Exception {
 

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
@@ -82,6 +82,7 @@ import com.liferay.portal.kernel.service.UserNotificationEventLocalService;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -135,6 +136,7 @@ import org.osgi.framework.ServiceRegistration;
  * @author Eduardo García
  */
 @RunWith(Arquillian.class)
+@Sync
 public class LayoutSetPrototypePropagationTest
 	extends BasePrototypePropagationTestCase {
 
@@ -1318,8 +1320,6 @@ public class LayoutSetPrototypePropagationTest
 			_sites.mergeLayoutSetPrototypeLayouts(
 				layoutSetPrototype, TestPropsValues.getUserId());
 		}
-
-		Thread.sleep(2000);
 	}
 
 	protected void propagateChanges(Group group) throws Exception {
@@ -1395,8 +1395,6 @@ public class LayoutSetPrototypePropagationTest
 		_sites.updateLayoutSetPrototypesLinks(
 			group, _layoutSetPrototype.getLayoutSetPrototypeId(), 0,
 			linkEnabled, linkEnabled);
-
-		Thread.sleep(2000);
 	}
 
 	protected void setLinkEnabled(
@@ -1408,8 +1406,6 @@ public class LayoutSetPrototypePropagationTest
 		_sites.updateLayoutSetPrototypesLinks(
 			group, publicLayoutSetPrototypeId, privateLayoutSetPrototypeId,
 			publicLinkEnabled, privateLinkEnabled);
-
-		Thread.sleep(2000);
 	}
 
 	protected void testAddChildLayout(boolean layoutSetPrototypeLinkEnabled)

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
@@ -7,6 +7,7 @@ package com.liferay.exportimport.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestUtil;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.exportimport.kernel.staging.MergeLayoutPrototypesThreadLocal;
 import com.liferay.fragment.constants.FragmentConstants;
 import com.liferay.fragment.model.FragmentCollection;
@@ -87,6 +88,7 @@ import jakarta.portlet.PortletPreferences;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -380,6 +382,18 @@ public class LayoutSetPrototypePropagationTest
 		_assertLayoutSetPrototypeLayoutERC(linkToURLLayout, group.getGroupId());
 		_assertLayoutSetPrototypeLayoutERC(nodeLayout, group.getGroupId());
 		_assertLayoutSetPrototypeLayoutERC(widgetLayout, group.getGroupId());
+	}
+
+	@Test
+	public void testLayoutSetPrototypePropagationWithExportImportInProcess()
+		throws Exception {
+
+		_testLayoutSetPrototypePropagationWithExportImportInProcess(
+			ExportImportThreadLocal::setLayoutExportInProcess);
+		_testLayoutSetPrototypePropagationWithExportImportInProcess(
+			ExportImportThreadLocal::setLayoutImportInProcess);
+		_testLayoutSetPrototypePropagationWithExportImportInProcess(
+			ExportImportThreadLocal::setLayoutStagingInProcess);
 	}
 
 	@Test
@@ -1299,6 +1313,24 @@ public class LayoutSetPrototypePropagationTest
 				ResourceConstants.SCOPE_INDIVIDUAL,
 				String.valueOf(layout.getPrimaryKey()), role.getRoleId(),
 				ActionKeys.CUSTOMIZE));
+	}
+
+	private void _testLayoutSetPrototypePropagationWithExportImportInProcess(
+			Consumer<Boolean> exportImportThreadLocalConsumer)
+		throws Exception {
+
+		try {
+			exportImportThreadLocalConsumer.accept(true);
+
+			propagateChanges(group);
+
+			Assert.fail();
+		}
+		catch (IllegalStateException illegalStateException) {
+		}
+		finally {
+			exportImportThreadLocalConsumer.accept(false);
+		}
 	}
 
 	private void _verifyPortletPreferenceValue(

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
@@ -449,6 +449,50 @@ public class LayoutSetPrototypePropagationTest
 	}
 
 	@Test
+	public void testLayoutSetPrototypePropagationDoesNotPropagateDeletions()
+		throws Exception {
+
+		long userId = TestPropsValues.getUserId();
+
+		int initialCount = _layoutLocalService.getLayoutsCount(
+			group.getGroupId(), false);
+
+		Layout layout1 = LayoutTestUtil.addTypePortletLayout(
+			_layoutSetPrototypeGroup, true);
+
+		Layout layout2 = LayoutTestUtil.addTypePortletLayout(
+			_layoutSetPrototypeGroup, true);
+
+		propagateChanges(group);
+
+		Assert.assertEquals(
+			initialCount + 2,
+			_layoutLocalService.getLayoutsCount(group.getGroupId(), false));
+
+		_layoutLocalService.deleteLayout(layout1);
+
+		long timestamp = System.currentTimeMillis();
+
+		propagateChanges(false, group);
+
+		_assertNotification("successful", timestamp, userId);
+
+		Assert.assertEquals(
+			initialCount + 2,
+			_layoutLocalService.getLayoutsCount(group.getGroupId(), false));
+
+		layout1 = LayoutLocalServiceUtil.getFriendlyURLLayout(
+			group.getGroupId(), false, layout1.getFriendlyURL());
+
+		Assert.assertNull(layout1.getLayoutSetPrototypeLayout());
+
+		layout2 = LayoutLocalServiceUtil.getFriendlyURLLayout(
+			group.getGroupId(), false, layout2.getFriendlyURL());
+
+		Assert.assertNotNull(layout2.getLayoutSetPrototypeLayout());
+	}
+
+	@Test
 	public void testLayoutSetPrototypePropagationWithExportImportInProcess()
 		throws Exception {
 

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
@@ -549,6 +549,12 @@ public class LayoutSetPrototypePropagationTest
 		String title = layoutSetPrototypeAssetCategory.getTitle(
 			LocaleUtil.getSiteDefault());
 
+		AssetVocabulary siteAssetVocabulary = AssetTestUtil.addVocabulary(
+			group.getGroupId());
+
+		AssetCategory siteAssetCategory = AssetTestUtil.addCategory(
+			group.getGroupId(), siteAssetVocabulary.getVocabularyId());
+
 		long timestamp = System.currentTimeMillis();
 
 		propagateChanges(false, group);
@@ -586,6 +592,10 @@ public class LayoutSetPrototypePropagationTest
 
 		Assert.assertEquals(
 			title, assetCategory.getTitle(LocaleUtil.getSiteDefault()));
+
+		Assert.assertNotNull(
+			AssetCategoryLocalServiceUtil.fetchAssetCategory(
+				siteAssetCategory.getCategoryId()));
 	}
 
 	@Test

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
@@ -1083,8 +1083,14 @@ public class LayoutSetPrototypePropagationTest
 
 		propagateChanges(group);
 
-		Assert.assertEquals(
-			_initialPrototypeLayoutsCount, getGroupLayoutCount());
+		if (linkEnabled) {
+			Assert.assertEquals(
+				_initialPrototypeLayoutsCount + 2, getGroupLayoutCount());
+		}
+		else {
+			Assert.assertEquals(
+				_initialPrototypeLayoutsCount, getGroupLayoutCount());
+		}
 	}
 
 	protected void doTestLayoutPropagationWithLayoutPrototype(

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
@@ -1189,6 +1189,11 @@ public class LayoutSetPrototypePropagationTest
 		}
 	}
 
+	@Override
+	protected boolean useColumnCustomizable() {
+		return false;
+	}
+
 	private Layout _addLayout(long groupId) throws Exception {
 		Layout layout = _layoutLocalService.addLayout(
 			null, TestPropsValues.getUserId(), groupId, true,

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
@@ -88,7 +88,6 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.Constants;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -1371,18 +1370,6 @@ public class LayoutSetPrototypePropagationTest
 		}
 
 		Thread.sleep(2000);
-
-		LayoutSet layoutSetPrototypeLayoutSet =
-			layoutSetPrototype.getLayoutSet();
-
-		UnicodeProperties layoutSetPrototypeSettingsUnicodeProperties =
-			layoutSetPrototypeLayoutSet.getSettingsProperties();
-
-		int mergeFailCount = GetterUtil.getInteger(
-			layoutSetPrototypeSettingsUnicodeProperties.getProperty(
-				Sites.MERGE_FAIL_COUNT));
-
-		Assert.assertEquals(0, mergeFailCount);
 	}
 
 	protected void propagateChanges(Group group) throws Exception {

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
@@ -687,16 +687,6 @@ public class LayoutSetPrototypePropagationTest
 
 		LayoutSetLocalServiceUtil.updateLayoutSet(prototypePublicLayoutSet);
 
-		_layoutSetPrototype =
-			LayoutSetPrototypeLocalServiceUtil.fetchLayoutSetPrototype(
-				_layoutSetPrototype.getLayoutSetPrototypeId());
-
-		_layoutSetPrototype.setModifiedDate(new Date());
-
-		_layoutSetPrototype =
-			LayoutSetPrototypeLocalServiceUtil.updateLayoutSetPrototype(
-				_layoutSetPrototype);
-
 		LayoutPageTemplateEntry masterLayoutPageTemplateEntry =
 			LayoutPageTemplateTestUtil.addLayoutPageTemplateEntry(
 				_layoutSetPrototypeGroup.getGroupId(),
@@ -866,16 +856,6 @@ public class LayoutSetPrototypePropagationTest
 
 		LayoutSetLocalServiceUtil.updateLayoutSet(prototypePublicLayoutSet);
 
-		_layoutSetPrototype =
-			LayoutSetPrototypeLocalServiceUtil.fetchLayoutSetPrototype(
-				_layoutSetPrototype.getLayoutSetPrototypeId());
-
-		_layoutSetPrototype.setModifiedDate(new Date());
-
-		_layoutSetPrototype =
-			LayoutSetPrototypeLocalServiceUtil.updateLayoutSetPrototype(
-				_layoutSetPrototype);
-
 		propagateChanges(group);
 
 		LayoutSet propagatedLayoutSet = group.getPrivateLayoutSet();
@@ -909,16 +889,6 @@ public class LayoutSetPrototypePropagationTest
 			prototypePrivateLayoutSet =
 				LayoutSetLocalServiceUtil.updateLayoutSet(
 					prototypePrivateLayoutSet);
-
-			layoutSetPrototype =
-				LayoutSetPrototypeLocalServiceUtil.fetchLayoutSetPrototype(
-					layoutSetPrototype.getLayoutSetPrototypeId());
-
-			layoutSetPrototype.setModifiedDate(new Date());
-
-			layoutSetPrototype =
-				LayoutSetPrototypeLocalServiceUtil.updateLayoutSetPrototype(
-					layoutSetPrototype);
 
 			LayoutSet privateLayoutSet =
 				LayoutSetLocalServiceUtil.fetchLayoutSet(
@@ -977,16 +947,6 @@ public class LayoutSetPrototypePropagationTest
 			prototypePrivateLayoutSet =
 				LayoutSetLocalServiceUtil.updateLayoutSet(
 					prototypePrivateLayoutSet);
-
-			layoutSetPrototype =
-				LayoutSetPrototypeLocalServiceUtil.fetchLayoutSetPrototype(
-					layoutSetPrototype.getLayoutSetPrototypeId());
-
-			layoutSetPrototype.setModifiedDate(new Date());
-
-			layoutSetPrototype =
-				LayoutSetPrototypeLocalServiceUtil.updateLayoutSetPrototype(
-					layoutSetPrototype);
 
 			LayoutSet publicLayoutSet =
 				LayoutSetLocalServiceUtil.fetchLayoutSet(
@@ -1053,16 +1013,6 @@ public class LayoutSetPrototypePropagationTest
 			prototypeLayoutSet);
 
 		setLinkEnabled(true);
-
-		_layoutSetPrototype =
-			LayoutSetPrototypeLocalServiceUtil.fetchLayoutSetPrototype(
-				_layoutSetPrototype.getLayoutSetPrototypeId());
-
-		_layoutSetPrototype.setModifiedDate(new Date());
-
-		_layoutSetPrototype =
-			LayoutSetPrototypeLocalServiceUtil.updateLayoutSetPrototype(
-				_layoutSetPrototype);
 
 		propagateChanges(group);
 

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
@@ -23,7 +23,6 @@ import com.liferay.layout.constants.LayoutTypeSettingsConstants;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.test.util.LayoutPageTemplateTestUtil;
-import com.liferay.layout.set.prototype.helper.LayoutSetPrototypeHelper;
 import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.string.StringPool;
@@ -154,32 +153,9 @@ public class LayoutSetPrototypePropagationTest
 	}
 
 	@Test
-	public void testLayoutPermissionPropagationWithLinkEnabled()
-		throws Exception {
-
-		setLinkEnabled(true);
-
-		Role role = RoleLocalServiceUtil.getRole(
-			TestPropsValues.getCompanyId(), RoleConstants.POWER_USER);
-
-		ResourcePermissionServiceUtil.setIndividualResourcePermissions(
-			prototypeLayout.getGroupId(), prototypeLayout.getCompanyId(),
-			Layout.class.getName(),
-			String.valueOf(prototypeLayout.getPrimaryKey()), role.getRoleId(),
-			new String[] {ActionKeys.CUSTOMIZE});
-
-		prototypeLayout = updateModifiedDate(
-			prototypeLayout,
-			new Date(System.currentTimeMillis() + Time.MINUTE));
-
-		propagateChanges(group);
-
-		Assert.assertTrue(
-			ResourcePermissionLocalServiceUtil.hasResourcePermission(
-				layout.getCompanyId(), Layout.class.getName(),
-				ResourceConstants.SCOPE_INDIVIDUAL,
-				String.valueOf(layout.getPrimaryKey()), role.getRoleId(),
-				ActionKeys.CUSTOMIZE));
+	public void testLayoutPermissionPropagation() throws Exception {
+		_testLayoutPermissionPropagation(false);
+		_testLayoutPermissionPropagation(true);
 	}
 
 	@Test
@@ -1066,29 +1042,27 @@ public class LayoutSetPrototypePropagationTest
 		return LayoutLocalServiceUtil.getLayoutsCount(group, false);
 	}
 
-	protected void propagateChanges(Group group) throws Exception {
-		MergeLayoutPrototypesThreadLocal.clearMergeComplete();
+	protected void propagateChanges(boolean initial, Group group)
+		throws Exception {
 
 		LayoutSet layoutSet = LayoutSetLocalServiceUtil.getLayoutSet(
 			group.getGroupId(), false);
-
-		UnicodeProperties settingsUnicodeProperties =
-			layoutSet.getSettingsProperties();
-
-		settingsUnicodeProperties.remove(Sites.LAST_MERGE_TIME);
-		settingsUnicodeProperties.remove(Sites.LAST_MERGE_VERSION);
-
-		layoutSet = LayoutSetLocalServiceUtil.updateLayoutSet(layoutSet);
-
-		_sites.mergeLayoutSetPrototypeLayouts(layoutSet);
-
-		Thread.sleep(2000);
 
 		LayoutSetPrototype layoutSetPrototype =
 			LayoutSetPrototypeLocalServiceUtil.
 				getLayoutSetPrototypeByUuidAndCompanyId(
 					layoutSet.getLayoutSetPrototypeUuid(),
 					layoutSet.getCompanyId());
+
+		if (initial) {
+			_sites.mergeLayoutSetPrototypeLayouts(layoutSet);
+		}
+		else {
+			_sites.mergeLayoutSetPrototypeLayouts(
+				layoutSetPrototype, TestPropsValues.getUserId());
+		}
+
+		Thread.sleep(2000);
 
 		LayoutSet layoutSetPrototypeLayoutSet =
 			layoutSetPrototype.getLayoutSet();
@@ -1101,6 +1075,10 @@ public class LayoutSetPrototypePropagationTest
 				Sites.MERGE_FAIL_COUNT));
 
 		Assert.assertEquals(0, mergeFailCount);
+	}
+
+	protected void propagateChanges(Group group) throws Exception {
+		propagateChanges(false, group);
 	}
 
 	protected void setLayoutsUpdateable(boolean layoutsUpdateable)
@@ -1266,6 +1244,35 @@ public class LayoutSetPrototypePropagationTest
 			).build());
 	}
 
+	private void _testLayoutPermissionPropagation(boolean initial)
+		throws Exception {
+
+		setLinkEnabled(true);
+
+		Role role = RoleLocalServiceUtil.getRole(
+			TestPropsValues.getCompanyId(), RoleConstants.POWER_USER);
+
+		ResourcePermissionServiceUtil.setIndividualResourcePermissions(
+			prototypeLayout.getGroupId(), prototypeLayout.getCompanyId(),
+			Layout.class.getName(),
+			String.valueOf(prototypeLayout.getPrimaryKey()), role.getRoleId(),
+			new String[] {ActionKeys.CUSTOMIZE});
+
+		prototypeLayout = updateModifiedDate(
+			prototypeLayout,
+			new Date(System.currentTimeMillis() + Time.MINUTE));
+
+		propagateChanges(initial, group);
+
+		Assert.assertEquals(
+			initial,
+			ResourcePermissionLocalServiceUtil.hasResourcePermission(
+				layout.getCompanyId(), Layout.class.getName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(layout.getPrimaryKey()), role.getRoleId(),
+				ActionKeys.CUSTOMIZE));
+	}
+
 	private void _verifyPortletPreferenceValue(
 		Layout layout, String portletId, String key, String expectedValue) {
 
@@ -1317,10 +1324,6 @@ public class LayoutSetPrototypePropagationTest
 	private LayoutSetPrototype _layoutSetPrototype;
 
 	private Group _layoutSetPrototypeGroup;
-
-	@Inject
-	private LayoutSetPrototypeHelper _layoutSetPrototypeHelper;
-
 	private JournalArticle _layoutSetPrototypeJournalArticle;
 
 	@DeleteAfterTestRun

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
@@ -140,51 +140,6 @@ public class LayoutSetPrototypePropagationTest
 	}
 
 	@Test
-	@TestInfo("LPD-81592")
-	public void testIsLayoutSetMergeable() throws Exception {
-		setLinkEnabled(true);
-
-		LayoutSet layoutSet = LayoutSetLocalServiceUtil.getLayoutSet(
-			group.getGroupId(), false);
-
-		UnicodeProperties settingsUnicodeProperties =
-			layoutSet.getSettingsProperties();
-
-		settingsUnicodeProperties.remove(Sites.LAST_MERGE_TIME);
-		settingsUnicodeProperties.remove(Sites.LAST_MERGE_VERSION);
-
-		layoutSet = LayoutSetLocalServiceUtil.updateLayoutSet(layoutSet);
-
-		_layoutSetPrototype =
-			LayoutSetPrototypeLocalServiceUtil.getLayoutSetPrototype(
-				_layoutSetPrototype.getLayoutSetPrototypeId());
-
-		_layoutSetPrototype.setModifiedDate(new Date());
-
-		_layoutSetPrototype =
-			LayoutSetPrototypeLocalServiceUtil.updateLayoutSetPrototype(
-				_layoutSetPrototype);
-
-		Assert.assertTrue(_sites.isLayoutSetMergeable(layoutSet));
-
-		settingsUnicodeProperties = layoutSet.getSettingsProperties();
-
-		settingsUnicodeProperties.setProperty(
-			Sites.LAST_MERGE_TIME,
-			String.valueOf(System.currentTimeMillis() - Time.MINUTE));
-
-		_layoutSetPrototype.setModifiedDate(new Date());
-
-		_layoutSetPrototype =
-			LayoutSetPrototypeLocalServiceUtil.updateLayoutSetPrototype(
-				_layoutSetPrototype);
-
-		Assert.assertFalse(
-			_sites.isLayoutSetMergeable(
-				LayoutSetLocalServiceUtil.updateLayoutSet(layoutSet)));
-	}
-
-	@Test
 	public void testIsLayoutSortable() throws Exception {
 		Assert.assertFalse(layout.isLayoutSortable());
 
@@ -196,52 +151,6 @@ public class LayoutSetPrototypePropagationTest
 	@Test
 	public void testIsLayoutUpdateable() throws Exception {
 		doTestIsLayoutUpdateable();
-	}
-
-	@Test
-	public void testLayoutDeleteAndReadWithSameFriendlyURL() throws Exception {
-		setLinkEnabled(true);
-
-		Layout layout = LayoutTestUtil.addTypePortletLayout(
-			_layoutSetPrototypeGroup.getGroupId(), "test", true);
-
-		String friendlyURL = layout.getFriendlyURL();
-
-		Assert.assertEquals(
-			_initialPrototypeLayoutsCount, getGroupLayoutCount());
-
-		propagateChanges(group);
-
-		Assert.assertEquals(
-			_initialPrototypeLayoutsCount + 1, getGroupLayoutCount());
-
-		LayoutLocalServiceUtil.deleteLayout(
-			layout, ServiceContextTestUtil.getServiceContext());
-
-		Layout newLayout = LayoutTestUtil.addTypePortletLayout(
-			_layoutSetPrototypeGroup.getGroupId(), "test", true);
-
-		Assert.assertEquals(friendlyURL, newLayout.getFriendlyURL());
-
-		Assert.assertEquals(
-			_initialPrototypeLayoutsCount + 1, getGroupLayoutCount());
-
-		propagateChanges(group);
-
-		Assert.assertEquals(
-			_initialPrototypeLayoutsCount + 1, getGroupLayoutCount());
-
-		Layout propagatedLayout =
-			LayoutLocalServiceUtil.fetchLayoutByUuidAndGroupId(
-				newLayout.getUuid(), group.getGroupId(), false);
-
-		Assert.assertNotNull(
-			"Deleted and readded layout could not be found on propagated site",
-			propagatedLayout);
-
-		Assert.assertEquals(
-			"Friendly URLs of the source and target layouts should match",
-			friendlyURL, propagatedLayout.getFriendlyURL());
 	}
 
 	@Test

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
@@ -35,6 +35,7 @@ import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.image.ImageToolUtil;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTask;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskExecutor;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskResult;
@@ -105,6 +106,8 @@ import com.liferay.segments.service.SegmentsExperienceLocalService;
 import com.liferay.sites.kernel.util.Sites;
 
 import jakarta.portlet.PortletPreferences;
+
+import java.awt.image.BufferedImage;
 
 import java.util.Collections;
 import java.util.Date;
@@ -496,6 +499,38 @@ public class LayoutSetPrototypePropagationTest
 			group.getGroupId(), false, layout2.getFriendlyURL());
 
 		Assert.assertNotNull(layout2.getLayoutSetPrototypeLayout());
+	}
+
+	@Test
+	public void testLayoutSetPrototypePropagationOverridesLogo()
+		throws Exception {
+
+		LayoutSetLocalServiceUtil.updateLogo(
+			group.getGroupId(), false, true,
+			ImageToolUtil.getBytes(
+				new BufferedImage(1, 1, BufferedImage.TYPE_INT_RGB), "png"));
+
+		LayoutSet layoutSet = LayoutSetLocalServiceUtil.getLayoutSet(
+			group.getGroupId(), false);
+
+		long logoId = layoutSet.getLogoId();
+
+		LayoutSetLocalServiceUtil.updateLogo(
+			_layoutSetPrototypeGroup.getGroupId(), true, true,
+			ImageToolUtil.getBytes(
+				new BufferedImage(2, 2, BufferedImage.TYPE_INT_RGB), "png"));
+
+		long timestamp = System.currentTimeMillis();
+
+		propagateChanges(false, group);
+
+		_assertNotification(
+			"successful", timestamp, TestPropsValues.getUserId());
+
+		layoutSet = LayoutSetLocalServiceUtil.getLayoutSet(
+			group.getGroupId(), false);
+
+		Assert.assertNotEquals(logoId, layoutSet.getLogoId());
 	}
 
 	@Test

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SiteResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SiteResourceTest.java
@@ -12,6 +12,7 @@ import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.exportimport.test.rule.LazyReferencing;
 import com.liferay.exportimport.test.rule.LazyReferencingTestRule;
+import com.liferay.exportimport.test.util.ExportImportTestUtil;
 import com.liferay.headless.admin.site.client.dto.v1_0.AnalyticsConfiguration;
 import com.liferay.headless.admin.site.client.dto.v1_0.GoogleAnalyticsConfiguration;
 import com.liferay.headless.admin.site.client.dto.v1_0.RatingsTypes;
@@ -20,6 +21,7 @@ import com.liferay.headless.admin.site.client.pagination.Page;
 import com.liferay.headless.admin.site.client.pagination.Pagination;
 import com.liferay.headless.admin.site.client.problem.Problem;
 import com.liferay.headless.admin.site.client.resource.v1_0.SiteResource;
+import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -27,12 +29,14 @@ import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.LayoutSetPrototype;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutSetPrototypeLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -74,6 +78,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -1133,6 +1138,9 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 				).build(),
 				null, true, true, new ServiceContext());
 
+		Layout layoutSetPrototypeLayout = LayoutTestUtil.addTypePortletLayout(
+			layoutSetPrototype.getGroup(), true);
+
 		randomSite.setTemplateKey(
 			String.valueOf(layoutSetPrototype.getLayoutSetPrototypeId()));
 
@@ -1149,6 +1157,13 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		Assert.assertEquals(
 			layoutSetPrototype.getLayoutSetPrototypeId(),
 			publicLayoutSet.getLayoutSetPrototypeId());
+
+		ExportImportTestUtil.retryAssert(
+			1, TimeUnit.SECONDS, 30, TimeUnit.SECONDS,
+			() -> Assert.assertNotNull(
+				LayoutLocalServiceUtil.fetchLayoutByFriendlyURL(
+					group.getGroupId(), false,
+					layoutSetPrototypeLayout.getFriendlyURL())));
 	}
 
 	private void _testPostSiteWithFriendlyURLMissingSlash() throws Exception {

--- a/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/portlet/action/ActionUtil.java
+++ b/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/portlet/action/ActionUtil.java
@@ -161,7 +161,8 @@ public class ActionUtil {
 	}
 
 	public static void updateLayoutSetPrototypesLinks(
-			ActionRequest actionRequest, Group liveGroup, Sites sites)
+			ActionRequest actionRequest, Group liveGroup,
+			boolean mergeLayoutSetPrototype, Sites sites)
 		throws Exception {
 
 		long privateLayoutSetPrototypeId = ParamUtil.getLong(
@@ -224,8 +225,8 @@ public class ActionUtil {
 		}
 
 		sites.updateLayoutSetPrototypesLinks(
-			group, publicLayoutSetPrototypeId, privateLayoutSetPrototypeId,
-			publicLayoutSetPrototypeLinkEnabled,
+			group, mergeLayoutSetPrototype, publicLayoutSetPrototypeId,
+			privateLayoutSetPrototypeId, publicLayoutSetPrototypeLinkEnabled,
 			privateLayoutSetPrototypeLinkEnabled);
 	}
 

--- a/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/portlet/action/AddGroupMVCActionCommand.java
+++ b/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/portlet/action/AddGroupMVCActionCommand.java
@@ -652,7 +652,8 @@ public class AddGroupMVCActionCommand extends BaseMVCActionCommand {
 			ActionRequest actionRequest, Group group)
 		throws Exception {
 
-		ActionUtil.updateLayoutSetPrototypesLinks(actionRequest, group, _sites);
+		ActionUtil.updateLayoutSetPrototypesLinks(
+			actionRequest, group, true, _sites);
 
 		long layoutSetPrototypeId = ParamUtil.getLong(
 			actionRequest, "layoutSetPrototypeId");

--- a/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/portlet/action/EditPagesMVCActionCommand.java
+++ b/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/portlet/action/EditPagesMVCActionCommand.java
@@ -87,7 +87,7 @@ public class EditPagesMVCActionCommand
 			liveGroup.getGroupId(), typeSettingsUnicodeProperties.toString());
 
 		ActionUtil.updateLayoutSetPrototypesLinks(
-			actionRequest, liveGroup, _sites);
+			actionRequest, liveGroup, false, _sites);
 	}
 
 	@Reference

--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/util/SitesImpl.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/util/SitesImpl.java
@@ -993,8 +993,8 @@ public class SitesImpl implements Sites {
 		}
 
 		_layoutSetService.updateLayoutSetPrototypeLinkEnabled(
-			groupId, privateLayout, layoutSetPrototypeLinkEnabled,
-			layoutSetPrototypeUuid);
+			groupId, mergeLayoutSetPrototype, privateLayout,
+			layoutSetPrototypeLinkEnabled, layoutSetPrototypeUuid);
 
 		_layoutLocalService.updatePriorities(groupId, privateLayout);
 	}

--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/util/SitesImpl.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/util/SitesImpl.java
@@ -665,18 +665,32 @@ public class SitesImpl implements Sites {
 
 	@Override
 	public void updateLayoutSetPrototypesLinks(
+			Group group, boolean mergeLayoutSetPrototype,
+			long publicLayoutSetPrototypeId, long privateLayoutSetPrototypeId,
+			boolean publicLayoutSetPrototypeLinkEnabled,
+			boolean privateLayoutSetPrototypeLinkEnabled)
+		throws Exception {
+
+		updateLayoutSetPrototypeLink(
+			group.getGroupId(), mergeLayoutSetPrototype, true,
+			privateLayoutSetPrototypeId, privateLayoutSetPrototypeLinkEnabled);
+		updateLayoutSetPrototypeLink(
+			group.getGroupId(), mergeLayoutSetPrototype, false,
+			publicLayoutSetPrototypeId, publicLayoutSetPrototypeLinkEnabled);
+	}
+
+	@Override
+	public void updateLayoutSetPrototypesLinks(
 			Group group, long publicLayoutSetPrototypeId,
 			long privateLayoutSetPrototypeId,
 			boolean publicLayoutSetPrototypeLinkEnabled,
 			boolean privateLayoutSetPrototypeLinkEnabled)
 		throws Exception {
 
-		updateLayoutSetPrototypeLink(
-			group.getGroupId(), true, privateLayoutSetPrototypeId,
+		updateLayoutSetPrototypesLinks(
+			group, true, publicLayoutSetPrototypeId,
+			privateLayoutSetPrototypeId, publicLayoutSetPrototypeLinkEnabled,
 			privateLayoutSetPrototypeLinkEnabled);
-		updateLayoutSetPrototypeLink(
-			group.getGroupId(), false, publicLayoutSetPrototypeId,
-			publicLayoutSetPrototypeLinkEnabled);
 	}
 
 	protected void deleteUnreferencedPortlets(
@@ -940,7 +954,8 @@ public class SitesImpl implements Sites {
 	}
 
 	protected void updateLayoutSetPrototypeLink(
-			long groupId, boolean privateLayout, long layoutSetPrototypeId,
+			long groupId, boolean mergeLayoutSetPrototype,
+			boolean privateLayout, long layoutSetPrototypeId,
 			boolean layoutSetPrototypeLinkEnabled)
 		throws Exception {
 
@@ -957,7 +972,7 @@ public class SitesImpl implements Sites {
 				// Merge without enabling the link
 
 				if (!layoutSetPrototypeLinkEnabled &&
-					(layoutSetPrototypeId > 0)) {
+					(layoutSetPrototypeId > 0) && mergeLayoutSetPrototype) {
 
 					boolean mergeLayoutPrototypesThreadLocalInProgress =
 						MergeLayoutPrototypesThreadLocal.isInProgress();

--- a/modules/apps/user-groups-admin/user-groups-admin-web/src/main/java/com/liferay/user/groups/admin/web/internal/portlet/UserGroupsAdminPortlet.java
+++ b/modules/apps/user-groups-admin/user-groups-admin-web/src/main/java/com/liferay/user/groups/admin/web/internal/portlet/UserGroupsAdminPortlet.java
@@ -124,7 +124,7 @@ public class UserGroupsAdminPortlet extends MVCPortlet {
 				actionRequest, "privateLayoutSetPrototypeLinkEnabled");
 
 			_sites.updateLayoutSetPrototypesLinks(
-				userGroup.getGroup(), publicLayoutSetPrototypeId,
+				userGroup.getGroup(), false, publicLayoutSetPrototypeId,
 				privateLayoutSetPrototypeId,
 				publicLayoutSetPrototypeLinkEnabled,
 				privateLayoutSetPrototypeLinkEnabled);

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/EditProfileAndDashboardMVCActionCommand.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/EditProfileAndDashboardMVCActionCommand.java
@@ -82,7 +82,7 @@ public class EditProfileAndDashboardMVCActionCommand
 					privateLayoutSet.isLayoutSetPrototypeLinkEnabled())) {
 
 				_sites.updateLayoutSetPrototypesLinks(
-					group, publicLayoutSetPrototypeId,
+					group, false, publicLayoutSetPrototypeId,
 					privateLayoutSetPrototypeId,
 					publicLayoutSetPrototypeLinkEnabled,
 					privateLayoutSetPrototypeLinkEnabled);

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/UpdateOrganizationOrganizationSiteMVCActionCommand.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/UpdateOrganizationOrganizationSiteMVCActionCommand.java
@@ -124,7 +124,7 @@ public class UpdateOrganizationOrganizationSiteMVCActionCommand
 				privateLayoutSetPrototypeId > 0);
 
 			_sites.updateLayoutSetPrototypesLinks(
-				organizationGroup, publicLayoutSetPrototypeId,
+				organizationGroup, false, publicLayoutSetPrototypeId,
 				privateLayoutSetPrototypeId,
 				publicLayoutSetPrototypeLinkEnabled,
 				privateLayoutSetPrototypeLinkEnabled);

--- a/modules/test/playwright/helpers/ApiHelpers.ts
+++ b/modules/test/playwright/helpers/ApiHelpers.ts
@@ -71,6 +71,7 @@ import {JSONWebServicesJournalApiHelper} from './json-web-services/JSONWebServic
 import {JSONWebServicesLayoutApiHelper} from './json-web-services/JSONWebServicesLayoutApiHelper';
 import {JSONWebServicesLayoutPageTemplateCollectionApiHelper} from './json-web-services/JSONWebServicesLayoutPageTemplateCollection';
 import {JSONWebServicesLayoutPageTemplateEntryApiHelper} from './json-web-services/JSONWebServicesLayoutPageTemplateEntry';
+import {JSONWebServicesLayoutSetApiHelper} from './json-web-services/JSONWebServicesLayoutSetApiHelper';
 import {JSONWebServicesLayoutSetPrototypeApiHelper} from './json-web-services/JSONWebServicesLayoutSetPrototypeApiHelper';
 import {JSONWebServicesMBApiHelper} from './json-web-services/JSONWebServicesMBApiHelper';
 import {JSONWebServicesOSBAsahApiHelper} from './json-web-services/JSONWebServicesOSBAsahApiHelper';
@@ -170,6 +171,7 @@ export class ApiHelpers {
 	readonly jsonWebServicesLayout: JSONWebServicesLayoutApiHelper;
 	readonly jsonWebServicesLayoutPageTemplateEntry: JSONWebServicesLayoutPageTemplateEntryApiHelper;
 	readonly jsonWebServicesLayoutPageTemplateCollection: JSONWebServicesLayoutPageTemplateCollectionApiHelper;
+	readonly jsonWebServicesLayoutSet: JSONWebServicesLayoutSetApiHelper;
 	readonly jsonWebServicesLayoutSetPrototype: JSONWebServicesLayoutSetPrototypeApiHelper;
 	readonly jsonWebServicesMBApiHelper: JSONWebServicesMBApiHelper;
 	readonly jsonWebServicesOSBAsah: JSONWebServicesOSBAsahApiHelper;
@@ -278,6 +280,9 @@ export class ApiHelpers {
 			new JSONWebServicesLayoutPageTemplateEntryApiHelper(this);
 		this.jsonWebServicesLayoutPageTemplateCollection =
 			new JSONWebServicesLayoutPageTemplateCollectionApiHelper(this);
+		this.jsonWebServicesLayoutSet = new JSONWebServicesLayoutSetApiHelper(
+			this
+		);
 		this.jsonWebServicesLayoutSetPrototype =
 			new JSONWebServicesLayoutSetPrototypeApiHelper(this);
 		this.jsonWebServicesMBApiHelper = new JSONWebServicesMBApiHelper(this);

--- a/modules/test/playwright/helpers/json-web-services/JSONWebServicesGroupApiHelper.ts
+++ b/modules/test/playwright/helpers/json-web-services/JSONWebServicesGroupApiHelper.ts
@@ -52,6 +52,22 @@ export class JSONWebServicesGroupApiHelper {
 		);
 	}
 
+	async getUserGroup(companyId: string, userId: string): Promise<Group> {
+		const urlSearchParams = new URLSearchParams();
+
+		urlSearchParams.append('companyId', companyId);
+		urlSearchParams.append('userId', userId);
+
+		return this.apiHelpers.post(
+			`${liferayConfig.environment.baseUrl}${this.basePath}/get-user-group`,
+			{
+				data: urlSearchParams.toString(),
+				failOnStatusCode: true,
+				headers: await this.apiHelpers.getJSONWebServicesHeaders(),
+			}
+		);
+	}
+
 	async getGroupByKey(companyId: string, groupKey: string): Promise<Group> {
 		const urlSearchParams = new URLSearchParams();
 

--- a/modules/test/playwright/helpers/json-web-services/JSONWebServicesLayoutApiHelper.ts
+++ b/modules/test/playwright/helpers/json-web-services/JSONWebServicesLayoutApiHelper.ts
@@ -136,7 +136,7 @@ export class JSONWebServicesLayoutApiHelper {
 	async getLayoutsCount(
 		groupId: number,
 		privateLayout: boolean
-	): Promise<void> {
+	): Promise<number> {
 		const urlSearchParams = new URLSearchParams();
 
 		// @ts-ignore

--- a/modules/test/playwright/helpers/json-web-services/JSONWebServicesLayoutSetApiHelper.ts
+++ b/modules/test/playwright/helpers/json-web-services/JSONWebServicesLayoutSetApiHelper.ts
@@ -1,0 +1,49 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {liferayConfig} from '../../liferay.config';
+import {ApiHelpers} from '../ApiHelpers';
+
+export class JSONWebServicesLayoutSetApiHelper {
+	readonly apiHelpers: ApiHelpers;
+	readonly basePath: string;
+
+	constructor(apiHelpers: ApiHelpers) {
+		this.apiHelpers = apiHelpers;
+		this.basePath = '/api/jsonws/layoutset';
+	}
+
+	async updateLayoutSetPrototypeLinkEnabled({
+		groupId,
+		layoutSetPrototypeLinkEnabled,
+		layoutSetPrototypeUuid,
+	}: {
+		groupId: string;
+		layoutSetPrototypeLinkEnabled: boolean;
+		layoutSetPrototypeUuid: string;
+	}) {
+		const urlSearchParams = new URLSearchParams();
+
+		urlSearchParams.append('groupId', groupId);
+		urlSearchParams.append(
+			'layoutSetPrototypeLinkEnabled',
+			layoutSetPrototypeLinkEnabled.toString()
+		);
+		urlSearchParams.append(
+			'layoutSetPrototypeUuid',
+			layoutSetPrototypeUuid
+		);
+		urlSearchParams.append('privateLayout', false.toString());
+
+		return this.apiHelpers.post(
+			`${liferayConfig.environment.baseUrl}${this.basePath}/update-layout-set-prototype-link-enabled`,
+			{
+				data: urlSearchParams.toString(),
+				failOnStatusCode: true,
+				headers: await this.apiHelpers.getJSONWebServicesHeaders(),
+			}
+		);
+	}
+}

--- a/modules/test/playwright/helpers/json-web-services/JSONWebServicesLayoutSetPrototypeApiHelper.ts
+++ b/modules/test/playwright/helpers/json-web-services/JSONWebServicesLayoutSetPrototypeApiHelper.ts
@@ -61,21 +61,21 @@ export class JSONWebServicesLayoutSetPrototypeApiHelper {
 	}
 
 	async addLayoutSetPrototypes({
+		active = true,
 		layoutsUpdateable = true,
 		name,
 		url = liferayConfig.environment.baseUrl,
 	}: {
+		active?: boolean;
 		layoutsUpdateable?: boolean;
 		name: string;
 		url?: string;
 	}): Promise<LayoutSetPrototype> {
 		const urlSearchParams = new URLSearchParams();
 
-		const booleanTrue: boolean = true;
-
 		urlSearchParams.append('name', name);
 		urlSearchParams.append('description', '');
-		urlSearchParams.append('active', booleanTrue.toString());
+		urlSearchParams.append('active', active.toString());
 		urlSearchParams.append(
 			'layoutsUpdateable',
 			layoutsUpdateable.toString()

--- a/modules/test/playwright/pages/site-admin-web/SiteSettingsPage.ts
+++ b/modules/test/playwright/pages/site-admin-web/SiteSettingsPage.ts
@@ -65,6 +65,21 @@ export class SiteSettingsPage {
 		await waitForSPAToBeLoaded(this.page);
 	}
 
+	async linkSiteTemplate(
+		siteTemplateName: string,
+		{propagationEnabled = false}: {propagationEnabled?: boolean} = {}
+	) {
+		await this.page
+			.locator('select[name$="publicLayoutSetPrototypeId"]')
+			.selectOption({label: siteTemplateName});
+
+		await this.page
+			.locator('input[name$="publicLayoutSetPrototypeLinkEnabled"]')
+			.setChecked(propagationEnabled, {force: true});
+
+		await this.saveConfiguration();
+	}
+
 	async clickOnAction(actionName: string) {
 		await clickAndExpectToBeVisible({
 			autoClick: true,

--- a/modules/test/playwright/pages/users-admin-web/EditOrganizationPage.ts
+++ b/modules/test/playwright/pages/users-admin-web/EditOrganizationPage.ts
@@ -177,6 +177,40 @@ export class EditOrganizationPage {
 		return name;
 	}
 
+	async linkSiteTemplate(
+		organizationName: string,
+		siteTemplateName: string,
+		{propagationEnabled = false}: {propagationEnabled?: boolean} = {}
+	) {
+		await expect(async () => {
+			await (
+				await this.usersAndOrganizationsPage.organizationsTable.rowActions(
+					organizationName
+				)
+			).click();
+
+			await expect(this.organizationEditMenuItem).toBeVisible();
+		}).toPass({timeout: 5000});
+
+		await this.organizationEditMenuItem.click();
+
+		await this.organizationSiteLink.click();
+
+		await this.createSiteToggle.setChecked(true, {force: true});
+
+		await this.page
+			.locator('select[name$="publicLayoutSetPrototypeId"]')
+			.selectOption({label: siteTemplateName});
+
+		await this.page
+			.locator('input[name$="publicLayoutSetPrototypeLinkEnabled"]')
+			.setChecked(propagationEnabled, {force: true});
+
+		await this.organizationSiteSaveButton.click();
+
+		await waitForAlert(this.page);
+	}
+
 	async addTag(tagName: string) {
 		await this.tagsInput.fill(tagName);
 		await this.tagsInput.press('Enter');

--- a/modules/test/playwright/pages/users-admin-web/EditUserPage.ts
+++ b/modules/test/playwright/pages/users-admin-web/EditUserPage.ts
@@ -850,6 +850,25 @@ export class EditUserPage {
 			this.passwordConfirmationFrame.getByLabel('Your Password');
 	}
 
+	async linkSiteTemplate(
+		siteTemplateName: string,
+		{propagationEnabled = false}: {propagationEnabled?: boolean} = {}
+	) {
+		await this.profileAndDashboardLink.click();
+
+		await this.page
+			.locator('select[name$="publicLayoutSetPrototypeId"]')
+			.selectOption({label: siteTemplateName});
+
+		await this.page
+			.locator('input[name$="publicLayoutSetPrototypeLinkEnabled"]')
+			.setChecked(propagationEnabled, {force: true});
+
+		await this.saveButton.click();
+
+		await waitForAlert(this.page);
+	}
+
 	async addNewAddress(makePrimary: boolean, streetName: string) {
 		await expect(async () => {
 			await this.addAddressButton.click();

--- a/modules/test/playwright/pages/users-admin-web/UserGroupsPage.ts
+++ b/modules/test/playwright/pages/users-admin-web/UserGroupsPage.ts
@@ -3,8 +3,9 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {FrameLocator, Locator, Page} from '@playwright/test';
+import {FrameLocator, Locator, Page, expect} from '@playwright/test';
 
+import {waitForAlert} from '../../utils/waitForAlert';
 import {DataTablePage} from '../account-admin-web/DataTablePage';
 import {GlobalMenuPage} from '../product-navigation-applications-menu/GlobalMenuPage';
 
@@ -260,6 +261,32 @@ export class UserGroupsPage {
 		}
 
 		await this.globalMenuPage.goToControlPanel('User Groups');
+	}
+
+	async linkSiteTemplate(
+		userGroupName: string,
+		siteTemplateName: string,
+		{propagationEnabled = false}: {propagationEnabled?: boolean} = {}
+	) {
+		await expect(async () => {
+			await (await this.userGroupsTableRowActions(userGroupName)).click();
+
+			await expect(this.editUserGroupMenuItem).toBeVisible();
+		}).toPass({timeout: 5000});
+
+		await this.editUserGroupMenuItem.click();
+
+		await this.page
+			.locator('select[name$="publicLayoutSetPrototypeId"]')
+			.selectOption({label: siteTemplateName});
+
+		await this.page
+			.locator('input[name$="publicLayoutSetPrototypeLinkEnabled"]')
+			.setChecked(propagationEnabled, {force: true});
+
+		await this.saveButton.click();
+
+		await waitForAlert(this.page);
 	}
 
 	async goToWithLimitedAccess() {

--- a/modules/test/playwright/tests/layout-set-prototype-web/main/pages/LayoutSetPrototypePage.ts
+++ b/modules/test/playwright/tests/layout-set-prototype-web/main/pages/LayoutSetPrototypePage.ts
@@ -3,24 +3,33 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {Locator, Page} from '@playwright/test';
+import {Locator, Page, expect} from '@playwright/test';
 
 import {liferayConfig} from '../../../../liferay.config';
+import {clickAndExpectToBeVisible} from '../../../../utils/clickAndExpectToBeVisible';
 import {reloadUntilVisible} from '../../../../utils/reloadUntilVisible';
 
 export class LayoutSetPrototypePage {
+	readonly activateMenuItem: Locator;
 	readonly addLink: Locator;
+	readonly executeSyncMenuItem: Locator;
 	readonly homePageLink: Locator;
 	readonly nameBox: Locator;
+	readonly notificationsButton: Locator;
 	readonly page: Page;
 	readonly saveButton: Locator;
 
 	constructor(page: Page) {
 		this.page = page;
 
+		this.activateMenuItem = page.getByRole('menuitem', {name: 'Activate'});
 		this.addLink = page.getByRole('link', {name: 'Add'});
+		this.executeSyncMenuItem = page.getByRole('menuitem', {
+			name: 'Execute Site Template Sync',
+		});
 		this.homePageLink = page.getByLabel('Home', {exact: true});
 		this.nameBox = page.getByPlaceholder('Name');
+		this.notificationsButton = page.getByLabel('New Notification');
 		this.saveButton = page.getByRole('button', {name: 'Save'});
 	}
 
@@ -72,7 +81,51 @@ export class LayoutSetPrototypePage {
 		await this.page.getByText(webContentBody).isVisible();
 	}
 
+	async executeSync(templateName: string) {
+		await clickAndExpectToBeVisible({
+			target: this.executeSyncMenuItem,
+			trigger: this.rowActions(templateName),
+		});
+
+		this.page.once('dialog', (dialog) => dialog.accept());
+
+		await this.executeSyncMenuItem.click();
+
+		await expect(
+			this.page.getByText(
+				`The sync of the site template ${templateName} started. You will receive a notification when the process is complete.`
+			)
+		).toBeVisible();
+	}
+
+	async executeSyncAndWaitForSuccess(templateName: string) {
+		await this.executeSync(templateName);
+
+		await this.waitForSyncSuccessNotification(templateName);
+	}
+
 	async getSiteTemplateUrl(templateName: string) {
 		return await this.page.getByText(templateName).getAttribute('href');
+	}
+
+	rowActions(templateName: string): Locator {
+		return this.page
+			.locator('tr', {hasText: templateName})
+			.getByLabel('Actions');
+	}
+
+	async waitForSyncSuccessNotification(templateName: string) {
+		await expect(async () => {
+			await this.page.reload();
+
+			await this.notificationsButton.click({timeout: 100});
+
+			await expect(
+				this.page.getByText(
+					`The sync of the site template ${templateName} finished successfully.`,
+					{exact: true}
+				)
+			).toBeVisible({timeout: 100});
+		}).toPass();
 	}
 }

--- a/modules/test/playwright/tests/layout-set-prototype-web/main/siteTemplatesSync.spec.ts
+++ b/modules/test/playwright/tests/layout-set-prototype-web/main/siteTemplatesSync.spec.ts
@@ -14,6 +14,7 @@ import {sitesPageTest} from '../../../fixtures/sitesPageTest';
 import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
 import getRandomString from '../../../utils/getRandomString';
 import {sitesAdminPagesTest} from '../../site-admin-web/main/fixtures/sitesAdminPagesTest';
+import {layoutSetPrototypePageTest} from './fixtures/layoutSetPrototypePageTest';
 import createSiteTemplate from './utils/createSiteTemplate';
 
 export const test = mergeTests(
@@ -23,6 +24,7 @@ export const test = mergeTests(
 		'LPD-82107': {enabled: true},
 	}),
 	globalMenuPagesTest,
+	layoutSetPrototypePageTest,
 	loginTest(),
 	productMenuPageTest,
 	sitesAdminPagesTest,
@@ -32,7 +34,7 @@ export const test = mergeTests(
 test(
 	'Execute Site Template Sync action is hidden for inactive Site Templates',
 	{tag: '@LPD-87027'},
-	async ({apiHelpers, globalMenuPage, page}) => {
+	async ({apiHelpers, globalMenuPage, layoutSetPrototypePage}) => {
 
 		// Create an inactive Site Template
 
@@ -51,34 +53,24 @@ test(
 			type: 'layoutSetPrototype',
 		});
 
-		// Open the row Actions dropdown in the Site Templates list
-
 		await globalMenuPage.goToControlPanel('Site Templates');
 
-		// The sync action is hidden, and Activate is shown instead of Deactivate
+		// Inactive: Activate is shown and the sync action is hidden
 
 		await clickAndExpectToBeVisible({
-			target: page.getByRole('menuitem', {name: 'Activate'}),
-			trigger: page
-				.locator('tr', {hasText: siteTemplateName})
-				.getByLabel('Actions'),
+			target: layoutSetPrototypePage.activateMenuItem,
+			trigger: layoutSetPrototypePage.rowActions(siteTemplateName),
 		});
 
-		await expect(
-			page.getByRole('menuitem', {name: 'Execute Site Template Sync'})
-		).toBeHidden();
+		await expect(layoutSetPrototypePage.executeSyncMenuItem).toBeHidden();
 
 		// Activate the Site Template and verify the sync action is now visible
 
-		await page.getByRole('menuitem', {name: 'Activate'}).click();
+		await layoutSetPrototypePage.activateMenuItem.click();
 
 		await clickAndExpectToBeVisible({
-			target: page.getByRole('menuitem', {
-				name: 'Execute Site Template Sync',
-			}),
-			trigger: page
-				.locator('tr', {hasText: siteTemplateName})
-				.getByLabel('Actions'),
+			target: layoutSetPrototypePage.executeSyncMenuItem,
+			trigger: layoutSetPrototypePage.rowActions(siteTemplateName),
 		});
 	}
 );
@@ -89,6 +81,7 @@ test(
 	async ({
 		apiHelpers,
 		globalMenuPage,
+		layoutSetPrototypePage,
 		page,
 		productMenuPage,
 		sitesAdminPage,
@@ -140,47 +133,14 @@ test(
 			title: newPageName,
 		});
 
-		// Trigger the manual sync from the Site Templates list
+		// Trigger the manual sync from the Site Templates list and wait for the
+		// asynchronous completion notification
 
 		await globalMenuPage.goToControlPanel('Site Templates');
 
-		await clickAndExpectToBeVisible({
-			target: page.getByRole('menuitem', {
-				name: 'Execute Site Template Sync',
-			}),
-			trigger: page
-				.locator('tr', {hasText: siteTemplateName})
-				.getByLabel('Actions'),
-		});
-
-		page.once('dialog', (dialog) => dialog.accept());
-
-		await page
-			.getByRole('menuitem', {name: 'Execute Site Template Sync'})
-			.click();
-
-		await expect(
-			page.getByText(
-				`The sync of the site template ${siteTemplateName} started. You will receive a notification when the process is complete.`
-			)
-		).toBeVisible();
-
-		// Reload on each attempt so the bell reflects the latest server-side
-		// notification state instead of the dropdown rendered before the
-		// asynchronous sync notification arrived
-
-		await expect(async () => {
-			await page.reload();
-
-			await page.getByLabel('New Notification').click({timeout: 100});
-
-			await expect(
-				page.getByText(
-					`The sync of the site template ${siteTemplateName} finished successfully.`,
-					{exact: true}
-				)
-			).toBeVisible({timeout: 100});
-		}).toPass();
+		await layoutSetPrototypePage.executeSyncAndWaitForSuccess(
+			siteTemplateName
+		);
 
 		// The new page propagates to the linked Site
 

--- a/modules/test/playwright/tests/layout-set-prototype-web/main/siteTemplatesSync.spec.ts
+++ b/modules/test/playwright/tests/layout-set-prototype-web/main/siteTemplatesSync.spec.ts
@@ -1,0 +1,200 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
+import {globalMenuPagesTest} from '../../../fixtures/globalMenuPagesTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {productMenuPageTest} from '../../../fixtures/productMenuPageTest';
+import {sitesPageTest} from '../../../fixtures/sitesPageTest';
+import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
+import getRandomString from '../../../utils/getRandomString';
+import {sitesAdminPagesTest} from '../../site-admin-web/main/fixtures/sitesAdminPagesTest';
+import createSiteTemplate from './utils/createSiteTemplate';
+
+export const test = mergeTests(
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-35443': {enabled: true},
+		'LPD-82107': {enabled: true},
+	}),
+	globalMenuPagesTest,
+	loginTest(),
+	productMenuPageTest,
+	sitesAdminPagesTest,
+	sitesPageTest
+);
+
+test(
+	'Execute Site Template Sync action is hidden for inactive Site Templates',
+	{tag: '@LPD-87027'},
+	async ({apiHelpers, globalMenuPage, page}) => {
+
+		// Create an inactive Site Template
+
+		const siteTemplateName = 'SiteTemplate-' + getRandomString();
+
+		const layoutSetPrototype =
+			await apiHelpers.jsonWebServicesLayoutSetPrototype.addLayoutSetPrototypes(
+				{
+					active: false,
+					name: siteTemplateName,
+				}
+			);
+
+		apiHelpers.data.push({
+			id: layoutSetPrototype.layoutSetPrototypeId,
+			type: 'layoutSetPrototype',
+		});
+
+		// Open the row Actions dropdown in the Site Templates list
+
+		await globalMenuPage.goToControlPanel('Site Templates');
+
+		// The sync action is hidden, and Activate is shown instead of Deactivate
+
+		await clickAndExpectToBeVisible({
+			target: page.getByRole('menuitem', {name: 'Activate'}),
+			trigger: page
+				.locator('tr', {hasText: siteTemplateName})
+				.getByLabel('Actions'),
+		});
+
+		await expect(
+			page.getByRole('menuitem', {name: 'Execute Site Template Sync'})
+		).toBeHidden();
+
+		// Activate the Site Template and verify the sync action is now visible
+
+		await page.getByRole('menuitem', {name: 'Activate'}).click();
+
+		await clickAndExpectToBeVisible({
+			target: page.getByRole('menuitem', {
+				name: 'Execute Site Template Sync',
+			}),
+			trigger: page
+				.locator('tr', {hasText: siteTemplateName})
+				.getByLabel('Actions'),
+		});
+	}
+);
+
+test(
+	'Execute Site Template Sync propagates changes to a linked Site',
+	{tag: '@LPD-87027'},
+	async ({
+		apiHelpers,
+		globalMenuPage,
+		page,
+		productMenuPage,
+		sitesAdminPage,
+		sitesPage,
+	}) => {
+		test.slow();
+
+		// Create the Site Template and a linked Site
+
+		const siteTemplateName = 'SiteTemplate-' + getRandomString();
+
+		const layoutSetPrototype = await createSiteTemplate({
+			apiHelpers,
+			page,
+			productMenuPage,
+			templateName: siteTemplateName,
+		});
+
+		apiHelpers.data.push({
+			id: layoutSetPrototype.layoutSetPrototypeId,
+			type: 'layoutSetPrototype',
+		});
+
+		await sitesAdminPage.goto();
+
+		const siteName = 'Site-' + getRandomString();
+
+		const {externalReferenceCode} = await sitesPage.createSite({
+			isCustom: true,
+			siteName,
+			templateName: siteTemplateName,
+		});
+
+		apiHelpers.data.push({id: externalReferenceCode, type: 'site'});
+
+		// Add a new page to the Site Template
+
+		const layoutSetPrototypeGroup =
+			await apiHelpers.jsonWebServicesGroup.getGroupByKey(
+				layoutSetPrototype.companyId,
+				layoutSetPrototype.layoutSetPrototypeId
+			);
+
+		const newPageName = 'NewPage-' + getRandomString();
+
+		await apiHelpers.jsonWebServicesLayout.addLayout({
+			groupId: layoutSetPrototypeGroup.groupId,
+			privateLayout: 'true',
+			title: newPageName,
+		});
+
+		// Trigger the manual sync from the Site Templates list
+
+		await globalMenuPage.goToControlPanel('Site Templates');
+
+		await clickAndExpectToBeVisible({
+			target: page.getByRole('menuitem', {
+				name: 'Execute Site Template Sync',
+			}),
+			trigger: page
+				.locator('tr', {hasText: siteTemplateName})
+				.getByLabel('Actions'),
+		});
+
+		page.once('dialog', (dialog) => dialog.accept());
+
+		await page
+			.getByRole('menuitem', {name: 'Execute Site Template Sync'})
+			.click();
+
+		await expect(
+			page.getByText(
+				`The sync of the site template ${siteTemplateName} started. You will receive a notification when the process is complete.`
+			)
+		).toBeVisible();
+
+		// Reload on each attempt so the bell reflects the latest server-side
+		// notification state instead of the dropdown rendered before the
+		// asynchronous sync notification arrived
+
+		await expect(async () => {
+			await page.reload();
+
+			await page.getByLabel('New Notification').click({timeout: 100});
+
+			await expect(
+				page.getByText(
+					`The sync of the site template ${siteTemplateName} finished successfully.`,
+					{exact: true}
+				)
+			).toBeVisible({timeout: 100});
+		}).toPass();
+
+		// The new page propagates to the linked Site
+
+		await expect(async () => {
+			const sitePages = await apiHelpers.headlessAdminSite.getPages(
+				externalReferenceCode,
+				'pageSize=100&privateLayout=false'
+			);
+
+			expect(
+				sitePages.items.some(
+					(item) => item.name_i18n['en-US'] === newPageName
+				)
+			).toBeTruthy();
+		}).toPass();
+	}
+);

--- a/modules/test/playwright/tests/layout-set-prototype-web/main/siteTemplatesSync.spec.ts
+++ b/modules/test/playwright/tests/layout-set-prototype-web/main/siteTemplatesSync.spec.ts
@@ -11,6 +11,7 @@ import {globalMenuPagesTest} from '../../../fixtures/globalMenuPagesTest';
 import {loginTest} from '../../../fixtures/loginTest';
 import {productMenuPageTest} from '../../../fixtures/productMenuPageTest';
 import {sitesPageTest} from '../../../fixtures/sitesPageTest';
+import {ChangeTrackingPage} from '../../../pages/change-tracking-web/ChangeTrackingPage';
 import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
 import getRandomString from '../../../utils/getRandomString';
 import {sitesAdminPagesTest} from '../../site-admin-web/main/fixtures/sitesAdminPagesTest';
@@ -72,6 +73,68 @@ test(
 			target: layoutSetPrototypePage.executeSyncMenuItem,
 			trigger: layoutSetPrototypePage.rowActions(siteTemplateName),
 		});
+	}
+);
+
+test(
+	'Execute Site Template Sync is blocked when Publications is enabled',
+	{tag: '@LPD-87027'},
+	async ({apiHelpers, globalMenuPage, layoutSetPrototypePage, page}) => {
+		const siteTemplateName = 'SiteTemplate-' + getRandomString();
+
+		const layoutSetPrototype =
+			await apiHelpers.jsonWebServicesLayoutSetPrototype.addLayoutSetPrototypes(
+				{
+					name: siteTemplateName,
+				}
+			);
+
+		apiHelpers.data.push({
+			id: layoutSetPrototype.layoutSetPrototypeId,
+			type: 'layoutSetPrototype',
+		});
+
+		const changeTrackingPage = new ChangeTrackingPage(page);
+
+		try {
+			await changeTrackingPage.enablePublications(true);
+
+			await globalMenuPage.goToControlPanel('Site Templates');
+
+			await clickAndExpectToBeVisible({
+				target: layoutSetPrototypePage.executeSyncMenuItem,
+				trigger: layoutSetPrototypePage.rowActions(siteTemplateName),
+			});
+
+			await layoutSetPrototypePage.executeSyncMenuItem.click();
+
+			await expect(
+				page.getByText(
+					'The site template sync cannot be run with publications enabled.'
+				)
+			).toBeVisible();
+
+			await expect(
+				page.getByText(
+					'This will apply changes from your site template to linked sites'
+				)
+			).toBeHidden();
+
+			// Close the dialog so it does not block the navigation that
+			// disables publications during cleanup
+
+			const dialog = page.getByRole('alertdialog');
+
+			await dialog
+				.locator('.modal-footer')
+				.getByRole('button', {name: 'Close'})
+				.click();
+
+			await expect(dialog).toBeHidden();
+		}
+		finally {
+			await changeTrackingPage.enablePublications(false);
+		}
 	}
 );
 

--- a/modules/test/playwright/tests/layout-set-prototype-web/main/siteTemplatesUsecase.spec.ts
+++ b/modules/test/playwright/tests/layout-set-prototype-web/main/siteTemplatesUsecase.spec.ts
@@ -11,6 +11,7 @@ import {globalMenuPagesTest} from '../../../fixtures/globalMenuPagesTest';
 import {loginTest} from '../../../fixtures/loginTest';
 import {productMenuPageTest} from '../../../fixtures/productMenuPageTest';
 import {siteSettingsPagesTest} from '../../../fixtures/siteSettingsPagesTest';
+import {userGroupsPageTest} from '../../../fixtures/userGroupsPageTest';
 import {usersAndOrganizationsPagesTest} from '../../../fixtures/usersAndOrganizationsPagesTest';
 import {liferayConfig} from '../../../liferay.config';
 import getRandomString from '../../../utils/getRandomString';
@@ -43,6 +44,7 @@ const testWithSiteTemplateSync = mergeTests(
 	loginTest(),
 	productMenuPageTest,
 	siteSettingsPagesTest,
+	userGroupsPageTest,
 	usersAndOrganizationsPagesTest
 );
 
@@ -313,6 +315,131 @@ test(
 				expect(
 					await apiHelpers.jsonWebServicesLayout.getLayoutsCount(
 						Number(organizationGroup.groupId),
+						false
+					)
+				).toBe(0);
+			}
+		}
+	);
+});
+
+[
+	{label: 'with the propagation toggle enabled', propagationEnabled: true},
+	{label: 'with the propagation toggle disabled', propagationEnabled: false},
+].forEach(({label, propagationEnabled}) => {
+	testWithSiteTemplateSync(
+		"Linking an existing User Group's Site to a Site Template " +
+			`through the Settings ${label} does not execute the propagation`,
+		{tag: '@LPD-87027'},
+		async ({
+			apiHelpers,
+			globalMenuPage,
+			layoutSetPrototypePage,
+			page,
+			productMenuPage,
+			userGroupsPage,
+		}) => {
+			testWithSiteTemplateSync.slow();
+
+			// Create a Site Template with a Web Content and a page
+
+			const siteTemplateName = 'SiteTemplate-' + getRandomString();
+			const webContentBody = 'Body-' + getRandomString();
+			const webContentName = 'WebContent-' + getRandomString();
+
+			const layoutSetPrototype = await createSiteTemplate({
+				apiHelpers,
+				page,
+				productMenuPage,
+				templateName: siteTemplateName,
+				text: webContentBody,
+				webContentName,
+			});
+
+			apiHelpers.data.push({
+				id: layoutSetPrototype.layoutSetPrototypeId,
+				type: 'layoutSetPrototype',
+			});
+
+			const layoutSetPrototypeGroup =
+				await apiHelpers.jsonWebServicesGroup.getGroupByKey(
+					layoutSetPrototype.companyId,
+					layoutSetPrototype.layoutSetPrototypeId
+				);
+
+			const pageName = 'Page-' + getRandomString();
+
+			await apiHelpers.jsonWebServicesLayout.addLayout({
+				groupId: layoutSetPrototypeGroup.groupId,
+				privateLayout: 'true',
+				title: pageName,
+			});
+
+			// The Site Template has a page that a sync would propagate
+
+			expect(
+				await apiHelpers.jsonWebServicesLayout.getLayoutsCount(
+					Number(layoutSetPrototypeGroup.groupId),
+					true
+				)
+			).toBeGreaterThan(0);
+
+			// Create a User Group (its Site is not linked to any Site Template)
+
+			const userGroup =
+				await apiHelpers.headlessAdminUser.postUserGroup();
+
+			// Link the User Group's Site to the Site Template from its Site
+			// settings
+
+			await userGroupsPage.goto(true);
+
+			await userGroupsPage.linkSiteTemplate(
+				userGroup.name,
+				siteTemplateName,
+				{propagationEnabled}
+			);
+
+			// Relating a User Group to a Site Template must not trigger the sync
+
+			const userGroupGroup =
+				await apiHelpers.jsonWebServicesGroup.getGroupByKey(
+					layoutSetPrototype.companyId,
+					String(userGroup.id)
+				);
+
+			expect(
+				await apiHelpers.jsonWebServicesLayout.getLayoutsCount(
+					Number(userGroupGroup.groupId),
+					false
+				)
+			).toBe(0);
+
+			// Execute the Site Template Sync manually
+
+			await globalMenuPage.goToControlPanel('Site Templates');
+
+			await layoutSetPrototypePage.executeSyncAndWaitForSuccess(
+				siteTemplateName
+			);
+
+			// The sync only updates the Site when the propagation toggle is enabled
+			// (LPD-82108 AC3)
+
+			if (propagationEnabled) {
+				await expect(async () => {
+					expect(
+						await apiHelpers.jsonWebServicesLayout.getLayoutsCount(
+							Number(userGroupGroup.groupId),
+							false
+						)
+					).toBeGreaterThan(0);
+				}).toPass();
+			}
+			else {
+				expect(
+					await apiHelpers.jsonWebServicesLayout.getLayoutsCount(
+						Number(userGroupGroup.groupId),
 						false
 					)
 				).toBe(0);

--- a/modules/test/playwright/tests/layout-set-prototype-web/main/siteTemplatesUsecase.spec.ts
+++ b/modules/test/playwright/tests/layout-set-prototype-web/main/siteTemplatesUsecase.spec.ts
@@ -7,13 +7,16 @@ import {expect, mergeTests} from '@playwright/test';
 
 import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
 import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
+import {globalMenuPagesTest} from '../../../fixtures/globalMenuPagesTest';
 import {loginTest} from '../../../fixtures/loginTest';
 import {productMenuPageTest} from '../../../fixtures/productMenuPageTest';
 import {siteSettingsPagesTest} from '../../../fixtures/siteSettingsPagesTest';
+import {usersAndOrganizationsPagesTest} from '../../../fixtures/usersAndOrganizationsPagesTest';
 import {liferayConfig} from '../../../liferay.config';
 import getRandomString from '../../../utils/getRandomString';
 import {performLoginViaApi} from '../../../utils/performLogin';
 import {localizationPagesTest} from '../../site-admin-web/main/fixtures/localizationPagesTest';
+import {layoutSetPrototypePageTest} from './fixtures/layoutSetPrototypePageTest';
 import createSiteTemplate from './utils/createSiteTemplate';
 
 const DEFAULT_VIRTUAL_INSTANCE_NAME = 'www.able.com';
@@ -35,9 +38,12 @@ const testWithSiteTemplateSync = mergeTests(
 		'LPD-35443': {enabled: true},
 		'LPD-82107': {enabled: true},
 	}),
+	globalMenuPagesTest,
+	layoutSetPrototypePageTest,
 	loginTest(),
 	productMenuPageTest,
-	siteSettingsPagesTest
+	siteSettingsPagesTest,
+	usersAndOrganizationsPagesTest
 );
 
 test(
@@ -185,6 +191,132 @@ test(
 					webContentName.toLowerCase()
 				)
 			).rejects.toThrow();
+		}
+	);
+});
+
+[
+	{label: 'with the propagation toggle enabled', propagationEnabled: true},
+	{label: 'with the propagation toggle disabled', propagationEnabled: false},
+].forEach(({label, propagationEnabled}) => {
+	testWithSiteTemplateSync(
+		"Linking an existing Organization's Site to a Site Template " +
+			`through the Settings ${label} does not execute the propagation`,
+		{tag: '@LPD-87027'},
+		async ({
+			apiHelpers,
+			editOrganizationPage,
+			globalMenuPage,
+			layoutSetPrototypePage,
+			page,
+			productMenuPage,
+			usersAndOrganizationsPage,
+		}) => {
+			testWithSiteTemplateSync.slow();
+
+			// Create a Site Template with a Web Content and a page
+
+			const siteTemplateName = 'SiteTemplate-' + getRandomString();
+			const webContentBody = 'Body-' + getRandomString();
+			const webContentName = 'WebContent-' + getRandomString();
+
+			const layoutSetPrototype = await createSiteTemplate({
+				apiHelpers,
+				page,
+				productMenuPage,
+				templateName: siteTemplateName,
+				text: webContentBody,
+				webContentName,
+			});
+
+			apiHelpers.data.push({
+				id: layoutSetPrototype.layoutSetPrototypeId,
+				type: 'layoutSetPrototype',
+			});
+
+			const layoutSetPrototypeGroup =
+				await apiHelpers.jsonWebServicesGroup.getGroupByKey(
+					layoutSetPrototype.companyId,
+					layoutSetPrototype.layoutSetPrototypeId
+				);
+
+			const pageName = 'Page-' + getRandomString();
+
+			await apiHelpers.jsonWebServicesLayout.addLayout({
+				groupId: layoutSetPrototypeGroup.groupId,
+				privateLayout: 'true',
+				title: pageName,
+			});
+
+			// The Site Template has a page that a sync would propagate
+
+			expect(
+				await apiHelpers.jsonWebServicesLayout.getLayoutsCount(
+					Number(layoutSetPrototypeGroup.groupId),
+					true
+				)
+			).toBeGreaterThan(0);
+
+			// Create an Organization (its Site is not linked to any Site Template)
+
+			const organization =
+				await apiHelpers.headlessAdminUser.postOrganization();
+
+			// Link the Organization's Site to the Site Template from its Site
+			// settings
+
+			await usersAndOrganizationsPage.goToOrganizations(true);
+
+			await editOrganizationPage.linkSiteTemplate(
+				organization.name,
+				siteTemplateName,
+				{propagationEnabled}
+			);
+
+			// Relating an Organization to a Site Template must not trigger the sync
+
+			const organizationGroup =
+				await apiHelpers.jsonWebServicesGroup.getGroupByKey(
+					layoutSetPrototype.companyId,
+					organization.name + ' LFR_ORGANIZATION'
+				);
+
+			expect(
+				await apiHelpers.jsonWebServicesLayout.getLayoutsCount(
+					Number(organizationGroup.groupId),
+					false
+				)
+			).toBe(0);
+
+			// Execute the Site Template Sync manually
+
+			await globalMenuPage.goToControlPanel('Site Templates');
+
+			await layoutSetPrototypePage.executeSyncAndWaitForSuccess(
+				siteTemplateName
+			);
+
+			// The sync only updates the Site when the propagation toggle is enabled
+			// (LPD-82108 AC3)
+
+			if (propagationEnabled) {
+				await expect(async () => {
+					expect(
+						await apiHelpers.jsonWebServicesLayout.getLayoutsCount(
+							Number(organizationGroup.groupId),
+							false
+						)
+					).toBeGreaterThan(0);
+				}).toPass();
+			}
+			else {
+				expect(
+					await apiHelpers.jsonWebServicesLayout.getLayoutsCount(
+						Number(organizationGroup.groupId),
+						false
+					)
+				).toBe(0);
+			}
 		}
 	);
 });

--- a/modules/test/playwright/tests/layout-set-prototype-web/main/siteTemplatesUsecase.spec.ts
+++ b/modules/test/playwright/tests/layout-set-prototype-web/main/siteTemplatesUsecase.spec.ts
@@ -3,15 +3,18 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {mergeTests} from '@playwright/test';
+import {expect, mergeTests} from '@playwright/test';
 
 import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
 import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../fixtures/loginTest';
+import {productMenuPageTest} from '../../../fixtures/productMenuPageTest';
+import {siteSettingsPagesTest} from '../../../fixtures/siteSettingsPagesTest';
 import {liferayConfig} from '../../../liferay.config';
 import getRandomString from '../../../utils/getRandomString';
 import {performLoginViaApi} from '../../../utils/performLogin';
 import {localizationPagesTest} from '../../site-admin-web/main/fixtures/localizationPagesTest';
+import createSiteTemplate from './utils/createSiteTemplate';
 
 const DEFAULT_VIRTUAL_INSTANCE_NAME = 'www.able.com';
 const VIRTUAL_INSTANCE_DOMAIN = 'able.com';
@@ -24,6 +27,17 @@ export const test = mergeTests(
 	}),
 	loginTest(),
 	localizationPagesTest
+);
+
+const testWithSiteTemplateSync = mergeTests(
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-35443': {enabled: true},
+		'LPD-82107': {enabled: true},
+	}),
+	loginTest(),
+	productMenuPageTest,
+	siteSettingsPagesTest
 );
 
 test(
@@ -65,3 +79,112 @@ test(
 		await localizationInstanceSettingsPage.setLanguage(['en_US', 'es_ES']);
 	}
 );
+
+[
+	{label: 'with the propagation toggle enabled', propagationEnabled: true},
+	{label: 'with the propagation toggle disabled', propagationEnabled: false},
+].forEach(({label, propagationEnabled}) => {
+	testWithSiteTemplateSync(
+		'Linking an existing Site to a Site Template through the Settings ' +
+			`${label} does not execute the propagation`,
+		{tag: '@LPD-87027'},
+		async ({apiHelpers, page, productMenuPage, siteSettingsPage}) => {
+			testWithSiteTemplateSync.slow();
+
+			// Create a Site Template with a Web Content and a page
+
+			const siteTemplateName = 'SiteTemplate-' + getRandomString();
+			const webContentBody = 'Body-' + getRandomString();
+			const webContentName = 'WebContent-' + getRandomString();
+
+			const layoutSetPrototype = await createSiteTemplate({
+				apiHelpers,
+				page,
+				productMenuPage,
+				templateName: siteTemplateName,
+				text: webContentBody,
+				webContentName,
+			});
+
+			apiHelpers.data.push({
+				id: layoutSetPrototype.layoutSetPrototypeId,
+				type: 'layoutSetPrototype',
+			});
+
+			const layoutSetPrototypeGroup =
+				await apiHelpers.jsonWebServicesGroup.getGroupByKey(
+					layoutSetPrototype.companyId,
+					layoutSetPrototype.layoutSetPrototypeId
+				);
+
+			const pageName = 'Page-' + getRandomString();
+
+			await apiHelpers.jsonWebServicesLayout.addLayout({
+				groupId: layoutSetPrototypeGroup.groupId,
+				privateLayout: 'true',
+				title: pageName,
+			});
+
+			// Create an empty Site that is not linked to any Site Template
+
+			const site = await apiHelpers.headlessAdminSite.postSite({
+				name: 'Site-' + getRandomString(),
+			});
+
+			const sitePages = await apiHelpers.headlessAdminSite.getPages(
+				site.externalReferenceCode,
+				'pageSize=100&privateLayout=false'
+			);
+
+			expect(
+				sitePages.items.some(
+					(item) => item.name_i18n['en-US'] === pageName
+				)
+			).toBeFalsy();
+
+			await expect(
+				apiHelpers.jsonWebServicesJournal.getArticleByUrlTitle(
+					site.id,
+					webContentName.toLowerCase()
+				)
+			).rejects.toThrow();
+
+			// Link the Site to the Site Template from Site Settings > Site
+			// Template Sync
+
+			await siteSettingsPage.goToSiteSetting(
+				'Pages',
+				'Site Template Sync',
+				site.friendlyUrlPath
+			);
+
+			await siteSettingsPage.linkSiteTemplate(siteTemplateName, {
+				propagationEnabled,
+			});
+
+			// Connecting a Site to a Site Template must not trigger the sync
+			// (LPD-82108 AC22): neither the page nor the Web Content is
+			// propagated until a Site Template Sync is executed manually, even
+			// when the propagation toggle is enabled
+
+			const sitePagesAfterLink =
+				await apiHelpers.headlessAdminSite.getPages(
+					site.externalReferenceCode,
+					'pageSize=100&privateLayout=false'
+				);
+
+			expect(
+				sitePagesAfterLink.items.some(
+					(item) => item.name_i18n['en-US'] === pageName
+				)
+			).toBeFalsy();
+
+			await expect(
+				apiHelpers.jsonWebServicesJournal.getArticleByUrlTitle(
+					site.id,
+					webContentName.toLowerCase()
+				)
+			).rejects.toThrow();
+		}
+	);
+});

--- a/modules/test/playwright/tests/layout-set-prototype-web/main/siteTemplatesUsecase.spec.ts
+++ b/modules/test/playwright/tests/layout-set-prototype-web/main/siteTemplatesUsecase.spec.ts
@@ -447,3 +447,130 @@ test(
 		}
 	);
 });
+
+[
+	{label: 'with the propagation toggle enabled', propagationEnabled: true},
+	{label: 'with the propagation toggle disabled', propagationEnabled: false},
+].forEach(({label, propagationEnabled}) => {
+	testWithSiteTemplateSync(
+		"Linking an existing User's Site to a Site Template through the " +
+			`Settings ${label} does not execute the propagation`,
+		{tag: '@LPD-87027'},
+		async ({
+			apiHelpers,
+			editUserPage,
+			globalMenuPage,
+			layoutSetPrototypePage,
+			page,
+			productMenuPage,
+			usersAndOrganizationsPage,
+		}) => {
+			testWithSiteTemplateSync.slow();
+
+			// Create a Site Template with a Web Content and a page
+
+			const siteTemplateName = 'SiteTemplate-' + getRandomString();
+			const webContentBody = 'Body-' + getRandomString();
+			const webContentName = 'WebContent-' + getRandomString();
+
+			const layoutSetPrototype = await createSiteTemplate({
+				apiHelpers,
+				page,
+				productMenuPage,
+				templateName: siteTemplateName,
+				text: webContentBody,
+				webContentName,
+			});
+
+			apiHelpers.data.push({
+				id: layoutSetPrototype.layoutSetPrototypeId,
+				type: 'layoutSetPrototype',
+			});
+
+			const layoutSetPrototypeGroup =
+				await apiHelpers.jsonWebServicesGroup.getGroupByKey(
+					layoutSetPrototype.companyId,
+					layoutSetPrototype.layoutSetPrototypeId
+				);
+
+			const pageName = 'Page-' + getRandomString();
+
+			await apiHelpers.jsonWebServicesLayout.addLayout({
+				groupId: layoutSetPrototypeGroup.groupId,
+				privateLayout: 'true',
+				title: pageName,
+			});
+
+			// The Site Template has a page that a sync would propagate
+
+			expect(
+				await apiHelpers.jsonWebServicesLayout.getLayoutsCount(
+					Number(layoutSetPrototypeGroup.groupId),
+					true
+				)
+			).toBeGreaterThan(0);
+
+			// Create a User (the personal Site is not linked to any Site Template)
+
+			const user = await apiHelpers.headlessAdminUser.postUserAccount();
+
+			// Link the User's profile pages to the Site Template from its Profile
+			// and Dashboard settings
+
+			await usersAndOrganizationsPage.goToUsers(true);
+
+			await usersAndOrganizationsPage.goToUser(
+				`${user.givenName} ${user.familyName}`
+			);
+
+			await editUserPage.linkSiteTemplate(siteTemplateName, {
+				propagationEnabled,
+			});
+
+			// Relating a User to a Site Template must not trigger the sync
+
+			const userGroup =
+				await apiHelpers.jsonWebServicesGroup.getUserGroup(
+					layoutSetPrototype.companyId,
+					String(user.id)
+				);
+
+			expect(
+				await apiHelpers.jsonWebServicesLayout.getLayoutsCount(
+					Number(userGroup.groupId),
+					false
+				)
+			).toBe(0);
+
+			// Execute the Site Template Sync manually
+
+			await globalMenuPage.goToControlPanel('Site Templates');
+
+			await layoutSetPrototypePage.executeSyncAndWaitForSuccess(
+				siteTemplateName
+			);
+
+			// The sync only updates the Site when the propagation toggle is enabled
+			// (LPD-82108 AC3)
+
+			if (propagationEnabled) {
+				await expect(async () => {
+					expect(
+						await apiHelpers.jsonWebServicesLayout.getLayoutsCount(
+							Number(userGroup.groupId),
+							false
+						)
+					).toBeGreaterThan(0);
+				}).toPass();
+			}
+			else {
+				expect(
+					await apiHelpers.jsonWebServicesLayout.getLayoutsCount(
+						Number(userGroup.groupId),
+						false
+					)
+				).toBe(0);
+			}
+		}
+	);
+});

--- a/modules/test/playwright/tests/layout-set-prototype-web/main/siteTemplatesWithPage.spec.ts
+++ b/modules/test/playwright/tests/layout-set-prototype-web/main/siteTemplatesWithPage.spec.ts
@@ -15,6 +15,7 @@ import {sitesPageTest} from '../../../fixtures/sitesPageTest';
 import {uiElementsPageTest} from '../../../fixtures/uiElementsTest';
 import getRandomString from '../../../utils/getRandomString';
 import {reloadUntilVisible} from '../../../utils/reloadUntilVisible';
+import {sitesAdminPagesTest} from '../../site-admin-web/main/fixtures/sitesAdminPagesTest';
 import {layoutSetPrototypePageTest} from './fixtures/layoutSetPrototypePageTest';
 import createSiteTemplate from './utils/createSiteTemplate';
 
@@ -26,6 +27,7 @@ export const test = mergeTests(
 	pageEditorPagesTest,
 	pagesAdminPagesTest,
 	productMenuPageTest,
+	sitesAdminPagesTest,
 	sitesPageTest,
 	uiElementsPageTest
 );
@@ -35,11 +37,11 @@ test(
 	{tag: ['@LPD-49053', '@LPS-131903', '@LPS-132256']},
 	async ({
 		apiHelpers,
-		globalMenuPage,
 		page,
 		pageEditorPage,
 		pagesAdminPage,
 		productMenuPage,
+		sitesAdminPage,
 		sitesPage,
 		uiElementsPage,
 	}) => {
@@ -75,7 +77,7 @@ test(
 
 		// Create a site using the site template
 
-		await globalMenuPage.goToControlPanel('Sites');
+		await sitesAdminPage.goto();
 
 		const siteName: string = 'Site-' + getRandomString();
 
@@ -156,10 +158,10 @@ test(
 	{tag: '@LPD-70284'},
 	async ({
 		apiHelpers,
-		globalMenuPage,
 		page,
 		pagesAdminPage,
 		productMenuPage,
+		sitesAdminPage,
 		sitesPage,
 		uiElementsPage,
 	}) => {
@@ -194,7 +196,7 @@ test(
 
 		// Create site based on that template
 
-		await globalMenuPage.goToControlPanel('Sites');
+		await sitesAdminPage.goto();
 
 		const siteName = 'Site-' + getRandomString();
 

--- a/modules/test/playwright/tests/layout-set-prototype-web/main/siteTemplatesWithWebContent.spec.ts
+++ b/modules/test/playwright/tests/layout-set-prototype-web/main/siteTemplatesWithWebContent.spec.ts
@@ -20,6 +20,7 @@ import {webContentDisplayPageTest} from '../../../fixtures/webContentDisplayPage
 import {liferayConfig} from '../../../liferay.config';
 import getRandomString from '../../../utils/getRandomString';
 import getBasicWebContentStructureId from '../../../utils/structured-content/getBasicWebContentStructureId';
+import {sitesAdminPagesTest} from '../../site-admin-web/main/fixtures/sitesAdminPagesTest';
 import createSiteTemplate from './utils/createSiteTemplate';
 
 export const test = mergeTests(
@@ -34,6 +35,7 @@ export const test = mergeTests(
 	pageEditorPagesTest,
 	pagesAdminPagesTest,
 	productMenuPageTest,
+	sitesAdminPagesTest,
 	sitesPageTest,
 	uiElementsPageTest,
 	webContentDisplayPageTest
@@ -49,6 +51,7 @@ test(
 		pageEditorPage,
 		pagesAdminPage,
 		productMenuPage,
+		sitesAdminPage,
 		sitesPage,
 		uiElementsPage,
 		webContentDisplayPage,
@@ -98,7 +101,7 @@ test(
 			titleMap: {en_US: webContentName},
 		});
 
-		await globalMenuPage.goToControlPanel('Sites');
+		await sitesAdminPage.goto();
 
 		const siteName = getRandomString();
 

--- a/modules/test/playwright/tests/staging-configuration-web/main/stagingConfiguration.spec.ts
+++ b/modules/test/playwright/tests/staging-configuration-web/main/stagingConfiguration.spec.ts
@@ -18,6 +18,7 @@ import {pageViewModePagesTest} from '../../../fixtures/pageViewModePagesTest';
 import {pagesAdminPagesTest} from '../../../fixtures/pagesAdminPagesTest';
 import {portletConfigurationPermissionsPageTest} from '../../../fixtures/portletConfigurationPermissionsPagesTest';
 import {productMenuPageTest} from '../../../fixtures/productMenuPageTest';
+import {sitesPageTest} from '../../../fixtures/sitesPageTest';
 import {systemSettingsPageTest} from '../../../fixtures/systemSettingsPageTest';
 import {uiElementsPageTest} from '../../../fixtures/uiElementsTest';
 import {webContentDisplayPageTest} from '../../../fixtures/webContentDisplayPageTest';
@@ -43,6 +44,7 @@ export const test = mergeTests(
 	pageEditorPagesTest,
 	productMenuPageTest,
 	portletPublishToLivePageTest,
+	sitesPageTest,
 	stagingConfigurationPageTest,
 	webContentDisplayPageTest,
 	uiElementsPageTest,
@@ -64,6 +66,11 @@ export const testFlagsEnabled = mergeTests(
 	stagingPageTest,
 	test,
 	webContentDisplayPageTest
+);
+
+export const testWithSitePagesAPI = mergeTests(
+	test,
+	featureFlagsTest({'LPD-35443': {enabled: true}})
 );
 
 test(
@@ -452,5 +459,67 @@ testFlagsEnabled(
 
 		await webContentDisplayPage.gotoWebContentAdmin(layout.plid);
 		await page.getByText(webContentName).waitFor({state: 'visible'});
+	}
+);
+
+testWithSitePagesAPI(
+	'Staging is blocked for a Site linked to a Site Template with propagation enabled',
+	{tag: '@LPD-87027'},
+	async ({
+		apiHelpers,
+		globalMenuPage,
+		sitesPage,
+		stagingConfigurationPage,
+	}) => {
+		const siteTemplateName = 'SiteTemplate-' + getRandomString();
+
+		const layoutSetPrototype =
+			await apiHelpers.jsonWebServicesLayoutSetPrototype.addLayoutSetPrototypes(
+				{
+					name: siteTemplateName,
+				}
+			);
+
+		apiHelpers.data.push({
+			id: layoutSetPrototype.layoutSetPrototypeId,
+			type: 'layoutSetPrototype',
+		});
+
+		await globalMenuPage.goToControlPanel('Sites');
+
+		const siteName = 'Site-' + getRandomString();
+
+		const {externalReferenceCode} = await sitesPage.createSite({
+			isCustom: true,
+			siteName,
+			templateName: siteTemplateName,
+		});
+
+		apiHelpers.data.push({id: externalReferenceCode, type: 'site'});
+
+		// Wait until the Site Template pages propagate to the linked Site so the
+		// propagation background task completes before the cleanup deletes it
+
+		await expect(async () => {
+			const sitePages = await apiHelpers.headlessAdminSite.getPages(
+				externalReferenceCode,
+				'pageSize=100&privateLayout=false'
+			);
+
+			expect(sitePages.items.length).toBeGreaterThan(0);
+		}).toPass();
+
+		await stagingConfigurationPage.gotoStagingConfiguration(
+			'/' + siteName.toLowerCase()
+		);
+
+		await expect(
+			stagingConfigurationPage.page.getByText(
+				'Staging cannot be used for this site because the propagation ' +
+					'of changes from the site template is enabled.'
+			)
+		).toBeVisible();
+
+		await expect(stagingConfigurationPage.localLiveRadio).toBeHidden();
 	}
 );

--- a/portal-impl/src/com/liferay/portal/service/http/LayoutSetServiceHttp.java
+++ b/portal-impl/src/com/liferay/portal/service/http/LayoutSetServiceHttp.java
@@ -79,7 +79,8 @@ public class LayoutSetServiceHttp {
 	}
 
 	public static void updateLayoutSetPrototypeLinkEnabled(
-			HttpPrincipal httpPrincipal, long groupId, boolean privateLayout,
+			HttpPrincipal httpPrincipal, long groupId,
+			boolean mergeLayoutSetPrototype, boolean privateLayout,
 			boolean layoutSetPrototypeLinkEnabled,
 			String layoutSetPrototypeUuid)
 		throws com.liferay.portal.kernel.exception.PortalException {
@@ -89,6 +90,46 @@ public class LayoutSetServiceHttp {
 				LayoutSetServiceUtil.class,
 				"updateLayoutSetPrototypeLinkEnabled",
 				_updateLayoutSetPrototypeLinkEnabledParameterTypes1);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, groupId, mergeLayoutSetPrototype, privateLayout,
+				layoutSetPrototypeLinkEnabled, layoutSetPrototypeUuid);
+
+			try {
+				TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static void updateLayoutSetPrototypeLinkEnabled(
+			HttpPrincipal httpPrincipal, long groupId, boolean privateLayout,
+			boolean layoutSetPrototypeLinkEnabled,
+			String layoutSetPrototypeUuid)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				LayoutSetServiceUtil.class,
+				"updateLayoutSetPrototypeLinkEnabled",
+				_updateLayoutSetPrototypeLinkEnabledParameterTypes2);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, privateLayout,
@@ -126,7 +167,7 @@ public class LayoutSetServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				LayoutSetServiceUtil.class, "updateLogo",
-				_updateLogoParameterTypes2);
+				_updateLogoParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, privateLayout, hasLogo, bytes);
@@ -163,7 +204,7 @@ public class LayoutSetServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				LayoutSetServiceUtil.class, "updateLogo",
-				_updateLogoParameterTypes3);
+				_updateLogoParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, privateLayout, hasLogo, file);
@@ -200,7 +241,7 @@ public class LayoutSetServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				LayoutSetServiceUtil.class, "updateLogo",
-				_updateLogoParameterTypes4);
+				_updateLogoParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, privateLayout, hasLogo, inputStream);
@@ -238,7 +279,7 @@ public class LayoutSetServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				LayoutSetServiceUtil.class, "updateLogo",
-				_updateLogoParameterTypes5);
+				_updateLogoParameterTypes6);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, privateLayout, hasLogo, inputStream,
@@ -276,7 +317,7 @@ public class LayoutSetServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				LayoutSetServiceUtil.class, "updateLookAndFeel",
-				_updateLookAndFeelParameterTypes6);
+				_updateLookAndFeelParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, privateLayout, themeId, colorSchemeId, css);
@@ -317,7 +358,7 @@ public class LayoutSetServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				LayoutSetServiceUtil.class, "updateSettings",
-				_updateSettingsParameterTypes7);
+				_updateSettingsParameterTypes8);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, privateLayout, settings);
@@ -358,7 +399,7 @@ public class LayoutSetServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				LayoutSetServiceUtil.class, "updateVirtualHosts",
-				_updateVirtualHostsParameterTypes8);
+				_updateVirtualHostsParameterTypes9);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, privateLayout, virtualHostnames);
@@ -397,29 +438,34 @@ public class LayoutSetServiceHttp {
 		new Class[] {long.class, boolean.class, long.class};
 	private static final Class<?>[]
 		_updateLayoutSetPrototypeLinkEnabledParameterTypes1 = new Class[] {
+			long.class, boolean.class, boolean.class, boolean.class,
+			String.class
+		};
+	private static final Class<?>[]
+		_updateLayoutSetPrototypeLinkEnabledParameterTypes2 = new Class[] {
 			long.class, boolean.class, boolean.class, String.class
 		};
-	private static final Class<?>[] _updateLogoParameterTypes2 = new Class[] {
+	private static final Class<?>[] _updateLogoParameterTypes3 = new Class[] {
 		long.class, boolean.class, boolean.class, byte[].class
 	};
-	private static final Class<?>[] _updateLogoParameterTypes3 = new Class[] {
+	private static final Class<?>[] _updateLogoParameterTypes4 = new Class[] {
 		long.class, boolean.class, boolean.class, java.io.File.class
 	};
-	private static final Class<?>[] _updateLogoParameterTypes4 = new Class[] {
+	private static final Class<?>[] _updateLogoParameterTypes5 = new Class[] {
 		long.class, boolean.class, boolean.class, java.io.InputStream.class
 	};
-	private static final Class<?>[] _updateLogoParameterTypes5 = new Class[] {
+	private static final Class<?>[] _updateLogoParameterTypes6 = new Class[] {
 		long.class, boolean.class, boolean.class, java.io.InputStream.class,
 		boolean.class
 	};
-	private static final Class<?>[] _updateLookAndFeelParameterTypes6 =
+	private static final Class<?>[] _updateLookAndFeelParameterTypes7 =
 		new Class[] {
 			long.class, boolean.class, String.class, String.class, String.class
 		};
-	private static final Class<?>[] _updateSettingsParameterTypes7 =
+	private static final Class<?>[] _updateSettingsParameterTypes8 =
 		new Class[] {long.class, boolean.class, String.class};
-	private static final Class<?>[] _updateVirtualHostsParameterTypes8 =
+	private static final Class<?>[] _updateVirtualHostsParameterTypes9 =
 		new Class[] {long.class, boolean.class, java.util.TreeMap.class};
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:66248207
+// LIFERAY-SERVICE-BUILDER-HASH:-291592870

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutSetLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutSetLocalServiceImpl.java
@@ -262,20 +262,10 @@ public class LayoutSetLocalServiceImpl extends LayoutSetLocalServiceBaseImpl {
 		return layoutSetPersistence.update(layoutSet);
 	}
 
-	/**
-	 * Updates the state of the layout set prototype link.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param privateLayout whether the layout set is private to the group
-	 * @param layoutSetPrototypeLinkEnabled whether the layout set prototype is
-	 *        link enabled
-	 * @param layoutSetPrototypeUuid the uuid of the layout set prototype to
-	 *        link with
-	 */
 	@Override
 	public void updateLayoutSetPrototypeLinkEnabled(
-			long groupId, boolean privateLayout,
-			boolean layoutSetPrototypeLinkEnabled,
+			long groupId, boolean mergeLayoutSetPrototype,
+			boolean privateLayout, boolean layoutSetPrototypeLinkEnabled,
 			String layoutSetPrototypeUuid)
 		throws PortalException {
 
@@ -329,7 +319,7 @@ public class LayoutSetLocalServiceImpl extends LayoutSetLocalServiceBaseImpl {
 			_layoutSetBranchPersistence.update(layoutSetBranch);
 		}
 
-		if (!layoutSetPrototypeLinkEnabled ||
+		if (!mergeLayoutSetPrototype || !layoutSetPrototypeLinkEnabled ||
 			Validator.isNotNull(previousLayoutSetPrototypeUuid) ||
 			Validator.isNull(layoutSetPrototypeUuid)) {
 
@@ -348,6 +338,28 @@ public class LayoutSetLocalServiceImpl extends LayoutSetLocalServiceBaseImpl {
 					exception);
 			}
 		}
+	}
+
+	/**
+	 * Updates the state of the layout set prototype link.
+	 *
+	 * @param groupId the primary key of the group
+	 * @param privateLayout whether the layout set is private to the group
+	 * @param layoutSetPrototypeLinkEnabled whether the layout set prototype is
+	 *        link enabled
+	 * @param layoutSetPrototypeUuid the uuid of the layout set prototype to
+	 *        link with
+	 */
+	@Override
+	public void updateLayoutSetPrototypeLinkEnabled(
+			long groupId, boolean privateLayout,
+			boolean layoutSetPrototypeLinkEnabled,
+			String layoutSetPrototypeUuid)
+		throws PortalException {
+
+		layoutSetLocalService.updateLayoutSetPrototypeLinkEnabled(
+			groupId, true, privateLayout, layoutSetPrototypeLinkEnabled,
+			layoutSetPrototypeUuid);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutSetServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutSetServiceImpl.java
@@ -38,6 +38,31 @@ public class LayoutSetServiceImpl extends LayoutSetServiceBaseImpl {
 			groupId, privateLayout, faviconFileEntryId);
 	}
 
+	@Override
+	public void updateLayoutSetPrototypeLinkEnabled(
+			long groupId, boolean mergeLayoutSetPrototype,
+			boolean privateLayout, boolean layoutSetPrototypeLinkEnabled,
+			String layoutSetPrototypeUuid)
+		throws PortalException {
+
+		GroupPermissionUtil.check(
+			getPermissionChecker(), groupId, ActionKeys.UPDATE);
+
+		LayoutSet layoutSet = layoutSetLocalService.getLayoutSet(
+			groupId, privateLayout);
+
+		if (layoutSet.isLayoutSetPrototypeLinkEnabled() &&
+			!layoutSetPrototypeLinkEnabled) {
+
+			PortalPermissionUtil.check(
+				getPermissionChecker(), ActionKeys.UNLINK_LAYOUT_SET_PROTOTYPE);
+		}
+
+		layoutSetLocalService.updateLayoutSetPrototypeLinkEnabled(
+			groupId, mergeLayoutSetPrototype, privateLayout,
+			layoutSetPrototypeLinkEnabled, layoutSetPrototypeUuid);
+	}
+
 	/**
 	 * Updates the state of the layout set prototype link.
 	 *
@@ -63,21 +88,8 @@ public class LayoutSetServiceImpl extends LayoutSetServiceBaseImpl {
 			String layoutSetPrototypeUuid)
 		throws PortalException {
 
-		GroupPermissionUtil.check(
-			getPermissionChecker(), groupId, ActionKeys.UPDATE);
-
-		LayoutSet layoutSet = layoutSetLocalService.getLayoutSet(
-			groupId, privateLayout);
-
-		if (layoutSet.isLayoutSetPrototypeLinkEnabled() &&
-			!layoutSetPrototypeLinkEnabled) {
-
-			PortalPermissionUtil.check(
-				getPermissionChecker(), ActionKeys.UNLINK_LAYOUT_SET_PROTOTYPE);
-		}
-
-		layoutSetLocalService.updateLayoutSetPrototypeLinkEnabled(
-			groupId, privateLayout, layoutSetPrototypeLinkEnabled,
+		layoutSetService.updateLayoutSetPrototypeLinkEnabled(
+			groupId, true, privateLayout, layoutSetPrototypeLinkEnabled,
 			layoutSetPrototypeUuid);
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/service/LayoutSetLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/LayoutSetLocalService.java
@@ -301,6 +301,12 @@ public interface LayoutSetLocalService
 	@Indexable(type = IndexableType.REINDEX)
 	public LayoutSet updateLayoutSet(LayoutSet layoutSet);
 
+	public void updateLayoutSetPrototypeLinkEnabled(
+			long groupId, boolean mergeLayoutSetPrototype,
+			boolean privateLayout, boolean layoutSetPrototypeLinkEnabled,
+			String layoutSetPrototypeUuid)
+		throws PortalException;
+
 	/**
 	 * Updates the state of the layout set prototype link.
 	 *
@@ -368,4 +374,4 @@ public interface LayoutSetLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-604329677
+// LIFERAY-SERVICE-BUILDER-HASH:-501998919

--- a/portal-kernel/src/com/liferay/portal/kernel/service/LayoutSetLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/LayoutSetLocalServiceUtil.java
@@ -343,6 +343,17 @@ public class LayoutSetLocalServiceUtil {
 		return getService().updateLayoutSet(layoutSet);
 	}
 
+	public static void updateLayoutSetPrototypeLinkEnabled(
+			long groupId, boolean mergeLayoutSetPrototype,
+			boolean privateLayout, boolean layoutSetPrototypeLinkEnabled,
+			String layoutSetPrototypeUuid)
+		throws PortalException {
+
+		getService().updateLayoutSetPrototypeLinkEnabled(
+			groupId, mergeLayoutSetPrototype, privateLayout,
+			layoutSetPrototypeLinkEnabled, layoutSetPrototypeUuid);
+	}
+
 	/**
 	 * Updates the state of the layout set prototype link.
 	 *
@@ -440,4 +451,4 @@ public class LayoutSetLocalServiceUtil {
 	private static volatile LayoutSetLocalService _service;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1364889271
+// LIFERAY-SERVICE-BUILDER-HASH:-1659577655

--- a/portal-kernel/src/com/liferay/portal/kernel/service/LayoutSetLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/LayoutSetLocalServiceWrapper.java
@@ -378,6 +378,18 @@ public class LayoutSetLocalServiceWrapper
 		return _layoutSetLocalService.updateLayoutSet(layoutSet);
 	}
 
+	@Override
+	public void updateLayoutSetPrototypeLinkEnabled(
+			long groupId, boolean mergeLayoutSetPrototype,
+			boolean privateLayout, boolean layoutSetPrototypeLinkEnabled,
+			String layoutSetPrototypeUuid)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		_layoutSetLocalService.updateLayoutSetPrototypeLinkEnabled(
+			groupId, mergeLayoutSetPrototype, privateLayout,
+			layoutSetPrototypeLinkEnabled, layoutSetPrototypeUuid);
+	}
+
 	/**
 	 * Updates the state of the layout set prototype link.
 	 *
@@ -514,4 +526,4 @@ public class LayoutSetLocalServiceWrapper
 	private LayoutSetLocalService _layoutSetLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:738585151
+// LIFERAY-SERVICE-BUILDER-HASH:-1909598873

--- a/portal-kernel/src/com/liferay/portal/kernel/service/LayoutSetService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/LayoutSetService.java
@@ -57,6 +57,12 @@ public interface LayoutSetService extends BaseService {
 			long groupId, boolean privateLayout, long faviconFileEntryId)
 		throws PortalException;
 
+	public void updateLayoutSetPrototypeLinkEnabled(
+			long groupId, boolean mergeLayoutSetPrototype,
+			boolean privateLayout, boolean layoutSetPrototypeLinkEnabled,
+			String layoutSetPrototypeUuid)
+		throws PortalException;
+
 	/**
 	 * Updates the state of the layout set prototype link.
 	 *
@@ -114,4 +120,4 @@ public interface LayoutSetService extends BaseService {
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1293614224
+// LIFERAY-SERVICE-BUILDER-HASH:503048618

--- a/portal-kernel/src/com/liferay/portal/kernel/service/LayoutSetServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/LayoutSetServiceUtil.java
@@ -47,6 +47,17 @@ public class LayoutSetServiceUtil {
 			groupId, privateLayout, faviconFileEntryId);
 	}
 
+	public static void updateLayoutSetPrototypeLinkEnabled(
+			long groupId, boolean mergeLayoutSetPrototype,
+			boolean privateLayout, boolean layoutSetPrototypeLinkEnabled,
+			String layoutSetPrototypeUuid)
+		throws PortalException {
+
+		getService().updateLayoutSetPrototypeLinkEnabled(
+			groupId, mergeLayoutSetPrototype, privateLayout,
+			layoutSetPrototypeLinkEnabled, layoutSetPrototypeUuid);
+	}
+
 	/**
 	 * Updates the state of the layout set prototype link.
 	 *
@@ -144,4 +155,4 @@ public class LayoutSetServiceUtil {
 	private static volatile LayoutSetService _service;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1409975971
+// LIFERAY-SERVICE-BUILDER-HASH:-114156133

--- a/portal-kernel/src/com/liferay/portal/kernel/service/LayoutSetServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/LayoutSetServiceWrapper.java
@@ -44,6 +44,18 @@ public class LayoutSetServiceWrapper
 			groupId, privateLayout, faviconFileEntryId);
 	}
 
+	@Override
+	public void updateLayoutSetPrototypeLinkEnabled(
+			long groupId, boolean mergeLayoutSetPrototype,
+			boolean privateLayout, boolean layoutSetPrototypeLinkEnabled,
+			String layoutSetPrototypeUuid)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		_layoutSetService.updateLayoutSetPrototypeLinkEnabled(
+			groupId, mergeLayoutSetPrototype, privateLayout,
+			layoutSetPrototypeLinkEnabled, layoutSetPrototypeUuid);
+	}
+
 	/**
 	 * Updates the state of the layout set prototype link.
 	 *
@@ -153,4 +165,4 @@ public class LayoutSetServiceWrapper
 	private LayoutSetService _layoutSetService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1048476957
+// LIFERAY-SERVICE-BUILDER-HASH:-1837078418

--- a/portal-kernel/src/com/liferay/sites/kernel/util/Sites.java
+++ b/portal-kernel/src/com/liferay/sites/kernel/util/Sites.java
@@ -100,6 +100,13 @@ public interface Sites {
 		throws Exception;
 
 	public void updateLayoutSetPrototypesLinks(
+			Group group, boolean mergeLayoutSetPrototype,
+			long publicLayoutSetPrototypeId, long privateLayoutSetPrototypeId,
+			boolean publicLayoutSetPrototypeLinkEnabled,
+			boolean privateLayoutSetPrototypeLinkEnabled)
+		throws Exception;
+
+	public void updateLayoutSetPrototypesLinks(
 			Group group, long publicLayoutSetPrototypeId,
 			long privateLayoutSetPrototypeId,
 			boolean publicLayoutSetPrototypeLinkEnabled,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93823
https://liferay.atlassian.net/browse/LPD-87027

Created on top of the latest LPD-87027 PR (liferay-headless#3949).

## What Is Being Fixed

The new "Site Template Sync" process (LPD-87027) changes how a site template propagates changes to its linked sites: propagation no longer runs implicitly when a page is visited, it is always applied through an explicit sync, and staging cannot be enabled for a site while site template propagation is active. The existing propagation tests assumed the old behavior and there was no coverage for the new sync flow.

## How It Is Being Fixed

A new LayoutSet method takes a boolean to force the layout set prototype merge regardless of whether the link is enabled, and the merge is no longer launched on page visits. The existing LayoutSetPrototypePropagationTest and related cases are adapted to the always-propagate, explicit-sync model, and new Playwright and integration tests cover the Site Template sync for sites, users, user groups and organizations, the propagation of logos and pages, the cases that must not propagate (deletions, site-only entities), and the guards that block the sync when publications are enabled or staging when propagation is active.

## PR Check

**pr-check: PASS** — tested on `2ea6e9201ec027c5ea4e698b3db778f1a8c43a2b`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Portlet Title | PASS |
| Full Portal Build | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "2ea6e9201ec027c5ea4e698b3db778f1a8c43a2b"} -->
