### PR TITLE
LPD-96220 Fix enableLocalStaging to wait for all live layout names

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/staging/JSONStaging.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/staging/JSONStaging.macro
@@ -66,9 +66,9 @@ definition {
 				-d privateLayout=false
 		''';
 
-		var liveLayoutId = JSONCurlUtil.post(${liveLayoutsCurl}, "$.[?(@['nameCurrentValue'] != '')]['layoutId']");
+		var liveLayoutNames = JSONCurlUtil.post(${liveLayoutsCurl}, "$.[?(@['nameCurrentValue'] != '')]['nameCurrentValue']");
 
-		if (${liveLayoutId} != "") {
+		if (${liveLayoutNames} != "") {
 			var stagingLayoutsCurl = '''
 				${portalURL}/api/jsonws/layout/get-layouts \
 					-u ${userLoginInfo} \
@@ -76,10 +76,10 @@ definition {
 					-d privateLayout=false
 			''';
 
-			var stagingLayoutId = JSONCurlUtil.post(${stagingLayoutsCurl}, "$.[?(@['nameCurrentValue'] != '')]['layoutId']");
+			var stagingLayoutNames = JSONCurlUtil.post(${stagingLayoutsCurl}, "$.[?(@['nameCurrentValue'] != '')]['nameCurrentValue']");
 
-			while ((${stagingLayoutId} == "")) {
-				var stagingLayoutId = JSONCurlUtil.post(${stagingLayoutsCurl}, "$.[?(@['nameCurrentValue'] != '')]['layoutId']");
+			while (${stagingLayoutNames} != ${liveLayoutNames}) {
+				var stagingLayoutNames = JSONCurlUtil.post(${stagingLayoutsCurl}, "$.[?(@['nameCurrentValue'] != '')]['nameCurrentValue']");
 			}
 		}
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96220

## What Is Being Fixed

The `enableLocalStaging` macro polled until any staging layout had a non-empty `nameCurrentValue`. This caused premature exit when a different staging layout record received a name before the live layout's copy arrived, leading to "FAIL. Cannot find layout." test failures.

## How It Is Being Fixed

The macro now compares the full set of layout names present in the staging group against the full set of live layout names. It only returns once every live layout name is confirmed present in staging, eliminating the race condition.

## PR Check

**pr-check: PASS** — tested on `496877f06405de897269ac77da2b40be8255442f`

| Validation | Result |
| --- | --- |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "496877f06405de897269ac77da2b40be8255442f"} -->
