### PR TITLE
LPD-96103 Resolve staged asset library references to the live group on publish

### DIFF
--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutExportImportTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutExportImportTest.java
@@ -6,22 +6,37 @@
 package com.liferay.exportimport.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryGroupRelLocalService;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.exportimport.kernel.configuration.ExportImportConfigurationFactory;
 import com.liferay.exportimport.kernel.exception.LARTypeException;
 import com.liferay.exportimport.kernel.lar.ExportImportHelperUtil;
 import com.liferay.exportimport.kernel.lar.PortletDataHandlerKeys;
+import com.liferay.exportimport.kernel.staging.StagingUtil;
 import com.liferay.exportimport.test.util.lar.BaseExportImportTestCase;
 import com.liferay.fragment.constants.FragmentConstants;
 import com.liferay.fragment.contributor.FragmentCollectionContributorRegistry;
+import com.liferay.fragment.entry.processor.constants.FragmentEntryProcessorConstants;
+import com.liferay.fragment.renderer.FragmentRendererRegistry;
 import com.liferay.fragment.service.FragmentEntryLinkLocalService;
 import com.liferay.fragment.service.FragmentEntryLocalService;
 import com.liferay.friendly.url.constants.FriendlyURLEntryConstants;
 import com.liferay.friendly.url.model.FriendlyURLEntry;
 import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
+import com.liferay.journal.constants.JournalFolderConstants;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.service.JournalArticleLocalService;
+import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.layout.friendly.url.LayoutFriendlyURLEntryHelper;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
+import com.liferay.layout.provider.LayoutStructureProvider;
+import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.layout.util.LayoutServiceContextHelper;
 import com.liferay.layout.utility.page.kernel.constants.LayoutUtilityPageEntryConstants;
 import com.liferay.layout.utility.page.model.LayoutUtilityPageEntry;
 import com.liferay.layout.utility.page.service.LayoutUtilityPageEntryLocalService;
@@ -29,6 +44,7 @@ import com.liferay.petra.io.StreamUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.LayoutFriendlyURLsException;
 import com.liferay.portal.kernel.exception.LocaleException;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
@@ -55,6 +71,7 @@ import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.log.LogCapture;
@@ -563,6 +580,141 @@ public class LayoutExportImportTest extends BaseExportImportTestCase {
 	}
 
 	@Test
+	@TestInfo("LPD-96103")
+	public void testExportImportLayoutsWithStagingDepotMappedContent()
+		throws Exception {
+
+		Group group = GroupTestUtil.addGroup();
+
+		GroupTestUtil.enableLocalStaging(group);
+
+		Group stagingGroup = group.getStagingGroup();
+
+		DepotEntry liveDepotEntry = _depotEntryLocalService.addDepotEntry(
+			RandomTestUtil.randomLocaleStringMap(),
+			RandomTestUtil.randomLocaleStringMap(),
+			DepotConstants.TYPE_ASSET_LIBRARY,
+			ServiceContextTestUtil.getServiceContext());
+
+		Group liveDepotGroup = liveDepotEntry.getGroup();
+
+		GroupTestUtil.enableLocalStaging(liveDepotGroup);
+
+		Group stagingDepotGroup = liveDepotGroup.getStagingGroup();
+
+		DepotEntry stagingDepotEntry =
+			_depotEntryLocalService.getGroupDepotEntry(
+				stagingDepotGroup.getGroupId());
+
+		_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
+			stagingDepotEntry.getDepotEntryId(), stagingGroup.getGroupId());
+
+		JournalArticle journalArticle = JournalTestUtil.addArticle(
+			stagingDepotGroup.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+
+		String defaultLanguageId = journalArticle.getDefaultLanguageId();
+
+		String title = journalArticle.getTitle(defaultLanguageId);
+
+		StagingUtil.publishLayouts(
+			TestPropsValues.getUserId(),
+			ExportImportConfigurationFactory.
+				buildDefaultLocalPublishingExportImportConfiguration(
+					TestPropsValues.getUser(), stagingDepotGroup.getGroupId(),
+					liveDepotGroup.getGroupId(), false));
+
+		JournalArticle liveJournalArticle =
+			_journalArticleLocalService.getJournalArticleByUuidAndGroupId(
+				journalArticle.getUuid(), liveDepotGroup.getGroupId());
+
+		Assert.assertEquals(
+			title, liveJournalArticle.getTitle(defaultLanguageId));
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(stagingGroup);
+
+		Layout draftLayout = layout.fetchDraftLayout();
+
+		ContentLayoutTestUtil.addFragmentEntryLinkToLayout(
+			JSONUtil.put(
+				FragmentEntryProcessorConstants.
+					KEY_FREEMARKER_FRAGMENT_ENTRY_PROCESSOR,
+				JSONUtil.put(
+					"itemSelector",
+					JSONUtil.put(
+						"className", JournalArticle.class.getName()
+					).put(
+						"classNameId",
+						_portal.getClassNameId(JournalArticle.class)
+					).put(
+						"classPK", journalArticle.getResourcePrimKey()
+					).put(
+						"classTypeId", journalArticle.getDDMStructureId()
+					).put(
+						"externalReferenceCode",
+						journalArticle.getExternalReferenceCode()
+					).put(
+						"scopeExternalReferenceCode",
+						stagingDepotGroup.getExternalReferenceCode()
+					).put(
+						"template",
+						HashMapBuilder.put(
+							"infoItemRendererKey",
+							"com.liferay.journal.web.internal.info.item." +
+								"renderer.JournalArticleTitleInfoItemRenderer"
+						).build()
+					))
+			).toString(),
+			_fragmentRendererRegistry.getFragmentRenderer(
+				"com.liferay.fragment.internal.renderer." +
+					"ContentObjectFragmentRenderer"),
+			draftLayout, null, 0,
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+				draftLayout.getPlid()));
+
+		ContentLayoutTestUtil.publishLayout(draftLayout, layout);
+
+		StagingUtil.publishLayouts(
+			TestPropsValues.getUserId(),
+			ExportImportConfigurationFactory.
+				buildDefaultLocalPublishingExportImportConfiguration(
+					TestPropsValues.getUser(), stagingGroup.getGroupId(),
+					group.getGroupId(), false));
+
+		Layout liveLayout =
+			_layoutLocalService.getLayoutByExternalReferenceCode(
+				layout.getExternalReferenceCode(), group.getGroupId());
+
+		long segmentsExperienceId =
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+				liveLayout.getPlid());
+
+		String html = ContentLayoutTestUtil.getRenderLayoutHTML(
+			liveLayout, _layoutServiceContextHelper, _layoutStructureProvider,
+			segmentsExperienceId);
+
+		Assert.assertTrue(
+			html + " does not contain " + title, html.contains(title));
+
+		String updatedTitle = RandomTestUtil.randomString();
+
+		journalArticle = JournalTestUtil.updateArticle(
+			journalArticle, updatedTitle);
+
+		Assert.assertEquals(
+			updatedTitle, journalArticle.getTitle(defaultLanguageId));
+
+		html = ContentLayoutTestUtil.getRenderLayoutHTML(
+			liveLayout, _layoutServiceContextHelper, _layoutStructureProvider,
+			segmentsExperienceId);
+
+		Assert.assertFalse(
+			html + " contains " + updatedTitle, html.contains(updatedTitle));
+		Assert.assertTrue(
+			html + " does not contain " + title, html.contains(title));
+	}
+
+	@Test
 	@TestInfo("LPD-77689")
 	public void testExportImportLayoutUtilityPageEntryWithPreviewFileEntryWithBatch()
 		throws Exception {
@@ -893,6 +1045,12 @@ public class LayoutExportImportTest extends BaseExportImportTestCase {
 	private CompanyLocalService _companyLocalService;
 
 	@Inject
+	private DepotEntryGroupRelLocalService _depotEntryGroupRelLocalService;
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Inject
 	private FragmentCollectionContributorRegistry
 		_fragmentCollectionContributorRegistry;
 
@@ -903,7 +1061,13 @@ public class LayoutExportImportTest extends BaseExportImportTestCase {
 	private FragmentEntryLocalService _fragmentEntryLocalService;
 
 	@Inject
+	private FragmentRendererRegistry _fragmentRendererRegistry;
+
+	@Inject
 	private FriendlyURLEntryLocalService _friendlyURLEntryLocalService;
+
+	@Inject
+	private JournalArticleLocalService _journalArticleLocalService;
 
 	@Inject
 	private LayoutFriendlyURLEntryHelper _layoutFriendlyURLEntryHelper;
@@ -916,11 +1080,20 @@ public class LayoutExportImportTest extends BaseExportImportTestCase {
 		_layoutPageTemplateEntryLocalService;
 
 	@Inject
+	private LayoutServiceContextHelper _layoutServiceContextHelper;
+
+	@Inject
 	private LayoutSetPrototypeLocalService _layoutSetPrototypeLocalService;
+
+	@Inject
+	private LayoutStructureProvider _layoutStructureProvider;
 
 	@Inject
 	private LayoutUtilityPageEntryLocalService
 		_layoutUtilityPageEntryLocalService;
+
+	@Inject
+	private Portal _portal;
 
 	@Inject
 	private SegmentsExperienceLocalService _segmentsExperienceLocalService;

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/ItemScopeUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/ItemScopeUtil.java
@@ -7,7 +7,6 @@ package com.liferay.headless.admin.site.internal.dto.v1_0.util;
 
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.util.ScopeUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -32,12 +31,7 @@ public class ItemScopeUtil {
 			return null;
 		}
 
-		Group group = GroupLocalServiceUtil.getGroup(itemScopeGroupId);
-
-		Scope.Type type = (group.getType() == GroupConstants.TYPE_DEPOT) ?
-			Scope.Type.ASSET_LIBRARY : Scope.Type.SITE;
-
-		return Scope.ofReference(group.getExternalReferenceCode(), type);
+		return Scope.of(GroupLocalServiceUtil.getGroup(itemScopeGroupId));
 	}
 
 	public static Scope getItemScope(
@@ -60,10 +54,7 @@ public class ItemScopeUtil {
 			return null;
 		}
 
-		Scope.Type type = (group.getType() == GroupConstants.TYPE_DEPOT) ?
-			Scope.Type.ASSET_LIBRARY : Scope.Type.SITE;
-
-		return Scope.ofReference(group.getExternalReferenceCode(), type);
+		return Scope.of(group);
 	}
 
 	public static String getItemScopeExternalReferenceCode(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/ItemScopeUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/ItemScopeUtil.java
@@ -21,7 +21,8 @@ public class ItemScopeUtil {
 		long companyId, Scope scope, long scopeGroupId) {
 
 		return ScopeUtil.getItemGroupId(
-			companyId, _getScopeExternalReferenceCode(scope), scopeGroupId);
+			companyId, _getScopeExternalReferenceCode(scope, scopeGroupId),
+			scopeGroupId);
 	}
 
 	public static Scope getItemScope(long itemScopeGroupId, long scopeGroupId)
@@ -62,12 +63,25 @@ public class ItemScopeUtil {
 		throws PortalException {
 
 		return ScopeUtil.getItemScopeExternalReferenceCode(
-			_getScopeExternalReferenceCode(itemScope), scopeGroupId);
+			_getScopeExternalReferenceCode(itemScope, scopeGroupId),
+			scopeGroupId);
 	}
 
-	private static String _getScopeExternalReferenceCode(Scope scope) {
+	private static String _getScopeExternalReferenceCode(
+		Scope scope, long scopeGroupId) {
+
 		if (scope == null) {
 			return null;
+		}
+
+		if (Validator.isNull(scope.getLiveExternalReferenceCode())) {
+			return scope.getExternalReferenceCode();
+		}
+
+		Group group = GroupLocalServiceUtil.fetchGroup(scopeGroupId);
+
+		if ((group != null) && !group.isStagingGroup()) {
+			return scope.getLiveExternalReferenceCode();
 		}
 
 		return scope.getExternalReferenceCode();

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/ServiceContextUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/ServiceContextUtil.java
@@ -14,6 +14,7 @@ import com.liferay.headless.admin.site.dto.v1_0.PageSpecification;
 import com.liferay.headless.admin.site.dto.v1_0.ParentTaxonomyCategory;
 import com.liferay.headless.admin.site.dto.v1_0.ParentTaxonomyVocabulary;
 import com.liferay.headless.admin.site.dto.v1_0.TaxonomyCategoryBrief;
+import com.liferay.headless.admin.site.internal.dto.v1_0.util.ItemScopeUtil;
 import com.liferay.headless.admin.site.internal.util.LogUtil;
 import com.liferay.headless.common.spi.service.context.ServiceContextBuilder;
 import com.liferay.headless.common.spi.util.GroupUtil;
@@ -32,7 +33,6 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Validator;
-import com.liferay.portal.vulcan.scope.Scope;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -241,12 +241,14 @@ public class ServiceContextUtil {
 			taxonomyCategoryBrief -> {
 				long scopeGroupId = groupId;
 
-				Scope scope = taxonomyCategoryBrief.getScope();
+				String scopeExternalReferenceCode =
+					ItemScopeUtil.getItemScopeExternalReferenceCode(
+						taxonomyCategoryBrief.getScope(), scopeGroupId);
 
-				if (scope != null) {
+				if (scopeExternalReferenceCode != null) {
 					scopeGroupId = GroupUtil.getGroupId(
 						true, true, group.getCompanyId(),
-						scope.getExternalReferenceCode());
+						scopeExternalReferenceCode);
 				}
 
 				String parentTaxonomyCategoryExternalReferenceCode = null;

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/test/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/ItemScopeUtilTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/test/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/ItemScopeUtilTest.java
@@ -1,0 +1,204 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.site.internal.dto.v1_0.util;
+
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.vulcan.scope.Scope;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+public class ItemScopeUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@AfterClass
+	public static void tearDownClass() {
+		_groupLocalServiceUtilMockedStatic.close();
+	}
+
+	@Test
+	@TestInfo("LPD-96103")
+	public void testGetItemGroupId() {
+		Group liveGroup = _getGroup();
+		Group stagingGroup = _getGroup();
+
+		_setUpStagingGroup(stagingGroup, liveGroup);
+
+		Group group = _getGroup();
+
+		Assert.assertEquals(
+			Long.valueOf(liveGroup.getGroupId()),
+			ItemScopeUtil.getItemGroupId(
+				_COMPANY_ID, Scope.of(liveGroup), group.getGroupId()));
+
+		Scope scope = Scope.of(stagingGroup);
+
+		Assert.assertEquals(
+			Long.valueOf(liveGroup.getGroupId()),
+			ItemScopeUtil.getItemGroupId(
+				_COMPANY_ID, scope, group.getGroupId()));
+
+		Mockito.when(
+			group.isStagingGroup()
+		).thenReturn(
+			true
+		);
+
+		Assert.assertEquals(
+			Long.valueOf(stagingGroup.getGroupId()),
+			ItemScopeUtil.getItemGroupId(
+				_COMPANY_ID, scope, group.getGroupId()));
+	}
+
+	@Test
+	@TestInfo("LPD-96103")
+	public void testGetItemScope() {
+		Group group = _getGroup();
+
+		Assert.assertNull(
+			ItemScopeUtil.getItemScope(
+				_COMPANY_ID, group.getExternalReferenceCode(),
+				group.getGroupId()));
+
+		Scope scope = ItemScopeUtil.getItemScope(
+			_COMPANY_ID, group.getExternalReferenceCode(),
+			RandomTestUtil.randomLong());
+
+		Assert.assertEquals(
+			group.getExternalReferenceCode(), scope.getExternalReferenceCode());
+		Assert.assertNull(scope.getLiveExternalReferenceCode());
+
+		Group stagingGroup = _getGroup();
+
+		_setUpStagingGroup(stagingGroup, group);
+
+		scope = ItemScopeUtil.getItemScope(
+			_COMPANY_ID, stagingGroup.getExternalReferenceCode(),
+			RandomTestUtil.randomLong());
+
+		Assert.assertEquals(
+			stagingGroup.getExternalReferenceCode(),
+			scope.getExternalReferenceCode());
+		Assert.assertEquals(
+			group.getExternalReferenceCode(),
+			scope.getLiveExternalReferenceCode());
+	}
+
+	@Test
+	@TestInfo("LPD-96103")
+	public void testGetItemScopeExternalReferenceCode() throws Exception {
+		Group liveGroup = _getGroup();
+		Group stagingGroup = _getGroup();
+
+		_setUpStagingGroup(stagingGroup, liveGroup);
+
+		Scope liveGroupScope = Scope.of(liveGroup);
+
+		Group group = _getGroup();
+
+		Assert.assertEquals(
+			liveGroup.getExternalReferenceCode(),
+			ItemScopeUtil.getItemScopeExternalReferenceCode(
+				liveGroupScope, group.getGroupId()));
+
+		Scope stagingGroupScope = Scope.of(stagingGroup);
+
+		Assert.assertEquals(
+			liveGroup.getExternalReferenceCode(),
+			ItemScopeUtil.getItemScopeExternalReferenceCode(
+				stagingGroupScope, group.getGroupId()));
+
+		Mockito.when(
+			group.isStagingGroup()
+		).thenReturn(
+			true
+		);
+
+		Assert.assertEquals(
+			stagingGroup.getExternalReferenceCode(),
+			ItemScopeUtil.getItemScopeExternalReferenceCode(
+				stagingGroupScope, group.getGroupId()));
+
+		Assert.assertNull(
+			ItemScopeUtil.getItemScopeExternalReferenceCode(
+				liveGroupScope, liveGroup.getGroupId()));
+	}
+
+	private Group _getGroup() {
+		Group group = Mockito.mock(Group.class);
+
+		Mockito.when(
+			group.getExternalReferenceCode()
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+
+		Mockito.when(
+			group.getGroupId()
+		).thenReturn(
+			RandomTestUtil.randomLong()
+		);
+
+		_groupLocalServiceUtilMockedStatic.when(
+			() -> GroupLocalServiceUtil.fetchGroup(group.getGroupId())
+		).thenReturn(
+			group
+		);
+
+		_groupLocalServiceUtilMockedStatic.when(
+			() -> GroupLocalServiceUtil.getGroup(group.getGroupId())
+		).thenReturn(
+			group
+		);
+
+		_groupLocalServiceUtilMockedStatic.when(
+			() -> GroupLocalServiceUtil.fetchGroupByExternalReferenceCode(
+				group.getExternalReferenceCode(), _COMPANY_ID)
+		).thenReturn(
+			group
+		);
+
+		return group;
+	}
+
+	private void _setUpStagingGroup(Group group, Group liveGroup) {
+		Mockito.when(
+			group.getLiveGroup()
+		).thenReturn(
+			liveGroup
+		);
+
+		Mockito.when(
+			group.isStagingGroup()
+		).thenReturn(
+			true
+		);
+	}
+
+	private static final long _COMPANY_ID = RandomTestUtil.randomLong();
+
+	private static final MockedStatic<GroupLocalServiceUtil>
+		_groupLocalServiceUtilMockedStatic = Mockito.mockStatic(
+			GroupLocalServiceUtil.class);
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/scope/Scope.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/scope/Scope.java
@@ -46,6 +46,21 @@ import java.util.function.Supplier;
 @XmlRootElement(name = "Scope")
 public class Scope implements Serializable {
 
+	public static Scope of(Group group) {
+		if (group == null) {
+			return null;
+		}
+
+		return new Scope() {
+			{
+				setExternalReferenceCode(group::getExternalReferenceCode);
+				setLiveExternalReferenceCode(
+					() -> _getLiveExternalReferenceCode(group));
+				setType(() -> _getGroupType(group));
+			}
+		};
+	}
+
 	public static Scope of(Group group, Locale locale) {
 		if ((group == null) || !GroupCapabilityUtil.isSupportsScope(group)) {
 			return null;
@@ -61,6 +76,8 @@ public class Scope implements Serializable {
 					() -> NestedFieldsSupplier.supply(
 						"scope.label",
 						nestedField -> _getGroupName(group, locale)));
+				setLiveExternalReferenceCode(
+					() -> _getLiveExternalReferenceCode(group));
 				setType(() -> _getGroupType(group));
 			}
 		};
@@ -484,6 +501,16 @@ public class Scope implements Serializable {
 		}
 
 		return null;
+	}
+
+	private static String _getLiveExternalReferenceCode(Group group) {
+		Group liveGroup = group.getLiveGroup();
+
+		if (liveGroup == null) {
+			return null;
+		}
+
+		return liveGroup.getExternalReferenceCode();
 	}
 
 	private Scope() {

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/scope/Scope.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/scope/Scope.java
@@ -107,6 +107,9 @@ public class Scope implements Serializable {
 				getExternalReferenceCode(), scope.getExternalReferenceCode()) &&
 			Objects.equals(getKey(), scope.getKey()) &&
 			Objects.equals(getLabel(), scope.getLabel()) &&
+			Objects.equals(
+				getLiveExternalReferenceCode(),
+				scope.getLiveExternalReferenceCode()) &&
 			Objects.equals(getType(), scope.getType())) {
 
 			return true;
@@ -146,6 +149,18 @@ public class Scope implements Serializable {
 		}
 
 		return label;
+	}
+
+	@Schema(description = "The scope's live group external reference code.")
+	public String getLiveExternalReferenceCode() {
+		if (_liveExternalReferenceCodeSupplier != null) {
+			liveExternalReferenceCode =
+				_liveExternalReferenceCodeSupplier.get();
+
+			_liveExternalReferenceCodeSupplier = null;
+		}
+
+		return liveExternalReferenceCode;
 	}
 
 	@Schema(description = "The scope's type.")
@@ -242,6 +257,30 @@ public class Scope implements Serializable {
 		};
 	}
 
+	public void setLiveExternalReferenceCode(String liveExternalReferenceCode) {
+		this.liveExternalReferenceCode = liveExternalReferenceCode;
+
+		_liveExternalReferenceCodeSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setLiveExternalReferenceCode(
+		UnsafeSupplier<String, Exception>
+			liveExternalReferenceCodeUnsafeSupplier) {
+
+		_liveExternalReferenceCodeSupplier = () -> {
+			try {
+				return liveExternalReferenceCodeUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
 	public void setType(Type type) {
 		this.type = type;
 
@@ -264,7 +303,7 @@ public class Scope implements Serializable {
 	}
 
 	public String toString() {
-		StringBundler sb = new StringBundler(22);
+		StringBundler sb = new StringBundler(27);
 
 		sb.append("{");
 
@@ -312,6 +351,22 @@ public class Scope implements Serializable {
 			sb.append("\"");
 
 			sb.append(_escape(label));
+
+			sb.append("\"");
+		}
+
+		String liveExternalReferenceCode = getLiveExternalReferenceCode();
+
+		if (liveExternalReferenceCode != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"liveExternalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(liveExternalReferenceCode));
 
 			sb.append("\"");
 		}
@@ -392,6 +447,12 @@ public class Scope implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String label;
 
+	@GraphQLField(
+		description = "The scope's live group external reference code."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String liveExternalReferenceCode;
+
 	@GraphQLField(description = "The scope's type.")
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Type type;
@@ -449,6 +510,9 @@ public class Scope implements Serializable {
 
 	@JsonIgnore
 	private Supplier<String> _labelSupplier;
+
+	@JsonIgnore
+	private Supplier<String> _liveExternalReferenceCodeSupplier;
 
 	@JsonIgnore
 	private Supplier<Type> _typeSupplier;

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/scope/packageinfo
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/scope/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/test/java/com/liferay/portal/vulcan/scope/ScopeTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/test/java/com/liferay/portal/vulcan/scope/ScopeTest.java
@@ -31,13 +31,7 @@ public class ScopeTest {
 
 	@Before
 	public void setUp() {
-		_group = Mockito.mock(Group.class);
-
-		Mockito.when(
-			_group.getExternalReferenceCode()
-		).thenReturn(
-			_EXTERNAL_REFERENCE_CODE
-		);
+		_group = _mockGroup(_EXTERNAL_REFERENCE_CODE);
 	}
 
 	@Test
@@ -54,6 +48,29 @@ public class ScopeTest {
 		Assert.assertNull(Scope.of(_group, null));
 
 		groupCapabilityUtilMockedStatic.close();
+	}
+
+	@Test
+	public void testScopeOfGroup() {
+		Assert.assertNull(Scope.of(null));
+
+		Scope scope = Scope.of(_group);
+
+		Assert.assertNull(scope.getLiveExternalReferenceCode());
+
+		Group liveGroup = _mockGroup(RandomTestUtil.randomString());
+
+		Mockito.when(
+			_group.getLiveGroup()
+		).thenReturn(
+			liveGroup
+		);
+
+		scope = Scope.of(_group);
+
+		Assert.assertEquals(
+			liveGroup.getExternalReferenceCode(),
+			scope.getLiveExternalReferenceCode());
 	}
 
 	@Test
@@ -120,6 +137,18 @@ public class ScopeTest {
 		Assert.assertEquals(
 			_EXTERNAL_REFERENCE_CODE, scope.getExternalReferenceCode());
 		Assert.assertEquals(scopeType, scope.getType());
+	}
+
+	private Group _mockGroup(String externalReferenceCode) {
+		Group group = Mockito.mock(Group.class);
+
+		Mockito.when(
+			group.getExternalReferenceCode()
+		).thenReturn(
+			externalReferenceCode
+		);
+
+		return group;
 	}
 
 	private static final String _EXTERNAL_REFERENCE_CODE =


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96103

## What Is Being Fixed

When a site connected to an asset library has local staging enabled on both, publishing the site staging causes the live page to render the content of the asset library staging group instead of the live group. The mapping resolves against the staging group because the export step records the staging group's external reference code and the import step has no signal that it should redirect to the live group.

## How It Is Being Fixed

A new `liveExternalReferenceCode` field is added to the Vulcan `Scope` DTO. On the export side, `Scope.of(Group)` populates the field with the live group's external reference code when the source group is a staging group. On the import side, `ItemScopeUtil` reads `liveExternalReferenceCode` from the incoming scope and routes the reference to the live group when present, leaving non-staging payloads untouched.

The field is named `liveExternalReferenceCode` rather than `liveScopeExternalReferenceCode` for consistency with the existing `externalReferenceCode` field on the same `Scope` DTO.

The change is fully backward compatible: callers that do not set `liveExternalReferenceCode` and payloads that do not carry it behave exactly as before.

## PR Check

**pr-check: PASS** — tested on `f1041a5a146834b031d2da95aeb33374785616d4`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "f1041a5a146834b031d2da95aeb33374785616d4"} -->
