### PR TITLE
LPD-96488 Gate object panel app on panel category key, not portlet flag

### DIFF
--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/object/entries/application/list/test/ObjectEntriesPanelAppTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/object/entries/application/list/test/ObjectEntriesPanelAppTest.java
@@ -116,10 +116,19 @@ public class ObjectEntriesPanelAppTest {
 		panelApps = _panelAppRegistry.getPanelApps(
 			objectDefinition.getPanelCategoryKey());
 
+		portlet = null;
+
 		for (PanelApp panelApp : panelApps) {
-			Assert.assertNotEquals(
-				objectDefinition.getPortletId(), panelApp.getPortletId());
+			if (Objects.equals(
+					panelApp.getPortletId(), objectDefinition.getPortletId())) {
+
+				portlet = panelApp.getPortlet();
+			}
 		}
+
+		Assert.assertEquals(
+			"site_administration.content",
+			portlet.getControlPanelEntryCategory());
 	}
 
 	@Inject

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -683,13 +683,13 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		// Register ObjectEntriesPanelApp after ObjectEntriesPortlet. See
 		// LPS-140379.
 
-		if (objectDefinition.isPortlet()) {
-			String panelCategoryKey = objectDefinition.getPanelCategoryKey();
+		String panelCategoryKey = objectDefinition.getPanelCategoryKey();
 
-			if (!objectDefinition.isAllowStandaloneObjectEntry()) {
-				panelCategoryKey = StringPool.BLANK;
-			}
+		if (!objectDefinition.isAllowStandaloneObjectEntry()) {
+			panelCategoryKey = StringPool.BLANK;
+		}
 
+		if (Validator.isNotNull(panelCategoryKey)) {
 			serviceRegistrations.add(
 				_bundleContext.registerService(
 					PanelApp.class,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96488

## What Is Being Fixed

Object definitions that set a panel category key but are not exposed as portlets stopped appearing as Control Panel panel apps. [LPD-93931](https://liferay.atlassian.net/browse/LPD-93931) (commit [`65be2c5`](https://github.com/brianchandotcom/liferay-portal/commit/65be2c5ba260444177335b6374975ec39bfd03e7)) gated the [`ObjectEntriesPanelApp`](https://github.com/liferay-headless/liferay-portal/blob/master/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/application/list/ObjectEntriesPanelApp.java) registration in [`ObjectDefinitionDeployerImpl`](https://github.com/liferay-headless/liferay-portal/blob/master/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java) on `ObjectDefinition.isPortlet()` to silence startup warnings, but that also hid every non-portlet object definition that still configures a real panel category key.

## How It Is Being Fixed

The startup warnings came from object definitions with a blank panel category key colliding on the same empty order and category, not from non-portlet objects. The fix gates the panel app registration on the effective `panelCategoryKey` being non-blank (after the `allowStandaloneObjectEntry` blanking) instead of on `isPortlet()`. This silences the original warnings, since blank-category objects no longer register, and restores panel apps for any object definition that sets a real category. The underlying `ObjectEntriesPortlet` is registered regardless of the portlet flag, so the panel app still resolves.

## PR Check

**pr-check: PASS** — tested on `1183d6ff1afc033ac69cc417587785571e519bcd`

Validated on the upstream-master rebase (`b4085ff`); this is the byte-identical commit replayed onto liferay-headless master (which carries the same regression). object-web and object-test recompiled clean on this base, and ObjectEntriesPanelAppTest passed at runtime against the bundle.

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "1183d6ff1afc033ac69cc417587785571e519bcd"} -->
