### PR TITLE
LPD-93867 Remove unused merge constants and clean orphaned data

### DIFF
--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/LayoutLayoutSetPrototypeLayoutERCUpgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/LayoutLayoutSetPrototypeLayoutERCUpgradeProcessTest.java
@@ -14,7 +14,6 @@ import com.liferay.portal.kernel.cache.MultiVMPool;
 import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
-import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.LayoutSetPrototype;
 import com.liferay.portal.kernel.model.change.tracking.CTModel;
 import com.liferay.portal.kernel.service.LayoutLocalService;
@@ -27,7 +26,6 @@ import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
-import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -165,17 +163,8 @@ public class LayoutLayoutSetPrototypeLayoutERCUpgradeProcessTest
 
 		MergeLayoutPrototypesThreadLocal.clearMergeComplete();
 
-		LayoutSet layoutSet = _layoutSetLocalService.getLayoutSet(
-			_group.getGroupId(), false);
-
-		UnicodeProperties settingsUnicodeProperties =
-			layoutSet.getSettingsProperties();
-
-		settingsUnicodeProperties.remove(Sites.LAST_MERGE_TIME);
-
-		layoutSet = _layoutSetLocalService.updateLayoutSet(layoutSet);
-
-		_sites.mergeLayoutSetPrototypeLayouts(layoutSet);
+		_sites.mergeLayoutSetPrototypeLayouts(
+			_layoutSetLocalService.getLayoutSet(_group.getGroupId(), false));
 	}
 
 	@Inject

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/LayoutLayoutSetPrototypeLayoutERCUpgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/LayoutLayoutSetPrototypeLayoutERCUpgradeProcessTest.java
@@ -172,7 +172,6 @@ public class LayoutLayoutSetPrototypeLayoutERCUpgradeProcessTest
 			layoutSet.getSettingsProperties();
 
 		settingsUnicodeProperties.remove(Sites.LAST_MERGE_TIME);
-		settingsUnicodeProperties.remove(Sites.LAST_MERGE_VERSION);
 
 		layoutSet = _layoutSetLocalService.updateLayoutSet(layoutSet);
 

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/LayoutRemoveUnusedTypeSettingsUpgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/LayoutRemoveUnusedTypeSettingsUpgradeProcessTest.java
@@ -1,0 +1,116 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.upgrade.v7_4_x.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.portal.kernel.cache.CacheRegistryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upgrade.v7_4_x.LayoutRemoveUnusedTypeSettingsUpgradeProcess;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Carlos Correa
+ */
+@RunWith(Arquillian.class)
+public class LayoutRemoveUnusedTypeSettingsUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testUpgradeIgnoresLayoutWithoutLayoutSetPrototypeLayoutERC()
+		throws Exception {
+
+		Group group = GroupTestUtil.addGroup();
+
+		Layout layout = LayoutTestUtil.addTypePortletLayout(group);
+
+		String lastMergeLayoutModifiedTime = String.valueOf(
+			RandomTestUtil.randomLong());
+		String lastMergeTime = String.valueOf(RandomTestUtil.randomLong());
+
+		layout.setTypeSettingsProperties(
+			UnicodePropertiesBuilder.fastLoad(
+				layout.getTypeSettings()
+			).put(
+				"last-merge-layout-modified-time", lastMergeLayoutModifiedTime
+			).put(
+				"last-merge-time", lastMergeTime
+			).build());
+
+		layout = _layoutLocalService.updateLayout(layout);
+
+		UpgradeProcess upgradeProcess =
+			new LayoutRemoveUnusedTypeSettingsUpgradeProcess();
+
+		upgradeProcess.upgrade();
+
+		CacheRegistryUtil.clear();
+
+		layout = _layoutLocalService.getLayout(layout.getPlid());
+
+		Assert.assertEquals(
+			lastMergeLayoutModifiedTime,
+			layout.getTypeSettingsProperty("last-merge-layout-modified-time"));
+		Assert.assertEquals(
+			lastMergeTime, layout.getTypeSettingsProperty("last-merge-time"));
+	}
+
+	@Test
+	public void testUpgradeRemovesUnusedSettings() throws Exception {
+		Group group = GroupTestUtil.addGroup();
+
+		Layout layout = LayoutTestUtil.addTypePortletLayout(group);
+
+		layout.setLayoutSetPrototypeLayoutERC(RandomTestUtil.randomString());
+
+		layout.setTypeSettingsProperties(
+			UnicodePropertiesBuilder.fastLoad(
+				layout.getTypeSettings()
+			).put(
+				"last-merge-layout-modified-time",
+				String.valueOf(RandomTestUtil.randomLong())
+			).put(
+				"last-merge-time", String.valueOf(RandomTestUtil.randomLong())
+			).build());
+
+		layout = _layoutLocalService.updateLayout(layout);
+
+		UpgradeProcess upgradeProcess =
+			new LayoutRemoveUnusedTypeSettingsUpgradeProcess();
+
+		upgradeProcess.upgrade();
+
+		CacheRegistryUtil.clear();
+
+		layout = _layoutLocalService.getLayout(layout.getPlid());
+
+		Assert.assertNull(
+			layout.getTypeSettingsProperty("last-merge-layout-modified-time"));
+		Assert.assertNull(layout.getTypeSettingsProperty("last-merge-time"));
+	}
+
+	@Inject
+	private LayoutLocalService _layoutLocalService;
+
+}

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/LayoutSetPrototypeRemoveReadyForPropagationUpgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/LayoutSetPrototypeRemoveReadyForPropagationUpgradeProcessTest.java
@@ -71,9 +71,7 @@ public class LayoutSetPrototypeRemoveReadyForPropagationUpgradeProcessTest {
 				layoutSetPrototype.getLayoutSetPrototypeId());
 
 		Assert.assertEquals(
-			randomValue,
-			layoutSetPrototype.getSettingsProperty(randomKey));
-
+			randomValue, layoutSetPrototype.getSettingsProperty(randomKey));
 		Assert.assertNull(
 			layoutSetPrototype.getSettingsProperty("readyForPropagation"));
 	}

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/LayoutSetPrototypeRemoveReadyForPropagationUpgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/LayoutSetPrototypeRemoveReadyForPropagationUpgradeProcessTest.java
@@ -1,0 +1,105 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.upgrade.v7_4_x.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.portal.kernel.cache.CacheRegistryUtil;
+import com.liferay.portal.kernel.model.LayoutSetPrototype;
+import com.liferay.portal.kernel.service.LayoutSetPrototypeLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upgrade.v7_4_x.LayoutSetPrototypeRemoveReadyForPropagationUpgradeProcess;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Carlos Correa
+ */
+@RunWith(Arquillian.class)
+public class LayoutSetPrototypeRemoveReadyForPropagationUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testUpgradeRemovesReadyForPropagation() throws Exception {
+		LayoutSetPrototype layoutSetPrototype =
+			_layoutSetPrototypeLocalService.getLayoutSetPrototype(
+				LayoutTestUtil.addLayoutSetPrototype(
+					RandomTestUtil.randomString()
+				).getLayoutSetPrototypeId());
+
+		String randomKey = RandomTestUtil.randomString();
+		String randomValue = RandomTestUtil.randomString();
+
+		layoutSetPrototype.setSettingsProperties(
+			UnicodePropertiesBuilder.fastLoad(
+				layoutSetPrototype.getSettings()
+			).put(
+				randomKey, randomValue
+			).put(
+				"readyForPropagation", "true"
+			).build());
+
+		layoutSetPrototype =
+			_layoutSetPrototypeLocalService.updateLayoutSetPrototype(
+				layoutSetPrototype);
+
+		UpgradeProcess upgradeProcess =
+			new LayoutSetPrototypeRemoveReadyForPropagationUpgradeProcess();
+
+		upgradeProcess.upgrade();
+
+		CacheRegistryUtil.clear();
+
+		layoutSetPrototype =
+			_layoutSetPrototypeLocalService.getLayoutSetPrototype(
+				layoutSetPrototype.getLayoutSetPrototypeId());
+
+		Assert.assertEquals(
+			randomValue,
+			layoutSetPrototype.getSettingsProperty(randomKey));
+
+		Assert.assertNull(
+			layoutSetPrototype.getSettingsProperty("readyForPropagation"));
+	}
+
+	@Test
+	public void testUpgradeWithoutReadyForPropagation() throws Exception {
+		LayoutSetPrototype layoutSetPrototype =
+			LayoutTestUtil.addLayoutSetPrototype(RandomTestUtil.randomString());
+
+		String settings = layoutSetPrototype.getSettings();
+
+		UpgradeProcess upgradeProcess =
+			new LayoutSetPrototypeRemoveReadyForPropagationUpgradeProcess();
+
+		upgradeProcess.upgrade();
+
+		CacheRegistryUtil.clear();
+
+		layoutSetPrototype =
+			_layoutSetPrototypeLocalService.getLayoutSetPrototype(
+				layoutSetPrototype.getLayoutSetPrototypeId());
+
+		Assert.assertEquals(settings, layoutSetPrototype.getSettings());
+	}
+
+	@Inject
+	private LayoutSetPrototypeLocalService _layoutSetPrototypeLocalService;
+
+}

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/LayoutSetRemoveUnusedSettingsUpgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/LayoutSetRemoveUnusedSettingsUpgradeProcessTest.java
@@ -1,0 +1,117 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.upgrade.v7_4_x.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.cache.CacheRegistryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.LayoutSet;
+import com.liferay.portal.kernel.service.LayoutSetLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upgrade.v7_4_x.LayoutSetRemoveUnusedSettingsUpgradeProcess;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Carlos Correa
+ */
+@RunWith(Arquillian.class)
+public class LayoutSetRemoveUnusedSettingsUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testUpgradeRemovesUnusedSettings() throws Exception {
+		Group group = GroupTestUtil.addGroup();
+
+		LayoutSet layoutSet = _layoutSetLocalService.getLayoutSet(
+			group.getGroupId(), false);
+
+		String survivingKey = RandomTestUtil.randomString();
+		String survivingValue = RandomTestUtil.randomString();
+
+		layoutSet.setSettingsProperties(
+			UnicodePropertiesBuilder.fastLoad(
+				layoutSet.getSettings()
+			).put(
+				survivingKey, survivingValue
+			).put(
+				"last-merge-layout-modified-time",
+				String.valueOf(RandomTestUtil.randomLong())
+			).put(
+				"last-merge-time", String.valueOf(RandomTestUtil.randomLong())
+			).put(
+				"last-merge-version", String.valueOf(RandomTestUtil.randomInt())
+			).put(
+				"last-reset-time", String.valueOf(RandomTestUtil.randomLong())
+			).put(
+				"merge-fail-friendly-url-layouts",
+				"/" + RandomTestUtil.randomString()
+			).build());
+
+		layoutSet = _layoutSetLocalService.updateLayoutSet(layoutSet);
+
+		UpgradeProcess upgradeProcess =
+			new LayoutSetRemoveUnusedSettingsUpgradeProcess();
+
+		upgradeProcess.upgrade();
+
+		CacheRegistryUtil.clear();
+
+		layoutSet = _layoutSetLocalService.getLayoutSet(
+			layoutSet.getLayoutSetId());
+
+		Assert.assertEquals(
+			survivingValue, layoutSet.getSettingsProperty(survivingKey));
+
+		Assert.assertNull(
+			layoutSet.getSettingsProperty("last-merge-layout-modified-time"));
+		Assert.assertNull(layoutSet.getSettingsProperty("last-merge-time"));
+		Assert.assertNull(layoutSet.getSettingsProperty("last-merge-version"));
+		Assert.assertNull(layoutSet.getSettingsProperty("last-reset-time"));
+		Assert.assertNull(
+			layoutSet.getSettingsProperty("merge-fail-friendly-url-layouts"));
+	}
+
+	@Test
+	public void testUpgradeWithoutUnusedSettings() throws Exception {
+		Group group = GroupTestUtil.addGroup();
+
+		LayoutSet layoutSet = _layoutSetLocalService.getLayoutSet(
+			group.getGroupId(), false);
+
+		String settings = layoutSet.getSettings();
+
+		UpgradeProcess upgradeProcess =
+			new LayoutSetRemoveUnusedSettingsUpgradeProcess();
+
+		upgradeProcess.upgrade();
+
+		CacheRegistryUtil.clear();
+
+		layoutSet = _layoutSetLocalService.getLayoutSet(
+			layoutSet.getLayoutSetId());
+
+		Assert.assertEquals(settings, layoutSet.getSettings());
+	}
+
+	@Inject
+	private LayoutSetLocalService _layoutSetLocalService;
+
+}

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/LayoutSetRemoveUnusedSettingsUpgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/LayoutSetRemoveUnusedSettingsUpgradeProcessTest.java
@@ -52,14 +52,13 @@ public class LayoutSetRemoveUnusedSettingsUpgradeProcessTest {
 			).put(
 				survivingKey, survivingValue
 			).put(
-				"last-merge-layout-modified-time",
-				String.valueOf(RandomTestUtil.randomLong())
-			).put(
 				"last-merge-time", String.valueOf(RandomTestUtil.randomLong())
 			).put(
 				"last-merge-version", String.valueOf(RandomTestUtil.randomInt())
 			).put(
 				"last-reset-time", String.valueOf(RandomTestUtil.randomLong())
+			).put(
+				"merge-fail-count", String.valueOf(RandomTestUtil.randomInt())
 			).put(
 				"merge-fail-friendly-url-layouts",
 				"/" + RandomTestUtil.randomString()
@@ -80,11 +79,10 @@ public class LayoutSetRemoveUnusedSettingsUpgradeProcessTest {
 		Assert.assertEquals(
 			survivingValue, layoutSet.getSettingsProperty(survivingKey));
 
-		Assert.assertNull(
-			layoutSet.getSettingsProperty("last-merge-layout-modified-time"));
 		Assert.assertNull(layoutSet.getSettingsProperty("last-merge-time"));
 		Assert.assertNull(layoutSet.getSettingsProperty("last-merge-version"));
 		Assert.assertNull(layoutSet.getSettingsProperty("last-reset-time"));
+		Assert.assertNull(layoutSet.getSettingsProperty("merge-fail-count"));
 		Assert.assertNull(
 			layoutSet.getSettingsProperty("merge-fail-friendly-url-layouts"));
 	}

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/LayoutSetRemoveUnusedSettingsUpgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/LayoutSetRemoveUnusedSettingsUpgradeProcessTest.java
@@ -43,14 +43,14 @@ public class LayoutSetRemoveUnusedSettingsUpgradeProcessTest {
 		LayoutSet layoutSet = _layoutSetLocalService.getLayoutSet(
 			group.getGroupId(), false);
 
-		String survivingKey = RandomTestUtil.randomString();
-		String survivingValue = RandomTestUtil.randomString();
+		String randomKey = RandomTestUtil.randomString();
+		String randomValue = RandomTestUtil.randomString();
 
 		layoutSet.setSettingsProperties(
 			UnicodePropertiesBuilder.fastLoad(
 				layoutSet.getSettings()
 			).put(
-				survivingKey, survivingValue
+				randomKey, randomValue
 			).put(
 				"last-merge-time", String.valueOf(RandomTestUtil.randomLong())
 			).put(
@@ -77,8 +77,7 @@ public class LayoutSetRemoveUnusedSettingsUpgradeProcessTest {
 			layoutSet.getLayoutSetId());
 
 		Assert.assertEquals(
-			survivingValue, layoutSet.getSettingsProperty(survivingKey));
-
+			randomValue, layoutSet.getSettingsProperty(randomKey));
 		Assert.assertNull(layoutSet.getSettingsProperty("last-merge-time"));
 		Assert.assertNull(layoutSet.getSettingsProperty("last-merge-version"));
 		Assert.assertNull(layoutSet.getSettingsProperty("last-reset-time"));

--- a/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/menu/web/internal/exportimport/test/SiteNavigationMenuPropagationTest.java
+++ b/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/menu/web/internal/exportimport/test/SiteNavigationMenuPropagationTest.java
@@ -241,7 +241,6 @@ public class SiteNavigationMenuPropagationTest {
 			layoutSet.getSettingsProperties();
 
 		settingsUnicodeProperties.remove(Sites.LAST_MERGE_TIME);
-		settingsUnicodeProperties.remove(Sites.LAST_MERGE_VERSION);
 
 		layoutSet = _layoutSetLocalService.updateLayoutSet(layoutSet);
 

--- a/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/menu/web/internal/exportimport/test/SiteNavigationMenuPropagationTest.java
+++ b/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/menu/web/internal/exportimport/test/SiteNavigationMenuPropagationTest.java
@@ -235,16 +235,7 @@ public class SiteNavigationMenuPropagationTest {
 	private void _propagateLayout() throws Exception {
 		MergeLayoutPrototypesThreadLocal.clearMergeComplete();
 
-		LayoutSet layoutSet = _group.getPublicLayoutSet();
-
-		UnicodeProperties settingsUnicodeProperties =
-			layoutSet.getSettingsProperties();
-
-		settingsUnicodeProperties.remove(Sites.LAST_MERGE_TIME);
-
-		layoutSet = _layoutSetLocalService.updateLayoutSet(layoutSet);
-
-		_sites.mergeLayoutSetPrototypeLayouts(layoutSet);
+		_sites.mergeLayoutSetPrototypeLayouts(_group.getPublicLayoutSet());
 	}
 
 	@Inject

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/LayoutRemoveUnusedTypeSettingsUpgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/LayoutRemoveUnusedTypeSettingsUpgradeProcess.java
@@ -16,28 +16,29 @@ import java.sql.ResultSet;
 /**
  * @author Carlos Correa
  */
-public class LayoutSetRemoveUnusedSettingsUpgradeProcess
+public class LayoutRemoveUnusedTypeSettingsUpgradeProcess
 	extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
 		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
-				"select ctCollectionId, layoutSetId, settings_ from LayoutSet");
+				"select ctCollectionId, plid, typeSettings from Layout where " +
+					"layoutSetPrototypeLayoutERC is not null");
 
 			ResultSet resultSet = preparedStatement1.executeQuery();
 
 			PreparedStatement preparedStatement2 =
 				AutoBatchPreparedStatementUtil.autoBatch(
 					connection,
-					"update LayoutSet set settings_ = ? where ctCollectionId " +
-						"= ? and layoutSetId = ?")) {
+					"update Layout set typeSettings = ? where ctCollectionId " +
+						"= ? and plid = ?")) {
 
 			while (resultSet.next()) {
-				String settings = resultSet.getString("settings_");
+				String typeSettings = resultSet.getString("typeSettings");
 
 				UnicodeProperties unicodeProperties =
 					UnicodePropertiesBuilder.fastLoad(
-						settings
+						typeSettings
 					).build();
 
 				boolean modified = false;
@@ -57,7 +58,7 @@ public class LayoutSetRemoveUnusedSettingsUpgradeProcess
 				preparedStatement2.setLong(
 					2, resultSet.getLong("ctCollectionId"));
 
-				preparedStatement2.setLong(3, resultSet.getLong("layoutSetId"));
+				preparedStatement2.setLong(3, resultSet.getLong("plid"));
 
 				preparedStatement2.addBatch();
 			}
@@ -67,8 +68,7 @@ public class LayoutSetRemoveUnusedSettingsUpgradeProcess
 	}
 
 	private static final String[] _UNUSED_PROPERTY_KEYS = {
-		"last-merge-time", "last-merge-version", "last-reset-time",
-		"merge-fail-count", "merge-fail-friendly-url-layouts"
+		"last-merge-layout-modified-time", "last-merge-time"
 	};
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/LayoutSetPrototypeRemoveReadyForPropagationUpgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/LayoutSetPrototypeRemoveReadyForPropagationUpgradeProcess.java
@@ -16,21 +16,22 @@ import java.sql.ResultSet;
 /**
  * @author Carlos Correa
  */
-public class LayoutSetRemoveUnusedSettingsUpgradeProcess
+public class LayoutSetPrototypeRemoveReadyForPropagationUpgradeProcess
 	extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
 		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
-				"select ctCollectionId, layoutSetId, settings_ from LayoutSet");
+				"select ctCollectionId, layoutSetPrototypeId, settings_ from " +
+					"LayoutSetPrototype");
 
 			ResultSet resultSet = preparedStatement1.executeQuery();
 
 			PreparedStatement preparedStatement2 =
 				AutoBatchPreparedStatementUtil.autoBatch(
 					connection,
-					"update LayoutSet set settings_ = ? where ctCollectionId " +
-						"= ? and layoutSetId = ?")) {
+					"update LayoutSetPrototype set settings_ = ? where " +
+						"ctCollectionId = ? and layoutSetPrototypeId = ?")) {
 
 			while (resultSet.next()) {
 				String settings = resultSet.getString("settings_");
@@ -40,15 +41,7 @@ public class LayoutSetRemoveUnusedSettingsUpgradeProcess
 						settings
 					).build();
 
-				boolean modified = false;
-
-				for (String key : _UNUSED_PROPERTY_KEYS) {
-					if (unicodeProperties.remove(key) != null) {
-						modified = true;
-					}
-				}
-
-				if (!modified) {
+				if (unicodeProperties.remove("readyForPropagation") == null) {
 					continue;
 				}
 
@@ -57,7 +50,8 @@ public class LayoutSetRemoveUnusedSettingsUpgradeProcess
 				preparedStatement2.setLong(
 					2, resultSet.getLong("ctCollectionId"));
 
-				preparedStatement2.setLong(3, resultSet.getLong("layoutSetId"));
+				preparedStatement2.setLong(
+					3, resultSet.getLong("layoutSetPrototypeId"));
 
 				preparedStatement2.addBatch();
 			}
@@ -65,10 +59,5 @@ public class LayoutSetRemoveUnusedSettingsUpgradeProcess
 			preparedStatement2.executeBatch();
 		}
 	}
-
-	private static final String[] _UNUSED_PROPERTY_KEYS = {
-		"last-merge-time", "last-merge-version", "last-reset-time",
-		"merge-fail-count", "merge-fail-friendly-url-layouts"
-	};
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/LayoutSetRemoveUnusedSettingsUpgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/LayoutSetRemoveUnusedSettingsUpgradeProcess.java
@@ -1,0 +1,75 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.upgrade.v7_4_x;
+
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+/**
+ * @author Carlos Correa
+ */
+public class LayoutSetRemoveUnusedSettingsUpgradeProcess
+	extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
+				"select ctCollectionId, layoutSetId, settings_ from LayoutSet");
+
+			ResultSet resultSet = preparedStatement1.executeQuery();
+
+			PreparedStatement preparedStatement2 =
+				AutoBatchPreparedStatementUtil.autoBatch(
+					connection,
+					"update LayoutSet set settings_ = ? where ctCollectionId " +
+						"= ? and layoutSetId = ?")) {
+
+			while (resultSet.next()) {
+				String settings = resultSet.getString("settings_");
+
+				UnicodeProperties unicodeProperties =
+					UnicodePropertiesBuilder.fastLoad(
+						settings
+					).build();
+
+				boolean modified = false;
+
+				for (String key : _UNUSED_PROPERTY_KEYS) {
+					if (unicodeProperties.remove(key) != null) {
+						modified = true;
+					}
+				}
+
+				if (!modified) {
+					continue;
+				}
+
+				preparedStatement2.setString(1, unicodeProperties.toString());
+
+				preparedStatement2.setLong(
+					2, resultSet.getLong("ctCollectionId"));
+
+				preparedStatement2.setLong(3, resultSet.getLong("layoutSetId"));
+
+				preparedStatement2.addBatch();
+			}
+
+			preparedStatement2.executeBatch();
+		}
+	}
+
+	private static final String[] _UNUSED_PROPERTY_KEYS = {
+		"last-merge-layout-modified-time", "last-merge-time",
+		"last-merge-version", "last-reset-time",
+		"merge-fail-friendly-url-layouts"
+	};
+
+}

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
@@ -793,6 +793,10 @@ public class PortalUpgradeProcessRegistryImpl
 			new Version(38, 7, 1),
 			UpgradeModulesFactory.create(
 				new String[] {"com.liferay.portal.vulcan.impl"}, null));
+
+		upgradeVersionTreeMap.put(
+			new Version(38, 7, 2),
+			new LayoutSetRemoveUnusedSettingsUpgradeProcess());
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
@@ -796,6 +796,12 @@ public class PortalUpgradeProcessRegistryImpl
 
 		upgradeVersionTreeMap.put(
 			new Version(38, 7, 2),
+			new LayoutRemoveUnusedTypeSettingsUpgradeProcess());
+		upgradeVersionTreeMap.put(
+			new Version(38, 7, 3),
+			new LayoutSetPrototypeRemoveReadyForPropagationUpgradeProcess());
+		upgradeVersionTreeMap.put(
+			new Version(38, 7, 4),
 			new LayoutSetRemoveUnusedSettingsUpgradeProcess());
 	}
 

--- a/portal-kernel/src/com/liferay/sites/kernel/util/Sites.java
+++ b/portal-kernel/src/com/liferay/sites/kernel/util/Sites.java
@@ -37,21 +37,11 @@ public interface Sites {
 	public static final int CONTENT_SHARING_WITH_CHILDREN_ENABLED_BY_DEFAULT =
 		2;
 
-	public static final String LAST_MERGE_LAYOUT_MODIFIED_TIME =
-		"last-merge-layout-modified-time";
-
 	public static final String LAST_MERGE_TIME = "last-merge-time";
-
-	public static final String LAST_MERGE_VERSION = "last-merge-version";
-
-	public static final String LAST_RESET_TIME = "last-reset-time";
 
 	public static final String LAYOUT_UPDATEABLE = "layoutUpdateable";
 
 	public static final String MERGE_FAIL_COUNT = "merge-fail-count";
-
-	public static final String MERGE_FAIL_FRIENDLY_URL_LAYOUTS =
-		"merge-fail-friendly-url-layouts";
 
 	public static final String SHOW_SITE_NAME = "showSiteName";
 

--- a/portal-kernel/src/com/liferay/sites/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/sites/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 5.0.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93867

## What Is Being Fixed

Site template propagation still declared several merge-tracking constants in `Sites` that no production code references anymore, and connected sites, their site templates, and the pages derived from them could still hold the orphaned property values those constants used to write. The dead constants are `LAST_MERGE_LAYOUT_MODIFIED_TIME`, `LAST_MERGE_VERSION`, `LAST_RESET_TIME`, and `MERGE_FAIL_FRIENDLY_URL_LAYOUTS`.

## How It Is Being Fixed

The four unused constants are removed from `Sites`, and the `com.liferay.sites.kernel.util` package is bumped to 5.0.0 to reflect the API removal.

Three upgrade processes then strip the orphaned property values, each scoped to the exact column where the value actually lived. They talk to the database directly rather than through the service layer, matching the sibling processes and avoiding model listeners, cache invalidation, and change-tracking scoping during startup. Each runs in its own schema version (38.6.1 through 38.6.3) so a rerun replays them independently.

The cleanup deliberately preserves the keys that are still live for page template propagation: `last-merge-time` and `merge-fail-count` stay in `Layout.typeSettings` for pages linked to a page template. `LayoutRemoveUnusedTypeSettingsUpgradeProcess` therefore filters on `layoutSetPrototypeLayoutERC is not null` so it only cleans pages derived from a site template, and `merge-fail-count` is dropped from `LayoutSet` (the site template side, now unused) but never from `Layout`.

## Removed Properties

| Property | Column | Table | Upgrade Process |
| --- | --- | --- | --- |
| `last-merge-layout-modified-time` | `typeSettings` | `Layout` | `LayoutRemoveUnusedTypeSettingsUpgradeProcess` |
| `last-merge-time` | `typeSettings` | `Layout` (only where `layoutSetPrototypeLayoutERC is not null`) | `LayoutRemoveUnusedTypeSettingsUpgradeProcess` |
| `readyForPropagation` | `settings_` | `LayoutSetPrototype` | `LayoutSetPrototypeRemoveReadyForPropagationUpgradeProcess` |
| `last-merge-time` | `settings_` | `LayoutSet` | `LayoutSetRemoveUnusedSettingsUpgradeProcess` |
| `last-merge-version` | `settings_` | `LayoutSet` | `LayoutSetRemoveUnusedSettingsUpgradeProcess` |
| `last-reset-time` | `settings_` | `LayoutSet` | `LayoutSetRemoveUnusedSettingsUpgradeProcess` |
| `merge-fail-count` | `settings_` | `LayoutSet` | `LayoutSetRemoveUnusedSettingsUpgradeProcess` |
| `merge-fail-friendly-url-layouts` | `settings_` | `LayoutSet` | `LayoutSetRemoveUnusedSettingsUpgradeProcess` |

## PR Check

**pr-check: PASS** — tested on `86d1f76585fc11d349c9d8fd7cf85c476f753323`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |
| Full Portal Build | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "86d1f76585fc11d349c9d8fd7cf85c476f753323"} -->
