### PR TITLE
LPD-96220 Fix staging layout poll limit to prevent silent timeout on CI

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/staging/JSONStaging.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/staging/JSONStaging.macro
@@ -78,7 +78,7 @@ definition {
 
 			var stagingLayoutNames = JSONCurlUtil.post(${stagingLayoutsCurl}, "$.[?(@['nameCurrentValue'] != '')]['nameCurrentValue']");
 
-			while (${stagingLayoutNames} != ${liveLayoutNames}) {
+			while ((${stagingLayoutNames} != ${liveLayoutNames}) && (maxIterations = "100")) {
 				var stagingLayoutNames = JSONCurlUtil.post(${stagingLayoutsCurl}, "$.[?(@['nameCurrentValue'] != '')]['nameCurrentValue']");
 			}
 		}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96220

## What Is Being Fixed

`JSONStaging.enableLocalStaging` polls the staging group for layout names to confirm the async copy is done before returning. The `while` loop had no explicit iteration cap, so it fell through to Poshi's default of 15. On CI, the staging layout copy takes more than 15 polls (locally it converges in 8), so the loop silently exited before the layouts were ready. The next step then failed with `FAIL. Cannot find layout.`

## How It Is Being Fixed

The cap is raised to 100 via the `(maxIterations = "100")` Poshi syntax in the while condition.

## PR Check

**pr-check: PASS** — tested on `8c9bd8420998d8d6cbdec086408e96d376e5d7ac`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "8c9bd8420998d8d6cbdec086408e96d376e5d7ac"} -->
