### PR TITLE
LPD-93866 Delete the cached site template LAR file after a merge

### DIFF
--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
@@ -96,6 +96,7 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.Constants;
+import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -117,8 +118,6 @@ import com.liferay.sites.kernel.util.Sites;
 import jakarta.portlet.PortletPreferences;
 
 import java.awt.image.BufferedImage;
-
-import java.io.File;
 
 import java.util.Collections;
 import java.util.Date;
@@ -1530,12 +1529,6 @@ public class LayoutSetPrototypePropagationTest
 			});
 	}
 
-	private boolean _fileExists(String path) {
-		File file = new File(path);
-
-		return file.exists();
-	}
-
 	private String _getLatestMergeNotificationResult(
 			long timestamp, long userId)
 		throws Exception {
@@ -1669,14 +1662,10 @@ public class LayoutSetPrototypePropagationTest
 				"successful", timestamp, TestPropsValues.getUserId());
 
 			Assert.assertEquals(
-				!deleteCacheFile, _fileExists(testMessageListener._path));
+				!deleteCacheFile, FileUtil.exists(testMessageListener._path));
 		}
 		finally {
-			File file = new File(testMessageListener._path);
-
-			if (file.exists()) {
-				file.delete();
-			}
+			FileUtil.delete(testMessageListener._path);
 		}
 	}
 
@@ -1914,7 +1903,7 @@ public class LayoutSetPrototypePropagationTest
 
 			_path = _TEMP_DIR + sessionId + ".lar";
 
-			_fileExists = _fileExists(_path);
+			_fileExists = FileUtil.exists(_path);
 		}
 
 		private boolean _fileExists;

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
@@ -45,6 +45,7 @@ import com.liferay.portal.kernel.backgroundtask.BaseBackgroundTaskExecutor;
 import com.liferay.portal.kernel.backgroundtask.constants.BackgroundTaskConstants;
 import com.liferay.portal.kernel.backgroundtask.display.BackgroundTaskDisplay;
 import com.liferay.portal.kernel.exception.LayoutParentLayoutIdException;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.log.Log;
@@ -1869,7 +1870,7 @@ public class LayoutSetPrototypePropagationTest
 	private class TestMessageListener extends BaseMessageListener {
 
 		@Override
-		protected void doReceive(Message message) {
+		protected void doReceive(Message message) throws PortalException {
 			if (!Objects.equals(
 					message.getString("taskExecutorClassName"),
 					BackgroundTaskExecutorNames.
@@ -1893,9 +1894,8 @@ public class LayoutSetPrototypePropagationTest
 			}
 
 			com.liferay.portal.background.task.model.BackgroundTask
-				backgroundTask =
-					_backgroundTaskLocalService.fetchBackgroundTask(
-						message.getLong("backgroundTaskId"));
+				backgroundTask = _backgroundTaskLocalService.getBackgroundTask(
+					message.getLong("backgroundTaskId"));
 
 			String sessionId = MapUtil.getString(
 				backgroundTask.getTaskContextMap(),

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
@@ -12,6 +12,7 @@ import com.liferay.asset.kernel.service.AssetCategoryLocalServiceUtil;
 import com.liferay.asset.test.util.AssetTestUtil;
 import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestUtil;
 import com.liferay.exportimport.kernel.background.task.BackgroundTaskExecutorNames;
+import com.liferay.exportimport.kernel.background.task.constants.LayoutSetPrototypeBackgroundTaskConstants;
 import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.exportimport.kernel.staging.MergeLayoutPrototypesThreadLocal;
 import com.liferay.exportimport.test.util.ExportImportTestUtil;
@@ -35,6 +36,7 @@ import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.background.task.service.BackgroundTaskLocalService;
 import com.liferay.portal.image.ImageToolUtil;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTask;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskExecutor;
@@ -47,6 +49,10 @@ import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.messaging.BaseMessageListener;
+import com.liferay.portal.kernel.messaging.DestinationNames;
+import com.liferay.portal.kernel.messaging.Message;
+import com.liferay.portal.kernel.messaging.MessageListener;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
@@ -84,6 +90,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -92,7 +99,9 @@ import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.SystemProperties;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -109,6 +118,8 @@ import jakarta.portlet.PortletPreferences;
 
 import java.awt.image.BufferedImage;
 
+import java.io.File;
+
 import java.util.Collections;
 import java.util.Date;
 import java.util.Dictionary;
@@ -120,6 +131,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -144,6 +156,14 @@ public class LayoutSetPrototypePropagationTest
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() {
+		Bundle bundle = FrameworkUtil.getBundle(
+			LayoutSetPrototypePropagationTest.class);
+
+		_bundleContext = bundle.getBundleContext();
+	}
 
 	@Test
 	public void testAddChildLayoutWithLinkDisabled() throws Exception {
@@ -459,6 +479,13 @@ public class LayoutSetPrototypePropagationTest
 	}
 
 	@Test
+	public void testLayoutSetPrototypePropagationDeletesCacheFile()
+		throws Exception {
+
+		_testLayoutSetPrototypePropagation(true);
+	}
+
+	@Test
 	public void testLayoutSetPrototypePropagationDoesNotPropagateDeletions()
 		throws Exception {
 
@@ -499,6 +526,13 @@ public class LayoutSetPrototypePropagationTest
 			group.getGroupId(), false, layout2.getFriendlyURL());
 
 		Assert.assertNotNull(layout2.getLayoutSetPrototypeLayout());
+	}
+
+	@Test
+	public void testLayoutSetPrototypePropagationKeepsCacheFile()
+		throws Exception {
+
+		_testLayoutSetPrototypePropagation(false);
 	}
 
 	@Test
@@ -1496,6 +1530,12 @@ public class LayoutSetPrototypePropagationTest
 			});
 	}
 
+	private boolean _fileExists(String path) {
+		File file = new File(path);
+
+		return file.exists();
+	}
+
 	private String _getLatestMergeNotificationResult(
 			long timestamp, long userId)
 		throws Exception {
@@ -1527,6 +1567,19 @@ public class LayoutSetPrototypePropagationTest
 
 	private int _getRandomStatus(int... statuses) {
 		return statuses[RandomTestUtil.randomInt(0, statuses.length - 1)];
+	}
+
+	private SafeCloseable _registerMessageListenerWithSafeCloseable(
+		MessageListener messageListener) {
+
+		return _registerServiceWithSafeCloseable(
+			MessageListener.class,
+			HashMapDictionaryBuilder.<String, Object>put(
+				"destination.name", DestinationNames.BACKGROUND_TASK_STATUS
+			).put(
+				"service.ranking", Integer.MAX_VALUE
+			).build(),
+			messageListener);
 	}
 
 	private <S> SafeCloseable _registerServiceWithSafeCloseable(
@@ -1589,6 +1642,42 @@ public class LayoutSetPrototypePropagationTest
 				ResourceConstants.SCOPE_INDIVIDUAL,
 				String.valueOf(layout.getPrimaryKey()), role.getRoleId(),
 				ActionKeys.CUSTOMIZE));
+	}
+
+	private void _testLayoutSetPrototypePropagation(boolean deleteCacheFile)
+		throws Exception {
+
+		TestMessageListener testMessageListener = new TestMessageListener();
+
+		try (SafeCloseable safeCloseable1 =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"LAYOUT_SET_PROTOTYPE_MERGE_DELETE_CACHE_FILE_ENABLED",
+					deleteCacheFile);
+			SafeCloseable safeCloseable2 =
+				_registerMessageListenerWithSafeCloseable(
+					testMessageListener)) {
+
+			LayoutTestUtil.addTypePortletLayout(_layoutSetPrototypeGroup, true);
+
+			long timestamp = System.currentTimeMillis();
+
+			propagateChanges(false, group);
+
+			Assert.assertTrue(testMessageListener._fileExists);
+
+			_assertNotification(
+				"successful", timestamp, TestPropsValues.getUserId());
+
+			Assert.assertEquals(
+				!deleteCacheFile, _fileExists(testMessageListener._path));
+		}
+		finally {
+			File file = new File(testMessageListener._path);
+
+			if (file.exists()) {
+				file.delete();
+			}
+		}
 	}
 
 	private void _testLayoutSetPrototypePropagationCheckNotification(
@@ -1679,10 +1768,19 @@ public class LayoutSetPrototypePropagationTest
 	private static final String _COLOR_SCHEME_ID =
 		RandomTestUtil.randomString();
 
+	private static final String _TEMP_DIR =
+		SystemProperties.get(SystemProperties.TMP_DIR) +
+			"/liferay/layout_set_prototype/";
+
 	private static final String _THEME_ID = "minium_WAR_miniumtheme";
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		LayoutSetPrototypePropagationTest.class);
+
+	private static BundleContext _bundleContext;
+
+	@Inject
+	private BackgroundTaskLocalService _backgroundTaskLocalService;
 
 	@Inject
 	private FragmentCollectionLocalService _fragmentCollectionLocalService;
@@ -1776,6 +1874,51 @@ public class LayoutSetPrototypePropagationTest
 		}
 
 		private final Map<Long, Integer> _groupIdStatusMap;
+
+	}
+
+	private class TestMessageListener extends BaseMessageListener {
+
+		@Override
+		protected void doReceive(Message message) {
+			if (!Objects.equals(
+					message.getString("taskExecutorClassName"),
+					BackgroundTaskExecutorNames.
+						LAYOUT_SET_PROTOTYPE_MERGE_BACKGROUND_TASK_EXECUTOR)) {
+
+				return;
+			}
+
+			int backgroundTaskStatus = message.getInteger("status");
+
+			if ((backgroundTaskStatus !=
+					BackgroundTaskConstants.STATUS_CANCELLED) &&
+				(backgroundTaskStatus !=
+					BackgroundTaskConstants.STATUS_COMPLETED_WITH_ERRORS) &&
+				(backgroundTaskStatus !=
+					BackgroundTaskConstants.STATUS_FAILED) &&
+				(backgroundTaskStatus !=
+					BackgroundTaskConstants.STATUS_SUCCESSFUL)) {
+
+				return;
+			}
+
+			com.liferay.portal.background.task.model.BackgroundTask
+				backgroundTask =
+					_backgroundTaskLocalService.fetchBackgroundTask(
+						message.getLong("backgroundTaskId"));
+
+			String sessionId = MapUtil.getString(
+				backgroundTask.getTaskContextMap(),
+				LayoutSetPrototypeBackgroundTaskConstants.SESSION_ID);
+
+			_path = _TEMP_DIR + sessionId + ".lar";
+
+			_fileExists = _fileExists(_path);
+		}
+
+		private boolean _fileExists;
+		private String _path;
 
 	}
 

--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/exportimport/internal/messaging/LayoutSetPrototypeMergeBackgroundTaskStatusMessageListener.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/exportimport/internal/messaging/LayoutSetPrototypeMergeBackgroundTaskStatusMessageListener.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.messaging.MessageListenerException;
 import com.liferay.portal.kernel.model.LayoutSetPrototype;
 import com.liferay.portal.kernel.service.LayoutSetPrototypeLocalService;
 import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.SystemProperties;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
@@ -216,6 +217,10 @@ public class LayoutSetPrototypeMergeBackgroundTaskStatusMessageListener
 	}
 
 	private void _deleteCacheFile(String sessionId) {
+		if (!PropsValues.LAYOUT_SET_PROTOTYPE_MERGE_DELETE_CACHE_FILE_ENABLED) {
+			return;
+		}
+
 		File file = new File(_TEMP_DIR + sessionId + ".lar");
 
 		if ((file != null) && file.exists()) {

--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/exportimport/internal/messaging/LayoutSetPrototypeMergeBackgroundTaskStatusMessageListener.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/exportimport/internal/messaging/LayoutSetPrototypeMergeBackgroundTaskStatusMessageListener.java
@@ -24,10 +24,12 @@ import com.liferay.portal.kernel.messaging.MessageListenerException;
 import com.liferay.portal.kernel.model.LayoutSetPrototype;
 import com.liferay.portal.kernel.service.LayoutSetPrototypeLocalService;
 import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.SystemProperties;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
 import com.liferay.site.internal.exportimport.internal.notifications.LayoutSetPrototypeNotificationUtil;
 
+import java.io.File;
 import java.io.Serializable;
 
 import java.util.Date;
@@ -164,6 +166,8 @@ public class LayoutSetPrototypeMergeBackgroundTaskStatusMessageListener
 					_markNotificationProcessed(completedBackgroundTask);
 				}
 			}
+
+			_deleteCacheFile(sessionId);
 		}
 		finally {
 			_lockManager.unlock(
@@ -208,6 +212,14 @@ public class LayoutSetPrototypeMergeBackgroundTaskStatusMessageListener
 				"Unable to delete background task " +
 					backgroundTask.getBackgroundTaskId(),
 				exception);
+		}
+	}
+
+	private void _deleteCacheFile(String sessionId) {
+		File file = new File(_TEMP_DIR + sessionId + ".lar");
+
+		if ((file != null) && file.exists()) {
+			file.delete();
 		}
 	}
 
@@ -274,6 +286,10 @@ public class LayoutSetPrototypeMergeBackgroundTaskStatusMessageListener
 	}
 
 	private static final long _LOCK_EXPIRATION_TIME = 5 * 60 * 1000;
+
+	private static final String _TEMP_DIR =
+		SystemProperties.get(SystemProperties.TMP_DIR) +
+			"/liferay/layout_set_prototype/";
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		LayoutSetPrototypeMergeBackgroundTaskStatusMessageListener.class);

--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/exportimport/internal/messaging/LayoutSetPrototypeMergeBackgroundTaskStatusMessageListener.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/exportimport/internal/messaging/LayoutSetPrototypeMergeBackgroundTaskStatusMessageListener.java
@@ -219,7 +219,16 @@ public class LayoutSetPrototypeMergeBackgroundTaskStatusMessageListener
 		File file = new File(_TEMP_DIR + sessionId + ".lar");
 
 		if ((file != null) && file.exists()) {
-			file.delete();
+			try {
+				file.delete();
+			}
+			catch (Exception exception) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						"Unable to delete cache file " + file.getAbsolutePath(),
+						exception);
+				}
+			}
 		}
 	}
 

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -5175,6 +5175,15 @@
 ##
 
     #
+    # Set this to true to delete the cached site template LAR file once the
+    # merge process completes. Set this to false to keep the file for debugging
+    # purposes.
+    #
+    # Env: LIFERAY_LAYOUT_PERIOD_SET_PERIOD_PROTOTYPE_PERIOD_MERGE_PERIOD_DELETE_PERIOD_CACHE_PERIOD_FILE_PERIOD_ENABLED
+    #
+    layout.set.prototype.merge.delete.cache.file.enabled=true
+
+    #
     # In the case that a site template would fail to merge, make sure that we
     # prevent repeated attempts that will inevitably fail by setting a fail
     # threshold.

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -1414,6 +1414,10 @@ public interface PropsKeys {
 	public static final String LAYOUT_SET_FORM_UPDATE =
 		"layout.set.form.update";
 
+	public static final String
+		LAYOUT_SET_PROTOTYPE_MERGE_DELETE_CACHE_FILE_ENABLED =
+			"layout.set.prototype.merge.delete.cache.file.enabled";
+
 	public static final String LAYOUT_SET_PROTOTYPE_MERGE_FAIL_THRESHOLD =
 		"layout.set.prototype.merge.fail.threshold";
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
@@ -1134,6 +1134,13 @@ public class PropsValues {
 		GetterUtil.getInteger(
 			PropsUtil.get(PropsKeys.LAYOUT_SCOPE_GROUP_FINDER_THRESHOLD));
 
+	public static final boolean
+		LAYOUT_SET_PROTOTYPE_MERGE_DELETE_CACHE_FILE_ENABLED =
+			GetterUtil.getBoolean(
+				PropsUtil.get(
+					PropsKeys.
+						LAYOUT_SET_PROTOTYPE_MERGE_DELETE_CACHE_FILE_ENABLED));
+
 	public static final int LAYOUT_SET_PROTOTYPE_MERGE_FAIL_THRESHOLD =
 		GetterUtil.getInteger(
 			PropsUtil.get(PropsKeys.LAYOUT_SET_PROTOTYPE_MERGE_FAIL_THRESHOLD));

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 98.1.0
+version 98.2.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93866

Follow-up to #3985 (forwarded to [brianchandotcom#177980](https://github.com/brianchandotcom/liferay-portal/pull/177980)), addressing Brian's review comment: https://github.com/brianchandotcom/liferay-portal/pull/177980#issuecomment-4855499185

## What Is Being Fixed

The site template merge process exports the layout set prototype to a cached LAR file (keyed by the merge session id) and reuses it across every site merged in the same session. Once the merge completed, that cached file was never removed, so stale `.lar` files accumulated in the temp directory.

## How It Is Being Fixed

The background task status listener now deletes the cached LAR file once all of the session's merge background tasks complete. The deletion is governed by a new portal property `layout.set.prototype.merge.delete.cache.file.enabled` (default `true`), so the file can be kept for debugging by setting it to `false`. Integration tests cover deletion on completion, retention while a merge task is still incomplete, and retention when the property is disabled.

## Review Feedback Addressed

Brian [pointed out](https://github.com/brianchandotcom/liferay-portal/pull/177971#issuecomment-4853567239) that the test's `_fileExists` helper wrapping `new File(path).exists()` is not the standard pattern and that `FileUtil` should be used instead. This branch replaces the hand-rolled helper and the manual `File` deletion in the test with `FileUtil.exists` and `FileUtil.delete`.

Brian also [pointed out](https://github.com/brianchandotcom/liferay-portal/pull/177980#issuecomment-4855499185) that the test's use of `_backgroundTaskLocalService.fetchBackgroundTask(...)` is not our pattern. This branch switches to `getBackgroundTask(...)`, which throws instead of returning `null`, propagating the resulting `PortalException` from `doReceive`.

## PR Check

**pr-check: PASS** — tested on `8ce1de28d11638bfab6e2ea34293d8e76bb39ba6`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |

Cross-Module Compile was not run because the only portal-kernel change is purely additive (a new `PropsKeys`/`PropsValues` constant, `packageinfo` bumped `98.1.0` → `98.2.0`) and its consumer set exceeds the cap; it is covered by Full Portal Build and Integration Test Compile. Per-Module Compile is subsumed by Full Portal Build (`site-impl` carries `.lfrbuild-portal`; `export-import-test` is testIntegration-only). No unit-test counterparts exist for the changed files.

<!-- pr-check {"result": "success", "sha": "8ce1de28d11638bfab6e2ea34293d8e76bb39ba6"} -->
