### PR TITLE
LPD-96982 Fix staging publish form error for group page templates

### DIFF
--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/portlet/LayoutPageTemplatesPortlet.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/portlet/LayoutPageTemplatesPortlet.java
@@ -61,6 +61,7 @@ import org.osgi.service.component.annotations.Reference;
 		"com.liferay.portlet.css-class-wrapper=portlet-layout-templates-admin",
 		"com.liferay.portlet.icon=/icons/group_pages.png",
 		"com.liferay.portlet.preferences-owned-by-group=true",
+		"com.liferay.portlet.preferences-unique-per-layout=false",
 		"com.liferay.portlet.private-request-attributes=false",
 		"com.liferay.portlet.private-session-attributes=false",
 		"com.liferay.portlet.render-weight=50",


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96982

## What Is Being Fixed

On a staged site, opening Publishing → Staging → New did not show the portlet data counts for the "From Last Publish Date" option for the Group Page Templates portlet. The portlet's preferences could not be resolved on the staging publish form, so the counts were not visible.

## How It Is Being Fixed

The Group Page Templates portlet stores its preferences at the group level (`com.liferay.portlet.preferences-owned-by-group=true`) but still defaulted to unique-per-layout preferences. Since this system portlet is not bound to a specific layout, resolving per-layout preferences on the staging publish form broke the data-count lookup. Adding `com.liferay.portlet.preferences-unique-per-layout=false` makes the portlet share a single group-scoped preferences instance, so the staging form can read it and render the "From Last Publish Date" data counts.

## Why Are There No Tests?

This change directly fixes the existing Poshi test `LocalFile.StagingUsecaseWithVersioning#StagingPublishLast`, which already covers this scenario, so no new tests are added in this PR.

## PR Check

**pr-check: PASS** — tested on `ea796f93a0a8767da40fbd3d1dd78de8c9e16042`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Portlet Title | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "ea796f93a0a8767da40fbd3d1dd78de8c9e16042"} -->
