### PR TITLE
LPD-97133 Fix restClient template test's Terms of Use failure

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/template/test/RESTClientTemplateContextContributorTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/template/test/RESTClientTemplateContextContributorTest.java
@@ -17,6 +17,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.ZipFileTestUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.zip.ZipWriterFactory;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -73,15 +74,20 @@ public class RESTClientTemplateContextContributorTest {
 				"friendlyUrlPath"
 			);
 
-			User user = TestPropsValues.getUser();
+			boolean termsOfUseRequired = PropsValues.TERMS_OF_USE_REQUIRED;
 
-			_userLocalService.updateAgreedToTermsOfUse(user.getUserId(), true);
+			PropsValues.TERMS_OF_USE_REQUIRED = false;
 
-			HTTPTestUtil.customize(
-			).withoutModulePath(
-			).apply(
-				() -> _test(friendlyUrlPath, user)
-			);
+			try {
+				HTTPTestUtil.customize(
+				).withoutModulePath(
+				).apply(
+					() -> _test(friendlyUrlPath, TestPropsValues.getUser())
+				);
+			}
+			finally {
+				PropsValues.TERMS_OF_USE_REQUIRED = termsOfUseRequired;
+			}
 
 			HTTPTestUtil.customize(
 			).withoutModulePath(

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/template/test/RESTClientTemplateContextContributorTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/template/test/RESTClientTemplateContextContributorTest.java
@@ -73,10 +73,14 @@ public class RESTClientTemplateContextContributorTest {
 				"friendlyUrlPath"
 			);
 
+			User user = TestPropsValues.getUser();
+
+			_userLocalService.updateAgreedToTermsOfUse(user.getUserId(), true);
+
 			HTTPTestUtil.customize(
 			).withoutModulePath(
 			).apply(
-				() -> _test(friendlyUrlPath, TestPropsValues.getUser())
+				() -> _test(friendlyUrlPath, user)
 			);
 
 			HTTPTestUtil.customize(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97133

## What Is Being Fixed

`RESTClientTemplateContextContributorTest` fails whenever `terms.of.use.required` is enabled and the test admin has not yet agreed to Terms of Use (the default in CI, though most local dev bundles override it). LPD-94309 made the test's Basic-Auth-header request genuinely authenticate the admin on this page-view code path, instead of silently resolving as guest as it did before; the portal then serves the Terms of Use interstitial instead of the fragment page, and the test fails on its very first assertion.

## How It Is Being Fixed

The test now calls `UserLocalService.updateAgreedToTermsOfUse(user.getUserId(), true)` before the authenticated assertion, so the fragment renders as expected instead of the Terms of Use page. Verified locally end-to-end: reproduced the exact CI failure by matching both conditions the gate requires (`terms.of.use.required=true` and `agreedToTermsOfUse=false`), then confirmed the fix resolves it.

## Why Are There No Tests?

The entire change lives inside the failing test itself — there is no product behavior change to cover with a new test.

## PR Check

**pr-check: PASS** — tested on `52508e8a709517be122e5faf96e3355fabc5359a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "52508e8a709517be122e5faf96e3355fabc5359a"} -->
