### PR TITLE
LPD-97197 Fix Job Scheduler Run Now under database partitioning

### DIFF
--- a/modules/apps/dispatch/dispatch-rest-impl/src/main/java/com/liferay/dispatch/rest/internal/resource/v1_0/DispatchTriggerResourceImpl.java
+++ b/modules/apps/dispatch/dispatch-rest-impl/src/main/java/com/liferay/dispatch/rest/internal/resource/v1_0/DispatchTriggerResourceImpl.java
@@ -65,7 +65,12 @@ public class DispatchTriggerResourceImpl
 			PermissionThreadLocal.getPermissionChecker(), dispatchTriggerId,
 			ActionKeys.UPDATE);
 
+		com.liferay.dispatch.model.DispatchTrigger dispatchTrigger =
+			_dispatchTriggerService.getDispatchTrigger(dispatchTriggerId);
+
 		Message message = new Message();
+
+		message.put("companyId", dispatchTrigger.getCompanyId());
 
 		message.setPayload(
 			JSONUtil.put(

--- a/modules/apps/dispatch/dispatch-rest-impl/src/main/java/com/liferay/dispatch/rest/internal/resource/v1_0/DispatchTriggerResourceImpl.java
+++ b/modules/apps/dispatch/dispatch-rest-impl/src/main/java/com/liferay/dispatch/rest/internal/resource/v1_0/DispatchTriggerResourceImpl.java
@@ -65,10 +65,10 @@ public class DispatchTriggerResourceImpl
 			PermissionThreadLocal.getPermissionChecker(), dispatchTriggerId,
 			ActionKeys.UPDATE);
 
+		Message message = new Message();
+
 		com.liferay.dispatch.model.DispatchTrigger dispatchTrigger =
 			_dispatchTriggerService.getDispatchTrigger(dispatchTriggerId);
-
-		Message message = new Message();
 
 		message.put("companyId", dispatchTrigger.getCompanyId());
 

--- a/modules/apps/dispatch/dispatch-rest-impl/src/test/java/com/liferay/dispatch/rest/internal/resource/v1_0/DispatchTriggerResourceImplTest.java
+++ b/modules/apps/dispatch/dispatch-rest-impl/src/test/java/com/liferay/dispatch/rest/internal/resource/v1_0/DispatchTriggerResourceImplTest.java
@@ -1,0 +1,96 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.dispatch.rest.internal.resource.v1_0;
+
+import com.liferay.dispatch.constants.DispatchConstants;
+import com.liferay.dispatch.model.DispatchTrigger;
+import com.liferay.dispatch.service.DispatchTriggerService;
+import com.liferay.portal.kernel.messaging.Message;
+import com.liferay.portal.kernel.messaging.MessageBus;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * @author Magdalena Jedraszak
+ */
+public class DispatchTriggerResourceImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		MockitoAnnotations.initMocks(this);
+	}
+
+	@Test
+	public void test() throws Exception {
+		long companyId = RandomTestUtil.randomLong();
+
+		Mockito.when(
+			_dispatchTrigger.getCompanyId()
+		).thenReturn(
+			companyId
+		);
+
+		long dispatchTriggerId = RandomTestUtil.randomLong();
+
+		Mockito.when(
+			_dispatchTriggerService.getDispatchTrigger(dispatchTriggerId)
+		).thenReturn(
+			_dispatchTrigger
+		);
+
+		_dispatchTriggerResourceImpl.postDispatchTriggerRun(dispatchTriggerId);
+
+		ArgumentCaptor<Message> messageArgumentCaptor = ArgumentCaptor.forClass(
+			Message.class);
+
+		Mockito.verify(
+			_messageBus
+		).sendMessage(
+			Mockito.eq(DispatchConstants.EXECUTOR_DESTINATION_NAME),
+			messageArgumentCaptor.capture()
+		);
+
+		Message message = messageArgumentCaptor.getValue();
+
+		Assert.assertEquals(companyId, message.getLong("companyId"));
+	}
+
+	@Mock
+	private DispatchTrigger _dispatchTrigger;
+
+	@Mock
+	private ModelResourcePermission<DispatchTrigger>
+		_dispatchTriggerModelResourcePermission;
+
+	@InjectMocks
+	private final DispatchTriggerResourceImpl _dispatchTriggerResourceImpl =
+		new DispatchTriggerResourceImpl();
+
+	@Mock
+	private DispatchTriggerService _dispatchTriggerService;
+
+	@Mock
+	private MessageBus _messageBus;
+
+}

--- a/modules/apps/dispatch/dispatch-rest-impl/src/test/java/com/liferay/dispatch/rest/internal/resource/v1_0/DispatchTriggerResourceImplTest.java
+++ b/modules/apps/dispatch/dispatch-rest-impl/src/test/java/com/liferay/dispatch/rest/internal/resource/v1_0/DispatchTriggerResourceImplTest.java
@@ -11,6 +11,7 @@ import com.liferay.dispatch.service.DispatchTriggerService;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.messaging.MessageBus;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
@@ -21,10 +22,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
 
 /**
  * @author Magdalena Jedraszak
@@ -38,11 +36,21 @@ public class DispatchTriggerResourceImplTest {
 
 	@Before
 	public void setUp() {
-		MockitoAnnotations.initMocks(this);
+		ReflectionTestUtil.setFieldValue(
+			_dispatchTriggerResourceImpl,
+			"_dispatchTriggerModelResourcePermission",
+			_dispatchTriggerModelResourcePermission);
+		ReflectionTestUtil.setFieldValue(
+			_dispatchTriggerResourceImpl, "_dispatchTriggerService",
+			_dispatchTriggerService);
+		ReflectionTestUtil.setFieldValue(
+			_dispatchTriggerResourceImpl, "_messageBus", _messageBus);
 	}
 
 	@Test
-	public void test() throws Exception {
+	public void testPostDispatchTriggerRunPropagatesCompanyId()
+		throws Exception {
+
 		long companyId = RandomTestUtil.randomLong();
 
 		Mockito.when(
@@ -61,36 +69,30 @@ public class DispatchTriggerResourceImplTest {
 
 		_dispatchTriggerResourceImpl.postDispatchTriggerRun(dispatchTriggerId);
 
-		ArgumentCaptor<Message> messageArgumentCaptor = ArgumentCaptor.forClass(
+		ArgumentCaptor<Message> argumentCaptor = ArgumentCaptor.forClass(
 			Message.class);
 
 		Mockito.verify(
 			_messageBus
 		).sendMessage(
 			Mockito.eq(DispatchConstants.EXECUTOR_DESTINATION_NAME),
-			messageArgumentCaptor.capture()
+			argumentCaptor.capture()
 		);
 
-		Message message = messageArgumentCaptor.getValue();
+		Message message = argumentCaptor.getValue();
 
 		Assert.assertEquals(companyId, message.getLong("companyId"));
 	}
 
-	@Mock
-	private DispatchTrigger _dispatchTrigger;
-
-	@Mock
-	private ModelResourcePermission<DispatchTrigger>
-		_dispatchTriggerModelResourcePermission;
-
-	@InjectMocks
+	private final DispatchTrigger _dispatchTrigger = Mockito.mock(
+		DispatchTrigger.class);
+	private final ModelResourcePermission<DispatchTrigger>
+		_dispatchTriggerModelResourcePermission = Mockito.mock(
+			ModelResourcePermission.class);
 	private final DispatchTriggerResourceImpl _dispatchTriggerResourceImpl =
 		new DispatchTriggerResourceImpl();
-
-	@Mock
-	private DispatchTriggerService _dispatchTriggerService;
-
-	@Mock
-	private MessageBus _messageBus;
+	private final DispatchTriggerService _dispatchTriggerService = Mockito.mock(
+		DispatchTriggerService.class);
+	private final MessageBus _messageBus = Mockito.mock(MessageBus.class);
 
 }

--- a/modules/apps/dispatch/dispatch-web/src/main/java/com/liferay/dispatch/web/internal/portlet/action/EditDispatchTriggerMVCActionCommand.java
+++ b/modules/apps/dispatch/dispatch-web/src/main/java/com/liferay/dispatch/web/internal/portlet/action/EditDispatchTriggerMVCActionCommand.java
@@ -236,8 +236,13 @@ public class EditDispatchTriggerMVCActionCommand extends BaseMVCActionCommand {
 			startDateYear, startDateHour, startDateMinute, timeZoneId);
 	}
 
-	private void _sendMessage(long dispatchTriggerId) {
+	private void _sendMessage(long dispatchTriggerId) throws PortalException {
+		DispatchTrigger dispatchTrigger =
+			_dispatchTriggerLocalService.getDispatchTrigger(dispatchTriggerId);
+
 		Message message = new Message();
+
+		message.put("companyId", dispatchTrigger.getCompanyId());
 
 		message.setPayload(
 			JSONUtil.put(

--- a/modules/apps/dispatch/dispatch-web/src/main/java/com/liferay/dispatch/web/internal/portlet/action/EditDispatchTriggerMVCActionCommand.java
+++ b/modules/apps/dispatch/dispatch-web/src/main/java/com/liferay/dispatch/web/internal/portlet/action/EditDispatchTriggerMVCActionCommand.java
@@ -237,10 +237,10 @@ public class EditDispatchTriggerMVCActionCommand extends BaseMVCActionCommand {
 	}
 
 	private void _sendMessage(long dispatchTriggerId) throws PortalException {
+		Message message = new Message();
+
 		DispatchTrigger dispatchTrigger =
 			_dispatchTriggerLocalService.getDispatchTrigger(dispatchTriggerId);
-
-		Message message = new Message();
 
 		message.put("companyId", dispatchTrigger.getCompanyId());
 

--- a/modules/apps/dispatch/dispatch-web/src/test/java/com/liferay/dispatch/web/internal/portlet/action/EditDispatchTriggerMVCActionCommandTest.java
+++ b/modules/apps/dispatch/dispatch-web/src/test/java/com/liferay/dispatch/web/internal/portlet/action/EditDispatchTriggerMVCActionCommandTest.java
@@ -1,0 +1,95 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.dispatch.web.internal.portlet.action;
+
+import com.liferay.dispatch.constants.DispatchConstants;
+import com.liferay.dispatch.model.DispatchTrigger;
+import com.liferay.dispatch.service.DispatchTriggerLocalService;
+import com.liferay.portal.kernel.messaging.Message;
+import com.liferay.portal.kernel.messaging.MessageBus;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * @author Magdalena Jedraszak
+ */
+public class EditDispatchTriggerMVCActionCommandTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		MockitoAnnotations.initMocks(this);
+	}
+
+	@Test
+	public void test() throws Exception {
+		long companyId = RandomTestUtil.randomLong();
+
+		Mockito.when(
+			_dispatchTrigger.getCompanyId()
+		).thenReturn(
+			companyId
+		);
+
+		long dispatchTriggerId = RandomTestUtil.randomLong();
+
+		Mockito.when(
+			_dispatchTriggerLocalService.getDispatchTrigger(dispatchTriggerId)
+		).thenReturn(
+			_dispatchTrigger
+		);
+
+		ReflectionTestUtil.invoke(
+			_editDispatchTriggerMVCActionCommand, "_sendMessage",
+			new Class<?>[] {long.class}, dispatchTriggerId);
+
+		ArgumentCaptor<Message> messageArgumentCaptor = ArgumentCaptor.forClass(
+			Message.class);
+
+		Mockito.verify(
+			_messageBus
+		).sendMessage(
+			Mockito.eq(DispatchConstants.EXECUTOR_DESTINATION_NAME),
+			messageArgumentCaptor.capture()
+		);
+
+		Message message = messageArgumentCaptor.getValue();
+
+		Assert.assertEquals(companyId, message.getLong("companyId"));
+	}
+
+	@Mock
+	private DispatchTrigger _dispatchTrigger;
+
+	@Mock
+	private DispatchTriggerLocalService _dispatchTriggerLocalService;
+
+	@InjectMocks
+	private final EditDispatchTriggerMVCActionCommand
+		_editDispatchTriggerMVCActionCommand =
+			new EditDispatchTriggerMVCActionCommand();
+
+	@Mock
+	private MessageBus _messageBus;
+
+}

--- a/modules/apps/dispatch/dispatch-web/src/test/java/com/liferay/dispatch/web/internal/portlet/action/EditDispatchTriggerMVCActionCommandTest.java
+++ b/modules/apps/dispatch/dispatch-web/src/test/java/com/liferay/dispatch/web/internal/portlet/action/EditDispatchTriggerMVCActionCommandTest.java
@@ -21,10 +21,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
 
 /**
  * @author Magdalena Jedraszak
@@ -38,11 +35,15 @@ public class EditDispatchTriggerMVCActionCommandTest {
 
 	@Before
 	public void setUp() {
-		MockitoAnnotations.initMocks(this);
+		ReflectionTestUtil.setFieldValue(
+			_editDispatchTriggerMVCActionCommand,
+			"_dispatchTriggerLocalService", _dispatchTriggerLocalService);
+		ReflectionTestUtil.setFieldValue(
+			_editDispatchTriggerMVCActionCommand, "_messageBus", _messageBus);
 	}
 
 	@Test
-	public void test() throws Exception {
+	public void testSendMessagePropagatesCompanyId() throws Exception {
 		long companyId = RandomTestUtil.randomLong();
 
 		Mockito.when(
@@ -63,33 +64,28 @@ public class EditDispatchTriggerMVCActionCommandTest {
 			_editDispatchTriggerMVCActionCommand, "_sendMessage",
 			new Class<?>[] {long.class}, dispatchTriggerId);
 
-		ArgumentCaptor<Message> messageArgumentCaptor = ArgumentCaptor.forClass(
+		ArgumentCaptor<Message> argumentCaptor = ArgumentCaptor.forClass(
 			Message.class);
 
 		Mockito.verify(
 			_messageBus
 		).sendMessage(
 			Mockito.eq(DispatchConstants.EXECUTOR_DESTINATION_NAME),
-			messageArgumentCaptor.capture()
+			argumentCaptor.capture()
 		);
 
-		Message message = messageArgumentCaptor.getValue();
+		Message message = argumentCaptor.getValue();
 
 		Assert.assertEquals(companyId, message.getLong("companyId"));
 	}
 
-	@Mock
-	private DispatchTrigger _dispatchTrigger;
-
-	@Mock
-	private DispatchTriggerLocalService _dispatchTriggerLocalService;
-
-	@InjectMocks
+	private final DispatchTrigger _dispatchTrigger = Mockito.mock(
+		DispatchTrigger.class);
+	private final DispatchTriggerLocalService _dispatchTriggerLocalService =
+		Mockito.mock(DispatchTriggerLocalService.class);
 	private final EditDispatchTriggerMVCActionCommand
 		_editDispatchTriggerMVCActionCommand =
 			new EditDispatchTriggerMVCActionCommand();
-
-	@Mock
-	private MessageBus _messageBus;
+	private final MessageBus _messageBus = Mockito.mock(MessageBus.class);
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97197

## What Is Being Fixed

When database partitioning is enabled, using "Run Now" on a Job Scheduler trigger that belongs to a secondary virtual instance fails to execute the trigger. The message sent to the background executor never included the trigger's companyId, so the executor thread processed it under the ambient/default company context instead of the trigger's own company. Under partitioning, this caused the follow-up trigger lookup to run against the wrong database partition, so the trigger wasn't found there. Depending on the release, this either throws a NoSuchTriggerException (as reported by a customer, see LPP-64657) or, on more recent code that changed the lookup to a null-safe fetch for an unrelated reason (LPD-68953), silently no-ops instead, so the job simply never runs with no visible error.

## How It Is Being Fixed

Both "Run Now" send sites, the Job Scheduler UI's EditDispatchTriggerMVCActionCommand and the REST API's DispatchTriggerResourceImpl, now look up the trigger and propagate its own companyId onto the outgoing message, matching the pattern already used by the working cron-scheduled path in DispatchTriggerHelper.addSchedulerJob. This ensures the executor thread runs under the trigger's actual company before the trigger is looked up again downstream, so the lookup resolves against the correct partition.

Test coverage is a dedicated integration test class, DispatchMessageListenerDBPartitionTest, kept separate from the existing DispatchMessageListenerTest rather than merged into it. This is a deliberate choice: CI wiring for the real, actively-running "[master] ci:test:db-partition" routine works at file granularity, through test.batch.class.names.includes[db-partition] in the root test.properties, alongside other individually-named DBPartitionTest classes such as UpgradeProcessDBPartitionTest and QuartzDBPartitionUpgradeProcessTest. A separate file lets the new tests be wired into that routine without dragging in DispatchMessageListenerTest's unrelated existing tests or running them redundantly under the partition-enabled batch. This PR adds that wiring entry directly, since the same pattern was found missing for at least one other existing DBPartitionTest class in the codebase, meaning it likely never actually runs under real partitioning in CI without this kind of explicit registration.

The fix was additionally validated end to end against the exact customer environment, DXP 2024.Q2.12 with hotfix-299, PostgreSQL, database partitioning enabled, in a Docker reproduction, confirming it resolves the originally reported exception.

## PR Check

**pr-check: PASS** — tested on `9ead31bfcda1277b09f80d7ea308dddf98448585`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| PQL Validation | PASS |

<!-- pr-check {"result": "success", "sha": "9ead31bfcda1277b09f80d7ea308dddf98448585"} -->
