### PR TITLE
LPD-96945 Fix object entry comments dropped by batch export/import

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandlerUtil.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandlerUtil.java
@@ -99,7 +99,7 @@ public class BatchEnginePortletDataHandlerUtil {
 							portletDataContext.getParameterMap(),
 							PortletDataHandlerKeys.COMMENTS)) {
 
-						batchNestedFields.add("comments");
+						batchNestedFields.add("systemProperties.comments");
 					}
 
 					if (MapUtil.getBoolean(
@@ -197,7 +197,7 @@ public class BatchEnginePortletDataHandlerUtil {
 							portletDataContext.getParameterMap(),
 							PortletDataHandlerKeys.COMMENTS)) {
 
-						batchRestrictFields.add("comments");
+						batchRestrictFields.add("systemProperties.comments");
 					}
 
 					if (!MapUtil.getBoolean(

--- a/modules/apps/export-import/export-import-service/src/test/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandlerUtilTest.java
+++ b/modules/apps/export-import/export-import-service/src/test/java/com/liferay/exportimport/internal/data/handler/BatchEnginePortletDataHandlerUtilTest.java
@@ -185,8 +185,8 @@ public class BatchEnginePortletDataHandlerUtilTest {
 			_getStagingGroupHelper(false));
 
 		Assert.assertEquals(
-			"customFields.attributeType,comments,permissions,nestedField1," +
-				"nestedField2",
+			"customFields.attributeType,systemProperties.comments," +
+				"permissions,nestedField1,nestedField2",
 			parameters.get("batchNestedFields"));
 	}
 
@@ -275,7 +275,7 @@ public class BatchEnginePortletDataHandlerUtilTest {
 					PortletDataHandlerKeys.PERMISSIONS, new String[] {"true"}
 				).build()));
 		Assert.assertEquals(
-			"comments",
+			"systemProperties.comments",
 			_getBatchRestrictFields(
 				HashMapBuilder.put(
 					PortletDataHandlerKeys.COMMENTS, new String[] {"false"}
@@ -283,13 +283,13 @@ public class BatchEnginePortletDataHandlerUtilTest {
 					PortletDataHandlerKeys.PERMISSIONS, new String[] {"true"}
 				).build()));
 		Assert.assertEquals(
-			"comments,permissions",
+			"systemProperties.comments,permissions",
 			_getBatchRestrictFields(
 				HashMapBuilder.put(
 					PortletDataHandlerKeys.COMMENTS, new String[] {"false"}
 				).build()));
 		Assert.assertEquals(
-			"comments,permissions",
+			"systemProperties.comments,permissions",
 			_getBatchRestrictFields(
 				HashMapBuilder.put(
 					PortletDataHandlerKeys.COMMENTS, new String[] {"false"}
@@ -297,7 +297,7 @@ public class BatchEnginePortletDataHandlerUtilTest {
 					PortletDataHandlerKeys.PERMISSIONS, new String[] {"false"}
 				).build()));
 		Assert.assertEquals(
-			"comments,permissions",
+			"systemProperties.comments,permissions",
 			_getBatchRestrictFields(
 				HashMapBuilder.put(
 					PortletDataHandlerKeys.PERMISSIONS, new String[] {"false"}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96945

## What Is Being Fixed

Object entry comments were silently dropped when object entries were exported and reimported through the batch engine portlet data handler. On import nothing recreated the comment, so a subsequent lookup threw NoSuchMessageException.

## How It Is Being Fixed

LPD-93214 moved the object entry comments field on the REST DTO into systemProperties, changing the registered nested-field key from comments to systemProperties.comments. BatchEnginePortletDataHandlerUtil still requested the stale comments key when building the export nested-fields list and the import restrict-fields list. Because comments are a lazy nested field, requesting the wrong key meant the exporter never embedded them. This updates both lists to systemProperties.comments and aligns the BatchEnginePortletDataHandlerUtilTest expectations with the new key.

## Why Are There No Tests?

The regression is already covered by the existing integration test BatchEnginePortletDataHandlerTest.testExportImportObjectEntriesWithComments, which failed before the fix (NoSuchMessageException) and passes after it. The unit test BatchEnginePortletDataHandlerUtilTest was updated to assert the new key.

## PR Check

**pr-check: PASS** — tested on `918a96070ab225c7f2d08a799cf297814c97a280`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "918a96070ab225c7f2d08a799cf297814c97a280"} -->
