### PR TITLE
LPD-87027 Add ProviderType annotation to Sites

### DIFF
--- a/portal-kernel/src/com/liferay/sites/kernel/util/Sites.java
+++ b/portal-kernel/src/com/liferay/sites/kernel/util/Sites.java
@@ -18,9 +18,12 @@ import java.io.Serializable;
 
 import java.util.Map;
 
+import org.osgi.annotation.versioning.ProviderType;
+
 /**
  * @author Eudaldo Alonso
  */
+@ProviderType
 public interface Sites {
 
 	public static final String ANALYTICS_PREFIX = "analytics_";


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87027

## What Is Being Fixed

The `Sites` interface in `portal-kernel` carried no OSGi provider/consumer annotation, so bnd treated it as a `@ConsumerType` by default. That assumption is wrong: `Sites` is implemented only by Liferay's internal `SitesImpl`, and every other caller consumes it through `SitesUtil`. Under the consumer-type default, adding any method to `Sites` counts as a breaking change and forces a major package version bump.

## How It Is Being Fixed

Annotate `Sites` with `@ProviderType` (the standard `org.osgi.annotation.versioning.ProviderType`, matching sibling kernel interfaces such as `Portal`, `Http`, and `Localization`). This declares that only the provider implements the interface, so future method additions stay backward compatible for consumers and baseline treats them as minor rather than major changes. The bnd baseline confirms the annotated interface remains compatible with the published version at 5.0.0, requiring no package version bump.

## Why Are There No Tests?

`@ProviderType` has CLASS retention and no runtime effect; its correctness is verified by the bnd baseline, which was run and passed cleanly. There is no runtime behavior to test.

## PR Check

**pr-check: PASS** — tested on `fc207e245d8a7e403d8c2125d22d1dd945bb2ef0`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "fc207e245d8a7e403d8c2125d22d1dd945bb2ef0"} -->
