### PR TITLE
LPD-96323 Handle public and private page sets in export and import

### DIFF
--- a/modules/apps/export-import/export-import-api/bnd.bnd
+++ b/modules/apps/export-import/export-import-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Export Import API
 Bundle-SymbolicName: com.liferay.exportimport.api
-Bundle-Version: 17.2.1
+Bundle-Version: 18.0.0
 Export-Package:\
 	com.liferay.exportimport.attachment,\
 	com.liferay.exportimport.configuration,\

--- a/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/lar/DeletionSystemEventExporter.java
+++ b/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/lar/DeletionSystemEventExporter.java
@@ -16,4 +16,8 @@ public interface DeletionSystemEventExporter {
 			PortletDataContext portletDataContext)
 		throws Exception;
 
+	public long getDeletionSystemEventsCount(
+			PortletDataContext portletDataContext)
+		throws Exception;
+
 }

--- a/modules/apps/export-import/export-import-api/src/main/resources/com/liferay/exportimport/lar/packageinfo
+++ b/modules/apps/export-import/export-import-api/src/main/resources/com/liferay/exportimport/lar/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 2.0.0

--- a/modules/apps/export-import/export-import-rest-api/bnd.bnd
+++ b/modules/apps/export-import/export-import-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Export Import REST API
 Bundle-SymbolicName: com.liferay.exportimport.rest.api
-Bundle-Version: 5.0.1
+Bundle-Version: 5.1.0
 Export-Package:\
 	com.liferay.exportimport.rest.dto.v1_0,\
 	com.liferay.exportimport.rest.resource.v1_0

--- a/modules/apps/export-import/export-import-rest-api/src/main/java/com/liferay/exportimport/rest/dto/v1_0/Choice.java
+++ b/modules/apps/export-import/export-import-rest-api/src/main/java/com/liferay/exportimport/rest/dto/v1_0/Choice.java
@@ -47,6 +47,88 @@ public class Choice implements Serializable {
 	}
 
 	@io.swagger.v3.oas.annotations.media.Schema
+	public Long getAdditionCount() {
+		if (_additionCountSupplier != null) {
+			additionCount = _additionCountSupplier.get();
+
+			_additionCountSupplier = null;
+		}
+
+		return additionCount;
+	}
+
+	public void setAdditionCount(Long additionCount) {
+		this.additionCount = additionCount;
+
+		_additionCountSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setAdditionCount(
+		UnsafeSupplier<Long, Exception> additionCountUnsafeSupplier) {
+
+		_additionCountSupplier = () -> {
+			try {
+				return additionCountUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Long additionCount;
+
+	@JsonIgnore
+	private Supplier<Long> _additionCountSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Long getDeletionCount() {
+		if (_deletionCountSupplier != null) {
+			deletionCount = _deletionCountSupplier.get();
+
+			_deletionCountSupplier = null;
+		}
+
+		return deletionCount;
+	}
+
+	public void setDeletionCount(Long deletionCount) {
+		this.deletionCount = deletionCount;
+
+		_deletionCountSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setDeletionCount(
+		UnsafeSupplier<Long, Exception> deletionCountUnsafeSupplier) {
+
+		_deletionCountSupplier = () -> {
+			try {
+				return deletionCountUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Long deletionCount;
+
+	@JsonIgnore
+	private Supplier<Long> _deletionCountSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
 	public String getLabel() {
 		if (_labelSupplier != null) {
 			label = _labelSupplier.get();
@@ -152,6 +234,30 @@ public class Choice implements Serializable {
 		StringBundler sb = new StringBundler();
 
 		sb.append("{");
+
+		Long additionCount = getAdditionCount();
+
+		if (additionCount != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"additionCount\": ");
+
+			sb.append(additionCount);
+		}
+
+		Long deletionCount = getDeletionCount();
+
+		if (deletionCount != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"deletionCount\": ");
+
+			sb.append(deletionCount);
+		}
 
 		String label = getLabel();
 
@@ -286,4 +392,4 @@ public class Choice implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-74624559
+// LIFERAY-REST-BUILDER-HASH:-103211983

--- a/modules/apps/export-import/export-import-rest-api/src/main/resources/com/liferay/exportimport/rest/dto/v1_0/packageinfo
+++ b/modules/apps/export-import/export-import-rest-api/src/main/resources/com/liferay/exportimport/rest/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 4.1.0

--- a/modules/apps/export-import/export-import-rest-client/src/main/java/com/liferay/exportimport/rest/client/dto/v1_0/Choice.java
+++ b/modules/apps/export-import/export-import-rest-client/src/main/java/com/liferay/exportimport/rest/client/dto/v1_0/Choice.java
@@ -25,6 +25,48 @@ public class Choice implements Cloneable, Serializable {
 		return ChoiceSerDes.toDTO(json);
 	}
 
+	public Long getAdditionCount() {
+		return additionCount;
+	}
+
+	public void setAdditionCount(Long additionCount) {
+		this.additionCount = additionCount;
+	}
+
+	public void setAdditionCount(
+		UnsafeSupplier<Long, Exception> additionCountUnsafeSupplier) {
+
+		try {
+			additionCount = additionCountUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long additionCount;
+
+	public Long getDeletionCount() {
+		return deletionCount;
+	}
+
+	public void setDeletionCount(Long deletionCount) {
+		this.deletionCount = deletionCount;
+	}
+
+	public void setDeletionCount(
+		UnsafeSupplier<Long, Exception> deletionCountUnsafeSupplier) {
+
+		try {
+			deletionCount = deletionCountUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long deletionCount;
+
 	public String getLabel() {
 		return label;
 	}
@@ -97,4 +139,4 @@ public class Choice implements Cloneable, Serializable {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1215006446
+// LIFERAY-REST-BUILDER-HASH:1591303040

--- a/modules/apps/export-import/export-import-rest-client/src/main/java/com/liferay/exportimport/rest/client/serdes/v1_0/ChoiceSerDes.java
+++ b/modules/apps/export-import/export-import-rest-client/src/main/java/com/liferay/exportimport/rest/client/serdes/v1_0/ChoiceSerDes.java
@@ -44,6 +44,26 @@ public class ChoiceSerDes {
 
 		sb.append("{");
 
+		if (choice.getAdditionCount() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"additionCount\": ");
+
+			sb.append(choice.getAdditionCount());
+		}
+
+		if (choice.getDeletionCount() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"deletionCount\": ");
+
+			sb.append(choice.getDeletionCount());
+		}
+
 		if (choice.getLabel() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -90,6 +110,20 @@ public class ChoiceSerDes {
 
 		Map<String, String> map = new TreeMap<>();
 
+		if (choice.getAdditionCount() == null) {
+			map.put("additionCount", null);
+		}
+		else {
+			map.put("additionCount", String.valueOf(choice.getAdditionCount()));
+		}
+
+		if (choice.getDeletionCount() == null) {
+			map.put("deletionCount", null);
+		}
+		else {
+			map.put("deletionCount", String.valueOf(choice.getDeletionCount()));
+		}
+
 		if (choice.getLabel() == null) {
 			map.put("label", null);
 		}
@@ -121,7 +155,13 @@ public class ChoiceSerDes {
 
 		@Override
 		protected boolean parseMaps(String jsonParserFieldName) {
-			if (Objects.equals(jsonParserFieldName, "label")) {
+			if (Objects.equals(jsonParserFieldName, "additionCount")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "deletionCount")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "label")) {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "name")) {
@@ -136,7 +176,19 @@ public class ChoiceSerDes {
 			Choice choice, String jsonParserFieldName,
 			Object jsonParserFieldValue) {
 
-			if (Objects.equals(jsonParserFieldName, "label")) {
+			if (Objects.equals(jsonParserFieldName, "additionCount")) {
+				if (jsonParserFieldValue != null) {
+					choice.setAdditionCount(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "deletionCount")) {
+				if (jsonParserFieldValue != null) {
+					choice.setDeletionCount(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "label")) {
 				if (jsonParserFieldValue != null) {
 					choice.setLabel((String)jsonParserFieldValue);
 				}
@@ -227,4 +279,4 @@ public class ChoiceSerDes {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1193362731
+// LIFERAY-REST-BUILDER-HASH:-1549071689

--- a/modules/apps/export-import/export-import-rest-impl/rest-openapi.yaml
+++ b/modules/apps/export-import/export-import-rest-impl/rest-openapi.yaml
@@ -276,6 +276,14 @@ components:
                         choices:
                             items:
                                 properties:
+                                    additionCount:
+                                        format: int64
+                                        readOnly: true
+                                        type: integer
+                                    deletionCount:
+                                        format: int64
+                                        readOnly: true
+                                        type: integer
                                     label:
                                         readOnly: true
                                         type: string

--- a/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/ExportPreviewResourceImpl.java
+++ b/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/ExportPreviewResourceImpl.java
@@ -58,7 +58,7 @@ public class ExportPreviewResourceImpl extends BaseExportPreviewResourceImpl {
 
 		Group group = _getAssetLibraryGroup(assetLibraryExternalReferenceCode);
 
-		return _getExportPreview(endDate, group, 0, null, false, startDate);
+		return _getExportPreview(endDate, group, 0, null, startDate);
 	}
 
 	@Override
@@ -70,8 +70,7 @@ public class ExportPreviewResourceImpl extends BaseExportPreviewResourceImpl {
 		Group group = _getAssetLibraryGroup(assetLibraryExternalReferenceCode);
 
 		return _getExportPreview(
-			endDate, group, GetterUtil.getLong(plid), portletId, false,
-			startDate);
+			endDate, group, GetterUtil.getLong(plid), portletId, startDate);
 	}
 
 	@Override
@@ -85,7 +84,7 @@ public class ExportPreviewResourceImpl extends BaseExportPreviewResourceImpl {
 			throw new NotFoundException();
 		}
 
-		return _getExportPreview(endDate, group, 0, null, false, startDate);
+		return _getExportPreview(endDate, group, 0, null, startDate);
 	}
 
 	@Override
@@ -95,7 +94,7 @@ public class ExportPreviewResourceImpl extends BaseExportPreviewResourceImpl {
 
 		Group group = _getSiteGroup(siteExternalReferenceCode);
 
-		return _getExportPreview(endDate, group, 0, null, false, startDate);
+		return _getExportPreview(endDate, group, 0, null, startDate);
 	}
 
 	@Override
@@ -107,8 +106,7 @@ public class ExportPreviewResourceImpl extends BaseExportPreviewResourceImpl {
 		Group group = _getSiteGroup(siteExternalReferenceCode);
 
 		return _getExportPreview(
-			endDate, group, GetterUtil.getLong(plid), portletId, false,
-			startDate);
+			endDate, group, GetterUtil.getLong(plid), portletId, startDate);
 	}
 
 	private Group _getAssetLibraryGroup(String externalReferenceCode) {
@@ -124,7 +122,7 @@ public class ExportPreviewResourceImpl extends BaseExportPreviewResourceImpl {
 
 	private ExportPreview _getExportPreview(
 			Date endDate, Group group, long plid, String portletId,
-			boolean privateLayout, Date startDate)
+			Date startDate)
 		throws Exception {
 
 		long groupId = group.getGroupId();
@@ -173,8 +171,6 @@ public class ExportPreviewResourceImpl extends BaseExportPreviewResourceImpl {
 				_portletDataContextFactory.createPreparePortletDataContext(
 					contextCompany.getCompanyId(), groupId, range, startDate,
 					endDate);
-
-			portletDataContext.setPrivateLayout(privateLayout);
 
 			portletDataHandler.prepareManifestSummary(portletDataContext);
 
@@ -240,7 +236,7 @@ public class ExportPreviewResourceImpl extends BaseExportPreviewResourceImpl {
 							portletDataHandler.
 								getExportConfigurationPortletDataHandlerControls(
 									contextCompany.getCompanyId(), groupId,
-									portlet, plid, privateLayout),
+									portlet, plid, false),
 							previewPortletDataHandlersMap);
 				}
 			}

--- a/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/ExportPreviewResourceImpl.java
+++ b/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/ExportPreviewResourceImpl.java
@@ -7,9 +7,11 @@ package com.liferay.exportimport.rest.internal.resource.v1_0;
 
 import com.liferay.exportimport.kernel.lar.ExportImportDateUtil;
 import com.liferay.exportimport.kernel.lar.ExportImportHelper;
+import com.liferay.exportimport.kernel.lar.ManifestSummary;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.PortletDataContextFactory;
 import com.liferay.exportimport.kernel.lar.PortletDataHandler;
+import com.liferay.exportimport.lar.DeletionSystemEventExporter;
 import com.liferay.exportimport.portlet.data.handler.provider.PortletDataHandlerProvider;
 import com.liferay.exportimport.rest.dto.v1_0.ExportPreview;
 import com.liferay.exportimport.rest.dto.v1_0.PreviewPortletDataHandler;
@@ -17,6 +19,7 @@ import com.liferay.exportimport.rest.internal.util.DateRangeUtil;
 import com.liferay.exportimport.rest.internal.util.PermissionUtil;
 import com.liferay.exportimport.rest.internal.util.PreviewPortletDataHandlerUtil;
 import com.liferay.exportimport.rest.resource.v1_0.ExportPreviewResource;
+import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.service.PortletLocalService;
@@ -55,8 +58,7 @@ public class ExportPreviewResourceImpl extends BaseExportPreviewResourceImpl {
 
 		Group group = _getAssetLibraryGroup(assetLibraryExternalReferenceCode);
 
-		return _getExportPreview(
-			endDate, group.getGroupId(), 0, null, false, startDate);
+		return _getExportPreview(endDate, group, 0, null, false, startDate);
 	}
 
 	@Override
@@ -68,8 +70,8 @@ public class ExportPreviewResourceImpl extends BaseExportPreviewResourceImpl {
 		Group group = _getAssetLibraryGroup(assetLibraryExternalReferenceCode);
 
 		return _getExportPreview(
-			endDate, group.getGroupId(), GetterUtil.getLong(plid), portletId,
-			false, startDate);
+			endDate, group, GetterUtil.getLong(plid), portletId, false,
+			startDate);
 	}
 
 	@Override
@@ -83,8 +85,7 @@ public class ExportPreviewResourceImpl extends BaseExportPreviewResourceImpl {
 			throw new NotFoundException();
 		}
 
-		return _getExportPreview(
-			endDate, group.getGroupId(), 0, null, false, startDate);
+		return _getExportPreview(endDate, group, 0, null, false, startDate);
 	}
 
 	@Override
@@ -94,8 +95,7 @@ public class ExportPreviewResourceImpl extends BaseExportPreviewResourceImpl {
 
 		Group group = _getSiteGroup(siteExternalReferenceCode);
 
-		return _getExportPreview(
-			endDate, group.getGroupId(), 0, null, false, startDate);
+		return _getExportPreview(endDate, group, 0, null, false, startDate);
 	}
 
 	@Override
@@ -107,8 +107,8 @@ public class ExportPreviewResourceImpl extends BaseExportPreviewResourceImpl {
 		Group group = _getSiteGroup(siteExternalReferenceCode);
 
 		return _getExportPreview(
-			endDate, group.getGroupId(), GetterUtil.getLong(plid), portletId,
-			false, startDate);
+			endDate, group, GetterUtil.getLong(plid), portletId, false,
+			startDate);
 	}
 
 	private Group _getAssetLibraryGroup(String externalReferenceCode) {
@@ -123,9 +123,11 @@ public class ExportPreviewResourceImpl extends BaseExportPreviewResourceImpl {
 	}
 
 	private ExportPreview _getExportPreview(
-			Date endDate, long groupId, long plid, String portletId,
+			Date endDate, Group group, long plid, String portletId,
 			boolean privateLayout, Date startDate)
 		throws Exception {
+
+		long groupId = group.getGroupId();
 
 		PermissionUtil.checkExportPermission(
 			contextCompany.getCompanyId(), groupId);
@@ -172,24 +174,75 @@ public class ExportPreviewResourceImpl extends BaseExportPreviewResourceImpl {
 					contextCompany.getCompanyId(), groupId, range, startDate,
 					endDate);
 
+			portletDataContext.setPrivateLayout(privateLayout);
+
 			portletDataHandler.prepareManifestSummary(portletDataContext);
 
-			PreviewPortletDataHandlerUtil.addPreviewPortletDataHandler(
-				contextCompany.getCompanyId(), locale,
-				portletDataContext.getManifestSummary(), portlet,
-				portletDataHandler,
-				PortletDataHandler::getExportPortletDataHandlerControls,
-				portletScoped, previewPortletDataHandlersMap);
+			if (LayoutAdminPortletKeys.LAYOUT_SET_LAYOUTS.equals(
+					portlet.getPortletId())) {
 
-			if (portletScoped) {
+				portletDataContext.addDeletionSystemEventStagedModelTypes(
+					portletDataHandler.
+						getDeletionSystemEventStagedModelTypes());
+
+				long publicDeletionSystemEventsCount =
+					_deletionSystemEventExporter.getDeletionSystemEventsCount(
+						portletDataContext);
+
+				ManifestSummary privateManifestSummary = null;
+				long privateDeletionSystemEventsCount = 0;
+
+				if (!portletScoped && group.isPrivateLayoutsEnabled()) {
+					PortletDataContext privatePortletDataContext =
+						_portletDataContextFactory.
+							createPreparePortletDataContext(
+								contextCompany.getCompanyId(), groupId, range,
+								startDate, endDate);
+
+					privatePortletDataContext.setPrivateLayout(true);
+
+					portletDataHandler.prepareManifestSummary(
+						privatePortletDataContext);
+
+					privatePortletDataContext.
+						addDeletionSystemEventStagedModelTypes(
+							portletDataHandler.
+								getDeletionSystemEventStagedModelTypes());
+
+					privateManifestSummary =
+						privatePortletDataContext.getManifestSummary();
+					privateDeletionSystemEventsCount =
+						_deletionSystemEventExporter.
+							getDeletionSystemEventsCount(
+								privatePortletDataContext);
+				}
+
 				PreviewPortletDataHandlerUtil.
-					addConfigurationPreviewPortletDataHandler(
-						locale, portlet,
-						portletDataHandler.
-							getExportConfigurationPortletDataHandlerControls(
-								contextCompany.getCompanyId(), groupId, portlet,
-								plid, privateLayout),
-						previewPortletDataHandlersMap);
+					addLayoutSetPreviewPortletDataHandler(
+						contextCompany.getCompanyId(), locale, portlet,
+						portletDataHandler, previewPortletDataHandlersMap,
+						privateDeletionSystemEventsCount,
+						privateManifestSummary, publicDeletionSystemEventsCount,
+						portletDataContext.getManifestSummary());
+			}
+			else {
+				PreviewPortletDataHandlerUtil.addPreviewPortletDataHandler(
+					contextCompany.getCompanyId(), locale,
+					portletDataContext.getManifestSummary(), portlet,
+					portletDataHandler,
+					PortletDataHandler::getExportPortletDataHandlerControls,
+					portletScoped, previewPortletDataHandlersMap);
+
+				if (portletScoped) {
+					PreviewPortletDataHandlerUtil.
+						addConfigurationPreviewPortletDataHandler(
+							locale, portlet,
+							portletDataHandler.
+								getExportConfigurationPortletDataHandlerControls(
+									contextCompany.getCompanyId(), groupId,
+									portlet, plid, privateLayout),
+							previewPortletDataHandlersMap);
+				}
 			}
 		}
 
@@ -220,6 +273,9 @@ public class ExportPreviewResourceImpl extends BaseExportPreviewResourceImpl {
 
 		return group;
 	}
+
+	@Reference
+	private DeletionSystemEventExporter _deletionSystemEventExporter;
 
 	@Reference
 	private ExportImportHelper _exportImportHelper;

--- a/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/ExportProcessResourceImpl.java
+++ b/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/ExportProcessResourceImpl.java
@@ -21,9 +21,9 @@ import com.liferay.exportimport.rest.internal.util.BackgroundTaskUtil;
 import com.liferay.exportimport.rest.internal.util.DateRangeUtil;
 import com.liferay.exportimport.rest.internal.util.ParameterMapUtil;
 import com.liferay.exportimport.rest.internal.util.PermissionUtil;
+import com.liferay.exportimport.rest.internal.util.PreviewPortletDataHandlerUtil;
 import com.liferay.exportimport.rest.resource.v1_0.ExportProcessResource;
 import com.liferay.headless.delivery.dto.v1_0.util.CreatorUtil;
-import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.background.task.model.BackgroundTask;
 import com.liferay.portal.background.task.service.BackgroundTaskLocalService;
@@ -41,7 +41,6 @@ import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateRange;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.MapUtil;
@@ -52,6 +51,7 @@ import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.staging.StagingGroupHelper;
 
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response;
 
@@ -439,18 +439,35 @@ public class ExportProcessResourceImpl extends BaseExportProcessResourceImpl {
 		Map<String, String[]> parameterMap = ParameterMapUtil.toParameterMap(
 			exportProcessRequest, false);
 
-		long[] layoutIds = GetterUtil.getLongValues(
-			parameterMap.get("layoutIds"));
-		boolean privateLayout = MapUtil.getBoolean(
-			parameterMap, "privateLayout");
+		boolean privateLayout = parameterMap.containsKey(
+			PreviewPortletDataHandlerUtil.PRIVATE_PAGES_CONTROL_NAME);
+		boolean publicLayout = parameterMap.containsKey(
+			PreviewPortletDataHandlerUtil.PUBLIC_PAGES_CONTROL_NAME);
 
-		if (ArrayUtil.isEmpty(layoutIds) &&
-			MapUtil.getBoolean(
-				parameterMap,
-				"PORTLET_DATA_" + LayoutAdminPortletKeys.LAYOUT_SET_LAYOUTS)) {
+		if (privateLayout && publicLayout) {
+			throw new BadRequestException(
+				"Cannot request both private and public pages");
+		}
 
-			layoutIds = _exportImportHelper.getAllLayoutIds(
-				groupId, privateLayout);
+		if (privateLayout && !group.isPrivateLayoutsEnabled()) {
+			throw new BadRequestException("Private pages are not enabled");
+		}
+
+		String[] values = parameterMap.get(
+			privateLayout ?
+				PreviewPortletDataHandlerUtil.PRIVATE_PAGES_CONTROL_NAME :
+					PreviewPortletDataHandlerUtil.PUBLIC_PAGES_CONTROL_NAME);
+
+		long[] layoutIds = new long[0];
+
+		if (values != null) {
+			if (Boolean.parseBoolean(values[0])) {
+				layoutIds = _exportImportHelper.getAllLayoutIds(
+					groupId, privateLayout);
+			}
+			else {
+				layoutIds = GetterUtil.getLongValues(values);
+			}
 		}
 
 		Map<String, Serializable> settingsMap =

--- a/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/ImportProcessResourceImpl.java
+++ b/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/resource/v1_0/ImportProcessResourceImpl.java
@@ -39,11 +39,15 @@ import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TempFileEntryUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.xml.Document;
+import com.liferay.portal.kernel.xml.Element;
+import com.liferay.portal.kernel.xml.SAXReaderUtil;
+import com.liferay.portal.kernel.zip.ZipReader;
+import com.liferay.portal.kernel.zip.ZipReaderFactory;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.staging.StagingGroupHelper;
@@ -365,6 +369,27 @@ public class ImportProcessResourceImpl extends BaseImportProcessResourceImpl {
 		return group;
 	}
 
+	private boolean _isPrivateLayout(FileEntry fileEntry) throws Exception {
+		try (InputStream inputStream = fileEntry.getContentStream();
+
+			ZipReader zipReader = _zipReaderFactory.getZipReader(inputStream)) {
+
+			Document document = SAXReaderUtil.read(
+				zipReader.getEntryAsString("/manifest.xml"));
+
+			Element rootElement = document.getRootElement();
+
+			Element headerElement = rootElement.element("header");
+
+			if (headerElement == null) {
+				return false;
+			}
+
+			return GetterUtil.getBoolean(
+				headerElement.attributeValue("private-layout"));
+		}
+	}
+
 	private ImportProcess _postLayoutImportProcess(
 			Group group, ImportProcessRequest importProcessRequest)
 		throws Exception {
@@ -389,8 +414,8 @@ public class ImportProcessResourceImpl extends BaseImportProcessResourceImpl {
 			_exportImportConfigurationSettingsMapFactory.
 				buildImportLayoutSettingsMap(
 					contextUser.getUserId(), groupId,
-					MapUtil.getBoolean(parameterMap, "privateLayout"), null,
-					parameterMap, contextAcceptLanguage.getPreferredLocale(),
+					_isPrivateLayout(fileEntry), null, parameterMap,
+					contextAcceptLanguage.getPreferredLocale(),
 					contextUser.getTimeZone());
 
 		ExportImportConfiguration exportImportConfiguration =
@@ -595,5 +620,8 @@ public class ImportProcessResourceImpl extends BaseImportProcessResourceImpl {
 
 	@Reference
 	private UserLocalService _userLocalService;
+
+	@Reference
+	private ZipReaderFactory _zipReaderFactory;
 
 }

--- a/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/util/PreviewPortletDataHandlerUtil.java
+++ b/modules/apps/export-import/export-import-rest-impl/src/main/java/com/liferay/exportimport/rest/internal/util/PreviewPortletDataHandlerUtil.java
@@ -38,6 +38,11 @@ import java.util.Map;
  */
 public class PreviewPortletDataHandlerUtil {
 
+	public static final String PRIVATE_PAGES_CONTROL_NAME =
+		"privateLayoutPages";
+
+	public static final String PUBLIC_PAGES_CONTROL_NAME = "publicLayoutPages";
+
 	public static void addConfigurationPreviewPortletDataHandler(
 		Locale locale, Portlet portlet,
 		PortletDataHandlerControl[] portletDataHandlerControls,
@@ -68,6 +73,88 @@ public class PreviewPortletDataHandlerUtil {
 						() -> _toPreviewPortletDataHandlerControls(
 							locale, portletDataHandlerControls,
 							portlet.getRootPortletId()));
+				}
+			});
+	}
+
+	public static void addLayoutSetPreviewPortletDataHandler(
+		long companyId, Locale locale, Portlet portlet,
+		PortletDataHandler portletDataHandler,
+		Map<String, List<PreviewPortletDataHandler>>
+			previewPortletDataHandlersMap,
+		long privateLayoutDeletionCount, ManifestSummary privateManifestSummary,
+		long publicLayoutDeletionCount, ManifestSummary publicManifestSummary) {
+
+		if ((portletDataHandler == null) ||
+			!portletDataHandler.isEnabled(companyId)) {
+
+			return;
+		}
+
+		long publicLayoutAdditionCount = Math.max(
+			0L, portletDataHandler.getExportModelCount(publicManifestSummary));
+
+		long privateLayoutAdditionCount = 0;
+
+		if (privateManifestSummary != null) {
+			privateLayoutAdditionCount = Math.max(
+				0L,
+				portletDataHandler.getExportModelCount(privateManifestSummary));
+		}
+
+		if ((privateLayoutAdditionCount == 0) &&
+			(privateLayoutDeletionCount == 0) &&
+			(publicLayoutAdditionCount == 0) &&
+			(publicLayoutDeletionCount == 0)) {
+
+			return;
+		}
+
+		long finalPrivateLayoutAdditionCount = privateLayoutAdditionCount;
+
+		String sectionKey = portletDataHandler.getSectionKey();
+
+		if (sectionKey == null) {
+			sectionKey = ExportImportConstants.SECTION_KEY_OTHER;
+		}
+
+		List<PreviewPortletDataHandler> previewPortletDataHandlers =
+			previewPortletDataHandlersMap.computeIfAbsent(
+				sectionKey, key -> new ArrayList<>());
+
+		previewPortletDataHandlers.add(
+			new PreviewPortletDataHandler() {
+				{
+					setAdditionCount(() -> publicLayoutAdditionCount);
+					setDeletionCount(() -> publicLayoutDeletionCount);
+					setDescription(
+						() -> portletDataHandler.getDescription(locale));
+					setLabel(
+						() -> {
+							String portletTitle = portletDataHandler.getTitle(
+								locale);
+
+							if (portletTitle != null) {
+								return portletTitle;
+							}
+
+							return PortalUtil.getPortletTitle(portlet, locale);
+						});
+					setName(
+						() ->
+							PortletDataHandlerKeys.PORTLET_DATA + "_" +
+								portlet.getPortletId());
+					setPreviewPortletDataHandlerControls(
+						() -> new PreviewPortletDataHandlerControl[] {
+							_toPreviewPortletDataHandlerChoice(
+								locale, portlet,
+								finalPrivateLayoutAdditionCount,
+								privateLayoutDeletionCount,
+								privateManifestSummary != null,
+								publicLayoutAdditionCount,
+								publicLayoutDeletionCount)
+						});
+					setTag(() -> portletDataHandler.getTag(locale));
 				}
 			});
 	}
@@ -234,6 +321,59 @@ public class PreviewPortletDataHandlerUtil {
 						locale, manifestSummary,
 						sourcePortletDataHandlerControls));
 				setTag(() -> portletDataHandler.getTag(locale));
+			}
+		};
+	}
+
+	private static PreviewPortletDataHandlerChoice
+		_toPreviewPortletDataHandlerChoice(
+			Locale locale, Portlet portlet, long privateLayoutAdditionCount,
+			long privateLayoutDeletionCount, boolean privateLayoutsEnabled,
+			long publicLayoutAdditionCount, long publicLayoutDeletionCount) {
+
+		return new PreviewPortletDataHandlerChoice() {
+			{
+				setChoices(
+					() -> {
+						List<Choice> choices = new ArrayList<>();
+
+						choices.add(
+							new Choice() {
+								{
+									setAdditionCount(
+										() -> publicLayoutAdditionCount);
+									setDeletionCount(
+										() -> publicLayoutDeletionCount);
+									setLabel(
+										() -> LanguageUtil.get(
+											locale, "public-pages"));
+									setName(() -> PUBLIC_PAGES_CONTROL_NAME);
+								}
+							});
+
+						if (privateLayoutsEnabled) {
+							choices.add(
+								new Choice() {
+									{
+										setAdditionCount(
+											() -> privateLayoutAdditionCount);
+										setDeletionCount(
+											() -> privateLayoutDeletionCount);
+										setLabel(
+											() -> LanguageUtil.get(
+												locale, "private-pages"));
+										setName(
+											() -> PRIVATE_PAGES_CONTROL_NAME);
+									}
+								});
+						}
+
+						return choices.toArray(new Choice[0]);
+					});
+				setDefaultChoice(() -> PUBLIC_PAGES_CONTROL_NAME);
+				setLabel(() -> PortalUtil.getPortletTitle(portlet, locale));
+				setName(() -> "layoutSet");
+				setType(() -> PreviewPortletDataHandlerControl.Type.CHOICE);
 			}
 		};
 	}

--- a/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ExportPreviewResourceTest.java
+++ b/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ExportPreviewResourceTest.java
@@ -7,8 +7,11 @@ package com.liferay.exportimport.rest.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.exportimport.constants.ExportImportConstants;
+import com.liferay.exportimport.rest.client.dto.v1_0.Choice;
 import com.liferay.exportimport.rest.client.dto.v1_0.ExportPreview;
 import com.liferay.exportimport.rest.client.dto.v1_0.PreviewPortletDataHandler;
+import com.liferay.exportimport.rest.client.dto.v1_0.PreviewPortletDataHandlerChoice;
+import com.liferay.exportimport.rest.client.dto.v1_0.PreviewPortletDataHandlerControl;
 import com.liferay.exportimport.rest.client.dto.v1_0.PreviewPortletDataHandlerSection;
 import com.liferay.exportimport.rest.client.resource.v1_0.ExportPreviewResource;
 import com.liferay.layout.test.util.LayoutTestUtil;
@@ -28,6 +31,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -36,6 +40,7 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -184,6 +189,7 @@ public class ExportPreviewResourceTest
 			_depotObjectDefinition, _siteObjectDefinition);
 	}
 
+	@FeatureFlag("LPD-38869")
 	@Override
 	@Test
 	public void testGetSiteExportPreview() throws Exception {
@@ -200,6 +206,9 @@ public class ExportPreviewResourceTest
 			exportPreviewResource.getSiteExportPreview(
 				testGroup.getExternalReferenceCode(), null, null),
 			_companyObjectDefinition, _depotObjectDefinition);
+		_testGetExportPreviewWithLayoutSet(
+			(startDate, endDate) -> exportPreviewResource.getSiteExportPreview(
+				testGroup.getExternalReferenceCode(), endDate, startDate));
 	}
 
 	@Override
@@ -283,6 +292,52 @@ public class ExportPreviewResourceTest
 		}
 
 		return 0L;
+	}
+
+	private Choice _getChoice(
+		PreviewPortletDataHandler previewPortletDataHandler, String name) {
+
+		for (PreviewPortletDataHandlerControl previewPortletDataHandlerControl :
+				previewPortletDataHandler.
+					getPreviewPortletDataHandlerControls()) {
+
+			if (!(previewPortletDataHandlerControl instanceof
+					PreviewPortletDataHandlerChoice)) {
+
+				continue;
+			}
+
+			PreviewPortletDataHandlerChoice previewPortletDataHandlerChoice =
+				(PreviewPortletDataHandlerChoice)
+					previewPortletDataHandlerControl;
+
+			for (Choice choice : previewPortletDataHandlerChoice.getChoices()) {
+				if (name.equals(choice.getName())) {
+					return choice;
+				}
+			}
+		}
+
+		return null;
+	}
+
+	private PreviewPortletDataHandler _getPreviewPortletDataHandler(
+		ExportPreview exportPreview, String name) {
+
+		for (PreviewPortletDataHandlerSection previewPortletDataHandlerSection :
+				exportPreview.getPreviewPortletDataHandlerSections()) {
+
+			for (PreviewPortletDataHandler previewPortletDataHandler :
+					previewPortletDataHandlerSection.
+						getPreviewPortletDataHandlers()) {
+
+				if (name.equals(previewPortletDataHandler.getName())) {
+					return previewPortletDataHandler;
+				}
+			}
+		}
+
+		return null;
 	}
 
 	private PreviewPortletDataHandlerSection
@@ -392,6 +447,39 @@ public class ExportPreviewResourceTest
 		}
 	}
 
+	private void _testGetExportPreviewWithLayoutSet(
+			UnsafeBiFunction<Date, Date, ExportPreview, Exception>
+				unsafeBiFunction)
+		throws Exception {
+
+		LayoutTestUtil.addTypeContentLayout(testGroup, false, false);
+		LayoutTestUtil.addTypeContentLayout(testGroup, true, false);
+		LayoutTestUtil.addTypeContentLayout(testGroup, true, false);
+
+		_layoutLocalService.deleteLayout(
+			LayoutTestUtil.addTypeContentLayout(testGroup, false, false),
+			ServiceContextTestUtil.getServiceContext());
+
+		PreviewPortletDataHandler previewPortletDataHandler =
+			_getPreviewPortletDataHandler(
+				unsafeBiFunction.apply(null, null),
+				"PORTLET_DATA_com_liferay_layout_admin_web_portlet_" +
+					"LayoutSetLayoutsPortlet");
+
+		Assert.assertNotNull(previewPortletDataHandler);
+
+		Choice choice = _getChoice(
+			previewPortletDataHandler, "publicLayoutPages");
+
+		Assert.assertEquals(1L, GetterUtil.getLong(choice.getAdditionCount()));
+		Assert.assertEquals(1L, GetterUtil.getLong(choice.getDeletionCount()));
+
+		choice = _getChoice(previewPortletDataHandler, "privateLayoutPages");
+
+		Assert.assertEquals(2L, GetterUtil.getLong(choice.getAdditionCount()));
+		Assert.assertEquals(0L, GetterUtil.getLong(choice.getDeletionCount()));
+	}
+
 	private void _testGetPortletExportPreview(
 		ExportPreview exportPreview, String portletId) {
 
@@ -430,6 +518,9 @@ public class ExportPreviewResourceTest
 	private ObjectDefinition _companyObjectDefinition;
 	private ObjectDefinition _depotObjectDefinition;
 	private ExportPreviewResource _exportPreviewResource;
+
+	@Inject
+	private LayoutLocalService _layoutLocalService;
 
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;

--- a/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ExportProcessResourceTest.java
+++ b/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ExportProcessResourceTest.java
@@ -11,6 +11,7 @@ import com.liferay.exportimport.rest.client.dto.v1_0.ExportProcess;
 import com.liferay.exportimport.rest.client.dto.v1_0.ExportProcessRequest;
 import com.liferay.exportimport.rest.client.dto.v1_0.ProcessProgress;
 import com.liferay.exportimport.rest.client.dto.v1_0.RequestPortletDataHandler;
+import com.liferay.exportimport.rest.client.dto.v1_0.RequestPortletDataHandlerControl;
 import com.liferay.exportimport.rest.client.http.HttpInvoker;
 import com.liferay.exportimport.rest.client.resource.v1_0.ExportProcessResource;
 import com.liferay.exportimport.test.util.ExportImportTestUtil;
@@ -49,6 +50,7 @@ import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.staging.StagingGroupHelper;
 
@@ -195,20 +197,16 @@ public class ExportProcessResourceTest
 		ObjectDefinition objectDefinition = _publishObjectDefinition(
 			ObjectDefinitionConstants.SCOPE_DEPOT);
 
-		try {
-			_testPostExportProcessWithObjectDefinition(
-				exportProcessRequest ->
-					exportProcessResource.postAssetLibraryExportProcess(
-						testDepotEntryGroup.getExternalReferenceCode(),
-						exportProcessRequest),
-				testDepotEntryGroup.getGroupId(), objectDefinition,
-				_addObjectEntries(
-					objectDefinition, testDepotEntryGroup.getGroupId()));
-		}
-		finally {
-			_objectDefinitionLocalService.deleteObjectDefinition(
-				objectDefinition);
-		}
+		_testPostExportProcessWithObjectDefinition(
+			exportProcessRequest ->
+				exportProcessResource.postAssetLibraryExportProcess(
+					testDepotEntryGroup.getExternalReferenceCode(),
+					exportProcessRequest),
+			testDepotEntryGroup.getGroupId(), objectDefinition,
+			_addObjectEntries(
+				objectDefinition, testDepotEntryGroup.getGroupId()));
+
+		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
 	}
 
 	@Override
@@ -275,19 +273,16 @@ public class ExportProcessResourceTest
 		ObjectDefinition objectDefinition = _publishObjectDefinition(
 			ObjectDefinitionConstants.SCOPE_COMPANY);
 
-		try {
-			_testPostExportProcessWithObjectDefinition(
-				exportProcessResource::postExportProcess,
-				companyGroup.getGroupId(), objectDefinition,
-				_addObjectEntries(
-					objectDefinition, GroupConstants.DEFAULT_PARENT_GROUP_ID));
-		}
-		finally {
-			_objectDefinitionLocalService.deleteObjectDefinition(
-				objectDefinition);
-		}
+		_testPostExportProcessWithObjectDefinition(
+			exportProcessResource::postExportProcess, companyGroup.getGroupId(),
+			objectDefinition,
+			_addObjectEntries(
+				objectDefinition, GroupConstants.DEFAULT_PARENT_GROUP_ID));
+
+		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
 	}
 
+	@FeatureFlag("LPD-38869")
 	@Override
 	@Test
 	public void testPostSiteExportProcess() throws Exception {
@@ -306,23 +301,23 @@ public class ExportProcessResourceTest
 				exportProcessResource.postSiteExportProcessHttpResponse(
 					testGroup.getExternalReferenceCode(),
 					exportProcessRequest));
+		_testPostExportProcessWithLayoutSet(
+			exportProcessRequest ->
+				exportProcessResource.postSiteExportProcessHttpResponse(
+					testGroup.getExternalReferenceCode(), exportProcessRequest),
+			exportProcessRequest -> exportProcessResource.postSiteExportProcess(
+				testGroup.getExternalReferenceCode(), exportProcessRequest));
 
 		ObjectDefinition objectDefinition = _publishObjectDefinition(
 			ObjectDefinitionConstants.SCOPE_SITE);
 
-		try {
-			_testPostExportProcessWithObjectDefinition(
-				exportProcessRequest ->
-					exportProcessResource.postSiteExportProcess(
-						testGroup.getExternalReferenceCode(),
-						exportProcessRequest),
-				testGroup.getGroupId(), objectDefinition,
-				_addObjectEntries(objectDefinition, testGroup.getGroupId()));
-		}
-		finally {
-			_objectDefinitionLocalService.deleteObjectDefinition(
-				objectDefinition);
-		}
+		_testPostExportProcessWithObjectDefinition(
+			exportProcessRequest -> exportProcessResource.postSiteExportProcess(
+				testGroup.getExternalReferenceCode(), exportProcessRequest),
+			testGroup.getGroupId(), objectDefinition,
+			_addObjectEntries(objectDefinition, testGroup.getGroupId()));
+
+		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
 	}
 
 	@Override
@@ -590,6 +585,83 @@ public class ExportProcessResourceTest
 			).build());
 	}
 
+	private <T> void _assertExportedExternalReferenceCodes(
+			BackgroundTask backgroundTask, String fileNamePrefix, long groupId,
+			T[] items, UnsafeFunction<T, String, Exception> unsafeFunction)
+		throws Exception {
+
+		List<FileEntry> fileEntries =
+			backgroundTask.getAttachmentsFileEntries();
+
+		Assert.assertEquals(fileEntries.toString(), 1, fileEntries.size());
+
+		FileEntry larFileEntry = fileEntries.get(0);
+
+		JSONAssert.assertEquals(
+			JSONUtil.toJSONArray(
+				items,
+				item -> JSONUtil.put(
+					"externalReferenceCode", unsafeFunction.apply(item))
+			).toString(),
+			String.valueOf(
+				ExportImportTestUtil.getExportedJSONArray(
+					fileNamePrefix, groupId, larFileEntry.getContentStream())),
+			JSONCompareMode.LENIENT);
+	}
+
+	private void _assertExportedLayouts(
+			String controlName,
+			UnsafeFunction<ExportProcessRequest, ExportProcess, Exception>
+				unsafeFunction,
+			Layout... layouts)
+		throws Exception {
+
+		ExportProcess exportProcess = unsafeFunction.apply(
+			new ExportProcessRequest() {
+				{
+					name = RandomTestUtil.randomString();
+
+					setRequestPortletDataHandlers(
+						new RequestPortletDataHandler[] {
+							new RequestPortletDataHandler() {
+								{
+									name =
+										"PORTLET_DATA_" + _LAYOUT_SET_LAYOUTS;
+
+									setRequestPortletDataHandlerControls(
+										new RequestPortletDataHandlerControl[] {
+											new RequestPortletDataHandlerControl() {
+												{
+													name = controlName;
+												}
+											}
+										});
+								}
+							}
+						});
+				}
+			});
+
+		ExportImportTestUtil.retryAssert(
+			1, TimeUnit.SECONDS, 30, TimeUnit.SECONDS,
+			() -> {
+				BackgroundTask backgroundTask =
+					_backgroundTaskLocalService.getBackgroundTask(
+						exportProcess.getId());
+
+				Assert.assertEquals(
+					BackgroundTaskConstants.STATUS_SUCCESSFUL,
+					backgroundTask.getStatus());
+			});
+
+		_assertExportedExternalReferenceCodes(
+			_backgroundTaskLocalService.getBackgroundTask(
+				exportProcess.getId()),
+			"com.liferay.headless.admin.site.internal.resource.v1_0." +
+				"SitePageResourceImpl",
+			testGroup.getGroupId(), layouts, Layout::getExternalReferenceCode);
+	}
+
 	private long _getCompanyGroupId() throws Exception {
 		Group group = _stagingGroupHelper.fetchCompanyGroup(
 			testCompany.getCompanyId());
@@ -654,6 +726,63 @@ public class ExportProcessResourceTest
 		}
 	}
 
+	private void _testPostExportProcessWithLayoutSet(
+			UnsafeFunction
+				<ExportProcessRequest, HttpInvoker.HttpResponse, Exception>
+					httpResponseUnsafeFunction,
+			UnsafeFunction<ExportProcessRequest, ExportProcess, Exception>
+				unsafeFunction)
+		throws Exception {
+
+		Layout privateLayout = LayoutTestUtil.addTypeContentLayout(
+			testGroup, true, false);
+		Layout publicLayout = LayoutTestUtil.addTypeContentLayout(
+			testGroup, false, false);
+
+		_assertExportedLayouts(
+			"privateLayoutPages", unsafeFunction, privateLayout);
+		_assertExportedLayouts(
+			"publicLayoutPages", unsafeFunction, publicLayout);
+
+		ExportProcessRequest exportProcessRequest = new ExportProcessRequest() {
+			{
+				name = RandomTestUtil.randomString();
+
+				setRequestPortletDataHandlers(
+					new RequestPortletDataHandler[] {
+						new RequestPortletDataHandler() {
+							{
+								name = "PORTLET_DATA_" + _LAYOUT_SET_LAYOUTS;
+
+								setRequestPortletDataHandlerControls(
+									new RequestPortletDataHandlerControl[] {
+										new RequestPortletDataHandlerControl() {
+											{
+												name = "publicLayoutPages";
+											}
+										},
+										new RequestPortletDataHandlerControl() {
+											{
+												name = "privateLayoutPages";
+											}
+										}
+									});
+							}
+						}
+					});
+			}
+		};
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.portal.vulcan.internal.jaxrs.exception.mapper." +
+					"WebApplicationExceptionMapper",
+				LoggerTestUtil.WARN)) {
+
+			assertHttpResponseStatusCode(
+				400, httpResponseUnsafeFunction.apply(exportProcessRequest));
+		}
+	}
+
 	private void _testPostExportProcessWithObjectDefinition(
 			UnsafeFunction<ExportProcessRequest, ExportProcess, Exception>
 				unsafeFunction,
@@ -700,30 +829,15 @@ public class ExportProcessResourceTest
 				});
 		}
 
-		BackgroundTask backgroundTask =
+		_assertExportedExternalReferenceCodes(
 			_backgroundTaskLocalService.getBackgroundTask(
-				exportProcess.getId());
-
-		List<FileEntry> fileEntries =
-			backgroundTask.getAttachmentsFileEntries();
-
-		Assert.assertEquals(fileEntries.toString(), 1, fileEntries.size());
-
-		FileEntry larFileEntry = fileEntries.get(0);
-
-		JSONAssert.assertEquals(
-			JSONUtil.toJSONArray(
-				objectEntries,
-				objectEntry -> JSONUtil.put(
-					"externalReferenceCode",
-					objectEntry.getExternalReferenceCode())
-			).toString(),
-			String.valueOf(
-				ExportImportTestUtil.getExportedObjectEntriesJSONArray(
-					objectDefinition.getExternalReferenceCode(),
-					larFileEntry.getContentStream(), groupId)),
-			JSONCompareMode.LENIENT);
+				exportProcess.getId()),
+			objectDefinition.getExternalReferenceCode(), groupId, objectEntries,
+			ObjectEntry::getExternalReferenceCode);
 	}
+
+	private static final String _LAYOUT_SET_LAYOUTS =
+		"com_liferay_layout_admin_web_portlet_LayoutSetLayoutsPortlet";
 
 	@Inject
 	private BackgroundTaskLocalService _backgroundTaskLocalService;

--- a/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ImportProcessResourceTest.java
+++ b/modules/apps/export-import/export-import-rest-test/src/testIntegration/java/com/liferay/exportimport/rest/resource/v1_0/test/ImportProcessResourceTest.java
@@ -48,9 +48,11 @@ import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.DigesterUtil;
@@ -330,6 +332,14 @@ public class ImportProcessResourceTest
 				importProcessResource.postSiteImportProcessHttpResponse(
 					testGroup.getExternalReferenceCode(),
 					importProcessRequest));
+		_testPostImportProcessWithLayoutSet(
+			file -> _importPreviewResource.postSiteImportPreview(
+				testGroup.getExternalReferenceCode(), null,
+				HashMapBuilder.put(
+					"file", file
+				).build()),
+			importProcessRequest -> importProcessResource.postSiteImportProcess(
+				testGroup.getExternalReferenceCode(), importProcessRequest));
 	}
 
 	@FeatureFlag("LPD-17564")
@@ -584,10 +594,18 @@ public class ImportProcessResourceTest
 	}
 
 	private File _exportLayoutAsFile(long groupId) throws Exception {
+		return _exportLayoutAsFile(groupId, false, null);
+	}
+
+	private File _exportLayoutAsFile(
+			long groupId, boolean privateLayout, long[] layoutIds)
+		throws Exception {
+
 		Map<String, Serializable> parameterMap =
 			ExportImportConfigurationSettingsMapFactoryUtil.
 				buildExportLayoutSettingsMap(
-					TestPropsValues.getUser(), groupId, false, null,
+					TestPropsValues.getUser(), groupId, privateLayout,
+					layoutIds,
 					HashMapBuilder.put(
 						PortletDataHandlerKeys.PORTLET_DATA,
 						new String[] {Boolean.TRUE.toString()}
@@ -652,6 +670,48 @@ public class ImportProcessResourceTest
 		return group.getGroupId();
 	}
 
+	private void _importLayoutSet(
+			UnsafeFunction<File, ImportPreview, Exception>
+				postImportPreviewUnsafeFunction,
+			UnsafeFunction<ImportProcessRequest, ImportProcess, Exception>
+				postImportProcessUnsafeFunction,
+			boolean privateLayout)
+		throws Exception {
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(
+			testGroup, privateLayout, false);
+
+		File file = _exportLayoutAsFile(
+			testGroup.getGroupId(), privateLayout,
+			new long[] {layout.getLayoutId()});
+
+		_layoutLocalService.deleteLayout(
+			layout, ServiceContextTestUtil.getServiceContext());
+
+		postImportPreviewUnsafeFunction.apply(file);
+
+		ImportProcess importProcess = postImportProcessUnsafeFunction.apply(
+			new ImportProcessRequest());
+
+		assertValid(importProcess);
+
+		ExportImportTestUtil.retryAssert(
+			1, TimeUnit.SECONDS, 30, TimeUnit.SECONDS,
+			() -> {
+				BackgroundTask backgroundTask =
+					_backgroundTaskLocalService.getBackgroundTask(
+						importProcess.getId());
+
+				Assert.assertEquals(
+					BackgroundTaskConstants.STATUS_SUCCESSFUL,
+					backgroundTask.getStatus());
+			});
+
+		Assert.assertNotNull(
+			_layoutLocalService.fetchLayoutByUuidAndGroupId(
+				layout.getUuid(), testGroup.getGroupId(), privateLayout));
+	}
+
 	private ObjectDefinition _publishObjectDefinition(String scope)
 		throws Exception {
 
@@ -674,6 +734,21 @@ public class ImportProcessResourceTest
 		}
 
 		return objectDefinition;
+	}
+
+	private void _testPostImportProcessWithLayoutSet(
+			UnsafeFunction<File, ImportPreview, Exception>
+				postImportPreviewUnsafeFunction,
+			UnsafeFunction<ImportProcessRequest, ImportProcess, Exception>
+				postImportProcessUnsafeFunction)
+		throws Exception {
+
+		_importLayoutSet(
+			postImportPreviewUnsafeFunction, postImportProcessUnsafeFunction,
+			false);
+		_importLayoutSet(
+			postImportPreviewUnsafeFunction, postImportProcessUnsafeFunction,
+			true);
 	}
 
 	private void _testPostImportProcessWithObjectDefinition(
@@ -844,6 +919,9 @@ public class ImportProcessResourceTest
 
 	private ImportPreviewResource _importPreviewResource;
 	private ImportProcessResource _importProcessResource;
+
+	@Inject
+	private LayoutLocalService _layoutLocalService;
 
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/DeletionSystemEventExporterImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/DeletionSystemEventExporterImpl.java
@@ -156,6 +156,25 @@ public class DeletionSystemEventExporterImpl
 		}
 	}
 
+	@Override
+	public long getDeletionSystemEventsCount(
+			PortletDataContext portletDataContext)
+		throws Exception {
+
+		Set<StagedModelType> deletionSystemEventStagedModelTypes =
+			portletDataContext.getDeletionSystemEventStagedModelTypes();
+
+		if (deletionSystemEventStagedModelTypes.isEmpty()) {
+			return 0;
+		}
+
+		ActionableDynamicQuery actionableDynamicQuery =
+			_getActionableDynamicQuery(
+				portletDataContext, deletionSystemEventStagedModelTypes);
+
+		return actionableDynamicQuery.performCount();
+	}
+
 	protected void addCreateDateProperty(
 		PortletDataContext portletDataContext, DynamicQuery dynamicQuery) {
 
@@ -317,12 +336,9 @@ public class DeletionSystemEventExporterImpl
 				systemEvent.getReferrerClassNameId()));
 	}
 
-	private List<SystemEvent> _getDeletionSystemEvents(
-			PortletDataContext portletDataContext,
-			Set<StagedModelType> deletionSystemEventStagedModelTypes)
-		throws Exception {
-
-		List<SystemEvent> systemEvents = new ArrayList<>();
+	private ActionableDynamicQuery _getActionableDynamicQuery(
+		PortletDataContext portletDataContext,
+		Set<StagedModelType> deletionSystemEventStagedModelTypes) {
 
 		ActionableDynamicQuery actionableDynamicQuery =
 			_systemEventLocalService.getActionableDynamicQuery();
@@ -332,6 +348,21 @@ public class DeletionSystemEventExporterImpl
 				portletDataContext, deletionSystemEventStagedModelTypes,
 				dynamicQuery));
 		actionableDynamicQuery.setCompanyId(portletDataContext.getCompanyId());
+
+		return actionableDynamicQuery;
+	}
+
+	private List<SystemEvent> _getDeletionSystemEvents(
+			PortletDataContext portletDataContext,
+			Set<StagedModelType> deletionSystemEventStagedModelTypes)
+		throws Exception {
+
+		List<SystemEvent> systemEvents = new ArrayList<>();
+
+		ActionableDynamicQuery actionableDynamicQuery =
+			_getActionableDynamicQuery(
+				portletDataContext, deletionSystemEventStagedModelTypes);
+
 		actionableDynamicQuery.setPerformActionMethod(
 			(SystemEvent systemEvent) -> systemEvents.add(systemEvent));
 

--- a/modules/apps/export-import/export-import-test-util/src/main/java/com/liferay/exportimport/test/util/ExportImportTestUtil.java
+++ b/modules/apps/export-import/export-import-test-util/src/main/java/com/liferay/exportimport/test/util/ExportImportTestUtil.java
@@ -40,8 +40,8 @@ public class ExportImportTestUtil {
 			"group/", groupId, StringPool.FORWARD_SLASH, fileName);
 	}
 
-	public static JSONArray getExportedObjectEntriesJSONArray(
-			String fileNamePrefix, InputStream inputStream, long groupId)
+	public static JSONArray getExportedJSONArray(
+			String fileNamePrefix, long groupId, InputStream inputStream)
 		throws Exception {
 
 		String batchFileNameWithPath = getBatchFileNameWithPath(

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
@@ -2727,8 +2727,8 @@ public class BatchEnginePortletDataHandlerTest {
 		throws Exception {
 
 		try (InputStream inputStream = new FileInputStream(file)) {
-			return ExportImportTestUtil.getExportedObjectEntriesJSONArray(
-				fileNamePrefix, inputStream, groupId);
+			return ExportImportTestUtil.getExportedJSONArray(
+				fileNamePrefix, groupId, inputStream);
 		}
 	}
 
@@ -2827,9 +2827,8 @@ public class BatchEnginePortletDataHandlerTest {
 		JSONArray exportedJSONArray;
 
 		try (InputStream inputStream = new FileInputStream(file)) {
-			exportedJSONArray =
-				ExportImportTestUtil.getExportedObjectEntriesJSONArray(
-					fileNamePrefix + "_deletions", inputStream, groupId);
+			exportedJSONArray = ExportImportTestUtil.getExportedJSONArray(
+				fileNamePrefix + "_deletions", groupId, inputStream);
 		}
 
 		if (exportedJSONArray == null) {

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/export/new_export.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/export/new_export.jsp
@@ -52,7 +52,7 @@ renderResponse.setTitle(exportImportPreviewDisplayContext.getExportTitle());
 				).put(
 					"pageSize", PropsValues.LAYOUT_MANAGE_PAGES_INITIAL_CHILDREN
 				).put(
-					"privateLayoutsEnabled", liveGroup.isPrivateLayoutsEnabled()
+					"privateLayoutsAvailable", liveGroup.isPrivateLayoutsEnabled() && liveGroup.hasPrivateLayouts()
 				).build()
 			).build()
 		%>'

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSection.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSection.tsx
@@ -15,7 +15,7 @@ import {ExportImportProcess} from '../../../types/exportImportProcess';
 import {PreviewPortletDataHandlerSection as PortletDataHandlerSectionType} from '../../../types/portletDataHandler';
 import {
 	COMPACT_SECTION_NAMES,
-	HandlerSelection,
+	PortletDataHandlerSelection,
 	SCROLLABLE_SECTION_NAMES,
 	SECTION_KEY_CONTENT,
 	SECTION_KEY_CONTENT_AND_DATA,
@@ -30,17 +30,17 @@ import PortletDataControl from './PortletDataControl';
 import SectionFooter from './SectionFooter';
 import SectionTags from './SectionTags';
 
-export type SectionSelection = Record<string, HandlerSelection>;
+export type SectionSelection = Record<string, PortletDataHandlerSelection>;
 
 interface ContentSectionProps {
 	commentsAndRatingsEnabled?: boolean;
 	lookAndFeelEnabled?: boolean;
 	onChange: (value: SectionSelection | undefined) => void;
 	pageTreeModalConfiguration?: PageTreeModalConfiguration;
+	previewPortletDataHandlerSection: PortletDataHandlerSectionType;
 	process?: ExportImportProcess;
-	section: PortletDataHandlerSectionType;
+	sectionSelection: SectionSelection | undefined;
 	showDeletions?: boolean;
-	value: SectionSelection | undefined;
 }
 
 export default function ContentSection({
@@ -48,17 +48,21 @@ export default function ContentSection({
 	lookAndFeelEnabled = false,
 	onChange,
 	pageTreeModalConfiguration,
+	previewPortletDataHandlerSection,
 	process = 'export',
-	section,
+	sectionSelection = {},
 	showDeletions,
-	value,
 }: ContentSectionProps) {
 	const bodyRef = useRef<HTMLDivElement>(null);
 	const checkboxId = useId();
 	const [overflowing, setOverflowing] = useState(false);
 
-	const compact = COMPACT_SECTION_NAMES.includes(section.name);
-	const scrollable = SCROLLABLE_SECTION_NAMES.includes(section.name);
+	const compact = COMPACT_SECTION_NAMES.includes(
+		previewPortletDataHandlerSection.name
+	);
+	const scrollable = SCROLLABLE_SECTION_NAMES.includes(
+		previewPortletDataHandlerSection.name
+	);
 
 	useEffect(() => {
 		const element = bodyRef.current;
@@ -78,29 +82,34 @@ export default function ContentSection({
 		}
 
 		return () => resizeObserver.disconnect();
-	}, [scrollable, section]);
+	}, [scrollable, previewPortletDataHandlerSection]);
 
 	const allPreviewPortletDataHandlers = getSectionPreviewPortletDataHandlers(
-		section,
+		previewPortletDataHandlerSection,
 		{lookAndFeelEnabled}
 	);
 
-	const sectionSelection = value || {};
-
-	const allSelected = allPreviewPortletDataHandlers.every((context) =>
-		isSelected(sectionSelection[context.name], context)
+	const allSelected = allPreviewPortletDataHandlers.every(
+		(previewPortletDataHandler) =>
+			isSelected(
+				sectionSelection[previewPortletDataHandler.name],
+				previewPortletDataHandler
+			)
 	);
 
 	const anySelected = allPreviewPortletDataHandlers.some(
-		(context) => sectionSelection[context.name] !== undefined
+		(previewPortletDataHandler) =>
+			sectionSelection[previewPortletDataHandler.name] !== undefined
 	);
 
 	const sectionFooters = [
 		{
 			applies:
 				commentsAndRatingsEnabled &&
-				(section.name === SECTION_KEY_CONTENT ||
-					section.name === SECTION_KEY_CONTENT_AND_DATA) &&
+				(previewPortletDataHandlerSection.name ===
+					SECTION_KEY_CONTENT ||
+					previewPortletDataHandlerSection.name ===
+						SECTION_KEY_CONTENT_AND_DATA) &&
 				anySelected,
 			fields: [
 				{key: 'comments', label: Liferay.Language.get('comments')},
@@ -135,11 +144,11 @@ export default function ContentSection({
 							expanded
 								? sub(
 										Liferay.Language.get('collapse-x'),
-										section.label
+										previewPortletDataHandlerSection.label
 									)
 								: sub(
 										Liferay.Language.get('expand-x'),
-										section.label
+										previewPortletDataHandlerSection.label
 									)
 						}
 						className="text-secondary"
@@ -150,20 +159,24 @@ export default function ContentSection({
 				indeterminate={
 					!allSelected &&
 					allPreviewPortletDataHandlers.some(
-						(context) =>
-							sectionSelection[context.name] !== undefined
+						(previewPortletDataHandler) =>
+							sectionSelection[previewPortletDataHandler.name] !==
+							undefined
 					)
 				}
-				label={section.label}
+				label={previewPortletDataHandlerSection.label}
 				labelClassName="font-weight-bold text-6"
 				onToggle={() =>
 					onChange(
 						allSelected
 							? undefined
-							: getSectionSelection(section, {
-									commentsAndRatingsEnabled,
-									lookAndFeelEnabled,
-								})
+							: getSectionSelection(
+									previewPortletDataHandlerSection,
+									{
+										commentsAndRatingsEnabled,
+										lookAndFeelEnabled,
+									}
+								)
 					)
 				}
 				selected={allSelected}
@@ -173,51 +186,65 @@ export default function ContentSection({
 				)}
 				tags={
 					<SectionTags
-						additionCount={section.additionCount}
+						additionCount={
+							previewPortletDataHandlerSection.additionCount
+						}
 						deletionCount={
-							showDeletions ? section.deletionCount : undefined
+							showDeletions
+								? previewPortletDataHandlerSection.deletionCount
+								: undefined
 						}
 					/>
 				}
 			>
-				{allPreviewPortletDataHandlers.map((context) => (
-					<PortletDataControl
-						compact={compact}
-						control={context}
-						key={context.name}
-						onChange={(controlValue) =>
-							onChange(
-								updateSelection(
-									sectionSelection,
-									context.name,
-									controlValue
+				{allPreviewPortletDataHandlers.map(
+					(previewPortletDataHandler) => (
+						<PortletDataControl
+							compact={compact}
+							key={previewPortletDataHandler.name}
+							onChange={(portletDataHandlerSelection) =>
+								onChange(
+									updateSelection(
+										sectionSelection,
+										previewPortletDataHandler.name,
+										portletDataHandlerSelection
+									)
 								)
-							)
-						}
-						pageTreeModalConfiguration={pageTreeModalConfiguration}
-						showDeletions={showDeletions}
-						topLevel
-						value={sectionSelection[context.name]}
-					/>
-				))}
+							}
+							pageTreeModalConfiguration={
+								pageTreeModalConfiguration
+							}
+							portletDataHandlerSelection={
+								sectionSelection[previewPortletDataHandler.name]
+							}
+							previewPortletDataHandlerControl={
+								previewPortletDataHandler
+							}
+							showDeletions={showDeletions}
+							topLevel
+						/>
+					)
+				)}
 
 				{sectionFooters.map((sectionFooter) => (
 					<SectionFooter
 						fields={sectionFooter.fields}
 						key={sectionFooter.name}
 						name={sectionFooter.name}
-						onChange={(sectionFooterValue) =>
+						onChange={(portletDataHandlerSelection) =>
 							onChange(
 								updateSelection(
 									sectionSelection,
 									sectionFooter.name,
-									sectionFooterValue
+									portletDataHandlerSelection
 								)
 							)
 						}
+						portletDataHandlerSelection={
+							sectionSelection[sectionFooter.name]
+						}
 						subtitle={sectionFooter.subtitle}
 						title={sectionFooter.title}
-						value={sectionSelection[sectionFooter.name]}
 					/>
 				))}
 			</CollapsibleGroup>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSelector.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/ContentSelector.tsx
@@ -20,37 +20,39 @@ export type ContentSelection = Record<string, SectionSelection>;
 interface ContentSelectorProps {
 	'aria-labelledby'?: string;
 	'commentsAndRatingsEnabled'?: boolean;
+	'contentSelection': ContentSelection | undefined;
 	'errorMessage'?: string;
 	'lookAndFeelEnabled'?: boolean;
 	'name': string;
 	'onChange': (value: ContentSelection | undefined) => void;
 	'pageTreeModalConfiguration'?: PageTreeModalConfiguration;
+	'previewPortletDataHandlerSections': PreviewPortletDataHandlerSection[];
 	'process'?: ExportImportProcess;
-	'sections': PreviewPortletDataHandlerSection[];
 	'showDeletions'?: boolean;
-	'value': ContentSelection | undefined;
 }
 
 export default function ContentSelector({
 	'aria-labelledby': ariaLabelledby,
 	commentsAndRatingsEnabled = false,
+	contentSelection = {},
 	errorMessage,
 	lookAndFeelEnabled = false,
 	name,
 	onChange,
 	pageTreeModalConfiguration,
 	process = 'export',
-	sections,
+	previewPortletDataHandlerSections,
 	showDeletions,
-	value,
 }: ContentSelectorProps) {
-	const currentValue = value || {};
 	const errorId = errorMessage ? `${name}-error-message` : undefined;
 
-	const visibleSections = getVisibleSections(sections, {
-		lookAndFeelEnabled,
-		showDeletions,
-	});
+	const visibleSections = getVisibleSections(
+		previewPortletDataHandlerSections,
+		{
+			lookAndFeelEnabled,
+			showDeletions,
+		}
+	);
 
 	return (
 		<div
@@ -61,25 +63,33 @@ export default function ContentSelector({
 			role="group"
 		>
 			{visibleSections.map(
-				(section: PreviewPortletDataHandlerSection) => (
+				(
+					previewPortletDataHandlerSection: PreviewPortletDataHandlerSection
+				) => (
 					<ContentSection
 						commentsAndRatingsEnabled={commentsAndRatingsEnabled}
-						key={section.name}
+						key={previewPortletDataHandlerSection.name}
 						lookAndFeelEnabled={lookAndFeelEnabled}
-						onChange={(sectionValue) =>
+						onChange={(sectionSelection) =>
 							onChange(
 								updateSelection(
-									currentValue,
-									section.name,
-									sectionValue
+									contentSelection,
+									previewPortletDataHandlerSection.name,
+									sectionSelection
 								)
 							)
 						}
 						pageTreeModalConfiguration={pageTreeModalConfiguration}
+						previewPortletDataHandlerSection={
+							previewPortletDataHandlerSection
+						}
 						process={process}
-						section={section}
+						sectionSelection={
+							contentSelection[
+								previewPortletDataHandlerSection.name
+							]
+						}
 						showDeletions={showDeletions}
-						value={currentValue[section.name]}
 					/>
 				)
 			)}

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/LayoutSetControl.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/LayoutSetControl.tsx
@@ -100,7 +100,7 @@ export default function LayoutSetControl({
 	pageTreeModalConfiguration,
 	portletDataHandlerSelection,
 }: Props) {
-	const {privateLayoutsEnabled, ...modalConfiguration} =
+	const {privateLayoutsAvailable, ...modalConfiguration} =
 		pageTreeModalConfiguration;
 
 	const checkboxId = useId();
@@ -157,7 +157,7 @@ export default function LayoutSetControl({
 				</ClayLayout.ContentCol>
 			</ClayLayout.ContentRow>
 
-			{privateLayoutsEnabled && selected && (
+			{privateLayoutsAvailable && selected && (
 				<LayoutVisibilitySelector
 					label={label}
 					onSetMode={(nextPrivateLayout) =>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/LayoutSetControl.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/LayoutSetControl.tsx
@@ -13,7 +13,7 @@ import PageTreeModal, {
 	PageTreeModalConfiguration,
 } from '../../../pages/export/components/PageTreeModal';
 import {
-	HandlerSelection,
+	PortletDataHandlerSelection,
 	isAllLayoutsSelected,
 } from '../../../utils/contentSelection';
 import SectionTags from './SectionTags';
@@ -22,9 +22,9 @@ interface Props {
 	additionCount?: number;
 	deletionCount?: number;
 	label: string;
-	onChange: (value: HandlerSelection | undefined) => void;
+	onChange: (value: PortletDataHandlerSelection | undefined) => void;
 	pageTreeModalConfiguration: PageTreeModalConfiguration;
-	value: HandlerSelection | undefined;
+	portletDataHandlerSelection: PortletDataHandlerSelection | undefined;
 }
 
 function SelectPagesButton({
@@ -98,7 +98,7 @@ export default function LayoutSetControl({
 	label,
 	onChange,
 	pageTreeModalConfiguration,
-	value,
+	portletDataHandlerSelection,
 }: Props) {
 	const {privateLayoutsEnabled, ...modalConfiguration} =
 		pageTreeModalConfiguration;
@@ -108,12 +108,14 @@ export default function LayoutSetControl({
 	const [showModal, setShowModal] = useState(false);
 
 	const {layoutIds = [], privateLayout = false} = (
-		typeof value === 'object' ? value : {}
+		typeof portletDataHandlerSelection === 'object'
+			? portletDataHandlerSelection
+			: {}
 	) as {layoutIds?: number[]; privateLayout?: boolean};
 
-	const isAll = isAllLayoutsSelected(value);
+	const isAll = isAllLayoutsSelected(portletDataHandlerSelection);
 
-	const selected = typeof value === 'object';
+	const selected = typeof portletDataHandlerSelection === 'object';
 
 	const openModal = () => setShowModal(true);
 
@@ -158,7 +160,9 @@ export default function LayoutSetControl({
 			{privateLayoutsEnabled && selected && (
 				<LayoutVisibilitySelector
 					label={label}
-					onSetMode={(next) => onChange({privateLayout: next})}
+					onSetMode={(nextPrivateLayout) =>
+						onChange({privateLayout: nextPrivateLayout})
+					}
 					privateLayout={privateLayout}
 				/>
 			)}
@@ -169,10 +173,12 @@ export default function LayoutSetControl({
 					initialAll={isAll}
 					initialSelectedIds={layoutIds.map(String)}
 					onClose={() => setShowModal(false)}
-					onSubmit={(result) => {
+					onSubmit={(selectedPortletDataHandlerSelection) => {
 						setShowModal(false);
 
-						onChange(result ?? undefined);
+						onChange(
+							selectedPortletDataHandlerSelection ?? undefined
+						);
 					}}
 					privateLayout={privateLayout}
 				/>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/LayoutSetControl.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/LayoutSetControl.tsx
@@ -13,6 +13,7 @@ import PageTreeModal, {
 	PageTreeModalConfiguration,
 } from '../../../pages/export/components/PageTreeModal';
 import {
+	LayoutSetSelection,
 	PortletDataHandlerSelection,
 	isAllLayoutsSelected,
 } from '../../../utils/contentSelection';
@@ -111,7 +112,7 @@ export default function LayoutSetControl({
 		typeof portletDataHandlerSelection === 'object'
 			? portletDataHandlerSelection
 			: {}
-	) as {layoutIds?: number[]; privateLayout?: boolean};
+	) as LayoutSetSelection;
 
 	const isAll = isAllLayoutsSelected(portletDataHandlerSelection);
 

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/LayoutSetControl.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/LayoutSetControl.tsx
@@ -58,17 +58,15 @@ function SelectPagesButton({
 
 function LayoutVisibilitySelector({
 	label,
-	onSelectPages,
 	onSetMode,
 	privateLayout,
 }: {
 	label: string;
-	onSelectPages: () => void;
 	onSetMode: (mode: boolean) => void;
 	privateLayout: boolean;
 }) {
 	return (
-		<div aria-label={label} className="pl-4" role="radiogroup">
+		<div aria-label={label} className="mt-2 pl-4" role="radiogroup">
 			<div className="align-items-center d-flex">
 				<ClayRadio
 					checked={!privateLayout}
@@ -78,13 +76,6 @@ function LayoutVisibilitySelector({
 					onChange={() => onSetMode(false)}
 					value="false"
 				/>
-
-				{!privateLayout && (
-					<SelectPagesButton
-						onClick={onSelectPages}
-						privateLayout={false}
-					/>
-				)}
 			</div>
 
 			<div className="align-items-center d-flex mb-1">
@@ -96,10 +87,6 @@ function LayoutVisibilitySelector({
 					onChange={() => onSetMode(true)}
 					value="true"
 				/>
-
-				{privateLayout && (
-					<SelectPagesButton onClick={onSelectPages} privateLayout />
-				)}
 			</div>
 		</div>
 	);
@@ -132,7 +119,7 @@ export default function LayoutSetControl({
 
 	return (
 		<div className="p-3">
-			<ClayLayout.ContentRow className="align-items-center mb-2">
+			<ClayLayout.ContentRow className="align-items-center">
 				<ClayLayout.ContentCol className="pr-2" expand={false}>
 					<ClayCheckbox
 						checked={isAll}
@@ -160,9 +147,10 @@ export default function LayoutSetControl({
 							/>
 						</div>
 
-						{!privateLayoutsEnabled && (
-							<SelectPagesButton onClick={openModal} />
-						)}
+						<SelectPagesButton
+							onClick={openModal}
+							privateLayout={privateLayout}
+						/>
 					</div>
 				</ClayLayout.ContentCol>
 			</ClayLayout.ContentRow>
@@ -170,7 +158,6 @@ export default function LayoutSetControl({
 			{privateLayoutsEnabled && selected && (
 				<LayoutVisibilitySelector
 					label={label}
-					onSelectPages={openModal}
 					onSetMode={(next) => onChange({privateLayout: next})}
 					privateLayout={privateLayout}
 				/>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/LayoutSetControl.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/LayoutSetControl.tsx
@@ -16,8 +16,11 @@ import {
 	HandlerSelection,
 	isAllLayoutsSelected,
 } from '../../../utils/contentSelection';
+import SectionTags from './SectionTags';
 
 interface Props {
+	additionCount?: number;
+	deletionCount?: number;
 	label: string;
 	onChange: (value: HandlerSelection | undefined) => void;
 	pageTreeModalConfiguration: PageTreeModalConfiguration;
@@ -103,6 +106,8 @@ function LayoutVisibilitySelector({
 }
 
 export default function LayoutSetControl({
+	additionCount,
+	deletionCount,
 	label,
 	onChange,
 	pageTreeModalConfiguration,
@@ -120,6 +125,8 @@ export default function LayoutSetControl({
 	) as {layoutIds?: number[]; privateLayout?: boolean};
 
 	const isAll = isAllLayoutsSelected(value);
+
+	const selected = typeof value === 'object';
 
 	const openModal = () => setShowModal(true);
 
@@ -139,12 +146,19 @@ export default function LayoutSetControl({
 
 				<ClayLayout.ContentCol expand>
 					<div className="align-items-center d-flex justify-content-between">
-						<label
-							className="cursor-pointer font-weight-semi-bold mb-0 small"
-							htmlFor={checkboxId}
-						>
-							{label}
-						</label>
+						<div className="align-items-center d-flex">
+							<label
+								className="cursor-pointer font-weight-semi-bold mb-0 small"
+								htmlFor={checkboxId}
+							>
+								{label}
+							</label>
+
+							<SectionTags
+								additionCount={additionCount}
+								deletionCount={deletionCount}
+							/>
+						</div>
 
 						{!privateLayoutsEnabled && (
 							<SelectPagesButton onClick={openModal} />
@@ -153,7 +167,7 @@ export default function LayoutSetControl({
 				</ClayLayout.ContentCol>
 			</ClayLayout.ContentRow>
 
-			{privateLayoutsEnabled && (
+			{privateLayoutsEnabled && selected && (
 				<LayoutVisibilitySelector
 					label={label}
 					onSelectPages={openModal}

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/PortletDataControl.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/PortletDataControl.tsx
@@ -180,7 +180,12 @@ function PortletDataHandlerPanel({
 	rowProps: React.ComponentProps<typeof ControlRow>;
 }) {
 	return (
-		<div className={classnames('px-3', compact ? 'py-2' : 'py-3')}>
+		<div
+			className={classnames({
+				[`p-3`]: !compact,
+				[`py-2 py-3`]: compact,
+			})}
+		>
 			{expandable ? (
 				<CollapsibleGroup
 					{...rowProps}

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/PortletDataControl.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/PortletDataControl.tsx
@@ -12,9 +12,9 @@ import React, {ReactNode, useId} from 'react';
 import {PageTreeModalConfiguration} from '../../../pages/export/components/PageTreeModal';
 import {PreviewPortletDataHandlerControl} from '../../../types/portletDataHandler';
 import {
-	HandlerSelection,
 	LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY,
-	getHandlerSelection,
+	PortletDataHandlerSelection,
+	getPortletDataHandlerSelection,
 	getSelectionSummary,
 	isSelected,
 	updateSelection,
@@ -27,87 +27,113 @@ import SectionTags from './SectionTags';
 
 export default function PortletDataControl({
 	compact = false,
-	control,
 	onChange,
 	pageTreeModalConfiguration,
+	portletDataHandlerSelection,
+	previewPortletDataHandlerControl,
 	showDeletions,
 	topLevel = false,
-	value,
 }: {
 	compact?: boolean;
-	control: PreviewPortletDataHandlerControl;
-	onChange: (value: HandlerSelection | undefined) => void;
+	onChange: (value: PortletDataHandlerSelection | undefined) => void;
 	pageTreeModalConfiguration?: PageTreeModalConfiguration;
+	portletDataHandlerSelection: PortletDataHandlerSelection | undefined;
+	previewPortletDataHandlerControl: PreviewPortletDataHandlerControl;
 	showDeletions?: boolean;
 	topLevel?: boolean;
-	value: HandlerSelection | undefined;
 }) {
 	const checkboxId = useId();
 
 	if (
-		control.name === LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY &&
+		previewPortletDataHandlerControl.name ===
+			LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY &&
 		pageTreeModalConfiguration
 	) {
 		return (
 			<LayoutSetControl
 				additionCount={
-					control.type === 'Boolean'
-						? control.additionCount
+					previewPortletDataHandlerControl.type === 'Boolean'
+						? previewPortletDataHandlerControl.additionCount
 						: undefined
 				}
 				deletionCount={
-					control.type === 'Boolean' && showDeletions
-						? control.deletionCount
+					previewPortletDataHandlerControl.type === 'Boolean' &&
+					showDeletions
+						? previewPortletDataHandlerControl.deletionCount
 						: undefined
 				}
-				label={control.label}
+				label={previewPortletDataHandlerControl.label}
 				onChange={onChange}
 				pageTreeModalConfiguration={pageTreeModalConfiguration}
-				value={value}
+				portletDataHandlerSelection={portletDataHandlerSelection}
 			/>
 		);
 	}
 
-	if (control.type === 'Choice') {
+	if (previewPortletDataHandlerControl.type === 'Choice') {
 		return (
 			<PortletDataControlChoice
-				control={control}
 				onChange={onChange}
-				value={typeof value === 'string' ? value : ''}
+				previewPortletDataHandlerChoice={
+					previewPortletDataHandlerControl
+				}
+				value={
+					typeof portletDataHandlerSelection === 'string'
+						? portletDataHandlerSelection
+						: ''
+				}
 			/>
 		);
 	}
 
-	const selected = isSelected(value, control);
-	const currentSelection =
-		typeof value === 'object'
-			? (value as Record<string, HandlerSelection>)
+	const selected = isSelected(
+		portletDataHandlerSelection,
+		previewPortletDataHandlerControl
+	);
+	const portletDataHandlerSelections =
+		typeof portletDataHandlerSelection === 'object'
+			? (portletDataHandlerSelection as Record<
+					string,
+					PortletDataHandlerSelection
+				>)
 			: {};
-	const nestedControls = control.previewPortletDataHandlerControls ?? [];
+	const previewPortletDataHandlerControls =
+		previewPortletDataHandlerControl.previewPortletDataHandlerControls ??
+		[];
 
 	const additionCount =
-		control.type === 'Boolean' ? control.additionCount : undefined;
+		previewPortletDataHandlerControl.type === 'Boolean'
+			? previewPortletDataHandlerControl.additionCount
+			: undefined;
 	const deletionCount =
-		control.type === 'Boolean' && showDeletions
-			? control.deletionCount
+		previewPortletDataHandlerControl.type === 'Boolean' && showDeletions
+			? previewPortletDataHandlerControl.deletionCount
 			: undefined;
 	const description =
-		topLevel && control.type === 'Boolean'
-			? control.description
+		topLevel && previewPortletDataHandlerControl.type === 'Boolean'
+			? previewPortletDataHandlerControl.description
 			: undefined;
 	const tag =
-		topLevel && control.type === 'Boolean' ? control.tag : undefined;
+		topLevel && previewPortletDataHandlerControl.type === 'Boolean'
+			? previewPortletDataHandlerControl.tag
+			: undefined;
 
 	const rowProps = {
 		checkboxId,
 		description,
-		indeterminate: !!value && !selected,
-		label: control.label,
+		indeterminate: !!portletDataHandlerSelection && !selected,
+		label: previewPortletDataHandlerControl.label,
 		labelClassName: topLevel
 			? 'font-weight-semi-bold'
 			: 'font-weight-normal',
 		onToggle: () =>
-			onChange(selected ? undefined : getHandlerSelection(control)),
+			onChange(
+				selected
+					? undefined
+					: getPortletDataHandlerSelection(
+							previewPortletDataHandlerControl
+						)
+			),
 		selected,
 		tags: (
 			<SectionTags
@@ -118,23 +144,33 @@ export default function PortletDataControl({
 		),
 	};
 
-	const body = nestedControls
-		.filter((nestedControl) => nestedControl.type !== 'Choice' || !!value)
-		.map((nestedControl) => (
+	const body = previewPortletDataHandlerControls
+		.filter(
+			(nestedPreviewPortletDataHandlerControl) =>
+				nestedPreviewPortletDataHandlerControl.type !== 'Choice' ||
+				!!portletDataHandlerSelection
+		)
+		.map((nestedPreviewPortletDataHandlerControl) => (
 			<PortletDataControl
-				control={nestedControl}
-				key={nestedControl.name}
-				onChange={(controlValue) =>
+				key={nestedPreviewPortletDataHandlerControl.name}
+				onChange={(nestedPortletDataHandlerSelection) =>
 					onChange(
 						updateSelection(
-							currentSelection,
-							nestedControl.name,
-							controlValue
+							portletDataHandlerSelections,
+							nestedPreviewPortletDataHandlerControl.name,
+							nestedPortletDataHandlerSelection
 						)
 					)
 				}
 				pageTreeModalConfiguration={pageTreeModalConfiguration}
-				value={currentSelection[nestedControl.name]}
+				portletDataHandlerSelection={
+					portletDataHandlerSelections[
+						nestedPreviewPortletDataHandlerControl.name
+					]
+				}
+				previewPortletDataHandlerControl={
+					nestedPreviewPortletDataHandlerControl
+				}
 			/>
 		));
 
@@ -145,9 +181,11 @@ export default function PortletDataControl({
 			<PortletDataHandlerPanel
 				bodyChildren={body}
 				compact={compact}
-				currentSelection={currentSelection}
 				expandable={expandable}
-				nestedControls={nestedControls}
+				portletDataHandlerSelections={portletDataHandlerSelections}
+				previewPortletDataHandlerControls={
+					previewPortletDataHandlerControls
+				}
 				rowProps={rowProps}
 			/>
 		);
@@ -167,16 +205,16 @@ export default function PortletDataControl({
 function PortletDataHandlerPanel({
 	bodyChildren,
 	compact = false,
-	currentSelection,
 	expandable,
-	nestedControls,
+	portletDataHandlerSelections,
+	previewPortletDataHandlerControls,
 	rowProps,
 }: {
 	bodyChildren: ReactNode;
 	compact?: boolean;
-	currentSelection: Record<string, HandlerSelection>;
 	expandable: boolean;
-	nestedControls: PreviewPortletDataHandlerControl[];
+	portletDataHandlerSelections: Record<string, PortletDataHandlerSelection>;
+	previewPortletDataHandlerControls: PreviewPortletDataHandlerControl[];
 	rowProps: React.ComponentProps<typeof ControlRow>;
 }) {
 	return (
@@ -220,8 +258,8 @@ function PortletDataHandlerPanel({
 						</ClayButton>
 					)}
 					summary={getSelectionSummary(
-						nestedControls,
-						currentSelection
+						previewPortletDataHandlerControls,
+						portletDataHandlerSelections
 					)}
 				>
 					{bodyChildren}

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/PortletDataControl.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/PortletDataControl.tsx
@@ -50,6 +50,16 @@ export default function PortletDataControl({
 	) {
 		return (
 			<LayoutSetControl
+				additionCount={
+					control.type === 'Boolean'
+						? control.additionCount
+						: undefined
+				}
+				deletionCount={
+					control.type === 'Boolean' && showDeletions
+						? control.deletionCount
+						: undefined
+				}
 				label={control.label}
 				onChange={onChange}
 				pageTreeModalConfiguration={pageTreeModalConfiguration}

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/PortletDataControlChoice.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/PortletDataControlChoice.tsx
@@ -11,30 +11,32 @@ import FieldSelectWithOption from '../FieldSelectWithOption';
 
 interface PortletDataControlChoiceProps {
 	className?: string;
-	control: PreviewPortletDataHandlerChoice;
 	onChange: (value: string) => void;
+	previewPortletDataHandlerChoice: PreviewPortletDataHandlerChoice;
 	value: string;
 }
 
 export default function PortletDataControlChoice({
 	className = 'ml-1',
-	control,
 	onChange,
+	previewPortletDataHandlerChoice,
 	value,
 }: PortletDataControlChoiceProps) {
 	return (
 		<FieldSelectWithOption
 			className="w-auto"
 			formGroupProps={{className: classnames('mb-0', className)}}
-			label={control.label}
-			name={control.name}
+			label={previewPortletDataHandlerChoice.label}
+			name={previewPortletDataHandlerChoice.name}
 			onChange={(event) => {
 				onChange(event.target.value);
 			}}
-			options={control.choices.map(({label, name}) => ({
-				label,
-				value: name,
-			}))}
+			options={previewPortletDataHandlerChoice.choices.map(
+				({label, name}) => ({
+					label,
+					value: name,
+				})
+			)}
 			value={value}
 		/>
 	);

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/SectionFooter.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/content_selector/SectionFooter.tsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 
-import {HandlerSelection} from '../../../utils/contentSelection';
+import {PortletDataHandlerSelection} from '../../../utils/contentSelection';
 import {FieldCheckbox} from '../FieldCheckbox';
 
 export interface SectionFooterField {
@@ -16,21 +16,25 @@ export interface SectionFooterField {
 interface SectionFooterProps {
 	fields: readonly SectionFooterField[];
 	name: string;
-	onChange: (value: HandlerSelection | undefined) => void;
+	onChange: (value: PortletDataHandlerSelection | undefined) => void;
+	portletDataHandlerSelection: PortletDataHandlerSelection | undefined;
 	subtitle?: string;
 	title: string;
-	value: HandlerSelection | undefined;
 }
 
 export default function SectionFooter({
 	fields,
 	name,
 	onChange,
+	portletDataHandlerSelection,
 	subtitle,
 	title,
-	value,
 }: SectionFooterProps) {
-	const selection = value && typeof value === 'object' ? value : undefined;
+	const portletDataHandlerSelections =
+		portletDataHandlerSelection &&
+		typeof portletDataHandlerSelection === 'object'
+			? portletDataHandlerSelection
+			: undefined;
 
 	return (
 		<>
@@ -49,28 +53,39 @@ export default function SectionFooter({
 					{fields.map((field) => (
 						<FieldCheckbox
 							bordered={false}
-							checked={Boolean(selection?.[field.key])}
+							checked={Boolean(
+								portletDataHandlerSelections?.[field.key]
+							)}
 							key={field.key}
 							label={field.label}
 							name={`${name}.${field.key}`}
 							onChange={(checked) => {
-								const nextSelection: Record<string, true> = {};
+								const nextPortletDataHandlerSelections: Record<
+									string,
+									true
+								> = {};
 
 								fields.forEach((otherField) => {
 									if (
 										otherField.key === field.key
 											? checked
 											: Boolean(
-													selection?.[otherField.key]
+													portletDataHandlerSelections?.[
+														otherField.key
+													]
 												)
 									) {
-										nextSelection[otherField.key] = true;
+										nextPortletDataHandlerSelections[
+											otherField.key
+										] = true;
 									}
 								});
 
 								onChange(
-									Object.keys(nextSelection).length
-										? (nextSelection as HandlerSelection)
+									Object.keys(
+										nextPortletDataHandlerSelections
+									).length
+										? (nextPortletDataHandlerSelections as PortletDataHandlerSelection)
 										: undefined
 								);
 							}}

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/formik/FormikFieldContentSelector.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/components/forms/formik/FormikFieldContentSelector.tsx
@@ -20,8 +20,8 @@ interface FormikFieldContentSelectorProps {
 	'lookAndFeelEnabled'?: boolean;
 	'name': string;
 	'pageTreeModalConfiguration'?: PageTreeModalConfiguration;
+	'previewPortletDataHandlerSections': PreviewPortletDataHandlerSection[];
 	'process'?: ExportImportProcess;
-	'sections': PreviewPortletDataHandlerSection[];
 }
 
 export function FormikFieldContentSelector({
@@ -30,8 +30,8 @@ export function FormikFieldContentSelector({
 	lookAndFeelEnabled = false,
 	name,
 	pageTreeModalConfiguration,
+	previewPortletDataHandlerSections,
 	process = 'export',
-	sections,
 }: FormikFieldContentSelectorProps) {
 	const [field, meta, helpers] = useField<ContentSelection | undefined>(name);
 	const [{value: deletions}] = useField<boolean | undefined>('deletions');
@@ -40,10 +40,12 @@ export function FormikFieldContentSelector({
 	const showDeletions = !!deletions;
 
 	const shouldSeed =
-		!!sections.length && field.value === undefined && !meta.touched;
+		!!previewPortletDataHandlerSections.length &&
+		field.value === undefined &&
+		!meta.touched;
 
 	const defaultContentSelection = shouldSeed
-		? getFullDataSelection(sections, {
+		? getFullDataSelection(previewPortletDataHandlerSections, {
 				commentsAndRatingsEnabled,
 				lookAndFeelEnabled,
 				showDeletions,
@@ -66,6 +68,7 @@ export function FormikFieldContentSelector({
 		<ContentSelector
 			aria-labelledby={ariaLabelledby}
 			commentsAndRatingsEnabled={commentsAndRatingsEnabled}
+			contentSelection={field.value ?? defaultContentSelection}
 			errorMessage={meta.touched && meta.error ? meta.error : undefined}
 			lookAndFeelEnabled={lookAndFeelEnabled}
 			name={name}
@@ -74,10 +77,11 @@ export function FormikFieldContentSelector({
 				setFieldTouched(name, true, false);
 			}}
 			pageTreeModalConfiguration={pageTreeModalConfiguration}
+			previewPortletDataHandlerSections={
+				previewPortletDataHandlerSections
+			}
 			process={process}
-			sections={sections}
 			showDeletions={showDeletions}
-			value={field.value ?? defaultContentSelection}
 		/>
 	);
 }

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/NewExport.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/NewExport.tsx
@@ -64,20 +64,23 @@ export function NewExport({
 			setLoading(true);
 			setError(null);
 
-			getExportPreview(exportPreviewParams).then((result) => {
-				if (result.error !== null) {
-					setError(result.error);
-				}
-				else {
-					setPreview(result.data);
-
-					if (!initialPreviewRef.current) {
-						initialPreviewRef.current = result.data;
+			getExportPreview(exportPreviewParams).then(
+				(exportPreviewResponse) => {
+					if (exportPreviewResponse.error !== null) {
+						setError(exportPreviewResponse.error);
 					}
-				}
+					else {
+						setPreview(exportPreviewResponse.data);
 
-				setLoading(false);
-			});
+						if (!initialPreviewRef.current) {
+							initialPreviewRef.current =
+								exportPreviewResponse.data;
+						}
+					}
+
+					setLoading(false);
+				}
+			);
 		},
 		[]
 	);
@@ -94,7 +97,8 @@ export function NewExport({
 		return <ClayAlert displayType="danger">{error}</ClayAlert>;
 	}
 
-	const sections = preview?.previewPortletDataHandlerSections ?? [];
+	const previewPortletDataHandlerSections =
+		preview?.previewPortletDataHandlerSections ?? [];
 
 	const handleApplyFilter = (filterValues: DateFilterValues) => {
 		appliedDateFilterRef.current = normalizeDateFilter(filterValues);
@@ -134,7 +138,7 @@ export function NewExport({
 						permissions: !!values.permissions,
 						requestPortletDataHandlers:
 							toRequestPortletDataHandlers(
-								sections,
+								previewPortletDataHandlerSections,
 								values.contentSelection
 							),
 					},
@@ -186,12 +190,12 @@ export function NewExport({
 							}
 							deletionCount={getSelectedDeletionCount(
 								preview?.deletionCount,
-								sections,
+								previewPortletDataHandlerSections,
 								contentSelection
 							)}
 							itemsCount={getSelectedItemsCount(
 								preview?.additionCount,
-								sections,
+								previewPortletDataHandlerSections,
 								contentSelection
 							)}
 							loading={loading}
@@ -200,8 +204,8 @@ export function NewExport({
 							pageTreeModalConfiguration={
 								pageTreeModalConfiguration
 							}
-							sections={withSelectedLayoutSetCount(
-								sections,
+							previewPortletDataHandlerSections={withSelectedLayoutSetCount(
+								previewPortletDataHandlerSections,
 								contentSelection
 							)}
 						/>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/NewExport.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/NewExport.tsx
@@ -23,7 +23,12 @@ import {
 } from '../../services/getExportPreview';
 import {postExportProcess} from '../../services/postExportProcess';
 import {ExportPreview} from '../../types/exportImportPreview';
-import {toProcessRequestFlags} from '../../utils/contentSelection';
+import {
+	getSelectedDeletionCount,
+	getSelectedItemsCount,
+	toProcessRequestFlags,
+	withSelectedLayoutSetCount,
+} from '../../utils/contentSelection';
 import {toRequestPortletDataHandlers} from '../../utils/toRequestPortletDataHandlers';
 import DataSelection from './components/DataSelection';
 import {PageTreeModalConfiguration} from './components/PageTreeModal';
@@ -166,43 +171,64 @@ export function NewExport({
 			}}
 			validateOnMount
 		>
-			{(formik) => (
-				<Form noValidate>
-					<Setup />
+			{(formik) => {
+				const contentSelection = formik.values.contentSelection as
+					| ContentSelection
+					| undefined;
 
-					<DataSelection
-						commentsAndRatingsEnabled={commentsAndRatingsEnabled}
-						deletionCount={preview?.deletionCount}
-						itemsCount={preview?.additionCount}
-						loading={loading}
-						lookAndFeelEnabled={lookAndFeelEnabled}
-						onApplyFilter={handleApplyFilter}
-						pageTreeModalConfiguration={pageTreeModalConfiguration}
-						sections={sections}
-					/>
+				return (
+					<Form noValidate>
+						<Setup />
 
-					<Footer
-						actionButton={
-							<ClayButton
-								disabled={
-									formik.isSubmitting || !formik.isValid
-								}
-								type="submit"
-							>
-								<span className="inline-item inline-item-before">
-									<ClayIcon
-										className="mr-1"
-										symbol="export"
-									/>
-								</span>
+						<DataSelection
+							commentsAndRatingsEnabled={
+								commentsAndRatingsEnabled
+							}
+							deletionCount={getSelectedDeletionCount(
+								preview?.deletionCount,
+								sections,
+								contentSelection
+							)}
+							itemsCount={getSelectedItemsCount(
+								preview?.additionCount,
+								sections,
+								contentSelection
+							)}
+							loading={loading}
+							lookAndFeelEnabled={lookAndFeelEnabled}
+							onApplyFilter={handleApplyFilter}
+							pageTreeModalConfiguration={
+								pageTreeModalConfiguration
+							}
+							sections={withSelectedLayoutSetCount(
+								sections,
+								contentSelection
+							)}
+						/>
 
-								{Liferay.Language.get('export')}
-							</ClayButton>
-						}
-						backURL={backURL}
-					/>
-				</Form>
-			)}
+						<Footer
+							actionButton={
+								<ClayButton
+									disabled={
+										formik.isSubmitting || !formik.isValid
+									}
+									type="submit"
+								>
+									<span className="inline-item inline-item-before">
+										<ClayIcon
+											className="mr-1"
+											symbol="export"
+										/>
+									</span>
+
+									{Liferay.Language.get('export')}
+								</ClayButton>
+							}
+							backURL={backURL}
+						/>
+					</Form>
+				);
+			}}
 		</Formik>
 	);
 }

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/components/DataSelection.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/components/DataSelection.tsx
@@ -27,7 +27,7 @@ export default function DataSelection({
 	lookAndFeelEnabled = false,
 	onApplyFilter,
 	pageTreeModalConfiguration,
-	sections,
+	previewPortletDataHandlerSections,
 }: {
 	commentsAndRatingsEnabled?: boolean;
 	deletionCount?: number;
@@ -36,7 +36,7 @@ export default function DataSelection({
 	lookAndFeelEnabled?: boolean;
 	onApplyFilter: (filterValues: DateFilterValues) => void;
 	pageTreeModalConfiguration: PageTreeModalConfiguration;
-	sections: PreviewPortletDataHandlerSection[];
+	previewPortletDataHandlerSections: PreviewPortletDataHandlerSection[];
 }) {
 	return (
 		<>
@@ -95,8 +95,10 @@ export default function DataSelection({
 						lookAndFeelEnabled={lookAndFeelEnabled}
 						name="contentSelection"
 						pageTreeModalConfiguration={pageTreeModalConfiguration}
+						previewPortletDataHandlerSections={
+							previewPortletDataHandlerSections
+						}
 						process="export"
-						sections={sections}
 					/>
 				)}
 			</div>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/components/PageTreeModal.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/export/components/PageTreeModal.tsx
@@ -20,11 +20,11 @@ const SESSION_TREE_JS_CLICK_URL = `${PATH_MAIN}/portal/session_tree_js_click`;
 export interface PageTreeModalConfiguration {
 	liveGroupId: number;
 	pageSize: number;
-	privateLayoutsEnabled: boolean;
+	privateLayoutsAvailable: boolean;
 }
 
 interface Props
-	extends Omit<PageTreeModalConfiguration, 'privateLayoutsEnabled'> {
+	extends Omit<PageTreeModalConfiguration, 'privateLayoutsAvailable'> {
 	initialAll?: boolean;
 	initialSelectedIds: string[];
 	onClose: () => void;

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/steps/DataSelectionStep.tsx
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/pages/import/steps/DataSelectionStep.tsx
@@ -54,8 +54,10 @@ export default function DataSelectionStep({
 				commentsAndRatingsEnabled={commentsAndRatingsEnabled}
 				lookAndFeelEnabled={lookAndFeelEnabled}
 				name="contentSelection"
+				previewPortletDataHandlerSections={
+					importPreview.previewPortletDataHandlerSections
+				}
 				process="import"
-				sections={importPreview.previewPortletDataHandlerSections}
 			/>
 		</>
 	);

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/types/portletDataHandler.ts
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/types/portletDataHandler.ts
@@ -15,7 +15,12 @@ export interface PreviewPortletDataHandlerBoolean {
 }
 
 export interface PreviewPortletDataHandlerChoice {
-	choices: {label: string; name: string}[];
+	choices: {
+		additionCount?: number;
+		deletionCount?: number;
+		label: string;
+		name: string;
+	}[];
 	label: string;
 	name: string;
 	type: 'Choice';

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/contentSelection.ts
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/contentSelection.ts
@@ -6,6 +6,7 @@
 import {sub} from 'frontend-js-web';
 
 import {
+	PreviewPortletDataHandler,
 	PreviewPortletDataHandlerBoolean,
 	PreviewPortletDataHandlerControl,
 	PreviewPortletDataHandlerSection,
@@ -27,6 +28,10 @@ export const COMPACT_SECTION_NAMES = [
 
 export const LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY =
 	'PORTLET_DATA_com_liferay_layout_admin_web_portlet_LayoutSetLayoutsPortlet';
+
+export const PRIVATE_PAGES_CONTROL_NAME = 'privateLayoutPages';
+
+export const PUBLIC_PAGES_CONTROL_NAME = 'publicLayoutPages';
 
 export const SCROLLABLE_SECTION_NAMES = ['objects'];
 
@@ -280,4 +285,178 @@ export function toProcessRequestFlags(
 		siteTemplateSettings: !!lookAndFeel.siteTemplateSettings,
 		themeSettings: !!lookAndFeel.themeSettings,
 	};
+}
+
+export function getLayoutSetHandler(
+	sections: PreviewPortletDataHandlerSection[]
+): PreviewPortletDataHandler | undefined {
+	for (const section of sections) {
+		const handler = section.previewPortletDataHandlers?.find(
+			(previewPortletDataHandler) =>
+				previewPortletDataHandler.name ===
+				LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY
+		);
+
+		if (handler) {
+			return handler;
+		}
+	}
+
+	return undefined;
+}
+
+export function getLayoutSetCount(
+	sections: PreviewPortletDataHandlerSection[],
+	privateLayout: boolean,
+	key: 'additionCount' | 'deletionCount' = 'additionCount'
+): number | undefined {
+	const handler = getLayoutSetHandler(sections);
+
+	if (!handler) {
+		return undefined;
+	}
+
+	const choiceControl = handler.previewPortletDataHandlerControls?.find(
+		(previewPortletDataHandlerControl) =>
+			previewPortletDataHandlerControl.type === 'Choice'
+	);
+
+	if (choiceControl?.type === 'Choice') {
+		const choiceName = privateLayout
+			? PRIVATE_PAGES_CONTROL_NAME
+			: PUBLIC_PAGES_CONTROL_NAME;
+
+		const choice = choiceControl.choices.find(
+			({name}) => name === choiceName
+		);
+
+		if (choice) {
+			return choice[key];
+		}
+	}
+
+	return handler[key];
+}
+
+export function isPrivateLayoutSelected(
+	contentSelection: ContentSelection | undefined
+): boolean {
+	if (!contentSelection) {
+		return false;
+	}
+
+	for (const sectionSelection of Object.values(contentSelection)) {
+		const selection = sectionSelection?.[
+			LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY
+		] as {privateLayout?: boolean} | undefined;
+
+		if (selection && typeof selection === 'object') {
+			return selection.privateLayout === true;
+		}
+	}
+
+	return false;
+}
+
+export function getSelectedItemsCount(
+	additionCount: number | undefined,
+	sections: PreviewPortletDataHandlerSection[],
+	contentSelection: ContentSelection | undefined
+): number | undefined {
+	if (additionCount === undefined) {
+		return undefined;
+	}
+
+	return (
+		additionCount +
+		getLayoutSetCountDelta(sections, contentSelection, 'additionCount')
+	);
+}
+
+export function getSelectedDeletionCount(
+	deletionCount: number | undefined,
+	sections: PreviewPortletDataHandlerSection[],
+	contentSelection: ContentSelection | undefined
+): number | undefined {
+	if (deletionCount === undefined) {
+		return undefined;
+	}
+
+	return (
+		deletionCount +
+		getLayoutSetCountDelta(sections, contentSelection, 'deletionCount')
+	);
+}
+
+export function getLayoutSetCountDelta(
+	sections: PreviewPortletDataHandlerSection[],
+	contentSelection: ContentSelection | undefined,
+	key: 'additionCount' | 'deletionCount' = 'additionCount'
+): number {
+	const privateLayout = isPrivateLayoutSelected(contentSelection);
+
+	const publicCount = getLayoutSetCount(sections, false, key) ?? 0;
+	const selectedCount = getLayoutSetCount(sections, privateLayout, key) ?? 0;
+
+	return selectedCount - publicCount;
+}
+
+export function withSelectedLayoutSetCount(
+	sections: PreviewPortletDataHandlerSection[],
+	contentSelection: ContentSelection | undefined
+): PreviewPortletDataHandlerSection[] {
+	const additionCountDelta = getLayoutSetCountDelta(
+		sections,
+		contentSelection,
+		'additionCount'
+	);
+	const deletionCountDelta = getLayoutSetCountDelta(
+		sections,
+		contentSelection,
+		'deletionCount'
+	);
+
+	if (!additionCountDelta && !deletionCountDelta) {
+		return sections;
+	}
+
+	const privateLayout = isPrivateLayoutSelected(contentSelection);
+
+	const selectedAdditionCount = getLayoutSetCount(
+		sections,
+		privateLayout,
+		'additionCount'
+	);
+	const selectedDeletionCount = getLayoutSetCount(
+		sections,
+		privateLayout,
+		'deletionCount'
+	);
+
+	return sections.map((section) => {
+		if (
+			!section.previewPortletDataHandlers?.some(
+				(handler) =>
+					handler.name === LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY
+			)
+		) {
+			return section;
+		}
+
+		return {
+			...section,
+			additionCount: (section.additionCount ?? 0) + additionCountDelta,
+			deletionCount: (section.deletionCount ?? 0) + deletionCountDelta,
+			previewPortletDataHandlers: section.previewPortletDataHandlers.map(
+				(handler) =>
+					handler.name === LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY
+						? {
+								...handler,
+								additionCount: selectedAdditionCount,
+								deletionCount: selectedDeletionCount,
+							}
+						: handler
+			),
+		};
+	});
 }

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/contentSelection.ts
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/contentSelection.ts
@@ -14,9 +14,9 @@ import {
 
 import type {ContentSelection} from '../components/forms/content_selector/ContentSelector';
 
-export type HandlerSelection =
+export type PortletDataHandlerSelection =
 	| {
-			[key: string]: HandlerSelection | boolean | number[];
+			[key: string]: PortletDataHandlerSelection | boolean | number[];
 	  }
 	| string
 	| true;
@@ -43,75 +43,111 @@ export const SECTION_KEY_CONTENT_AND_DATA =
 export const SECTION_KEY_SITE_BUILDER = 'category.site_administration.build';
 
 export function isAllLayoutsSelected(
-	value: HandlerSelection | undefined
+	portletDataHandlerSelection: PortletDataHandlerSelection | undefined
 ): boolean {
-	return typeof value === 'object' && !value.layoutIds;
+	return (
+		typeof portletDataHandlerSelection === 'object' &&
+		!portletDataHandlerSelection.layoutIds
+	);
 }
 
 export function isSelected(
-	value: HandlerSelection | undefined,
-	entry: PreviewPortletDataHandlerControl
+	portletDataHandlerSelection: PortletDataHandlerSelection | undefined,
+	previewPortletDataHandlerControl: PreviewPortletDataHandlerControl
 ): boolean {
-	if (!value) {
+	if (!portletDataHandlerSelection) {
 		return false;
 	}
 
-	if (entry.name === LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY) {
-		return isAllLayoutsSelected(value);
+	if (
+		previewPortletDataHandlerControl.name ===
+		LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY
+	) {
+		return isAllLayoutsSelected(portletDataHandlerSelection);
 	}
 
-	if (entry.type === 'Choice') {
+	if (previewPortletDataHandlerControl.type === 'Choice') {
 		return true;
 	}
 
 	if (
-		!entry.previewPortletDataHandlerControls?.length ||
-		typeof value !== 'object'
+		!previewPortletDataHandlerControl.previewPortletDataHandlerControls
+			?.length ||
+		typeof portletDataHandlerSelection !== 'object'
 	) {
 		return true;
 	}
 
-	return entry.previewPortletDataHandlerControls.every((control) =>
-		isSelected(value[control.name] as HandlerSelection, control)
+	return previewPortletDataHandlerControl.previewPortletDataHandlerControls.every(
+		(previewPortletDataHandlerControl) =>
+			isSelected(
+				portletDataHandlerSelection[
+					previewPortletDataHandlerControl.name
+				] as PortletDataHandlerSelection,
+				previewPortletDataHandlerControl
+			)
 	);
 }
 
-export function getHandlerSelection(
-	entry: PreviewPortletDataHandlerControl
-): HandlerSelection {
-	if (entry.name === LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY) {
+export function getPortletDataHandlerSelection(
+	previewPortletDataHandlerControl: PreviewPortletDataHandlerControl
+): PortletDataHandlerSelection {
+	if (
+		previewPortletDataHandlerControl.name ===
+		LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY
+	) {
 		return {privateLayout: false};
 	}
 
-	if (entry.type === 'Choice') {
-		return entry.choices[0].name;
+	if (previewPortletDataHandlerControl.type === 'Choice') {
+		return previewPortletDataHandlerControl.choices[0].name;
 	}
 
-	if (!entry.previewPortletDataHandlerControls?.length) {
+	if (
+		!previewPortletDataHandlerControl.previewPortletDataHandlerControls
+			?.length
+	) {
 		return true;
 	}
 
-	return getHandlerSelections(entry.previewPortletDataHandlerControls);
+	return getPortletDataHandlerSelections(
+		previewPortletDataHandlerControl.previewPortletDataHandlerControls
+	);
 }
 
-export function getHandlerSelections(
-	controls: PreviewPortletDataHandlerControl[]
-): Record<string, HandlerSelection> {
+export function getPortletDataHandlerSelections(
+	previewPortletDataHandlerControls: PreviewPortletDataHandlerControl[]
+): Record<string, PortletDataHandlerSelection> {
 	return Object.fromEntries(
-		controls.map((control) => [control.name, getHandlerSelection(control)])
+		previewPortletDataHandlerControls.map(
+			(previewPortletDataHandlerControl) => [
+				previewPortletDataHandlerControl.name,
+				getPortletDataHandlerSelection(
+					previewPortletDataHandlerControl
+				),
+			]
+		)
 	);
 }
 
 export function getSectionPreviewPortletDataHandlers(
-	section: PreviewPortletDataHandlerSection,
+	previewPortletDataHandlerSection: PreviewPortletDataHandlerSection,
 	{lookAndFeelEnabled = false}: {lookAndFeelEnabled?: boolean} = {}
 ): PreviewPortletDataHandlerBoolean[] {
 	const previewPortletDataHandlers =
-		section.previewPortletDataHandlers.map<PreviewPortletDataHandlerBoolean>(
-			(handler) => ({...handler, type: 'Boolean'})
+		previewPortletDataHandlerSection.previewPortletDataHandlers.map<PreviewPortletDataHandlerBoolean>(
+			(previewPortletDataHandler) => ({
+				...previewPortletDataHandler,
+				type: 'Boolean',
+			})
 		);
 
-	if (!(lookAndFeelEnabled && section.name === SECTION_KEY_SITE_BUILDER)) {
+	if (
+		!(
+			lookAndFeelEnabled &&
+			previewPortletDataHandlerSection.name === SECTION_KEY_SITE_BUILDER
+		)
+	) {
 		return previewPortletDataHandlers;
 	}
 
@@ -148,29 +184,35 @@ export function getSectionPreviewPortletDataHandlers(
 }
 
 export function getSectionSelection(
-	section: PreviewPortletDataHandlerSection,
+	previewPortletDataHandlerSection: PreviewPortletDataHandlerSection,
 	{
 		commentsAndRatingsEnabled = false,
 		lookAndFeelEnabled = false,
 	}: {commentsAndRatingsEnabled?: boolean; lookAndFeelEnabled?: boolean} = {}
-): Record<string, HandlerSelection> {
-	const selection = getHandlerSelections(
-		getSectionPreviewPortletDataHandlers(section, {lookAndFeelEnabled})
+): Record<string, PortletDataHandlerSelection> {
+	const portletDataHandlerSelections = getPortletDataHandlerSelections(
+		getSectionPreviewPortletDataHandlers(previewPortletDataHandlerSection, {
+			lookAndFeelEnabled,
+		})
 	);
 
 	if (
 		commentsAndRatingsEnabled &&
-		(section.name === SECTION_KEY_CONTENT ||
-			section.name === SECTION_KEY_CONTENT_AND_DATA)
+		(previewPortletDataHandlerSection.name === SECTION_KEY_CONTENT ||
+			previewPortletDataHandlerSection.name ===
+				SECTION_KEY_CONTENT_AND_DATA)
 	) {
-		selection.commentsAndRatings = {comments: true, ratings: true};
+		portletDataHandlerSelections.commentsAndRatings = {
+			comments: true,
+			ratings: true,
+		};
 	}
 
-	return selection;
+	return portletDataHandlerSelections;
 }
 
 export function getFullDataSelection(
-	sections: PreviewPortletDataHandlerSection[],
+	previewPortletDataHandlerSections: PreviewPortletDataHandlerSection[],
 	{
 		commentsAndRatingsEnabled = false,
 		lookAndFeelEnabled = false,
@@ -182,15 +224,16 @@ export function getFullDataSelection(
 	} = {}
 ): ContentSelection {
 	return Object.fromEntries(
-		getVisibleSections(sections, {lookAndFeelEnabled, showDeletions}).map(
-			(section) => [
-				section.name,
-				getSectionSelection(section, {
-					commentsAndRatingsEnabled,
-					lookAndFeelEnabled,
-				}),
-			]
-		)
+		getVisibleSections(previewPortletDataHandlerSections, {
+			lookAndFeelEnabled,
+			showDeletions,
+		}).map((previewPortletDataHandlerSection) => [
+			previewPortletDataHandlerSection.name,
+			getSectionSelection(previewPortletDataHandlerSection, {
+				commentsAndRatingsEnabled,
+				lookAndFeelEnabled,
+			}),
+		])
 	);
 }
 
@@ -206,12 +249,20 @@ export function updateSelection<V>(
 }
 
 export function getSelectionSummary(
-	controls: {label: string; name: string}[],
-	selection: Record<string, HandlerSelection>
+	previewPortletDataHandlerControls: {label: string; name: string}[],
+	portletDataHandlerSelections: Record<string, PortletDataHandlerSelection>
 ): string {
-	const selectedLabels = controls
-		.filter((control) => selection[control.name] !== undefined)
-		.map((control) => control.label);
+	const selectedLabels = previewPortletDataHandlerControls
+		.filter(
+			(previewPortletDataHandlerControl) =>
+				portletDataHandlerSelections[
+					previewPortletDataHandlerControl.name
+				] !== undefined
+		)
+		.map(
+			(previewPortletDataHandlerControl) =>
+				previewPortletDataHandlerControl.label
+		);
 
 	if (selectedLabels.length) {
 		return sub(
@@ -220,7 +271,10 @@ export function getSelectionSummary(
 		);
 	}
 
-	const labels = controls.map((control) => control.label);
+	const labels = previewPortletDataHandlerControls.map(
+		(previewPortletDataHandlerControl) =>
+			previewPortletDataHandlerControl.label
+	);
 
 	if (labels.length) {
 		return sub(Liferay.Language.get('select-x'), labels.join(', '));
@@ -230,15 +284,21 @@ export function getSelectionSummary(
 }
 
 export function withSiteBuilderSection(
-	sections: PreviewPortletDataHandlerSection[],
+	previewPortletDataHandlerSections: PreviewPortletDataHandlerSection[],
 	label = ''
 ): PreviewPortletDataHandlerSection[] {
-	if (sections.some((section) => section.name === SECTION_KEY_SITE_BUILDER)) {
-		return sections;
+	if (
+		previewPortletDataHandlerSections.some(
+			(previewPortletDataHandlerSection) =>
+				previewPortletDataHandlerSection.name ===
+				SECTION_KEY_SITE_BUILDER
+		)
+	) {
+		return previewPortletDataHandlerSections;
 	}
 
 	return [
-		...sections,
+		...previewPortletDataHandlerSections,
 		{
 			label,
 			name: SECTION_KEY_SITE_BUILDER,
@@ -248,15 +308,17 @@ export function withSiteBuilderSection(
 }
 
 export function getVisibleSections(
-	sections: PreviewPortletDataHandlerSection[],
+	previewPortletDataHandlerSections: PreviewPortletDataHandlerSection[],
 	{
 		lookAndFeelEnabled = false,
 		showDeletions = false,
 	}: {lookAndFeelEnabled?: boolean; showDeletions?: boolean} = {}
 ): PreviewPortletDataHandlerSection[] {
-	const filteredSections = sections.filter(
-		(section) =>
-			showDeletions || !!section.additionCount || !section.deletionCount
+	const filteredSections = previewPortletDataHandlerSections.filter(
+		(previewPortletDataHandlerSection) =>
+			showDeletions ||
+			!!previewPortletDataHandlerSection.additionCount ||
+			!previewPortletDataHandlerSection.deletionCount
 	);
 
 	return lookAndFeelEnabled
@@ -287,18 +349,19 @@ export function toProcessRequestFlags(
 	};
 }
 
-export function getLayoutSetHandler(
-	sections: PreviewPortletDataHandlerSection[]
+export function getLayoutSetPreviewPortletDataHandler(
+	previewPortletDataHandlerSections: PreviewPortletDataHandlerSection[]
 ): PreviewPortletDataHandler | undefined {
-	for (const section of sections) {
-		const handler = section.previewPortletDataHandlers?.find(
-			(previewPortletDataHandler) =>
-				previewPortletDataHandler.name ===
-				LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY
-		);
+	for (const previewPortletDataHandlerSection of previewPortletDataHandlerSections) {
+		const previewPortletDataHandler =
+			previewPortletDataHandlerSection.previewPortletDataHandlers?.find(
+				(previewPortletDataHandler) =>
+					previewPortletDataHandler.name ===
+					LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY
+			);
 
-		if (handler) {
-			return handler;
+		if (previewPortletDataHandler) {
+			return previewPortletDataHandler;
 		}
 	}
 
@@ -306,20 +369,23 @@ export function getLayoutSetHandler(
 }
 
 export function getLayoutSetCount(
-	sections: PreviewPortletDataHandlerSection[],
+	previewPortletDataHandlerSections: PreviewPortletDataHandlerSection[],
 	privateLayout: boolean,
 	key: 'additionCount' | 'deletionCount' = 'additionCount'
 ): number | undefined {
-	const handler = getLayoutSetHandler(sections);
+	const previewPortletDataHandler = getLayoutSetPreviewPortletDataHandler(
+		previewPortletDataHandlerSections
+	);
 
-	if (!handler) {
+	if (!previewPortletDataHandler) {
 		return undefined;
 	}
 
-	const choiceControl = handler.previewPortletDataHandlerControls?.find(
-		(previewPortletDataHandlerControl) =>
-			previewPortletDataHandlerControl.type === 'Choice'
-	);
+	const choiceControl =
+		previewPortletDataHandler.previewPortletDataHandlerControls?.find(
+			(previewPortletDataHandlerControl) =>
+				previewPortletDataHandlerControl.type === 'Choice'
+		);
 
 	if (choiceControl?.type === 'Choice') {
 		const choiceName = privateLayout
@@ -335,7 +401,7 @@ export function getLayoutSetCount(
 		}
 	}
 
-	return handler[key];
+	return previewPortletDataHandler[key];
 }
 
 export function isPrivateLayoutSelected(
@@ -346,12 +412,15 @@ export function isPrivateLayoutSelected(
 	}
 
 	for (const sectionSelection of Object.values(contentSelection)) {
-		const selection = sectionSelection?.[
+		const portletDataHandlerSelection = sectionSelection?.[
 			LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY
 		] as {privateLayout?: boolean} | undefined;
 
-		if (selection && typeof selection === 'object') {
-			return selection.privateLayout === true;
+		if (
+			portletDataHandlerSelection &&
+			typeof portletDataHandlerSelection === 'object'
+		) {
+			return portletDataHandlerSelection.privateLayout === true;
 		}
 	}
 
@@ -360,7 +429,7 @@ export function isPrivateLayoutSelected(
 
 export function getSelectedItemsCount(
 	additionCount: number | undefined,
-	sections: PreviewPortletDataHandlerSection[],
+	previewPortletDataHandlerSections: PreviewPortletDataHandlerSection[],
 	contentSelection: ContentSelection | undefined
 ): number | undefined {
 	if (additionCount === undefined) {
@@ -369,13 +438,17 @@ export function getSelectedItemsCount(
 
 	return (
 		additionCount +
-		getLayoutSetCountDelta(sections, contentSelection, 'additionCount')
+		getLayoutSetCountDelta(
+			previewPortletDataHandlerSections,
+			contentSelection,
+			'additionCount'
+		)
 	);
 }
 
 export function getSelectedDeletionCount(
 	deletionCount: number | undefined,
-	sections: PreviewPortletDataHandlerSection[],
+	previewPortletDataHandlerSections: PreviewPortletDataHandlerSection[],
 	contentSelection: ContentSelection | undefined
 ): number | undefined {
 	if (deletionCount === undefined) {
@@ -384,79 +457,98 @@ export function getSelectedDeletionCount(
 
 	return (
 		deletionCount +
-		getLayoutSetCountDelta(sections, contentSelection, 'deletionCount')
+		getLayoutSetCountDelta(
+			previewPortletDataHandlerSections,
+			contentSelection,
+			'deletionCount'
+		)
 	);
 }
 
 export function getLayoutSetCountDelta(
-	sections: PreviewPortletDataHandlerSection[],
+	previewPortletDataHandlerSections: PreviewPortletDataHandlerSection[],
 	contentSelection: ContentSelection | undefined,
 	key: 'additionCount' | 'deletionCount' = 'additionCount'
 ): number {
 	const privateLayout = isPrivateLayoutSelected(contentSelection);
 
-	const publicCount = getLayoutSetCount(sections, false, key) ?? 0;
-	const selectedCount = getLayoutSetCount(sections, privateLayout, key) ?? 0;
+	const publicCount =
+		getLayoutSetCount(previewPortletDataHandlerSections, false, key) ?? 0;
+	const selectedCount =
+		getLayoutSetCount(
+			previewPortletDataHandlerSections,
+			privateLayout,
+			key
+		) ?? 0;
 
 	return selectedCount - publicCount;
 }
 
 export function withSelectedLayoutSetCount(
-	sections: PreviewPortletDataHandlerSection[],
+	previewPortletDataHandlerSections: PreviewPortletDataHandlerSection[],
 	contentSelection: ContentSelection | undefined
 ): PreviewPortletDataHandlerSection[] {
 	const additionCountDelta = getLayoutSetCountDelta(
-		sections,
+		previewPortletDataHandlerSections,
 		contentSelection,
 		'additionCount'
 	);
 	const deletionCountDelta = getLayoutSetCountDelta(
-		sections,
+		previewPortletDataHandlerSections,
 		contentSelection,
 		'deletionCount'
 	);
 
 	if (!additionCountDelta && !deletionCountDelta) {
-		return sections;
+		return previewPortletDataHandlerSections;
 	}
 
 	const privateLayout = isPrivateLayoutSelected(contentSelection);
 
 	const selectedAdditionCount = getLayoutSetCount(
-		sections,
+		previewPortletDataHandlerSections,
 		privateLayout,
 		'additionCount'
 	);
 	const selectedDeletionCount = getLayoutSetCount(
-		sections,
+		previewPortletDataHandlerSections,
 		privateLayout,
 		'deletionCount'
 	);
 
-	return sections.map((section) => {
-		if (
-			!section.previewPortletDataHandlers?.some(
-				(handler) =>
-					handler.name === LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY
-			)
-		) {
-			return section;
-		}
+	return previewPortletDataHandlerSections.map(
+		(previewPortletDataHandlerSection) => {
+			if (
+				!previewPortletDataHandlerSection.previewPortletDataHandlers?.some(
+					(previewPortletDataHandler) =>
+						previewPortletDataHandler.name ===
+						LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY
+				)
+			) {
+				return previewPortletDataHandlerSection;
+			}
 
-		return {
-			...section,
-			additionCount: (section.additionCount ?? 0) + additionCountDelta,
-			deletionCount: (section.deletionCount ?? 0) + deletionCountDelta,
-			previewPortletDataHandlers: section.previewPortletDataHandlers.map(
-				(handler) =>
-					handler.name === LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY
-						? {
-								...handler,
-								additionCount: selectedAdditionCount,
-								deletionCount: selectedDeletionCount,
-							}
-						: handler
-			),
-		};
-	});
+			return {
+				...previewPortletDataHandlerSection,
+				additionCount:
+					(previewPortletDataHandlerSection.additionCount ?? 0) +
+					additionCountDelta,
+				deletionCount:
+					(previewPortletDataHandlerSection.deletionCount ?? 0) +
+					deletionCountDelta,
+				previewPortletDataHandlers:
+					previewPortletDataHandlerSection.previewPortletDataHandlers.map(
+						(previewPortletDataHandler) =>
+							previewPortletDataHandler.name ===
+							LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY
+								? {
+										...previewPortletDataHandler,
+										additionCount: selectedAdditionCount,
+										deletionCount: selectedDeletionCount,
+									}
+								: previewPortletDataHandler
+					),
+			};
+		}
+	);
 }

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/contentSelection.ts
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/contentSelection.ts
@@ -307,6 +307,15 @@ export function withSiteBuilderSection(
 	];
 }
 
+function isDeletionOnlySection(
+	previewPortletDataHandlerSection: PreviewPortletDataHandlerSection
+): boolean {
+	return (
+		!previewPortletDataHandlerSection.additionCount &&
+		!!previewPortletDataHandlerSection.deletionCount
+	);
+}
+
 export function getVisibleSections(
 	previewPortletDataHandlerSections: PreviewPortletDataHandlerSection[],
 	{
@@ -317,8 +326,7 @@ export function getVisibleSections(
 	const filteredSections = previewPortletDataHandlerSections.filter(
 		(previewPortletDataHandlerSection) =>
 			showDeletions ||
-			!!previewPortletDataHandlerSection.additionCount ||
-			!previewPortletDataHandlerSection.deletionCount
+			!isDeletionOnlySection(previewPortletDataHandlerSection)
 	);
 
 	return lookAndFeelEnabled

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/contentSelection.ts
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/contentSelection.ts
@@ -21,6 +21,11 @@ export type PortletDataHandlerSelection =
 	| string
 	| true;
 
+export interface LayoutSetSelection {
+	layoutIds?: number[];
+	privateLayout?: boolean;
+}
+
 export const COMPACT_SECTION_NAMES = [
 	'category.control_panel.users',
 	'objects',
@@ -422,13 +427,10 @@ export function isPrivateLayoutSelected(
 	for (const sectionSelection of Object.values(contentSelection)) {
 		const portletDataHandlerSelection = sectionSelection?.[
 			LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY
-		] as {privateLayout?: boolean} | undefined;
+		] as LayoutSetSelection | undefined;
 
-		if (
-			portletDataHandlerSelection &&
-			typeof portletDataHandlerSelection === 'object'
-		) {
-			return portletDataHandlerSelection.privateLayout === true;
+		if (portletDataHandlerSelection) {
+			return !!portletDataHandlerSelection.privateLayout;
 		}
 	}
 

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/toRequestPortletDataHandlers.ts
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/toRequestPortletDataHandlers.ts
@@ -13,6 +13,8 @@ import {
 import {
 	HandlerSelection,
 	LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY,
+	PRIVATE_PAGES_CONTROL_NAME,
+	PUBLIC_PAGES_CONTROL_NAME,
 } from './contentSelection';
 
 export function toRequestPortletDataHandlers(
@@ -121,32 +123,20 @@ function toLayoutSetRequestHandler(
 		return {name};
 	}
 
-	const {layoutIds, privateLayout} = selection as {
+	const {layoutIds, privateLayout = false} = selection as {
 		layoutIds?: number[];
 		privateLayout?: boolean;
 	};
 
-	const requestPortletDataHandlerControls: RequestPortletDataHandlerControl[] =
-		[];
-
-	if (privateLayout !== undefined) {
-		requestPortletDataHandlerControls.push({
-			name: 'privateLayout',
-			values: [String(privateLayout)],
-		});
-	}
-
-	if (layoutIds?.length) {
-		requestPortletDataHandlerControls.push({
-			name: 'layoutIds',
-			values: layoutIds.map(String),
-		});
-	}
+	const requestPortletDataHandlerControl: RequestPortletDataHandlerControl = {
+		name: privateLayout
+			? PRIVATE_PAGES_CONTROL_NAME
+			: PUBLIC_PAGES_CONTROL_NAME,
+		...(layoutIds?.length && {values: layoutIds.map(String)}),
+	};
 
 	return {
 		name,
-		...(requestPortletDataHandlerControls.length && {
-			requestPortletDataHandlerControls,
-		}),
+		requestPortletDataHandlerControls: [requestPortletDataHandlerControl],
 	};
 }

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/toRequestPortletDataHandlers.ts
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/toRequestPortletDataHandlers.ts
@@ -12,6 +12,7 @@ import {
 } from '../types/portletDataHandler';
 import {
 	LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY,
+	LayoutSetSelection,
 	PRIVATE_PAGES_CONTROL_NAME,
 	PUBLIC_PAGES_CONTROL_NAME,
 	PortletDataHandlerSelection,
@@ -150,10 +151,8 @@ function toLayoutSetRequestPortletDataHandler(
 		return {name};
 	}
 
-	const {layoutIds, privateLayout = false} = portletDataHandlerSelection as {
-		layoutIds?: number[];
-		privateLayout?: boolean;
-	};
+	const {layoutIds, privateLayout = false} =
+		portletDataHandlerSelection as LayoutSetSelection;
 
 	const requestPortletDataHandlerControl: RequestPortletDataHandlerControl = {
 		name: privateLayout

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/toRequestPortletDataHandlers.ts
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/revamp/js/utils/toRequestPortletDataHandlers.ts
@@ -11,14 +11,14 @@ import {
 	RequestPortletDataHandlerControl,
 } from '../types/portletDataHandler';
 import {
-	HandlerSelection,
 	LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY,
 	PRIVATE_PAGES_CONTROL_NAME,
 	PUBLIC_PAGES_CONTROL_NAME,
+	PortletDataHandlerSelection,
 } from './contentSelection';
 
 export function toRequestPortletDataHandlers(
-	sections: PreviewPortletDataHandlerSection[],
+	previewPortletDataHandlerSections: PreviewPortletDataHandlerSection[],
 	contentSelection: ContentSelection | undefined
 ): RequestPortletDataHandler[] {
 	if (!contentSelection) {
@@ -27,35 +27,45 @@ export function toRequestPortletDataHandlers(
 
 	const requestPortletDataHandlers: RequestPortletDataHandler[] = [];
 
-	for (const section of sections) {
-		const sectionSelection = contentSelection[section.name];
+	for (const previewPortletDataHandlerSection of previewPortletDataHandlerSections) {
+		const sectionSelection =
+			contentSelection[previewPortletDataHandlerSection.name];
 
 		if (!sectionSelection) {
 			continue;
 		}
 
-		for (const handler of section.previewPortletDataHandlers ?? []) {
-			const handlerSelection = sectionSelection[handler.name];
+		for (const previewPortletDataHandler of previewPortletDataHandlerSection.previewPortletDataHandlers ??
+			[]) {
+			const portletDataHandlerSelection =
+				sectionSelection[previewPortletDataHandler.name];
 
-			if (!handlerSelection) {
+			if (!portletDataHandlerSelection) {
 				continue;
 			}
 
-			if (handler.name === LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY) {
+			if (
+				previewPortletDataHandler.name ===
+				LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY
+			) {
 				requestPortletDataHandlers.push(
-					toLayoutSetRequestHandler(handler.name, handlerSelection)
+					toLayoutSetRequestPortletDataHandler(
+						previewPortletDataHandler.name,
+						portletDataHandlerSelection
+					)
 				);
 
 				continue;
 			}
 
-			const requestPortletDataHandlerControls = toRequestControls(
-				handler.previewPortletDataHandlerControls,
-				handlerSelection
-			);
+			const requestPortletDataHandlerControls =
+				toRequestPortletDataHandlerControls(
+					previewPortletDataHandler.previewPortletDataHandlerControls,
+					portletDataHandlerSelection
+				);
 
 			requestPortletDataHandlers.push({
-				name: handler.name,
+				name: previewPortletDataHandler.name,
 				...(requestPortletDataHandlerControls.length && {
 					requestPortletDataHandlerControls,
 				}),
@@ -66,64 +76,81 @@ export function toRequestPortletDataHandlers(
 	return requestPortletDataHandlers;
 }
 
-function toRequestControls(
-	controls: PreviewPortletDataHandlerControl[] | undefined,
-	selection: HandlerSelection
+function toRequestPortletDataHandlerControls(
+	previewPortletDataHandlerControls:
+		| PreviewPortletDataHandlerControl[]
+		| undefined,
+	portletDataHandlerSelection: PortletDataHandlerSelection
 ): RequestPortletDataHandlerControl[] {
-	if (!controls || typeof selection !== 'object') {
+	if (
+		!previewPortletDataHandlerControls ||
+		typeof portletDataHandlerSelection !== 'object'
+	) {
 		return [];
 	}
 
-	const map = selection as Record<string, HandlerSelection>;
-	const result: RequestPortletDataHandlerControl[] = [];
+	const portletDataHandlerSelections = portletDataHandlerSelection as Record<
+		string,
+		PortletDataHandlerSelection
+	>;
+	const requestPortletDataHandlerControls: RequestPortletDataHandlerControl[] =
+		[];
 
-	for (const control of controls) {
-		const value = map[control.name];
+	for (const previewPortletDataHandlerControl of previewPortletDataHandlerControls) {
+		const nestedPortletDataHandlerSelection =
+			portletDataHandlerSelections[previewPortletDataHandlerControl.name];
 
-		if (!value) {
+		if (!nestedPortletDataHandlerSelection) {
 			continue;
 		}
 
-		if (typeof value === 'string') {
-			result.push({name: control.name, values: [value]});
+		if (typeof nestedPortletDataHandlerSelection === 'string') {
+			requestPortletDataHandlerControls.push({
+				name: previewPortletDataHandlerControl.name,
+				values: [nestedPortletDataHandlerSelection],
+			});
 
 			continue;
 		}
 
-		if (value === true) {
-			result.push({name: control.name});
+		if (nestedPortletDataHandlerSelection === true) {
+			requestPortletDataHandlerControls.push({
+				name: previewPortletDataHandlerControl.name,
+			});
 
 			continue;
 		}
 
-		const nested =
-			'previewPortletDataHandlerControls' in control
-				? toRequestControls(
-						control.previewPortletDataHandlerControls,
-						value as HandlerSelection
+		const nestedRequestPortletDataHandlerControls =
+			'previewPortletDataHandlerControls' in
+			previewPortletDataHandlerControl
+				? toRequestPortletDataHandlerControls(
+						previewPortletDataHandlerControl.previewPortletDataHandlerControls,
+						nestedPortletDataHandlerSelection as PortletDataHandlerSelection
 					)
 				: [];
 
-		result.push({
-			name: control.name,
-			...(nested.length && {
-				requestPortletDataHandlerControls: nested,
+		requestPortletDataHandlerControls.push({
+			name: previewPortletDataHandlerControl.name,
+			...(nestedRequestPortletDataHandlerControls.length && {
+				requestPortletDataHandlerControls:
+					nestedRequestPortletDataHandlerControls,
 			}),
 		});
 	}
 
-	return result;
+	return requestPortletDataHandlerControls;
 }
 
-function toLayoutSetRequestHandler(
+function toLayoutSetRequestPortletDataHandler(
 	name: string,
-	selection: HandlerSelection
+	portletDataHandlerSelection: PortletDataHandlerSelection
 ): RequestPortletDataHandler {
-	if (typeof selection !== 'object') {
+	if (typeof portletDataHandlerSelection !== 'object') {
 		return {name};
 	}
 
-	const {layoutIds, privateLayout = false} = selection as {
+	const {layoutIds, privateLayout = false} = portletDataHandlerSelection as {
 		layoutIds?: number[];
 		privateLayout?: boolean;
 	};

--- a/modules/apps/export-import/export-import-web/test/revamp/js/components/forms/content_selector/ContentSection.test.tsx
+++ b/modules/apps/export-import/export-import-web/test/revamp/js/components/forms/content_selector/ContentSection.test.tsx
@@ -10,7 +10,7 @@ import ContentSection from '../../../../../../src/main/resources/META-INF/resour
 import {PreviewPortletDataHandlerSection} from '../../../../../../src/main/resources/META-INF/resources/revamp/js/types/portletDataHandler';
 import {SECTION_KEY_CONTENT} from '../../../../../../src/main/resources/META-INF/resources/revamp/js/utils/contentSelection';
 
-function makeSection(
+function getPreviewPortletDataHandlerSection(
 	name: string,
 	counts: {additionCount?: number; deletionCount?: number} = {}
 ): PreviewPortletDataHandlerSection {
@@ -22,7 +22,7 @@ function makeSection(
 	};
 }
 
-const contentSection: PreviewPortletDataHandlerSection = {
+const previewPortletDataHandlerSection: PreviewPortletDataHandlerSection = {
 	label: SECTION_KEY_CONTENT,
 	name: SECTION_KEY_CONTENT,
 	previewPortletDataHandlers: [
@@ -42,8 +42,10 @@ describe('ContentSection', () => {
 		const {container} = render(
 			<ContentSection
 				onChange={jest.fn()}
-				section={makeSection('objects')}
-				value={undefined}
+				previewPortletDataHandlerSection={getPreviewPortletDataHandlerSection(
+					'objects'
+				)}
+				sectionSelection={undefined}
 			/>
 		);
 
@@ -56,8 +58,10 @@ describe('ContentSection', () => {
 		const {container} = render(
 			<ContentSection
 				onChange={jest.fn()}
-				section={makeSection('web-content')}
-				value={undefined}
+				previewPortletDataHandlerSection={getPreviewPortletDataHandlerSection(
+					'web-content'
+				)}
+				sectionSelection={undefined}
 			/>
 		);
 
@@ -68,12 +72,15 @@ describe('ContentSection', () => {
 		const {queryByText} = render(
 			<ContentSection
 				onChange={jest.fn()}
-				section={makeSection('web-content', {
-					additionCount: 1,
-					deletionCount: 1,
-				})}
+				previewPortletDataHandlerSection={getPreviewPortletDataHandlerSection(
+					'web-content',
+					{
+						additionCount: 1,
+						deletionCount: 1,
+					}
+				)}
+				sectionSelection={undefined}
 				showDeletions
-				value={undefined}
 			/>
 		);
 
@@ -88,8 +95,10 @@ describe('ContentSection', () => {
 			<ContentSection
 				commentsAndRatingsEnabled
 				onChange={jest.fn()}
-				section={contentSection}
-				value={undefined}
+				previewPortletDataHandlerSection={
+					previewPortletDataHandlerSection
+				}
+				sectionSelection={undefined}
 			/>
 		);
 
@@ -101,8 +110,10 @@ describe('ContentSection', () => {
 			<ContentSection
 				commentsAndRatingsEnabled
 				onChange={jest.fn()}
-				section={contentSection}
-				value={{handler: {child1: true, child2: true}}}
+				previewPortletDataHandlerSection={
+					previewPortletDataHandlerSection
+				}
+				sectionSelection={{handler: {child1: true, child2: true}}}
 			/>
 		);
 
@@ -114,8 +125,10 @@ describe('ContentSection', () => {
 			<ContentSection
 				commentsAndRatingsEnabled
 				onChange={jest.fn()}
-				section={contentSection}
-				value={{handler: {child1: true}}}
+				previewPortletDataHandlerSection={
+					previewPortletDataHandlerSection
+				}
+				sectionSelection={{handler: {child1: true}}}
 			/>
 		);
 

--- a/modules/apps/export-import/export-import-web/test/revamp/js/mocks/mockExportPreview.ts
+++ b/modules/apps/export-import/export-import-web/test/revamp/js/mocks/mockExportPreview.ts
@@ -4,10 +4,10 @@
  */
 
 import {ExportPreview} from '../../../../src/main/resources/META-INF/resources/revamp/js/types/exportImportPreview';
-import {mockPortletDataHandlerSections} from './mockPortletDataHandlerSections';
+import {mockPreviewPortletDataHandlerSections} from './mockPortletDataHandlerSections';
 
 export const mockExportPreview: ExportPreview = {
 	additionCount: 42,
 	deletionCount: 5,
-	previewPortletDataHandlerSections: mockPortletDataHandlerSections,
+	previewPortletDataHandlerSections: mockPreviewPortletDataHandlerSections,
 };

--- a/modules/apps/export-import/export-import-web/test/revamp/js/mocks/mockImportPreview.ts
+++ b/modules/apps/export-import/export-import-web/test/revamp/js/mocks/mockImportPreview.ts
@@ -4,7 +4,7 @@
  */
 
 import {ImportPreview} from '../../../../src/main/resources/META-INF/resources/revamp/js/types/exportImportPreview';
-import {mockPortletDataHandlerSections} from './mockPortletDataHandlerSections';
+import {mockPreviewPortletDataHandlerSections} from './mockPortletDataHandlerSections';
 
 export const mockImportPreview: ImportPreview = {
 	additionCount: 42,
@@ -13,5 +13,5 @@ export const mockImportPreview: ImportPreview = {
 	exportDate: '2000-07-27T00:00:00Z',
 	fileName: 'site.lar',
 	fileSize: 4096,
-	previewPortletDataHandlerSections: mockPortletDataHandlerSections,
+	previewPortletDataHandlerSections: mockPreviewPortletDataHandlerSections,
 };

--- a/modules/apps/export-import/export-import-web/test/revamp/js/mocks/mockPortletDataHandlerSections.ts
+++ b/modules/apps/export-import/export-import-web/test/revamp/js/mocks/mockPortletDataHandlerSections.ts
@@ -5,7 +5,7 @@
 
 import {PreviewPortletDataHandlerSection} from '../../../../src/main/resources/META-INF/resources/revamp/js/types/portletDataHandler';
 
-export const mockPortletDataHandlerSections: PreviewPortletDataHandlerSection[] =
+export const mockPreviewPortletDataHandlerSections: PreviewPortletDataHandlerSection[] =
 	[
 		{
 			label: 'Design',

--- a/modules/apps/export-import/export-import-web/test/revamp/js/mocks/mockSectionsForFilterTest.ts
+++ b/modules/apps/export-import/export-import-web/test/revamp/js/mocks/mockSectionsForFilterTest.ts
@@ -5,31 +5,32 @@
 
 import {PreviewPortletDataHandlerSection} from '../../../../src/main/resources/META-INF/resources/revamp/js/types/portletDataHandler';
 
-export const mockSectionsForFilterTest: PreviewPortletDataHandlerSection[] = [
-	{
-		additionCount: 5,
-		deletionCount: 0,
-		label: 'Additions Only',
-		name: 'additions-only',
-		previewPortletDataHandlers: [],
-	},
-	{
-		additionCount: 0,
-		deletionCount: 3,
-		label: 'Deletions Only',
-		name: 'deletions-only',
-		previewPortletDataHandlers: [],
-	},
-	{
-		additionCount: 2,
-		deletionCount: 4,
-		label: 'Both',
-		name: 'both',
-		previewPortletDataHandlers: [],
-	},
-	{
-		label: 'No Counts',
-		name: 'no-counts',
-		previewPortletDataHandlers: [],
-	},
-];
+export const mockPreviewPortletDataHandlerSectionsForFilterTest: PreviewPortletDataHandlerSection[] =
+	[
+		{
+			additionCount: 5,
+			deletionCount: 0,
+			label: 'Additions Only',
+			name: 'additions-only',
+			previewPortletDataHandlers: [],
+		},
+		{
+			additionCount: 0,
+			deletionCount: 3,
+			label: 'Deletions Only',
+			name: 'deletions-only',
+			previewPortletDataHandlers: [],
+		},
+		{
+			additionCount: 2,
+			deletionCount: 4,
+			label: 'Both',
+			name: 'both',
+			previewPortletDataHandlers: [],
+		},
+		{
+			label: 'No Counts',
+			name: 'no-counts',
+			previewPortletDataHandlers: [],
+		},
+	];

--- a/modules/apps/export-import/export-import-web/test/revamp/js/pages/export/NewExport.test.tsx
+++ b/modules/apps/export-import/export-import-web/test/revamp/js/pages/export/NewExport.test.tsx
@@ -396,7 +396,7 @@ describe('NewExport', () => {
 					{
 						name: LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY,
 						requestPortletDataHandlerControls: [
-							{name: 'privateLayout', values: ['false']},
+							{name: 'publicLayoutPages'},
 						],
 					},
 				])
@@ -418,7 +418,7 @@ describe('NewExport', () => {
 			expect(screen.queryAllByRole('radio')).toHaveLength(0);
 
 			await userEvent.click(
-				screen.getByRole('button', {name: 'select-layouts'})
+				screen.getByRole('button', {name: 'select-x'})
 			);
 
 			expect(await screen.findByLabelText('page-1')).toBeChecked();
@@ -434,8 +434,7 @@ describe('NewExport', () => {
 					{
 						name: LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY,
 						requestPortletDataHandlerControls: [
-							{name: 'privateLayout', values: ['false']},
-							{name: 'layoutIds', values: ['1']},
+							{name: 'publicLayoutPages', values: ['1']},
 						],
 					},
 				])
@@ -468,7 +467,7 @@ describe('NewExport', () => {
 					{
 						name: LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY,
 						requestPortletDataHandlerControls: [
-							{name: 'privateLayout', values: ['true']},
+							{name: 'privateLayoutPages'},
 						],
 					},
 				])
@@ -541,8 +540,7 @@ describe('NewExport', () => {
 					{
 						name: LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY,
 						requestPortletDataHandlerControls: [
-							{name: 'privateLayout', values: ['true']},
-							{name: 'layoutIds', values: ['1']},
+							{name: 'privateLayoutPages', values: ['1']},
 						],
 					},
 				])

--- a/modules/apps/export-import/export-import-web/test/revamp/js/pages/export/NewExport.test.tsx
+++ b/modules/apps/export-import/export-import-web/test/revamp/js/pages/export/NewExport.test.tsx
@@ -587,7 +587,8 @@ describe('NewExport', () => {
 			expect(body.siteTemplateSettings).toBe(false);
 
 			const handlerNames = body.requestPortletDataHandlers.map(
-				(handler: {name: string}) => handler.name
+				(previewPortletDataHandler: {name: string}) =>
+					previewPortletDataHandler.name
 			);
 
 			expect(handlerNames).not.toContain('lookAndFeel');
@@ -666,7 +667,8 @@ describe('NewExport', () => {
 			expect(body.ratings).toBe(false);
 
 			const handlerNames = body.requestPortletDataHandlers.map(
-				(handler: {name: string}) => handler.name
+				(previewPortletDataHandler: {name: string}) =>
+					previewPortletDataHandler.name
 			);
 
 			expect(handlerNames).not.toContain('commentsAndRatings');

--- a/modules/apps/export-import/export-import-web/test/revamp/js/pages/export/NewExport.test.tsx
+++ b/modules/apps/export-import/export-import-web/test/revamp/js/pages/export/NewExport.test.tsx
@@ -38,7 +38,7 @@ const DEFAULT_PROPS = {
 	pageTreeModalConfiguration: {
 		liveGroupId: 20121,
 		pageSize: 20,
-		privateLayoutsEnabled: false,
+		privateLayoutsAvailable: false,
 	},
 };
 
@@ -330,7 +330,7 @@ describe('NewExport', () => {
 
 		const privatePageTreeModalConfiguration = {
 			...DEFAULT_PROPS.pageTreeModalConfiguration,
-			privateLayoutsEnabled: true,
+			privateLayoutsAvailable: true,
 		};
 
 		const getExportRequest = () => {

--- a/modules/apps/export-import/export-import-web/test/revamp/js/pages/import/NewImport.test.tsx
+++ b/modules/apps/export-import/export-import-web/test/revamp/js/pages/import/NewImport.test.tsx
@@ -14,7 +14,7 @@ import {postImportPreview} from '../../../../../src/main/resources/META-INF/reso
 import {SCOPES} from '../../../../../src/main/resources/META-INF/resources/revamp/js/types/scope';
 import formatDate from '../../../../../src/main/resources/META-INF/resources/revamp/js/utils/formatDate';
 import {mockImportPreview} from '../../mocks/mockImportPreview';
-import {mockSectionsForFilterTest} from '../../mocks/mockSectionsForFilterTest';
+import {mockPreviewPortletDataHandlerSectionsForFilterTest} from '../../mocks/mockSectionsForFilterTest';
 
 jest.mock(
 	'../../../../../src/main/resources/META-INF/resources/revamp/js/services/postImportPreview',
@@ -378,7 +378,7 @@ describe('NewImport', () => {
 				data: {
 					...mockImportPreview,
 					previewPortletDataHandlerSections:
-						mockSectionsForFilterTest,
+						mockPreviewPortletDataHandlerSectionsForFilterTest,
 				},
 				error: null,
 			})

--- a/modules/apps/export-import/export-import-web/test/revamp/js/utils/contentSelection.test.ts
+++ b/modules/apps/export-import/export-import-web/test/revamp/js/utils/contentSelection.test.ts
@@ -16,7 +16,7 @@ import {
 	withSelectedLayoutSetCount,
 } from '../../../../src/main/resources/META-INF/resources/revamp/js/utils/contentSelection';
 
-function getSections(
+function getPreviewPortletDataHandlerSections(
 	publicAdditionCount: number,
 	privateAdditionCount: number,
 	publicDeletionCount = 0,
@@ -75,17 +75,35 @@ const publicSelection = {
 
 describe('contentSelection layout set counts', () => {
 	it('reads the public and private addition counts from the choices', () => {
-		const sections = getSections(2, 5);
+		const previewPortletDataHandlerSections =
+			getPreviewPortletDataHandlerSections(2, 5);
 
-		expect(getLayoutSetCount(sections, false)).toBe(2);
-		expect(getLayoutSetCount(sections, true)).toBe(5);
+		expect(
+			getLayoutSetCount(previewPortletDataHandlerSections, false)
+		).toBe(2);
+		expect(getLayoutSetCount(previewPortletDataHandlerSections, true)).toBe(
+			5
+		);
 	});
 
 	it('reads the public and private deletion counts from the choices', () => {
-		const sections = getSections(2, 5, 1, 3);
+		const previewPortletDataHandlerSections =
+			getPreviewPortletDataHandlerSections(2, 5, 1, 3);
 
-		expect(getLayoutSetCount(sections, false, 'deletionCount')).toBe(1);
-		expect(getLayoutSetCount(sections, true, 'deletionCount')).toBe(3);
+		expect(
+			getLayoutSetCount(
+				previewPortletDataHandlerSections,
+				false,
+				'deletionCount'
+			)
+		).toBe(1);
+		expect(
+			getLayoutSetCount(
+				previewPortletDataHandlerSections,
+				true,
+				'deletionCount'
+			)
+		).toBe(3);
 	});
 
 	it('detects whether the private layout set is selected', () => {
@@ -95,43 +113,75 @@ describe('contentSelection layout set counts', () => {
 	});
 
 	it('keeps the public counts in the totals when the public set is selected', () => {
-		const sections = getSections(2, 5, 1, 3);
+		const previewPortletDataHandlerSections =
+			getPreviewPortletDataHandlerSections(2, 5, 1, 3);
 
-		expect(getSelectedItemsCount(10, sections, publicSelection)).toBe(10);
-		expect(getSelectedDeletionCount(4, sections, publicSelection)).toBe(4);
+		expect(
+			getSelectedItemsCount(
+				10,
+				previewPortletDataHandlerSections,
+				publicSelection
+			)
+		).toBe(10);
+		expect(
+			getSelectedDeletionCount(
+				4,
+				previewPortletDataHandlerSections,
+				publicSelection
+			)
+		).toBe(4);
 	});
 
 	it('swaps in the private counts in the totals when private is selected', () => {
-		const sections = getSections(2, 5, 1, 3);
+		const previewPortletDataHandlerSections =
+			getPreviewPortletDataHandlerSections(2, 5, 1, 3);
 
-		expect(getSelectedItemsCount(10, sections, privateSelection)).toBe(13);
-		expect(getSelectedDeletionCount(4, sections, privateSelection)).toBe(6);
+		expect(
+			getSelectedItemsCount(
+				10,
+				previewPortletDataHandlerSections,
+				privateSelection
+			)
+		).toBe(13);
+		expect(
+			getSelectedDeletionCount(
+				4,
+				previewPortletDataHandlerSections,
+				privateSelection
+			)
+		).toBe(6);
 	});
 
 	it('leaves the sections untouched when the public set is selected', () => {
-		const sections = getSections(2, 5, 1, 3);
+		const previewPortletDataHandlerSections =
+			getPreviewPortletDataHandlerSections(2, 5, 1, 3);
 
-		expect(withSelectedLayoutSetCount(sections, publicSelection)).toBe(
-			sections
-		);
+		expect(
+			withSelectedLayoutSetCount(
+				previewPortletDataHandlerSections,
+				publicSelection
+			)
+		).toBe(previewPortletDataHandlerSections);
 	});
 
 	it('adjusts the section and handler counts when private is selected', () => {
-		const sections = getSections(2, 5, 1, 3);
+		const previewPortletDataHandlerSections =
+			getPreviewPortletDataHandlerSections(2, 5, 1, 3);
 
-		const [section] = withSelectedLayoutSetCount(
-			sections,
+		const [previewPortletDataHandlerSection] = withSelectedLayoutSetCount(
+			previewPortletDataHandlerSections,
 			privateSelection
 		);
 
-		expect(section.additionCount).toBe(5);
-		expect(section.deletionCount).toBe(3);
+		expect(previewPortletDataHandlerSection.additionCount).toBe(5);
+		expect(previewPortletDataHandlerSection.deletionCount).toBe(3);
 
-		const handler = section.previewPortletDataHandlers.find(
-			({name}) => name === LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY
-		);
+		const previewPortletDataHandler =
+			previewPortletDataHandlerSection.previewPortletDataHandlers.find(
+				({name}) => name === LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY
+			);
 
-		expect(handler?.additionCount).toBe(5);
-		expect(handler?.deletionCount).toBe(3);
+		expect(previewPortletDataHandler?.additionCount).toBe(5);
+		expect(previewPortletDataHandler?.deletionCount).toBe(3);
 	});
 });

--- a/modules/apps/export-import/export-import-web/test/revamp/js/utils/contentSelection.test.ts
+++ b/modules/apps/export-import/export-import-web/test/revamp/js/utils/contentSelection.test.ts
@@ -16,12 +16,17 @@ import {
 	withSelectedLayoutSetCount,
 } from '../../../../src/main/resources/META-INF/resources/revamp/js/utils/contentSelection';
 
-function getPreviewPortletDataHandlerSections(
-	publicAdditionCount: number,
-	privateAdditionCount: number,
+function mockLayoutSetSections({
+	privateAdditionCount = 5,
+	privateDeletionCount = 0,
+	publicAdditionCount = 2,
 	publicDeletionCount = 0,
-	privateDeletionCount = 0
-): PreviewPortletDataHandlerSection[] {
+}: {
+	privateAdditionCount?: number;
+	privateDeletionCount?: number;
+	publicAdditionCount?: number;
+	publicDeletionCount?: number;
+} = {}): PreviewPortletDataHandlerSection[] {
 	return [
 		{
 			additionCount: publicAdditionCount,
@@ -75,8 +80,7 @@ const publicSelection = {
 
 describe('contentSelection layout set counts', () => {
 	it('reads the public and private addition counts from the choices', () => {
-		const previewPortletDataHandlerSections =
-			getPreviewPortletDataHandlerSections(2, 5);
+		const previewPortletDataHandlerSections = mockLayoutSetSections();
 
 		expect(
 			getLayoutSetCount(previewPortletDataHandlerSections, false)
@@ -87,8 +91,10 @@ describe('contentSelection layout set counts', () => {
 	});
 
 	it('reads the public and private deletion counts from the choices', () => {
-		const previewPortletDataHandlerSections =
-			getPreviewPortletDataHandlerSections(2, 5, 1, 3);
+		const previewPortletDataHandlerSections = mockLayoutSetSections({
+			privateDeletionCount: 3,
+			publicDeletionCount: 1,
+		});
 
 		expect(
 			getLayoutSetCount(
@@ -113,8 +119,10 @@ describe('contentSelection layout set counts', () => {
 	});
 
 	it('keeps the public counts in the totals when the public set is selected', () => {
-		const previewPortletDataHandlerSections =
-			getPreviewPortletDataHandlerSections(2, 5, 1, 3);
+		const previewPortletDataHandlerSections = mockLayoutSetSections({
+			privateDeletionCount: 3,
+			publicDeletionCount: 1,
+		});
 
 		expect(
 			getSelectedItemsCount(
@@ -133,8 +141,10 @@ describe('contentSelection layout set counts', () => {
 	});
 
 	it('swaps in the private counts in the totals when private is selected', () => {
-		const previewPortletDataHandlerSections =
-			getPreviewPortletDataHandlerSections(2, 5, 1, 3);
+		const previewPortletDataHandlerSections = mockLayoutSetSections({
+			privateDeletionCount: 3,
+			publicDeletionCount: 1,
+		});
 
 		expect(
 			getSelectedItemsCount(
@@ -153,8 +163,10 @@ describe('contentSelection layout set counts', () => {
 	});
 
 	it('leaves the sections untouched when the public set is selected', () => {
-		const previewPortletDataHandlerSections =
-			getPreviewPortletDataHandlerSections(2, 5, 1, 3);
+		const previewPortletDataHandlerSections = mockLayoutSetSections({
+			privateDeletionCount: 3,
+			publicDeletionCount: 1,
+		});
 
 		expect(
 			withSelectedLayoutSetCount(
@@ -165,8 +177,10 @@ describe('contentSelection layout set counts', () => {
 	});
 
 	it('adjusts the section and handler counts when private is selected', () => {
-		const previewPortletDataHandlerSections =
-			getPreviewPortletDataHandlerSections(2, 5, 1, 3);
+		const previewPortletDataHandlerSections = mockLayoutSetSections({
+			privateDeletionCount: 3,
+			publicDeletionCount: 1,
+		});
 
 		const [previewPortletDataHandlerSection] = withSelectedLayoutSetCount(
 			previewPortletDataHandlerSections,

--- a/modules/apps/export-import/export-import-web/test/revamp/js/utils/contentSelection.test.ts
+++ b/modules/apps/export-import/export-import-web/test/revamp/js/utils/contentSelection.test.ts
@@ -1,0 +1,137 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {PreviewPortletDataHandlerSection} from '../../../../src/main/resources/META-INF/resources/revamp/js/types/portletDataHandler';
+import {
+	LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY,
+	PRIVATE_PAGES_CONTROL_NAME,
+	PUBLIC_PAGES_CONTROL_NAME,
+	SECTION_KEY_SITE_BUILDER,
+	getLayoutSetCount,
+	getSelectedDeletionCount,
+	getSelectedItemsCount,
+	isPrivateLayoutSelected,
+	withSelectedLayoutSetCount,
+} from '../../../../src/main/resources/META-INF/resources/revamp/js/utils/contentSelection';
+
+function getSections(
+	publicAdditionCount: number,
+	privateAdditionCount: number,
+	publicDeletionCount = 0,
+	privateDeletionCount = 0
+): PreviewPortletDataHandlerSection[] {
+	return [
+		{
+			additionCount: publicAdditionCount,
+			deletionCount: publicDeletionCount,
+			label: 'Site Builder',
+			name: SECTION_KEY_SITE_BUILDER,
+			previewPortletDataHandlers: [
+				{
+					additionCount: publicAdditionCount,
+					deletionCount: publicDeletionCount,
+					label: 'Static Pages',
+					name: LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY,
+					previewPortletDataHandlerControls: [
+						{
+							choices: [
+								{
+									additionCount: publicAdditionCount,
+									deletionCount: publicDeletionCount,
+									label: 'Public Pages',
+									name: PUBLIC_PAGES_CONTROL_NAME,
+								},
+								{
+									additionCount: privateAdditionCount,
+									deletionCount: privateDeletionCount,
+									label: 'Private Pages',
+									name: PRIVATE_PAGES_CONTROL_NAME,
+								},
+							],
+							label: 'Static Pages',
+							name: 'layoutSet',
+							type: 'Choice',
+						},
+					],
+				},
+			],
+		},
+	];
+}
+
+const privateSelection = {
+	[SECTION_KEY_SITE_BUILDER]: {
+		[LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY]: {privateLayout: true},
+	},
+};
+
+const publicSelection = {
+	[SECTION_KEY_SITE_BUILDER]: {
+		[LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY]: {privateLayout: false},
+	},
+};
+
+describe('contentSelection layout set counts', () => {
+	it('reads the public and private addition counts from the choices', () => {
+		const sections = getSections(2, 5);
+
+		expect(getLayoutSetCount(sections, false)).toBe(2);
+		expect(getLayoutSetCount(sections, true)).toBe(5);
+	});
+
+	it('reads the public and private deletion counts from the choices', () => {
+		const sections = getSections(2, 5, 1, 3);
+
+		expect(getLayoutSetCount(sections, false, 'deletionCount')).toBe(1);
+		expect(getLayoutSetCount(sections, true, 'deletionCount')).toBe(3);
+	});
+
+	it('detects whether the private layout set is selected', () => {
+		expect(isPrivateLayoutSelected(undefined)).toBe(false);
+		expect(isPrivateLayoutSelected(publicSelection)).toBe(false);
+		expect(isPrivateLayoutSelected(privateSelection)).toBe(true);
+	});
+
+	it('keeps the public counts in the totals when the public set is selected', () => {
+		const sections = getSections(2, 5, 1, 3);
+
+		expect(getSelectedItemsCount(10, sections, publicSelection)).toBe(10);
+		expect(getSelectedDeletionCount(4, sections, publicSelection)).toBe(4);
+	});
+
+	it('swaps in the private counts in the totals when private is selected', () => {
+		const sections = getSections(2, 5, 1, 3);
+
+		expect(getSelectedItemsCount(10, sections, privateSelection)).toBe(13);
+		expect(getSelectedDeletionCount(4, sections, privateSelection)).toBe(6);
+	});
+
+	it('leaves the sections untouched when the public set is selected', () => {
+		const sections = getSections(2, 5, 1, 3);
+
+		expect(withSelectedLayoutSetCount(sections, publicSelection)).toBe(
+			sections
+		);
+	});
+
+	it('adjusts the section and handler counts when private is selected', () => {
+		const sections = getSections(2, 5, 1, 3);
+
+		const [section] = withSelectedLayoutSetCount(
+			sections,
+			privateSelection
+		);
+
+		expect(section.additionCount).toBe(5);
+		expect(section.deletionCount).toBe(3);
+
+		const handler = section.previewPortletDataHandlers.find(
+			({name}) => name === LAYOUT_SET_LAYOUTS_PORTLET_DATA_KEY
+		);
+
+		expect(handler?.additionCount).toBe(5);
+		expect(handler?.deletionCount).toBe(3);
+	});
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96323

## What Is Being Fixed

The export and import flow did not properly account for a group's public and private page sets. The export preview did not report how many pages, additions, or deletions each set contained, the export form did not reflect which page set was selected, and imported pages were not restored into the layout set they came from. The private-pages case also rendered the "Select Pages" button in the wrong position.

## How It Is Being Fixed

Deletion system events are now counted per layout set, and those addition and deletion counts are carried on the export preview choices so the preview can report public and private page counts. The export form reflects the selected page set through the preview page controls, and the export process rejects requests that ask for both page sets at once or for private pages when private pages are not enabled. On import, pages are restored into their originating layout set. The misplaced "Select Pages" button for private pages is repositioned. Jest coverage for the content-selection utilities and the export page, plus REST integration tests, back the changes.

## PR Check

**pr-check: PASS** — tested on `501b6900a8616b76d69c209ef4644a8b152ef18d`

| Validation | Result |
| --- | --- |
| REST Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "501b6900a8616b76d69c209ef4644a8b152ef18d"} -->
