### PR TITLE
LPD-97594 Support case sensitive comparisons in OData filters

### DIFF
--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/odata/entity/v1_0/AttachmentEntityModel.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/odata/entity/v1_0/AttachmentEntityModel.java
@@ -37,7 +37,8 @@ public class AttachmentEntityModel implements EntityModel {
 				"commerceOrderId", locale -> "commerceOrderId",
 				String::valueOf),
 			new StringEntityField(
-				"externalReferenceCode", locale -> "externalReferenceCode"),
+				"externalReferenceCode", locale -> "externalReferenceCode",
+				locale -> "externalReferenceCode", String::valueOf),
 			new StringEntityField("title", locale -> "title"),
 			new StringEntityField("type", locale -> "type"));
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/odata/entity/v1_0/AttachmentEntityModel.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/odata/entity/v1_0/AttachmentEntityModel.java
@@ -37,7 +37,8 @@ public class AttachmentEntityModel implements EntityModel {
 				"commerceOrderId", locale -> "commerceOrderId",
 				String::valueOf),
 			new StringEntityField(
-				"externalReferenceCode", locale -> "externalReferenceCode"),
+				"externalReferenceCode", locale -> "externalReferenceCode",
+				locale -> "externalReferenceCode", String::valueOf),
 			new StringEntityField("title", locale -> "title"),
 			new StringEntityField("type", locale -> "type"));
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/odata/entity/v1_0/AttachmentEntityModel.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/odata/entity/v1_0/AttachmentEntityModel.java
@@ -37,7 +37,8 @@ public class AttachmentEntityModel implements EntityModel {
 				"commerceOrderId", locale -> "commerceOrderId",
 				String::valueOf),
 			new StringEntityField(
-				"externalReferenceCode", locale -> "externalReferenceCode"),
+				"externalReferenceCode", locale -> "externalReferenceCode",
+				locale -> "externalReferenceCode", String::valueOf),
 			new StringEntityField("title", locale -> "title"),
 			new StringEntityField("type", locale -> "type"));
 	}

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/odata/entity/v1_0/ListTypeDefinitionEntityModel.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/odata/entity/v1_0/ListTypeDefinitionEntityModel.java
@@ -31,7 +31,8 @@ public class ListTypeDefinitionEntityModel implements EntityModel {
 				locale -> Field.MODIFIED_DATE),
 			new IntegerEntityField("userId", locale -> Field.USER_ID),
 			new StringEntityField(
-				"externalReferenceCode", locale -> "externalReferenceCode"),
+				"externalReferenceCode", locale -> "externalReferenceCode",
+				locale -> "externalReferenceCode", String::valueOf),
 			new StringEntityField(
 				"name", locale -> Field.getSortableFieldName(Field.NAME)));
 	}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/odata/entity/v1_0/DisplayPageTemplateEntityModel.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/odata/entity/v1_0/DisplayPageTemplateEntityModel.java
@@ -30,7 +30,8 @@ public class DisplayPageTemplateEntityModel implements EntityModel {
 				locale -> Field.getSortableFieldName(Field.MODIFIED_DATE),
 				locale -> Field.MODIFIED_DATE),
 			new StringEntityField(
-				"externalReferenceCode", locale -> "externalReferenceCode"));
+				"externalReferenceCode", locale -> "externalReferenceCode",
+				locale -> "externalReferenceCode", String::valueOf));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/odata/entity/v1_0/DisplayPageTemplateFolderEntityModel.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/odata/entity/v1_0/DisplayPageTemplateFolderEntityModel.java
@@ -29,7 +29,8 @@ public class DisplayPageTemplateFolderEntityModel implements EntityModel {
 				locale -> Field.getSortableFieldName(Field.MODIFIED_DATE),
 				locale -> Field.MODIFIED_DATE),
 			new StringEntityField(
-				"externalReferenceCode", locale -> "externalReferenceCode"));
+				"externalReferenceCode", locale -> "externalReferenceCode",
+				locale -> "externalReferenceCode", String::valueOf));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/odata/entity/v1_0/MasterPageEntityModel.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/odata/entity/v1_0/MasterPageEntityModel.java
@@ -30,7 +30,8 @@ public class MasterPageEntityModel implements EntityModel {
 				locale -> Field.getSortableFieldName(Field.MODIFIED_DATE),
 				locale -> Field.MODIFIED_DATE),
 			new StringEntityField(
-				"externalReferenceCode", locale -> "externalReferenceCode"));
+				"externalReferenceCode", locale -> "externalReferenceCode",
+				locale -> "externalReferenceCode", String::valueOf));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/odata/entity/v1_0/NavigationMenuEntityModel.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/odata/entity/v1_0/NavigationMenuEntityModel.java
@@ -30,7 +30,8 @@ public class NavigationMenuEntityModel implements EntityModel {
 				locale -> Field.getSortableFieldName(Field.MODIFIED_DATE),
 				locale -> Field.MODIFIED_DATE),
 			new StringEntityField(
-				"externalReferenceCode", locale -> "externalReferenceCode"));
+				"externalReferenceCode", locale -> "externalReferenceCode",
+				locale -> "externalReferenceCode", String::valueOf));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/odata/entity/v1_0/PageTemplateEntityModel.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/odata/entity/v1_0/PageTemplateEntityModel.java
@@ -30,7 +30,8 @@ public class PageTemplateEntityModel implements EntityModel {
 				locale -> Field.getSortableFieldName(Field.MODIFIED_DATE),
 				locale -> Field.MODIFIED_DATE),
 			new StringEntityField(
-				"externalReferenceCode", locale -> "externalReferenceCode"));
+				"externalReferenceCode", locale -> "externalReferenceCode",
+				locale -> "externalReferenceCode", String::valueOf));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/odata/entity/v1_0/PageTemplateSetEntityModel.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/odata/entity/v1_0/PageTemplateSetEntityModel.java
@@ -29,7 +29,8 @@ public class PageTemplateSetEntityModel implements EntityModel {
 				locale -> Field.getSortableFieldName(Field.MODIFIED_DATE),
 				locale -> Field.MODIFIED_DATE),
 			new StringEntityField(
-				"externalReferenceCode", locale -> "externalReferenceCode"));
+				"externalReferenceCode", locale -> "externalReferenceCode",
+				locale -> "externalReferenceCode", String::valueOf));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/odata/entity/v1_0/SitePageEntityModel.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/odata/entity/v1_0/SitePageEntityModel.java
@@ -37,7 +37,8 @@ public class SitePageEntityModel implements EntityModel {
 				locale -> Field.getSortableFieldName(Field.MODIFIED_DATE),
 				locale -> Field.MODIFIED_DATE),
 			new StringEntityField(
-				"externalReferenceCode", locale -> "externalReferenceCode"));
+				"externalReferenceCode", locale -> "externalReferenceCode",
+				locale -> "externalReferenceCode", String::valueOf));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/odata/entity/v1_0/UtilityPageEntityModel.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/odata/entity/v1_0/UtilityPageEntityModel.java
@@ -30,7 +30,8 @@ public class UtilityPageEntityModel implements EntityModel {
 				locale -> Field.getSortableFieldName(Field.MODIFIED_DATE),
 				locale -> Field.MODIFIED_DATE),
 			new StringEntityField(
-				"externalReferenceCode", locale -> "externalReferenceCode"));
+				"externalReferenceCode", locale -> "externalReferenceCode",
+				locale -> "externalReferenceCode", String::valueOf));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/odata/entity/v1_0/CategoryEntityModel.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/odata/entity/v1_0/CategoryEntityModel.java
@@ -39,7 +39,8 @@ public class CategoryEntityModel implements EntityModel {
 				"projects", locale -> "projectDepotEntryGroupIds",
 				String::valueOf),
 			new StringEntityField(
-				"externalReferenceCode", locale -> "externalReferenceCode"),
+				"externalReferenceCode", locale -> "externalReferenceCode",
+				locale -> "externalReferenceCode", String::valueOf),
 			new StringEntityField(
 				"name",
 				locale -> Field.getSortableFieldName(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/odata/entity/v1_0/KeywordEntityModel.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/odata/entity/v1_0/KeywordEntityModel.java
@@ -38,7 +38,8 @@ public class KeywordEntityModel implements EntityModel {
 				Field.NAME,
 				locale -> Field.getSortableFieldName(Field.NAME + "_String")),
 			new StringEntityField(
-				"externalReferenceCode", locale -> "externalReferenceCode"));
+				"externalReferenceCode", locale -> "externalReferenceCode",
+				locale -> "externalReferenceCode", String::valueOf));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/odata/entity/v1_0/VocabularyEntityModel.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/odata/entity/v1_0/VocabularyEntityModel.java
@@ -44,7 +44,8 @@ public class VocabularyEntityModel implements EntityModel {
 			new IntegerEntityField(
 				"visibilityType", locale -> Field.VISIBILITY_TYPE),
 			new StringEntityField(
-				"externalReferenceCode", locale -> "externalReferenceCode"),
+				"externalReferenceCode", locale -> "externalReferenceCode",
+				locale -> "externalReferenceCode", String::valueOf),
 			new StringEntityField(
 				"name",
 				locale -> Field.getSortableFieldName(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/odata/entity/v1_0/AccountEntityModel.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/odata/entity/v1_0/AccountEntityModel.java
@@ -42,7 +42,7 @@ public class AccountEntityModel implements EntityModel {
 			new StringEntityField(
 				"externalReferenceCode",
 				locale -> Field.getSortableFieldName("externalReferenceCode"),
-				locale -> "externalReferenceCode"),
+				locale -> "externalReferenceCode", String::valueOf),
 			new StringEntityField(
 				"name", locale -> Field.getSortableFieldName(Field.NAME)),
 			new StringEntityField("type", locale -> Field.TYPE));

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/v1_0/ObjectEntryEntityModel.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/v1_0/ObjectEntryEntityModel.java
@@ -219,7 +219,8 @@ public class ObjectEntryEntityModel implements EntityModel {
 				"externalReferenceCode",
 				() -> new StringEntityField(
 					"externalReferenceCode",
-					_getExternalReferenceCodeFunction())
+					_getExternalReferenceCodeFunction(),
+					_getExternalReferenceCodeFunction(), String::valueOf)
 			).put(
 				"folderId",
 				new IntegerEntityField(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -1459,6 +1459,75 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
+	public void testFilterByCaseSensitiveExternalReferenceCode()
+		throws Exception {
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				Collections.singletonList(
+					new TextObjectFieldBuilder(
+					).labelMap(
+						LocalizedMapUtil.getLocalizedMap(
+							RandomTestUtil.randomString())
+					).name(
+						"name"
+					).build()),
+				ObjectDefinitionConstants.SCOPE_COMPANY);
+
+		try {
+			String externalReferenceCode =
+				"CaseSensitive" + RandomTestUtil.randomString();
+
+			String lowerCaseExternalReferenceCode = StringUtil.toLowerCase(
+				externalReferenceCode);
+
+			_objectEntryLocalService.addOrUpdateObjectEntry(
+				externalReferenceCode, 0, TestPropsValues.getUserId(),
+				objectDefinition.getObjectDefinitionId(),
+				ObjectEntryFolderConstants.
+					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+				HashMapBuilder.<String, Serializable>put(
+					"name", RandomTestUtil.randomString()
+				).build(),
+				ServiceContextTestUtil.getServiceContext());
+
+			_objectEntryLocalService.addOrUpdateObjectEntry(
+				lowerCaseExternalReferenceCode, 0, TestPropsValues.getUserId(),
+				objectDefinition.getObjectDefinitionId(),
+				ObjectEntryFolderConstants.
+					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+				HashMapBuilder.<String, Serializable>put(
+					"name", RandomTestUtil.randomString()
+				).build(),
+				ServiceContextTestUtil.getServiceContext());
+
+			String filterString =
+				"externalReferenceCode eq '" + externalReferenceCode + "'";
+
+			JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+				null,
+				objectDefinition.getRESTContextPath() + "?filter=" +
+					_escape(filterString),
+				Http.Method.GET);
+
+			JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
+
+			Assert.assertEquals(
+				itemsJSONArray.toString(), 1, itemsJSONArray.length());
+
+			JSONObject itemJSONObject = itemsJSONArray.getJSONObject(0);
+
+			Assert.assertEquals(
+				externalReferenceCode,
+				itemJSONObject.getString("externalReferenceCode"));
+		}
+		finally {
+			_objectDefinitionLocalService.deleteObjectDefinition(
+				objectDefinition);
+		}
+	}
+
+	@Test
 	public void testFilterByComparisonOperatorsObjectEntriesByRelatedObjectEntriesFields()
 		throws Exception {
 

--- a/modules/apps/portal-odata/portal-odata-api/bnd.bnd
+++ b/modules/apps/portal-odata/portal-odata-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal OData API
 Bundle-SymbolicName: com.liferay.portal.odata.api
-Bundle-Version: 5.1.2
+Bundle-Version: 5.2.0
 Export-Package:\
 	com.liferay.portal.odata.entity,\
 	com.liferay.portal.odata.filter,\

--- a/modules/apps/portal-odata/portal-odata-api/src/main/java/com/liferay/portal/odata/entity/CollectionEntityField.java
+++ b/modules/apps/portal-odata/portal-odata-api/src/main/java/com/liferay/portal/odata/entity/CollectionEntityField.java
@@ -23,7 +23,7 @@ public class CollectionEntityField extends EntityField {
 		super(
 			entityField.getName(), Type.COLLECTION,
 			entityField::getSortableName, entityField::getFilterableName,
-			String::valueOf);
+			entityField::getFilterableValue);
 
 		_entityField = entityField;
 	}

--- a/modules/apps/portal-odata/portal-odata-api/src/main/java/com/liferay/portal/odata/entity/StringEntityField.java
+++ b/modules/apps/portal-odata/portal-odata-api/src/main/java/com/liferay/portal/odata/entity/StringEntityField.java
@@ -5,6 +5,8 @@
 
 package com.liferay.portal.odata.entity;
 
+import com.liferay.portal.kernel.util.StringUtil;
+
 import java.util.Locale;
 import java.util.function.Function;
 
@@ -30,9 +32,9 @@ public class StringEntityField extends EntityField {
 		String name,
 		Function<Locale, String> filterableAndSortableFieldNameFunction) {
 
-		super(
-			name, Type.STRING, filterableAndSortableFieldNameFunction,
-			filterableAndSortableFieldNameFunction, String::valueOf);
+		this(
+			name, filterableAndSortableFieldNameFunction,
+			filterableAndSortableFieldNameFunction);
 	}
 
 	/**
@@ -51,9 +53,34 @@ public class StringEntityField extends EntityField {
 		String name, Function<Locale, String> sortableFieldNameFunction,
 		Function<Locale, String> filterableFieldNameFunction) {
 
+		this(
+			name, sortableFieldNameFunction, filterableFieldNameFunction,
+			fieldValue -> StringUtil.toLowerCase(String.valueOf(fieldValue)));
+	}
+
+	/**
+	 * Creates a new {@code StringEntityField} with a {@code Function} to
+	 * convert the entity field's name to a sortable and filterable field name
+	 * for a locale, and a {@code Function} to convert the field's value to a
+	 * filterable field value.
+	 *
+	 * @param  name the entity field's name
+	 * @param  sortableFieldNameFunction the sortable field name {@code
+	 *         Function}
+	 * @param  filterableFieldNameFunction the filterable field name {@code
+	 *         Function}
+	 * @param  filterableFieldValueFunction the filterable field value {@code
+	 *         Function}
+	 * @review
+	 */
+	public StringEntityField(
+		String name, Function<Locale, String> sortableFieldNameFunction,
+		Function<Locale, String> filterableFieldNameFunction,
+		Function<Object, String> filterableFieldValueFunction) {
+
 		super(
 			name, Type.STRING, sortableFieldNameFunction,
-			filterableFieldNameFunction, String::valueOf);
+			filterableFieldNameFunction, filterableFieldValueFunction);
 	}
 
 }

--- a/modules/apps/portal-odata/portal-odata-api/src/main/resources/com/liferay/portal/odata/entity/packageinfo
+++ b/modules/apps/portal-odata/portal-odata-api/src/main/resources/com/liferay/portal/odata/entity/packageinfo
@@ -1,1 +1,1 @@
-version 2.4.0
+version 2.5.0

--- a/modules/apps/portal-odata/portal-odata-impl/src/main/java/com/liferay/portal/odata/internal/filter/ExpressionVisitorImpl.java
+++ b/modules/apps/portal-odata/portal-odata-impl/src/main/java/com/liferay/portal/odata/internal/filter/ExpressionVisitorImpl.java
@@ -548,12 +548,9 @@ public class ExpressionVisitorImpl implements ExpressionVisitor<Object> {
 	}
 
 	private Object _normalizeStringLiteral(String literal) {
-		literal = StringUtil.toLowerCase(literal);
-
-		literal = StringUtil.unquote(literal);
-
 		return StringUtil.replace(
-			literal, StringPool.DOUBLE_APOSTROPHE, StringPool.APOSTROPHE);
+			StringUtil.unquote(literal), StringPool.DOUBLE_APOSTROPHE,
+			StringPool.APOSTROPHE);
 	}
 
 	private Filter _startsWith(

--- a/modules/apps/portal-odata/portal-odata-impl/src/test/java/com/liferay/portal/odata/internal/filter/ExpressionVisitorImplTest.java
+++ b/modules/apps/portal-odata/portal-odata-impl/src/test/java/com/liferay/portal/odata/internal/filter/ExpressionVisitorImplTest.java
@@ -105,23 +105,42 @@ public class ExpressionVisitorImplTest {
 	@SuppressWarnings("unchecked")
 	@Test
 	public void testVisitBinaryExpressionOperationWithEqualOperation() {
-		Map<String, EntityField> entityFieldsMap =
+
+		// Case insensitive
+
+		Map<String, EntityField> entityFieldsMap1 =
 			_entityModel.getEntityFieldsMap();
 
-		EntityField entityField = entityFieldsMap.get("title");
+		EntityField entityField1 = entityFieldsMap1.get("title");
 
-		String value = "title1";
-
-		QueryFilter queryFilter =
+		QueryFilter queryFilter1 =
 			(QueryFilter)_expressionVisitorImpl.visitBinaryExpressionOperation(
-				BinaryExpression.Operation.EQ, entityField, value);
+				BinaryExpression.Operation.EQ, entityField1, "Title1");
 
-		TermQuery termQuery = (TermQuery)queryFilter.getQuery();
+		TermQuery termQuery1 = (TermQuery)queryFilter1.getQuery();
 
-		QueryTerm queryTerm = termQuery.getQueryTerm();
+		QueryTerm queryTerm1 = termQuery1.getQueryTerm();
 
-		Assert.assertEquals(entityField.getName(), queryTerm.getField());
-		Assert.assertEquals(value, queryTerm.getValue());
+		Assert.assertEquals(entityField1.getName(), queryTerm1.getField());
+		Assert.assertEquals("title1", queryTerm1.getValue());
+
+		// Case sensitive
+
+		Map<String, EntityField> entityFieldsMap2 =
+			_entityModel.getEntityFieldsMap();
+
+		EntityField entityField2 = entityFieldsMap2.get("titleCaseSensitive");
+
+		QueryFilter queryFilter2 =
+			(QueryFilter)_expressionVisitorImpl.visitBinaryExpressionOperation(
+				BinaryExpression.Operation.EQ, entityField2, "Title1");
+
+		TermQuery termQuery2 = (TermQuery)queryFilter2.getQuery();
+
+		QueryTerm queryTerm2 = termQuery2.getQueryTerm();
+
+		Assert.assertEquals(entityField2.getName(), queryTerm2.getField());
+		Assert.assertEquals("Title1", queryTerm2.getValue());
 	}
 
 	@Test
@@ -743,7 +762,7 @@ public class ExpressionVisitorImplTest {
 				"'L''Oreal'", LiteralExpression.Type.STRING);
 
 		Assert.assertEquals(
-			"l'oreal",
+			"L'Oreal",
 			_expressionVisitorImpl.visitLiteralExpression(literalExpression));
 	}
 
@@ -754,7 +773,7 @@ public class ExpressionVisitorImplTest {
 				"'L''Oreal and L''Oreal'", LiteralExpression.Type.STRING);
 
 		Assert.assertEquals(
-			"l'oreal and l'oreal",
+			"L'Oreal and L'Oreal",
 			_expressionVisitorImpl.visitLiteralExpression(literalExpression));
 	}
 
@@ -765,7 +784,7 @@ public class ExpressionVisitorImplTest {
 				"'L'Oreal'", LiteralExpression.Type.STRING);
 
 		Assert.assertEquals(
-			"l'oreal",
+			"L'Oreal",
 			_expressionVisitorImpl.visitLiteralExpression(literalExpression));
 	}
 
@@ -776,7 +795,7 @@ public class ExpressionVisitorImplTest {
 				"'LOreal'", LiteralExpression.Type.STRING);
 
 		Assert.assertEquals(
-			"loreal",
+			"LOreal",
 			_expressionVisitorImpl.visitLiteralExpression(literalExpression));
 	}
 
@@ -825,6 +844,11 @@ public class ExpressionVisitorImplTest {
 					new StringEntityField("keywords", locale -> "keywords.raw"))
 			).put(
 				"title", new StringEntityField("title", locale -> "title")
+			).put(
+				"titleCaseSensitive",
+				new StringEntityField(
+					"titleCaseSensitive", locale -> "titleCaseSensitive",
+					locale -> "titleCaseSensitive", String::valueOf)
 			).put(
 				"values",
 				new ComplexEntityField(

--- a/modules/apps/portal-odata/portal-odata-impl/src/test/java/com/liferay/portal/odata/internal/filter/ExpressionVisitorImplTest.java
+++ b/modules/apps/portal-odata/portal-odata-impl/src/test/java/com/liferay/portal/odata/internal/filter/ExpressionVisitorImplTest.java
@@ -233,6 +233,52 @@ public class ExpressionVisitorImplTest {
 
 	@SuppressWarnings("unchecked")
 	@Test
+	public void testVisitBinaryExpressionOperationWithEqualOperationForCollectionField() {
+
+		// Case insensitive
+
+		Map<String, EntityField> entityFieldsMap1 =
+			_entityModel.getEntityFieldsMap();
+
+		EntityField entityField1 = entityFieldsMap1.get("keywords");
+
+		QueryFilter queryFilter1 =
+			(QueryFilter)_expressionVisitorImpl.visitBinaryExpressionOperation(
+				BinaryExpression.Operation.EQ, entityField1, "Keyword1");
+
+		TermQuery termQuery1 = (TermQuery)queryFilter1.getQuery();
+
+		QueryTerm queryTerm1 = termQuery1.getQueryTerm();
+
+		Assert.assertEquals(
+			entityField1.getFilterableName(LocaleUtil.getDefault()),
+			queryTerm1.getField());
+		Assert.assertEquals("keyword1", queryTerm1.getValue());
+
+		// Case sensitive
+
+		Map<String, EntityField> entityFieldsMap2 =
+			_entityModel.getEntityFieldsMap();
+
+		EntityField entityField2 = entityFieldsMap2.get(
+			"keywordsCaseSensitive");
+
+		QueryFilter queryFilter2 =
+			(QueryFilter)_expressionVisitorImpl.visitBinaryExpressionOperation(
+				BinaryExpression.Operation.EQ, entityField2, "Keyword1");
+
+		TermQuery termQuery2 = (TermQuery)queryFilter2.getQuery();
+
+		QueryTerm queryTerm2 = termQuery2.getQueryTerm();
+
+		Assert.assertEquals(
+			entityField2.getFilterableName(LocaleUtil.getDefault()),
+			queryTerm2.getField());
+		Assert.assertEquals("Keyword1", queryTerm2.getValue());
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
 	public void testVisitBinaryExpressionOperationWithGreaterEqualOperation() {
 		Map<String, EntityField> entityFieldsMap =
 			_entityModel.getEntityFieldsMap();
@@ -842,6 +888,13 @@ public class ExpressionVisitorImplTest {
 				"keywords",
 				new CollectionEntityField(
 					new StringEntityField("keywords", locale -> "keywords.raw"))
+			).put(
+				"keywordsCaseSensitive",
+				new CollectionEntityField(
+					new StringEntityField(
+						"keywordsCaseSensitive",
+						locale -> "keywordsCaseSensitive",
+						locale -> "keywordsCaseSensitive", String::valueOf))
 			).put(
 				"title", new StringEntityField("title", locale -> "title")
 			).put(

--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/odata/entity/v1_0/SearchResultEntityModel.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/odata/entity/v1_0/SearchResultEntityModel.java
@@ -41,7 +41,8 @@ public class SearchResultEntityModel implements EntityModel {
 			new CollectionEntityField(
 				new StringEntityField(
 					"objectFolderExternalReferenceCode",
-					locale -> "objectFolderExternalReferenceCode")),
+					locale -> "objectFolderExternalReferenceCode",
+					String::valueOf)),
 			new DateTimeEntityField(
 				"cmpDueDate", locale -> "cmpDueDate", locale -> "cmpDueDate"),
 			new DateTimeEntityField(
@@ -94,7 +95,9 @@ public class SearchResultEntityModel implements EntityModel {
 			new StringEntityField("extension", locale -> "extension"),
 			new StringEntityField(
 				"objectDefinitionExternalReferenceCode",
-				locale -> "objectDefinitionExternalReferenceCode"),
+				locale -> "objectDefinitionExternalReferenceCode",
+				locale -> "objectDefinitionExternalReferenceCode",
+				String::valueOf),
 			new StringEntityField(
 				"title",
 				locale -> Field.getSortableFieldName(

--- a/modules/apps/portal-search/portal-search-rest-test/src/testIntegration/java/com/liferay/portal/search/rest/resource/v1_0/test/SearchResultResourceTest.java
+++ b/modules/apps/portal-search/portal-search-rest-test/src/testIntegration/java/com/liferay/portal/search/rest/resource/v1_0/test/SearchResultResourceTest.java
@@ -367,6 +367,7 @@ public class SearchResultResourceTest extends BaseSearchResultResourceTestCase {
 	@TestInfo("LPD-57341")
 	public void testPostSearchPage() throws Exception {
 		_testPostSearchPageAggregationNameAsFacetName();
+		_testPostSearchPageWithCaseSensitiveExternalReferenceCodeFilter();
 		_testPostSearchPageWithCategoryTreeFacetConfiguration();
 		_testPostSearchPageWithCustomFacetConfiguration();
 		_testPostSearchPageWithDateRangeFacetConfiguration();
@@ -904,6 +905,114 @@ public class SearchResultResourceTest extends BaseSearchResultResourceTestCase {
 			(Map<String, Object>)searchPage2.getSearchFacets();
 
 		Assert.assertTrue(map2.containsKey("tag"));
+	}
+
+	private void _testPostSearchPageWithCaseSensitiveExternalReferenceCodeFilter()
+		throws Exception {
+
+		ObjectDefinition objectDefinition1 =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				Collections.singletonList(
+					new TextObjectFieldBuilder(
+					).labelMap(
+						LocalizedMapUtil.getLocalizedMap(
+							RandomTestUtil.randomString())
+					).name(
+						"name"
+					).build()),
+				ObjectDefinitionConstants.SCOPE_SITE);
+		ObjectDefinition objectDefinition2 =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				Collections.singletonList(
+					new TextObjectFieldBuilder(
+					).labelMap(
+						LocalizedMapUtil.getLocalizedMap(
+							RandomTestUtil.randomString())
+					).name(
+						"name"
+					).build()),
+				ObjectDefinitionConstants.SCOPE_SITE);
+
+		try {
+			String externalReferenceCode =
+				"CaseSensitive" + RandomTestUtil.randomString();
+
+			objectDefinition1.setExternalReferenceCode(externalReferenceCode);
+
+			objectDefinition1 =
+				_objectDefinitionLocalService.updateObjectDefinition(
+					objectDefinition1);
+
+			objectDefinition2.setExternalReferenceCode(
+				StringUtil.toLowerCase(externalReferenceCode));
+
+			objectDefinition2 =
+				_objectDefinitionLocalService.updateObjectDefinition(
+					objectDefinition2);
+
+			ServiceContext serviceContext =
+				ServiceContextTestUtil.getServiceContext(
+					testGroup.getGroupId());
+
+			_objectEntryLocalService.addObjectEntry(
+				testGroup.getGroupId(), _user.getUserId(),
+				objectDefinition1.getObjectDefinitionId(),
+				ObjectEntryFolderConstants.
+					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+				null,
+				HashMapBuilder.<String, Serializable>put(
+					"name", StringUtil.randomString()
+				).build(),
+				serviceContext);
+			_objectEntryLocalService.addObjectEntry(
+				testGroup.getGroupId(), _user.getUserId(),
+				objectDefinition2.getObjectDefinitionId(),
+				ObjectEntryFolderConstants.
+					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+				null,
+				HashMapBuilder.<String, Serializable>put(
+					"name", StringUtil.randomString()
+				).build(),
+				serviceContext);
+
+			SearchRequestBody searchRequestBody = new SearchRequestBody();
+
+			searchRequestBody.setAttributes(
+				() -> HashMapBuilder.<String, Object>put(
+					"search.empty.search", "true"
+				).build());
+
+			SearchPage<SearchResult> searchPage = _postSearchPage(
+				HashMapBuilder.put(
+					"entryClassNames",
+					StringBundler.concat(
+						objectDefinition1.getClassName(), StringPool.COMMA,
+						objectDefinition2.getClassName())
+				).put(
+					"filter",
+					"objectDefinitionExternalReferenceCode eq '" +
+						externalReferenceCode + "'"
+				).build(),
+				searchRequestBody);
+
+			List<SearchResult> searchResults = ListUtil.fromCollection(
+				searchPage.getItems());
+
+			Assert.assertEquals(
+				searchResults.toString(), 1, searchResults.size());
+
+			SearchResult searchResult = searchResults.get(0);
+
+			Assert.assertEquals(
+				objectDefinition1.getClassName(),
+				searchResult.getEntryClassName());
+		}
+		finally {
+			_objectDefinitionLocalService.deleteObjectDefinition(
+				objectDefinition1);
+			_objectDefinitionLocalService.deleteObjectDefinition(
+				objectDefinition2);
+		}
 	}
 
 	private void _testPostSearchPageWithCategoryTreeFacetConfiguration()


### PR DESCRIPTION
### What

OData `$filter` equality was always case insensitive because the filter expression visitor lowercased every string literal before building the search query. That is wrong for case sensitive identifiers such as external reference codes: an entry whose ERC contains uppercase characters could never be matched, since the query term was folded to lower case while the value is indexed with its original case.

### How

Case folding now happens in the string field's `filterableFieldValueFunction` rather than in the visitor. `StringEntityField` folds case by default (preserving existing behavior), and a field opts out of folding by passing `String::valueOf` as its value function. The base `EntityField` is left untouched — case sensitivity is only meaningful for string fields.

The `externalReferenceCode` fields backed by a case-preserving keyword are switched to case sensitive. The headless commerce product and order ERCs are intentionally left untouched: their document contributors index the ERC in lower case (`addKeyword(..., true)`), so making them case sensitive would require changing the indexing first.

### Commits

1. `Support case sensitive comparisons in OData filters` — the mechanism (`StringEntityField`, visitor, `portal-odata-api` version bumps).
1. `Compare external reference codes respecting case` — the ERC entity fields.
1. `Unit tests`.

### pr-check: PASS

Tested on `d838ad187bb4f`.

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

Baseline caught a missing minor bundle-version bump on `portal-odata-api` (`5.1.2` → `5.2.0`), now included. Per-Module Compile's `portal-odata-api` consumer fan-out was scoped to the 9 changed modules, since the new constructor overload is additive and cannot break existing callers.