### PR TITLE
LPD-97154 Migrate depot export/import Poshi tests to integration

### DIFF
--- a/modules/apps/depot/depot-test/build.gradle
+++ b/modules/apps/depot/depot-test/build.gradle
@@ -6,6 +6,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:change-tracking:change-tracking-test-util")
 	testIntegrationImplementation project(":apps:depot:depot-api")
 	testIntegrationImplementation project(":apps:document-library:document-library-api")
+	testIntegrationImplementation project(":apps:document-library:document-library-test-util")
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	testIntegrationImplementation project(":apps:export-import:export-import-api")
 	testIntegrationImplementation project(":apps:export-import:export-import-test-util")

--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotExportImport.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotExportImport.testcase
@@ -250,70 +250,6 @@ definition {
 			templateName = "WC Template Name");
 	}
 
-	@description = "This ensures that the user can import the asset library with document to a site."
-	@priority = 4
-	@refactordone
-	test ExportedDepotWithDMCanBeImportedToSite {
-		JSONDocument.addFile(
-			dmDocumentDescription = "DM Document Description",
-			dmDocumentTitle = "DM Document Title",
-			groupName = "Test Depot Name");
-
-		DepotNavigator.openDepotExportImportAdmin(
-			depotName = "Test Depot Name",
-			exportAdmin = "true");
-
-		LAR.exportSiteCP(depotName = "Test Depot Name");
-
-		var larFileName = LAR.getLarFileName();
-
-		LAR.downloadLar();
-
-		HeadlessSite.addSite(siteName = "New Site");
-
-		LAR.importSiteCP(
-			larFileName = ${larFileName},
-			siteName = "New Site");
-
-		DMNavigator.openToEntryInAdmin(
-			dmDocumentTitle = "DM Document Title",
-			groupName = "New Site",
-			siteURLKey = "new-site");
-
-		DMDocument.viewCP(dmDocumentTitle = "DM Document Title");
-	}
-
-	@description = "This ensures that the user can import the asset library with web content to a site."
-	@priority = 4
-	@refactordone
-	test ExportedDepotWithWCCanBeImportedToSite {
-		JSONWebcontent.addWebContent(
-			content = "WC WebContent Content",
-			groupName = "Test Depot Name",
-			site = "false",
-			title = "WC WebContent Title");
-
-		DepotNavigator.openDepotExportImportAdmin(
-			depotName = "Test Depot Name",
-			exportAdmin = "true");
-
-		LAR.exportSiteCP(depotName = "Test Depot Name");
-
-		var larFileName = LAR.getLarFileName();
-
-		LAR.downloadLar();
-
-		HeadlessSite.addSite(siteName = "New Site");
-
-		LAR.importSiteCP(
-			larFileName = ${larFileName},
-			siteName = "New Site");
-
-		WebContentNavigator.openWebContentAdmin(siteURLKey = "new-site");
-
-		WebContent.viewTitle(webContentTitle = "WC WebContent Title");
-	}
-
 	@description = "This ensures that the user can import the site with collections to a depot."
 	@priority = 4
 	@refactordone
@@ -343,68 +279,6 @@ definition {
 		AssetListsAdmin.viewAssetList(
 			assetListTitle = "Depot Manual Asset List",
 			type = "Manual");
-	}
-
-	@description = "This ensures that the user can import the site with document to a depot."
-	@priority = 4
-	@refactordone
-	test ExportedSiteWithDMCanBeImportedToDepot {
-		HeadlessSite.addSite(siteName = "Site Name");
-
-		JSONDocument.addFile(
-			dmDocumentDescription = "DM Document Description",
-			dmDocumentTitle = "DM Document Title",
-			groupName = "Site Name");
-
-		LAR.exportSiteCP(siteScopeName = "Site Name");
-
-		var larFileName = LAR.getLarFileName();
-
-		LAR.downloadLar();
-
-		DepotNavigator.openDepotExportImportAdmin(
-			depotName = "Test Depot Name",
-			importAdmin = "true");
-
-		LAR.importSiteCP(
-			depotName = "Test Depot Name",
-			larFileName = ${larFileName});
-
-		DepotNavigator.openToDMEntryInDepot(
-			depotName = "Test Depot Name",
-			dmDocumentTitle = "DM Document Title");
-
-		DMDocument.viewCP(dmDocumentTitle = "DM Document Title");
-	}
-
-	@description = "This ensures that the user can import the site with web content to a depot."
-	@priority = 4
-	@refactordone
-	test ExportedSiteWithWCCanBeImportedToDepot {
-		HeadlessSite.addSite(siteName = "Site Name");
-
-		JSONWebcontent.addWebContent(
-			content = "WC WebContent Content",
-			groupName = "Site Name",
-			title = "WC WebContent Title");
-
-		LAR.exportSiteCP(siteScopeName = "Site Name");
-
-		var larFileName = LAR.getLarFileName();
-
-		LAR.downloadLar();
-
-		DepotNavigator.openDepotExportImportAdmin(
-			depotName = "Test Depot Name",
-			importAdmin = "true");
-
-		LAR.importSiteCP(
-			depotName = "Test Depot Name",
-			larFileName = ${larFileName});
-
-		DepotNavigator.openDepotWebContentAdmin(depotName = "Test Depot Name");
-
-		WebContent.viewTitle(webContentTitle = "WC WebContent Title");
 	}
 
 }

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/exportimport/test/DepotExportImportTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/exportimport/test/DepotExportImportTest.java
@@ -103,7 +103,9 @@ public class DepotExportImportTest {
 	}
 
 	@Test
-	public void testExportImportDepotWithJournalArticleToGroup() throws Exception {
+	public void testExportImportDepotWithJournalArticleToGroup()
+		throws Exception {
+
 		JournalArticle journalArticle = JournalTestUtil.addArticle(
 			_depotGroup.getGroupId(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString());
@@ -122,8 +124,7 @@ public class DepotExportImportTest {
 
 	@Test
 	public void testExportImportGroupWithFileEntryToDepot() throws Exception {
-		FileEntry fileEntry = DLAppTestUtil.addFileEntry(
-			_group.getGroupId());
+		FileEntry fileEntry = DLAppTestUtil.addFileEntry(_group.getGroupId());
 
 		_larFile = _export(_group.getGroupId());
 
@@ -137,7 +138,9 @@ public class DepotExportImportTest {
 	}
 
 	@Test
-	public void testExportImportGroupWithJournalArticleToDepot() throws Exception {
+	public void testExportImportGroupWithJournalArticleToDepot()
+		throws Exception {
+
 		JournalArticle journalArticle = JournalTestUtil.addArticle(
 			_group.getGroupId(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString());
@@ -222,9 +225,9 @@ public class DepotExportImportTest {
 	@Inject
 	private ExportImportLocalService _exportImportLocalService;
 
-	private File _larFile;
-
 	@DeleteAfterTestRun
 	private Group _group;
+
+	private File _larFile;
 
 }

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/exportimport/test/DepotExportImportTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/exportimport/test/DepotExportImportTest.java
@@ -1,0 +1,232 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.depot.exportimport.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
+import com.liferay.document.library.test.util.DLAppTestUtil;
+import com.liferay.exportimport.kernel.configuration.ExportImportConfigurationSettingsMapFactoryUtil;
+import com.liferay.exportimport.kernel.configuration.constants.ExportImportConfigurationConstants;
+import com.liferay.exportimport.kernel.lar.PortletDataHandlerKeys;
+import com.liferay.exportimport.kernel.service.ExportImportConfigurationLocalService;
+import com.liferay.exportimport.kernel.service.ExportImportLocalService;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.service.JournalArticleLocalServiceUtil;
+import com.liferay.journal.test.util.JournalTestUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.rule.Sync;
+import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.io.File;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jaime Leon
+ */
+@RunWith(Arquillian.class)
+@Sync(cleanTransaction = true)
+public class DepotExportImportTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_depotEntry = _depotEntryLocalService.addDepotEntry(
+			Collections.singletonMap(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+			Collections.singletonMap(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+			DepotConstants.TYPE_ASSET_LIBRARY,
+			ServiceContextTestUtil.getServiceContext());
+
+		_depotGroup = _depotEntry.getGroup();
+
+		_siteGroup = GroupTestUtil.addGroup();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		if ((_larFile != null) && _larFile.exists()) {
+			FileUtil.delete(_larFile);
+		}
+	}
+
+	@Test
+	public void testExportImportDepotWithDocumentToSite() throws Exception {
+		FileEntry fileEntry = DLAppTestUtil.addFileEntry(
+			_depotGroup.getGroupId());
+
+		_larFile = _export(_depotGroup.getGroupId());
+
+		_import(_siteGroup.getGroupId(), _larFile);
+
+		FileEntry importedFileEntry =
+			DLAppLocalServiceUtil.getFileEntryByUuidAndGroupId(
+				fileEntry.getUuid(), _siteGroup.getGroupId());
+
+		Assert.assertEquals(fileEntry.getTitle(), importedFileEntry.getTitle());
+	}
+
+	@Test
+	public void testExportImportDepotWithWebContentToSite() throws Exception {
+		JournalArticle journalArticle = JournalTestUtil.addArticle(
+			_depotGroup.getGroupId(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString());
+
+		_larFile = _export(_depotGroup.getGroupId());
+
+		_import(_siteGroup.getGroupId(), _larFile);
+
+		JournalArticle importedJournalArticle =
+			JournalArticleLocalServiceUtil.fetchJournalArticleByUuidAndGroupId(
+				journalArticle.getUuid(), _siteGroup.getGroupId());
+
+		Assert.assertNotNull(importedJournalArticle);
+		Assert.assertEquals(
+			journalArticle.getTitle(), importedJournalArticle.getTitle());
+	}
+
+	@Test
+	public void testExportImportSiteWithDocumentToDepot() throws Exception {
+		FileEntry fileEntry = DLAppTestUtil.addFileEntry(
+			_siteGroup.getGroupId());
+
+		_larFile = _export(_siteGroup.getGroupId());
+
+		_import(_depotGroup.getGroupId(), _larFile);
+
+		FileEntry importedFileEntry =
+			DLAppLocalServiceUtil.getFileEntryByUuidAndGroupId(
+				fileEntry.getUuid(), _depotGroup.getGroupId());
+
+		Assert.assertEquals(fileEntry.getTitle(), importedFileEntry.getTitle());
+	}
+
+	@Test
+	public void testExportImportSiteWithWebContentToDepot() throws Exception {
+		JournalArticle journalArticle = JournalTestUtil.addArticle(
+			_siteGroup.getGroupId(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString());
+
+		_larFile = _export(_siteGroup.getGroupId());
+
+		_import(_depotGroup.getGroupId(), _larFile);
+
+		JournalArticle importedJournalArticle =
+			JournalArticleLocalServiceUtil.fetchJournalArticleByUuidAndGroupId(
+				journalArticle.getUuid(), _depotGroup.getGroupId());
+
+		Assert.assertNotNull(importedJournalArticle);
+		Assert.assertEquals(
+			journalArticle.getTitle(), importedJournalArticle.getTitle());
+	}
+
+	private File _export(long groupId) throws Exception {
+		return _exportImportLocalService.exportLayoutsAsFile(
+			_exportImportConfigurationLocalService.
+				addDraftExportImportConfiguration(
+					TestPropsValues.getUserId(),
+					ExportImportConfigurationConstants.TYPE_EXPORT_LAYOUT,
+					ExportImportConfigurationSettingsMapFactoryUtil.
+						buildExportLayoutSettingsMap(
+							TestPropsValues.getUser(), groupId, false,
+							new long[0], _getParameterMap())));
+	}
+
+	private Map<String, String[]> _getParameterMap() {
+		return HashMapBuilder.put(
+			PortletDataHandlerKeys.DATA_STRATEGY,
+			new String[] {PortletDataHandlerKeys.DATA_STRATEGY_MIRROR_OVERWRITE}
+		).put(
+			PortletDataHandlerKeys.DELETIONS,
+			new String[] {Boolean.FALSE.toString()}
+		).put(
+			PortletDataHandlerKeys.PERMISSIONS,
+			new String[] {Boolean.FALSE.toString()}
+		).put(
+			PortletDataHandlerKeys.PORTLET_CONFIGURATION,
+			new String[] {Boolean.TRUE.toString()}
+		).put(
+			PortletDataHandlerKeys.PORTLET_CONFIGURATION_ALL,
+			new String[] {Boolean.TRUE.toString()}
+		).put(
+			PortletDataHandlerKeys.PORTLET_DATA,
+			new String[] {Boolean.TRUE.toString()}
+		).put(
+			PortletDataHandlerKeys.PORTLET_DATA_ALL,
+			new String[] {Boolean.TRUE.toString()}
+		).put(
+			PortletDataHandlerKeys.PORTLET_SETUP_ALL,
+			new String[] {Boolean.TRUE.toString()}
+		).build();
+	}
+
+	private void _import(long groupId, File larFile) throws Exception {
+		_exportImportLocalService.importLayouts(
+			_exportImportConfigurationLocalService.
+				addDraftExportImportConfiguration(
+					TestPropsValues.getUserId(),
+					ExportImportConfigurationConstants.TYPE_IMPORT_LAYOUT,
+					ExportImportConfigurationSettingsMapFactoryUtil.
+						buildImportLayoutSettingsMap(
+							TestPropsValues.getUser(), groupId, false, null,
+							_getParameterMap())),
+			larFile);
+	}
+
+	@DeleteAfterTestRun
+	private DepotEntry _depotEntry;
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	private Group _depotGroup;
+
+	@Inject
+	private ExportImportConfigurationLocalService
+		_exportImportConfigurationLocalService;
+
+	@Inject
+	private ExportImportLocalService _exportImportLocalService;
+
+	private File _larFile;
+
+	@DeleteAfterTestRun
+	private Group _siteGroup;
+
+}

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/exportimport/test/DepotExportImportTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/exportimport/test/DepotExportImportTest.java
@@ -9,7 +9,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
-import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.test.util.DLAppTestUtil;
 import com.liferay.exportimport.kernel.configuration.ExportImportConfigurationSettingsMapFactoryUtil;
 import com.liferay.exportimport.kernel.configuration.constants.ExportImportConfigurationConstants;
@@ -17,7 +17,7 @@ import com.liferay.exportimport.kernel.lar.PortletDataHandlerKeys;
 import com.liferay.exportimport.kernel.service.ExportImportConfigurationLocalService;
 import com.liferay.exportimport.kernel.service.ExportImportLocalService;
 import com.liferay.journal.model.JournalArticle;
-import com.liferay.journal.service.JournalArticleLocalServiceUtil;
+import com.liferay.journal.service.JournalArticleLocalService;
 import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.repository.model.FileEntry;
@@ -38,7 +38,6 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import java.io.File;
 
-import java.util.Collections;
 import java.util.Map;
 
 import org.junit.After;
@@ -67,10 +66,12 @@ public class DepotExportImportTest {
 	@Before
 	public void setUp() throws Exception {
 		_depotEntry = _depotEntryLocalService.addDepotEntry(
-			Collections.singletonMap(
-				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			Collections.singletonMap(
-				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
 			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext());
 
@@ -96,7 +97,7 @@ public class DepotExportImportTest {
 		_import(_group.getGroupId(), _larFile);
 
 		FileEntry importedFileEntry =
-			DLAppLocalServiceUtil.getFileEntryByUuidAndGroupId(
+			_dlAppLocalService.getFileEntryByUuidAndGroupId(
 				fileEntry.getUuid(), _group.getGroupId());
 
 		Assert.assertEquals(fileEntry.getTitle(), importedFileEntry.getTitle());
@@ -115,7 +116,7 @@ public class DepotExportImportTest {
 		_import(_group.getGroupId(), _larFile);
 
 		JournalArticle importedJournalArticle =
-			JournalArticleLocalServiceUtil.fetchJournalArticleByUuidAndGroupId(
+			_journalArticleLocalService.fetchJournalArticleByUuidAndGroupId(
 				journalArticle.getUuid(), _group.getGroupId());
 
 		Assert.assertEquals(
@@ -131,7 +132,7 @@ public class DepotExportImportTest {
 		_import(_depotGroup.getGroupId(), _larFile);
 
 		FileEntry importedFileEntry =
-			DLAppLocalServiceUtil.getFileEntryByUuidAndGroupId(
+			_dlAppLocalService.getFileEntryByUuidAndGroupId(
 				fileEntry.getUuid(), _depotGroup.getGroupId());
 
 		Assert.assertEquals(fileEntry.getTitle(), importedFileEntry.getTitle());
@@ -150,7 +151,7 @@ public class DepotExportImportTest {
 		_import(_depotGroup.getGroupId(), _larFile);
 
 		JournalArticle importedJournalArticle =
-			JournalArticleLocalServiceUtil.fetchJournalArticleByUuidAndGroupId(
+			_journalArticleLocalService.fetchJournalArticleByUuidAndGroupId(
 				journalArticle.getUuid(), _depotGroup.getGroupId());
 
 		Assert.assertEquals(
@@ -219,6 +220,9 @@ public class DepotExportImportTest {
 	private Group _depotGroup;
 
 	@Inject
+	private DLAppLocalService _dlAppLocalService;
+
+	@Inject
 	private ExportImportConfigurationLocalService
 		_exportImportConfigurationLocalService;
 
@@ -227,6 +231,9 @@ public class DepotExportImportTest {
 
 	@DeleteAfterTestRun
 	private Group _group;
+
+	@Inject
+	private JournalArticleLocalService _journalArticleLocalService;
 
 	private File _larFile;
 

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/exportimport/test/DepotExportImportTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/exportimport/test/DepotExportImportTest.java
@@ -76,7 +76,7 @@ public class DepotExportImportTest {
 
 		_depotGroup = _depotEntry.getGroup();
 
-		_siteGroup = GroupTestUtil.addGroup();
+		_group = GroupTestUtil.addGroup();
 	}
 
 	@After
@@ -87,45 +87,45 @@ public class DepotExportImportTest {
 	}
 
 	@Test
-	public void testExportImportDepotWithDocumentToSite() throws Exception {
+	public void testExportImportDepotWithFileEntryToGroup() throws Exception {
 		FileEntry fileEntry = DLAppTestUtil.addFileEntry(
 			_depotGroup.getGroupId());
 
 		_larFile = _export(_depotGroup.getGroupId());
 
-		_import(_siteGroup.getGroupId(), _larFile);
+		_import(_group.getGroupId(), _larFile);
 
 		FileEntry importedFileEntry =
 			DLAppLocalServiceUtil.getFileEntryByUuidAndGroupId(
-				fileEntry.getUuid(), _siteGroup.getGroupId());
+				fileEntry.getUuid(), _group.getGroupId());
 
 		Assert.assertEquals(fileEntry.getTitle(), importedFileEntry.getTitle());
 	}
 
 	@Test
-	public void testExportImportDepotWithWebContentToSite() throws Exception {
+	public void testExportImportDepotWithJournalArticleToGroup() throws Exception {
 		JournalArticle journalArticle = JournalTestUtil.addArticle(
 			_depotGroup.getGroupId(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString());
 
 		_larFile = _export(_depotGroup.getGroupId());
 
-		_import(_siteGroup.getGroupId(), _larFile);
+		_import(_group.getGroupId(), _larFile);
 
 		JournalArticle importedJournalArticle =
 			JournalArticleLocalServiceUtil.fetchJournalArticleByUuidAndGroupId(
-				journalArticle.getUuid(), _siteGroup.getGroupId());
+				journalArticle.getUuid(), _group.getGroupId());
 
 		Assert.assertEquals(
 			journalArticle.getTitle(), importedJournalArticle.getTitle());
 	}
 
 	@Test
-	public void testExportImportSiteWithDocumentToDepot() throws Exception {
+	public void testExportImportGroupWithFileEntryToDepot() throws Exception {
 		FileEntry fileEntry = DLAppTestUtil.addFileEntry(
-			_siteGroup.getGroupId());
+			_group.getGroupId());
 
-		_larFile = _export(_siteGroup.getGroupId());
+		_larFile = _export(_group.getGroupId());
 
 		_import(_depotGroup.getGroupId(), _larFile);
 
@@ -137,12 +137,12 @@ public class DepotExportImportTest {
 	}
 
 	@Test
-	public void testExportImportSiteWithWebContentToDepot() throws Exception {
+	public void testExportImportGroupWithJournalArticleToDepot() throws Exception {
 		JournalArticle journalArticle = JournalTestUtil.addArticle(
-			_siteGroup.getGroupId(), RandomTestUtil.randomString(),
+			_group.getGroupId(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString());
 
-		_larFile = _export(_siteGroup.getGroupId());
+		_larFile = _export(_group.getGroupId());
 
 		_import(_depotGroup.getGroupId(), _larFile);
 
@@ -225,6 +225,6 @@ public class DepotExportImportTest {
 	private File _larFile;
 
 	@DeleteAfterTestRun
-	private Group _siteGroup;
+	private Group _group;
 
 }

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/exportimport/test/DepotExportImportTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/exportimport/test/DepotExportImportTest.java
@@ -116,7 +116,6 @@ public class DepotExportImportTest {
 			JournalArticleLocalServiceUtil.fetchJournalArticleByUuidAndGroupId(
 				journalArticle.getUuid(), _siteGroup.getGroupId());
 
-		Assert.assertNotNull(importedJournalArticle);
 		Assert.assertEquals(
 			journalArticle.getTitle(), importedJournalArticle.getTitle());
 	}
@@ -151,7 +150,6 @@ public class DepotExportImportTest {
 			JournalArticleLocalServiceUtil.fetchJournalArticleByUuidAndGroupId(
 				journalArticle.getUuid(), _depotGroup.getGroupId());
 
-		Assert.assertNotNull(importedJournalArticle);
 		Assert.assertEquals(
 			journalArticle.getTitle(), importedJournalArticle.getTitle());
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97154

## What Is Being Fixed

The depot export/import behavior was covered only by a legacy Poshi functional test (`DepotExportImport.testcase`). Poshi is a legacy tool kept for maintenance, and this UI-driven coverage is slow and brittle for behavior that can be exercised directly against the services.

## How It Is Being Fixed

The legacy Poshi scenarios are replaced with a Java integration test, `DepotExportImportTest`, that exercises the same flows at the service layer: exporting and importing a depot containing a file entry or a journal article to a group, and exporting and importing a group containing those assets to a depot. The obsolete Poshi cases are removed, and `depot-test`'s build gains the `document-library-test-util` dependency needed to build the fixtures.

## PR Check

**pr-check: PASS** — tested on `1dc250b5d0cd5d51cc7a58ce1febc3f81c9f476e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |
| Poshi Syntax | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "1dc250b5d0cd5d51cc7a58ce1febc3f81c9f476e"} -->
