### PR TITLE
LPD-97735 Wait for the API Explorer operation block before clicking it

### DIFF
--- a/modules/apps/headless/headless-discovery/headless-discovery-test/src/testFunctional/macros/APIExplorer.macro
+++ b/modules/apps/headless/headless-discovery/headless-discovery-test/src/testFunctional/macros/APIExplorer.macro
@@ -215,6 +215,11 @@ definition {
 	macro expandAPIMethod(method = null, service = null) {
 		Variables.assertDefined(parameterList = "${service},${method}");
 
+		WaitForElementPresent(
+			locator1 = "OpenAPI#API_METHOD",
+			method = ${method},
+			service = ${service});
+
 		Click(
 			locator1 = "OpenAPI#API_METHOD",
 			method = ${method},


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97735

## What Is Being Fixed

Two Poshi functional tests under the API Builder component fail intermittently on ci:test:headless:

- ExposeQueryParametersInAPIExplorerForGeneratedAPI#CanApplyFilterParameter
- AllowUsersToDefineSorts#CanApplySortingAndSortParameter

Both fail with the same trace:

    com.liferay.poshi.runner.exception.ElementNotFoundPoshiRunnerException: Element is not present at "//*[@id="operations-testSchema-getTestendpointPage"]"

The history on that routine shows an alternating pass/fail pattern (24% fail rate, 95 pass/fail transitions over 186 runs, 54 runs manually marked BLOCKED), so this is flakiness rather than a product regression.

## How It Is Being Fixed

The shared APIExplorer.expandAPIMethod macro clicked the Swagger operation block immediately after navigateToOpenAPI. The Poshi Click function only waits via WaitForSPARefresh (SennaJS navigation) plus a single waitForVisible; neither covers Swagger UI's separate asynchronous openapi.json fetch and render. On slower CI runs the operation block is not yet in the DOM when the click fires. Adding an explicit WaitForElementPresent on the operation block before the click gives the async render a dedicated wait window. Because every interaction (executeAPIMethod, executeAPIMethodCompact, and standalone expand calls) funnels through expandAPIMethod, this single change hardens the whole macro. Both affected tests were re-run locally with the fix and pass.

## Why Are There No Tests?

The change is entirely within test infrastructure — a shared Poshi macro — and touches no product code. Its purpose is to make existing functional tests reliable, verified by re-running both affected tests locally.

## PR Check

**pr-check: PASS** — tested on `609d3d684096a154772d322c1c4a39bc01e45fa4`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "609d3d684096a154772d322c1c4a39bc01e45fa4"} -->
