### PR TITLE
LPD-97694 Fix validation of private page references in web content

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
@@ -1122,6 +1122,11 @@ public class LayoutReferencesExportImportContentProcessor
 			Layout layout = _layoutLocalService.fetchLayoutByFriendlyURL(
 				groupId, privateLayout, url);
 
+			if (layout == null) {
+				layout = _layoutLocalService.fetchLayoutByFriendlyURL(
+					groupId, !privateLayout, url);
+			}
+
 			if (layout != null) {
 				continue;
 			}

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/LayoutReferencesExportImportContentProcessorTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/LayoutReferencesExportImportContentProcessorTest.java
@@ -657,6 +657,26 @@ public class LayoutReferencesExportImportContentProcessorTest {
 	}
 
 	@Test
+	@TestInfo("LPD-97694")
+	public void testValidateContentRelativePrivatePageURLWithVirtualHost()
+		throws Exception {
+
+		Group group = GroupTestUtil.addGroup();
+
+		GroupTestUtil.addLayoutSetVirtualHost(group, true);
+		GroupTestUtil.addLayoutSetVirtualHost(group, false);
+
+		Layout layout = LayoutTestUtil.addTypePortletLayout(group, true);
+
+		_layoutReferencesExportImportContentProcessor.validateContentReferences(
+			group.getGroupId(),
+			StringBundler.concat(
+				_CONTENT_PREFIX, layout.getFriendlyURL(),
+				_CONTENT_POSTFIX));
+
+	}
+
+	@Test
 	public void testValidateContentRelativePublicDefaultPageURLWithLocale()
 		throws Exception {
 

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/LayoutReferencesExportImportContentProcessorTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/LayoutReferencesExportImportContentProcessorTest.java
@@ -671,9 +671,7 @@ public class LayoutReferencesExportImportContentProcessorTest {
 		_layoutReferencesExportImportContentProcessor.validateContentReferences(
 			group.getGroupId(),
 			StringBundler.concat(
-				_CONTENT_PREFIX, layout.getFriendlyURL(),
-				_CONTENT_POSTFIX));
-
+				_CONTENT_PREFIX, layout.getFriendlyURL(), _CONTENT_POSTFIX));
 	}
 
 	@Test


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97694

## What Is Being Fixed

Referencing a private page from web content could fail export/import
reference validation even when the page exists. When a layout set uses a
virtual host, the private/public flag derived from the relative page URL
did not necessarily match the layout set the page actually lives in, so
the lookup missed the layout and the reference was reported as invalid.

## How It Is Being Fixed

`LayoutReferencesExportImportContentProcessor` now falls back to the
opposite layout set when the friendly URL lookup against the assumed
layout set returns no layout. If the page is found in either the private
or public layout set, the reference is treated as valid. A new
integration test covers a private page reference in a group with virtual
hosts configured on both layout sets.

## PR Check

**pr-check: PASS** — tested on `85f87ddf5f3bf0d965de6459535db85c40f1bf3b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "85f87ddf5f3bf0d965de6459535db85c40f1bf3b"} -->
