### PR TITLE
LPD-82310 Skip deletions in the initial staging publication

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/DeletionSystemEventExporterImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/DeletionSystemEventExporterImpl.java
@@ -89,7 +89,9 @@ public class DeletionSystemEventExporterImpl
 
 		Element rootElement = document.addElement("deletion-system-events");
 
-		if (systemEvents != null) {
+		if ((systemEvents != null) &&
+			!ExportImportThreadLocal.isInitialLayoutStagingInProcess()) {
+
 			Map<String, List<SystemEvent>> batchSystemEventsMap =
 				new HashMap<>();
 
@@ -160,6 +162,10 @@ public class DeletionSystemEventExporterImpl
 	public long getDeletionSystemEventsCount(
 			PortletDataContext portletDataContext)
 		throws Exception {
+
+		if (ExportImportThreadLocal.isInitialLayoutStagingInProcess()) {
+			return 0;
+		}
 
 		Set<StagedModelType> deletionSystemEventStagedModelTypes =
 			portletDataContext.getDeletionSystemEventStagedModelTypes();

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
@@ -92,6 +92,8 @@ import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.SystemEvent;
+import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
@@ -106,6 +108,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.SystemEventLocalService;
 import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -245,6 +248,47 @@ public class BatchEnginePortletDataHandlerTest {
 
 			Assert.assertTrue(logEntries.toString(), logEntries.isEmpty());
 		}
+	}
+
+	@Test
+	@TestInfo("LPD-82310")
+	public void testEnableLocalStagingWithDeletedLayout() throws Exception {
+		Group group = GroupTestUtil.addGroup();
+
+		Layout layout = LayoutTestUtil.addTypePortletLayout(group);
+
+		_layoutLocalService.deleteLayout(
+			layout,
+			ServiceContextTestUtil.getServiceContext(
+				group.getGroupId(), TestPropsValues.getUserId()));
+
+		SystemEvent systemEvent = _systemEventLocalService.fetchSystemEvent(
+			group.getGroupId(),
+			_classNameLocalService.getClassNameId(Layout.class),
+			layout.getPlid(), SystemEventConstants.TYPE_DELETE);
+
+		Assert.assertNotNull(systemEvent);
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.batch.engine.internal." +
+					"BatchEngineImportTaskExecutorImpl",
+				LoggerTestUtil.ERROR)) {
+
+			_stagingLocalService.enableLocalStaging(
+				TestPropsValues.getUserId(), group, false, false,
+				ServiceContextTestUtil.getServiceContext(
+					group.getGroupId(), TestPropsValues.getUserId()));
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertTrue(logEntries.toString(), logEntries.isEmpty());
+		}
+
+		Assert.assertNull(
+			_systemEventLocalService.fetchSystemEvent(
+				group.getGroupId(),
+				_classNameLocalService.getClassNameId(Layout.class),
+				layout.getPlid(), SystemEventConstants.TYPE_DELETE));
 	}
 
 	@Test
@@ -3829,6 +3873,9 @@ public class BatchEnginePortletDataHandlerTest {
 
 	@Inject
 	private StagingLocalService _stagingLocalService;
+
+	@Inject
+	private SystemEventLocalService _systemEventLocalService;
 
 	private static class TestExportImportVulcanBatchEngineTaskItemDelegate
 		implements EntityModelResource,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-82310

## What Is Being Fixed

When local staging is enabled on a site that already had content deleted before staging existed, the initial publication replays those pre-staging deletions and fails. The most visible symptom is a `NoSuchLayoutException` surfaced by the batch engine when it tries to delete a page (or any other batch-exported entity) that never existed on the target.

## How It Is Being Fixed

The initial staging publication is a full copy into a freshly created staging group, so there is nothing on the target to delete. The deletion system event export only bounded its query by create date for an explicit date range, so the initial publication (which runs with an "all" range) collected every delete system event ever recorded for the group, including those predating staging, and replayed them on import.

The exporter now skips writing and replaying deletion system events while the initial layout staging publication is in process. It still collects and prunes those events so the `SystemEvent` table ends in the same state a regular publication would leave it in, and reports a matching zero count for the manifest summary.

## PR Check

**pr-check: PASS** — tested on `6e3f54f5a22a4f9ac0e060d2bf0239b02d25953c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "6e3f54f5a22a4f9ac0e060d2bf0239b02d25953c"} -->
