### PR TITLE
LPD-62166 Sort numeric OData fields by their numeric type

### DIFF
--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/UserAccountResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/UserAccountResourceTest.java
@@ -715,6 +715,7 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 		_testGetUserAccountsPageWithCustomFields();
 		_testGetUserAccountsPageWithSortCustomField();
 		_testGetUserAccountsPageWithSortFullName();
+		_testGetUserAccountsPageWithSortId();
 	}
 
 	@Ignore
@@ -2370,6 +2371,36 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 
 		page = userAccountResource.getUserAccountsPage(
 			domainName, null, Pagination.of(1, 10), "name:desc");
+
+		assertEquals(userAccounts, (List<UserAccount>)page.getItems());
+	}
+
+	private void _testGetUserAccountsPageWithSortId() throws Exception {
+		String domainName = StringUtil.randomString() + ".com";
+		List<UserAccount> userAccounts = new ArrayList<>();
+
+		userAccounts.add(
+			userAccountResource.postUserAccount(
+				null, null,
+				_randomUserAccount(
+					userAccount -> userAccount.setEmailAddress(
+						"aaa@" + domainName))));
+		userAccounts.add(
+			userAccountResource.postUserAccount(
+				null, null,
+				_randomUserAccount(
+					userAccount -> userAccount.setEmailAddress(
+						"bbb@" + domainName))));
+
+		Page<UserAccount> page = userAccountResource.getUserAccountsPage(
+			domainName, null, Pagination.of(1, 10), "id:asc");
+
+		assertEquals(userAccounts, (List<UserAccount>)page.getItems());
+
+		Collections.reverse(userAccounts);
+
+		page = userAccountResource.getUserAccountsPage(
+			domainName, null, Pagination.of(1, 10), "id:desc");
 
 		assertEquals(userAccounts, (List<UserAccount>)page.getItems());
 	}

--- a/modules/apps/portal-odata/portal-odata-api/bnd.bnd
+++ b/modules/apps/portal-odata/portal-odata-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal OData API
 Bundle-SymbolicName: com.liferay.portal.odata.api
-Bundle-Version: 5.1.2
+Bundle-Version: 5.2.0
 Export-Package:\
 	com.liferay.portal.odata.entity,\
 	com.liferay.portal.odata.filter,\

--- a/modules/apps/portal-odata/portal-odata-api/src/main/java/com/liferay/portal/odata/sort/SortField.java
+++ b/modules/apps/portal-odata/portal-odata-api/src/main/java/com/liferay/portal/odata/sort/SortField.java
@@ -64,6 +64,14 @@ public class SortField implements Serializable {
 		_parentEntityFields = null;
 	}
 
+	public EntityField.Type getEntityFieldType() {
+		if (_entityField == null) {
+			return null;
+		}
+
+		return _entityField.getType();
+	}
+
 	/**
 	 * Returns the field's name.
 	 *

--- a/modules/apps/portal-odata/portal-odata-api/src/main/resources/com/liferay/portal/odata/sort/packageinfo
+++ b/modules/apps/portal-odata/portal-odata-api/src/main/resources/com/liferay/portal/odata/sort/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/SortUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/SortUtil.java
@@ -9,6 +9,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.sort.SortField;
 import com.liferay.portal.odata.sort.SortParser;
@@ -65,10 +66,27 @@ public class SortUtil {
 					acceptLanguage.getPreferredLocale()),
 				sortField.getSortableFieldPath(
 					acceptLanguage.getPreferredLocale()),
-				Sort.STRING_TYPE, !sortField.isAscending());
+				_getSortType(sortField.getEntityFieldType()),
+				!sortField.isAscending());
 		}
 
 		return sorts;
+	}
+
+	private static int _getSortType(EntityField.Type entityFieldType) {
+		if (entityFieldType == EntityField.Type.DOUBLE) {
+			return Sort.DOUBLE_TYPE;
+		}
+
+		if (entityFieldType == EntityField.Type.ID) {
+			return Sort.LONG_TYPE;
+		}
+
+		if (entityFieldType == EntityField.Type.INTEGER) {
+			return Sort.INT_TYPE;
+		}
+
+		return Sort.STRING_TYPE;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(SortUtil.class);

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/test/java/com/liferay/portal/vulcan/util/SortUtilTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/test/java/com/liferay/portal/vulcan/util/SortUtilTest.java
@@ -1,0 +1,127 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.vulcan.util;
+
+import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.odata.entity.DateTimeEntityField;
+import com.liferay.portal.odata.entity.DoubleEntityField;
+import com.liferay.portal.odata.entity.EntityField;
+import com.liferay.portal.odata.entity.IdEntityField;
+import com.liferay.portal.odata.entity.IntegerEntityField;
+import com.liferay.portal.odata.entity.StringEntityField;
+import com.liferay.portal.odata.sort.SortField;
+import com.liferay.portal.odata.sort.SortParser;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class SortUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		_acceptLanguage = Mockito.mock(AcceptLanguage.class);
+
+		Mockito.when(
+			_acceptLanguage.getPreferredLocale()
+		).thenReturn(
+			LocaleUtil.US
+		);
+	}
+
+	@Test
+	public void testGetSorts() {
+		_testGetSortsWithDateTimeField();
+		_testGetSortsWithDoubleField();
+		_testGetSortsWithIdField();
+		_testGetSortsWithIdFieldDescending();
+		_testGetSortsWithIntegerField();
+		_testGetSortsWithStringField();
+	}
+
+	private Sort[] _getSorts(EntityField entityField, boolean ascending) {
+		SortParser sortParser = Mockito.mock(SortParser.class);
+
+		Mockito.when(
+			sortParser.parse(Mockito.anyString())
+		).thenReturn(
+			Collections.singletonList(new SortField(entityField, ascending))
+		);
+
+		return SortUtil.getSorts(
+			_acceptLanguage, null, sortParser, entityField.getName());
+	}
+
+	private void _testGetSortsWithDateTimeField() {
+		Sort[] sorts = _getSorts(
+			new DateTimeEntityField(
+				"dateCreated", locale -> "createDate_sortable",
+				locale -> "createDate"),
+			true);
+
+		Assert.assertEquals(Sort.STRING_TYPE, sorts[0].getType());
+	}
+
+	private void _testGetSortsWithDoubleField() {
+		Sort[] sorts = _getSorts(
+			new DoubleEntityField("latitude", locale -> "latitude"), true);
+
+		Assert.assertEquals(Sort.DOUBLE_TYPE, sorts[0].getType());
+	}
+
+	private void _testGetSortsWithIdField() {
+		Sort[] sorts = _getSorts(
+			new IdEntityField("id", locale -> "entryClassPK", String::valueOf),
+			true);
+
+		Assert.assertEquals(Sort.LONG_TYPE, sorts[0].getType());
+		Assert.assertEquals("entryClassPK", sorts[0].getFieldName());
+		Assert.assertFalse(sorts[0].isReverse());
+	}
+
+	private void _testGetSortsWithIdFieldDescending() {
+		Sort[] sorts = _getSorts(
+			new IdEntityField("id", locale -> "entryClassPK", String::valueOf),
+			false);
+
+		Assert.assertEquals(Sort.LONG_TYPE, sorts[0].getType());
+		Assert.assertTrue(sorts[0].isReverse());
+	}
+
+	private void _testGetSortsWithIntegerField() {
+		Sort[] sorts = _getSorts(
+			new IntegerEntityField("status", locale -> "status"), true);
+
+		Assert.assertEquals(Sort.INT_TYPE, sorts[0].getType());
+	}
+
+	private void _testGetSortsWithStringField() {
+		Sort[] sorts = _getSorts(
+			new StringEntityField("name", locale -> "name_sortable"), true);
+
+		Assert.assertEquals(Sort.STRING_TYPE, sorts[0].getType());
+	}
+
+	private AcceptLanguage _acceptLanguage;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-62166

## What Is Being Fixed

The Headless Admin User API could not sort user accounts by `id`. Calling `getUserAccountsPage` with `sort=id:desc` (or `id:asc`) returned results in an arbitrary order instead of by account id. The same problem affected every Vulcan-based endpoint sorting by a numeric field, because `SortUtil` always requested a string sort.

## How It Is Being Fixed

`SortUtil.getSorts` hardcoded `Sort.STRING_TYPE` for every sort field. The default `id` field maps to `entryClassPK`, a long, and `Field.getSortFieldName` falls back to the score field when a `STRING_TYPE` sort targets a non-sortable-text field — so no real sorting happened. The fix exposes the OData entity field type through `SortField.getEntityFieldType()` and derives the correct search sort type from it: `ID` becomes `LONG_TYPE`, `INTEGER` becomes `INT_TYPE`, and `DOUBLE` becomes `DOUBLE_TYPE`, while string and date fields keep `STRING_TYPE` (they already resolve to their `*_sortable` index fields, so their behavior is unchanged).

## PR Check

**pr-check: PASS** — tested on `7b9c549c97284b544ecea07349332d64ebd98744`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "7b9c549c97284b544ecea07349332d64ebd98744"} -->
